### PR TITLE
refactor(day-indicators): share the day-mark model and cells between goals and habits

### DIFF
--- a/changelog.d/2026-08-29-shared-day-indicators.md
+++ b/changelog.d/2026-08-29-shared-day-indicators.md
@@ -1,0 +1,7 @@
+### Changed
+
+- **Habit day squares on dashboard habit cards now speak the same language as
+  goal day cells.** The success fill, a dash for skipped and a cross for missed
+  days as non-color cues, and a dashed ring on today match the goal pages; a
+  range longer than the card can hold pans back through the chain, anchored on
+  today, instead of silently dropping its oldest days.

--- a/knowledge/architecture/day-indicators.md
+++ b/knowledge/architecture/day-indicators.md
@@ -1,0 +1,145 @@
+---
+type: Architecture
+title: Day indicators — the shared day-mark model and cells
+description: One model (DayMark, DayMarkState, DayVerdict) and one component set (cells, strip, track geometry, legend) that both goals and habits draw their per-day squares with, so a day looks the same wherever it is judged.
+resource: ../../lib/widgets/day_indicators
+tags: [day-indicators, habits, goals, design-system, accessibility]
+status: draft
+generated: { by: claude-code/fable-5, at: 2026-08-29T12:00:00Z }
+stale_after: 2027-02-28
+sources:
+  - id: src
+    resource: ../../lib/widgets/day_indicators
+    title: Day indicators package source
+    last_modified: 2026-08-29
+  - id: goal-adapter
+    resource: ../../lib/features/goals/ui/goal_day_marks.dart
+    title: goalDayMarks — the goal side's adapter
+    last_modified: 2026-08-29
+  - id: habit-card
+    resource: ../../lib/features/habits/ui/widgets/habit_completion_card.dart
+    title: HabitCompletionCard — the habit side's consumer
+    last_modified: 2026-08-29
+  - id: goal-card
+    resource: ../../lib/features/goals/ui/goal_progress_card.dart
+    title: GoalProgressCard — the tappable habit-day cells and the metric bars
+    last_modified: 2026-08-29
+---
+
+`lib/widgets/day_indicators/` exists because a goal's habit dimension and a
+habit's own history strip are **two views of the same day**, and for a while
+they drew it two ways — different fills, different corner radii, one with a
+today ring and one without. The package promotes the goal side's primitives
+into a module both features consume. It imports neither `features/goals` nor
+`features/habits`; each feature adapts its own state into the shared model.
+
+# The model
+
+```mermaid
+classDiagram
+  class DayMark {
+    DateTime? day
+    DayMarkState state
+    DayVerdict? verdict
+    DayVerdictProvenance? verdictProvenance
+    bool isToday
+    bool successful
+  }
+  class DayMarkState {
+    <<enumeration>>
+    none
+    partial
+    full
+    skipped
+    missed
+  }
+  class DayVerdict {
+    <<enumeration>>
+    met
+    improving
+    mixed
+    missed
+  }
+  class DayVerdictProvenance {
+    <<enumeration>>
+    ratedByUser
+    suggestedAndAccepted
+  }
+  DayMark --> DayMarkState
+  DayMark --> DayVerdict
+  DayMark --> DayVerdictProvenance
+```
+
+- **`DayMarkState` is what the app measured.** `full` means the requirement
+  held as of that day; `partial` means the routine was kept while a window
+  target was still building (the lighter wash plus a dot); `skipped` and
+  `missed` are recorded habit outcomes. `missed` is never the grey of `none`:
+  deciding a day was missed and never looking at it are different facts.
+- **`DayVerdict` is the user's ruling**, and a recorded verdict outranks the
+  measurement wherever both are shown. The enum is persisted by `name` in
+  goal assessment records (see [goals](../features/goals.md)), so the names
+  are frozen even though the type moved here.
+- **`day` is nullable** only for undated figures — a loading placeholder or a
+  strip whose cells carry no dates and therefore no weekday letters. A
+  tappable strip asserts that every mark is dated, because a tap must resolve
+  to a day.
+- **`isToday` is explicit.** The goal adapter flags the last cell; the habit
+  card compares each day against `clock.now()`.
+
+# The component set
+
+| Piece | File | Role |
+| --- | --- | --- |
+| Fills, glyphs, inks, labels, letter, ring, dot | `day_mark_styles.dart` | The ONE mapping from state/verdict to token colors and shapes. Every cell and every legend swatch goes through it. |
+| `DayTrack`, `dayTrackMetrics`, `fitOrScrollDayTrack`, `LinkedDayTrackScroller` | `day_track.dart` | Column geometry shared by every day row on a page, and the fit-or-pan policy. |
+| `DayMarkCell`, `PlaceholderDayCell` | `day_mark_cell.dart` | One square. Read-only by default; with `onTap` it becomes a labelled button whose hit slot clears the touch floor while the square keeps its size. |
+| `DayMarkStrip` | `day_mark_strip.dart` | A row of cells with one semantic summary; dated strips sit on the shared track, undated ones on a plain row. |
+| `DayMarkLegend` | `day_mark_legend.dart` | The key, drawn from the same helpers as the cells. |
+
+```mermaid
+flowchart LR
+  GV["GoalProgressView.compactWindow<br/>+ latestRatingsByDay"] --> GA["goalDayMarks()"]
+  HR["List&lt;HabitResult&gt;<br/>(dashboard range)"] --> HA["habitCompletionDayMarkState()"]
+  GA --> M["List&lt;DayMark&gt;"]
+  HA --> M
+  M --> S["DayMarkStrip"]
+  S --> C["DayMarkCell ×N"]
+  C --> ST["day_mark_styles"]
+  L["DayMarkLegend"] --> ST
+  P["_ProgressDayCell<br/>(goal detail, tappable outcome menu)"] --> ST
+```
+
+# Invariants
+
+- **Data never wears the interactive teal.** States use the `alert` families
+  and `background.level03`; the today ring is `text.mediumEmphasis`.
+- **Every non-neutral state has a non-color cue**: the partial dot, the skip
+  dash, the missed cross, a verdict's own glyph. A red-green deficiency can
+  read the strip.
+- **Read-only strips publish one semantics node** (the successful-day count
+  plus any verdicts); tappable strips publish one button per day, each naming
+  its date and outcome.
+- **A verdict outranks a state** for fill, glyph and the success tally.
+- **One pitch per page.** Anything that draws days on a goal detail page —
+  the whole-goal strip, the habit squares, the metric bars, the page chrome —
+  sizes its columns with `dayTrackMetrics` so a date lines up down the page.
+
+# Gotchas
+
+- `_ProgressDayCell` in `goal_progress_card.dart` is not a `DayMarkCell`: it
+  hosts the outcome menu, the saving spinner and the ages-out ring. It draws
+  with the shared styles and the shared state enum, so its squares still
+  match; only its interaction shell is its own.
+- The habit dashboard strip used to drop its oldest days to fit; it now pans
+  like every other track. There is no `LinkedScrollGroup` on a dashboard, so
+  each card pans alone.
+- The strip's semantics strings are still the `goalProgress*` l10n keys. They
+  read generically ("3 successful days in the trailing seven-day window") and
+  renaming them would touch every catalogue for no user-visible change.
+
+# Not yet shared
+
+The issue that created this package (lotti3-co1) also asks for habit day
+verdicts with the reflect sheet reachable from habit surfaces, a complete
+legend including the verdict hues on habit surfaces, and longer spans on the
+habits page. Those build on this module and are separate changes.

--- a/knowledge/architecture/index.md
+++ b/knowledge/architecture/index.md
@@ -10,6 +10,7 @@ Cross-cutting runtime structure — the parts no single feature owns.
 * [Security and privacy posture](security-and-privacy.md) - what is encrypted, what is not, where secrets live, and what leaves the device.
 * [Logging and diagnostics](logging-and-diagnostics.md) - the opt-in logging domains, where their lines land, and why errors bypass the gate.
 * [Signals](signals.md) - the journal series goals and habits both evaluate, bucketed by calendar day, and the habit rule evaluator.
+* [Day indicators](day-indicators.md) - the shared day-mark model and the cells, strip, track geometry and legend goals and habits draw their per-day squares with.
 * [Shared widgets](shared-widgets.md) - the widgets that belong to no single feature.
 * [Platform targets, CI and release](platform-and-release.md) - every platform target from one codebase, the checks each branch runs, and the tag that triggers the release pipelines.
 

--- a/knowledge/architecture/shared-widgets.md
+++ b/knowledge/architecture/shared-widgets.md
@@ -42,6 +42,7 @@ composition and app-shell chrome.
 | `picker/` | `EntityPickerSheet`, shared by categories, labels and the task link pickers |
 | `nav_bar/` | The bottom navigation shell and its FAB clearance wrapper |
 | `media/` | The lifecycle scope that temporarily permits landscape in full-screen image viewers |
+| `day_indicators/` | The `DayMark` model and the day cells, strip, track geometry and legend goals and habits share |
 | `misc/` | The sidebar activity summary and similar cross-feature pieces |
 
 **Buttons are not here.** They all come from `DesignSystemButton` and its
@@ -52,6 +53,14 @@ holds sixteen groups; the eight not described above — `cards/`, `charts/`,
 `create/`, `date_time/`, `flags/`, `form/`, `search/`, `ui/` — are
 undocumented here. Read them directly, and do not infer from this concept that a
 widget has no shared home just because it is absent.
+
+# Day indicators are the one cross-feature data figure
+
+`day_indicators/` is the exception to "composition and chrome only": it is a
+small data-visualisation vocabulary — one day square, a strip of them, the
+column geometry, a legend — shared by goals and habits so a day is drawn the
+same way wherever it is judged. It has its own concept:
+[day indicators](day-indicators.md).
 
 # Image viewers temporarily widen the mobile orientation policy
 

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -402,7 +402,7 @@ flowchart TD
 
   **A recorded verdict outranks the measurement wherever both are shown.** The
   seven-day strip colours a day from `latestRatingsByDay`, falling back to the
-  measured `GoalCompactDayState` only where no verdict exists — the
+  measured `DayMarkState` only where no verdict exists — the
   measurement is evidence about a day, the reflection is the user's ruling on
   it. Those lookups are scoped to the active `specVersionId`: spec versions are
   immutable and the history keeps them all, so an unscoped map would let a
@@ -916,12 +916,12 @@ flowchart TD
   range. The retained snapshot is scoped to the active spec version and only
   promoted from a settled provider value, so a spec reload cannot relabel
   prior-spec evidence. A day track FITS before it scrolls:
-  `goalDayTrackMetrics` narrows the column pitch — and the square inside it
+  `dayTrackMetrics` narrows the column pitch — and the square inside it
   — until the whole span fits the width it was given, and only a span that
   overflows even at the legibility floor becomes a trailing-anchored
   (`reverse: true`) scroller joined to one `LinkedScrollGroup`, where every
   track then pans in unison. The habit squares and the whole-goal strip carry their weekday
