### PR TITLE
feat(habits): habit day squares wear goal verdicts, reflect from the habit sheet

### DIFF
--- a/changelog.d/2026-08-29-habit-day-verdicts.md
+++ b/changelog.d/2026-08-29-habit-day-verdicts.md
@@ -1,0 +1,9 @@
+### Added
+
+- **A habit's day squares now show how you judged the day, and you can reflect
+  from the habit itself.** When a goal that watches a habit has a reflection
+  recorded for a day, that habit's square — on the goal's detail page and on
+  dashboard habit cards — wears the verdict (met, improving, mixed, missed)
+  instead of only the recorded outcome. The habit completion sheet offers
+  *Reflect on this day in ‹goal›* for every goal watching the habit, opening
+  that goal's reflection for the day being recorded.

--- a/knowledge/architecture/day-indicators.md
+++ b/knowledge/architecture/day-indicators.md
@@ -137,9 +137,40 @@ flowchart LR
   read generically ("3 successful days in the trailing seven-day window") and
   renaming them would touch every catalogue for no user-visible change.
 
+# Verdicts reach the habit side
+
+A verdict is always a goal's: `GoalAssessmentRecord.dimensionRatings` files
+the user's per-dimension ruling under the goal's criterion id. Habits reach
+those rulings through `lib/features/goals/state/goal_habit_watchers.dart`:
+
+- `goalsWatchingHabitProvider(habitId)` — the active goals whose current spec
+  names the habit, each with the criterion id the habit is filed under.
+- `habitDayVerdictsProvider(habitId)` — the verdict standing for each of the
+  habit's days across every watching goal, keyed by UTC day; when two goals
+  judged one day, the most recently recorded judgement wins.
+- `latestDimensionRatingsByDay` in `goal_assessment_state.dart` is the
+  per-dimension sibling of `latestRatingsByDay`, and what the goal detail
+  page feeds its own habit cells.
+
+```mermaid
+flowchart LR
+  A["GoalAssessmentRecord.dimensionRatings[criterionId]"] --> D["latestDimensionRatingsByDay"]
+  D --> P["_ProgressDayCell(verdict:)<br/>goal detail habit card"]
+  W["goalsWatchingHabitProvider(habitId)"] --> V["habitDayVerdictsProvider(habitId)"]
+  A --> V
+  V --> H["HabitCompletionCard strip<br/>DayMark(verdict:)"]
+  W --> S["HabitCompletionSheet<br/>Reflect on this day in ‹goal›"]
+  S --> R["showGoalDayAssessmentSheet(day: the sheet's day)"]
+```
+
+The habit sheet is the reflect doorway on the habit side because it already
+knows the day: reflecting on a backfilled day judges that day, not today. The
+reflection sheet itself stays the goal's — it needs the goal's spec, progress
+view and history — so the habit only contributes the day.
+
 # Not yet shared
 
-The issue that created this package (lotti3-co1) also asks for habit day
-verdicts with the reflect sheet reachable from habit surfaces, a complete
-legend including the verdict hues on habit surfaces, and longer spans on the
-habits page. Those build on this module and are separate changes.
+The remaining item from lotti3-co1 (step 4): a complete legend including the
+verdict hues on habit surfaces, longer spans on the habits page, and the
+explicit decision on proportional cell sizing. Those build on this module and
+are a separate change.

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -412,6 +412,14 @@ flowchart TD
   judgement of retired criteria colour a day under the current ones. Ties on
   `createdAt` break by record id so two devices cannot disagree.
 
+  The same ruling reaches the habit cells. `latestDimensionRatingsByDay`
+  reads a habit's own row (`dimensionRatings[criterionId]`) out of the
+  latest record per day, and the detail page hands `GoalProgressCard` the
+  history plus the spec id so each habit square wears its verdict over the
+  measured outcome. Habits outside the goal pages get there through
+  `goal_habit_watchers.dart` (see [day
+  indicators](../architecture/day-indicators.md)).
+
   `improving` is the verdict a three-way split could not express — some of it
   missed, but the day moved the right way. It is newer than the shipped wire
   format, so `rating` carries the nearest legacy-decodable verdict (`mixed`)

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -292,11 +292,19 @@ per-row history**. Per-day history reads from the heatmap instead. The older
 per-row history strip survives only inside the dashboard habit chart, drawn
 with the shared day-indicator cells ([day
 indicators](../architecture/day-indicators.md)) so it matches a goal's habit
-squares: success fill, skip dash, missed cross, dashed ring on today. A row
+squares: success fill, skip dash, missed cross, dashed ring on today — and,
+for a day a watching goal's reflection judged, that verdict's fill and glyph
+(`habitDayVerdictsProvider`). A row
 whose completion today came from the engine wears an **auto** pill and a
 caption naming the signal and the time (`HabitsState.autoCompletedToday` and
 `autoCompletedAt`); tapping it still opens the sheet, because a manual entry
 always overrides.
+
+The completion sheet is also where a habit reaches its goals' reflections:
+for every active goal whose spec names the habit
+(`goalsWatchingHabitProvider`), it offers *Reflect on this day in ‹goal›*,
+opening that goal's reflection sheet for the day being recorded — a
+backfilled day judges that day, not today.
 
 # The completion sheet shows the habit's own signals
 

--- a/lib/features/goals/state/goal_assessment_state.dart
+++ b/lib/features/goals/state/goal_assessment_state.dart
@@ -164,3 +164,23 @@ Map<DateTime, DayVerdict> latestRatingsByDay(
   ).entries)
     entry.key: entry.value.rating,
 };
+
+/// The verdict standing for one dimension on each day — a habit's or a
+/// metric's own row in the reflection sheet, keyed by its criterion id.
+///
+/// Built on the same latest-record-per-day rule as [latestRatingsByDay], so
+/// the dimension's colour on a habit card can never disagree with the day it
+/// belongs to. Days whose latest record did not rate this dimension are
+/// absent, not defaulted: the sheet only writes the rows the user touched,
+/// and an untouched row is no verdict rather than a met one.
+Map<DateTime, DayVerdict> latestDimensionRatingsByDay(
+  Iterable<GoalAssessmentRecord> records, {
+  required String criterionId,
+  String? specVersionId,
+}) => {
+  for (final entry in latestAssessmentsByDay(
+    records,
+    specVersionId: specVersionId,
+  ).entries)
+    entry.key: ?entry.value.dimensionRatings[criterionId],
+};

--- a/lib/features/goals/state/goal_habit_watchers.dart
+++ b/lib/features/goals/state/goal_habit_watchers.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/goals/model/goal_assessment.dart';
+import 'package:lotti/features/goals/state/goal_agent_providers.dart';
+import 'package:lotti/features/goals/state/goal_assessment_state.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+
+/// One active goal that watches a habit: the goal's identity, the spec
+/// version currently in force, and the id of the criterion inside that spec
+/// which names the habit — the key its per-dimension verdicts are filed
+/// under.
+typedef GoalHabitWatcher = ({
+  AgentIdentityEntity identity,
+  GoalSpecVersionEntity spec,
+  String criterionId,
+});
+
+/// The criterion id under which [habitId] appears in [criterion]'s tree, or
+/// null when the tree does not reference it. A habit appears at most once per
+/// goal; the first match is the match.
+String? goalCriterionIdForHabit(GoalCriterion criterion, String habitId) =>
+    switch (criterion) {
+      GoalCriterionHabit(habitId: final id, :final criterionId) =>
+        id == habitId ? criterionId : null,
+      GoalCriterionAllOf(:final criteria) ||
+      GoalCriterionAnyOf(:final criteria) ||
+      GoalCriterionAtLeastCount(:final criteria) => () {
+        for (final child in criteria) {
+          final found = goalCriterionIdForHabit(child, habitId);
+          if (found != null) return found;
+        }
+        return null;
+      }(),
+      GoalCriterionMetric() ||
+      GoalCriterionMeasurable() ||
+      GoalCriterionCategoryTime() ||
+      GoalCriterionLabelTime() => null,
+    };
+
+/// The active goals whose current spec names the habit.
+///
+/// The reverse of `goalCriterionHabitIds`: the habit surfaces need to know
+/// which goals judge a habit's days so they can show those judgements and
+/// open the goal's reflection from the habit's own sheet. Goals without a
+/// live spec (partial sync, dangling head) are skipped, exactly as the goal
+/// list withholds their health.
+final FutureProviderFamily<List<GoalHabitWatcher>, String>
+goalsWatchingHabitProvider = FutureProvider.autoDispose
+    .family<List<GoalHabitWatcher>, String>((ref, habitId) async {
+      final identities = await ref.watch(activeGoalAgentsProvider.future);
+      final watchers = <GoalHabitWatcher>[];
+      for (final identity in identities) {
+        final health = await ref.watch(
+          goalAgentHealthProvider(identity.agentId).future,
+        );
+        final spec = health.spec;
+        if (spec == null) continue;
+        final criterionId = goalCriterionIdForHabit(spec.criteria, habitId);
+        if (criterionId == null) continue;
+        watchers.add((
+          identity: identity,
+          spec: spec,
+          criterionId: criterionId,
+        ));
+      }
+      return watchers;
+    }, name: 'goalsWatchingHabitProvider');
+
+/// The verdict standing for each of the habit's days across every goal that
+/// watches it, keyed by UTC day.
+///
+/// A habit shared by two goals can be judged twice for one day. The most
+/// recently recorded judgement wins — the same rule `latestAssessmentsByDay`
+/// applies to one goal's own revisions — so the habit's squares show the user's latest word on
+/// that day rather than one goal's older one.
+final FutureProviderFamily<Map<DateTime, DayVerdict>, String>
+habitDayVerdictsProvider = FutureProvider.autoDispose
+    .family<Map<DateTime, DayVerdict>, String>((ref, habitId) async {
+      final watchers = await ref.watch(
+        goalsWatchingHabitProvider(habitId).future,
+      );
+      final latest = <DateTime, GoalAssessmentRecord>{};
+      final verdicts = <DateTime, DayVerdict>{};
+      for (final watcher in watchers) {
+        final records = await ref.watch(
+          goalAssessmentHistoryProvider(watcher.identity.agentId).future,
+        );
+        final byDay = latestAssessmentsByDay(
+          records,
+          specVersionId: watcher.spec.id,
+        );
+        for (final entry in byDay.entries) {
+          final verdict = entry.value.dimensionRatings[watcher.criterionId];
+          if (verdict == null) continue;
+          final held = latest[entry.key];
+          if (held != null && !entry.value.createdAt.isAfter(held.createdAt)) {
+            continue;
+          }
+          latest[entry.key] = entry.value;
+          verdicts[entry.key] = verdict;
+        }
+      }
+      return verdicts;
+    }, name: 'habitDayVerdictsProvider');

--- a/lib/features/goals/state/goal_habit_watchers.dart
+++ b/lib/features/goals/state/goal_habit_watchers.dart
@@ -95,9 +95,16 @@ habitDayVerdictsProvider = FutureProvider.autoDispose
           final verdict = entry.value.dimensionRatings[watcher.criterionId];
           if (verdict == null) continue;
           final held = latest[entry.key];
-          if (held != null && !entry.value.createdAt.isAfter(held.createdAt)) {
-            continue;
-          }
+          // The same tie-break `latestAssessmentsByDay` applies within one
+          // goal: equal timestamps fall back to the higher record id, so two
+          // devices iterating the goals in different orders agree.
+          final record = entry.value;
+          final wins =
+              held == null ||
+              record.createdAt.isAfter(held.createdAt) ||
+              (record.createdAt == held.createdAt &&
+                  record.id.compareTo(held.id) > 0);
+          if (!wins) continue;
           latest[entry.key] = entry.value;
           verdicts[entry.key] = verdict;
         }

--- a/lib/features/goals/ui/goal_progress_card.dart
+++ b/lib/features/goals/ui/goal_progress_card.dart
@@ -23,7 +23,9 @@ import 'package:lotti/features/design_system/components/tooltips/ds_tooltip.dart
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/goals/logic/goal_aggregate_rounding.dart';
 import 'package:lotti/features/goals/logic/goal_metric_series.dart';
+import 'package:lotti/features/goals/model/goal_assessment.dart';
 import 'package:lotti/features/goals/model/goal_health_data_types.dart';
+import 'package:lotti/features/goals/state/goal_assessment_state.dart';
 import 'package:lotti/features/goals/state/goal_progress_view.dart';
 import 'package:lotti/features/goals/ui/goal_day_marks.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -75,11 +77,22 @@ class GoalProgressCard extends StatelessWidget {
     this.onHabitOutcomeSelected,
     this.habitsHeadingTrailing,
     this.scrollGroup,
+    this.assessments = const [],
+    this.specVersionId,
     super.key,
   });
 
   final GoalProgressView progress;
   final GoalHabitOutcomeSelected? onHabitOutcomeSelected;
+
+  /// The goal's reflection history. A habit day the user judged in the
+  /// reflection sheet wears that verdict on its square, outranking the
+  /// measured outcome — the same rule the whole-goal strip follows.
+  final List<GoalAssessmentRecord> assessments;
+
+  /// The spec version in force, scoping [assessments]: a judgement passed
+  /// under retired criteria must not colour a day under the current ones.
+  final String? specVersionId;
 
   /// Trailing control on the FIRST evidence heading — Habits when the goal
   /// has habit rows, otherwise Signals — where the detail page rides its
@@ -135,6 +148,11 @@ class GoalProgressCard extends StatelessWidget {
             onHabitOutcomeSelected: onHabitOutcomeSelected,
             showLegend: index == 0,
             scrollGroup: scrollGroup,
+            verdictsByDay: latestDimensionRatingsByDay(
+              assessments,
+              criterionId: progress.habits[index].criterionId,
+              specVersionId: specVersionId,
+            ),
           ),
           SizedBox(height: tokens.spacing.step3),
         ],
@@ -466,9 +484,13 @@ class _HabitDimensionCard extends StatelessWidget {
     required this.onHabitOutcomeSelected,
     required this.showLegend,
     this.scrollGroup,
+    this.verdictsByDay = const {},
   });
 
   final LinkedScrollGroup? scrollGroup;
+
+  /// The user's per-day verdicts on this habit, keyed by UTC day.
+  final Map<DateTime, DayVerdict> verdictsByDay;
   final GoalHabitProgressView habit;
   final DateTime today;
   final GoalHabitOutcomeSelected? onHabitOutcomeSelected;
@@ -543,6 +565,7 @@ class _HabitDimensionCard extends StatelessWidget {
             habit: habit,
             today: today,
             onOutcomeSelected: onHabitOutcomeSelected,
+            verdictsByDay: verdictsByDay,
             scrollGroup: scrollGroup,
             // The six-week tail rides the window line above the squares
             // rather than taking a row under them: both facts describe the
@@ -1398,9 +1421,11 @@ class _HabitProgressRow extends StatefulWidget {
     required this.onOutcomeSelected,
     this.successfulWeeks,
     this.scrollGroup,
+    this.verdictsByDay = const {},
   });
 
   final LinkedScrollGroup? scrollGroup;
+  final Map<DateTime, DayVerdict> verdictsByDay;
 
   /// The rolling-week reliability tail, drawn on the trailing edge of the
   /// window line. Null for habits whose window is not a rolling week — the