-  axis INSIDE the cells (`goalDayCellLetter`: a small bottom-left corner
+  axis INSIDE the cells (`dayCellLetter`: a small bottom-left corner
   initial that yields to a center mark — verdict glyph, partial dot, missed
   cross, which collide with it at the compact cell size — and is suppressed
   below `IconSizes.l`) instead of a label
@@ -932,7 +932,7 @@ flowchart TD
   ink painted on the Scaffold's Material sits under the opaque cards and
   never shows, which is why the day grids and rail rows previously had no
   hover feedback. One policy
-  (`_fitOrScroll`), by WIDTH, for all three tracks: deciding by day count
+  (`fitOrScrollDayTrack`), by WIDTH, for all three tracks: deciding by day count
   wrapped a span that provably fitted, and a fortnight at the authored pitch
   is wider than a phone card, so the scroller opened with the first days of
   the span cut in half off the left edge. A gutter is reserved where a VALUE
@@ -1021,7 +1021,9 @@ flowchart TD
   therefore be green while the current goal remains Behind or At risk.
   Numeric leaves still respect `atLeast` versus `atMost` direction, and missing
   samples never count as successful days. Both the compact strip and the
-  detail day cells are tri-state (`GoalCompactDayState`): the
+  detail day cells draw with the shared day-indicator cells and styles
+  ([day indicators](../architecture/day-indicators.md)), whose measured states
+  (`DayMarkState`) render as: the
   `alert.success` family at full strength when the goal requirement held as
   of that day, the same hue at `SurfaceAlphas.muted` (no new token) plus a
   full-strength inner dot — the non-color cue — for a partial success (the

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -283,7 +283,10 @@ action content stays a comfortable column.
 
 Tab rows are lean **action rows**: icon, name, swipe, one-tap complete — **no
 per-row history**. Per-day history reads from the heatmap instead. The older
-per-row history strip survives only inside the dashboard habit chart. A row
+per-row history strip survives only inside the dashboard habit chart, drawn
+with the shared day-indicator cells ([day
+indicators](../architecture/day-indicators.md)) so it matches a goal's habit
+squares: success fill, skip dash, missed cross, dashed ring on today. A row
 whose completion today came from the engine wears an **auto** pill and a
 caption naming the signal and the time (`HabitsState.autoCompletedToday` and
 `autoCompletedAt`); tapping it still opens the sheet, because a manual entry

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -80,6 +80,7 @@ README, this is the way in:
 | [`lib/features/goals/`](../lib/features/goals) | [Goal agents — deterministic runtime](features/goals.md) | Phase A: signal reading, evaluation, registers, escalation; entities/vocabulary live in `lib/classes` |
 | [`lib/l10n/`](../lib/l10n) | [Localization](conventions/localization.md) | the ARB workflow |
 | [`lib/logic/signals/`](../lib/logic/signals) | [Signals — shared journal series](architecture/signals.md) | the whole directory: day bucketing, `SignalReader`, `HabitRuleEvaluator` |
+| [`lib/widgets/day_indicators/`](../lib/widgets/day_indicators) | [Day indicators — shared day-mark model and cells](architecture/day-indicators.md) | `DayMark`/`DayMarkState`/`DayVerdict`, `DayMarkCell`, `DayMarkStrip`, `DayTrack`, `DayMarkLegend` |
 | [`lib/logic/`](../lib/logic) | [Persistence layer](architecture/persistence.md) | **almost nothing** — `PersistenceLogic` appears only as a node in the write-path diagram. The import paths and the rest of the tree are undocumented; read the code |
 | [`lib/themes/`](../lib/themes) | [Tokens and theming](features/design_system/tokens-and-theming.md) | **`theme_overrides.dart` only**, as the token-injection seam |
 | [`lib/utils/`](../lib/utils) | — | nothing; small helpers, read the code |

--- a/lib/features/goals/logic/goal_day_verdict.dart
+++ b/lib/features/goals/logic/goal_day_verdict.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart' show DateUtils;
-import 'package:lotti/features/goals/model/goal_assessment.dart';
 import 'package:lotti/features/goals/state/goal_progress_view.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
 
 /// How one day's criteria actually turned out, per the evidence.
 typedef GoalDayOutcome = ({int met, int total});
@@ -48,16 +48,16 @@ GoalDayOutcome goalDayOutcome(GoalProgressView progress, DateTime day) {
 ///  * Nothing tracked, or nothing recorded all day → **null**. Suggesting
 ///    "missed" for a day the user simply did not open the app would be the app
 ///    passing judgement on its own blind spot.
-///  * Everything met → [GoalAssessmentRating.met].
-///  * Nothing met → [GoalAssessmentRating.missed].
+///  * Everything met → [DayVerdict.met].
+///  * Nothing met → [DayVerdict.missed].
 ///  * Some met, and more than the day before →
-///    [GoalAssessmentRating.improving]. This is the case the three-way verdict
+///    [DayVerdict.improving]. This is the case the three-way verdict
 ///    could not express: not a clean day, but a better one.
-///  * Some met otherwise → [GoalAssessmentRating.mixed].
+///  * Some met otherwise → [DayVerdict.mixed].
 ///
 /// The user can always override; the suggestion only decides what the sheet
 /// opens on.
-GoalAssessmentRating? suggestedDayVerdict(
+DayVerdict? suggestedDayVerdict(
   GoalProgressView progress,
   DateTime day,
 ) {
@@ -65,18 +65,18 @@ GoalAssessmentRating? suggestedDayVerdict(
   if (today.total == 0 || today.met == 0 && !_anyEvidence(progress, day)) {
     return null;
   }
-  if (today.met == today.total) return GoalAssessmentRating.met;
-  if (today.met == 0) return GoalAssessmentRating.missed;
+  if (today.met == today.total) return DayVerdict.met;
+  if (today.met == 0) return DayVerdict.missed;
   // Improving is a comparison, so it needs something to compare against. With
   // no observations yesterday its met count is zero for want of DATA, not for
   // want of effort, and calling today an improvement on it would be inventing
   // a baseline — then recording that invention as a suggestion the user
   // accepted.
   final previousDay = day.subtract(const Duration(days: 1));
-  if (!_anyEvidence(progress, previousDay)) return GoalAssessmentRating.mixed;
+  if (!_anyEvidence(progress, previousDay)) return DayVerdict.mixed;
   return today.met > goalDayOutcome(progress, previousDay).met
-      ? GoalAssessmentRating.improving
-      : GoalAssessmentRating.mixed;
+      ? DayVerdict.improving
+      : DayVerdict.mixed;
 }
 
 /// Whether the day carries any observation at all, met or not.

--- a/lib/features/goals/model/goal_assessment.dart
+++ b/lib/features/goals/model/goal_assessment.dart
@@ -1,17 +1,5 @@
 import 'package:flutter/foundation.dart';
-
-/// How a day turned out, in the user's own judgement.
-///
-/// [improving] is the case a three-way verdict could not express: some of it
-/// was missed, but the day moved the right way. Without it a day like that
-/// had to be filed as [mixed] alongside days that simply stalled, and the
-/// strip could not show "not perfect, but on the right track".
-///
-/// Ordered best to worst. Persisted by `name`, so the order is free to change
-/// but the names are not.
-enum GoalAssessmentRating { met, improving, mixed, missed }
-
-enum GoalAssessmentProvenance { ratedByUser, suggestedAndAccepted }
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
 
 @immutable
 class GoalAssessmentRecord {
@@ -30,10 +18,10 @@ class GoalAssessmentRecord {
   final String id;
   final DateTime day;
   final String specVersionId;
-  final GoalAssessmentRating rating;
+  final DayVerdict rating;
   final String? note;
-  final Map<String, GoalAssessmentRating> dimensionRatings;
+  final Map<String, DayVerdict> dimensionRatings;
   final DateTime createdAt;
-  final GoalAssessmentProvenance provenance;
+  final DayVerdictProvenance provenance;
   final String? suggestedBy;
 }

--- a/lib/features/goals/service/goal_assessment_service.dart
+++ b/lib/features/goals/service/goal_assessment_service.dart
@@ -3,7 +3,7 @@ import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
-import 'package:lotti/features/goals/model/goal_assessment.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
 import 'package:uuid/uuid.dart';
 
 abstract final class GoalAssessmentToolNames {
@@ -21,10 +21,10 @@ class GoalAssessmentService {
     required String agentId,
     required DateTime day,
     required String specVersionId,
-    required GoalAssessmentRating rating,
-    required Map<String, GoalAssessmentRating> dimensionRatings,
+    required DayVerdict rating,
+    required Map<String, DayVerdict> dimensionRatings,
     String? note,
-    GoalAssessmentProvenance provenance = GoalAssessmentProvenance.ratedByUser,
+    DayVerdictProvenance provenance = DayVerdictProvenance.ratedByUser,
     String? suggestedBy,
   }) async {
     final now = clock.now();
@@ -86,16 +86,13 @@ class GoalAssessmentService {
   }
 }
 
-/// The nearest verdict a client predating [GoalAssessmentRating.improving]
+/// The nearest verdict a client predating [DayVerdict.improving]
 /// can decode.
 ///
 /// "Some of it was missed, but the day moved the right way" collapses to
 /// `mixed` there, which is the honest reading: it was not a clean sweep. Every
 /// other verdict is its own legacy form.
-GoalAssessmentRating _legacyRating(GoalAssessmentRating rating) =>
-    rating == GoalAssessmentRating.improving
-    ? GoalAssessmentRating.mixed
-    : rating;
+DayVerdict _legacyRating(DayVerdict rating) =>
+    rating == DayVerdict.improving ? DayVerdict.mixed : rating;
 
-String _legacyRatingName(GoalAssessmentRating rating) =>
-    _legacyRating(rating).name;
+String _legacyRatingName(DayVerdict rating) => _legacyRating(rating).name;

--- a/lib/features/goals/state/goal_assessment_state.dart
+++ b/lib/features/goals/state/goal_assessment_state.dart
@@ -6,6 +6,7 @@ import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/goals/model/goal_assessment.dart';
 import 'package:lotti/features/goals/service/goal_assessment_service.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
 
 final goalAssessmentServiceProvider = Provider<GoalAssessmentService>(
   (ref) => GoalAssessmentService(ref.watch(agentSyncServiceProvider)),
@@ -64,7 +65,7 @@ goalAssessmentHistoryProvider = FutureProvider.autoDispose
           }
           final rawDimensions =
               content['dimensionRatingsV2'] ?? content['dimensionRatings'];
-          final dimensionRatings = <String, GoalAssessmentRating>{};
+          final dimensionRatings = <String, DayVerdict>{};
           if (rawDimensions is Map) {
             for (final entry in rawDimensions.entries) {
               if (entry.key is! String || entry.value is! String) continue;
@@ -82,10 +83,10 @@ goalAssessmentHistoryProvider = FutureProvider.autoDispose
               dimensionRatings: dimensionRatings,
               createdAt: action.createdAt,
               provenance:
-                  GoalAssessmentProvenance.values
+                  DayVerdictProvenance.values
                       .where((value) => value.name == content['provenance'])
                       .firstOrNull ??
-                  GoalAssessmentProvenance.ratedByUser,
+                  DayVerdictProvenance.ratedByUser,
               suggestedBy: content['suggestedBy'] as String?,
             ),
           );
@@ -104,17 +105,15 @@ goalAssessmentHistoryProvider = FutureProvider.autoDispose
 /// A record whose rating cannot be read is skipped entirely by the caller, so
 /// an unknown name would make the whole day's reflection — note, per-dimension
 /// verdicts and all — vanish from a device running an older build. A value
-/// this build does not know is therefore read as [GoalAssessmentRating.mixed],
+/// this build does not know is therefore read as [DayVerdict.mixed],
 /// the honest middle: the day was reflected on and it was not a clean sweep.
 ///
 /// Returns null only for a value that is not a string at all, which is
 /// corruption rather than a version skew.
-GoalAssessmentRating? _decodeRating(Object? raw) {
+DayVerdict? _decodeRating(Object? raw) {
   if (raw is! String) return null;
-  return GoalAssessmentRating.values
-          .where((value) => value.name == raw)
-          .firstOrNull ??
-      GoalAssessmentRating.mixed;
+  return DayVerdict.values.where((value) => value.name == raw).firstOrNull ??
+      DayVerdict.mixed;
 }
 
 /// The record that stands for each day, keyed by UTC day.
@@ -155,7 +154,7 @@ Map<DateTime, GoalAssessmentRecord> latestAssessmentsByDay(
 }
 
 /// The verdict standing for each day, for surfaces that only need the colour.
-Map<DateTime, GoalAssessmentRating> latestRatingsByDay(
+Map<DateTime, DayVerdict> latestRatingsByDay(
   Iterable<GoalAssessmentRecord> records, {
   String? specVersionId,
 }) => {

--- a/lib/features/goals/state/goal_progress_view.dart
+++ b/lib/features/goals/state/goal_progress_view.dart
@@ -14,16 +14,11 @@ import 'package:lotti/features/goals/model/goal_health_data_types.dart';
 import 'package:lotti/features/goals/state/goal_agent_providers.dart';
 import 'package:lotti/features/goals/state/goal_measurable_capture_state.dart';
 import 'package:lotti/providers/service_providers.dart' show journalDbProvider;
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
 
 enum GoalDimensionKind { habit, health, measurable, categoryTime, labelTime }
 
 enum GoalCompositeRuleKind { all, any, atLeast }
-
-/// One cell of the seven-day picture. [full] means the goal requirement was
-/// satisfied as of that day; [partial] means the user did everything within
-/// their control that day (habits completed) while the goal target was not
-/// yet met — rendered as a lighter wash of the same success hue.
-enum GoalCompactDayState { none, partial, full }
 
 class GoalRecordedMeasurementProvenance {
   const GoalRecordedMeasurementProvenance({
@@ -254,7 +249,7 @@ class GoalProgressView {
   final DateTime today;
   final List<GoalHabitProgressView> habits;
   final List<GoalMetricProgressView> metrics;
-  final List<GoalCompactDayState>? compositeCompactWindow;
+  final List<DayMarkState>? compositeCompactWindow;
   final GoalCompositeRuleKind? compositeRule;
   final int? requiredSuccesses;
   final bool rootOnTrack;
@@ -268,7 +263,7 @@ class GoalProgressView {
   /// Metric goals respect their at-least/at-most direction. A day is `full`
   /// when the goal requirement held as of that day, `partial` when the
   /// routine was completed while the requirement was still building up.
-  List<GoalCompactDayState> get compactWindow {
+  List<DayMarkState> get compactWindow {
     if (compositeCompactWindow case final compact?) return compact;
     final activeDays = [
       for (var offset = compactWindowDays - 1; offset >= 0; offset--)
@@ -295,37 +290,34 @@ class GoalProgressView {
         // The same per-day policy as the bars and the reflection sheet this
         // cell opens — a strip cell must not call a day missed while the
         // sheet suggests "met" for it.
-        if (series.dayMark(day))
-          GoalCompactDayState.full
-        else
-          GoalCompactDayState.none,
+        if (series.dayMark(day)) DayMarkState.full else DayMarkState.none,
     ];
   }
 
-  static GoalCompactDayState _habitDayState({
+  static DayMarkState _habitDayState({
     required GoalHabitProgressView habit,
     required DateTime day,
   }) {
     final entry = habit.days
         .where((candidate) => candidate.day == day && candidate.hasValue)
         .firstOrNull;
-    if (entry == null) return GoalCompactDayState.none;
+    if (entry == null) return DayMarkState.none;
     return (entry.targetSatisfied ?? true)
-        ? GoalCompactDayState.full
-        : GoalCompactDayState.partial;
+        ? DayMarkState.full
+        : DayMarkState.partial;
   }
 
   /// A multi-habit day is only as strong as its weakest completed habit, and
   /// only counts at all when every habit was completed.
-  static GoalCompactDayState _combinedDayState(
-    List<GoalCompactDayState> states,
+  static DayMarkState _combinedDayState(
+    List<DayMarkState> states,
   ) {
-    if (states.any((state) => state == GoalCompactDayState.none)) {
-      return GoalCompactDayState.none;
+    if (states.any((state) => state == DayMarkState.none)) {
+      return DayMarkState.none;
     }
-    return states.any((state) => state == GoalCompactDayState.partial)
-        ? GoalCompactDayState.partial
-        : GoalCompactDayState.full;
+    return states.any((state) => state == DayMarkState.partial)
+        ? DayMarkState.partial
+        : DayMarkState.full;
   }
 }
 
@@ -417,7 +409,7 @@ GoalHabitProgressView _withCheckOffSuggestion({
   return habit;
 }
 
-GoalCompactDayState _criterionDayState(
+DayMarkState _criterionDayState(
   GoalCriterion criterion,
   GoalSignalWindow signals,
   DateTime day,
@@ -425,11 +417,11 @@ GoalCompactDayState _criterionDayState(
   if (const GoalProgressEvaluator()
       .evaluate(criterion, signals, day)
       .satisfied) {
-    return GoalCompactDayState.full;
+    return DayMarkState.full;
   }
   return _criterionCompletedOnDay(criterion, signals, day)
-      ? GoalCompactDayState.partial
-      : GoalCompactDayState.none;
+      ? DayMarkState.partial
+      : DayMarkState.none;
 }
 
 bool _criterionCompletedOnDay(

--- a/lib/features/goals/ui/checkins/goal_checkin_timeline.dart
+++ b/lib/features/goals/ui/checkins/goal_checkin_timeline.dart
@@ -14,10 +14,11 @@ import 'package:lotti/features/goals/logic/goal_timeline_projection.dart';
 import 'package:lotti/features/goals/model/goal_assessment.dart';
 import 'package:lotti/features/goals/model/goal_timeline_item.dart';
 import 'package:lotti/features/goals/state/goal_checkin_providers.dart';
-import 'package:lotti/features/goals/ui/goal_progress_card.dart';
 import 'package:lotti/features/speech/ui/widgets/audio_player.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
 import 'package:lotti/widgets/timeline/timeline_models.dart';
 import 'package:lotti/widgets/timeline/timeline_view.dart';
 
@@ -277,10 +278,10 @@ class _GoalCheckInTimelineState extends ConsumerState<GoalCheckInTimeline> {
           id: reflection.id,
           timeLabel: timeLabel,
           kindLabel: context.messages.goalCheckInKindReflection,
-          glyph: goalAssessmentRatingGlyph(rating),
+          glyph: dayVerdictGlyph(rating),
           // The verdict's own colour, so the rail agrees with the day strip
           // and the reflection sheet rather than inventing a third vocabulary.
-          accent: goalAssessmentRatingSurfaceInk(tokens, rating),
+          accent: dayVerdictSurfaceInk(tokens, rating),
           // One tight row: the verdict rides the header's trailing slot,
           // fully right-aligned, instead of stacking beneath the label. No
           // "Rated by you"-style attribution — the provenance stays on the
@@ -340,7 +341,7 @@ class _ReflectionTrailing extends StatelessWidget {
 class _VerdictPill extends StatelessWidget {
   const _VerdictPill({required this.rating});
 
-  final GoalAssessmentRating rating;
+  final DayVerdict rating;
 
   @override
   Widget build(BuildContext context) {
@@ -351,17 +352,17 @@ class _VerdictPill extends StatelessWidget {
         vertical: tokens.spacing.step1,
       ),
       decoration: BoxDecoration(
-        color: goalAssessmentRatingFill(tokens, rating).withValues(alpha: 0.16),
+        color: dayVerdictFill(tokens, rating).withValues(alpha: 0.16),
         // Informative, not tappable: the small-chip radius, never the pill —
         // full rounding is reserved for clickable elements on this surface.
         borderRadius: BorderRadius.circular(tokens.radii.smallChips),
       ),
       child: Text(
-        goalAssessmentRatingLabel(context, rating),
+        dayVerdictLabel(context, rating),
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
         style: tokens.typography.styles.others.caption.copyWith(
-          color: goalAssessmentRatingSurfaceInk(tokens, rating),
+          color: dayVerdictSurfaceInk(tokens, rating),
           fontWeight: tokens.typography.weight.semiBold,
         ),
       ),

--- a/lib/features/goals/ui/goal_assessment_widgets.dart
+++ b/lib/features/goals/ui/goal_assessment_widgets.dart
@@ -15,6 +15,8 @@ import 'package:lotti/features/goals/state/goal_progress_view.dart';
 import 'package:lotti/features/goals/ui/checkins/goal_reflection_voice_notes.dart';
 import 'package:lotti/features/goals/ui/goal_progress_card.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
 
 /// The sheet's gap scale, so whitespace means something.
 ///
@@ -74,9 +76,9 @@ void showGoalDayAssessmentSheet(
 /// Both the day toggle and the per-dimension toggles read from here: hand-
 /// listing them twice is how a fourth verdict ends up offered on one and
 /// missing from the other.
-List<DsSegment<GoalAssessmentRating>> _ratingSegments(BuildContext context) => [
-  for (final rating in GoalAssessmentRating.values)
-    DsSegment(rating, goalAssessmentRatingLabel(context, rating)),
+List<DsSegment<DayVerdict>> _ratingSegments(BuildContext context) => [
+  for (final rating in DayVerdict.values)
+    DsSegment(rating, dayVerdictLabel(context, rating)),
 ];
 
 class GoalDayAssessmentSheet extends ConsumerStatefulWidget {
@@ -118,14 +120,14 @@ class GoalDayAssessmentSheet extends ConsumerStatefulWidget {
 class _GoalDayAssessmentSheetState
     extends ConsumerState<GoalDayAssessmentSheet> {
   final _note = TextEditingController();
-  late GoalAssessmentRating _rating;
-  final _dimensionRatings = <String, GoalAssessmentRating>{};
+  late DayVerdict _rating;
+  final _dimensionRatings = <String, DayVerdict>{};
   var _saving = false;
   String? _error;
 
   /// What the evidence suggests for this day. Null when there is nothing to
   /// judge, in which case the sheet opens on Met as it always did.
-  GoalAssessmentRating? _suggested;
+  DayVerdict? _suggested;
 
   @override
   void initState() {
@@ -135,7 +137,7 @@ class _GoalDayAssessmentSheetState
     // A day already reflected on opens on what was recorded. Otherwise the
     // evidence picks the starting point — the verdict used to default to Met
     // regardless of what the numbers directly above it said.
-    _rating = existing?.rating ?? _suggested ?? GoalAssessmentRating.met;
+    _rating = existing?.rating ?? _suggested ?? DayVerdict.met;
     _note.text = existing?.note ?? '';
     if (existing != null) _dimensionRatings.addAll(existing.dimensionRatings);
   }
@@ -180,8 +182,8 @@ class _GoalDayAssessmentSheetState
             dimensionRatings: _dimensionRatings,
             note: _note.text.trim().isEmpty ? null : _note.text.trim(),
             provenance: _acceptedSuggestion
-                ? GoalAssessmentProvenance.suggestedAndAccepted
-                : GoalAssessmentProvenance.ratedByUser,
+                ? DayVerdictProvenance.suggestedAndAccepted
+                : DayVerdictProvenance.ratedByUser,
           );
     } on Object {
       if (mounted) {
@@ -312,7 +314,7 @@ class _GoalDayAssessmentSheetState
                 ),
               ),
               SizedBox(height: _bindGap(tokens)),
-              DsSegmentedToggle<GoalAssessmentRating>(
+              DsSegmentedToggle<DayVerdict>(
                 expand: true,
                 selected: _rating,
                 onChanged: (value) => setState(() {
@@ -391,7 +393,7 @@ class _GoalDayAssessmentSheetState
                                   ),
                             ),
                             SizedBox(height: _bindGap(tokens)),
-                            DsSegmentedToggle<GoalAssessmentRating>(
+                            DsSegmentedToggle<DayVerdict>(
                               expand: true,
                               selected:
                                   _dimensionRatings[row.criterionId] ?? _rating,

--- a/lib/features/goals/ui/goal_day_marks.dart
+++ b/lib/features/goals/ui/goal_day_marks.dart
@@ -1,0 +1,39 @@
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+
+/// Lines a goal's compact window up with the verdicts the user has recorded
+/// for it, producing the [DayMark]s the shared strip renders.
+///
+/// [states] runs oldest to newest and ends on [lastDay]; every earlier mark
+/// counts back from it, which is how a tap resolves to a date without a
+/// second parallel list that could fall out of step with the states. The last
+/// cell is today's. Without a [lastDay] the marks carry no dates — the strip
+/// then renders no weekday letters and cannot be tapped.
+///
+/// A recorded verdict wins over the measured state for its day: the
+/// measurement is evidence about a day, the reflection is the user's ruling
+/// on it. Verdicts are keyed by UTC day, as the assessment history stores
+/// them.
+List<DayMark> goalDayMarks({
+  required List<DayMarkState> states,
+  DateTime? lastDay,
+  Map<DateTime, DayVerdict> verdictsByDay = const {},
+}) {
+  final length = states.length;
+  DateTime? dateAt(int index) =>
+      lastDay?.subtract(Duration(days: length - 1 - index));
+  DayVerdict? verdictAt(DateTime? date) {
+    if (date == null || verdictsByDay.isEmpty) return null;
+    return verdictsByDay[DateTime.utc(date.year, date.month, date.day)];
+  }
+
+  return [
+    for (var index = 0; index < length; index++)
+      if (dateAt(index) case final date)
+        DayMark(
+          day: date,
+          state: states[index],
+          verdict: verdictAt(date),
+          isToday: index == length - 1,
+        ),
+  ];
+}

--- a/lib/features/goals/ui/goal_progress_card.dart
+++ b/lib/features/goals/ui/goal_progress_card.dart
@@ -23,421 +23,17 @@ import 'package:lotti/features/design_system/components/tooltips/ds_tooltip.dart
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/goals/logic/goal_aggregate_rounding.dart';
 import 'package:lotti/features/goals/logic/goal_metric_series.dart';
-import 'package:lotti/features/goals/model/goal_assessment.dart';
 import 'package:lotti/features/goals/model/goal_health_data_types.dart';
 import 'package:lotti/features/goals/state/goal_progress_view.dart';
+import 'package:lotti/features/goals/ui/goal_day_marks.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/charts/utils.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_legend.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_strip.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
+import 'package:lotti/widgets/day_indicators/day_track.dart';
 import 'package:lotti/widgets/misc/linked_scroll_group.dart';
-
-/// The handover's seven-cell picture used on each Agents-list row. It is
-/// intentionally unlabeled visually, but exposes one concise semantic summary.
-class GoalCompactWindowStrip extends StatelessWidget {
-  const GoalCompactWindowStrip({
-    required this.days,
-    this.placeholder = false,
-    this.lastDay,
-    this.onDaySelected,
-    this.ratingsByDay = const {},
-    this.scrollGroup,
-    super.key,
-  }) : assert(
-         onDaySelected == null || lastDay != null,
-         'A tappable strip needs lastDay to date the cell that was tapped.',
-       );
-
-  final List<GoalCompactDayState> days;
-
-  /// True while the strip stands in for a window that has not resolved yet.
-  /// Placeholder cells render as dashed outlines, never as the filled grey a
-  /// genuinely-empty week wears — "no data yet" and "nothing happened" must
-  /// not share an encoding, or the strip contradicts a Healthy chip beside
-  /// it.
-  final bool placeholder;
-
-  /// The day the last cell stands for. Every earlier cell counts back from
-  /// it, which is how a tap resolves to a date without a second parallel
-  /// list that could fall out of step with [days].
-  final DateTime? lastDay;
-
-  /// Opens the day's reflection. Null leaves the strip a read-only figure —
-  /// which is what the list rows want, since a tap there navigates.
-  final ValueChanged<DateTime>? onDaySelected;
-
-  /// Day verdicts the user has recorded, keyed by UTC day. Ignored without a
-  /// [lastDay] to line them up against.
-  ///
-  /// A recorded verdict wins over the measured state for that cell. The
-  /// measurement is evidence about a day; the reflection is the user's ruling
-  /// on it, and a strip that kept showing grey after they filed the day as
-  /// missed would be contradicting them.
-  final Map<DateTime, GoalAssessmentRating> ratingsByDay;
-
-  /// Joins the page's unison day-track scrolling when the strip renders a
-  /// span longer than a week.
-  final LinkedScrollGroup? scrollGroup;
-
-  DateTime _dateAt(int index, int length) =>
-      lastDay!.subtract(Duration(days: length - 1 - index));
-
-  GoalAssessmentRating? _ratingAt(int index, int length) {
-    if (ratingsByDay.isEmpty || lastDay == null) return null;
-    final date = _dateAt(index, length);
-    return ratingsByDay[DateTime.utc(date.year, date.month, date.day)];
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // The full span, not a seven-day cap: on the detail page the strip
-    // follows the page's shared range like every other day track (the list
-    // rows keep passing seven-day windows).
-    if (days.isEmpty) return const SizedBox.shrink();
-    // Only the extended span needs to know the width it has to fit into; the
-    // seven-cell list rows keep their authored pitch and their scale-down fit.
-    if (days.length <= 7) return _build(context, availableWidth: null);
-    return LayoutBuilder(
-      builder: (context, constraints) => _build(
-        context,
-        availableWidth: constraints.maxWidth.isFinite
-            ? constraints.maxWidth
-            : null,
-      ),
-    );
-  }
-
-  Widget _build(BuildContext context, {required double? availableWidth}) {
-    final tokens = context.designTokens;
-    final visible = days;
-    final onDaySelected = this.onDaySelected;
-    final locale = Localizations.localeOf(context).toLanguageTag();
-    final metrics = goalDayTrackMetrics(
-      context,
-      dayCount: visible.length,
-      availableWidth: availableWidth,
-    );
-    final resolvedCellSize = metrics.cellSize;
-
-    // One-letter weekday initials, nested inside the cells themselves — the
-    // separate label row above the strip spent a full row on what a letter
-    // per node now carries. Dateless strips render no letters.
-    final letterFormat = DateFormat.EEEEE(locale);
-    String? letterAt(int index) => lastDay == null
-        ? null
-        : letterFormat.format(_dateAt(index, visible.length));
-
-    Widget cellAt(int index) {
-      if (placeholder) return _PlaceholderDayCell(size: resolvedCellSize);
-      final today = index == visible.length - 1;
-      final rating = _ratingAt(index, visible.length);
-      if (onDaySelected == null) {
-        return _CompactDayCell(
-          state: visible[index],
-          today: today,
-          size: resolvedCellSize,
-          rating: rating,
-          weekdayLetter: letterAt(index),
-        );
-      }
-      final date = _dateAt(index, visible.length);
-      final dayName = DateFormat.MMMEd(locale).format(date);
-      // Colour and an inner dot are the only thing separating these cells,
-      // and neither reaches a screen reader. Each day therefore announces its
-      // own state, not just its date — the strip's summary gives a count and
-      // cannot say WHICH days went well, which is exactly what a reader needs
-      // once every cell is individually actionable.
-      final outcome = rating != null
-          ? goalAssessmentRatingLabel(context, rating)
-          : switch (visible[index]) {
-              GoalCompactDayState.full => context.messages.goalProgressDone,
-              GoalCompactDayState.partial =>
-                context.messages.goalProgressPartial,
-              GoalCompactDayState.none =>
-                context.messages.goalProgressHabitDayNoEntry,
-            };
-      return _CompactDayCell(
-        state: visible[index],
-        today: today,
-        size: resolvedCellSize,
-        rating: rating,
-        weekdayLetter: letterAt(index),
-        label: context.messages.goalProgressHabitDaySemantics(
-          dayName,
-          outcome,
-        ),
-        tooltipDay: dayName,
-        tooltipOutcome: outcome,
-        onTap: () => onDaySelected(date),
-      );
-    }
-
-    // On the page's shared seven-column track when it carries dates, so the
-    // whole-goal week lines up column-for-column with the habit squares and
-    // the metric bars below it. Three grids for one week meant a reader
-    // could not follow a Wednesday down the page.
-    //
-    // The pitch is narrower than the 48px touch floor — seven of those do not
-    // fit a phone card — so, exactly as the habit cells already do, the slot
-    // takes the full pitch horizontally and clears the floor vertically.
-    final row = lastDay == null
-        ? Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              for (var index = 0; index < visible.length; index++) ...[
-                if (index > 0) SizedBox(width: tokens.spacing.step1),
-                cellAt(index),
-              ],
-            ],
-          )
-        : _DayTrack(
-            height: onDaySelected == null
-                ? resolvedCellSize + tokens.spacing.step2
-                : TapTargets.minimum,
-            pitch: metrics.pitch,
-            children: [
-              for (var index = 0; index < visible.length; index++)
-                cellAt(index),
-            ],
-          );
-
-    // A read-only strip publishes one summary rather than seven nodes, so any
-    // recorded verdicts have to reach it there — otherwise the list announces
-    // a measured day count while showing four verdict hues.
-    final verdictSummary = ratingsByDay.isEmpty || lastDay == null
-        ? ''
-        : [
-            for (var index = 0; index < visible.length; index++)
-              if (_ratingAt(index, visible.length) case final rating?)
-                context.messages.goalProgressHabitDaySemantics(
-                  DateFormat.MMMEd(locale).format(
-                    _dateAt(index, visible.length),
-                  ),
-                  goalAssessmentRatingLabel(context, rating),
-                ),
-          ].join(', ');
-
-    return Semantics(
-      label: placeholder
-          ? context.messages.goalProgressStripLoading
-          : [
-              // Counted with the verdicts applied. Taken from the measured
-              // states alone, the strip could announce "1 successful day"
-              // and name that same date as Missed in the next breath, while
-              // the cell itself correctly showed the verdict.
-              context.messages.goalProgressCompactSemantics(
-                [
-                  for (var index = 0; index < visible.length; index++)
-                    if (_ratingAt(index, visible.length) case final rating?)
-                      rating == GoalAssessmentRating.met
-                    else
-                      visible[index] != GoalCompactDayState.none,
-                ].where((successful) => successful).length,
-              ),
-              if (verdictSummary.isNotEmpty) verdictSummary,
-            ].join('. '),
-      // A tappable strip publishes each day as its own button, so the summary
-      // above becomes the container's label rather than the whole story.
-      // The scale-down FittedBox is the overflow bound: the track (and the
-      // dateless placeholder Row) size themselves to `pitch * days`, and on
-      // a 320px phone a list row's column is a few pixels narrower than
-      // seven full-size cells. Everywhere with room, the fit is identity.
-      // An extended span goes through the page's shared fit-or-scroll policy
-      // instead — by WIDTH, like every other track. Wrapping it by day count
-      // put a span that fits into a trailing-anchored scroller, which is what
-      // opened it with its first days cut off the left edge.
-      child: availableWidth != null
-          ? _fitOrScroll(
-              contentWidth: metrics.pitch * visible.length,
-              availableWidth: availableWidth,
-              group: scrollGroup,
-              child: row,
-            )
-          : onDaySelected == null
-          ? ExcludeSemantics(
-              child: FittedBox(
-                fit: BoxFit.scaleDown,
-                alignment: AlignmentDirectional.centerStart,
-                child: row,
-              ),
-            )
-          : Align(
-              alignment: AlignmentDirectional.centerStart,
-              child: FittedBox(
-                fit: BoxFit.scaleDown,
-                alignment: AlignmentDirectional.centerStart,
-                child: row,
-              ),
-            ),
-    );
-  }
-}
-
-/// A not-yet-resolved day slot: same footprint as a real cell, dashed
-/// outline instead of a fill, so the silhouette holds without borrowing the
-/// empty-week encoding.
-class _PlaceholderDayCell extends StatelessWidget {
-  const _PlaceholderDayCell({this.size = IconSizes.xs});
-
-  final double size;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    return Padding(
-      padding: EdgeInsets.all(tokens.spacing.step1),
-      child: DsDashedBorder(
-        color: tokens.colors.text.lowEmphasis,
-        radius: goalDayCellRadius(tokens),
-        child: SizedBox(width: size, height: size),
-      ),
-    );
-  }
-}
-
-class _CompactDayCell extends StatelessWidget {
-  const _CompactDayCell({
-    required this.state,
-    required this.today,
-    this.size = IconSizes.xs,
-    this.onTap,
-    this.label,
-    this.tooltipDay,
-    this.tooltipOutcome,
-    this.rating,
-    this.weekdayLetter,
-  });
-
-  final GoalCompactDayState state;
-  final bool today;
-  final double size;
-  final VoidCallback? onTap;
-
-  /// One-letter weekday initial nested in the cell, replacing the label row
-  /// that used to run above the strip. Null on strips without dates.
-  final String? weekdayLetter;
-
-  /// The user's verdict for this day, when they have recorded one. It decides
-  /// the fill; [state] is only what the app measured.
-  final GoalAssessmentRating? rating;
-
-  /// Spoken name for a tappable cell. Null on a read-only strip, whose
-  /// semantics are carried by the summary above it.
-  final String? label;
-
-  /// The same fact split for the hover tooltip: the day names the subject,
-  /// the outcome describes it. Both null exactly when [label] is.
-  final String? tooltipDay;
-  final String? tooltipOutcome;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    final rating = this.rating;
-    // The dot is the measured-partial cue; a recorded verdict wears its own
-    // glyph instead. Either way the cell says something a reader who cannot
-    // separate the hues can still act on.
-    final showsPartialDot =
-        rating == null && state == GoalCompactDayState.partial;
-    final Widget? centerMark = showsPartialDot
-        ? Center(
-            child: goalPartialDayDot(
-              tokens,
-              // The dot has to stay legible inside the square it marks, so
-              // it scales with it rather than sitting at one fixed size.
-              size <= IconSizes.xs
-                  ? tokens.spacing.step1
-                  : tokens.spacing.step2,
-            ),
-          )
-        : rating != null
-        // The verdict's own shape at every size. Collapsing the three
-        // non-met verdicts into one dot on the list's 12px cells left
-        // Improving, Mixed and Missed distinguishable by hue alone —
-        // which is the one thing the shapes exist to avoid.
-        ? Center(
-            child: Icon(
-              goalAssessmentRatingGlyph(rating),
-              size: size * 0.75,
-              // The ink of the fill's OWN family. Painting every glyph in
-              // the success ink put a green tick's colour on a red missed
-              // cell and an orange mixed one.
-              color: goalAssessmentRatingInk(tokens, rating),
-            ),
-          )
-        : null;
-    // The corner weekday tag renders only when the center is empty: at the
-    // compact cell size a glyph and a corner letter collide, and the glyph
-    // is the rarer, more meaningful mark — neighbouring plain cells keep
-    // carrying the axis.
-    final letterTag = centerMark != null
-        ? null
-        : goalDayCellLetter(
-            tokens,
-            letter: weekdayLetter,
-            cellSize: size,
-            filled: rating != null || state == GoalCompactDayState.full,
-          );
-    final cell = Container(
-      width: size,
-      height: size,
-      decoration: BoxDecoration(
-        color: rating == null
-            ? goalDayStateFill(tokens, state)
-            : goalAssessmentRatingFill(tokens, rating),
-        borderRadius: BorderRadius.circular(goalDayCellRadius(tokens)),
-      ),
-      child: centerMark == null && letterTag == null
-          ? null
-          : Stack(
-              children: [?centerMark, ?letterTag],
-            ),
-    );
-    // Every cell shares one outer footprint; today only adds the dashed
-    // ring inside it, so the strip's rhythm never bulges at the last cell.
-    final padded = Padding(
-      padding: EdgeInsets.all(tokens.spacing.step1),
-      child: cell,
-    );
-    final decorated = today
-        ? DsDashedBorder(
-            color: goalTodayRingInk(tokens),
-            strokeWidth: BorderWidths.emphasis,
-            radius: goalDayCellRadius(tokens),
-            child: padded,
-          )
-        : padded;
-    final onTap = this.onTap;
-    if (onTap == null) return decorated;
-    // The square keeps its size; the hit slot around it takes the full height
-    // of the touch floor and whatever width the row can spare. Growing the
-    // square itself to 48px would make the strip shout over the habit rows it
-    // is meant to summarise.
-    // No hover fill: the hit slot is far larger than the square it serves,
-    // so Material's overlay drew a phantom button bulging around the cell.
-    // The cell is a data readout — hover answers with the styled tooltip
-    // naming the day and its outcome, not with a fill on the data itself.
-    return Semantics(
-      label: label,
-      button: true,
-      excludeSemantics: true,
-      child: DsTooltip(
-        title: tooltipDay,
-        message: tooltipOutcome ?? '',
-        preferBelow: false,
-        child: DsQuietInk(
-          onTap: onTap,
-          borderRadius: BorderRadius.circular(tokens.radii.s),
-          focusRing: true,
-          builder: (context, highlighted) => ConstrainedBox(
-            constraints: const BoxConstraints(
-              minHeight: TapTargets.minimum,
-            ),
-            child: Center(child: decorated),
-          ),
-        ),
-      ),
-    );
-  }
-}
 
 /// Formats an aggregate for display at a precision the number can actually
 /// carry.
@@ -463,219 +59,6 @@ String formatGoalAggregate(NumberFormat number, num value, {num? against}) {
   // spurious ".0".
   return number.format(roundGoalAggregate(value, against: against));
 }
-
-/// The corner radius every day cell on this page shares.
-///
-/// The whole-goal strip drew its squares at `radii.xs` while the habit
-/// squares — the identical footprint, one card below — drew theirs at
-/// `radii.s`. Same instrument, same week, two shapes.
-double goalDayCellRadius(DsTokens tokens) => tokens.radii.s;
-
-/// Where the weekday initial sits inside a day cell, and how big it gets.
-///
-/// Deliberately NOT an extension on `DsTokens`. Hanging these off the token
-/// object put feature-specific geometry into the canonical token API, where
-/// every caller in the app would see `tokens.letterInsetStart` offered
-/// alongside real exported tokens — which is a bigger claim than "these
-/// three numbers live in one place" was ever meant to make.
-///
-/// Proportions of the cell rather than absolute lengths: the cell itself is
-/// sized by [goalDayTrackMetrics] from the available width, so a fixed inset
-/// that looked right on a fortnight track would crowd the corner on a
-/// ninety-day one. They are geometry, not spacing — there is no
-/// design-system token for "a fraction of a cell" — so they live here, named
-/// and in ONE place, rather than as bare numbers inside the widget.
-///
-/// [GoalDayCellLetter.scaleBox] is a ceiling, not a size: the rendered letter
-/// is `min(fontSize, cellSize * scaleBox)`, because the glyph is fitted
-/// with [BoxFit.scaleDown] and that never scales UP. The box therefore
-/// governs small cells while the style's own size caps large ones.
-abstract final class GoalDayCellLetter {
-  /// Inset from the cell's leading edge.
-  static const double insetStart = 0.18;
-
-  /// Inset from the cell's bottom edge.
-  static const double insetBottom = 0.14;
-
-  /// Ceiling on the letter's height, as a fraction of the cell.
-  static const double scaleBox = 0.38;
-}
-
-/// Shared fill for a day cell: the full-strength success hue when the goal
-/// requirement held as of that day, a lighter wash of the same hue for a
-/// partial success (routine kept, target still building), neutral otherwise.
-/// `SurfaceAlphas.muted` is the sanctioned "reduced-strength accent" alpha,
-/// so no new color token is introduced. Data-that-happened wears the
-/// `alert.success` family; the interactive teal stays strictly for things
-/// the user can tap.
-Color goalDayStateFill(DsTokens tokens, GoalCompactDayState state) =>
-    switch (state) {
-      GoalCompactDayState.full => tokens.colors.alert.success.defaultColor,
-      GoalCompactDayState.partial =>
-        tokens.colors.alert.success.defaultColor.withValues(
-          alpha: SurfaceAlphas.muted,
-        ),
-      GoalCompactDayState.none => tokens.colors.background.level03,
-    };
-
-/// Hue for a day the user has actually judged, which outranks what the app
-/// measured: a reflection is a statement about the day, and the measurement is
-/// only evidence toward one.
-///
-/// Four distinct hues, all existing alert tokens, and the same three the
-/// reflections-history pill has always used — extended with the blue a
-/// restarting agent wears for [GoalAssessmentRating.improving], which is
-/// progress that is not yet arrival. Sharing one scheme is the point: the
-/// strip and the history are two views of the same verdict, and a day filed
-/// as missed must not be grey in one place and red in another.
-///
-/// Notably [GoalAssessmentRating.missed] is not the neutral grey a day with no
-/// data wears. Deciding a day was missed and never looking at it are different
-/// facts, and the strip has to be able to say which.
-Color goalAssessmentRatingFill(DsTokens tokens, GoalAssessmentRating rating) =>
-    switch (rating) {
-      GoalAssessmentRating.met => tokens.colors.alert.success.defaultColor,
-      GoalAssessmentRating.improving => tokens.colors.alert.info.defaultColor,
-      GoalAssessmentRating.mixed => tokens.colors.alert.warning.defaultColor,
-      GoalAssessmentRating.missed => tokens.colors.alert.error.defaultColor,
-    };
-
-/// The ink a verdict glyph is drawn in, on top of that verdict's own fill.
-///
-/// One high-contrast ink for every verdict rather than each family's own:
-/// the families' inks are tuned to sit on a NEUTRAL surface, so a success ink
-/// on a success fill is green on green and the glyph all but disappears —
-/// which defeats the point of having a shape at all, since the shape exists
-/// for readers who cannot separate the hues. `onInteractiveAlert` is the
-/// design system's ink for exactly this: text over a saturated alert fill.
-Color goalAssessmentRatingInk(DsTokens tokens, GoalAssessmentRating rating) =>
-    tokens.colors.text.onInteractiveAlert;
-
-/// The verdict's ink for a glyph drawn on an ordinary card surface.
-///
-/// Distinct from [goalAssessmentRatingInk], which is for a glyph sitting on
-/// that verdict's own saturated fill. Using the on-alert ink here paints
-/// near-background on background; using this one on a fill would be its own
-/// hue on itself.
-Color goalAssessmentRatingSurfaceInk(
-  DsTokens tokens,
-  GoalAssessmentRating rating,
-) => switch (rating) {
-  GoalAssessmentRating.met => tokens.colors.alert.success.ink,
-  GoalAssessmentRating.improving => tokens.colors.alert.info.ink,
-  GoalAssessmentRating.mixed => tokens.colors.alert.warning.ink,
-  GoalAssessmentRating.missed => tokens.colors.alert.error.ink,
-};
-
-/// The glyph that names a recorded verdict without relying on its hue.
-///
-/// Four fills that differ only by colour are four fills a red-green colour
-/// deficiency cannot tell apart, and the strip's whole job is to be read at a
-/// glance. Each verdict therefore carries a shape as well: a tick for met, a
-/// rising arrow for improving, a half-filled circle for mixed, a cross for
-/// missed.
-IconData goalAssessmentRatingGlyph(GoalAssessmentRating rating) =>
-    switch (rating) {
-      GoalAssessmentRating.met => LottiIcons.confirm,
-      GoalAssessmentRating.improving => LottiIcons.trendingUp,
-      GoalAssessmentRating.mixed => LottiIcons.contrast,
-      GoalAssessmentRating.missed => LottiIcons.close,
-    };
-
-/// The localized name of a day verdict, shared by the strip's semantics and
-/// the reflection sheet's own toggle so the two can never drift apart.
-String goalAssessmentRatingLabel(
-  BuildContext context,
-  GoalAssessmentRating rating,
-) => switch (rating) {
-  GoalAssessmentRating.met => context.messages.goalAssessmentMet,
-  GoalAssessmentRating.improving => context.messages.goalAssessmentImproving,
-  GoalAssessmentRating.mixed => context.messages.goalAssessmentMixed,
-  GoalAssessmentRating.missed => context.messages.goalAssessmentMissed,
-};
-
-/// The weekday's one-letter initial, tucked into the bottom-left corner of
-/// its own day cell.
-///
-/// Replaces the separate label row that used to run above every track: one
-/// letter per node keeps the weekday axis without spending a full row on it.
-/// A quiet corner tag rather than a centered label. It yields entirely to
-/// the marks that outrank it — a verdict glyph, the partial dot, the missed
-/// cross — because at the compact cell size a corner letter and a center
-/// glyph collide; the rarer mark wins and neighbouring plain cells keep
-/// carrying the axis. Scaled down with the cell (never up past the
-/// `bodySmall` size), and null when the cell is too small to hold a legible
-/// letter — a squeezed ninety-day track drops the letters rather than
-/// painting mush.
-///
-/// Ink follows the fill so the letter stays readable on both states: the
-/// on-alert ink over a saturated fill, medium emphasis over the neutral and
-/// washed fills. Returns a [PositionedDirectional]; the cell hosts it in a
-/// [Stack].
-Widget? goalDayCellLetter(
-  DsTokens tokens, {
-  required String? letter,
-  required double cellSize,
-  required bool filled,
-}) {
-  if (letter == null || cellSize < IconSizes.l) return null;
-  return PositionedDirectional(
-    // Off the corner, not in it. The letter reads better with a little air
-    // under and behind it than pinned to the rounded rect's inner angle —
-    // but it stays an annotation, so it moves TOWARD the center rather than
-    // to it.
-    start: cellSize * GoalDayCellLetter.insetStart,
-    bottom: cellSize * GoalDayCellLetter.insetBottom,
-    child: SizedBox(
-      // The scale bound: the glyph shrinks into this box, so the letter
-      // stays a small corner annotation at every cell size instead of
-      // competing with the mark in the center. The effective size is
-      // `min(fontSize, this height)` — `scaleDown` never scales UP — so
-      // raising the letter one step means raising BOTH: the box governs the
-      // small cells, the style's own size caps the large ones.
-      height: cellSize * GoalDayCellLetter.scaleBox,
-      child: FittedBox(
-        fit: BoxFit.scaleDown,
-        child: Text(
-          letter,
-          maxLines: 1,
-          // One step up the type scale from caption (12 → 14), so a cell
-          // roomy enough to show the letter at full size shows it a step
-          // larger too.
-          style: tokens.typography.styles.body.bodySmall.copyWith(
-            color: filled
-                ? tokens.colors.text.onInteractiveAlert
-                : tokens.colors.text.mediumEmphasis,
-            height: 1,
-          ),
-        ),
-      ),
-    ),
-  );
-}
-
-/// The ink the "today" ring is drawn in, on every surface that draws one —
-/// the habit day cells, the whole-goal strip and the legend swatch that keys
-/// them.
-///
-/// Medium emphasis rather than low: at `radii.xs` on a dark surface a
-/// hairline in the low-emphasis ink is a rumour, not a ring. It still has to
-/// stay quieter than a day's own fill, which is the thing the cell is
-/// actually reporting — so it lifts one step and takes the emphasis stroke,
-/// rather than becoming an accent.
-Color goalTodayRingInk(DsTokens tokens) => tokens.colors.text.mediumEmphasis;
-
-/// The non-color cue for a partial day: a full-strength dot inside the
-/// lighter wash, so full/partial/none survive without a legend (the list
-/// rows carry none) and for color-blind readers.
-Widget goalPartialDayDot(DsTokens tokens, double diameter) => Container(
-  width: diameter,
-  height: diameter,
-  decoration: BoxDecoration(
-    shape: BoxShape.circle,
-    color: tokens.colors.alert.success.ink,
-  ),
-);
 
 /// Rolling-window detail visual. Habit routines render one row per watched
 /// habit; metric goals render seven bars against the target frame.
@@ -833,7 +216,7 @@ class GoalThisWeekCard extends StatelessWidget {
   /// reflected on — a retired agent, or a spec that has not resolved.
   final ValueChanged<DateTime>? onReflectDay;
 
-  final Map<DateTime, GoalAssessmentRating> ratingsByDay;
+  final Map<DateTime, DayVerdict> ratingsByDay;
 
   @override
   Widget build(BuildContext context) {
@@ -917,11 +300,13 @@ class GoalThisWeekCard extends StatelessWidget {
           // gutter so it would line up with plots on other cards — but this
           // card draws no plot, so the gutter was 52px of nothing between the
           // caption above and the first day of the week.
-          GoalCompactWindowStrip(
-            days: progress.compactWindow,
-            lastDay: progress.today,
+          DayMarkStrip(
+            marks: goalDayMarks(
+              states: progress.compactWindow,
+              lastDay: progress.today,
+              verdictsByDay: ratingsByDay,
+            ),
             onDaySelected: onReflectDay,
-            ratingsByDay: ratingsByDay,
             scrollGroup: scrollGroup,
           ),
           // "3 of 5 dimensions · 4 required" says nothing about a goal with
@@ -1048,7 +433,7 @@ class _ReflectTodayButton extends StatelessWidget {
     required this.onReflect,
   });
 
-  final GoalAssessmentRating? recorded;
+  final DayVerdict? recorded;
   final VoidCallback onReflect;
 
   @override
@@ -1058,13 +443,13 @@ class _ReflectTodayButton extends StatelessWidget {
       key: const ValueKey('goal-reflect-today'),
       label: recorded == null
           ? context.messages.goalAssessmentReflectToday
-          : goalAssessmentRatingLabel(context, recorded),
+          : dayVerdictLabel(context, recorded),
       onPressed: onReflect,
       // The sparkle stays exclusive to agent suggestions; this button is the
       // USER writing a reflection.
       leadingIcon: recorded == null
           ? LottiIcons.editNote
-          : goalAssessmentRatingGlyph(recorded),
+          : dayVerdictGlyph(recorded),
       variant: DesignSystemButtonVariant.tertiary,
       size: DesignSystemButtonSize.dense,
       // The header rail is the card's trailing edge: the ink may bleed into
@@ -1175,7 +560,7 @@ class _HabitDimensionCard extends StatelessWidget {
             // the card's own bottom edge, and read as the card being cut in
             // two.
             SizedBox(height: tokens.spacing.step2),
-            const _ProgressLegend(),
+            const DayMarkLegend(),
           ],
         ],
       ),
@@ -1935,7 +1320,7 @@ class _WeekdayTrack extends StatelessWidget {
   /// criterion id. Not a habit id as such: a metric track wearing a habit's
   /// identity to reach this widget was the field name lying about itself.
   final String trackId;
-  final GoalDayTrackMetrics metrics;
+  final DayTrackMetrics metrics;
 
   @override
   Widget build(BuildContext context) {
@@ -1946,7 +1331,7 @@ class _WeekdayTrack extends StatelessWidget {
     final format = metrics.narrowLabels
         ? DateFormat.EEEEE(locale)
         : DateFormat.E(locale);
-    return _DayTrack(
+    return DayTrack(
       height: metrics.labelHeight,
       pitch: metrics.pitch,
       children: [
@@ -1992,219 +1377,6 @@ String _dimensionSource(BuildContext context, GoalDimensionKind kind) =>
       GoalDimensionKind.labelTime =>
         context.messages.goalDimensionLabelTimeSource,
     };
-
-/// The widest and tallest weekday caption a track will paint.
-///
-/// Measured over the SEVEN distinct weekday names, not over the track's days:
-/// a ninety-day span still draws only seven different strings, and laying out
-/// one TextPainter per day put ninety layouts in the middle of `build` to
-/// learn what seven already answer.
-({double width, double height}) _weekdayLabelMetrics(BuildContext context) {
-  final locale = Localizations.localeOf(context).toLanguageTag();
-  final style = context.designTokens.typography.styles.others.caption;
-  final format = DateFormat.E(locale);
-  // Any seven consecutive days cover every weekday exactly once.
-  final week = DateTime.utc(2024, 1, 8);
-  var width = 0.0;
-  var height = 0.0;
-  for (var offset = 0; offset < DateTime.daysPerWeek; offset++) {
-    final painter = TextPainter(
-      text: TextSpan(
-        text: format.format(week.add(Duration(days: offset))),
-        style: style,
-      ),
-      textDirection: Directionality.of(context),
-      textScaler: MediaQuery.textScalerOf(context),
-      maxLines: 1,
-    )..layout();
-    width = math.max(width, painter.width);
-    height = math.max(height, painter.height);
-  }
-  return (width: width, height: height);
-}
-
-/// The geometry one day track draws on: the column pitch, the square inside
-/// each column, whether the weekday captions still fit at full length, and
-/// how tall a caption row has to be.
-///
-/// The caption height rides along so the caption track does not re-measure
-/// the same seven strings the pitch was already derived from.
-typedef GoalDayTrackMetrics = ({
-  double pitch,
-  double cellSize,
-  bool narrowLabels,
-  double labelHeight,
-});
-
-/// The narrowest column a day is still legible in — a 12px square with a
-/// hairline of air either side. Below this a track scrolls instead of
-/// shrinking further.
-double _minimumDayPitch(DsTokens tokens) => IconSizes.xs + tokens.spacing.step2;
-
-/// The column pitch every day row on this page shares.
-///
-/// One pitch, one origin, one width: the whole-goal verdict strip, the habit
-/// squares and the metric bars all draw the SAME week, and drawn on three
-/// different grids the same Wednesday landed in three different places on one
-/// scroll. A reader cannot follow a day across the page unless the columns
-/// line up.
-///
-/// Wide enough for the weekday label at raised text scales, which is what
-/// makes the axis readable rather than merely aligned — and, when
-/// [availableWidth] is known, narrow enough that a span longer than a week
-/// still FITS. A fourteen-day track at the authored pitch is wider than a
-/// phone card, and the trailing-edge scroller that resulted opened with the
-/// first days of the span cut in half off the left edge.
-GoalDayTrackMetrics goalDayTrackMetrics(
-  BuildContext context, {
-  required int dayCount,
-  double? availableWidth,
-}) {
-  final tokens = context.designTokens;
-  final defaultPitch = ControlSizes.iconChipCompact + tokens.spacing.step2;
-  final label = _weekdayLabelMetrics(context);
-  final labelWidth = label.width;
-  final expandedPitch = labelWidth + tokens.spacing.step1;
-  final textScaledUp = MediaQuery.textScalerOf(context).scale(1) > 1;
-  var pitch = textScaledUp && expandedPitch > defaultPitch
-      ? expandedPitch
-      : defaultPitch;
-  if (availableWidth != null && availableWidth > 0 && dayCount > 0) {
-    // Floored, so `pitch * days` can never round up past the width it was
-    // derived from and reintroduce a one-pixel scroller.
-    final fitted = (availableWidth / dayCount).floorToDouble();
-    if (fitted < pitch) {
-      pitch = math.max(fitted, _minimumDayPitch(tokens));
-    }
-  }
-  return (
-    pitch: pitch,
-    labelHeight: math.max(IconSizes.s, label.height),
-    // The square shrinks with its column, or neighbouring cells would touch
-    // and the track would read as one bar — but it never GROWS past the
-    // authored chip size: spreading the span means wider gutters between
-    // same-sized nodes, not inflated squares.
-    cellSize: math.min(
-      ControlSizes.iconChipCompact,
-      math.max(IconSizes.xs, pitch - tokens.spacing.step2),
-    ),
-    // "Mon" needs its own width; a SQUEEZED column takes the one-letter form
-    // rather than letting neighbouring captions overlap into mush. Only a
-    // squeezed one: at the authored pitch the captions are centered and
-    // overhang their cell into the gap by design, which is the established
-    // rendering and stays untouched.
-    narrowLabels: pitch < defaultPitch && pitch < labelWidth,
-  );
-}
-
-/// Keeps weekday labels and day cells on the compact handoff grid.
-/// One horizontal scroller per extended day track, all linked through the
-/// page's [LinkedScrollGroup] and anchored at the TRAILING edge
-/// (`reverse: true`): a span longer than the viewport opens with TODAY on
-/// screen, dragging any track moves every track, and because reversed
-/// offsets measure from the trailing edge, the same date stays vertically
-/// aligned across cards even where extents differ.
-class _LinkedDayTrackScroller extends StatefulWidget {
-  const _LinkedDayTrackScroller({required this.child, this.group});
-
-  final LinkedScrollGroup? group;
-  final Widget child;
-
-  @override
-  State<_LinkedDayTrackScroller> createState() =>
-      _LinkedDayTrackScrollerState();
-}
-
-class _LinkedDayTrackScrollerState extends State<_LinkedDayTrackScroller> {
-  ScrollController? _controller;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller = widget.group?.attach();
-  }
-
-  @override
-  void didUpdateWidget(covariant _LinkedDayTrackScroller oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (!identical(oldWidget.group, widget.group)) {
-      final old = _controller;
-      if (old != null) oldWidget.group?.detach(old);
-      _controller = widget.group?.attach();
-    }
-  }
-
-  @override
-  void dispose() {
-    final controller = _controller;
-    if (controller != null) widget.group?.detach(controller);
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) => SingleChildScrollView(
-    scrollDirection: Axis.horizontal,
-    reverse: true,
-    controller: _controller,
-    child: widget.child,
-  );
-}
-
-/// A day track, panning only where it genuinely cannot fit.
-///
-/// ONE policy for all three tracks — the whole-goal strip, the habit squares
-/// and the metric bars. They each used to decide for themselves, and the strip
-/// decided by day COUNT, so it wrapped a span that provably fitted in a
-/// trailing-anchored scroller and opened it with the first days cut off.
-Widget _fitOrScroll({
-  required double contentWidth,
-  required double availableWidth,
-  required LinkedScrollGroup? group,
-  required Widget child,
-}) {
-  if (contentWidth <= availableWidth) return child;
-  // Trailing-anchored, and joined to the page's group: a span wider than the
-  // viewport opens with today on screen, and every track pans together so the
-  // same date stays aligned down the page.
-  return _LinkedDayTrackScroller(group: group, child: child);
-}
-
-class _DayTrack extends StatelessWidget {
-  const _DayTrack({
-    required this.height,
-    required this.pitch,
-    required this.children,
-  });
-
-  final double height;
-  final double pitch;
-  final List<Widget> children;
-
-  @override
-  Widget build(BuildContext context) {
-    if (children.isEmpty) return const SizedBox.shrink();
-    // Slots span the full pitch, so adjacent hit regions touch without
-    // overlapping — each editable cell gets the widest tap area the
-    // authored density allows, and labels stay centered over their cells.
-    final width = pitch * children.length;
-    return SizedBox(
-      width: width,
-      height: height,
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: [
-          for (var index = 0; index < children.length; index++)
-            Positioned(
-              left: pitch * index,
-              width: pitch,
-              height: height,
-              child: Center(child: children[index]),
-            ),
-        ],
-      ),
-    );
-  }
-}
 
 /// Index of the authored rolling window's first day inside [activeDays] —
 /// the cell the ages-out ring belongs to. Falls back to the list head for
@@ -2298,20 +1470,20 @@ class _HabitProgressRowState extends State<_HabitProgressRow> {
     final noteStyle = tokens.typography.styles.others.caption.copyWith(
       color: tokens.colors.text.mediumEmphasis,
     );
-    // Weekday initials live INSIDE the squares (see [goalDayCellLetter]);
+    // Weekday initials live INSIDE the squares (see [dayCellLetter]);
     // the separate label row above the track is gone.
     final letterFormat = DateFormat.EEEEE(
       Localizations.localeOf(context).toLanguageTag(),
     );
 
-    Widget cells(GoalDayTrackMetrics metrics) {
+    Widget cells(DayTrackMetrics metrics) {
       // Interactive rows own a touch-floor-high track so each cell's hit
       // slot meets TapTargets.minimum vertically; read-only rows keep the
       // compact height.
       final trackHeight = widget.onOutcomeSelected == null
           ? metrics.cellSize
           : TapTargets.minimum;
-      return _DayTrack(
+      return DayTrack(
         height: trackHeight,
         pitch: metrics.pitch,
         children: [
@@ -2345,14 +1517,14 @@ class _HabitProgressRowState extends State<_HabitProgressRow> {
     }
 
     // Just the squares: their weekday initials ride inside the cells.
-    Widget track(GoalDayTrackMetrics metrics) => cells(metrics);
+    Widget track(DayTrackMetrics metrics) => cells(metrics);
 
     return LayoutBuilder(
       builder: (context, constraints) {
         // The track is sized to the width it actually has, so a fortnight of
         // days fits the card instead of opening scrolled past its own first
         // day.
-        final metrics = goalDayTrackMetrics(
+        final metrics = dayTrackMetrics(
           context,
           dayCount: activeDays.length,
           availableWidth: constraints.maxWidth,
@@ -2450,7 +1622,7 @@ class _HabitProgressRowState extends State<_HabitProgressRow> {
                   SizedBox(height: tokens.spacing.step1),
                   // Labels and squares pan as one unit, and only where even
                   // the narrowest column overflows.
-                  _fitOrScroll(
+                  fitOrScrollDayTrack(
                     contentWidth: contentWidth,
                     availableWidth: constraints.maxWidth,
                     group: widget.scrollGroup,
@@ -2544,11 +1716,15 @@ class _ProgressDayCell extends StatelessWidget {
     // A completed day is a partial success (lighter wash) while the habit's
     // own window target was not yet met as of that day; a null verdict from
     // older projections keeps the established full-strength rendering.
-    final dayState = !hit
-        ? GoalCompactDayState.none
+    final dayState = missed
+        ? DayMarkState.missed
+        : skipped
+        ? DayMarkState.skipped
+        : !hit
+        ? DayMarkState.none
         : (day.targetSatisfied ?? true)
-        ? GoalCompactDayState.full
-        : GoalCompactDayState.partial;
+        ? DayMarkState.full
+        : DayMarkState.partial;
     // The square's own edge; the interactive slot around it is larger.
     final visualDimension = size;
     final glyphSize = math.min(IconSizes.xs, visualDimension * 0.6);
@@ -2568,24 +1744,17 @@ class _ProgressDayCell extends StatelessWidget {
         : null;
     // The glyph scales with the square it sits in, so a squeezed column
     // does not paint a 12px cross onto a 14px cell.
-    final Widget? centerMark = missed
+    final stateGlyph = dayMarkStateGlyph(dayState);
+    final Widget? centerMark = stateGlyph != null
         ? Center(
             child: Icon(
-              LottiIcons.close,
+              stateGlyph,
               size: glyphSize,
-              color: tokens.colors.alert.error.ink,
+              color: dayMarkStateGlyphInk(tokens, dayState),
             ),
           )
-        : skipped
-        ? Center(
-            child: Icon(
-              LottiIcons.remove,
-              size: glyphSize,
-              color: tokens.colors.text.mediumEmphasis,
-            ),
-          )
-        : dayState == GoalCompactDayState.partial
-        ? Center(child: goalPartialDayDot(tokens, tokens.spacing.step2))
+        : dayState == DayMarkState.partial
+        ? Center(child: partialDayDot(tokens, tokens.spacing.step2))
         : null;
     // The corner weekday tag renders only when the center is empty: at the
     // compact cell size a cross, dash or dot and a corner letter collide,
@@ -2593,11 +1762,11 @@ class _ProgressDayCell extends StatelessWidget {
     // plain cells keep carrying the axis.
     final letterTag = centerMark != null
         ? null
-        : goalDayCellLetter(
+        : dayCellLetter(
             tokens,
             letter: weekdayLetter,
             cellSize: visualDimension,
-            filled: dayState == GoalCompactDayState.full,
+            filled: dayState == DayMarkState.full,
           );
     Widget cell = Container(
       key: ValueKey(
@@ -2607,12 +1776,8 @@ class _ProgressDayCell extends StatelessWidget {
       width: visualDimension,
       height: visualDimension,
       decoration: BoxDecoration(
-        color: missed
-            ? tokens.colors.alert.error.defaultColor
-            : skipped
-            ? tokens.colors.background.level03
-            : goalDayStateFill(tokens, dayState),
-        borderRadius: BorderRadius.circular(goalDayCellRadius(tokens)),
+        color: dayMarkStateFill(tokens, dayState),
+        borderRadius: BorderRadius.circular(dayCellRadius(tokens)),
         border: border,
       ),
       child: centerMark == null && letterTag == null
@@ -2621,7 +1786,7 @@ class _ProgressDayCell extends StatelessWidget {
               children: [?centerMark, ?letterTag],
             ),
     );
-    if (dayState == GoalCompactDayState.partial) {
+    if (dayState == DayMarkState.partial) {
       cell = KeyedSubtree(
         key: ValueKey(
           'goal-day-partial-$habitId-'
@@ -2642,9 +1807,9 @@ class _ProgressDayCell extends StatelessWidget {
     final decoratedCell = !today || hit
         ? cell
         : DsDashedBorder(
-            color: goalTodayRingInk(tokens),
+            color: todayRingInk(tokens),
             strokeWidth: BorderWidths.emphasis,
-            radius: goalDayCellRadius(tokens),
+            radius: dayCellRadius(tokens),
             child: cell,
           );
     final locale = Localizations.localeOf(context).toLanguageTag();
@@ -3089,7 +2254,7 @@ class _MetricProgressSeries extends StatelessWidget {
           constraints.maxWidth - kChartLeftAxisWidth,
           0,
         );
-        final metrics = goalDayTrackMetrics(
+        final metrics = dayTrackMetrics(
           context,
           dayCount: metric.days.length,
           availableWidth: plotWidth,
@@ -3129,7 +2294,7 @@ class _MetricProgressSeries extends StatelessWidget {
                             height: chartHeight,
                           ),
                         Positioned.fill(
-                          child: _fitOrScroll(
+                          child: fitOrScrollDayTrack(
                             contentWidth: contentWidth,
                             availableWidth: plotWidth,
                             group: scrollGroup,
@@ -3174,15 +2339,15 @@ class _MetricProgressSeries extends StatelessWidget {
     DsTokens tokens,
   ) => [
     DashboardLegendEntry(
-      color: goalDayStateFill(tokens, GoalCompactDayState.full),
+      color: dayMarkStateFill(tokens, DayMarkState.full),
       label: context.messages.goalMetricLegendOnTarget,
     ),
     DashboardLegendEntry(
-      color: goalDayStateFill(tokens, GoalCompactDayState.partial),
+      color: dayMarkStateFill(tokens, DayMarkState.partial),
       label: context.messages.goalMetricLegendOffTarget,
     ),
     DashboardLegendEntry(
-      color: goalDayStateFill(tokens, GoalCompactDayState.none),
+      color: dayMarkStateFill(tokens, DayMarkState.none),
       label: context.messages.goalProgressHabitDayNoEntry,
     ),
     if (metric.targetIsPerDay)
@@ -3195,14 +2360,14 @@ class _MetricProgressSeries extends StatelessWidget {
 
   /// The bars on the page's shared day grid.
   ///
-  /// `_DayTrack` with [goalDayTrackMetrics], exactly like the habit squares
+  /// `DayTrack` with [dayTrackMetrics], exactly like the habit squares
   /// and the whole-goal strip: a plain Row with fixed gaps matched the default
   /// pitch but not the text-scale-expanded one, so at raised text scales the
   /// bars' Wednesday drifted away from the Wednesday one card above.
   Widget _track(
     BuildContext context,
     num maxValue,
-    GoalDayTrackMetrics metrics,
+    DayTrackMetrics metrics,
   ) {
     final tokens = context.designTokens;
     final height = _chartHeight(tokens);
@@ -3217,7 +2382,7 @@ class _MetricProgressSeries extends StatelessWidget {
       tooltip: chartTooltipDecoration(context),
       unit: metric.unitName?.trim() ?? '',
     );
-    return _DayTrack(
+    return DayTrack(
       height: height,
       pitch: metrics.pitch,
       children: [
@@ -3271,10 +2436,10 @@ class _MetricProgressSeries extends StatelessWidget {
         // from a day with no data. Met is the day-cell success fill; short is
         // the muted wash of the same family; unobserved keeps the neutral.
         color: !day.isObserved
-            ? goalDayStateFill(tokens, GoalCompactDayState.none)
-            : goalDayStateFill(
+            ? dayMarkStateFill(tokens, DayMarkState.none)
+            : dayMarkStateFill(
                 tokens,
-                met ? GoalCompactDayState.full : GoalCompactDayState.partial,
+                met ? DayMarkState.full : DayMarkState.partial,
               ),
         border: !day.isObserved
             ? Border.all(
@@ -3494,7 +2659,7 @@ class _CategoryBandSeries extends StatelessWidget {
                               ? tokens.colors.alert.warning.defaultColor
                               : tokens.colors.interactive.enabled,
                           borderRadius: BorderRadius.circular(
-                            goalDayCellRadius(tokens),
+                            dayCellRadius(tokens),
                           ),
                         ),
                       ),
@@ -3607,112 +2772,6 @@ class _CategoryPatternCard extends StatelessWidget {
             text: context.messages.goalPatternBusiestHour(
               busiestHour.toString().padLeft(2, '0'),
             ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _ProgressLegend extends StatelessWidget {
-  const _ProgressLegend();
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    Widget item(
-      Color color,
-      String label, {
-      bool outlined = false,
-      bool dotted = false,
-      bool dashed = false,
-    }) {
-      Widget swatch = Container(
-        width: IconSizes.xs,
-        height: IconSizes.xs,
-        decoration: BoxDecoration(
-          color: outlined || dashed ? Colors.transparent : color,
-          border: outlined
-              ? Border.all(color: color, width: BorderWidths.emphasis)
-              : null,
-          borderRadius: BorderRadius.circular(goalDayCellRadius(tokens)),
-        ),
-        // The legend swatch carries the same shape and non-color cue as the
-        // cells it keys — at `radii.xs` it was a different shape from both.
-        child: dotted
-            ? Center(child: goalPartialDayDot(tokens, tokens.spacing.step1))
-            : null,
-      );
-      if (dashed) {
-        // Same stroke as the ring it keys — a hairline swatch beside a
-        // two-pixel ring is a key to a mark that is not on the map.
-        swatch = DsDashedBorder(
-          color: color,
-          strokeWidth: BorderWidths.emphasis,
-          radius: goalDayCellRadius(tokens),
-          child: swatch,
-        );
-      }
-      return Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          swatch,
-          SizedBox(width: tokens.spacing.step2),
-          // Flexible so the longer done/partial labels line-break on narrow
-          // cards instead of overflowing the legend row.
-          Flexible(
-            child: Text(
-              label,
-              style: tokens.typography.styles.others.caption.copyWith(
-                color: tokens.colors.text.lowEmphasis,
-              ),
-            ),
-          ),
-        ],
-      );
-    }
-
-    // Centered, like every legend and summary line on these cards: the key
-    // is card-level annotation, not a row in the leading-aligned data stack.
-    return SizedBox(
-      width: double.infinity,
-      child: Wrap(
-        alignment: WrapAlignment.center,
-        spacing: tokens.spacing.step4,
-        runSpacing: tokens.spacing.step2,
-        children: [
-          // The SAME fills the cells draw, through the same helper — spelled
-          // out by hand here, this key could drift from the squares it
-          // explains (and from the metric legend three cards down, which
-          // reads the helper).
-          item(
-            goalDayStateFill(tokens, GoalCompactDayState.full),
-            context.messages.goalProgressDone,
-          ),
-          item(
-            goalDayStateFill(tokens, GoalCompactDayState.partial),
-            context.messages.goalProgressPartial,
-            dotted: true,
-          ),
-          // Quiet outline, matching the ring the cells actually draw — an
-          // on-track row must not wear the alarm hue in its key either.
-          // The state most cells are actually IN. The key explained the two
-          // green ones and both edge cases while staying silent about the
-          // majority fill, which is the one a reader most needs named.
-          item(
-            goalDayStateFill(tokens, GoalCompactDayState.none),
-            context.messages.goalProgressHabitDayNoEntry,
-          ),
-          item(
-            tokens.colors.text.lowEmphasis,
-            context.messages.goalProgressAgesOut,
-            outlined: true,
-          ),
-          // Dashed, exactly like the today cell — the key must match the map.
-          item(
-            goalTodayRingInk(tokens),
-            context.messages.goalProgressToday,
-            dashed: true,
           ),
         ],
       ),

--- a/lib/features/goals/ui/pages/goal_agent_detail_page.dart
+++ b/lib/features/goals/ui/pages/goal_agent_detail_page.dart
@@ -53,6 +53,7 @@ import 'package:lotti/features/projects/ui/widgets/expandable_report_section.dar
 import 'package:lotti/l10n/app_localizations.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/widgets/day_indicators/day_track.dart';
 import 'package:lotti/widgets/misc/linked_scroll_group.dart';
 import 'package:lotti/widgets/misc/timespan_segmented_control.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
@@ -115,7 +116,7 @@ class _GoalAgentDetailPageState extends ConsumerState<GoalAgentDetailPage>
   }) {
     if (_rangePicked) return;
     final tokens = context.designTokens;
-    final pitch = goalDayTrackMetrics(context, dayCount: 1).pitch;
+    final pitch = dayTrackMetrics(context, dayCount: 1).pitch;
     final contentWidth =
         math.min(
           kUnifiedGoalsContentMaxWidth,

--- a/lib/features/goals/ui/unified/unified_goal_card.dart
+++ b/lib/features/goals/ui/unified/unified_goal_card.dart
@@ -4,17 +4,18 @@ import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/design_system/components/ds_quiet_ink.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
-import 'package:lotti/features/goals/model/goal_assessment.dart';
 import 'package:lotti/features/goals/state/goal_agent_providers.dart';
 import 'package:lotti/features/goals/state/goal_assessment_state.dart';
 import 'package:lotti/features/goals/state/goal_progress_view.dart';
+import 'package:lotti/features/goals/ui/goal_day_marks.dart';
 import 'package:lotti/features/goals/ui/goal_health_direction.dart';
-import 'package:lotti/features/goals/ui/goal_progress_card.dart';
 import 'package:lotti/features/goals/ui/goal_routes.dart';
 import 'package:lotti/features/goals/ui/unified/unified_goal_status.dart';
 import 'package:lotti/features/nudges/ui/nudge_banner_widgets.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_strip.dart';
 
 /// One goal on the unified Goals list (design handover "Goals, Unified"
 /// §4.2): header (persona chip · name · status pill with folded recovery
@@ -86,10 +87,9 @@ class UnifiedGoalCard extends ConsumerWidget {
       _ => null,
     };
     final days =
-        resolvedDays ??
-        List<GoalCompactDayState>.filled(7, GoalCompactDayState.none);
+        resolvedDays ?? List<DayMarkState>.filled(7, DayMarkState.none);
     final ratingsByDay = health?.spec == null
-        ? const <DateTime, GoalAssessmentRating>{}
+        ? const <DateTime, DayVerdict>{}
         : latestRatingsByDay(
             ref.watch(goalAssessmentHistoryProvider(identity.agentId)).value ??
                 const [],
@@ -148,11 +148,13 @@ class UnifiedGoalCard extends ConsumerWidget {
                 ],
               ],
             );
-            final strip = GoalCompactWindowStrip(
-              days: days,
+            final strip = DayMarkStrip(
+              marks: goalDayMarks(
+                states: days,
+                lastDay: progress?.today,
+                verdictsByDay: ratingsByDay,
+              ),
               placeholder: resolvedDays == null,
-              lastDay: progress?.today,
-              ratingsByDay: ratingsByDay,
             );
             final leading = NudgeBannerPersonaChip(
               monogram: NudgeBannerPersonaChip.monogramFor(

--- a/lib/features/habits/ui/widgets/habit_completion_card.dart
+++ b/lib/features/habits/ui/widgets/habit_completion_card.dart
@@ -1,17 +1,15 @@
+import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/features/design_system/theme/design_tokens.dart';
-import 'package:lotti/features/design_system/theme/ds_surface_elevation.dart';
 import 'package:lotti/features/habits/state/habit_completion_controller.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_action_row.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/l10n/app_localizations.dart';
-import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/entities_cache_service.dart';
-import 'package:lotti/themes/colors.dart';
+import 'package:lotti/utils/date_utils_extension.dart';
 import 'package:lotti/widgets/charts/habits/dashboard_habits_data.dart';
-import 'package:lotti/widgets/charts/utils.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_strip.dart';
 
 /// A habit row that carries its own per-day completion history strip — used by
 /// the dashboard habit chart, where seeing the chain over the dashboard's range
@@ -27,14 +25,12 @@ class HabitCompletionCard extends ConsumerStatefulWidget {
     required this.habitId,
     required this.rangeStart,
     required this.rangeEnd,
-    this.showGaps = true,
     super.key,
   });
 
   final String habitId;
   final DateTime rangeStart;
   final DateTime rangeEnd;
-  final bool showGaps;
 
   @override
   ConsumerState<HabitCompletionCard> createState() =>
@@ -96,197 +92,47 @@ class _HabitCompletionCardState extends ConsumerState<HabitCompletionCard> {
     return HabitActionRow(
       habitId: habitDefinition.id,
       completedToday: completedToday,
-      history: _HistoryStrip(
-        results: results,
-        showGaps: widget.showGaps,
-        habitName: habitDefinition.name,
-      ),
+      history: _HistoryStrip(results: results),
     );
   }
 }
 
 /// The per-day completion history strip — a compact "don't break the chain"
-/// calendar, one rounded cell per day in range. Each cell is coloured by
-/// outcome AND carries a glyph (✓ / – / ✕), so state never depends on colour
-/// alone.
+/// calendar drawn with the shared day-indicator cells, so a habit's chain here
+/// wears exactly the language a goal's habit dimension does: the success fill,
+/// the skip dash and missed cross as non-color cues, the dashed ring on today.
 ///
 /// The strip is read-only: it's a glanceable record, not a control. Tapping
 /// anywhere on the row (or the complete button) opens the dialog, where any
 /// past day can be backfilled via the date field — so the strip needs no tiny,
-/// swipe-conflicting per-cell tap targets. Each cell still exposes its date +
-/// outcome to screen readers. Cells are fixed-size squares (never the stretchy
-/// "pill bars" of the old layout); they shrink toward a legibility floor as the
-/// range grows, and once the range is longer than the width can hold even at
-/// that floor, the strip keeps the most recent days and drops the oldest.
+/// swipe-conflicting per-cell tap targets. A range longer than the width can
+/// hold pans, anchored on today, like every other day track.
 class _HistoryStrip extends StatelessWidget {
-  const _HistoryStrip({
-    required this.results,
-    required this.showGaps,
-    required this.habitName,
-  });
+  const _HistoryStrip({required this.results});
 
   final List<HabitResult> results;
-  final bool showGaps;
-  final String habitName;
-
-  /// Data-viz dimensions (not layout spacing): cells are square, never larger
-  /// than [_maxCell] nor smaller than [_minCell] (below which the colour + shape
-  /// stop reading), and the outcome glyph is only drawn once a cell clears the
-  /// [_glyphFloor]. When the range holds more days than fit at [_minCell], the
-  /// oldest are dropped so the strip shows the most recent chain (see build).
-  static const double _maxCell = 24;
-  static const double _minCell = 6;
-  static const double _glyphFloor = 14;
 
   @override
   Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    final messages = context.messages;
-    final surface = dsCardSurface(context);
-    final n = results.length;
-    if (n == 0) return const SizedBox.shrink();
-    final gap = showGaps ? tokens.spacing.step1 : 0.0;
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final maxWidth = constraints.maxWidth;
-        // How many fixed-size cells fit at the smallest legible size. When the
-        // range is longer than that, render the most recent days that fit and
-        // drop the oldest (left edge) rather than overflow — fixed cells can't
-        // shrink past [_minCell], and the deep chain lives in the heatmap now.
-        final fits = maxWidth.isFinite
-            ? ((maxWidth + gap) / (_minCell + gap)).floor()
-            : n;
-        final count = fits < n ? (fits < 0 ? 0 : fits) : n;
-        if (count == 0) return const SizedBox.shrink();
-        final visible = results.sublist(n - count);
-
-        final raw = (maxWidth - gap * (count - 1)) / count;
-        final size = raw.clamp(_minCell, _maxCell);
-        final showGlyph = size >= _glyphFloor;
-
-        return Row(
-          children: [
-            for (var i = 0; i < count; i++) ...[
-              if (i > 0) SizedBox(width: gap),
-              _cell(tokens, messages, surface, visible[i], size, showGlyph),
-            ],
-          ],
-        );
-      },
-    );
-  }
-
-  Widget _cell(
-    DsTokens tokens,
-    AppLocalizations messages,
-    Color surface,
-    HabitResult res,
-    double size,
-    bool showGlyph,
-  ) {
-    final appearance = _cellAppearance(res.completionType, tokens, surface);
-    final statusWord = _statusWord(res.completionType, messages);
-
-    return Tooltip(
-      excludeFromSemantics: true,
-      message: chartDateFormatter(res.dayString),
-      child: Semantics(
-        label: messages.habitDayStatusSemantic(habitName, statusWord),
-        // The date distinguishes same-status cells for screen readers (the
-        // visual tooltip is excluded from semantics above).
-        value: chartDateFormatter(res.dayString),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(showGaps ? tokens.radii.xs : 0),
-          child: Container(
-            width: size,
-            height: size,
-            alignment: Alignment.center,
-            color: appearance.background,
-            child: showGlyph && appearance.glyph != null
-                ? Icon(
-                    appearance.glyph,
-                    size: size * 0.68,
-                    color: appearance.ink,
-                  )
-                : null,
+    final today = clock.now().ymd;
+    return DayMarkStrip(
+      marks: [
+        for (final result in results)
+          DayMark(
+            day: DateTime.parse(result.dayString),
+            state: habitCompletionDayMarkState(result.completionType),
+            isToday: result.dayString == today,
           ),
-        ),
-      ),
+      ],
     );
   }
 }
 
-/// The localized outcome word for a strip cell's screen-reader label, so the
-/// glyph's meaning is conveyed non-visually too.
-String _statusWord(HabitCompletionType type, AppLocalizations messages) {
-  switch (type) {
-    case HabitCompletionType.success:
-      return messages.completeHabitSuccessButton;
-    case HabitCompletionType.skip:
-      return messages.completeHabitSkipButton;
-    case HabitCompletionType.fail:
-      return messages.completeHabitFailButton;
-    case HabitCompletionType.open:
-      return messages.habitNotRecordedLabel;
-  }
-}
-
-/// The higher-contrast ink (near-black or white) for a glyph drawn on [bg],
-/// chosen by actual WCAG contrast ratio rather than a luminance threshold — the
-/// outcome fills are mid-tones where a naive `luminance > 0.5` test picks the
-/// *wrong* (low-contrast) ink. Callers pass the fill already composited over the
-/// card surface so translucent fills resolve to their true on-screen colour.
-Color _glyphInk(Color bg) {
-  double ratio(double a, double b) {
-    final hi = a > b ? a : b;
-    final lo = a > b ? b : a;
-    return (hi + 0.05) / (lo + 0.05);
-  }
-
-  final l = bg.computeLuminance();
-  return ratio(0, l) >= ratio(1, l) ? Colors.black87 : Colors.white;
-}
-
-/// Resolves a per-day strip cell's fill, optional glyph, and on-fill ink.
-///
-/// The palette is deliberately calm so the chain reads as "mostly done with a
-/// few quiet gaps", not a battlefield:
-/// - success is the only saturated fill (the win should be visible);
-/// - a miss is a *light tint*, never a solid red block, so it registers without
-///   shouting;
-/// - skip is a neutral grey; an empty (not-yet-recorded) day is the faintest
-///   neutral and carries no glyph — "not done yet" must never read as "failed".
-///
-/// Every recorded outcome also carries a distinct glyph (✓ / – / ✕) so state is
-/// never colour-only (colour-blind + low-vision support). [surface] is the card
-/// colour the cell sits on, so the ink contrast is computed against the real
-/// composited fill.
-({Color background, IconData? glyph, Color ink}) _cellAppearance(
-  HabitCompletionType type,
-  DsTokens tokens,
-  Color surface,
-) {
-  Color inkOn(Color fill) => _glyphInk(Color.alphaBlend(fill, surface));
-
-  switch (type) {
-    case HabitCompletionType.success:
-      return (
-        background: successColor,
-        glyph: LottiIcons.confirm,
-        ink: inkOn(successColor),
-      );
-    case HabitCompletionType.skip:
-      final fill = tokens.colors.background.level03;
-      return (background: fill, glyph: LottiIcons.remove, ink: inkOn(fill));
-    case HabitCompletionType.fail:
-      final fill = alarm.withValues(alpha: 0.32);
-      return (background: fill, glyph: LottiIcons.close, ink: inkOn(fill));
-    case HabitCompletionType.open:
-      return (
-        background: tokens.colors.decorative.level01,
-        glyph: null,
-        ink: Colors.transparent,
-      );
-  }
-}
+/// The shared day-mark state a recorded habit outcome renders as.
+DayMarkState habitCompletionDayMarkState(HabitCompletionType type) =>
+    switch (type) {
+      HabitCompletionType.success => DayMarkState.full,
+      HabitCompletionType.skip => DayMarkState.skipped,
+      HabitCompletionType.fail => DayMarkState.missed,
+      HabitCompletionType.open => DayMarkState.none,
+    };

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2876,7 +2876,6 @@
   "habitCompletionStatusFailed": "Nezdařeno",
   "habitCompletionStatusOpen": "Otevřeno",
   "habitCompletionStatusSkipped": "Přeskočeno",
-  "habitDayStatusSemantic": "{habit}, {status}",
   "habitDeleteConfirm": "Ano, smazat tento návyk",
   "habitDeleteQuestion": "Chceš tento návyk smazat?",
   "habitEditorAddSignal": "Přidat signál",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -3133,17 +3133,6 @@
   "habitCompletionStatusFailed": "Mislykkedes",
   "habitCompletionStatusOpen": "Åben",
   "habitCompletionStatusSkipped": "Sprunget over",
-  "habitDayStatusSemantic": "{habit}, {status}",
-  "@habitDayStatusSemantic": {
-    "placeholders": {
-      "habit": {
-        "type": "String"
-      },
-      "status": {
-        "type": "String"
-      }
-    }
-  },
   "habitDeleteConfirm": "Ja, slet denne vane",
   "habitDeleteQuestion": "Vil du slette denne vane?",
   "habitEditorAddSignal": "Tilføj et signal",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2869,7 +2869,6 @@
   "habitCompletionStatusFailed": "Fehlgeschlagen",
   "habitCompletionStatusOpen": "Offen",
   "habitCompletionStatusSkipped": "Übersprungen",
-  "habitDayStatusSemantic": "{habit}, {status}",
   "habitDeleteConfirm": "Ja, diese Gewohnheit löschen",
   "habitDeleteQuestion": "Möchtest du diese Gewohnheit löschen?",
   "habitEditorAddSignal": "Signal hinzufügen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4316,17 +4316,6 @@
   "habitCompletionStatusFailed": "Failed",
   "habitCompletionStatusOpen": "Open",
   "habitCompletionStatusSkipped": "Skipped",
-  "habitDayStatusSemantic": "{habit}, {status}",
-  "@habitDayStatusSemantic": {
-    "placeholders": {
-      "habit": {
-        "type": "String"
-      },
-      "status": {
-        "type": "String"
-      }
-    }
-  },
   "habitDeleteConfirm": "Yes, delete this habit",
   "habitDeleteQuestion": "Do you want to delete this habit?",
   "habitEditorAddSignal": "Add a signal",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2869,7 +2869,6 @@
   "habitCompletionStatusFailed": "Fallido",
   "habitCompletionStatusOpen": "Pendiente",
   "habitCompletionStatusSkipped": "Omitido",
-  "habitDayStatusSemantic": "{habit}, {status}",
   "habitDeleteConfirm": "Sí, borrar este hábito",
   "habitDeleteQuestion": "¿Quieres borrar este hábito?",
   "habitEditorAddSignal": "Añadir una señal",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2869,7 +2869,6 @@
   "habitCompletionStatusFailed": "Échoué",
   "habitCompletionStatusOpen": "Ouvert",
   "habitCompletionStatusSkipped": "Ignoré",
-  "habitDayStatusSemantic": "{habit}, {status}",
   "habitDeleteConfirm": "Oui, supprimer cette habitude",
   "habitDeleteQuestion": "Veux-tu supprimer cette habitude ?",
   "habitEditorAddSignal": "Ajouter un signal",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -3133,17 +3133,6 @@
   "habitCompletionStatusFailed": "Fatta.",
   "habitCompletionStatusOpen": "Aprire",
   "habitCompletionStatusSkipped": "Abilitato",
-  "habitDayStatusSemantic": "{habit}, {status}",
-  "@habitDayStatusSemantic": {
-    "placeholders": {
-      "habit": {
-        "type": "String"
-      },
-      "status": {
-        "type": "String"
-      }
-    }
-  },
   "habitDeleteConfirm": "Sì, elimina questa abitudine",
   "habitDeleteQuestion": "Vuoi eliminare questa abitudine?",
   "habitEditorAddSignal": "Aggiungi un segnale",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -12192,12 +12192,6 @@ abstract class AppLocalizations {
   /// **'Skipped'**
   String get habitCompletionStatusSkipped;
 
-  /// No description provided for @habitDayStatusSemantic.
-  ///
-  /// In en, this message translates to:
-  /// **'{habit}, {status}'**
-  String habitDayStatusSemantic(String habit, String status);
-
   /// No description provided for @habitDeleteConfirm.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -7287,11 +7287,6 @@ class AppLocalizationsCs extends AppLocalizations {
   String get habitCompletionStatusSkipped => 'Přeskočeno';
 
   @override
-  String habitDayStatusSemantic(String habit, String status) {
-    return '$habit, $status';
-  }
-
-  @override
   String get habitDeleteConfirm => 'Ano, smazat tento návyk';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -7208,11 +7208,6 @@ class AppLocalizationsDa extends AppLocalizations {
   String get habitCompletionStatusSkipped => 'Sprunget over';
 
   @override
-  String habitDayStatusSemantic(String habit, String status) {
-    return '$habit, $status';
-  }
-
-  @override
   String get habitDeleteConfirm => 'Ja, slet denne vane';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -7258,11 +7258,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get habitCompletionStatusSkipped => 'Übersprungen';
 
   @override
-  String habitDayStatusSemantic(String habit, String status) {
-    return '$habit, $status';
-  }
-
-  @override
   String get habitDeleteConfirm => 'Ja, diese Gewohnheit löschen';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7183,11 +7183,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get habitCompletionStatusSkipped => 'Skipped';
 
   @override
-  String habitDayStatusSemantic(String habit, String status) {
-    return '$habit, $status';
-  }
-
-  @override
   String get habitDeleteConfirm => 'Yes, delete this habit';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -7306,11 +7306,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get habitCompletionStatusSkipped => 'Omitido';
 
   @override
-  String habitDayStatusSemantic(String habit, String status) {
-    return '$habit, $status';
-  }
-
-  @override
   String get habitDeleteConfirm => 'Sí, borrar este hábito';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -7319,11 +7319,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get habitCompletionStatusSkipped => 'Ignoré';
 
   @override
-  String habitDayStatusSemantic(String habit, String status) {
-    return '$habit, $status';
-  }
-
-  @override
   String get habitDeleteConfirm => 'Oui, supprimer cette habitude';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -7298,11 +7298,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get habitCompletionStatusSkipped => 'Abilitato';
 
   @override
-  String habitDayStatusSemantic(String habit, String status) {
-    return '$habit, $status';
-  }
-
-  @override
   String get habitDeleteConfirm => 'Sì, elimina questa abitudine';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -7222,11 +7222,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get habitCompletionStatusSkipped => 'Overgeslagen';
 
   @override
-  String habitDayStatusSemantic(String habit, String status) {
-    return '$habit, $status';
-  }
-
-  @override
   String get habitDeleteConfirm => 'Ja, verwijder deze gewoonte';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -7280,11 +7280,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get habitCompletionStatusSkipped => 'Ignorado';
 
   @override
-  String habitDayStatusSemantic(String habit, String status) {
-    return '$habit, $status';
-  }
-
-  @override
   String get habitDeleteConfirm => 'Sim, excluir este hábito';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -7337,11 +7337,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get habitCompletionStatusSkipped => 'Omis';
 
   @override
-  String habitDayStatusSemantic(String habit, String status) {
-    return '$habit, $status';
-  }
-
-  @override
   String get habitDeleteConfirm => 'Da, ștergeți acest obicei';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -7217,11 +7217,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get habitCompletionStatusSkipped => 'Hoppade över';
 
   @override
-  String habitDayStatusSemantic(String habit, String status) {
-    return '$habit, $status';
-  }
-
-  @override
   String get habitDeleteConfirm => 'Ja, radera den här vanan';
 
   @override

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -3132,17 +3132,6 @@
   "habitCompletionStatusFailed": "Fout",
   "habitCompletionStatusOpen": "Openen",
   "habitCompletionStatusSkipped": "Overgeslagen",
-  "habitDayStatusSemantic": "{habit}, {status}",
-  "@habitDayStatusSemantic": {
-    "placeholders": {
-      "habit": {
-        "type": "String"
-      },
-      "status": {
-        "type": "String"
-      }
-    }
-  },
   "habitDeleteConfirm": "Ja, verwijder deze gewoonte",
   "habitDeleteQuestion": "Wilt u deze gewoonte verwijderen?",
   "habitEditorAddSignal": "Signaal toevoegen",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -3132,17 +3132,6 @@
   "habitCompletionStatusFailed": "Falha",
   "habitCompletionStatusOpen": "Abrir",
   "habitCompletionStatusSkipped": "Ignorado",
-  "habitDayStatusSemantic": "{habit}, {status}",
-  "@habitDayStatusSemantic": {
-    "placeholders": {
-      "habit": {
-        "type": "String"
-      },
-      "status": {
-        "type": "String"
-      }
-    }
-  },
   "habitDeleteConfirm": "Sim, excluir este hábito",
   "habitDeleteQuestion": "Quer eliminar esse hábito?",
   "habitEditorAddSignal": "Adicionar um sinal",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2869,7 +2869,6 @@
   "habitCompletionStatusFailed": "Eșuat",
   "habitCompletionStatusOpen": "Deschis",
   "habitCompletionStatusSkipped": "Omis",
-  "habitDayStatusSemantic": "{habit}, {status}",
   "habitDeleteConfirm": "Da, ștergeți acest obicei",
   "habitDeleteQuestion": "Doriți să ștergeți acest obicei?",
   "habitEditorAddSignal": "Adăugați un semnal",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -3133,17 +3133,6 @@
   "habitCompletionStatusFailed": "Misslyckades",
   "habitCompletionStatusOpen": "Öppet",
   "habitCompletionStatusSkipped": "Hoppade över",
-  "habitDayStatusSemantic": "{habit}, {status}",
-  "@habitDayStatusSemantic": {
-    "placeholders": {
-      "habit": {
-        "type": "String"
-      },
-      "status": {
-        "type": "String"
-      }
-    }
-  },
   "habitDeleteConfirm": "Ja, radera den här vanan",
   "habitDeleteQuestion": "Vill du ta bort den här vanan?",
   "habitEditorAddSignal": "Lägg till en signal",

--- a/lib/widgets/README.md
+++ b/lib/widgets/README.md
@@ -20,6 +20,7 @@ lib/widgets/
 ├── nav_bar/     # bottom navigation shell and FAB clearance
 ├── media/       # full-screen image-viewer orientation lifecycle
 ├── timeline/    # the one vertical timeline rail, shared by events and goals
+├── day_indicators/ # DayMark model, day cells, strip, track geometry and legend shared by goals and habits
 └── misc/        # sidebar activity summary and similar cross-feature pieces
 ```
 

--- a/lib/widgets/day_indicators/day_mark.dart
+++ b/lib/widgets/day_indicators/day_mark.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/foundation.dart';
+
+/// What the app measured for one day.
+///
+/// [full] means the requirement held as of that day; [partial] means the user
+/// did everything within their control (the routine was kept) while a window
+/// target was still building — rendered as a lighter wash of the same success
+/// hue. [skipped] and [missed] are recorded outcomes a habit day can carry:
+/// deciding a day was missed and never looking at it are different facts, so
+/// [missed] is never the neutral grey of [none].
+enum DayMarkState { none, partial, full, skipped, missed }
+
+/// How a day turned out, in the user's own judgement.
+///
+/// [improving] is the case a three-way verdict could not express: some of it
+/// was missed, but the day moved the right way. Without it a day like that
+/// had to be filed as [mixed] alongside days that simply stalled, and a strip
+/// could not show "not perfect, but on the right track".
+///
+/// Ordered best to worst. Persisted by `name`, so the order is free to change
+/// but the names are not.
+enum DayVerdict { met, improving, mixed, missed }
+
+/// Whether the user rated the day directly or accepted the deterministic
+/// suggestion derived from the day's own evidence.
+enum DayVerdictProvenance { ratedByUser, suggestedAndAccepted }
+
+/// One day on a day-indicator surface: the measured [state], the user's
+/// [verdict] where one was recorded, and whether the cell stands for today.
+///
+/// A recorded verdict outranks the measured state wherever both are shown. The
+/// measurement is evidence about a day; the reflection is the user's ruling on
+/// it, and a cell that kept showing grey after they filed the day as missed
+/// would be contradicting them.
+@immutable
+class DayMark {
+  const DayMark({
+    required this.state,
+    this.day,
+    this.verdict,
+    this.verdictProvenance,
+    this.isToday = false,
+  });
+
+  /// The calendar day, at midnight UTC. Null on an undated strip — a loading
+  /// placeholder row, or a figure whose cells carry no dates and therefore no
+  /// weekday letters.
+  final DateTime? day;
+
+  final DayMarkState state;
+  final DayVerdict? verdict;
+  final DayVerdictProvenance? verdictProvenance;
+  final bool isToday;
+
+  /// Whether the day counts toward a "successful days" tally: a verdict of
+  /// [DayVerdict.met] where one exists, otherwise any measured state that is
+  /// not an empty or missed day.
+  bool get successful => switch (verdict) {
+    final verdict? => verdict == DayVerdict.met,
+    null => switch (state) {
+      DayMarkState.full || DayMarkState.partial => true,
+      DayMarkState.none || DayMarkState.skipped || DayMarkState.missed => false,
+    },
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      other is DayMark &&
+      other.day == day &&
+      other.state == state &&
+      other.verdict == verdict &&
+      other.verdictProvenance == verdictProvenance &&
+      other.isToday == isToday;
+
+  @override
+  int get hashCode =>
+      Object.hash(day, state, verdict, verdictProvenance, isToday);
+
+  @override
+  String toString() =>
+      'DayMark(day: $day, state: $state, verdict: $verdict, '
+      'provenance: $verdictProvenance, isToday: $isToday)';
+}

--- a/lib/widgets/day_indicators/day_mark_cell.dart
+++ b/lib/widgets/day_indicators/day_mark_cell.dart
@@ -61,7 +61,9 @@ class DayMarkCell extends StatelessWidget {
   final String? label;
 
   /// The same fact split for the hover tooltip: the day names the subject,
-  /// the outcome describes it. Both null exactly when [label] is.
+  /// the outcome describes it. A read-only cell still answers hover with
+  /// them — the corner letter cannot tell one Tuesday from the next, and the
+  /// tooltip is where a dated cell reveals which day it stands for.
   final String? tooltipDay;
   final String? tooltipOutcome;
 
@@ -152,7 +154,16 @@ class DayMarkCell extends StatelessWidget {
           )
         : padded;
     final onTap = this.onTap;
-    if (onTap == null) return decorated;
+    if (onTap == null) {
+      final tooltipDay = this.tooltipDay;
+      if (tooltipDay == null) return decorated;
+      return DsTooltip(
+        title: tooltipDay,
+        message: tooltipOutcome ?? '',
+        preferBelow: false,
+        child: decorated,
+      );
+    }
     // The square keeps its size; the hit slot around it takes the full height
     // of the touch floor and whatever width the row can spare. Growing the
     // square itself to 48px would make the strip shout over the habit rows it

--- a/lib/widgets/day_indicators/day_mark_cell.dart
+++ b/lib/widgets/day_indicators/day_mark_cell.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
+import 'package:lotti/features/design_system/components/ds_quiet_ink.dart';
+import 'package:lotti/features/design_system/components/tooltips/ds_tooltip.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
+
+/// A not-yet-resolved day slot: same footprint as a real cell, dashed
+/// outline instead of a fill, so the silhouette holds without borrowing the
+/// empty-week encoding.
+class PlaceholderDayCell extends StatelessWidget {
+  const PlaceholderDayCell({this.size = IconSizes.xs, super.key});
+
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return Padding(
+      padding: EdgeInsets.all(tokens.spacing.step1),
+      child: DsDashedBorder(
+        color: tokens.colors.text.lowEmphasis,
+        radius: dayCellRadius(tokens),
+        child: SizedBox(width: size, height: size),
+      ),
+    );
+  }
+}
+
+/// One day square: the measured state's fill, the recorded verdict's fill and
+/// glyph where one outranks it, the partial dot or outcome glyph as the
+/// non-color cue, a corner weekday letter when nothing stronger claims the
+/// center, and the dashed ring on today.
+///
+/// Read-only by default. With [onTap] the square keeps its size while the
+/// hit slot around it clears the touch floor, and the cell announces itself
+/// as a button with [label].
+class DayMarkCell extends StatelessWidget {
+  const DayMarkCell({
+    required this.mark,
+    this.size = IconSizes.xs,
+    this.onTap,
+    this.label,
+    this.tooltipDay,
+    this.tooltipOutcome,
+    this.weekdayLetter,
+    super.key,
+  });
+
+  final DayMark mark;
+  final double size;
+  final VoidCallback? onTap;
+
+  /// One-letter weekday initial nested in the cell, replacing the label row
+  /// that used to run above the strip. Null on strips without dates.
+  final String? weekdayLetter;
+
+  /// Spoken name for a tappable cell. Null on a read-only strip, whose
+  /// semantics are carried by the summary above it.
+  final String? label;
+
+  /// The same fact split for the hover tooltip: the day names the subject,
+  /// the outcome describes it. Both null exactly when [label] is.
+  final String? tooltipDay;
+  final String? tooltipOutcome;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final verdict = mark.verdict;
+    final state = mark.state;
+    // The dot is the measured-partial cue; a recorded verdict wears its own
+    // glyph instead. Either way the cell says something a reader who cannot
+    // separate the hues can still act on.
+    final showsPartialDot = verdict == null && state == DayMarkState.partial;
+    final stateGlyph = verdict == null ? dayMarkStateGlyph(state) : null;
+    final Widget? centerMark = showsPartialDot
+        ? Center(
+            child: partialDayDot(
+              tokens,
+              // The dot has to stay legible inside the square it marks, so
+              // it scales with it rather than sitting at one fixed size.
+              size <= IconSizes.xs
+                  ? tokens.spacing.step1
+                  : tokens.spacing.step2,
+            ),
+          )
+        : verdict != null
+        // The verdict's own shape at every size. Collapsing the three
+        // non-met verdicts into one dot on the list's 12px cells left
+        // Improving, Mixed and Missed distinguishable by hue alone —
+        // which is the one thing the shapes exist to avoid.
+        ? Center(
+            child: Icon(
+              dayVerdictGlyph(verdict),
+              size: size * 0.75,
+              // The ink of the fill's OWN family. Painting every glyph in
+              // the success ink put a green tick's colour on a red missed
+              // cell and an orange mixed one.
+              color: dayVerdictInk(tokens, verdict),
+            ),
+          )
+        : stateGlyph != null
+        ? Center(
+            child: Icon(
+              stateGlyph,
+              size: size * 0.75,
+              color: dayMarkStateGlyphInk(tokens, state),
+            ),
+          )
+        : null;
+    // The corner weekday tag renders only when the center is empty: at the
+    // compact cell size a glyph and a corner letter collide, and the glyph
+    // is the rarer, more meaningful mark — neighbouring plain cells keep
+    // carrying the axis.
+    final letterTag = centerMark != null
+        ? null
+        : dayCellLetter(
+            tokens,
+            letter: weekdayLetter,
+            cellSize: size,
+            filled: verdict != null || state == DayMarkState.full,
+          );
+    final cell = Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: verdict == null
+            ? dayMarkStateFill(tokens, state)
+            : dayVerdictFill(tokens, verdict),
+        borderRadius: BorderRadius.circular(dayCellRadius(tokens)),
+      ),
+      child: centerMark == null && letterTag == null
+          ? null
+          : Stack(
+              children: [?centerMark, ?letterTag],
+            ),
+    );
+    // Every cell shares one outer footprint; today only adds the dashed
+    // ring inside it, so the strip's rhythm never bulges at the last cell.
+    final padded = Padding(
+      padding: EdgeInsets.all(tokens.spacing.step1),
+      child: cell,
+    );
+    final decorated = mark.isToday
+        ? DsDashedBorder(
+            color: todayRingInk(tokens),
+            strokeWidth: BorderWidths.emphasis,
+            radius: dayCellRadius(tokens),
+            child: padded,
+          )
+        : padded;
+    final onTap = this.onTap;
+    if (onTap == null) return decorated;
+    // The square keeps its size; the hit slot around it takes the full height
+    // of the touch floor and whatever width the row can spare. Growing the
+    // square itself to 48px would make the strip shout over the habit rows it
+    // is meant to summarise.
+    // No hover fill: the hit slot is far larger than the square it serves,
+    // so Material's overlay drew a phantom button bulging around the cell.
+    // The cell is a data readout — hover answers with the styled tooltip
+    // naming the day and its outcome, not with a fill on the data itself.
+    return Semantics(
+      label: label,
+      button: true,
+      excludeSemantics: true,
+      child: DsTooltip(
+        title: tooltipDay,
+        message: tooltipOutcome ?? '',
+        preferBelow: false,
+        child: DsQuietInk(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(tokens.radii.s),
+          focusRing: true,
+          builder: (context, highlighted) => ConstrainedBox(
+            constraints: const BoxConstraints(
+              minHeight: TapTargets.minimum,
+            ),
+            child: Center(child: decorated),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/day_indicators/day_mark_cell.dart
+++ b/lib/widgets/day_indicators/day_mark_cell.dart
@@ -172,9 +172,13 @@ class DayMarkCell extends StatelessWidget {
     // so Material's overlay drew a phantom button bulging around the cell.
     // The cell is a data readout — hover answers with the styled tooltip
     // naming the day and its outcome, not with a fill on the data itself.
+    // `excludeSemantics` drops the ink well's own node, so the activation
+    // action has to be published here or the button a reader hears has
+    // nothing to activate.
     return Semantics(
       label: label,
       button: true,
+      onTap: onTap,
       excludeSemantics: true,
       child: DsTooltip(
         title: tooltipDay,

--- a/lib/widgets/day_indicators/day_mark_legend.dart
+++ b/lib/widgets/day_indicators/day_mark_legend.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
+
+/// The key to the day squares: the same fills the cells draw, through the
+/// same helpers, so the key cannot drift from the map it explains. Swatches
+/// carry the cells' shape and non-color cues — the partial dot, the dashed
+/// today ring — because a key to a mark that is not on the map is no key.
+class DayMarkLegend extends StatelessWidget {
+  const DayMarkLegend({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    Widget item(
+      Color color,
+      String label, {
+      bool outlined = false,
+      bool dotted = false,
+      bool dashed = false,
+    }) {
+      Widget swatch = Container(
+        width: IconSizes.xs,
+        height: IconSizes.xs,
+        decoration: BoxDecoration(
+          color: outlined || dashed ? Colors.transparent : color,
+          border: outlined
+              ? Border.all(color: color, width: BorderWidths.emphasis)
+              : null,
+          borderRadius: BorderRadius.circular(dayCellRadius(tokens)),
+        ),
+        // The legend swatch carries the same shape and non-color cue as the
+        // cells it keys — at `radii.xs` it was a different shape from both.
+        child: dotted
+            ? Center(child: partialDayDot(tokens, tokens.spacing.step1))
+            : null,
+      );
+      if (dashed) {
+        // Same stroke as the ring it keys — a hairline swatch beside a
+        // two-pixel ring is a key to a mark that is not on the map.
+        swatch = DsDashedBorder(
+          color: color,
+          strokeWidth: BorderWidths.emphasis,
+          radius: dayCellRadius(tokens),
+          child: swatch,
+        );
+      }
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          swatch,
+          SizedBox(width: tokens.spacing.step2),
+          // Flexible so the longer done/partial labels line-break on narrow
+          // cards instead of overflowing the legend row.
+          Flexible(
+            child: Text(
+              label,
+              style: tokens.typography.styles.others.caption.copyWith(
+                color: tokens.colors.text.lowEmphasis,
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    // Centered, like every legend and summary line on these cards: the key
+    // is card-level annotation, not a row in the leading-aligned data stack.
+    return SizedBox(
+      width: double.infinity,
+      child: Wrap(
+        alignment: WrapAlignment.center,
+        spacing: tokens.spacing.step4,
+        runSpacing: tokens.spacing.step2,
+        children: [
+          item(
+            dayMarkStateFill(tokens, DayMarkState.full),
+            dayMarkStateLabel(context, DayMarkState.full),
+          ),
+          item(
+            dayMarkStateFill(tokens, DayMarkState.partial),
+            dayMarkStateLabel(context, DayMarkState.partial),
+            dotted: true,
+          ),
+          // The state most cells are actually IN. A key that explained the
+          // two green ones and both edge cases while staying silent about
+          // the majority fill left the one a reader most needs unnamed.
+          item(
+            dayMarkStateFill(tokens, DayMarkState.none),
+            dayMarkStateLabel(context, DayMarkState.none),
+          ),
+          // Quiet outline, matching the ring the cells actually draw — an
+          // on-track row must not wear the alarm hue in its key either.
+          item(
+            tokens.colors.text.lowEmphasis,
+            context.messages.goalProgressAgesOut,
+            outlined: true,
+          ),
+          // Dashed, exactly like the today cell — the key must match the map.
+          item(
+            todayRingInk(tokens),
+            context.messages.goalProgressToday,
+            dashed: true,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/day_indicators/day_mark_strip.dart
+++ b/lib/widgets/day_indicators/day_mark_strip.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_cell.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
+import 'package:lotti/widgets/day_indicators/day_track.dart';
+import 'package:lotti/widgets/misc/linked_scroll_group.dart';
+
+/// A row of day cells — the seven-cell picture on each goal row, the
+/// completion chain on a dashboard habit card. It is intentionally unlabeled
+/// visually, but exposes one concise semantic summary; a tappable strip
+/// publishes each day as its own button as well.
+class DayMarkStrip extends StatelessWidget {
+  const DayMarkStrip({
+    required this.marks,
+    this.placeholder = false,
+    this.onDaySelected,
+    this.scrollGroup,
+    super.key,
+  });
+
+  static bool _allDated(List<DayMark> marks) =>
+      marks.every((mark) => mark.day != null);
+
+  final List<DayMark> marks;
+
+  /// True while the strip stands in for a window that has not resolved yet.
+  /// Placeholder cells render as dashed outlines, never as the filled grey a
+  /// genuinely-empty week wears — "no data yet" and "nothing happened" must
+  /// not share an encoding, or the strip contradicts a Healthy chip beside
+  /// it.
+  final bool placeholder;
+
+  /// Opens the day's reflection. Null leaves the strip a read-only figure —
+  /// which is what the list rows want, since a tap there navigates.
+  final ValueChanged<DateTime>? onDaySelected;
+
+  /// Joins the page's unison day-track scrolling when the strip renders a
+  /// span longer than a week.
+  final LinkedScrollGroup? scrollGroup;
+
+  @override
+  Widget build(BuildContext context) {
+    // The full span, not a seven-day cap: on the detail page the strip
+    // follows the page's shared range like every other day track (the list
+    // rows keep passing seven-day windows).
+    if (marks.isEmpty) return const SizedBox.shrink();
+    // Only the extended span needs to know the width it has to fit into; the
+    // seven-cell list rows keep their authored pitch and their scale-down fit.
+    if (marks.length <= 7) return _build(context, availableWidth: null);
+    return LayoutBuilder(
+      builder: (context, constraints) => _build(
+        context,
+        availableWidth: constraints.maxWidth.isFinite
+            ? constraints.maxWidth
+            : null,
+      ),
+    );
+  }
+
+  Widget _build(BuildContext context, {required double? availableWidth}) {
+    final tokens = context.designTokens;
+    final onDaySelected = this.onDaySelected;
+    final locale = Localizations.localeOf(context).toLanguageTag();
+    final dated = _allDated(marks);
+    assert(
+      onDaySelected == null || placeholder || dated,
+      'A tappable strip needs dated marks to name the cell that was tapped.',
+    );
+    final metrics = dayTrackMetrics(
+      context,
+      dayCount: marks.length,
+      availableWidth: availableWidth,
+    );
+    final resolvedCellSize = metrics.cellSize;
+
+    // One-letter weekday initials, nested inside the cells themselves — the
+    // separate label row above the strip spent a full row on what a letter
+    // per node now carries. Dateless strips render no letters.
+    final letterFormat = DateFormat.EEEEE(locale);
+    final dayFormat = DateFormat.MMMEd(locale);
+
+    String outcomeOf(DayMark mark) => switch (mark.verdict) {
+      final verdict? => dayVerdictLabel(context, verdict),
+      null => dayMarkStateLabel(context, mark.state),
+    };
+
+    Widget cellAt(int index) {
+      if (placeholder) return PlaceholderDayCell(size: resolvedCellSize);
+      final mark = marks[index];
+      final day = mark.day;
+      final letter = day == null ? null : letterFormat.format(day);
+      if (onDaySelected == null || day == null) {
+        return DayMarkCell(
+          mark: mark,
+          size: resolvedCellSize,
+          weekdayLetter: letter,
+        );
+      }
+      final dayName = dayFormat.format(day);
+      // Colour and an inner dot are the only thing separating these cells,
+      // and neither reaches a screen reader. Each day therefore announces its
+      // own state, not just its date — the strip's summary gives a count and
+      // cannot say WHICH days went well, which is exactly what a reader needs
+      // once every cell is individually actionable.
+      final outcome = outcomeOf(mark);
+      return DayMarkCell(
+        mark: mark,
+        size: resolvedCellSize,
+        weekdayLetter: letter,
+        label: context.messages.goalProgressHabitDaySemantics(
+          dayName,
+          outcome,
+        ),
+        tooltipDay: dayName,
+        tooltipOutcome: outcome,
+        onTap: () => onDaySelected(day),
+      );
+    }
+
+    // On the page's shared seven-column track when it carries dates, so the
+    // whole-goal week lines up column-for-column with the habit squares and
+    // the metric bars below it. Three grids for one week meant a reader
+    // could not follow a Wednesday down the page.
+    //
+    // The pitch is narrower than the 48px touch floor — seven of those do not
+    // fit a phone card — so, exactly as the habit cells already do, the slot
+    // takes the full pitch horizontally and clears the floor vertically.
+    final row = !dated
+        ? Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (var index = 0; index < marks.length; index++) ...[
+                if (index > 0) SizedBox(width: tokens.spacing.step1),
+                cellAt(index),
+              ],
+            ],
+          )
+        : DayTrack(
+            height: onDaySelected == null
+                ? resolvedCellSize + tokens.spacing.step2
+                : TapTargets.minimum,
+            pitch: metrics.pitch,
+            children: [
+              for (var index = 0; index < marks.length; index++) cellAt(index),
+            ],
+          );
+
+    // A read-only strip publishes one summary rather than seven nodes, so any
+    // recorded verdicts have to reach it there — otherwise the list announces
+    // a measured day count while showing four verdict hues.
+    final verdictSummary = [
+      for (final mark in marks)
+        if (mark.verdict case final verdict?)
+          if (mark.day case final day?)
+            context.messages.goalProgressHabitDaySemantics(
+              dayFormat.format(day),
+              dayVerdictLabel(context, verdict),
+            ),
+    ].join(', ');
+
+    return Semantics(
+      label: placeholder
+          ? context.messages.goalProgressStripLoading
+          : [
+              // Counted with the verdicts applied. Taken from the measured
+              // states alone, the strip could announce "1 successful day"
+              // and name that same date as Missed in the next breath, while
+              // the cell itself correctly showed the verdict.
+              context.messages.goalProgressCompactSemantics(
+                marks.where((mark) => mark.successful).length,
+              ),
+              if (verdictSummary.isNotEmpty) verdictSummary,
+            ].join('. '),
+      // A tappable strip publishes each day as its own button, so the summary
+      // above becomes the container's label rather than the whole story.
+      // The scale-down FittedBox is the overflow bound: the track (and the
+      // dateless placeholder Row) size themselves to `pitch * days`, and on
+      // a 320px phone a list row's column is a few pixels narrower than
+      // seven full-size cells. Everywhere with room, the fit is identity.
+      // An extended span goes through the page's shared fit-or-scroll policy
+      // instead — by WIDTH, like every other track. Wrapping it by day count
+      // put a span that fits into a trailing-anchored scroller, which is what
+      // opened it with its first days cut off the left edge.
+      child: availableWidth != null
+          ? fitOrScrollDayTrack(
+              contentWidth: metrics.pitch * marks.length,
+              availableWidth: availableWidth,
+              group: scrollGroup,
+              child: row,
+            )
+          : onDaySelected == null
+          ? ExcludeSemantics(
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                alignment: AlignmentDirectional.centerStart,
+                child: row,
+              ),
+            )
+          : Align(
+              alignment: AlignmentDirectional.centerStart,
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                alignment: AlignmentDirectional.centerStart,
+                child: row,
+              ),
+            ),
+    );
+  }
+}

--- a/lib/widgets/day_indicators/day_mark_strip.dart
+++ b/lib/widgets/day_indicators/day_mark_strip.dart
@@ -197,7 +197,15 @@ class DayMarkStrip extends StatelessWidget {
       // opened it with its first days cut off the left edge.
       child: availableWidth != null
           ? fitOrScrollDayTrack(
-              contentWidth: metrics.pitch * marks.length,
+              // The dateless Row is not on the track: each cell carries its
+              // own step1 padding and the cells are separated by step1, so
+              // its width has to be measured from that geometry or a span
+              // that "fits" overflows the card by a gap per cell.
+              contentWidth: dated
+                  ? metrics.pitch * marks.length
+                  : marks.length *
+                            (resolvedCellSize + 2 * tokens.spacing.step1) +
+                        (marks.length - 1) * tokens.spacing.step1,
               availableWidth: availableWidth,
               group: scrollGroup,
               child: row,

--- a/lib/widgets/day_indicators/day_mark_strip.dart
+++ b/lib/widgets/day_indicators/day_mark_strip.dart
@@ -92,7 +92,7 @@ class DayMarkStrip extends StatelessWidget {
       final mark = marks[index];
       final day = mark.day;
       final letter = day == null ? null : letterFormat.format(day);
-      if (onDaySelected == null || day == null) {
+      if (day == null) {
         return DayMarkCell(
           mark: mark,
           size: resolvedCellSize,
@@ -100,12 +100,23 @@ class DayMarkStrip extends StatelessWidget {
         );
       }
       final dayName = dayFormat.format(day);
+      final outcome = outcomeOf(mark);
+      if (onDaySelected == null) {
+        // Read-only, but still dated: hover names the day and its outcome,
+        // because the corner letter cannot tell one Tuesday from the next.
+        return DayMarkCell(
+          mark: mark,
+          size: resolvedCellSize,
+          weekdayLetter: letter,
+          tooltipDay: dayName,
+          tooltipOutcome: outcome,
+        );
+      }
       // Colour and an inner dot are the only thing separating these cells,
       // and neither reaches a screen reader. Each day therefore announces its
       // own state, not just its date — the strip's summary gives a count and
       // cannot say WHICH days went well, which is exactly what a reader needs
       // once every cell is individually actionable.
-      final outcome = outcomeOf(mark);
       return DayMarkCell(
         mark: mark,
         size: resolvedCellSize,

--- a/lib/widgets/day_indicators/day_mark_styles.dart
+++ b/lib/widgets/day_indicators/day_mark_styles.dart
@@ -65,9 +65,14 @@ IconData? dayMarkStateGlyph(DayMarkState state) => switch (state) {
 };
 
 /// The ink a state glyph is drawn in, on top of that state's own fill.
+///
+/// The missed cross sits on the saturated error fill, so it takes the
+/// design system's on-alert ink — the family's own `ink` is tuned for a
+/// neutral surface and all but vanishes on its own hue. The skip dash sits
+/// on a neutral fill and keeps the medium-emphasis text ink.
 Color dayMarkStateGlyphInk(DsTokens tokens, DayMarkState state) =>
     switch (state) {
-      DayMarkState.missed => tokens.colors.alert.error.ink,
+      DayMarkState.missed => tokens.colors.text.onInteractiveAlert,
       DayMarkState.none ||
       DayMarkState.partial ||
       DayMarkState.full ||

--- a/lib/widgets/day_indicators/day_mark_styles.dart
+++ b/lib/widgets/day_indicators/day_mark_styles.dart
@@ -1,0 +1,239 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+
+/// The corner radius every day cell shares.
+///
+/// The whole-goal strip once drew its squares at `radii.xs` while the habit
+/// squares — the identical footprint, one card below — drew theirs at
+/// `radii.s`. Same instrument, same week, two shapes.
+double dayCellRadius(DsTokens tokens) => tokens.radii.s;
+
+/// Where the weekday initial sits inside a day cell, and how big it gets.
+///
+/// Deliberately NOT an extension on `DsTokens`. Hanging these off the token
+/// object put feature-specific geometry into the canonical token API, where
+/// every caller in the app would see `tokens.letterInsetStart` offered
+/// alongside real exported tokens — which is a bigger claim than "these
+/// three numbers live in one place" was ever meant to make.
+///
+/// Proportions of the cell rather than absolute lengths: the cell itself is
+/// sized by `dayTrackMetrics` from the available width, so a fixed inset that
+/// looked right on a fortnight track would crowd the corner on a ninety-day
+/// one. They are geometry, not spacing — there is no design-system token for
+/// "a fraction of a cell" — so they live here, named and in ONE place, rather
+/// than as bare numbers inside the widget.
+///
+/// [DayCellLetter.scaleBox] is a ceiling, not a size: the rendered letter is
+/// `min(fontSize, cellSize * scaleBox)`, because the glyph is fitted with
+/// [BoxFit.scaleDown] and that never scales UP. The box therefore governs
+/// small cells while the style's own size caps large ones.
+abstract final class DayCellLetter {
+  /// Inset from the cell's leading edge.
+  static const double insetStart = 0.18;
+
+  /// Inset from the cell's bottom edge.
+  static const double insetBottom = 0.14;
+
+  /// Ceiling on the letter's height, as a fraction of the cell.
+  static const double scaleBox = 0.38;
+}
+
+/// Shared fill for a measured day: the full-strength success hue when the
+/// requirement held as of that day, a lighter wash of the same hue for a
+/// partial success (routine kept, target still building), the error hue for a
+/// recorded miss, neutral for a skip or an empty day. `SurfaceAlphas.muted`
+/// is the sanctioned "reduced-strength accent" alpha, so no new color token
+/// is introduced. Data-that-happened wears the `alert` families; the
+/// interactive teal stays strictly for things the user can tap.
+Color dayMarkStateFill(DsTokens tokens, DayMarkState state) => switch (state) {
+  DayMarkState.full => tokens.colors.alert.success.defaultColor,
+  DayMarkState.partial => tokens.colors.alert.success.defaultColor.withValues(
+    alpha: SurfaceAlphas.muted,
+  ),
+  DayMarkState.missed => tokens.colors.alert.error.defaultColor,
+  DayMarkState.none || DayMarkState.skipped => tokens.colors.background.level03,
+};
+
+/// The non-color cue a recorded outcome carries: a cross for a miss, a dash
+/// for a skip. Null for the states whose cue is the fill (or the partial dot).
+IconData? dayMarkStateGlyph(DayMarkState state) => switch (state) {
+  DayMarkState.missed => LottiIcons.close,
+  DayMarkState.skipped => LottiIcons.remove,
+  DayMarkState.none || DayMarkState.partial || DayMarkState.full => null,
+};
+
+/// The ink a state glyph is drawn in, on top of that state's own fill.
+Color dayMarkStateGlyphInk(DsTokens tokens, DayMarkState state) =>
+    switch (state) {
+      DayMarkState.missed => tokens.colors.alert.error.ink,
+      DayMarkState.none ||
+      DayMarkState.partial ||
+      DayMarkState.full ||
+      DayMarkState.skipped => tokens.colors.text.mediumEmphasis,
+    };
+
+/// The localized name of a measured state, shared by every day cell's
+/// semantics and tooltip so a "done" day is called the same thing everywhere.
+String dayMarkStateLabel(BuildContext context, DayMarkState state) =>
+    switch (state) {
+      DayMarkState.full => context.messages.goalProgressDone,
+      DayMarkState.partial => context.messages.goalProgressPartial,
+      DayMarkState.none => context.messages.goalProgressHabitDayNoEntry,
+      DayMarkState.skipped => context.messages.completeHabitSkipButton,
+      DayMarkState.missed => context.messages.completeHabitFailButton,
+    };
+
+/// Hue for a day the user has actually judged, which outranks what the app
+/// measured: a reflection is a statement about the day, and the measurement is
+/// only evidence toward one.
+///
+/// Four distinct hues, all existing alert tokens, and the same three the
+/// reflections-history pill has always used — extended with the blue a
+/// restarting agent wears for [DayVerdict.improving], which is progress that
+/// is not yet arrival. Sharing one scheme is the point: the strip and the
+/// history are two views of the same verdict, and a day filed as missed must
+/// not be grey in one place and red in another.
+///
+/// Notably [DayVerdict.missed] is not the neutral grey a day with no data
+/// wears. Deciding a day was missed and never looking at it are different
+/// facts, and the strip has to be able to say which.
+Color dayVerdictFill(DsTokens tokens, DayVerdict verdict) => switch (verdict) {
+  DayVerdict.met => tokens.colors.alert.success.defaultColor,
+  DayVerdict.improving => tokens.colors.alert.info.defaultColor,
+  DayVerdict.mixed => tokens.colors.alert.warning.defaultColor,
+  DayVerdict.missed => tokens.colors.alert.error.defaultColor,
+};
+
+/// The ink a verdict glyph is drawn in, on top of that verdict's own fill.
+///
+/// One high-contrast ink for every verdict rather than each family's own:
+/// the families' inks are tuned to sit on a NEUTRAL surface, so a success ink
+/// on a success fill is green on green and the glyph all but disappears —
+/// which defeats the point of having a shape at all, since the shape exists
+/// for readers who cannot separate the hues. `onInteractiveAlert` is the
+/// design system's ink for exactly this: text over a saturated alert fill.
+Color dayVerdictInk(DsTokens tokens, DayVerdict verdict) =>
+    tokens.colors.text.onInteractiveAlert;
+
+/// The verdict's ink for a glyph drawn on an ordinary card surface.
+///
+/// Distinct from [dayVerdictInk], which is for a glyph sitting on that
+/// verdict's own saturated fill. Using the on-alert ink here paints
+/// near-background on background; using this one on a fill would be its own
+/// hue on itself.
+Color dayVerdictSurfaceInk(DsTokens tokens, DayVerdict verdict) =>
+    switch (verdict) {
+      DayVerdict.met => tokens.colors.alert.success.ink,
+      DayVerdict.improving => tokens.colors.alert.info.ink,
+      DayVerdict.mixed => tokens.colors.alert.warning.ink,
+      DayVerdict.missed => tokens.colors.alert.error.ink,
+    };
+
+/// The glyph that names a recorded verdict without relying on its hue.
+///
+/// Four fills that differ only by colour are four fills a red-green colour
+/// deficiency cannot tell apart, and the strip's whole job is to be read at a
+/// glance. Each verdict therefore carries a shape as well: a tick for met, a
+/// rising arrow for improving, a half-filled circle for mixed, a cross for
+/// missed.
+IconData dayVerdictGlyph(DayVerdict verdict) => switch (verdict) {
+  DayVerdict.met => LottiIcons.confirm,
+  DayVerdict.improving => LottiIcons.trendingUp,
+  DayVerdict.mixed => LottiIcons.contrast,
+  DayVerdict.missed => LottiIcons.close,
+};
+
+/// The localized name of a day verdict, shared by the strip's semantics and
+/// the reflection sheet's own toggle so the two can never drift apart.
+String dayVerdictLabel(BuildContext context, DayVerdict verdict) =>
+    switch (verdict) {
+      DayVerdict.met => context.messages.goalAssessmentMet,
+      DayVerdict.improving => context.messages.goalAssessmentImproving,
+      DayVerdict.mixed => context.messages.goalAssessmentMixed,
+      DayVerdict.missed => context.messages.goalAssessmentMissed,
+    };
+
+/// The weekday's one-letter initial, tucked into the bottom-left corner of
+/// its own day cell.
+///
+/// Replaces the separate label row that used to run above every track: one
+/// letter per node keeps the weekday axis without spending a full row on it.
+/// A quiet corner tag rather than a centered label. It yields entirely to
+/// the marks that outrank it — a verdict glyph, the partial dot, the missed
+/// cross — because at the compact cell size a corner letter and a center
+/// glyph collide; the rarer mark wins and neighbouring plain cells keep
+/// carrying the axis. Scaled down with the cell (never up past the
+/// `bodySmall` size), and null when the cell is too small to hold a legible
+/// letter — a squeezed ninety-day track drops the letters rather than
+/// painting mush.
+///
+/// Ink follows the fill so the letter stays readable on both states: the
+/// on-alert ink over a saturated fill, medium emphasis over the neutral and
+/// washed fills. Returns a [PositionedDirectional]; the cell hosts it in a
+/// [Stack].
+Widget? dayCellLetter(
+  DsTokens tokens, {
+  required String? letter,
+  required double cellSize,
+  required bool filled,
+}) {
+  if (letter == null || cellSize < IconSizes.l) return null;
+  return PositionedDirectional(
+    // Off the corner, not in it. The letter reads better with a little air
+    // under and behind it than pinned to the rounded rect's inner angle —
+    // but it stays an annotation, so it moves TOWARD the center rather than
+    // to it.
+    start: cellSize * DayCellLetter.insetStart,
+    bottom: cellSize * DayCellLetter.insetBottom,
+    child: SizedBox(
+      // The scale bound: the glyph shrinks into this box, so the letter
+      // stays a small corner annotation at every cell size instead of
+      // competing with the mark in the center. The effective size is
+      // `min(fontSize, this height)` — `scaleDown` never scales UP — so
+      // raising the letter one step means raising BOTH: the box governs the
+      // small cells, the style's own size caps the large ones.
+      height: cellSize * DayCellLetter.scaleBox,
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        child: Text(
+          letter,
+          maxLines: 1,
+          // One step up the type scale from caption (12 → 14), so a cell
+          // roomy enough to show the letter at full size shows it a step
+          // larger too.
+          style: tokens.typography.styles.body.bodySmall.copyWith(
+            color: filled
+                ? tokens.colors.text.onInteractiveAlert
+                : tokens.colors.text.mediumEmphasis,
+            height: 1,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+/// The ink the "today" ring is drawn in, on every surface that draws one —
+/// the habit day cells, the whole-goal strip and the legend swatch that keys
+/// them.
+///
+/// Medium emphasis rather than low: at `radii.xs` on a dark surface a
+/// hairline in the low-emphasis ink is a rumour, not a ring. It still has to
+/// stay quieter than a day's own fill, which is the thing the cell is
+/// actually reporting — so it lifts one step and takes the emphasis stroke,
+/// rather than becoming an accent.
+Color todayRingInk(DsTokens tokens) => tokens.colors.text.mediumEmphasis;
+
+/// The non-color cue for a partial day: a full-strength dot inside the
+/// lighter wash, so full/partial/none survive without a legend (the list
+/// rows carry none) and for color-blind readers.
+Widget partialDayDot(DsTokens tokens, double diameter) => Container(
+  width: diameter,
+  height: diameter,
+  decoration: BoxDecoration(
+    shape: BoxShape.circle,
+    color: tokens.colors.alert.success.ink,
+  ),
+);

--- a/lib/widgets/day_indicators/day_track.dart
+++ b/lib/widgets/day_indicators/day_track.dart
@@ -1,0 +1,221 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/widgets/misc/linked_scroll_group.dart';
+
+/// The geometry one day track draws on: the column pitch, the square inside
+/// each column, whether the weekday captions still fit at full length, and
+/// how tall a caption row has to be.
+///
+/// The caption height rides along so a caption track does not re-measure
+/// the same seven strings the pitch was already derived from.
+typedef DayTrackMetrics = ({
+  double pitch,
+  double cellSize,
+  bool narrowLabels,
+  double labelHeight,
+});
+
+/// The widest and tallest weekday caption a track will paint.
+///
+/// Measured over the SEVEN distinct weekday names, not over the track's days:
+/// a ninety-day span still draws only seven different strings, and laying out
+/// one TextPainter per day put ninety layouts in the middle of `build` to
+/// learn what seven already answer.
+({double width, double height}) _weekdayLabelMetrics(BuildContext context) {
+  final locale = Localizations.localeOf(context).toLanguageTag();
+  final style = context.designTokens.typography.styles.others.caption;
+  final format = DateFormat.E(locale);
+  // Any seven consecutive days cover every weekday exactly once.
+  final week = DateTime.utc(2024, 1, 8);
+  var width = 0.0;
+  var height = 0.0;
+  for (var offset = 0; offset < DateTime.daysPerWeek; offset++) {
+    final painter = TextPainter(
+      text: TextSpan(
+        text: format.format(week.add(Duration(days: offset))),
+        style: style,
+      ),
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+      maxLines: 1,
+    )..layout();
+    width = math.max(width, painter.width);
+    height = math.max(height, painter.height);
+  }
+  return (width: width, height: height);
+}
+
+/// The narrowest column a day is still legible in — a 12px square with a
+/// hairline of air either side. Below this a track scrolls instead of
+/// shrinking further.
+double _minimumDayPitch(DsTokens tokens) => IconSizes.xs + tokens.spacing.step2;
+
+/// The column pitch every day row on a page shares.
+///
+/// One pitch, one origin, one width: the whole-goal verdict strip, the habit
+/// squares and the metric bars all draw the SAME week, and drawn on three
+/// different grids the same Wednesday landed in three different places on one
+/// scroll. A reader cannot follow a day across the page unless the columns
+/// line up.
+///
+/// Wide enough for the weekday label at raised text scales, which is what
+/// makes the axis readable rather than merely aligned — and, when
+/// [availableWidth] is known, narrow enough that a span longer than a week
+/// still FITS. A fourteen-day track at the authored pitch is wider than a
+/// phone card, and the trailing-edge scroller that resulted opened with the
+/// first days of the span cut in half off the left edge.
+DayTrackMetrics dayTrackMetrics(
+  BuildContext context, {
+  required int dayCount,
+  double? availableWidth,
+}) {
+  final tokens = context.designTokens;
+  final defaultPitch = ControlSizes.iconChipCompact + tokens.spacing.step2;
+  final label = _weekdayLabelMetrics(context);
+  final labelWidth = label.width;
+  final expandedPitch = labelWidth + tokens.spacing.step1;
+  final textScaledUp = MediaQuery.textScalerOf(context).scale(1) > 1;
+  var pitch = textScaledUp && expandedPitch > defaultPitch
+      ? expandedPitch
+      : defaultPitch;
+  if (availableWidth != null && availableWidth > 0 && dayCount > 0) {
+    // Floored, so `pitch * days` can never round up past the width it was
+    // derived from and reintroduce a one-pixel scroller.
+    final fitted = (availableWidth / dayCount).floorToDouble();
+    if (fitted < pitch) {
+      pitch = math.max(fitted, _minimumDayPitch(tokens));
+    }
+  }
+  return (
+    pitch: pitch,
+    labelHeight: math.max(IconSizes.s, label.height),
+    // The square shrinks with its column, or neighbouring cells would touch
+    // and the track would read as one bar — but it never GROWS past the
+    // authored chip size: spreading the span means wider gutters between
+    // same-sized nodes, not inflated squares.
+    cellSize: math.min(
+      ControlSizes.iconChipCompact,
+      math.max(IconSizes.xs, pitch - tokens.spacing.step2),
+    ),
+    // "Mon" needs its own width; a SQUEEZED column takes the one-letter form
+    // rather than letting neighbouring captions overlap into mush. Only a
+    // squeezed one: at the authored pitch the captions are centered and
+    // overhang their cell into the gap by design, which is the established
+    // rendering and stays untouched.
+    narrowLabels: pitch < defaultPitch && pitch < labelWidth,
+  );
+}
+
+/// One horizontal scroller per extended day track, all linked through the
+/// page's [LinkedScrollGroup] and anchored at the TRAILING edge
+/// (`reverse: true`): a span longer than the viewport opens with TODAY on
+/// screen, dragging any track moves every track, and because reversed
+/// offsets measure from the trailing edge, the same date stays vertically
+/// aligned across cards even where extents differ.
+class LinkedDayTrackScroller extends StatefulWidget {
+  const LinkedDayTrackScroller({required this.child, this.group, super.key});
+
+  final LinkedScrollGroup? group;
+  final Widget child;
+
+  @override
+  State<LinkedDayTrackScroller> createState() => _LinkedDayTrackScrollerState();
+}
+
+class _LinkedDayTrackScrollerState extends State<LinkedDayTrackScroller> {
+  ScrollController? _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = widget.group?.attach();
+  }
+
+  @override
+  void didUpdateWidget(covariant LinkedDayTrackScroller oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.group, widget.group)) {
+      final old = _controller;
+      if (old != null) oldWidget.group?.detach(old);
+      _controller = widget.group?.attach();
+    }
+  }
+
+  @override
+  void dispose() {
+    final controller = _controller;
+    if (controller != null) widget.group?.detach(controller);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => SingleChildScrollView(
+    scrollDirection: Axis.horizontal,
+    reverse: true,
+    controller: _controller,
+    child: widget.child,
+  );
+}
+
+/// A day track, panning only where it genuinely cannot fit.
+///
+/// ONE policy for every track — the whole-goal strip, the habit squares and
+/// the metric bars. They each used to decide for themselves, and the strip
+/// decided by day COUNT, so it wrapped a span that provably fitted in a
+/// trailing-anchored scroller and opened it with the first days cut off.
+Widget fitOrScrollDayTrack({
+  required double contentWidth,
+  required double availableWidth,
+  required LinkedScrollGroup? group,
+  required Widget child,
+}) {
+  if (contentWidth <= availableWidth) return child;
+  // Trailing-anchored, and joined to the page's group: a span wider than the
+  // viewport opens with today on screen, and every track pans together so the
+  // same date stays aligned down the page.
+  return LinkedDayTrackScroller(group: group, child: child);
+}
+
+/// One row of day slots on a shared column grid: every child is centered in
+/// a slot exactly [pitch] wide, so tracks stacked on one page line up
+/// column-for-column regardless of what each slot draws.
+class DayTrack extends StatelessWidget {
+  const DayTrack({
+    required this.height,
+    required this.pitch,
+    required this.children,
+    super.key,
+  });
+
+  final double height;
+  final double pitch;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    if (children.isEmpty) return const SizedBox.shrink();
+    // Slots span the full pitch, so adjacent hit regions touch without
+    // overlapping — each editable cell gets the widest tap area the
+    // authored density allows, and labels stay centered over their cells.
+    final width = pitch * children.length;
+    return SizedBox(
+      width: width,
+      height: height,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          for (var index = 0; index < children.length; index++)
+            Positioned(
+              left: pitch * index,
+              width: pitch,
+              height: height,
+              child: Center(child: children[index]),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/goals/logic/goal_day_verdict_test.dart
+++ b/test/features/goals/logic/goal_day_verdict_test.dart
@@ -2,8 +2,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/goal_enums.dart';
 import 'package:lotti/features/goals/logic/goal_day_verdict.dart';
-import 'package:lotti/features/goals/model/goal_assessment.dart';
 import 'package:lotti/features/goals/state/goal_progress_view.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
 
 void main() {
   final today = DateTime.utc(2026, 8, 11);
@@ -45,7 +45,7 @@ void main() {
         ],
       );
 
-      expect(suggestedDayVerdict(progress, today), GoalAssessmentRating.met);
+      expect(suggestedDayVerdict(progress, today), DayVerdict.met);
     });
 
     test('logged everything and met nothing suggests Missed', () {
@@ -61,7 +61,7 @@ void main() {
 
       // The steps day IS observed — the user logged and fell short. That is a
       // real Missed, unlike a day nobody recorded.
-      expect(suggestedDayVerdict(progress, today), GoalAssessmentRating.missed);
+      expect(suggestedDayVerdict(progress, today), DayVerdict.missed);
     });
 
     test('a day with no observations at all suggests nothing', () {
@@ -103,11 +103,11 @@ void main() {
       // Missed could not express.
       expect(
         suggestedDayVerdict(progressWith(betterThanYesterday: true), today),
-        GoalAssessmentRating.improving,
+        DayVerdict.improving,
       );
       expect(
         suggestedDayVerdict(progressWith(betterThanYesterday: false), today),
-        GoalAssessmentRating.mixed,
+        DayVerdict.mixed,
       );
     });
 
@@ -134,7 +134,7 @@ void main() {
       // A logged failure carries no value, so checking `hasValue` alone read
       // a day the user explicitly marked as missed as a day they never
       // opened — and the sheet then fell back to suggesting Met.
-      expect(suggestedDayVerdict(progress, today), GoalAssessmentRating.missed);
+      expect(suggestedDayVerdict(progress, today), DayVerdict.missed);
     });
 
     test('improving needs a day to have improved on', () {
@@ -152,7 +152,7 @@ void main() {
       // is missing data, not a worse day, so calling today an improvement on
       // it would invent the baseline — and then record that invention as a
       // suggestion the user accepted.
-      expect(suggestedDayVerdict(progress, today), GoalAssessmentRating.mixed);
+      expect(suggestedDayVerdict(progress, today), DayVerdict.mixed);
     });
 
     test('a goal with nothing tracked suggests nothing', () {
@@ -175,7 +175,7 @@ void main() {
         ],
       );
 
-      expect(suggestedDayVerdict(progress, today), GoalAssessmentRating.met);
+      expect(suggestedDayVerdict(progress, today), DayVerdict.met);
     });
   });
 

--- a/test/features/goals/logic/goal_timeline_projection_test.dart
+++ b/test/features/goals/logic/goal_timeline_projection_test.dart
@@ -5,6 +5,7 @@ import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/goals/logic/goal_timeline_projection.dart';
 import 'package:lotti/features/goals/model/goal_assessment.dart';
 import 'package:lotti/features/goals/model/goal_timeline_item.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
 
 void main() {
   final day = DateTime(2026, 8, 18);
@@ -40,14 +41,14 @@ void main() {
     DateTime recordedDay, {
     required DateTime createdAt,
     String specVersionId = 'spec-1',
-    GoalAssessmentRating rating = GoalAssessmentRating.mixed,
+    DayVerdict rating = DayVerdict.mixed,
   }) => GoalAssessmentRecord(
     id: id,
     day: recordedDay,
     specVersionId: specVersionId,
     rating: rating,
     createdAt: createdAt,
-    provenance: GoalAssessmentProvenance.ratedByUser,
+    provenance: DayVerdictProvenance.ratedByUser,
   );
 
   group('goalTimelineItems', () {
@@ -87,7 +88,7 @@ void main() {
             'later',
             DateTime.utc(2026, 8, 17),
             createdAt: day.add(const Duration(hours: 21)),
-            rating: GoalAssessmentRating.met,
+            rating: DayVerdict.met,
           ),
         ],
         specVersionId: 'spec-1',

--- a/test/features/goals/service/goal_assessment_service_test.dart
+++ b/test/features/goals/service/goal_assessment_service_test.dart
@@ -1,8 +1,8 @@
 import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
-import 'package:lotti/features/goals/model/goal_assessment.dart';
 import 'package:lotti/features/goals/service/goal_assessment_service.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
@@ -30,13 +30,13 @@ void main() {
           agentId: 'goal-1',
           day: DateTime.utc(2026, 8, 11),
           specVersionId: 'goal-1:spec-v4',
-          rating: GoalAssessmentRating.mixed,
+          rating: DayVerdict.mixed,
           dimensionRatings: const {
-            'reading': GoalAssessmentRating.met,
-            'sleep': GoalAssessmentRating.missed,
+            'reading': DayVerdict.met,
+            'sleep': DayVerdict.missed,
           },
           note: 'Good reading, short sleep.',
-          provenance: GoalAssessmentProvenance.suggestedAndAccepted,
+          provenance: DayVerdictProvenance.suggestedAndAccepted,
           suggestedBy: 'Juno',
         ),
       );
@@ -83,10 +83,10 @@ void main() {
           agentId: 'goal-1',
           day: DateTime.utc(2026, 8, 11),
           specVersionId: 'goal-1:spec-v4',
-          rating: GoalAssessmentRating.improving,
+          rating: DayVerdict.improving,
           dimensionRatings: const {
-            'reading': GoalAssessmentRating.improving,
-            'sleep': GoalAssessmentRating.met,
+            'reading': DayVerdict.improving,
+            'sleep': DayVerdict.met,
           },
           note: 'Short sleep but trending up.',
         ),
@@ -127,8 +127,8 @@ void main() {
         agentId: 'goal-1',
         day: DateTime.utc(2026, 8, 11),
         specVersionId: 'goal-1:spec-v4',
-        rating: GoalAssessmentRating.met,
-        dimensionRatings: const {'reading': GoalAssessmentRating.met},
+        rating: DayVerdict.met,
+        dimensionRatings: const {'reading': DayVerdict.met},
       ),
     );
 

--- a/test/features/goals/state/goal_assessment_state_test.dart
+++ b/test/features/goals/state/goal_assessment_state_test.dart
@@ -8,6 +8,7 @@ import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/goals/model/goal_assessment.dart';
 import 'package:lotti/features/goals/service/goal_assessment_service.dart';
 import 'package:lotti/features/goals/state/goal_assessment_state.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
@@ -85,7 +86,7 @@ void main() {
       );
 
       expect(records.map((record) => record.id), ['newer', 'older']);
-      expect(records.first.rating, GoalAssessmentRating.met);
+      expect(records.first.rating, DayVerdict.met);
       verify(() => repository.getEntitiesByIds(any())).called(1);
       verifyNever(() => repository.getEntity(any()));
     },
@@ -163,13 +164,13 @@ void main() {
       // older device would show the day as never reflected on at all. Reading
       // it as the honest middle keeps the reflection and its note.
       expect(records, hasLength(1));
-      expect(records.single.rating, GoalAssessmentRating.mixed);
+      expect(records.single.rating, DayVerdict.mixed);
       expect(records.single.note, 'Felt strong today');
       // Per-dimension verdicts degrade the same way, and a non-string value
       // is dropped as corruption rather than guessed at.
       expect(records.single.dimensionRatings, {
-        'habit-gym': GoalAssessmentRating.met,
-        'health-weight': GoalAssessmentRating.mixed,
+        'habit-gym': DayVerdict.met,
+        'health-weight': DayVerdict.mixed,
       });
     },
   );
@@ -192,7 +193,7 @@ void main() {
     GoalAssessmentRecord record({
       required String id,
       required DateTime day,
-      required GoalAssessmentRating rating,
+      required DayVerdict rating,
       required DateTime createdAt,
     }) => GoalAssessmentRecord(
       id: id,
@@ -200,7 +201,7 @@ void main() {
       specVersionId: 'spec-1',
       rating: rating,
       createdAt: createdAt,
-      provenance: GoalAssessmentProvenance.ratedByUser,
+      provenance: DayVerdictProvenance.ratedByUser,
     );
 
     test('the most recent record decides the day', () {
@@ -209,19 +210,19 @@ void main() {
         record(
           id: 'first',
           day: day,
-          rating: GoalAssessmentRating.missed,
+          rating: DayVerdict.missed,
           createdAt: DateTime.utc(2026, 8, 10, 9),
         ),
         // The user reflected, then thought better of it. The revision stands.
         record(
           id: 'revised',
           day: day,
-          rating: GoalAssessmentRating.improving,
+          rating: DayVerdict.improving,
           createdAt: DateTime.utc(2026, 8, 10, 21),
         ),
       ]);
 
-      expect(ratings, {day: GoalAssessmentRating.improving});
+      expect(ratings, {day: DayVerdict.improving});
     });
 
     test('records written in the same instant resolve the same way twice', () {
@@ -230,21 +231,21 @@ void main() {
       final a = record(
         id: 'aaa',
         day: day,
-        rating: GoalAssessmentRating.met,
+        rating: DayVerdict.met,
         createdAt: at,
       );
       final b = record(
         id: 'bbb',
         day: day,
-        rating: GoalAssessmentRating.missed,
+        rating: DayVerdict.missed,
         createdAt: at,
       );
 
       // The query orders by timestamp alone, so tied rows arrive in no
       // defined order. Without a stable tie-break two devices colour the same
       // day differently from identical data.
-      expect(latestRatingsByDay([a, b]), {day: GoalAssessmentRating.missed});
-      expect(latestRatingsByDay([b, a]), {day: GoalAssessmentRating.missed});
+      expect(latestRatingsByDay([a, b]), {day: DayVerdict.missed});
+      expect(latestRatingsByDay([b, a]), {day: DayVerdict.missed});
     });
 
     test('a local timestamp still keys by its UTC calendar day', () {
@@ -252,7 +253,7 @@ void main() {
         record(
           id: 'a',
           day: DateTime.utc(2026, 8, 10, 23, 30),
-          rating: GoalAssessmentRating.met,
+          rating: DayVerdict.met,
           createdAt: DateTime.utc(2026, 8, 11),
         ),
       ]);
@@ -267,20 +268,20 @@ void main() {
         record(
           id: 'a',
           day: DateTime.utc(2026, 8, 9),
-          rating: GoalAssessmentRating.met,
+          rating: DayVerdict.met,
           createdAt: DateTime.utc(2026, 8, 9),
         ),
         record(
           id: 'b',
           day: DateTime.utc(2026, 8, 10),
-          rating: GoalAssessmentRating.mixed,
+          rating: DayVerdict.mixed,
           createdAt: DateTime.utc(2026, 8, 10),
         ),
       ]);
 
       expect(ratings, {
-        DateTime.utc(2026, 8, 9): GoalAssessmentRating.met,
-        DateTime.utc(2026, 8, 10): GoalAssessmentRating.mixed,
+        DateTime.utc(2026, 8, 9): DayVerdict.met,
+        DateTime.utc(2026, 8, 10): DayVerdict.mixed,
       });
     });
 
@@ -294,16 +295,16 @@ void main() {
         record(
           id: 'old-spec',
           day: day,
-          rating: GoalAssessmentRating.met,
+          rating: DayVerdict.met,
           createdAt: DateTime.utc(2026, 8, 10, 21),
         ),
         GoalAssessmentRecord(
           id: 'current-spec',
           day: day,
           specVersionId: 'spec-2',
-          rating: GoalAssessmentRating.missed,
+          rating: DayVerdict.missed,
           createdAt: DateTime.utc(2026, 8, 10, 9),
-          provenance: GoalAssessmentProvenance.ratedByUser,
+          provenance: DayVerdictProvenance.ratedByUser,
         ),
       ];
 
@@ -312,14 +313,14 @@ void main() {
       // criteria it never judged.
       expect(
         latestRatingsByDay(records, specVersionId: 'spec-2'),
-        {day: GoalAssessmentRating.missed},
+        {day: DayVerdict.missed},
       );
       expect(
         latestRatingsByDay(records, specVersionId: 'spec-1'),
-        {day: GoalAssessmentRating.met},
+        {day: DayVerdict.met},
       );
       // Unscoped still means "whatever was written last".
-      expect(latestRatingsByDay(records), {day: GoalAssessmentRating.met});
+      expect(latestRatingsByDay(records), {day: DayVerdict.met});
     });
 
     test('the standing record is available whole, not just its rating', () {
@@ -330,13 +331,13 @@ void main() {
         record(
           id: 'r',
           day: day,
-          rating: GoalAssessmentRating.improving,
+          rating: DayVerdict.improving,
           createdAt: DateTime.utc(2026, 8, 10),
         ),
       ])[day];
 
       expect(standing?.id, 'r');
-      expect(standing?.rating, GoalAssessmentRating.improving);
+      expect(standing?.rating, DayVerdict.improving);
     });
   });
 }

--- a/test/features/goals/state/goal_progress_view_test.dart
+++ b/test/features/goals/state/goal_progress_view_test.dart
@@ -12,6 +12,7 @@ import 'package:lotti/features/goals/state/goal_agent_providers.dart';
 import 'package:lotti/features/goals/state/goal_measurable_capture_state.dart';
 import 'package:lotti/features/goals/state/goal_progress_view.dart';
 import 'package:lotti/providers/service_providers.dart' show journalDbProvider;
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
@@ -199,15 +200,15 @@ void main() {
     expect(habit.oldestSuccessAgesOutTonight, isFalse);
     expect(habit.successfulWeeks, 2);
     expect(view.compactWindow, [
-      GoalCompactDayState.full,
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
-      GoalCompactDayState.full,
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
+      DayMarkState.full,
+      DayMarkState.none,
+      DayMarkState.none,
+      DayMarkState.full,
+      DayMarkState.none,
+      DayMarkState.none,
       // Completed today, but only three of four successes in the window:
       // a partial success, not a full one.
-      GoalCompactDayState.partial,
+      DayMarkState.partial,
     ]);
   });
 
@@ -279,13 +280,13 @@ void main() {
     // average of the observed days clears 8,000 — a strip cell is a
     // statement about that day's own number.
     expect(view.compactWindow, [
-      GoalCompactDayState.full,
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
-      GoalCompactDayState.full,
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
+      DayMarkState.full,
+      DayMarkState.none,
+      DayMarkState.none,
+      DayMarkState.none,
+      DayMarkState.full,
+      DayMarkState.none,
+      DayMarkState.none,
     ]);
   });
 
@@ -310,10 +311,10 @@ void main() {
     expect(view.metric?.direction, GoalDirection.atMost);
     expect(
       view.compactWindow.take(5),
-      everyElement(GoalCompactDayState.none),
+      everyElement(DayMarkState.none),
     );
-    expect(view.compactWindow.last, GoalCompactDayState.none);
-    expect(view.compactWindow[5], GoalCompactDayState.none);
+    expect(view.compactWindow.last, DayMarkState.none);
+    expect(view.compactWindow[5], DayMarkState.none);
   });
 
   test('a health metric with a bounded improving trend is on track', () {
@@ -406,13 +407,13 @@ void main() {
     expect(
       view.compactWindow,
       [
-        GoalCompactDayState.full,
-        GoalCompactDayState.full,
-        GoalCompactDayState.full,
-        GoalCompactDayState.full,
-        GoalCompactDayState.full,
-        GoalCompactDayState.none,
-        GoalCompactDayState.none,
+        DayMarkState.full,
+        DayMarkState.full,
+        DayMarkState.full,
+        DayMarkState.full,
+        DayMarkState.full,
+        DayMarkState.none,
+        DayMarkState.none,
       ],
       reason: 'a late session keeps the rolling at-most-zero window failed',
     );
@@ -507,19 +508,19 @@ void main() {
 
     expect(sum.metric?.aggregation, GoalAggregation.sum);
     expect(sum.compactWindow, [
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
-      GoalCompactDayState.full,
+      DayMarkState.none,
+      DayMarkState.none,
+      DayMarkState.none,
+      DayMarkState.none,
+      DayMarkState.full,
     ]);
     expect(count.metric?.aggregation, GoalAggregation.count);
     expect(count.compactWindow, [
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
-      GoalCompactDayState.full,
+      DayMarkState.none,
+      DayMarkState.none,
+      DayMarkState.none,
+      DayMarkState.none,
+      DayMarkState.full,
     ]);
   });
 
@@ -587,7 +588,7 @@ void main() {
 
     expect(dayView.metric?.days, hasLength(1));
     expect(dayView.metric?.window, const GoalWindow.day());
-    expect(dayView.compactWindow, [GoalCompactDayState.full]);
+    expect(dayView.compactWindow, [DayMarkState.full]);
     expect(monthView.metric?.days, hasLength(11));
     expect(monthView.metric?.days.first.day, DateTime.utc(2026, 8));
     expect(monthView.metric?.days.last.day, today);
@@ -628,13 +629,13 @@ void main() {
     );
 
     expect(view.compactWindow, [
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
-      GoalCompactDayState.full,
+      DayMarkState.none,
+      DayMarkState.none,
+      DayMarkState.none,
+      DayMarkState.none,
+      DayMarkState.none,
+      DayMarkState.none,
+      DayMarkState.full,
     ]);
   });
 
@@ -693,8 +694,8 @@ void main() {
     expect(view.metrics.last.days.last.value, 81);
     // Completed via the habit leaf while no leaf's window target held yet:
     // the accomplishment shows as a partial success.
-    expect(view.compactWindow[5], GoalCompactDayState.partial);
-    expect(view.compactWindow.last, GoalCompactDayState.full);
+    expect(view.compactWindow[5], DayMarkState.partial);
+    expect(view.compactWindow.last, DayMarkState.full);
   });
 
   test('composite strip rewards a fully completed day independently of the '
@@ -726,8 +727,8 @@ void main() {
       reference: today,
     );
 
-    expect(view.compactWindow[5], GoalCompactDayState.partial);
-    expect(view.compactWindow.last, GoalCompactDayState.none);
+    expect(view.compactWindow[5], DayMarkState.partial);
+    expect(view.compactWindow.last, DayMarkState.none);
   });
 
   test('composite strip stays green when the rolling quota is met', () {
@@ -758,7 +759,7 @@ void main() {
       reference: today,
     );
 
-    expect(view.compactWindow.last, GoalCompactDayState.full);
+    expect(view.compactWindow.last, DayMarkState.full);
   });
 
   test('composite progress preserves every metric leaf', () {
@@ -830,8 +831,8 @@ void main() {
       reference: today,
     );
 
-    expect(view.compactWindow[5], GoalCompactDayState.none);
-    expect(view.compactWindow.last, GoalCompactDayState.full);
+    expect(view.compactWindow[5], DayMarkState.none);
+    expect(view.compactWindow.last, DayMarkState.full);
   });
 
   test('habit days carry the as-of-day window verdict so completed days can '

--- a/test/features/goals/ui/checkins/goal_checkin_timeline_test.dart
+++ b/test/features/goals/ui/checkins/goal_checkin_timeline_test.dart
@@ -13,6 +13,7 @@ import 'package:lotti/features/goals/model/goal_timeline_item.dart';
 import 'package:lotti/features/goals/state/goal_checkin_providers.dart';
 import 'package:lotti/features/goals/ui/checkins/goal_checkin_timeline.dart';
 import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
 import 'package:lotti/widgets/timeline/timeline_view.dart';
 
 import '../../../../widget_test_utils.dart';
@@ -307,14 +308,14 @@ void main() {
             id: 'r1',
             day: day,
             specVersionId: 'spec-1',
-            rating: GoalAssessmentRating.mixed,
+            rating: DayVerdict.mixed,
             createdAt: today,
             note: 'Cutoff held, but the evening was scattered.',
             dimensionRatings: const {
-              'a': GoalAssessmentRating.met,
-              'b': GoalAssessmentRating.missed,
+              'a': DayVerdict.met,
+              'b': DayVerdict.missed,
             },
-            provenance: GoalAssessmentProvenance.ratedByUser,
+            provenance: DayVerdictProvenance.ratedByUser,
           ),
         ),
       ],
@@ -489,11 +490,11 @@ void main() {
           id: 'r1',
           day: DateTime.utc(today.year, today.month, today.day),
           specVersionId: 'spec-1',
-          rating: GoalAssessmentRating.met,
+          rating: DayVerdict.met,
           createdAt: today,
           // ignore: avoid_redundant_argument_values
           dimensionRatings: const {},
-          provenance: GoalAssessmentProvenance.ratedByUser,
+          provenance: DayVerdictProvenance.ratedByUser,
         ),
       ),
     ]);

--- a/test/features/goals/ui/goal_assessment_widgets_test.dart
+++ b/test/features/goals/ui/goal_assessment_widgets_test.dart
@@ -10,6 +10,7 @@ import 'package:lotti/features/goals/service/goal_assessment_service.dart';
 import 'package:lotti/features/goals/state/goal_assessment_state.dart';
 import 'package:lotti/features/goals/state/goal_progress_view.dart';
 import 'package:lotti/features/goals/ui/goal_assessment_widgets.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../widget_test_utils.dart';
@@ -19,8 +20,8 @@ class _MockGoalAssessmentService extends Mock
 
 void main() {
   setUpAll(() {
-    registerFallbackValue(GoalAssessmentRating.met);
-    registerFallbackValue(GoalAssessmentProvenance.ratedByUser);
+    registerFallbackValue(DayVerdict.met);
+    registerFallbackValue(DayVerdictProvenance.ratedByUser);
     registerFallbackValue(DateTime(2026));
   });
 
@@ -130,7 +131,7 @@ void main() {
     // above it already owns.
     expect(find.text('Steps · 7-day average'), findsOneWidget);
     expect(
-      find.byType(DsSegmentedToggle<GoalAssessmentRating>),
+      find.byType(DsSegmentedToggle<DayVerdict>),
       // The day's own verdict plus exactly one per-dimension control.
       findsNWidgets(2),
     );
@@ -182,7 +183,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final label = find.text('Measure Blood Pressure 🫀').last;
-    final toggle = find.byType(DsSegmentedToggle<GoalAssessmentRating>).last;
+    final toggle = find.byType(DsSegmentedToggle<DayVerdict>).last;
     final labelRect = tester.getRect(label);
     final toggleRect = tester.getRect(toggle);
 
@@ -208,7 +209,7 @@ void main() {
         agentId: 'goal-1',
         day: day,
         specVersionId: 'goal-1:spec-v1',
-        rating: GoalAssessmentRating.met,
+        rating: DayVerdict.met,
         dimensionRatings: const {},
         note: 'Felt manageable',
       ),
@@ -251,7 +252,7 @@ void main() {
         agentId: 'goal-1',
         day: day,
         specVersionId: 'goal-1:spec-v1',
-        rating: GoalAssessmentRating.met,
+        rating: DayVerdict.met,
         dimensionRatings: const {},
         note: 'Felt manageable',
       ),
@@ -267,9 +268,9 @@ void main() {
           agentId: 'goal-1',
           day: day,
           specVersionId: 'goal-1:spec-v2',
-          rating: GoalAssessmentRating.mixed,
+          rating: DayVerdict.mixed,
           dimensionRatings: const {
-            'walk': GoalAssessmentRating.missed,
+            'walk': DayVerdict.missed,
           },
           note: 'Hard weather',
         ),
@@ -345,19 +346,19 @@ void main() {
       expect(find.byIcon(LottiIcons.radioUnselected), findsOneWidget);
 
       tester
-          .widget<DsSegmentedToggle<GoalAssessmentRating>>(
-            find.byType(DsSegmentedToggle<GoalAssessmentRating>).first,
+          .widget<DsSegmentedToggle<DayVerdict>>(
+            find.byType(DsSegmentedToggle<DayVerdict>).first,
           )
-          .onChanged(GoalAssessmentRating.mixed);
+          .onChanged(DayVerdict.mixed);
       await tester.pump();
       await tester.tap(find.text('Rate individual dimensions (optional)'));
       await tester.pumpAndSettle();
       final toggles = tester
-          .widgetList<DsSegmentedToggle<GoalAssessmentRating>>(
-            find.byType(DsSegmentedToggle<GoalAssessmentRating>),
+          .widgetList<DsSegmentedToggle<DayVerdict>>(
+            find.byType(DsSegmentedToggle<DayVerdict>),
           )
           .toList();
-      toggles[1].onChanged(GoalAssessmentRating.missed);
+      toggles[1].onChanged(DayVerdict.missed);
       await tester.enterText(find.byType(EditableText), '  Hard weather  ');
       final recordButton = find.widgetWithText(
         DesignSystemButton,
@@ -372,9 +373,9 @@ void main() {
           agentId: 'goal-1',
           day: day,
           specVersionId: 'goal-1:spec-v2',
-          rating: GoalAssessmentRating.mixed,
+          rating: DayVerdict.mixed,
           dimensionRatings: const {
-            'walk': GoalAssessmentRating.missed,
+            'walk': DayVerdict.missed,
           },
           note: 'Hard weather',
         ),
@@ -406,10 +407,10 @@ void main() {
               id: 'record-1',
               day: day,
               specVersionId: 'goal-1:spec-v1',
-              rating: GoalAssessmentRating.missed,
+              rating: DayVerdict.missed,
               note: 'Travelled all day.',
               createdAt: DateTime.utc(2026, 8, 11, 21),
-              provenance: GoalAssessmentProvenance.ratedByUser,
+              provenance: DayVerdictProvenance.ratedByUser,
             ),
           ),
         ),
@@ -427,10 +428,10 @@ void main() {
       tester.widget<EditableText>(find.byType(EditableText)).controller.text,
       'Travelled all day.',
     );
-    final toggle = tester.widget<DsSegmentedToggle<GoalAssessmentRating>>(
-      find.byType(DsSegmentedToggle<GoalAssessmentRating>).first,
+    final toggle = tester.widget<DsSegmentedToggle<DayVerdict>>(
+      find.byType(DsSegmentedToggle<DayVerdict>).first,
     );
-    expect(toggle.selected, GoalAssessmentRating.missed);
+    expect(toggle.selected, DayVerdict.missed);
   });
 
   testWidgets('a day with no reflection yet still opens on Met', (
@@ -456,10 +457,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    final toggle = tester.widget<DsSegmentedToggle<GoalAssessmentRating>>(
-      find.byType(DsSegmentedToggle<GoalAssessmentRating>).first,
+    final toggle = tester.widget<DsSegmentedToggle<DayVerdict>>(
+      find.byType(DsSegmentedToggle<DayVerdict>).first,
     );
-    expect(toggle.selected, GoalAssessmentRating.met);
+    expect(toggle.selected, DayVerdict.met);
     expect(
       tester.widget<EditableText>(find.byType(EditableText)).controller.text,
       isEmpty,
@@ -552,10 +553,10 @@ void main() {
 
     // Everything was logged and nothing met its target. Opening on Met — as
     // it always did — contradicted the numbers printed directly above.
-    final toggle = tester.widget<DsSegmentedToggle<GoalAssessmentRating>>(
-      find.byType(DsSegmentedToggle<GoalAssessmentRating>).first,
+    final toggle = tester.widget<DsSegmentedToggle<DayVerdict>>(
+      find.byType(DsSegmentedToggle<DayVerdict>).first,
     );
-    expect(toggle.selected, GoalAssessmentRating.missed);
+    expect(toggle.selected, DayVerdict.missed);
     expect(
       find.text(
         'Suggested from what was measured — change it if you disagree.',
@@ -578,11 +579,11 @@ void main() {
         agentId: 'goal-1',
         day: day,
         specVersionId: 'goal-1:spec-v1',
-        rating: GoalAssessmentRating.missed,
+        rating: DayVerdict.missed,
         dimensionRatings: any(named: 'dimensionRatings'),
         // ignore: avoid_redundant_argument_values
         note: null,
-        provenance: GoalAssessmentProvenance.suggestedAndAccepted,
+        provenance: DayVerdictProvenance.suggestedAndAccepted,
       ),
     ).called(1);
   });
@@ -673,10 +674,10 @@ void main() {
     // choice as "suggested and accepted" credits the agent for the user's
     // own call.
     tester
-        .widget<DsSegmentedToggle<GoalAssessmentRating>>(
-          find.byType(DsSegmentedToggle<GoalAssessmentRating>).first,
+        .widget<DsSegmentedToggle<DayVerdict>>(
+          find.byType(DsSegmentedToggle<DayVerdict>).first,
         )
-        .onChanged(GoalAssessmentRating.missed);
+        .onChanged(DayVerdict.missed);
     await tester.pumpAndSettle();
     expect(
       find.text(

--- a/test/features/goals/ui/goal_day_marks_test.dart
+++ b/test/features/goals/ui/goal_day_marks_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/goals/ui/goal_day_marks.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+
+void main() {
+  final today = DateTime.utc(2026, 8, 11);
+
+  test('dates count back from the last day, which is today', () {
+    final marks = goalDayMarks(
+      states: const [
+        DayMarkState.none,
+        DayMarkState.partial,
+        DayMarkState.full,
+      ],
+      lastDay: today,
+    );
+    expect(marks.map((m) => m.day), [
+      DateTime.utc(2026, 8, 9),
+      DateTime.utc(2026, 8, 10),
+      today,
+    ]);
+    expect(marks.map((m) => m.state), [
+      DayMarkState.none,
+      DayMarkState.partial,
+      DayMarkState.full,
+    ]);
+    expect(marks.map((m) => m.isToday), [false, false, true]);
+  });
+
+  test('verdicts line up by UTC day even when the last day is local', () {
+    final localLastDay = DateTime(2026, 8, 11, 23, 30);
+    final marks = goalDayMarks(
+      states: List.filled(3, DayMarkState.none),
+      lastDay: localLastDay,
+      verdictsByDay: {
+        DateTime.utc(2026, 8, 10): DayVerdict.missed,
+        today: DayVerdict.met,
+      },
+    );
+    expect(marks.map((m) => m.verdict), [
+      null,
+      DayVerdict.missed,
+      DayVerdict.met,
+    ]);
+    expect(marks.map((m) => m.successful), [false, false, true]);
+  });
+
+  test('without a last day the marks are undated and carry no verdicts', () {
+    final marks = goalDayMarks(
+      states: const [DayMarkState.full, DayMarkState.none],
+      verdictsByDay: {today: DayVerdict.missed},
+    );
+    expect(marks.every((m) => m.day == null), isTrue);
+    expect(marks.every((m) => m.verdict == null), isTrue);
+    expect(marks.last.isToday, isTrue);
+  });
+
+  test('an empty window yields no marks', () {
+    expect(goalDayMarks(states: const [], lastDay: today), isEmpty);
+  });
+}

--- a/test/features/goals/ui/goal_progress_card_test.dart
+++ b/test/features/goals/ui/goal_progress_card_test.dart
@@ -22,11 +22,13 @@ import 'package:lotti/features/design_system/components/context_menus/design_sys
 import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
-import 'package:lotti/features/goals/model/goal_assessment.dart';
 import 'package:lotti/features/goals/model/goal_health_data_types.dart';
 import 'package:lotti/features/goals/state/goal_progress_view.dart';
 import 'package:lotti/features/goals/ui/goal_progress_card.dart';
 import 'package:lotti/l10n/app_localizations.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_strip.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
 import 'package:lotti/widgets/misc/linked_scroll_group.dart';
 
 import '../../../widget_test_utils.dart';
@@ -152,235 +154,6 @@ void main() {
       expect(find.text('Gym'), findsOneWidget);
     });
   }
-
-  testWidgets('compact strip reports the number of successful days once in '
-      'semantics', (tester) async {
-    await tester.pumpWidget(
-      makeTestableWidgetNoScroll(
-        const GoalCompactWindowStrip(
-          days: [
-            GoalCompactDayState.full,
-            GoalCompactDayState.none,
-            GoalCompactDayState.partial,
-            GoalCompactDayState.none,
-            GoalCompactDayState.none,
-            GoalCompactDayState.full,
-            GoalCompactDayState.none,
-          ],
-        ),
-      ),
-    );
-
-    expect(
-      find.bySemanticsLabel(
-        '3 successful days in the trailing seven-day window',
-      ),
-      findsOneWidget,
-    );
-  });
-
-  testWidgets('compact strip outlines the last cell as today when short', (
-    tester,
-  ) async {
-    await tester.pumpWidget(
-      makeTestableWidgetNoScroll(
-        const GoalCompactWindowStrip(
-          days: [
-            GoalCompactDayState.none,
-            GoalCompactDayState.full,
-            GoalCompactDayState.none,
-          ],
-        ),
-      ),
-    );
-
-    expect(find.byType(DsDashedBorder), findsOneWidget);
-  });
-
-  testWidgets('a read-only strip announces its verdicts and marks non-met '
-      'days with a shape', (tester) async {
-    await tester.pumpWidget(
-      makeTestableWidgetNoScroll(
-        GoalCompactWindowStrip(
-          days: List.filled(3, GoalCompactDayState.none),
-          lastDay: today,
-          ratingsByDay: {
-            today.subtract(const Duration(days: 2)): GoalAssessmentRating.met,
-            today.subtract(const Duration(days: 1)):
-                GoalAssessmentRating.missed,
-          },
-        ),
-      ),
-    );
-
-    // A read-only strip publishes one summary rather than seven nodes, so the
-    // verdicts have to reach it there — otherwise the list announced a
-    // measured day count while showing four verdict hues.
-    final label = tester
-        .getSemantics(find.byType(GoalCompactWindowStrip))
-        .label;
-    expect(label, contains('Met'));
-    expect(label, contains('Missed'));
-
-    // Each verdict keeps its OWN shape even on the list's 12px cells.
-    // Collapsing the three non-met verdicts into one dot left Improving,
-    // Mixed and Missed separable by hue alone, which is the single thing the
-    // shapes exist to prevent.
-    expect(
-      find.byIcon(goalAssessmentRatingGlyph(GoalAssessmentRating.met)),
-      findsOneWidget,
-    );
-    expect(
-      find.byIcon(goalAssessmentRatingGlyph(GoalAssessmentRating.missed)),
-      findsOneWidget,
-    );
-  });
-
-  testWidgets('a tappable strip reports the day each cell stands for, '
-      'counting back from the last', (tester) async {
-    final tapped = <DateTime>[];
-    await tester.pumpWidget(
-      makeTestableWidgetNoScroll(
-        GoalCompactWindowStrip(
-          days: const [
-            GoalCompactDayState.full,
-            GoalCompactDayState.none,
-            GoalCompactDayState.partial,
-            GoalCompactDayState.none,
-            GoalCompactDayState.none,
-            GoalCompactDayState.full,
-            GoalCompactDayState.none,
-          ],
-          lastDay: today,
-          onDaySelected: tapped.add,
-        ),
-      ),
-    );
-
-    // The oldest cell is six days back and the last one is today. Tapping a
-    // *past* day is the point: before this, the only way to reflect on a day
-    // was the "Reflect on today" row, so a day could never be closed off
-    // once it had passed.
-    String cell(int daysBack, String outcome) =>
-        '${DateFormat.MMMEd().format(today.subtract(Duration(days: daysBack)))}'
-        ': $outcome';
-
-    await tester.tap(find.bySemanticsLabel(cell(6, 'done · target met')));
-    await tester.tap(find.bySemanticsLabel(cell(0, 'No entry')));
-
-    expect(tapped, [today.subtract(const Duration(days: 6)), today]);
-
-    // Colour and an inner dot are the only visual difference between these
-    // cells, and neither reaches a screen reader. Each day names its own
-    // state; the strip's summary only gives a count and cannot say which
-    // days went well.
-    expect(
-      find.bySemanticsLabel(cell(4, 'done · target not met yet')),
-      findsOneWidget,
-    );
-  });
-
-  testWidgets('a recorded verdict outranks the measured state, and each '
-      'verdict has its own colour', (tester) async {
-    final week = List.filled(7, GoalCompactDayState.none);
-    await tester.pumpWidget(
-      makeTestableWidgetNoScroll(
-        GoalCompactWindowStrip(
-          days: week,
-          lastDay: today,
-          onDaySelected: (_) {},
-          ratingsByDay: {
-            today.subtract(const Duration(days: 3)): GoalAssessmentRating.met,
-            today.subtract(const Duration(days: 2)):
-                GoalAssessmentRating.improving,
-            today.subtract(const Duration(days: 1)): GoalAssessmentRating.mixed,
-            today: GoalAssessmentRating.missed,
-          },
-        ),
-      ),
-    );
-
-    final tokens = tester
-        .element(find.byType(GoalCompactWindowStrip))
-        .designTokens;
-    final cells = find.descendant(
-      of: find.byType(GoalCompactWindowStrip),
-      matching: find.byType(Container),
-    );
-    Color fillAt(int index) =>
-        (tester.widget<Container>(cells.at(index)).decoration! as BoxDecoration)
-            .color!;
-
-    // Every measured day here is `none` — grey. The user's own verdict is what
-    // decides the colour, because the measurement is evidence about a day and
-    // the reflection is their ruling on it.
-    expect(fillAt(0), goalDayStateFill(tokens, GoalCompactDayState.none));
-    expect(
-      fillAt(3),
-      goalAssessmentRatingFill(tokens, GoalAssessmentRating.met),
-    );
-    expect(
-      fillAt(4),
-      goalAssessmentRatingFill(tokens, GoalAssessmentRating.improving),
-    );
-    expect(
-      fillAt(5),
-      goalAssessmentRatingFill(tokens, GoalAssessmentRating.mixed),
-    );
-    expect(
-      fillAt(6),
-      goalAssessmentRatingFill(tokens, GoalAssessmentRating.missed),
-    );
-
-    // The verdict is what a screen reader hears too, not just what the eye
-    // sees — the colour is the only visual difference between these cells.
-    expect(
-      find.bySemanticsLabel(
-        '${DateFormat.MMMEd().format(
-          today.subtract(const Duration(days: 2)),
-        )}: Improving',
-      ),
-      findsOneWidget,
-    );
-
-    // Colour alone is not enough: four fills that differ only by hue are four
-    // fills a red-green deficiency cannot separate, and reading the week at a
-    // glance is the strip's entire job. Each verdict wears a shape too.
-    for (final rating in GoalAssessmentRating.values) {
-      expect(
-        find.byIcon(goalAssessmentRatingGlyph(rating)),
-        findsOneWidget,
-        reason: '${rating.name} has no shape of its own',
-      );
-      // Two inks per verdict, for two backgrounds. On its own saturated fill
-      // the glyph takes the on-alert ink; on a plain card — the reflect row —
-      // it takes its family's ink, because the on-alert ink is near-invisible
-      // there by design.
-      expect(
-        goalAssessmentRatingSurfaceInk(tokens, rating),
-        isNot(goalAssessmentRatingInk(tokens, rating)),
-        reason: '${rating.name} uses one ink for both surfaces',
-      );
-    }
-    expect(
-      {
-        for (final rating in GoalAssessmentRating.values)
-          goalAssessmentRatingGlyph(rating),
-      },
-      hasLength(GoalAssessmentRating.values.length),
-      reason: 'two verdicts share a glyph',
-    );
-
-    // All four are distinguishable, and none of them is the grey of a day
-    // nobody looked at — "I decided this was missed" and "no data" are
-    // different facts and the strip has to be able to say which.
-    final verdicts = {fillAt(3), fillAt(4), fillAt(5), fillAt(6)};
-    expect(verdicts, hasLength(4));
-    expect(
-      verdicts,
-      isNot(contains(goalDayStateFill(tokens, GoalCompactDayState.none))),
-    );
-  });
 
   group('formatGoalAggregate', () {
     final number = NumberFormat.decimalPattern('en');
@@ -606,7 +379,7 @@ void main() {
     // Wednesday landed in two different columns and a reader could not follow
     // a day down the page.
     final stripCells = find.descendant(
-      of: find.byType(GoalCompactWindowStrip),
+      of: find.byType(DayMarkStrip),
       matching: find.byType(InkWell),
     );
     final firstStrip = tester.getRect(stripCells.at(0));
@@ -674,7 +447,7 @@ void main() {
     final stripCell = tester
         .widgetList<Container>(
           find.descendant(
-            of: find.byType(GoalCompactWindowStrip),
+            of: find.byType(DayMarkStrip),
             matching: find.byType(Container),
           ),
         )
@@ -698,7 +471,7 @@ void main() {
   testWidgets('the reflect action rides the Goal-days header, and names '
       'the verdict once recorded', (tester) async {
     final tapped = <DateTime>[];
-    Future<void> pump({GoalAssessmentRating? recorded}) => tester.pumpWidget(
+    Future<void> pump({DayVerdict? recorded}) => tester.pumpWidget(
       makeTestableWidgetNoScroll(
         GoalThisWeekCard(
           progress: GoalProgressView(
@@ -726,7 +499,7 @@ void main() {
     // The day's action is the card header's trailing button, on the title's
     // own line: as a full-width row under the strip it cost a touch target's
     // height plus two gaps to say what a corner button says for free.
-    final strip = tester.getRect(find.byType(GoalCompactWindowStrip));
+    final strip = tester.getRect(find.byType(DayMarkStrip));
     final reflect = tester.getRect(find.text('Reflect on today'));
     final title = tester.getRect(
       find.textContaining(RegExp('Goal days|This week')),
@@ -752,7 +525,7 @@ void main() {
 
     // Once the day is judged the button states the verdict instead of
     // inviting an action the user already took.
-    await pump(recorded: GoalAssessmentRating.improving);
+    await pump(recorded: DayVerdict.improving);
     expect(find.text('Reflect on today'), findsNothing);
     expect(find.text('Improving'), findsOneWidget);
   });
@@ -803,7 +576,7 @@ void main() {
     // Named per surface rather than swept as one bag: a bare
     // `byType(DsDashedBorder)` passed while the strip was never mounted at
     // all, and would keep passing if it stopped being mounted again.
-    final stripRings = ringsIn(find.byType(GoalCompactWindowStrip));
+    final stripRings = ringsIn(find.byType(DayMarkStrip));
     final cardRings = ringsIn(find.byType(GoalProgressCard));
     expect(stripRings, hasLength(1), reason: 'the strip marks today once');
     expect(
@@ -816,10 +589,10 @@ void main() {
     // and key must not diverge either: a key drawn differently from the mark
     // is a key to nothing.
     for (final ring in [...stripRings, ...cardRings]) {
-      expect(ring.color, goalTodayRingInk(tokens));
+      expect(ring.color, todayRingInk(tokens));
       expect(ring.strokeWidth, BorderWidths.emphasis);
     }
-    expect(goalTodayRingInk(tokens), tokens.colors.text.mediumEmphasis);
+    expect(todayRingInk(tokens), tokens.colors.text.mediumEmphasis);
   });
 
   testWidgets('a habit card that ends on its squares gets a shallower foot '
@@ -997,10 +770,10 @@ void main() {
         GoalThisWeekCard(progress: progress, onReflectDay: (_) {}),
       ),
     );
-    expect(find.byType(GoalCompactWindowStrip), findsOneWidget);
+    expect(find.byType(DayMarkStrip), findsOneWidget);
     expect(
       find.descendant(
-        of: find.byType(GoalCompactWindowStrip),
+        of: find.byType(DayMarkStrip),
         matching: find.byType(InkWell),
       ),
       findsNWidgets(7),
@@ -1011,132 +784,6 @@ void main() {
     // Read-only, the card would only put a second, near-identical week above
     // the one the habit row already draws — the page's gate keeps it out.
     expect(GoalThisWeekCard.shouldShow(progress, canReflect: false), isFalse);
-  });
-
-  testWidgets('a read-only strip hugs its cells while a tappable one spans '
-      'the measure', (tester) async {
-    const week = [
-      GoalCompactDayState.full,
-      GoalCompactDayState.none,
-      GoalCompactDayState.partial,
-      GoalCompactDayState.none,
-      GoalCompactDayState.none,
-      GoalCompactDayState.full,
-      GoalCompactDayState.none,
-    ];
-    await tester.pumpWidget(
-      makeTestableWidgetNoScroll(
-        SizedBox(
-          width: 400,
-          child: Column(
-            children: [
-              const GoalCompactWindowStrip(days: week),
-              GoalCompactWindowStrip(
-                days: week,
-                lastDay: today,
-                onDaySelected: (_) {},
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-
-    final cells = find.descendant(
-      of: find.byType(GoalCompactWindowStrip).at(1),
-      matching: find.byType(InkWell),
-    );
-    var covered = 0.0;
-    for (var index = 0; index < 7; index++) {
-      covered += tester.getSize(cells.at(index)).width;
-    }
-    // Both strips sit on the page's shared seven-column track now, so the
-    // week lines up with the habit squares and the metric bars rather than
-    // being a third grid. Tapping does not change the pitch: the cells are
-    // the same width either way, and the span is seven of them.
-    final readOnlyCells = find.descendant(
-      of: find.byType(GoalCompactWindowStrip).at(0),
-      matching: find.byType(Padding),
-    );
-    expect(
-      tester.getSize(cells.at(0)).width,
-      moreOrLessEquals(covered / 7, epsilon: 1),
-      reason: 'the tappable cells do not sit on an even pitch',
-    );
-    expect(readOnlyCells, findsWidgets);
-  });
-
-  testWidgets('a placeholder strip keeps the silhouette without borrowing the '
-      'empty-week fill', (tester) async {
-    await tester.pumpWidget(
-      makeTestableWidgetNoScroll(
-        const GoalCompactWindowStrip(
-          days: [
-            GoalCompactDayState.none,
-            GoalCompactDayState.none,
-            GoalCompactDayState.none,
-          ],
-          placeholder: true,
-        ),
-      ),
-    );
-
-    // Dashed outlines, never the filled grey a genuinely-empty week wears:
-    // "no data yet" and "nothing happened" must not share an encoding.
-    expect(find.byType(DsDashedBorder), findsNWidgets(3));
-    final outlined = tester.getSize(
-      find
-          .descendant(
-            of: find.byType(DsDashedBorder).first,
-            matching: find.byType(SizedBox),
-          )
-          .first,
-    );
-    expect(outlined.width, ControlSizes.iconChipCompact);
-    expect(outlined.height, ControlSizes.iconChipCompact);
-  });
-
-  testWidgets('the partial-day dot scales with the square it marks', (
-    tester,
-  ) async {
-    // The square's size is derived from the width the track has to fit into,
-    // so a squeezed strip is how a small cell is produced.
-    Future<double> dotWidth({
-      required double width,
-      required int dayCount,
-    }) async {
-      await tester.pumpWidget(
-        makeTestableWidgetNoScroll(
-          Align(
-            alignment: Alignment.topLeft,
-            child: SizedBox(
-              width: width,
-              child: GoalCompactWindowStrip(
-                days: List.filled(dayCount, GoalCompactDayState.partial),
-              ),
-            ),
-          ),
-        ),
-      );
-      // The dot is the innermost Container inside the cell.
-      return tester
-          .getSize(
-            find
-                .descendant(
-                  of: find.byType(GoalCompactWindowStrip),
-                  matching: find.byType(Container),
-                )
-                .last,
-          )
-          .width;
-    }
-
-    final compact = await dotWidth(width: 200, dayCount: 30);
-    final large = await dotWidth(width: 760, dayCount: 8);
-    // A dot fixed at the compact size vanishes inside the 28px square the
-    // detail page uses, and the partial state is the one that has no colour
-    // of its own to fall back on.
-    expect(large, greaterThan(compact));
   });
 
   testWidgets('tappable day cells clear the touch floor and match the habit '
@@ -1165,7 +812,7 @@ void main() {
     );
 
     final cells = find.descendant(
-      of: find.byType(GoalCompactWindowStrip),
+      of: find.byType(DayMarkStrip),
       matching: find.byType(InkWell),
     );
     expect(cells, findsNWidgets(7));
@@ -1198,7 +845,7 @@ void main() {
     final square = tester.widget<Container>(
       find
           .descendant(
-            of: find.byType(GoalCompactWindowStrip),
+            of: find.byType(DayMarkStrip),
             matching: find.byType(Container),
           )
           .first,
@@ -2689,7 +2336,7 @@ void main() {
     // target looked identical to missing it.
     expect(
       barColor('2026-08-10'),
-      goalDayStateFill(tokens, GoalCompactDayState.full),
+      dayMarkStateFill(tokens, DayMarkState.full),
       reason:
           '12,400 steps beat the 10,000 target even though the '
           'trailing-week verdict for that day says short',
@@ -2699,7 +2346,7 @@ void main() {
     // success family instead — three states, three fills.
     expect(
       barColor('2026-08-11'),
-      goalDayStateFill(tokens, GoalCompactDayState.partial),
+      dayMarkStateFill(tokens, DayMarkState.partial),
       reason:
           '5,262 steps fell short but were still logged — the passing '
           'rolling verdict must not paint the day green',
@@ -3724,13 +3371,13 @@ void main() {
               compositeRule: GoalCompositeRuleKind.atLeast,
               requiredSuccesses: 2,
               compositeCompactWindow: const [
-                GoalCompactDayState.none,
-                GoalCompactDayState.full,
-                GoalCompactDayState.none,
-                GoalCompactDayState.full,
-                GoalCompactDayState.full,
-                GoalCompactDayState.none,
-                GoalCompactDayState.full,
+                DayMarkState.none,
+                DayMarkState.full,
+                DayMarkState.none,
+                DayMarkState.full,
+                DayMarkState.full,
+                DayMarkState.none,
+                DayMarkState.full,
               ],
               habits: [
                 GoalHabitProgressView(
@@ -3996,7 +3643,7 @@ void main() {
       compositeRule: GoalCompositeRuleKind.all,
       compositeCompactWindow: [
         for (var i = 0; i < span; i++)
-          if (i.isEven) GoalCompactDayState.full else GoalCompactDayState.none,
+          if (i.isEven) DayMarkState.full else DayMarkState.none,
       ],
       habits: [
         GoalHabitProgressView(
@@ -4039,7 +3686,7 @@ void main() {
     // The strip renders the WHOLE span, no seven-day cap.
     expect(
       find.descendant(
-        of: find.byType(GoalCompactWindowStrip),
+        of: find.byType(DayMarkStrip),
         matching: find.byType(InkWell),
       ),
       findsNWidgets(span),
@@ -4561,7 +4208,7 @@ void main() {
     );
 
     final cells = find.descendant(
-      of: find.byType(GoalCompactWindowStrip),
+      of: find.byType(DayMarkStrip),
       matching: find.byType(InkWell),
     );
     final ink = tester.widget<InkWell>(cells.last);

--- a/test/features/goals/ui/pages/goal_timeline_page_test.dart
+++ b/test/features/goals/ui/pages/goal_timeline_page_test.dart
@@ -19,6 +19,7 @@ import 'package:lotti/features/goals/ui/checkins/goal_checkin_composer.dart';
 import 'package:lotti/features/goals/ui/goal_assessment_widgets.dart';
 import 'package:lotti/features/goals/ui/pages/goal_timeline_page.dart';
 import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
 
 import '../../../../widget_test_utils.dart';
 
@@ -148,9 +149,9 @@ void main() {
       id: 'r1',
       day: DateTime.utc(2026, 8, 17),
       specVersionId: 'agent-1:spec-v1',
-      rating: GoalAssessmentRating.met,
+      rating: DayVerdict.met,
       createdAt: DateTime(2026, 8, 17, 21),
-      provenance: GoalAssessmentProvenance.ratedByUser,
+      provenance: DayVerdictProvenance.ratedByUser,
     );
     await withClock(
       Clock.fixed(now),

--- a/test/features/goals/ui/unified/unified_goal_card_test.dart
+++ b/test/features/goals/ui/unified/unified_goal_card_test.dart
@@ -13,12 +13,12 @@ import 'package:lotti/features/goals/state/goal_agent_providers.dart';
 import 'package:lotti/features/goals/state/goal_assessment_state.dart';
 import 'package:lotti/features/goals/state/goal_progress_view.dart';
 import 'package:lotti/features/goals/ui/goal_health_direction.dart';
-import 'package:lotti/features/goals/ui/goal_progress_card.dart';
 import 'package:lotti/features/goals/ui/unified/unified_goal_card.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_action_row.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_strip.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../mocks/mocks.dart';
@@ -336,7 +336,7 @@ void main() {
     // trailing it on the same row.
     final titleRect = tester.getRect(find.text('Fitness'));
     final stripRect = tester.getRect(
-      find.byType(GoalCompactWindowStrip).first,
+      find.byType(DayMarkStrip).first,
     );
     expect(stripRect.top, greaterThan(titleRect.bottom - 1));
   });

--- a/test/features/habits/ui/widgets/habit_completion_card_test.dart
+++ b/test/features/habits/ui/widgets/habit_completion_card_test.dart
@@ -1,7 +1,8 @@
-import 'package:flutter/material.dart';
+import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/habits/state/habit_completion_controller.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_action_row.dart';
@@ -10,6 +11,8 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/widgets/charts/habits/dashboard_habits_data.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_cell.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../mocks/mocks.dart';
@@ -137,12 +140,12 @@ void main() {
     });
   });
 
-  group('history strip glyphs', () {
-    testWidgets('renders the correct glyph per outcome with a Semantics label', (
-      tester,
-    ) async {
+  group('history strip', () {
+    testWidgets('draws every in-range day as a shared day-mark cell, with the '
+        'skip dash and missed cross as non-color cues', (tester) async {
+      final handle = tester.ensureSemantics();
       // The open day precedes the success day so `results.last` is success and
-      // the trailing button is the done-circle, not another check_rounded.
+      // the trailing button is the done-circle, not another check glyph.
       _results = [
         _result(DateTime(2024, 3, 11), HabitCompletionType.open),
         _result(DateTime(2024, 3, 12), HabitCompletionType.fail),
@@ -151,22 +154,32 @@ void main() {
       ];
       await pumpCard(tester);
 
-      expect(find.byIcon(LottiIcons.confirm), findsOneWidget); // success cell
+      final cells = tester
+          .widgetList<DayMarkCell>(find.byType(DayMarkCell))
+          .map((cell) => cell.mark.state)
+          .toList();
+      expect(cells, [
+        DayMarkState.none,
+        DayMarkState.missed,
+        DayMarkState.skipped,
+        DayMarkState.full,
+      ]);
       expect(find.byIcon(LottiIcons.close), findsOneWidget); // fail cell
       expect(find.byIcon(LottiIcons.remove), findsOneWidget); // skip cell
 
-      final labels = tester
-          .widgetList<Semantics>(find.byType(Semantics))
-          .map((s) => s.properties.label)
-          .whereType<String>();
+      // A read-only strip publishes one summary, counted from the marks: the
+      // success day is the only one that counts.
       expect(
-        labels.any((l) => l.contains(habitFlossing.name)),
-        isTrue,
-        reason: 'a strip cell labels itself with the habit name',
+        find.bySemanticsLabel(RegExp('1 successful day')),
+        findsOneWidget,
       );
+      handle.dispose();
     });
 
-    testWidgets('open-only days render no outcome glyph', (tester) async {
+    testWidgets('open-only days render no outcome glyph and count nothing', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
       _results = [
         _result(DateTime(2024, 3, 13), HabitCompletionType.open),
         _result(DateTime(2024, 3, 14), HabitCompletionType.open),
@@ -180,6 +193,57 @@ void main() {
       // shows no check glyph at all.
       expect(find.byIcon(LottiIcons.confirm), findsNothing);
       expect(find.byIcon(LottiIcons.add), findsOneWidget);
+      expect(
+        find.bySemanticsLabel(RegExp('No successful days')),
+        findsOneWidget,
+      );
+      handle.dispose();
+    });
+
+    testWidgets("only the cell for the clock's today wears the dashed ring", (
+      tester,
+    ) async {
+      _results = [
+        _result(DateTime(2024, 3, 14), HabitCompletionType.success),
+        _result(_rangeEnd, HabitCompletionType.open),
+      ];
+      await withClock(Clock.fixed(_rangeEnd.add(const Duration(hours: 9))), () {
+        return pumpCard(tester);
+      });
+
+      final marks = tester
+          .widgetList<DayMarkCell>(find.byType(DayMarkCell))
+          .map((cell) => cell.mark.isToday)
+          .toList();
+      expect(marks, [false, true]);
+      expect(find.byType(DsDashedBorder), findsOneWidget);
+    });
+
+    testWidgets("a day outside the clock's today wears no ring", (
+      tester,
+    ) async {
+      _results = _last(HabitCompletionType.success);
+      await withClock(Clock.fixed(DateTime(2024, 3, 20)), () {
+        return pumpCard(tester);
+      });
+      expect(find.byType(DsDashedBorder), findsNothing);
+    });
+  });
+
+  group('habitCompletionDayMarkState', () {
+    test('maps every recorded outcome onto the shared day-mark state', () {
+      expect(
+        {
+          for (final type in HabitCompletionType.values)
+            type: habitCompletionDayMarkState(type),
+        },
+        {
+          HabitCompletionType.success: DayMarkState.full,
+          HabitCompletionType.skip: DayMarkState.skipped,
+          HabitCompletionType.fail: DayMarkState.missed,
+          HabitCompletionType.open: DayMarkState.none,
+        },
+      );
     });
   });
 

--- a/test/widgets/day_indicators/day_mark_cell_test.dart
+++ b/test/widgets/day_indicators/day_mark_cell_test.dart
@@ -156,7 +156,10 @@ void main() {
       find.bySemanticsLabel('Mon, Aug 10: done'),
     );
     expect(node.getSemanticsData().hasAction(SemanticsAction.tap), isTrue);
-    tester.binding.rootPipelineOwner.semanticsOwner!.performAction(
+    // The test binding's semantics owner still lives on the legacy
+    // pipeline owner; the root owner has none in widget tests.
+    // ignore: deprecated_member_use
+    tester.binding.pipelineOwner.semanticsOwner!.performAction(
       node.id,
       SemanticsAction.tap,
     );

--- a/test/widgets/day_indicators/day_mark_cell_test.dart
+++ b/test/widgets/day_indicators/day_mark_cell_test.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
+import 'package:lotti/features/design_system/components/tooltips/ds_tooltip.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_cell.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
+
+import '../../widget_test_utils.dart';
+
+void main() {
+  Future<void> pump(WidgetTester tester, Widget child) => tester.pumpWidget(
+    makeTestableWidgetNoScroll(
+      Align(alignment: Alignment.topLeft, child: child),
+    ),
+  );
+
+  Container square(WidgetTester tester) => tester.widget<Container>(
+    find
+        .descendant(
+          of: find.byType(DayMarkCell),
+          matching: find.byType(Container),
+        )
+        .first,
+  );
+
+  testWidgets('a verdict outranks the state for fill and glyph', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      const DayMarkCell(
+        mark: DayMark(state: DayMarkState.none, verdict: DayVerdict.mixed),
+        size: 28,
+        weekdayLetter: 'M',
+      ),
+    );
+    final tokens = tester.element(find.byType(DayMarkCell)).designTokens;
+    expect(
+      (square(tester).decoration! as BoxDecoration).color,
+      dayVerdictFill(tokens, DayVerdict.mixed),
+    );
+    expect(find.byIcon(dayVerdictGlyph(DayVerdict.mixed)), findsOneWidget);
+    expect(
+      find.text('M'),
+      findsNothing,
+      reason: 'the glyph outranks the letter',
+    );
+  });
+
+  testWidgets('a plain full cell carries the weekday letter; a partial one '
+      'carries the dot instead', (tester) async {
+    await pump(
+      tester,
+      const DayMarkCell(
+        mark: DayMark(state: DayMarkState.full),
+        size: 28,
+        weekdayLetter: 'T',
+      ),
+    );
+    expect(find.text('T'), findsOneWidget);
+    expect(find.byType(Icon), findsNothing);
+
+    await pump(
+      tester,
+      const DayMarkCell(
+        mark: DayMark(state: DayMarkState.partial),
+        size: 28,
+        weekdayLetter: 'T',
+      ),
+    );
+    expect(find.text('T'), findsNothing);
+    // The dot is the innermost Container inside the cell.
+    final dot = find
+        .descendant(
+          of: find.byType(DayMarkCell),
+          matching: find.byType(Container),
+        )
+        .last;
+    expect(
+      (tester.widget<Container>(dot).decoration! as BoxDecoration).shape,
+      BoxShape.circle,
+    );
+  });
+
+  testWidgets('recorded outcomes show their shape without a verdict', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      const DayMarkCell(mark: DayMark(state: DayMarkState.missed), size: 20),
+    );
+    expect(find.byIcon(LottiIcons.close), findsOneWidget);
+    await pump(
+      tester,
+      const DayMarkCell(mark: DayMark(state: DayMarkState.skipped), size: 20),
+    );
+    expect(find.byIcon(LottiIcons.remove), findsOneWidget);
+  });
+
+  testWidgets('today wears the dashed ring inside the shared footprint', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      const DayMarkCell(mark: DayMark(state: DayMarkState.none), size: 20),
+    );
+    final plain = tester.getSize(find.byType(DayMarkCell));
+    expect(find.byType(DsDashedBorder), findsNothing);
+
+    await pump(
+      tester,
+      const DayMarkCell(
+        mark: DayMark(state: DayMarkState.none, isToday: true),
+        size: 20,
+      ),
+    );
+    expect(find.byType(DsDashedBorder), findsOneWidget);
+    expect(
+      tester.getSize(find.byType(DayMarkCell)),
+      plain,
+      reason: 'the ring never bulges the rhythm',
+    );
+  });
+
+  testWidgets('a tappable cell is a labelled button that clears the touch '
+      'floor and answers hover with the day and outcome', (tester) async {
+    final handle = tester.ensureSemantics();
+    var taps = 0;
+    await pump(
+      tester,
+      DayMarkCell(
+        mark: const DayMark(state: DayMarkState.full),
+        size: 20,
+        label: 'Mon, Aug 10: done',
+        tooltipDay: 'Mon, Aug 10',
+        tooltipOutcome: 'done',
+        onTap: () => taps++,
+      ),
+    );
+    expect(
+      tester.getSize(find.byType(DayMarkCell)).height,
+      greaterThanOrEqualTo(TapTargets.minimum),
+    );
+    final tooltip = tester.widget<DsTooltip>(find.byType(DsTooltip));
+    expect(tooltip.title, 'Mon, Aug 10');
+    expect(tooltip.message, 'done');
+    await tester.tap(find.bySemanticsLabel('Mon, Aug 10: done'));
+    expect(taps, 1);
+    handle.dispose();
+  });
+
+  testWidgets('a placeholder cell is a dashed outline at the cell size', (
+    tester,
+  ) async {
+    await pump(tester, const PlaceholderDayCell(size: 18));
+    expect(find.byType(DsDashedBorder), findsOneWidget);
+    expect(
+      tester.getSize(
+        find
+            .descendant(
+              of: find.byType(DsDashedBorder),
+              matching: find.byType(SizedBox),
+            )
+            .first,
+      ),
+      const Size(18, 18),
+    );
+  });
+}

--- a/test/widgets/day_indicators/day_mark_cell_test.dart
+++ b/test/widgets/day_indicators/day_mark_cell_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
+import 'package:lotti/features/design_system/components/ds_quiet_ink.dart';
 import 'package:lotti/features/design_system/components/tooltips/ds_tooltip.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/widgets/day_indicators/day_mark.dart';
@@ -149,6 +150,38 @@ void main() {
     await tester.tap(find.bySemanticsLabel('Mon, Aug 10: done'));
     expect(taps, 1);
     handle.dispose();
+  });
+
+  testWidgets('a read-only dated cell still answers hover with its day and '
+      'outcome, without becoming a button', (tester) async {
+    final handle = tester.ensureSemantics();
+    await pump(
+      tester,
+      const DayMarkCell(
+        mark: DayMark(state: DayMarkState.full),
+        size: 20,
+        tooltipDay: 'Tue, Aug 11',
+        tooltipOutcome: 'done',
+      ),
+    );
+    final tooltip = tester.widget<DsTooltip>(find.byType(DsTooltip));
+    expect(tooltip.title, 'Tue, Aug 11');
+    expect(tooltip.message, 'done');
+    expect(find.byType(DsQuietInk), findsNothing);
+    expect(
+      find.bySemanticsLabel('Tue, Aug 11: done'),
+      findsNothing,
+      reason: 'a read-only cell is not a button; the strip summarises it',
+    );
+    handle.dispose();
+  });
+
+  testWidgets('an undated read-only cell carries no tooltip', (tester) async {
+    await pump(
+      tester,
+      const DayMarkCell(mark: DayMark(state: DayMarkState.full), size: 20),
+    );
+    expect(find.byType(DsTooltip), findsNothing);
   });
 
   testWidgets('a placeholder cell is a dashed outline at the cell size', (

--- a/test/widgets/day_indicators/day_mark_cell_test.dart
+++ b/test/widgets/day_indicators/day_mark_cell_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
 import 'package:lotti/features/design_system/components/ds_quiet_ink.dart';
@@ -149,6 +150,17 @@ void main() {
     expect(tooltip.message, 'done');
     await tester.tap(find.bySemanticsLabel('Mon, Aug 10: done'));
     expect(taps, 1);
+    // The ink well's own node is excluded, so the activation action has to
+    // be published on the labelled button itself.
+    final node = tester.getSemantics(
+      find.bySemanticsLabel('Mon, Aug 10: done'),
+    );
+    expect(node.getSemanticsData().hasAction(SemanticsAction.tap), isTrue);
+    tester.binding.rootPipelineOwner.semanticsOwner!.performAction(
+      node.id,
+      SemanticsAction.tap,
+    );
+    expect(taps, 2);
     handle.dispose();
   });
 

--- a/test/widgets/day_indicators/day_mark_legend_test.dart
+++ b/test/widgets/day_indicators/day_mark_legend_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_legend.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
+
+import '../../widget_test_utils.dart';
+
+void main() {
+  testWidgets('the legend keys the cells with their own fills, dot and ring', (
+    tester,
+  ) async {
+    await tester.pumpWidget(makeTestableWidgetNoScroll(const DayMarkLegend()));
+    final tokens = tester.element(find.byType(DayMarkLegend)).designTokens;
+
+    for (final label in [
+      'done · target met',
+      'done · target not met yet',
+      'No entry',
+      'today',
+    ]) {
+      expect(find.text(label), findsOneWidget, reason: label);
+    }
+    expect(find.textContaining('ages out'), findsOneWidget);
+
+    Color? fillBeside(String label) {
+      final row = find
+          .ancestor(of: find.text(label), matching: find.byType(Row))
+          .first;
+      final swatch = tester.widget<Container>(
+        find.descendant(of: row, matching: find.byType(Container)).first,
+      );
+      return (swatch.decoration! as BoxDecoration).color;
+    }
+
+    expect(
+      fillBeside('done · target met'),
+      dayMarkStateFill(tokens, DayMarkState.full),
+    );
+    expect(
+      fillBeside('done · target not met yet'),
+      dayMarkStateFill(tokens, DayMarkState.partial),
+    );
+    expect(fillBeside('No entry'), dayMarkStateFill(tokens, DayMarkState.none));
+    // The today swatch is dashed like the cell, in the same ink and stroke.
+    final ring = tester.widget<DsDashedBorder>(find.byType(DsDashedBorder));
+    expect(ring.color, todayRingInk(tokens));
+    expect(ring.strokeWidth, BorderWidths.emphasis);
+    // The partial swatch carries the dot: a circle inside the square.
+    final partialRow = find
+        .ancestor(
+          of: find.text('done · target not met yet'),
+          matching: find.byType(Row),
+        )
+        .first;
+    final containers = tester.widgetList<Container>(
+      find.descendant(of: partialRow, matching: find.byType(Container)),
+    );
+    expect(
+      containers.any(
+        (c) => (c.decoration! as BoxDecoration).shape == BoxShape.circle,
+      ),
+      isTrue,
+    );
+  });
+}

--- a/test/widgets/day_indicators/day_mark_strip_test.dart
+++ b/test/widgets/day_indicators/day_mark_strip_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
+import 'package:lotti/features/design_system/components/tooltips/ds_tooltip.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/goals/ui/goal_day_marks.dart';
 import 'package:lotti/widgets/day_indicators/day_mark.dart';
@@ -416,6 +417,32 @@ void main() {
       findsOneWidget,
     );
     handle.dispose();
+  });
+
+  testWidgets('a read-only dated strip names each day on hover', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        DayMarkStrip(
+          marks: goalDayMarks(
+            states: const [DayMarkState.full, DayMarkState.skipped],
+            lastDay: today,
+          ),
+        ),
+      ),
+    );
+    final tooltips = tester
+        .widgetList<DsTooltip>(find.byType(DsTooltip))
+        .map((t) => '${t.title}: ${t.message}')
+        .toList();
+    final yesterday = DateFormat.MMMEd().format(
+      today.subtract(const Duration(days: 1)),
+    );
+    expect(tooltips, [
+      '$yesterday: done · target met',
+      '${DateFormat.MMMEd().format(today)}: Skip',
+    ]);
   });
 
   testWidgets('an explicit today flag places the ring, not the last slot', (

--- a/test/widgets/day_indicators/day_mark_strip_test.dart
+++ b/test/widgets/day_indicators/day_mark_strip_test.dart
@@ -1,0 +1,517 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/goals/ui/goal_day_marks.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_cell.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_strip.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
+import 'package:lotti/widgets/day_indicators/day_track.dart';
+
+import '../../widget_test_utils.dart';
+
+void main() {
+  final today = DateTime.utc(2026, 8, 11);
+
+  testWidgets('compact strip reports the number of successful days once in '
+      'semantics', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        DayMarkStrip(
+          marks: goalDayMarks(
+            states: const [
+              DayMarkState.full,
+              DayMarkState.none,
+              DayMarkState.partial,
+              DayMarkState.none,
+              DayMarkState.none,
+              DayMarkState.full,
+              DayMarkState.none,
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.bySemanticsLabel(
+        '3 successful days in the trailing seven-day window',
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('compact strip outlines the last cell as today when short', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        DayMarkStrip(
+          marks: goalDayMarks(
+            states: const [
+              DayMarkState.none,
+              DayMarkState.full,
+              DayMarkState.none,
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(DsDashedBorder), findsOneWidget);
+  });
+
+  testWidgets('a read-only strip announces its verdicts and marks non-met '
+      'days with a shape', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        DayMarkStrip(
+          marks: goalDayMarks(
+            states: List.filled(3, DayMarkState.none),
+            lastDay: today,
+            verdictsByDay: {
+              today.subtract(const Duration(days: 2)): DayVerdict.met,
+              today.subtract(const Duration(days: 1)): DayVerdict.missed,
+            },
+          ),
+        ),
+      ),
+    );
+
+    // A read-only strip publishes one summary rather than seven nodes, so the
+    // verdicts have to reach it there — otherwise the list announced a
+    // measured day count while showing four verdict hues.
+    final label = tester.getSemantics(find.byType(DayMarkStrip)).label;
+    expect(label, contains('Met'));
+    expect(label, contains('Missed'));
+
+    // Each verdict keeps its OWN shape even on the list's 12px cells.
+    // Collapsing the three non-met verdicts into one dot left Improving,
+    // Mixed and Missed separable by hue alone, which is the single thing the
+    // shapes exist to prevent.
+    expect(
+      find.byIcon(dayVerdictGlyph(DayVerdict.met)),
+      findsOneWidget,
+    );
+    expect(
+      find.byIcon(dayVerdictGlyph(DayVerdict.missed)),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('a tappable strip reports the day each cell stands for, '
+      'counting back from the last', (tester) async {
+    final tapped = <DateTime>[];
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        DayMarkStrip(
+          marks: goalDayMarks(
+            states: const [
+              DayMarkState.full,
+              DayMarkState.none,
+              DayMarkState.partial,
+              DayMarkState.none,
+              DayMarkState.none,
+              DayMarkState.full,
+              DayMarkState.none,
+            ],
+            lastDay: today,
+          ),
+          onDaySelected: tapped.add,
+        ),
+      ),
+    );
+
+    // The oldest cell is six days back and the last one is today. Tapping a
+    // *past* day is the point: before this, the only way to reflect on a day
+    // was the "Reflect on today" row, so a day could never be closed off
+    // once it had passed.
+    String cell(int daysBack, String outcome) =>
+        '${DateFormat.MMMEd().format(today.subtract(Duration(days: daysBack)))}'
+        ': $outcome';
+
+    await tester.tap(find.bySemanticsLabel(cell(6, 'done · target met')));
+    await tester.tap(find.bySemanticsLabel(cell(0, 'No entry')));
+
+    expect(tapped, [today.subtract(const Duration(days: 6)), today]);
+
+    // Colour and an inner dot are the only visual difference between these
+    // cells, and neither reaches a screen reader. Each day names its own
+    // state; the strip's summary only gives a count and cannot say which
+    // days went well.
+    expect(
+      find.bySemanticsLabel(cell(4, 'done · target not met yet')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('a recorded verdict outranks the measured state, and each '
+      'verdict has its own colour', (tester) async {
+    final week = List.filled(7, DayMarkState.none);
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        DayMarkStrip(
+          marks: goalDayMarks(
+            states: week,
+            lastDay: today,
+            verdictsByDay: {
+              today.subtract(const Duration(days: 3)): DayVerdict.met,
+              today.subtract(const Duration(days: 2)): DayVerdict.improving,
+              today.subtract(const Duration(days: 1)): DayVerdict.mixed,
+              today: DayVerdict.missed,
+            },
+          ),
+          onDaySelected: (_) {},
+        ),
+      ),
+    );
+
+    final tokens = tester.element(find.byType(DayMarkStrip)).designTokens;
+    final cells = find.descendant(
+      of: find.byType(DayMarkStrip),
+      matching: find.byType(Container),
+    );
+    Color fillAt(int index) =>
+        (tester.widget<Container>(cells.at(index)).decoration! as BoxDecoration)
+            .color!;
+
+    // Every measured day here is `none` — grey. The user's own verdict is what
+    // decides the colour, because the measurement is evidence about a day and
+    // the reflection is their ruling on it.
+    expect(fillAt(0), dayMarkStateFill(tokens, DayMarkState.none));
+    expect(
+      fillAt(3),
+      dayVerdictFill(tokens, DayVerdict.met),
+    );
+    expect(
+      fillAt(4),
+      dayVerdictFill(tokens, DayVerdict.improving),
+    );
+    expect(
+      fillAt(5),
+      dayVerdictFill(tokens, DayVerdict.mixed),
+    );
+    expect(
+      fillAt(6),
+      dayVerdictFill(tokens, DayVerdict.missed),
+    );
+
+    // The verdict is what a screen reader hears too, not just what the eye
+    // sees — the colour is the only visual difference between these cells.
+    expect(
+      find.bySemanticsLabel(
+        '${DateFormat.MMMEd().format(
+          today.subtract(const Duration(days: 2)),
+        )}: Improving',
+      ),
+      findsOneWidget,
+    );
+
+    // Colour alone is not enough: four fills that differ only by hue are four
+    // fills a red-green deficiency cannot separate, and reading the week at a
+    // glance is the strip's entire job. Each verdict wears a shape too.
+    for (final rating in DayVerdict.values) {
+      expect(
+        find.byIcon(dayVerdictGlyph(rating)),
+        findsOneWidget,
+        reason: '${rating.name} has no shape of its own',
+      );
+      // Two inks per verdict, for two backgrounds. On its own saturated fill
+      // the glyph takes the on-alert ink; on a plain card — the reflect row —
+      // it takes its family's ink, because the on-alert ink is near-invisible
+      // there by design.
+      expect(
+        dayVerdictSurfaceInk(tokens, rating),
+        isNot(dayVerdictInk(tokens, rating)),
+        reason: '${rating.name} uses one ink for both surfaces',
+      );
+    }
+    expect(
+      {
+        for (final rating in DayVerdict.values) dayVerdictGlyph(rating),
+      },
+      hasLength(DayVerdict.values.length),
+      reason: 'two verdicts share a glyph',
+    );
+
+    // All four are distinguishable, and none of them is the grey of a day
+    // nobody looked at — "I decided this was missed" and "no data" are
+    // different facts and the strip has to be able to say which.
+    final verdicts = {fillAt(3), fillAt(4), fillAt(5), fillAt(6)};
+    expect(verdicts, hasLength(4));
+    expect(
+      verdicts,
+      isNot(contains(dayMarkStateFill(tokens, DayMarkState.none))),
+    );
+  });
+
+  testWidgets('a read-only strip hugs its cells while a tappable one spans '
+      'the measure', (tester) async {
+    const week = [
+      DayMarkState.full,
+      DayMarkState.none,
+      DayMarkState.partial,
+      DayMarkState.none,
+      DayMarkState.none,
+      DayMarkState.full,
+      DayMarkState.none,
+    ];
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        SizedBox(
+          width: 400,
+          child: Column(
+            children: [
+              DayMarkStrip(
+                marks: goalDayMarks(states: week),
+              ),
+              DayMarkStrip(
+                marks: goalDayMarks(states: week, lastDay: today),
+                onDaySelected: (_) {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final cells = find.descendant(
+      of: find.byType(DayMarkStrip).at(1),
+      matching: find.byType(InkWell),
+    );
+    var covered = 0.0;
+    for (var index = 0; index < 7; index++) {
+      covered += tester.getSize(cells.at(index)).width;
+    }
+    // Both strips sit on the page's shared seven-column track now, so the
+    // week lines up with the habit squares and the metric bars rather than
+    // being a third grid. Tapping does not change the pitch: the cells are
+    // the same width either way, and the span is seven of them.
+    final readOnlyCells = find.descendant(
+      of: find.byType(DayMarkStrip).at(0),
+      matching: find.byType(Padding),
+    );
+    expect(
+      tester.getSize(cells.at(0)).width,
+      moreOrLessEquals(covered / 7, epsilon: 1),
+      reason: 'the tappable cells do not sit on an even pitch',
+    );
+    expect(readOnlyCells, findsWidgets);
+  });
+
+  testWidgets('a placeholder strip keeps the silhouette without borrowing the '
+      'empty-week fill', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        DayMarkStrip(
+          marks: goalDayMarks(
+            states: const [
+              DayMarkState.none,
+              DayMarkState.none,
+              DayMarkState.none,
+            ],
+          ),
+          placeholder: true,
+        ),
+      ),
+    );
+
+    // Dashed outlines, never the filled grey a genuinely-empty week wears:
+    // "no data yet" and "nothing happened" must not share an encoding.
+    expect(find.byType(DsDashedBorder), findsNWidgets(3));
+    final outlined = tester.getSize(
+      find
+          .descendant(
+            of: find.byType(DsDashedBorder).first,
+            matching: find.byType(SizedBox),
+          )
+          .first,
+    );
+    expect(outlined.width, ControlSizes.iconChipCompact);
+    expect(outlined.height, ControlSizes.iconChipCompact);
+  });
+
+  testWidgets('the partial-day dot scales with the square it marks', (
+    tester,
+  ) async {
+    // The square's size is derived from the width the track has to fit into,
+    // so a squeezed strip is how a small cell is produced.
+    Future<double> dotWidth({
+      required double width,
+      required int dayCount,
+    }) async {
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              width: width,
+              child: DayMarkStrip(
+                marks: goalDayMarks(
+                  states: List.filled(dayCount, DayMarkState.partial),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      // The dot is the innermost Container inside the cell.
+      return tester
+          .getSize(
+            find
+                .descendant(
+                  of: find.byType(DayMarkStrip),
+                  matching: find.byType(Container),
+                )
+                .last,
+          )
+          .width;
+    }
+
+    final compact = await dotWidth(width: 200, dayCount: 30);
+    final large = await dotWidth(width: 760, dayCount: 8);
+    // A dot fixed at the compact size vanishes inside the 28px square the
+    // detail page uses, and the partial state is the one that has no colour
+    // of its own to fall back on.
+    expect(large, greaterThan(compact));
+  });
+
+  testWidgets('a habit-outcome strip draws the skip dash and missed cross, '
+      'names each state, and counts only the kept days', (tester) async {
+    final handle = tester.ensureSemantics();
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        DayMarkStrip(
+          marks: [
+            DayMark(
+              day: today.subtract(const Duration(days: 3)),
+              state: DayMarkState.full,
+            ),
+            DayMark(
+              day: today.subtract(const Duration(days: 2)),
+              state: DayMarkState.skipped,
+            ),
+            DayMark(
+              day: today.subtract(const Duration(days: 1)),
+              state: DayMarkState.missed,
+            ),
+            DayMark(day: today, state: DayMarkState.none, isToday: true),
+          ],
+          onDaySelected: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.byIcon(LottiIcons.remove), findsOneWidget);
+    expect(find.byIcon(LottiIcons.close), findsOneWidget);
+    String cell(int daysBack, String outcome) =>
+        '${DateFormat.MMMEd().format(today.subtract(Duration(days: daysBack)))}'
+        ': $outcome';
+    expect(find.bySemanticsLabel(cell(2, 'Skip')), findsOneWidget);
+    expect(find.bySemanticsLabel(cell(1, 'Missed')), findsOneWidget);
+    expect(
+      find.bySemanticsLabel(RegExp('^1 successful day')),
+      findsOneWidget,
+    );
+    handle.dispose();
+  });
+
+  testWidgets('an explicit today flag places the ring, not the last slot', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        DayMarkStrip(
+          marks: [
+            DayMark(
+              day: today.subtract(const Duration(days: 1)),
+              state: DayMarkState.full,
+              isToday: true,
+            ),
+            DayMark(day: today, state: DayMarkState.none),
+          ],
+        ),
+      ),
+    );
+    final ringed = find.ancestor(
+      of: find.byType(DayMarkCell).first,
+      matching: find.byType(DsDashedBorder),
+    );
+    expect(find.byType(DsDashedBorder), findsOneWidget);
+    expect(ringed, findsNothing, reason: 'the ring is inside the cell');
+    expect(
+      tester.widget<DayMarkCell>(find.byType(DayMarkCell).first).mark.isToday,
+      isTrue,
+    );
+    expect(
+      tester.widget<DayMarkCell>(find.byType(DayMarkCell).last).mark.isToday,
+      isFalse,
+    );
+  });
+
+  testWidgets('a span longer than a week fits its width and shrinks the '
+      'cells rather than scrolling', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 320,
+            child: DayMarkStrip(
+              marks: goalDayMarks(
+                states: List.filled(14, DayMarkState.full),
+                lastDay: today,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(find.byType(LinkedDayTrackScroller), findsNothing);
+    expect(find.byType(DayTrack), findsOneWidget);
+    expect(tester.getSize(find.byType(DayTrack)).width, lessThanOrEqualTo(320));
+    expect(find.byType(DayMarkCell), findsNWidgets(14));
+  });
+
+  testWidgets('a span that cannot fit even at the narrowest pitch pans, '
+      'anchored on today', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 200,
+            child: DayMarkStrip(
+              marks: goalDayMarks(
+                states: List.filled(60, DayMarkState.none),
+                lastDay: today,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    final scroller = tester.widget<SingleChildScrollView>(
+      find.descendant(
+        of: find.byType(LinkedDayTrackScroller),
+        matching: find.byType(SingleChildScrollView),
+      ),
+    );
+    expect(scroller.reverse, isTrue);
+  });
+
+  testWidgets('an empty strip renders nothing', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        const Align(
+          alignment: Alignment.topLeft,
+          child: DayMarkStrip(marks: []),
+        ),
+      ),
+    );
+    expect(find.byType(DayMarkCell), findsNothing);
+    expect(tester.getSize(find.byType(DayMarkStrip)), Size.zero);
+  });
+}

--- a/test/widgets/day_indicators/day_mark_strip_test.dart
+++ b/test/widgets/day_indicators/day_mark_strip_test.dart
@@ -18,6 +18,7 @@ void main() {
 
   testWidgets('compact strip reports the number of successful days once in '
       'semantics', (tester) async {
+    final handle = tester.ensureSemantics();
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
         DayMarkStrip(
@@ -42,6 +43,7 @@ void main() {
       ),
       findsOneWidget,
     );
+    handle.dispose();
   });
 
   testWidgets('compact strip outlines the last cell as today when short', (
@@ -66,6 +68,7 @@ void main() {
 
   testWidgets('a read-only strip announces its verdicts and marks non-met '
       'days with a shape', (tester) async {
+    final handle = tester.ensureSemantics();
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
         DayMarkStrip(
@@ -100,10 +103,12 @@ void main() {
       find.byIcon(dayVerdictGlyph(DayVerdict.missed)),
       findsOneWidget,
     );
+    handle.dispose();
   });
 
   testWidgets('a tappable strip reports the day each cell stands for, '
       'counting back from the last', (tester) async {
+    final handle = tester.ensureSemantics();
     final tapped = <DateTime>[];
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
@@ -146,10 +151,12 @@ void main() {
       find.bySemanticsLabel(cell(4, 'done · target not met yet')),
       findsOneWidget,
     );
+    handle.dispose();
   });
 
   testWidgets('a recorded verdict outranks the measured state, and each '
       'verdict has its own colour', (tester) async {
+    final handle = tester.ensureSemantics();
     final week = List.filled(7, DayMarkState.none);
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
@@ -246,6 +253,7 @@ void main() {
       verdicts,
       isNot(contains(dayMarkStateFill(tokens, DayMarkState.none))),
     );
+    handle.dispose();
   });
 
   testWidgets('a read-only strip hugs its cells while a tappable one spans '
@@ -527,6 +535,31 @@ void main() {
       ),
     );
     expect(scroller.reverse, isTrue);
+  });
+
+  testWidgets('a dateless span longer than a week is measured with its gaps, '
+      'so a fit never overflows the card', (tester) async {
+    // 12 undated cells: on the Row branch each cell is padded and the cells
+    // are gapped, so `pitch * count` underestimates the row; at this width
+    // that underestimate used to declare a fit and overflow by ~11 gaps.
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 300,
+            child: DayMarkStrip(
+              marks: goalDayMarks(states: List.filled(12, DayMarkState.none)),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(tester.takeException(), isNull);
+    expect(find.byType(DayTrack), findsNothing, reason: 'undated → Row');
+    // The honest measure says it does not fit, so the row pans instead of
+    // being handed back unwrapped to overflow the card.
+    expect(find.byType(LinkedDayTrackScroller), findsOneWidget);
   });
 
   testWidgets('an empty strip renders nothing', (tester) async {

--- a/test/widgets/day_indicators/day_mark_styles_test.dart
+++ b/test/widgets/day_indicators/day_mark_styles_test.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
+
+import '../../widget_test_utils.dart';
+
+void main() {
+  Future<DsTokens> tokens(WidgetTester tester) async {
+    late DsTokens tokens;
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Builder(
+          builder: (context) {
+            tokens = context.designTokens;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    return tokens;
+  }
+
+  testWidgets('state fills: success family for kept days, error for a miss, '
+      'neutral for skip and empty', (tester) async {
+    final t = await tokens(tester);
+    final success = t.colors.alert.success.defaultColor;
+    expect(dayMarkStateFill(t, DayMarkState.full), success);
+    expect(
+      dayMarkStateFill(t, DayMarkState.partial),
+      success.withValues(alpha: SurfaceAlphas.muted),
+    );
+    expect(
+      dayMarkStateFill(t, DayMarkState.missed),
+      t.colors.alert.error.defaultColor,
+    );
+    expect(
+      dayMarkStateFill(t, DayMarkState.skipped),
+      t.colors.background.level03,
+    );
+    expect(
+      dayMarkStateFill(t, DayMarkState.none),
+      t.colors.background.level03,
+    );
+    // Data never wears the interactive teal.
+    for (final state in DayMarkState.values) {
+      expect(dayMarkStateFill(t, state), isNot(t.colors.interactive.enabled));
+    }
+  });
+
+  testWidgets('only recorded outcomes carry a state glyph, in their own ink', (
+    tester,
+  ) async {
+    final t = await tokens(tester);
+    expect(dayMarkStateGlyph(DayMarkState.missed), LottiIcons.close);
+    expect(dayMarkStateGlyph(DayMarkState.skipped), LottiIcons.remove);
+    for (final state in [
+      DayMarkState.none,
+      DayMarkState.partial,
+      DayMarkState.full,
+    ]) {
+      expect(dayMarkStateGlyph(state), isNull);
+    }
+    expect(
+      dayMarkStateGlyphInk(t, DayMarkState.missed),
+      t.colors.alert.error.ink,
+    );
+    expect(
+      dayMarkStateGlyphInk(t, DayMarkState.skipped),
+      t.colors.text.mediumEmphasis,
+    );
+  });
+
+  testWidgets('every verdict has a distinct fill, shape and surface ink', (
+    tester,
+  ) async {
+    final t = await tokens(tester);
+    expect(
+      DayVerdict.values.map((v) => dayVerdictFill(t, v)).toSet().length,
+      DayVerdict.values.length,
+    );
+    expect(
+      DayVerdict.values.map(dayVerdictGlyph).toSet().length,
+      DayVerdict.values.length,
+    );
+    expect(
+      DayVerdict.values.map((v) => dayVerdictSurfaceInk(t, v)).toSet().length,
+      DayVerdict.values.length,
+    );
+    expect(
+      dayVerdictFill(t, DayVerdict.met),
+      dayMarkStateFill(t, DayMarkState.full),
+      reason: 'met and measured-full are the same green',
+    );
+    expect(
+      dayVerdictFill(t, DayVerdict.missed),
+      isNot(dayMarkStateFill(t, DayMarkState.none)),
+      reason: 'a judged miss is never the empty-day grey',
+    );
+    for (final verdict in DayVerdict.values) {
+      expect(dayVerdictInk(t, verdict), t.colors.text.onInteractiveAlert);
+    }
+  });
+
+  testWidgets('labels are localized per state and verdict', (tester) async {
+    late BuildContext ctx;
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Builder(
+          builder: (context) {
+            ctx = context;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    expect(
+      DayMarkState.values.map((s) => dayMarkStateLabel(ctx, s)).toSet().length,
+      DayMarkState.values.length,
+    );
+    expect(dayMarkStateLabel(ctx, DayMarkState.skipped), 'Skip');
+    expect(dayMarkStateLabel(ctx, DayMarkState.missed), 'Missed');
+    expect(dayVerdictLabel(ctx, DayVerdict.met), 'Met');
+    expect(dayVerdictLabel(ctx, DayVerdict.improving), 'Improving');
+    expect(dayVerdictLabel(ctx, DayVerdict.mixed), 'Mixed');
+    expect(dayVerdictLabel(ctx, DayVerdict.missed), 'Missed');
+  });
+
+  testWidgets('the corner letter yields on cells too small to hold it and '
+      'follows the fill for ink', (tester) async {
+    final t = await tokens(tester);
+    expect(
+      dayCellLetter(t, letter: 'M', cellSize: IconSizes.xs, filled: false),
+      isNull,
+    );
+    expect(
+      dayCellLetter(t, letter: null, cellSize: IconSizes.l, filled: false),
+      isNull,
+    );
+    final tag = dayCellLetter(t, letter: 'M', cellSize: 28, filled: true);
+    expect(tag, isA<PositionedDirectional>());
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        SizedBox.square(dimension: 28, child: Stack(children: [tag!])),
+      ),
+    );
+    final text = tester.widget<Text>(find.text('M'));
+    expect(text.style?.color, t.colors.text.onInteractiveAlert);
+    final positioned = tester.widget<PositionedDirectional>(
+      find.byType(PositionedDirectional),
+    );
+    expect(positioned.start, 28 * DayCellLetter.insetStart);
+    expect(positioned.bottom, 28 * DayCellLetter.insetBottom);
+  });
+
+  testWidgets(
+    'the today ring and partial dot draw in quiet, non-interactive ink',
+    (
+      tester,
+    ) async {
+      final t = await tokens(tester);
+      expect(todayRingInk(t), t.colors.text.mediumEmphasis);
+      expect(dayCellRadius(t), t.radii.s);
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(Center(child: partialDayDot(t, 6))),
+      );
+      final dot = tester.widget<Container>(find.byType(Container));
+      expect(tester.getSize(find.byType(Container)), const Size(6, 6));
+      expect(
+        (dot.decoration! as BoxDecoration).color,
+        t.colors.alert.success.ink,
+      );
+    },
+  );
+}

--- a/test/widgets/day_indicators/day_mark_styles_test.dart
+++ b/test/widgets/day_indicators/day_mark_styles_test.dart
@@ -62,9 +62,11 @@ void main() {
     ]) {
       expect(dayMarkStateGlyph(state), isNull);
     }
+    // On the saturated error fill the cross takes the on-alert ink; the
+    // family's own ink is ~1.4:1 against its own hue.
     expect(
       dayMarkStateGlyphInk(t, DayMarkState.missed),
-      t.colors.alert.error.ink,
+      t.colors.text.onInteractiveAlert,
     );
     expect(
       dayMarkStateGlyphInk(t, DayMarkState.skipped),

--- a/test/widgets/day_indicators/day_mark_test.dart
+++ b/test/widgets/day_indicators/day_mark_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+
+void main() {
+  final day = DateTime.utc(2026, 8, 11);
+
+  group('DayMark.successful', () {
+    test('a recorded verdict outranks the measured state', () {
+      expect(
+        DayMark(
+          day: day,
+          state: DayMarkState.full,
+          verdict: DayVerdict.missed,
+        ).successful,
+        isFalse,
+        reason: 'a day filed as missed is not a success, however it measured',
+      );
+      expect(
+        DayMark(
+          day: day,
+          state: DayMarkState.none,
+          verdict: DayVerdict.met,
+        ).successful,
+        isTrue,
+      );
+      for (final verdict in [DayVerdict.improving, DayVerdict.mixed]) {
+        expect(
+          DayMark(
+            day: day,
+            state: DayMarkState.full,
+            verdict: verdict,
+          ).successful,
+          isFalse,
+          reason: '$verdict is not arrival',
+        );
+      }
+    });
+
+    test('without a verdict, only kept days count', () {
+      expect(
+        {
+          for (final state in DayMarkState.values)
+            state: DayMark(day: day, state: state).successful,
+        },
+        {
+          DayMarkState.none: false,
+          DayMarkState.partial: true,
+          DayMarkState.full: true,
+          DayMarkState.skipped: false,
+          DayMarkState.missed: false,
+        },
+      );
+    });
+  });
+
+  test('value equality covers every field', () {
+    const a = DayMark(state: DayMarkState.full);
+    const b = DayMark(state: DayMarkState.full);
+    expect(a, b);
+    expect(a.hashCode, b.hashCode);
+    expect(a, isNot(DayMark(day: day, state: DayMarkState.full)));
+    expect(a, isNot(const DayMark(state: DayMarkState.partial)));
+    expect(
+      a,
+      isNot(const DayMark(state: DayMarkState.full, verdict: DayVerdict.met)),
+    );
+    expect(
+      a,
+      isNot(
+        const DayMark(
+          state: DayMarkState.full,
+          verdictProvenance: DayVerdictProvenance.ratedByUser,
+        ),
+      ),
+    );
+    expect(a, isNot(const DayMark(state: DayMarkState.full, isToday: true)));
+    expect(a.toString(), contains('DayMarkState.full'));
+  });
+
+  test('verdict names are the persisted wire format and must not change', () {
+    expect(DayVerdict.values.map((v) => v.name), [
+      'met',
+      'improving',
+      'mixed',
+      'missed',
+    ]);
+    expect(DayVerdictProvenance.values.map((v) => v.name), [
+      'ratedByUser',
+      'suggestedAndAccepted',
+    ]);
+  });
+}

--- a/test/widgets/day_indicators/day_track_test.dart
+++ b/test/widgets/day_indicators/day_track_test.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/widgets/day_indicators/day_track.dart';
+import 'package:lotti/widgets/misc/linked_scroll_group.dart';
+
+import '../../widget_test_utils.dart';
+
+void main() {
+  testWidgets('DayTrack centers each child in a slot one pitch wide', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Align(
+          alignment: Alignment.topLeft,
+          child: DayTrack(
+            height: 20,
+            pitch: 30,
+            children: [
+              for (var i = 0; i < 3; i++)
+                SizedBox(key: ValueKey('slot-$i'), width: 10, height: 10),
+            ],
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(DayTrack)), const Size(90, 20));
+    for (var i = 0; i < 3; i++) {
+      expect(tester.getCenter(find.byKey(ValueKey('slot-$i'))).dx, 30 * i + 15);
+    }
+  });
+
+  testWidgets('an empty DayTrack takes no space', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        const Align(
+          alignment: Alignment.topLeft,
+          child: DayTrack(height: 20, pitch: 30, children: []),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(DayTrack)), Size.zero);
+  });
+
+  testWidgets('metrics keep the authored pitch when the span fits and shrink '
+      'toward the floor when it does not', (tester) async {
+    late DayTrackMetrics roomy;
+    late DayTrackMetrics squeezed;
+    late DayTrackMetrics floored;
+    late DsTokens tokens;
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Builder(
+          builder: (context) {
+            tokens = context.designTokens;
+            roomy = dayTrackMetrics(context, dayCount: 7, availableWidth: 1000);
+            squeezed = dayTrackMetrics(
+              context,
+              dayCount: 14,
+              availableWidth: 320,
+            );
+            floored = dayTrackMetrics(
+              context,
+              dayCount: 90,
+              availableWidth: 320,
+            );
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    final authored = ControlSizes.iconChipCompact + tokens.spacing.step2;
+    expect(roomy.pitch, authored);
+    expect(roomy.cellSize, ControlSizes.iconChipCompact);
+    expect(roomy.narrowLabels, isFalse);
+    expect(squeezed.pitch, lessThan(authored));
+    expect(squeezed.pitch * 14, lessThanOrEqualTo(320));
+    expect(squeezed.cellSize, squeezed.pitch - tokens.spacing.step2);
+    expect(floored.pitch, IconSizes.xs + tokens.spacing.step2);
+    expect(floored.cellSize, IconSizes.xs);
+    expect(floored.narrowLabels, isTrue);
+    expect(roomy.labelHeight, greaterThanOrEqualTo(IconSizes.s));
+  });
+
+  testWidgets('a raised text scale widens the pitch to hold the caption', (
+    tester,
+  ) async {
+    late DayTrackMetrics scaled;
+    late DayTrackMetrics normal;
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Builder(
+          builder: (context) {
+            normal = dayTrackMetrics(context, dayCount: 7);
+            return MediaQuery(
+              data: MediaQuery.of(
+                context,
+              ).copyWith(textScaler: const TextScaler.linear(2.5)),
+              child: Builder(
+                builder: (context) {
+                  scaled = dayTrackMetrics(context, dayCount: 7);
+                  return const SizedBox.shrink();
+                },
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    expect(scaled.pitch, greaterThan(normal.pitch));
+  });
+
+  testWidgets('fitOrScrollDayTrack wraps only content wider than its measure, '
+      'in a trailing-anchored scroller joined to the group', (tester) async {
+    final group = LinkedScrollGroup();
+    addTearDown(group.dispose);
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: 200,
+              child: fitOrScrollDayTrack(
+                contentWidth: 100,
+                availableWidth: 200,
+                group: group,
+                child: const SizedBox(
+                  key: ValueKey('fits'),
+                  width: 100,
+                  height: 10,
+                ),
+              ),
+            ),
+            SizedBox(
+              width: 200,
+              child: fitOrScrollDayTrack(
+                contentWidth: 400,
+                availableWidth: 200,
+                group: group,
+                child: const SizedBox(
+                  key: ValueKey('pans'),
+                  width: 400,
+                  height: 10,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+    expect(find.byType(LinkedDayTrackScroller), findsOneWidget);
+    expect(
+      find.ancestor(
+        of: find.byKey(const ValueKey('fits')),
+        matching: find.byType(LinkedDayTrackScroller),
+      ),
+      findsNothing,
+    );
+    final scroller = tester.widget<SingleChildScrollView>(
+      find.byType(SingleChildScrollView),
+    );
+    expect(scroller.reverse, isTrue);
+    expect(scroller.controller, isNotNull);
+    // Opens on today: the trailing edge of the content is on screen.
+    expect(tester.getTopRight(find.byKey(const ValueKey('pans'))).dx, 200);
+  });
+
+  testWidgets(
+    'a scroller re-attaches when its group changes and detaches on dispose',
+    (tester) async {
+      final first = LinkedScrollGroup();
+      final second = LinkedScrollGroup();
+      addTearDown(first.dispose);
+      addTearDown(second.dispose);
+      Widget build(LinkedScrollGroup group) => makeTestableWidgetNoScroll(
+        SizedBox(
+          width: 100,
+          child: LinkedDayTrackScroller(
+            group: group,
+            child: const SizedBox(width: 300, height: 10),
+          ),
+        ),
+      );
+      await tester.pumpWidget(build(first));
+      final firstController = tester
+          .widget<SingleChildScrollView>(find.byType(SingleChildScrollView))
+          .controller;
+      await tester.pumpWidget(build(second));
+      final secondController = tester
+          .widget<SingleChildScrollView>(find.byType(SingleChildScrollView))
+          .controller;
+      expect(secondController, isNot(same(firstController)));
+      // Detaching disposes the controller, so it refuses new listeners.
+      expect(
+        () => firstController!.addListener(() {}),
+        throwsFlutterError,
+        reason: 'detached from the old group',
+      );
+      await tester.pumpWidget(const SizedBox.shrink());
+      expect(() => secondController!.addListener(() {}), throwsFlutterError);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Beads lotti3-co1, steps 1–2: promote the goal side's day-cell primitives into one shared module both features consume, so a day is drawn the same way wherever it is judged.

- **New `lib/widgets/day_indicators/`** — `DayMark` / `DayMarkState {none, partial, full, skipped, missed}` / `DayVerdict` / `DayVerdictProvenance`; one styles file (fills, glyphs, inks, labels, weekday letter, today ring, partial dot); `DayTrack` + `dayTrackMetrics` + the fit-or-pan scroller; `DayMarkCell` / `PlaceholderDayCell`; `DayMarkStrip`; `DayMarkLegend`. The module imports neither feature.
- **Goals** adapt through `goalDayMarks()` (compact window + recorded verdicts → marks). `GoalCompactDayState`, `GoalAssessmentRating` and `GoalAssessmentProvenance` are now the shared enums; value names are unchanged, so persisted assessments (`rating.name`, `ratingV2`, `provenance.name`) decode as before — a test pins the wire names. `goal_progress_card.dart` loses ~940 lines. `_ProgressDayCell` stays bespoke (outcome menu, saving spinner, ages-out ring) but draws with the shared state and styles.
- **Habits**: the dashboard `HabitCompletionCard` history strip is a `DayMarkStrip` — success fill, skip dash and missed cross as non-color cues, dashed ring on today. Its private palette/WCAG-ink helpers, `showGaps`, and the now-unused `habitDayStatusSemantic` label are removed.
- **Docs**: new concept `knowledge/architecture/day-indicators.md`, index rows, pointers from the goals/habits/shared-widgets concepts and `lib/widgets/README.md`; changelog fragment.

Steps 3 (habit day verdicts, reflect sheet reachable from habit surfaces) and 4 (verdict-hue legend on habit surfaces, longer spans, proportional-cell decision) follow in separate PRs.

## Screenshots — dashboard habit card

| | before | after |
|---|---|---|
| desktop | ![before desktop](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/shared-day-indicators/58a8ea947a3d1445c4f19eeb707af08ab9112eec/before/dashboard_habit_card_desktop_dark.png) | ![after desktop](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/shared-day-indicators/58a8ea947a3d1445c4f19eeb707af08ab9112eec/after/dashboard_habit_card_desktop_dark.png) |
| mobile | ![before mobile](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/shared-day-indicators/58a8ea947a3d1445c4f19eeb707af08ab9112eec/before/dashboard_habit_card_mobile_dark.png) | ![after mobile](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/shared-day-indicators/58a8ea947a3d1445c4f19eeb707af08ab9112eec/after/dashboard_habit_card_mobile_dark.png) |

Note the phone: a 14-day chain now pans anchored on today (the goal tracks' policy) instead of dropping its oldest days, so the first cell sits clipped at the card edge.

## Tests

One test file per module file under `test/widgets/day_indicators/` (the strip-only tests moved there out of the goal card test), `goal_day_marks_test`, rewritten habit strip tests. Analyzer and formatter clean; every touched file green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Habit and goal day indicators now share consistent visuals for success, skipped, missed, partial, and today states.
  * Added non-color cues, including dashes, crosses, dots, weekday letters, and dashed today rings.
  * Longer day ranges now remain accessible through anchored horizontal scrolling.
  * Improved accessibility with clearer strip summaries, per-day labels, tooltips, and tappable day cells.

* **Documentation**
  * Added architecture and feature documentation for shared day indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->