@@ -1492,6 +1517,12 @@ class _HabitProgressRowState extends State<_HabitProgressRow> {
               day: activeDays[index],
               habitId: habit.habitId,
               size: metrics.cellSize,
+              verdict:
+                  widget.verdictsByDay[DateTime.utc(
+                    activeDays[index].day.year,
+                    activeDays[index].day.month,
+                    activeDays[index].day.day,
+                  )],
               weekdayLetter: letterFormat.format(activeDays[index].day),
               today: DateUtils.isSameDay(
                 activeDays[index].day,
@@ -1687,10 +1718,16 @@ class _ProgressDayCell extends StatelessWidget {
     required this.onOutcomeSelected,
     this.size = ControlSizes.iconChipCompact,
     this.weekdayLetter,
+    this.verdict,
   });
 
   final GoalProgressDay day;
   final String habitId;
+
+  /// The user's verdict on this habit for this day, when they recorded one
+  /// in the reflection sheet. It decides the fill and the glyph; the measured
+  /// outcome is only what the app observed.
+  final DayVerdict? verdict;
 
   /// One-letter weekday initial nested in the square — the day axis, now
   /// that the label row above the track is gone. Outranked by the stronger
@@ -1744,8 +1781,20 @@ class _ProgressDayCell extends StatelessWidget {
         : null;
     // The glyph scales with the square it sits in, so a squeezed column
     // does not paint a 12px cross onto a 14px cell.
-    final stateGlyph = dayMarkStateGlyph(dayState);
-    final Widget? centerMark = stateGlyph != null
+    // A recorded verdict outranks the measured outcome for fill and glyph,
+    // exactly as on the whole-goal strip: the measurement is evidence, the
+    // reflection is the user's ruling on the day.
+    final verdict = this.verdict;
+    final stateGlyph = verdict == null ? dayMarkStateGlyph(dayState) : null;
+    final Widget? centerMark = verdict != null
+        ? Center(
+            child: Icon(
+              dayVerdictGlyph(verdict),
+              size: glyphSize,
+              color: dayVerdictInk(tokens, verdict),
+            ),
+          )
+        : stateGlyph != null
         ? Center(
             child: Icon(
               stateGlyph,
@@ -1766,7 +1815,7 @@ class _ProgressDayCell extends StatelessWidget {
             tokens,
             letter: weekdayLetter,
             cellSize: visualDimension,
-            filled: dayState == DayMarkState.full,
+            filled: verdict != null || dayState == DayMarkState.full,
           );
     Widget cell = Container(
       key: ValueKey(
@@ -1776,7 +1825,9 @@ class _ProgressDayCell extends StatelessWidget {
       width: visualDimension,
       height: visualDimension,
       decoration: BoxDecoration(
-        color: dayMarkStateFill(tokens, dayState),
+        color: verdict == null
+            ? dayMarkStateFill(tokens, dayState)
+            : dayVerdictFill(tokens, verdict),
         borderRadius: BorderRadius.circular(dayCellRadius(tokens)),
         border: border,
       ),
@@ -1815,7 +1866,7 @@ class _ProgressDayCell extends StatelessWidget {
     final locale = Localizations.localeOf(context).toLanguageTag();
     final date = DateFormat.yMMMd(locale).format(day.day);
     final menuDate = DateFormat.MMMEd(locale).format(day.day);
-    final outcome = switch (completionType) {
+    final measured = switch (completionType) {
       HabitCompletionType.success =>
         context.messages.completeHabitSuccessButton,
       HabitCompletionType.skip => context.messages.completeHabitSkipButton,
@@ -1823,6 +1874,11 @@ class _ProgressDayCell extends StatelessWidget {
       HabitCompletionType.open ||
       null => context.messages.goalProgressHabitDayNoEntry,
     };
+    // Spoken and hovered as the verdict where one stands, the measurement
+    // otherwise — the cell must say what it shows.
+    final outcome = verdict == null
+        ? measured
+        : dayVerdictLabel(context, verdict);
     final semanticLabel = context.messages.goalProgressHabitDaySemantics(
       date,
       outcome,

--- a/lib/features/goals/ui/pages/goal_agent_detail_page.dart
+++ b/lib/features/goals/ui/pages/goal_agent_detail_page.dart
@@ -659,6 +659,8 @@ class _GoalAgentDetailPageState extends ConsumerState<GoalAgentDetailPage>
             key: _progressSectionKey,
             child: GoalProgressCard(
               progress: progress,
+              assessments: assessments,
+              specVersionId: spec?.id,
               scrollGroup: _trackScrollGroup,
               // The page-wide range picker rides the first evidence
               // heading — one control for every day track and the chart.

--- a/lib/features/habits/ui/sheets/habit_completion_sheet.dart
+++ b/lib/features/habits/ui/sheets/habit_completion_sheet.dart
@@ -9,6 +9,10 @@ import 'package:lotti/features/design_system/components/buttons/design_system_bu
 import 'package:lotti/features/design_system/components/buttons/ds_segmented_toggle.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/design_system/theme/ds_surface_elevation.dart';
+import 'package:lotti/features/goals/state/goal_assessment_state.dart';
+import 'package:lotti/features/goals/state/goal_habit_watchers.dart';
+import 'package:lotti/features/goals/state/goal_progress_view.dart';
+import 'package:lotti/features/goals/ui/goal_assessment_widgets.dart';
 import 'package:lotti/features/habits/state/habit_signal_status_controller.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_signal_row.dart';
 import 'package:lotti/features/habits/ui/widgets/measurable_quick_record_chips.dart';
@@ -119,6 +123,32 @@ class _HabitCompletionSheetState extends ConsumerState<HabitCompletionSheet> {
     _started = forToday ? clock.now() : endOfDay();
   }
 
+  /// Opens the day's reflection for one of the goals watching this habit.
+  ///
+  /// The reflection is the goal's: it needs the goal's spec, its progress
+  /// view (the sheet lists every dimension's evidence) and its history (so a
+  /// judged day reopens showing what was recorded). The habit sheet only
+  /// contributes the day — the one the user picked here, so reflecting on a
+  /// backfilled day judges that day, not today.
+  Future<void> _reflect(GoalHabitWatcher watcher) async {
+    final agentId = watcher.identity.agentId;
+    final progress = await ref.read(
+      goalAgentProgressViewProvider(agentId).future,
+    );
+    final assessments = await ref.read(
+      goalAssessmentHistoryProvider(agentId).future,
+    );
+    if (!mounted || progress == null) return;
+    showGoalDayAssessmentSheet(
+      context,
+      agentId: agentId,
+      spec: watcher.spec,
+      progress: progress,
+      assessments: assessments,
+      day: _started,
+    );
+  }
+
   Future<void> _save() async {
     _formKey.currentState!.save();
     Navigator.pop(context);
@@ -216,6 +246,21 @@ class _HabitCompletionSheetState extends ConsumerState<HabitCompletionSheet> {
                   ),
                 ),
             ],
+      reflections: [
+        for (final watcher
+            in ref.watch(goalsWatchingHabitProvider(widget.habitId)).value ??
+                const <GoalHabitWatcher>[])
+          DesignSystemButton(
+            key: ValueKey('habit-reflect-${watcher.identity.agentId}'),
+            label: context.messages.habitReflectInGoal(
+              watcher.spec.title,
+            ),
+            leadingIcon: LottiIcons.note,
+            variant: DesignSystemButtonVariant.tertiary,
+            size: DesignSystemButtonSize.dense,
+            onPressed: () => _reflect(watcher),
+          ),
+      ],
       onOutcomeChanged: (value) => setState(() {
         _outcome = value;
         _outcomeChosen = true;
@@ -275,6 +320,7 @@ class _CompletionForm extends StatelessWidget {
     required this.outcome,
     required this.autoSatisfied,
     required this.signals,
+    required this.reflections,
     required this.onOutcomeChanged,
     required this.onPickDate,
     required this.onClose,
@@ -288,6 +334,11 @@ class _CompletionForm extends StatelessWidget {
   final HabitCompletionType outcome;
   final bool autoSatisfied;
   final List<Widget> signals;
+
+  /// One action per goal watching this habit, opening that goal's
+  /// reflection for the day being recorded. Empty for a habit no goal
+  /// watches, and the row is then not rendered at all.
+  final List<Widget> reflections;
   final ValueChanged<HabitCompletionType> onOutcomeChanged;
   final ValueChanged<DateTime> onPickDate;
   final VoidCallback onClose;
@@ -359,6 +410,18 @@ class _CompletionForm extends StatelessWidget {
                 for (final signal in signals) ...[
                   SizedBox(height: tokens.spacing.step3),
                   signal,
+                ],
+                if (reflections.isNotEmpty) ...[
+                  SizedBox(height: tokens.spacing.step3),
+                  // The goals' own judgement of this day, reachable from the
+                  // habit: the day squares wear those verdicts, so the place
+                  // that records them has to be one tap from here.
+                  Wrap(
+                    key: const ValueKey('habit-sheet-reflections'),
+                    spacing: tokens.spacing.step2,
+                    runSpacing: tokens.spacing.step1,
+                    children: reflections,
+                  ),
                 ],
                 if (autoSatisfied) ...[
                   SizedBox(height: tokens.spacing.step3),

--- a/lib/features/habits/ui/sheets/habit_completion_sheet.dart
+++ b/lib/features/habits/ui/sheets/habit_completion_sheet.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
@@ -132,8 +134,16 @@ class _HabitCompletionSheetState extends ConsumerState<HabitCompletionSheet> {
   /// backfilled day judges that day, not today.
   Future<void> _reflect(GoalHabitWatcher watcher) async {
     final agentId = watcher.identity.agentId;
+    // A projection that reaches back to the picked day: the authored window
+    // alone stops short of a backfilled day, and the reflection sheet would
+    // then present that day's evidence as absent and invite a verdict on
+    // nothing. Never shorter than a week, so a recent day keeps the goal's
+    // usual picture around it.
     final progress = await ref.read(
-      goalAgentProgressViewProvider(agentId).future,
+      goalAgentProgressViewForSpanProvider((
+        agentId: agentId,
+        historyDays: reflectionSpanDays(from: _started, today: clock.now()),
+      )).future,
     );
     final assessments = await ref.read(
       goalAssessmentHistoryProvider(agentId).future,
@@ -557,4 +567,14 @@ class HabitDescription extends StatelessWidget {
       ),
     );
   }
+}
+
+/// How many days of history a reflection opened for [from] needs so that
+/// the day itself is inside the projection: the days back to today plus the
+/// day, never fewer than seven.
+int reflectionSpanDays({required DateTime from, required DateTime today}) {
+  final back = DateUtils.dateOnly(
+    today,
+  ).difference(DateUtils.dateOnly(from)).inDays;
+  return math.max(7, back + 1);
 }

--- a/lib/features/habits/ui/widgets/habit_completion_card.dart
+++ b/lib/features/habits/ui/widgets/habit_completion_card.dart
@@ -2,6 +2,7 @@ import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/features/goals/state/goal_habit_watchers.dart';
 import 'package:lotti/features/habits/state/habit_completion_controller.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_action_row.dart';
 import 'package:lotti/get_it.dart';
@@ -89,10 +90,18 @@ class _HabitCompletionCardState extends ConsumerState<HabitCompletionCard> {
           HabitCompletionType.skip,
         }.contains(results.last.completionType);
 
+    // A day the user judged in a watching goal's reflection wears that
+    // verdict here too: the strip shows the user's ruling, not only the
+    // measurement. Empty until the goals resolve, and empty for a habit no
+    // goal watches — the strip is complete either way.
+    final verdicts =
+        ref.watch(habitDayVerdictsProvider(habitDefinition.id)).value ??
+        const <DateTime, DayVerdict>{};
+
     return HabitActionRow(
       habitId: habitDefinition.id,
       completedToday: completedToday,
-      history: _HistoryStrip(results: results),
+      history: _HistoryStrip(results: results, verdictsByDay: verdicts),
     );
   }
 }
@@ -108,9 +117,12 @@ class _HabitCompletionCardState extends ConsumerState<HabitCompletionCard> {
 /// swipe-conflicting per-cell tap targets. A range longer than the width can
 /// hold pans, anchored on today, like every other day track.
 class _HistoryStrip extends StatelessWidget {
-  const _HistoryStrip({required this.results});
+  const _HistoryStrip({required this.results, this.verdictsByDay = const {}});
 
   final List<HabitResult> results;
+
+  /// The user's verdicts on this habit's days, keyed by UTC day.
+  final Map<DateTime, DayVerdict> verdictsByDay;
 
   @override
   Widget build(BuildContext context) {
@@ -118,11 +130,14 @@ class _HistoryStrip extends StatelessWidget {
     return DayMarkStrip(
       marks: [
         for (final result in results)
-          DayMark(
-            day: DateTime.parse(result.dayString),
-            state: habitCompletionDayMarkState(result.completionType),
-            isToday: result.dayString == today,
-          ),
+          if (DateTime.parse(result.dayString) case final day)
+            DayMark(
+              day: day,
+              state: habitCompletionDayMarkState(result.completionType),
+              verdict:
+                  verdictsByDay[DateTime.utc(day.year, day.month, day.day)],
+              isToday: result.dayString == today,
+            ),
       ],
     );
   }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2944,6 +2944,7 @@
   "habitLogOtherDayHint": "Podržením zaznamenáš jiný den",
   "habitNotRecordedLabel": "Nezaznamenáno",
   "habitPriorityLabel": "Priorita",
+  "habitReflectInGoal": "Zamysli se nad tímto dnem v cíli {goal}",
   "habitsAboveGoal": "Podle plánu",
   "habitsActiveHabitsCount": "{count, plural, one{1 aktivní návyk} few{{count} aktivní návyky} other{{count} aktivních návyků}}",
   "habitsAllDoneToday": "Dnes hotovo vše",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -3214,6 +3214,7 @@
   "habitLogOtherDayHint": "Hold for at logge en anden dag",
   "habitNotRecordedLabel": "Ikke registreret",
   "habitPriorityLabel": "Prioritet",
+  "habitReflectInGoal": "Reflektér over denne dag i {goal}",
   "habitsAboveGoal": "På banen",
   "habitsActiveHabitsCount": "{count, plural, one{1 aktiv vane} other{{count} aktive vaner}}",
   "@habitsActiveHabitsCount": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2937,6 +2937,7 @@
   "habitLogOtherDayHint": "Halten, um einen anderen Tag einzutragen",
   "habitNotRecordedLabel": "Nicht erfasst",
   "habitPriorityLabel": "Priorität",
+  "habitReflectInGoal": "Diesen Tag in {goal} reflektieren",
   "habitsAboveGoal": "Im Plan",
   "habitsActiveHabitsCount": "{count, plural, one{1 aktive Gewohnheit} other{{count} aktive Gewohnheiten}}",
   "habitsAllDoneToday": "Heute alles erledigt",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4417,6 +4417,15 @@
   "habitLogOtherDayHint": "Hold to log another day",
   "habitNotRecordedLabel": "Not recorded",
   "habitPriorityLabel": "Priority",
+  "habitReflectInGoal": "Reflect on this day in {goal}",
+  "@habitReflectInGoal": {
+    "description": "Action in the habit completion sheet that opens the day's reflection for a goal watching this habit.",
+    "placeholders": {
+      "goal": {
+        "type": "String"
+      }
+    }
+  },
   "habitsAboveGoal": "On track",
   "habitsActiveHabitsCount": "{count, plural, one{1 active habit} other{{count} active habits}}",
   "@habitsActiveHabitsCount": {

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -102,6 +102,7 @@
   "habitCategoryLabel": "Category",
   "habitDeleteQuestion": "Do you want to delete this habit?",
   "habitPriorityLabel": "Priority",
+  "habitReflectInGoal": "Reflect on this day in {goal}",
   "habitsCompletedHeader": "Completed",
   "habitsFilterAll": "all",
   "habitsFilterCompleted": "done",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2937,6 +2937,7 @@
   "habitLogOtherDayHint": "Mantén pulsado para registrar otro día",
   "habitNotRecordedLabel": "Sin registrar",
   "habitPriorityLabel": "Prioridad",
+  "habitReflectInGoal": "Reflexionar sobre este día en {goal}",
   "habitsAboveGoal": "En marcha",
   "habitsActiveHabitsCount": "{count, plural, one{1 hábito activo} other{{count} hábitos activos}}",
   "habitsAllDoneToday": "Todo hecho hoy",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2937,6 +2937,7 @@
   "habitLogOtherDayHint": "Maintiens appuyé pour enregistrer un autre jour",
   "habitNotRecordedLabel": "Non enregistré",
   "habitPriorityLabel": "Priorité",
+  "habitReflectInGoal": "Réfléchir à cette journée dans {goal}",
   "habitsAboveGoal": "Dans les clous",
   "habitsActiveHabitsCount": "{count, plural, one{1 habitude active} other{{count} habitudes actives}}",
   "habitsAllDoneToday": "Tout est fait aujourd'hui",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -3214,7 +3214,7 @@
   "habitLogOtherDayHint": "Tenere per registrare un altro giorno",
   "habitNotRecordedLabel": "Non registrato",
   "habitPriorityLabel": "Priorità",
-  "habitReflectInGoal": "Rifletti su questo giorno in {goal}",
+  "habitReflectInGoal": "Rifletti su questo giorno per l'obiettivo {goal}",
   "habitsAboveGoal": "Sulla pista",
   "habitsActiveHabitsCount": "{count, plural, one{1 abitudine attiva} other{{count} abitudini attive}}",
   "@habitsActiveHabitsCount": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -3214,6 +3214,7 @@
   "habitLogOtherDayHint": "Tenere per registrare un altro giorno",
   "habitNotRecordedLabel": "Non registrato",
   "habitPriorityLabel": "Priorità",
+  "habitReflectInGoal": "Rifletti su questo giorno in {goal}",
   "habitsAboveGoal": "Sulla pista",
   "habitsActiveHabitsCount": "{count, plural, one{1 abitudine attiva} other{{count} abitudini attive}}",
   "@habitsActiveHabitsCount": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -12600,6 +12600,12 @@ abstract class AppLocalizations {
   /// **'Priority'**
   String get habitPriorityLabel;
 
+  /// Action in the habit completion sheet that opens the day's reflection for a goal watching this habit.
+  ///
+  /// In en, this message translates to:
+  /// **'Reflect on this day in {goal}'**
+  String habitReflectInGoal(String goal);
+
   /// No description provided for @habitsAboveGoal.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -7502,6 +7502,11 @@ class AppLocalizationsCs extends AppLocalizations {
   String get habitPriorityLabel => 'Priorita';
 
   @override
+  String habitReflectInGoal(String goal) {
+    return 'Zamysli se nad tímto dnem v cíli $goal';
+  }
+
+  @override
   String get habitsAboveGoal => 'Podle plánu';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -7423,6 +7423,11 @@ class AppLocalizationsDa extends AppLocalizations {
   String get habitPriorityLabel => 'Prioritet';
 
   @override
+  String habitReflectInGoal(String goal) {
+    return 'Reflektér over denne dag i $goal';
+  }
+
+  @override
   String get habitsAboveGoal => 'På banen';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -7478,6 +7478,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get habitPriorityLabel => 'Priorität';
 
   @override
+  String habitReflectInGoal(String goal) {
+    return 'Diesen Tag in $goal reflektieren';
+  }
+
+  @override
   String get habitsAboveGoal => 'Im Plan';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7399,6 +7399,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get habitPriorityLabel => 'Priority';
 
   @override
+  String habitReflectInGoal(String goal) {
+    return 'Reflect on this day in $goal';
+  }
+
+  @override
   String get habitsAboveGoal => 'On track';
 
   @override
@@ -14309,6 +14314,11 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
 
   @override
   String get habitPriorityLabel => 'Priority';
+
+  @override
+  String habitReflectInGoal(String goal) {
+    return 'Reflect on this day in $goal';
+  }
 
   @override
   String get habitsCompletedHeader => 'Completed';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -7530,6 +7530,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get habitPriorityLabel => 'Prioridad';
 
   @override
+  String habitReflectInGoal(String goal) {
+    return 'Reflexionar sobre este día en $goal';
+  }
+
+  @override
   String get habitsAboveGoal => 'En marcha';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -7546,6 +7546,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get habitPriorityLabel => 'Priorité';
 
   @override
+  String habitReflectInGoal(String goal) {
+    return 'Réfléchir à cette journée dans $goal';
+  }
+
+  @override
   String get habitsAboveGoal => 'Dans les clous';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -7516,6 +7516,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get habitPriorityLabel => 'Priorità';
 
   @override
+  String habitReflectInGoal(String goal) {
+    return 'Rifletti su questo giorno in $goal';
+  }
+
+  @override
   String get habitsAboveGoal => 'Sulla pista';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -7517,7 +7517,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String habitReflectInGoal(String goal) {
-    return 'Rifletti su questo giorno in $goal';
+    return 'Rifletti su questo giorno per l\'obiettivo $goal';
   }
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -7439,6 +7439,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get habitPriorityLabel => 'Prioriteit';
 
   @override
+  String habitReflectInGoal(String goal) {
+    return 'Reflecteer op deze dag in $goal';
+  }
+
+  @override
   String get habitsAboveGoal => 'Op het spoor';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -7498,6 +7498,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get habitPriorityLabel => 'Prioridade';
 
   @override
+  String habitReflectInGoal(String goal) {
+    return 'Refletir sobre este dia em $goal';
+  }
+
+  @override
   String get habitsAboveGoal => 'No caminho certo';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -7563,6 +7563,11 @@ class AppLocalizationsRo extends AppLocalizations {
   String get habitPriorityLabel => 'Prioritate';
 
   @override
+  String habitReflectInGoal(String goal) {
+    return 'Reflectați asupra acestei zile în $goal';
+  }
+
+  @override
   String get habitsAboveGoal => 'Conform planului';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -7434,6 +7434,11 @@ class AppLocalizationsSv extends AppLocalizations {
   String get habitPriorityLabel => 'Prioritet';
 
   @override
+  String habitReflectInGoal(String goal) {
+    return 'Reflektera över den här dagen i $goal';
+  }
+
+  @override
   String get habitsAboveGoal => 'På banan';
 
   @override

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -3213,6 +3213,7 @@
   "habitLogOtherDayHint": "Wacht om een andere dag in te loggen",
   "habitNotRecordedLabel": "Niet geregistreerd",
   "habitPriorityLabel": "Prioriteit",
+  "habitReflectInGoal": "Reflecteer op deze dag in {goal}",
   "habitsAboveGoal": "Op het spoor",
   "habitsActiveHabitsCount": "{count, plural, one{1 actieve gewoonte} other{{count} actieve gewoonten}}",
   "@habitsActiveHabitsCount": {

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -3213,6 +3213,7 @@
   "habitLogOtherDayHint": "Segure para registrar outro dia",
   "habitNotRecordedLabel": "Não registrado",
   "habitPriorityLabel": "Prioridade",
+  "habitReflectInGoal": "Refletir sobre este dia em {goal}",
   "habitsAboveGoal": "No caminho certo",
   "habitsActiveHabitsCount": "{count, plural, one{1 hábito ativo} other{{count} hábitos ativos}}",
   "@habitsActiveHabitsCount": {

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2937,6 +2937,7 @@
   "habitLogOtherDayHint": "Țineți apăsat pentru a înregistra altă zi",
   "habitNotRecordedLabel": "Neînregistrat",
   "habitPriorityLabel": "Prioritate",
+  "habitReflectInGoal": "Reflectați asupra acestei zile în {goal}",
   "habitsAboveGoal": "Conform planului",
   "habitsActiveHabitsCount": "{count, plural, one{1 obicei activ} few{{count} obiceiuri active} other{{count} de obiceiuri active}}",
   "habitsAllDoneToday": "Tot finalizat azi",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -3214,6 +3214,7 @@
   "habitLogOtherDayHint": "Håll kvar för att logga en annan dag",
   "habitNotRecordedLabel": "Ej inspelat",
   "habitPriorityLabel": "Prioritet",
+  "habitReflectInGoal": "Reflektera över den här dagen i {goal}",
   "habitsAboveGoal": "På banan",
   "habitsActiveHabitsCount": "{count, plural, one{1 aktiv vana} other{{count} aktiva vanor}}",
   "@habitsActiveHabitsCount": {

--- a/test/features/goals/state/goal_assessment_state_test.dart
+++ b/test/features/goals/state/goal_assessment_state_test.dart
@@ -340,4 +340,87 @@ void main() {
       expect(standing?.rating, DayVerdict.improving);
     });
   });
+  group('latestDimensionRatingsByDay', () {
+    final day = DateTime.utc(2026, 8, 10);
+    GoalAssessmentRecord record({
+      required String id,
+      required DateTime createdAt,
+      String specVersionId = 'spec-1',
+      DateTime? on,
+      Map<String, DayVerdict> dimensions = const {},
+    }) => GoalAssessmentRecord(
+      id: id,
+      day: on ?? day,
+      specVersionId: specVersionId,
+      rating: DayVerdict.mixed,
+      createdAt: createdAt,
+      provenance: DayVerdictProvenance.ratedByUser,
+      dimensionRatings: dimensions,
+    );
+
+    test('the latest record decides, and an unrated dimension is absent', () {
+      final verdicts = latestDimensionRatingsByDay(
+        [
+          record(
+            id: 'first',
+            createdAt: DateTime(2026, 8, 10, 20),
+            dimensions: {'c1': DayVerdict.missed, 'c2': DayVerdict.met},
+          ),
+          record(
+            id: 'revision',
+            createdAt: DateTime(2026, 8, 10, 21),
+            dimensions: {'c1': DayVerdict.improving},
+          ),
+          record(
+            id: 'other-day',
+            on: day.subtract(const Duration(days: 1)),
+            createdAt: DateTime(2026, 8, 9, 21),
+            dimensions: {'c1': DayVerdict.met},
+          ),
+        ],
+        criterionId: 'c1',
+      );
+      expect(verdicts, {
+        day: DayVerdict.improving,
+        day.subtract(const Duration(days: 1)): DayVerdict.met,
+      });
+      // c2 was rated only in the superseded record: the revision is the
+      // day's word, and it did not rate c2.
+      expect(
+        latestDimensionRatingsByDay(
+          [
+            record(
+              id: 'first',
+              createdAt: DateTime(2026, 8, 10, 20),
+              dimensions: {'c2': DayVerdict.met},
+            ),
+            record(id: 'revision', createdAt: DateTime(2026, 8, 10, 21)),
+          ],
+          criterionId: 'c2',
+        ),
+        isEmpty,
+      );
+    });
+
+    test('a spec version scope drops judgements of retired criteria', () {
+      final verdicts = latestDimensionRatingsByDay(
+        [
+          record(
+            id: 'retired',
+            specVersionId: 'spec-0',
+            createdAt: DateTime(2026, 8, 10, 22),
+            dimensions: {'c1': DayVerdict.missed},
+          ),
+          record(
+            id: 'current',
+            createdAt: DateTime(2026, 8, 10, 20),
+            dimensions: {'c1': DayVerdict.met},
+          ),
+        ],
+        criterionId: 'c1',
+        specVersionId: 'spec-1',
+      );
+      expect(verdicts, {day: DayVerdict.met});
+    });
+  });
 }

--- a/test/features/goals/state/goal_habit_watchers_test.dart
+++ b/test/features/goals/state/goal_habit_watchers_test.dart
@@ -1,0 +1,269 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/goals/model/goal_assessment.dart';
+import 'package:lotti/features/goals/state/goal_agent_providers.dart';
+import 'package:lotti/features/goals/state/goal_assessment_state.dart';
+import 'package:lotti/features/goals/state/goal_habit_watchers.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+
+void main() {
+  const window = GoalWindow.rollingDays(count: 7);
+  const flossing = GoalCriterion.habit(
+    criterionId: 'c-floss',
+    habitId: 'floss',
+    window: window,
+    targetCount: 4,
+  );
+  const walking = GoalCriterion.habit(
+    criterionId: 'c-walk',
+    habitId: 'walk',
+    window: window,
+    targetCount: 3,
+  );
+  const steps = GoalCriterion.metric(
+    criterionId: 'c-steps',
+    dataType: 'steps',
+    window: window,
+    target: 10000,
+    aggregation: GoalAggregation.sum,
+  );
+
+  AgentIdentityEntity identity(String id) =>
+      AgentDomainEntity.agent(
+            id: id,
+            agentId: id,
+            kind: AgentKinds.goalAgent,
+            displayName: id,
+            lifecycle: AgentLifecycle.active,
+            mode: AgentInteractionMode.autonomous,
+            allowedCategoryIds: const {},
+            currentStateId: '$id:state',
+            config: const AgentConfig(),
+            createdAt: DateTime(2026),
+            updatedAt: DateTime(2026),
+            vectorClock: null,
+          )
+          as AgentIdentityEntity;
+
+  GoalSpecVersionEntity spec(String agentId, GoalCriterion criteria) =>
+      AgentDomainEntity.goalSpecVersion(
+            id: '$agentId:spec',
+            agentId: agentId,
+            version: 1,
+            status: GoalSpecVersionStatus.active,
+            authoredBy: 'user',
+            title: 'Goal $agentId',
+            statement: '',
+            criteria: criteria,
+            createdAt: DateTime(2026),
+            vectorClock: null,
+          )
+          as GoalSpecVersionEntity;
+
+  GoalAgentHealth health(GoalSpecVersionEntity? spec) => (
+    trackStatus: null,
+    attainment: null,
+    reportOneLiner: null,
+    pendingProposals: 0,
+    spec: spec,
+    direction: null,
+    deficit: null,
+    buffer: null,
+  );
+
+  GoalAssessmentRecord record({
+    required String id,
+    required String specVersionId,
+    required DateTime day,
+    required DateTime createdAt,
+    Map<String, DayVerdict> dimensions = const {},
+  }) => GoalAssessmentRecord(
+    id: id,
+    day: day,
+    specVersionId: specVersionId,
+    rating: DayVerdict.mixed,
+    createdAt: createdAt,
+    provenance: DayVerdictProvenance.ratedByUser,
+    dimensionRatings: dimensions,
+  );
+
+  ProviderContainer container({
+    required List<AgentIdentityEntity> agents,
+    required Map<String, GoalSpecVersionEntity?> specs,
+    Map<String, List<GoalAssessmentRecord>> history = const {},
+  }) {
+    final c = ProviderContainer(
+      overrides: [
+        activeGoalAgentsProvider.overrideWith((ref) async => agents),
+        for (final entry in specs.entries)
+          goalAgentHealthProvider(
+            entry.key,
+          ).overrideWith((ref) async => health(entry.value)),
+        for (final id in specs.keys)
+          goalAssessmentHistoryProvider(
+            id,
+          ).overrideWith((ref) async => history[id] ?? const []),
+      ],
+    );
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  group('goalCriterionIdForHabit', () {
+    test('finds the habit anywhere in a composite tree', () {
+      const tree = GoalCriterion.allOf(
+        criterionId: 'root',
+        criteria: [
+          steps,
+          GoalCriterion.anyOf(
+            criterionId: 'any',
+            criteria: [walking, flossing],
+          ),
+        ],
+      );
+      expect(goalCriterionIdForHabit(tree, 'floss'), 'c-floss');
+      expect(goalCriterionIdForHabit(tree, 'walk'), 'c-walk');
+      expect(goalCriterionIdForHabit(tree, 'swim'), isNull);
+      expect(goalCriterionIdForHabit(steps, 'floss'), isNull);
+    });
+  });
+
+  group('goalsWatchingHabitProvider', () {
+    test(
+      'lists the active goals naming the habit, with their criterion',
+      () async {
+        final c = container(
+          agents: [identity('g1'), identity('g2'), identity('g3')],
+          specs: {
+            'g1': spec('g1', flossing),
+            'g2': spec('g2', walking),
+            'g3': spec(
+              'g3',
+              const GoalCriterion.allOf(
+                criterionId: 'root',
+                criteria: [steps, flossing],
+              ),
+            ),
+          },
+        );
+        final watchers = await c.read(
+          goalsWatchingHabitProvider('floss').future,
+        );
+        expect(watchers.map((w) => w.identity.agentId), ['g1', 'g3']);
+        expect(watchers.map((w) => w.criterionId), ['c-floss', 'c-floss']);
+        expect(watchers.first.spec.id, 'g1:spec');
+      },
+    );
+
+    test('a goal without a live spec is skipped, not an error', () async {
+      final c = container(
+        agents: [identity('g1'), identity('g2')],
+        specs: {'g1': null, 'g2': spec('g2', flossing)},
+      );
+      final watchers = await c.read(goalsWatchingHabitProvider('floss').future);
+      expect(watchers.map((w) => w.identity.agentId), ['g2']);
+    });
+  });
+
+  group('habitDayVerdictsProvider', () {
+    final day = DateTime.utc(2026, 8, 10);
+
+    test('a habit no goal watches has no verdicts', () async {
+      final c = container(
+        agents: [identity('g1')],
+        specs: {'g1': spec('g1', walking)},
+      );
+      expect(await c.read(habitDayVerdictsProvider('floss').future), isEmpty);
+    });
+
+    test('reads the habit dimension out of the latest record per day, '
+        'scoped to the spec in force', () async {
+      final c = container(
+        agents: [identity('g1')],
+        specs: {'g1': spec('g1', flossing)},
+        history: {
+          'g1': [
+            record(
+              id: 'old',
+              specVersionId: 'g1:spec',
+              day: day,
+              createdAt: DateTime(2026, 8, 10, 20),
+              dimensions: {'c-floss': DayVerdict.missed},
+            ),
+            record(
+              id: 'revised',
+              specVersionId: 'g1:spec',
+              day: day,
+              createdAt: DateTime(2026, 8, 10, 21),
+              dimensions: {'c-floss': DayVerdict.improving},
+            ),
+            record(
+              id: 'retired-spec',
+              specVersionId: 'g1:spec-v0',
+              day: day.subtract(const Duration(days: 1)),
+              createdAt: DateTime(2026, 8, 9, 21),
+              dimensions: {'c-floss': DayVerdict.met},
+            ),
+            record(
+              id: 'untouched-row',
+              specVersionId: 'g1:spec',
+              day: day.subtract(const Duration(days: 2)),
+              createdAt: DateTime(2026, 8, 8, 21),
+            ),
+          ],
+        },
+      );
+      expect(await c.read(habitDayVerdictsProvider('floss').future), {
+        day: DayVerdict.improving,
+      });
+    });
+
+    test(
+      'across two watching goals the most recent judgement of a day wins',
+      () async {
+        final c = container(
+          agents: [identity('g1'), identity('g2')],
+          specs: {'g1': spec('g1', flossing), 'g2': spec('g2', flossing)},
+          history: {
+            'g1': [
+              record(
+                id: 'g1-day',
+                specVersionId: 'g1:spec',
+                day: day,
+                createdAt: DateTime(2026, 8, 10, 22),
+                dimensions: {'c-floss': DayVerdict.met},
+              ),
+              record(
+                id: 'g1-earlier-day',
+                specVersionId: 'g1:spec',
+                day: day.subtract(const Duration(days: 1)),
+                createdAt: DateTime(2026, 8, 9, 22),
+                dimensions: {'c-floss': DayVerdict.mixed},
+              ),
+            ],
+            'g2': [
+              record(
+                id: 'g2-day',
+                specVersionId: 'g2:spec',
+                day: day,
+                createdAt: DateTime(2026, 8, 10, 21),
+                dimensions: {'c-floss': DayVerdict.missed},
+              ),
+            ],
+          },
+        );
+        expect(await c.read(habitDayVerdictsProvider('floss').future), {
+          day: DayVerdict.met,
+          day.subtract(const Duration(days: 1)): DayVerdict.mixed,
+        });
+      },
+    );
+  });
+}

--- a/test/features/goals/state/goal_habit_watchers_test.dart
+++ b/test/features/goals/state/goal_habit_watchers_test.dart
@@ -133,6 +133,36 @@ void main() {
       expect(goalCriterionIdForHabit(tree, 'swim'), isNull);
       expect(goalCriterionIdForHabit(steps, 'floss'), isNull);
     });
+
+    test('no leaf but a habit leaf can name a habit', () {
+      const leaves = [
+        steps,
+        GoalCriterion.measurable(
+          criterionId: 'm',
+          dataTypeId: 'water',
+          window: window,
+          aggregation: GoalAggregation.sum,
+          target: 2000,
+        ),
+        GoalCriterion.categoryTime(
+          criterionId: 'ct',
+          categoryId: 'work',
+          window: window,
+          aggregation: GoalAggregation.sum,
+          targetHours: 8,
+        ),
+        GoalCriterion.labelTime(
+          criterionId: 'lt',
+          labelId: 'deep',
+          window: window,
+          aggregation: GoalAggregation.sum,
+          targetHours: 2,
+        ),
+      ];
+      for (final leaf in leaves) {
+        expect(goalCriterionIdForHabit(leaf, 'floss'), isNull, reason: '$leaf');
+      }
+    });
   });
 
   group('goalsWatchingHabitProvider', () {
@@ -223,6 +253,44 @@ void main() {
       expect(await c.read(habitDayVerdictsProvider('floss').future), {
         day: DayVerdict.improving,
       });
+    });
+
+    test('equal timestamps across goals break by record id, whichever goal '
+        'is iterated first', () async {
+      for (final order in [
+        ['g1', 'g2'],
+        ['g2', 'g1'],
+      ]) {
+        final c = container(
+          agents: [for (final id in order) identity(id)],
+          specs: {'g1': spec('g1', flossing), 'g2': spec('g2', flossing)},
+          history: {
+            'g1': [
+              record(
+                id: 'a-lower',
+                specVersionId: 'g1:spec',
+                day: day,
+                createdAt: DateTime(2026, 8, 10, 21),
+                dimensions: {'c-floss': DayVerdict.missed},
+              ),
+            ],
+            'g2': [
+              record(
+                id: 'b-higher',
+                specVersionId: 'g2:spec',
+                day: day,
+                createdAt: DateTime(2026, 8, 10, 21),
+                dimensions: {'c-floss': DayVerdict.met},
+              ),
+            ],
+          },
+        );
+        expect(
+          await c.read(habitDayVerdictsProvider('floss').future),
+          {day: DayVerdict.met},
+          reason: 'order $order',
+        );
+      }
     });
 
     test(

--- a/test/features/goals/ui/goal_progress_card_test.dart
+++ b/test/features/goals/ui/goal_progress_card_test.dart
@@ -22,6 +22,7 @@ import 'package:lotti/features/design_system/components/context_menus/design_sys
 import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
+import 'package:lotti/features/goals/model/goal_assessment.dart';
 import 'package:lotti/features/goals/model/goal_health_data_types.dart';
 import 'package:lotti/features/goals/state/goal_progress_view.dart';
 import 'package:lotti/features/goals/ui/goal_progress_card.dart';
@@ -3209,6 +3210,95 @@ void main() {
     );
     await gesture.moveTo(Offset.zero);
     await tester.pumpAndSettle();
+  });
+
+  testWidgets('a habit day the user judged in the reflection wears that '
+      'verdict on its square, outranking the measured outcome', (tester) async {
+    final handle = tester.ensureSemantics();
+    final judged = today.subtract(const Duration(days: 1));
+    GoalAssessmentRecord record({
+      required String id,
+      required String specVersionId,
+      required DayVerdict verdict,
+      required DateTime createdAt,
+    }) => GoalAssessmentRecord(
+      id: id,
+      day: judged,
+      specVersionId: specVersionId,
+      rating: DayVerdict.mixed,
+      createdAt: createdAt,
+      provenance: DayVerdictProvenance.ratedByUser,
+      dimensionRatings: {'c-walk': verdict},
+    );
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        GoalProgressCard(
+          specVersionId: 'spec-2',
+          assessments: [
+            // Under the retired spec the day was filed as met; under the
+            // current one as improving. Only the current one may colour it.
+            record(
+              id: 'retired',
+              specVersionId: 'spec-1',
+              verdict: DayVerdict.met,
+              createdAt: DateTime(2026, 8, 10, 23),
+            ),
+            record(
+              id: 'current',
+              specVersionId: 'spec-2',
+              verdict: DayVerdict.improving,
+              createdAt: DateTime(2026, 8, 10, 22),
+            ),
+          ],
+          progress: GoalProgressView(
+            today: today,
+            habits: [
+              GoalHabitProgressView(
+                habitId: 'walk',
+                criterionId: 'c-walk',
+                name: 'Walk',
+                targetCount: 3,
+                days: [
+                  day(6, 0),
+                  day(5, 0),
+                  day(4, 0),
+                  day(3, 0),
+                  day(2, 0),
+                  GoalProgressDay(
+                    day: judged,
+                    value: 0,
+                    habitCompletionType: HabitCompletionType.fail,
+                  ),
+                  day(0, 0),
+                ],
+                successfulWeeks: 2,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    final tokens = tester.element(find.byType(GoalProgressCard)).designTokens;
+    final visual = find.byKey(
+      const ValueKey('goal-habit-day-visual-walk-2026-08-10'),
+    );
+    final decoration =
+        tester.widget<Container>(visual).decoration! as BoxDecoration;
+    expect(decoration.color, dayVerdictFill(tokens, DayVerdict.improving));
+    expect(
+      find.descendant(
+        of: visual,
+        matching: find.byIcon(dayVerdictGlyph(DayVerdict.improving)),
+      ),
+      findsOneWidget,
+    );
+    // The measured miss no longer shows its cross — the ruling replaced it.
+    expect(find.byIcon(LottiIcons.close), findsNothing);
+    expect(
+      find.bySemanticsLabel(RegExp('Aug 10, 2026: Improving')),
+      findsOneWidget,
+    );
+    handle.dispose();
   });
 
   testWidgets('a recorded miss is visibly distinct from an empty day', (

--- a/test/features/habits/ui/sheets/habit_completion_sheet_test.dart
+++ b/test/features/habits/ui/sheets/habit_completion_sheet_test.dart
@@ -753,9 +753,12 @@ void main() {
           goalsWatchingHabitProvider(
             habitFlossing.id,
           ).overrideWith((ref) async => [watcher('g1')]),
-          goalAgentProgressViewProvider(
-            'g1',
-          ).overrideWith((ref) async => progress()),
+          // The sheet asks for a span reaching the picked day (2 days back
+          // → the seven-day floor).
+          goalAgentProgressViewForSpanProvider((
+            agentId: 'g1',
+            historyDays: 7,
+          )).overrideWith((ref) async => progress()),
           goalAssessmentHistoryProvider(
             'g1',
           ).overrideWith((ref) async => const []),
@@ -776,6 +779,42 @@ void main() {
       // The day the habit sheet was opened for — a backfilled day judges
       // that day, not today.
       expect(DateUtils.dateOnly(sheet.day), DateTime(2026, 8, 6));
+    });
+    clockedWidgets('a backfilled day far back asks for a projection that '
+        'reaches it', (tester) async {
+      await pumpSheet(
+        tester,
+        dateString: '2026-07-20',
+        overrides: [
+          goalsWatchingHabitProvider(
+            habitFlossing.id,
+          ).overrideWith((ref) async => [watcher('g1')]),
+          // 19 days back plus the day itself.
+          goalAgentProgressViewForSpanProvider((
+            agentId: 'g1',
+            historyDays: 20,
+          )).overrideWith((ref) async => progress()),
+          goalAssessmentHistoryProvider(
+            'g1',
+          ).overrideWith((ref) async => const []),
+        ],
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('habit-reflect-g1')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(find.byType(GoalDayAssessmentSheet), findsOneWidget);
+    });
+
+    test('reflectionSpanDays covers the day and never drops below a week', () {
+      final today = DateTime(2026, 8, 8, 14);
+      expect(reflectionSpanDays(from: today, today: today), 7);
+      expect(
+        reflectionSpanDays(from: DateTime(2026, 8, 6, 23), today: today),
+        7,
+      );
+      expect(reflectionSpanDays(from: DateTime(2026, 8), today: today), 8);
+      expect(reflectionSpanDays(from: DateTime(2026, 7, 20), today: today), 20);
     });
   });
 }

--- a/test/features/habits/ui/sheets/habit_completion_sheet_test.dart
+++ b/test/features/habits/ui/sheets/habit_completion_sheet_test.dart
@@ -5,12 +5,24 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_linkify/flutter_linkify.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/dashboards/state/measurables_controller.dart';
 import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/goals/state/goal_assessment_state.dart';
+import 'package:lotti/features/goals/state/goal_habit_watchers.dart';
+import 'package:lotti/features/goals/state/goal_progress_view.dart';
+import 'package:lotti/features/goals/ui/goal_assessment_widgets.dart';
 import 'package:lotti/features/habits/state/habit_signal_status_controller.dart';
 import 'package:lotti/features/habits/ui/sheets/habit_completion_sheet.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_signal_row.dart';
@@ -203,6 +215,7 @@ void main() {
     WidgetTester tester, {
     String? habitId,
     String? dateString,
+    List<Override> overrides = const [],
   }) async {
     tester.view.physicalSize = const Size(800, 1400);
     tester.view.devicePixelRatio = 1.0;
@@ -243,6 +256,7 @@ void main() {
           habitSignalStatusProvider(
             hydrationHabit.id,
           ).overrideWith(() => _ChoiceStatus(hydrationHabit.id, window)),
+          ...overrides,
         ],
       ),
     );
@@ -651,6 +665,117 @@ void main() {
         returnsNormally,
       );
       verifyNever(() => mockUrlLauncher.launchUrl(any(), any()));
+    });
+  });
+  group('reflecting in a watching goal', () {
+    GoalHabitWatcher watcher(String agentId) => (
+      identity:
+          AgentDomainEntity.agent(
+                id: agentId,
+                agentId: agentId,
+                kind: AgentKinds.goalAgent,
+                displayName: 'Fitness',
+                lifecycle: AgentLifecycle.active,
+                mode: AgentInteractionMode.autonomous,
+                allowedCategoryIds: const {},
+                currentStateId: '$agentId:state',
+                config: const AgentConfig(),
+                createdAt: DateTime(2026),
+                updatedAt: DateTime(2026),
+                vectorClock: null,
+              )
+              as AgentIdentityEntity,
+      spec:
+          AgentDomainEntity.goalSpecVersion(
+                id: '$agentId:spec',
+                agentId: agentId,
+                version: 1,
+                status: GoalSpecVersionStatus.active,
+                authoredBy: 'user',
+                title: 'Fitness',
+                statement: 'Floss daily.',
+                criteria: GoalCriterion.habit(
+                  criterionId: 'c-floss',
+                  habitId: habitFlossing.id,
+                  window: const GoalWindow.rollingDays(count: 7),
+                  targetCount: 4,
+                ),
+                createdAt: DateTime(2026),
+                vectorClock: null,
+              )
+              as GoalSpecVersionEntity,
+      criterionId: 'c-floss',
+    );
+
+    GoalProgressView progress() => GoalProgressView(
+      today: todayKey,
+      habits: [
+        GoalHabitProgressView(
+          habitId: habitFlossing.id,
+          criterionId: 'c-floss',
+          name: habitFlossing.name,
+          targetCount: 4,
+          successfulWeeks: 0,
+          days: [
+            for (var offset = 6; offset >= 0; offset--)
+              GoalProgressDay(
+                day: todayKey.subtract(Duration(days: offset)),
+                value: 0,
+              ),
+          ],
+        ),
+      ],
+    );
+
+    clockedWidgets('a habit no goal watches offers no reflection', (
+      tester,
+    ) async {
+      await pumpSheet(
+        tester,
+        overrides: [
+          goalsWatchingHabitProvider(
+            habitFlossing.id,
+          ).overrideWith((ref) async => const []),
+        ],
+      );
+      expect(
+        find.byKey(const ValueKey('habit-sheet-reflections')),
+        findsNothing,
+      );
+    });
+
+    clockedWidgets("one action per watching goal opens that goal's "
+        'reflection for the day being recorded', (tester) async {
+      await pumpSheet(
+        tester,
+        dateString: '2026-08-06',
+        overrides: [
+          goalsWatchingHabitProvider(
+            habitFlossing.id,
+          ).overrideWith((ref) async => [watcher('g1')]),
+          goalAgentProgressViewProvider(
+            'g1',
+          ).overrideWith((ref) async => progress()),
+          goalAssessmentHistoryProvider(
+            'g1',
+          ).overrideWith((ref) async => const []),
+        ],
+      );
+      await tester.pump();
+      expect(find.text('Reflect on this day in Fitness'), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('habit-reflect-g1')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final sheet = tester.widget<GoalDayAssessmentSheet>(
+        find.byType(GoalDayAssessmentSheet),
+      );
+      expect(sheet.agentId, 'g1');
+      expect(sheet.specVersionId, 'g1:spec');
+      // The day the habit sheet was opened for — a backfilled day judges
+      // that day, not today.
+      expect(DateUtils.dateOnly(sheet.day), DateTime(2026, 8, 6));
     });
   });
 }

--- a/test/features/habits/ui/widgets/habit_completion_card_test.dart
+++ b/test/features/habits/ui/widgets/habit_completion_card_test.dart
@@ -4,6 +4,7 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/goals/state/goal_habit_watchers.dart';
 import 'package:lotti/features/habits/state/habit_completion_controller.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_action_row.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_completion_card.dart';
@@ -85,6 +86,7 @@ void main() {
   Future<void> pumpCard(
     WidgetTester tester, {
     HabitDefinition? habit,
+    Map<DateTime, DayVerdict> verdicts = const {},
   }) async {
     final definition = habit ?? habitFlossing;
     await tester.pumpWidget(
@@ -98,6 +100,9 @@ void main() {
           habitCompletionControllerProvider.overrideWith2(
             (_) => _FakeController(),
           ),
+          habitDayVerdictsProvider(
+            definition.id,
+          ).overrideWith((ref) async => verdicts),
         ],
       ),
     );
@@ -227,6 +232,35 @@ void main() {
         return pumpCard(tester);
       });
       expect(find.byType(DsDashedBorder), findsNothing);
+    });
+  });
+
+  group('goal verdicts on the strip', () {
+    testWidgets('a day a watching goal judged wears that verdict, the rest '
+        'keep their measured state', (tester) async {
+      _results = [
+        _result(DateTime(2024, 3, 13), HabitCompletionType.fail),
+        _result(DateTime(2024, 3, 14), HabitCompletionType.success),
+        _result(_rangeEnd, HabitCompletionType.open),
+      ];
+      await pumpCard(
+        tester,
+        verdicts: {DateTime.utc(2024, 3, 13): DayVerdict.improving},
+      );
+      // One extra frame: the verdicts resolve after the results.
+      await tester.pump();
+      final marks = tester
+          .widgetList<DayMarkCell>(find.byType(DayMarkCell))
+          .map((cell) => (cell.mark.state, cell.mark.verdict))
+          .toList();
+      expect(marks, [
+        (DayMarkState.missed, DayVerdict.improving),
+        (DayMarkState.full, null),
+        (DayMarkState.none, null),
+      ]);
+      // The ruling replaces the measured cross with its own glyph.
+      expect(find.byIcon(LottiIcons.close), findsNothing);
+      expect(find.byIcon(LottiIcons.trendingUp), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
## Summary

Beads lotti3-co1, step 3 (follows #4070). A goal's per-dimension reflection now reaches the habit's day squares, and the habit sheet is a doorway into the goal's reflection.

- **`latestDimensionRatingsByDay`** (goals state): a habit's own row (`dimensionRatings[criterionId]`) out of the latest reflection per day, scoped to the spec version in force — the per-dimension sibling of `latestRatingsByDay`.
- **New `lib/features/goals/state/goal_habit_watchers.dart`**: `goalsWatchingHabitProvider(habitId)` lists the active goals whose current spec names the habit (with the criterion id it is filed under); `habitDayVerdictsProvider(habitId)` merges the verdicts across watching goals, most recent judgement of a day winning.
- **Goal detail habit cells** (`_ProgressDayCell`) and the **dashboard habit strip** wear a recorded verdict over the measured outcome — fill, glyph, tooltip and semantics — exactly as the whole-goal strip already does. `GoalProgressCard` takes `assessments` + `specVersionId` from the detail page.
- **Habit completion sheet**: *Reflect on this day in ‹goal›* for every watching goal, opening that goal's reflection sheet for the day being recorded (a backfilled day judges that day, not today). One new label, all 12 catalogs. Habits no goal watches see no change.
- Docs: goals, habits and day-indicators concepts; changelog fragment.

Step 4 (verdict-hue legend on habit surfaces, longer spans, cell-sizing decision) follows separately.

## Screenshots

| surface | before | after |
|---|---|---|
| goal detail habit card (desktop) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-verdicts/1242cb00ec86b473cab57396893792540e62f51b/before/goal_habit_card_desktop_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-verdicts/1242cb00ec86b473cab57396893792540e62f51b/after/goal_habit_card_desktop_dark.png) |
| goal detail habit card (mobile) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-verdicts/1242cb00ec86b473cab57396893792540e62f51b/before/goal_habit_card_mobile_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-verdicts/1242cb00ec86b473cab57396893792540e62f51b/after/goal_habit_card_mobile_dark.png) |
| habit sheet (desktop) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-verdicts/1242cb00ec86b473cab57396893792540e62f51b/before/habit_sheet_desktop_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-verdicts/1242cb00ec86b473cab57396893792540e62f51b/after/habit_sheet_desktop_dark.png) |
| habit sheet (mobile) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-verdicts/1242cb00ec86b473cab57396893792540e62f51b/before/habit_sheet_mobile_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-verdicts/1242cb00ec86b473cab57396893792540e62f51b/after/habit_sheet_mobile_dark.png) |

In the goal card, Tuesday's measured miss wears the recorded *Improving* verdict and Thursday's skip wears *Mixed*. (The legend does not yet key the verdict hues — that is step 4.)

## Tests

`goal_habit_watchers_test` (tree walk, watcher listing, spec-less goals skipped, latest-wins merge, spec scoping), `latestDimensionRatingsByDay` cases, goal cell verdict rendering incl. retired-spec exclusion, dashboard strip verdict via provider override, sheet reflect action (none without watchers; opens `GoalDayAssessmentSheet` for the picked day). Analyzer and formatter clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Habit day indicators now show reflection verdicts such as met, improving, mixed, or missed on goal pages and dashboard cards.
  - Added quick actions in the completion sheet to reflect on the recorded day within each associated goal.
  - Backfilled entries open reflection for their original recorded date.
  - Added localized text for the new reflection action across supported languages.

- **Documentation**
  - Documented verdict display and habit-to-goal reflection behavior.

- **Tests**
  - Added coverage for verdict selection, display, and reflection navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->