### PR TITLE
feat(habits): open the habit editor as a desktop side panel with two columns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@
 ## Commit & Pull Request Guidelines
 - Use Conventional Commits (e.g., `feat:`, `fix:`, `chore:`, `ci:`). Keep subjects concise and imperative.
 - PRs must pass `make analyze` and `make test`; include a clear description and linked issues.
-- **UI changes need a before/after screenshot pair per surface**, captured with the harness (see the `app-screenshots` skill). Capture `before/` from the base commit *first* — it cannot be reconstructed once the change is in. **Never commit images to any repo.** Publish the pair to the R2 bucket with `make pr_screenshots_publish` and link the printed public URLs from the PR body. The staging layout, the naming rules and the publish command are in [knowledge/conventions/screenshots.md](knowledge/conventions/screenshots.md).
+- **UI changes need a before/after screenshot pair per surface**, captured with the harness (see the `app-screenshots` skill). Capture `before/` from the base commit *first* — it cannot be reconstructed once the change is in. **Fixtures come from `test/test_data` and the penguin demo world only — never from a user's own habits, tasks, notes or bug screenshots**; a capture is published to a public bucket and a public PR. **Never commit images to any repo.** Publish the pair to the R2 bucket with `make pr_screenshots_publish` and link the printed public URLs from the PR body. The staging layout, the naming rules and the publish command are in [knowledge/conventions/screenshots.md](knowledge/conventions/screenshots.md).
 - Update docs and localization as needed (run `make l10n`).
 
 ## Security & Configuration Tips

--- a/changelog.d/2026-08-29-habit-editor-desktop.md
+++ b/changelog.d/2026-08-29-habit-editor-desktop.md
@@ -1,0 +1,13 @@
+### Changed
+
+- **On desktop the habit editor opens as a side panel over the Habits page
+  instead of a separate screen.** It slides in from the right over a dimmed
+  page, lays the signals and the settings out side by side so the whole form
+  is visible without scrolling, and closes on save, on the scrim or with
+  Escape — you stay on the list you were reading. Phones keep the full-screen
+  editor.
+
+### Fixed
+
+- The edit page's "How do we know it's done?" heading no longer draws an empty
+  bordered box under itself.

--- a/knowledge/conventions/screenshots.md
+++ b/knowledge/conventions/screenshots.md
@@ -197,6 +197,14 @@ Matching filenames on both sides are what make the pair readable — a reviewer
 should be able to flip between two images of the same name and see only the
 change.
 
+**Fixtures are never the user's own data.** A capture harness populates its
+surface from `test/test_data` and the penguin demo world — never from a habit,
+task, goal, note or description seen in a maintainer's own app, database or bug
+screenshot. Everything captured here is published to a public bucket and
+embedded in a public pull request, so a real entry in a fixture is a real entry
+on the internet. Read every string in a scratch harness before running it, and
+every image before publishing it.
+
 **Capture `before/` first, from the base commit**, before the change exists.
 Reconstructing it afterwards means stashing work and re-running the harness, which
 is the step people skip; that is why the pairs go missing.

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -146,6 +146,21 @@ description with example pills, then "how do we know it's done?"); editing is
 one flat page with the same sections plus Favorite / Private / Active and
 Delete.
 
+How it is reached depends on the window. `openHabitEditor`
+(`ui/pages/habit_editor_launcher.dart`) is the one doorway the FAB, the row
+long-press and the sheet's pencil use: on a phone it beams to the route above;
+on desktop (`isDesktopLayout`) it opens the same page **embedded in a
+right-anchored side panel** (`SizedWoltSideSheetType`, up to
+`kHabitEditorPanelWidth` = 800px) over the list, with a scrim — a form the user
+closes in a moment should not navigate them away from the list. Embedded
+(`HabitEditorPage.onClose`) the page renders no scaffold or app bar; back,
+save and delete close the panel instead of beaming, and the create wizard's
+signals step carries its own *Back*. At desktop widths the signals step lays
+identity + signals and Settings + Options out as two columns
+(`habit-editor-columns`), so two phone-width columns show the whole form
+without scrolling; the create wizard's name step stays a single narrow column.
+Deep links and Settings › Habits still mount the full route on any width.
+
 The definition itself stays in `HabitSettingsController` (`FormBuilder` for
 name, description and the three switches; setters for category, dates, the
 rule and `autoCompleteNotify`). The page owns only the signal card's form:

--- a/lib/features/design_system/theme/breakpoints.dart
+++ b/lib/features/design_system/theme/breakpoints.dart
@@ -68,3 +68,9 @@ const kRowInlineControlMinWidth = 496.0;
 /// five-digit value plus its unit label, narrow enough to leave the row's
 /// title its measure.
 const kInlineTargetInputWidth = 320.0;
+
+/// The habit editor's desktop side panel: two phone-width columns
+/// (`kActionListContentMaxWidth` each, less the gutter between them) so the
+/// whole form is on screen without scrolling. Like [kGoalChatDrawerWidth], a
+/// reviewed layout width rather than a token — a panel is not a component.
+const kHabitEditorPanelWidth = 800.0;

--- a/lib/features/habits/ui/habits_page.dart
+++ b/lib/features/habits/ui/habits_page.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lotti/beamer/locations/habits_location.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -10,6 +9,7 @@ import 'package:lotti/features/design_system/theme/ds_surface_elevation.dart';
 import 'package:lotti/features/habits/state/habits_controller.dart';
 import 'package:lotti/features/habits/state/habits_state.dart';
 import 'package:lotti/features/habits/state/heatmap/habit_heatmap_controller.dart';
+import 'package:lotti/features/habits/ui/pages/habit_editor_launcher.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_action_row.dart';
 import 'package:lotti/features/habits/ui/widgets/habits_chart_card.dart';
 import 'package:lotti/features/habits/ui/widgets/habits_header.dart';
@@ -23,7 +23,6 @@ import 'package:lotti/features/keyboard/ui/app_command_scope.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
-import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
 
 /// Top-level habits tab: a dashboard on the calm [dsPageSurface] canvas, driven
@@ -271,7 +270,7 @@ class _HabitsTabPageState extends ConsumerState<HabitsTabPage> {
           child: DesignSystemFloatingActionButton(
             key: const ValueKey('habits-create-fab'),
             semanticLabel: messages.habitEditorCreateTitle,
-            onPressed: () => beamToNamed(HabitsLocation.createPath),
+            onPressed: () => openHabitEditor(context),
           ),
         ),
         backgroundColor: dsPageSurface(context),

--- a/lib/features/habits/ui/pages/habit_editor_launcher.dart
+++ b/lib/features/habits/ui/pages/habit_editor_launcher.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/beamer/locations/habits_location.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
+import 'package:lotti/features/habits/ui/pages/habit_editor_page.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/widgets/modal/modal_utils.dart';
+import 'package:lotti/widgets/modal/sized_wolt_side_sheet_type.dart';
+
+/// The width the editor panel aims for on desktop: two phone-width columns
+/// side by side, so the whole form is on screen without scrolling.
+const kHabitEditorPanelWidth = 800.0;
+
+/// The vertical room the side sheet's own chrome takes above the editor's
+/// content — its top bar with the title and close button. The embedded
+/// editor sizes itself to the window minus this, so its action row sits at
+/// the panel's foot. Measured against the sheet as configured here; a
+/// slight undershoot only leaves a little air, an overshoot would overflow.
+const kHabitEditorPanelChromeHeight = 80.0;
+
+/// Opens the habit editor — for [habitId], or a new habit when null.
+///
+/// On a phone the editor is its own route, reached and left through the
+/// navigator. On desktop it is a right-anchored panel over the page the user
+/// is on: a form they will close in a moment should not navigate them away
+/// from the list they were reading, and a page-wide route for it was a
+/// phone-width column between two empty gutters.
+void openHabitEditor(BuildContext context, {String? habitId}) {
+  if (!isDesktopLayout(context)) {
+    beamToNamed(
+      habitId == null
+          ? HabitsLocation.createPath
+          : HabitsLocation.editPath(habitId),
+    );
+    return;
+  }
+  final messages = context.messages;
+  ModalUtils.showSinglePageModal<void>(
+    context: context,
+    title: habitId == null
+        ? messages.habitEditorCreateTitle
+        : messages.habitEditorEditTitle,
+    modalTypeBuilderOverride: (_) => const SizedWoltSideSheetType(
+      widthFraction: 0.6,
+      minWidth: 560,
+      maxWidth: kHabitEditorPanelWidth,
+    ),
+    builder: (sheetContext) => HabitEditorPage(
+      habitId: habitId,
+      // The sheet nests a navigator of its own for its pages; the panel
+      // itself is a route on the navigator it was shown from.
+      onClose: () => Navigator.of(sheetContext, rootNavigator: true).pop(),
+    ),
+  );
+}

--- a/lib/features/habits/ui/pages/habit_editor_launcher.dart
+++ b/lib/features/habits/ui/pages/habit_editor_launcher.dart
@@ -7,17 +7,6 @@ import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
 import 'package:lotti/widgets/modal/sized_wolt_side_sheet_type.dart';
 
-/// The width the editor panel aims for on desktop: two phone-width columns
-/// side by side, so the whole form is on screen without scrolling.
-const kHabitEditorPanelWidth = 800.0;
-
-/// The vertical room the side sheet's own chrome takes above the editor's
-/// content — its top bar with the title and close button. The embedded
-/// editor sizes itself to the window minus this, so its action row sits at
-/// the panel's foot. Measured against the sheet as configured here; a
-/// slight undershoot only leaves a little air, an overshoot would overflow.
-const kHabitEditorPanelChromeHeight = 80.0;
-
 /// Opens the habit editor — for [habitId], or a new habit when null.
 ///
 /// On a phone the editor is its own route, reached and left through the
@@ -35,21 +24,28 @@ void openHabitEditor(BuildContext context, {String? habitId}) {
     return;
   }
   final messages = context.messages;
+  // The navigator the sheet is pushed on — resolved here, from the same
+  // context Wolt resolves it from, so a close pops exactly that route.
+  // Re-deriving it inside the sheet found a different navigator on the
+  // desktop tabs, which each run a nested one.
+  final navigator = Navigator.of(context, rootNavigator: true);
   ModalUtils.showSinglePageModal<void>(
     context: context,
+    // On the root navigator, explicitly: the desktop tabs each run a nested
+    // Beamer navigator, and a sheet pushed there dims only the tab. The
+    // scrim is meant to cover the whole window, and [navigator] above is
+    // the same root, so the close pops the sheet and nothing else.
+    useRootNavigator: true,
     title: habitId == null
         ? messages.habitEditorCreateTitle
         : messages.habitEditorEditTitle,
+    // One reviewed width (see [kHabitEditorPanelWidth]), clamped to the
+    // window by the sheet type on narrow desktops.
     modalTypeBuilderOverride: (_) => const SizedWoltSideSheetType(
-      widthFraction: 0.6,
-      minWidth: 560,
+      widthFraction: 1,
+      minWidth: kHabitEditorPanelWidth,
       maxWidth: kHabitEditorPanelWidth,
     ),
-    builder: (sheetContext) => HabitEditorPage(
-      habitId: habitId,
-      // The sheet nests a navigator of its own for its pages; the panel
-      // itself is a route on the navigator it was shown from.
-      onClose: () => Navigator.of(sheetContext, rootNavigator: true).pop(),
-    ),
+    builder: (_) => HabitEditorPage(habitId: habitId, onClose: navigator.pop),
   );
 }

--- a/lib/features/habits/ui/pages/habit_editor_page.dart
+++ b/lib/features/habits/ui/pages/habit_editor_page.dart
@@ -15,7 +15,6 @@ import 'package:lotti/features/goals/model/goal_health_data_types.dart';
 import 'package:lotti/features/habits/model/habit_form_mapping.dart';
 import 'package:lotti/features/habits/state/habit_editor_providers.dart';
 import 'package:lotti/features/habits/state/habit_settings_controller.dart';
-import 'package:lotti/features/habits/ui/pages/habit_editor_launcher.dart';
 import 'package:lotti/features/habits/ui/widgets/editor/habit_composite_picker.dart';
 import 'package:lotti/features/habits/ui/widgets/editor/habit_signal_card.dart';
 import 'package:lotti/features/habits/ui/widgets/editor/habit_signal_picker.dart';
@@ -482,8 +481,13 @@ class HabitEditorPageState extends ConsumerState<HabitEditorPage> {
       // the primary action stays pinned at the foot — a Save the user has to
       // scroll to find was the complaint that moved the editor off its own
       // route in the first place.
+      // The sheet's nav bar is `spacing.step10` tall (ModalUtils' default);
+      // one step of slack under that keeps the foot clear of the sheet edge
+      // without ever overshooting into an overflow.
       final height =
-          MediaQuery.sizeOf(context).height - kHabitEditorPanelChromeHeight;
+          MediaQuery.sizeOf(context).height -
+          tokens.spacing.step10 -
+          tokens.spacing.step4;
       return AppCommandScope(
         handlers: {
           AppCommandId.save: AppCommandHandler(

--- a/lib/features/habits/ui/pages/habit_editor_page.dart
+++ b/lib/features/habits/ui/pages/habit_editor_page.dart
@@ -15,6 +15,7 @@ import 'package:lotti/features/goals/model/goal_health_data_types.dart';
 import 'package:lotti/features/habits/model/habit_form_mapping.dart';
 import 'package:lotti/features/habits/state/habit_editor_providers.dart';
 import 'package:lotti/features/habits/state/habit_settings_controller.dart';
+import 'package:lotti/features/habits/ui/pages/habit_editor_launcher.dart';
 import 'package:lotti/features/habits/ui/widgets/editor/habit_composite_picker.dart';
 import 'package:lotti/features/habits/ui/widgets/editor/habit_signal_card.dart';
 import 'package:lotti/features/habits/ui/widgets/editor/habit_signal_picker.dart';
@@ -47,6 +48,7 @@ class HabitEditorPage extends ConsumerStatefulWidget {
   const HabitEditorPage({
     this.habitId,
     this.returnPath = habitsRootPath,
+    this.onClose,
     super.key,
   });
 
@@ -59,6 +61,14 @@ class HabitEditorPage extends ConsumerStatefulWidget {
   /// Where Save, Cancel and Delete lead — the habits page, or the settings
   /// list when opened from there.
   final String returnPath;
+
+  /// Set when the editor is hosted inside a panel rather than on its own
+  /// route: leaving (back, save, delete) then closes the panel instead of
+  /// navigating, and the page renders no scaffold or app bar of its own.
+  final VoidCallback? onClose;
+
+  /// Whether this editor is hosted inside a panel.
+  bool get embedded => onClose != null;
 
   static const habitsRootPath = '/habits';
 
@@ -89,6 +99,17 @@ class HabitEditorPageState extends ConsumerState<HabitEditorPage> {
   void _setSignals(HabitSignalsForm form) {
     setState(() => _signals = form);
     _controller.setAutoCompleteRule(HabitFormMapping.toRule(form));
+  }
+
+  /// Leaves the editor: closes the hosting panel, or returns to the route
+  /// the editor was opened from.
+  void _leave() {
+    final onClose = widget.onClose;
+    if (onClose != null) {
+      onClose();
+    } else {
+      beamToNamed(widget.returnPath);
+    }
   }
 
   Future<void> _save() async {
@@ -123,7 +144,7 @@ class HabitEditorPageState extends ConsumerState<HabitEditorPage> {
         title: context.messages.habitEditorCreatedToast,
       );
     }
-    beamToNamed(widget.returnPath);
+    _leave();
   }
 
   void _continue(HabitSettingsState state) {
@@ -151,7 +172,7 @@ class HabitEditorPageState extends ConsumerState<HabitEditorPage> {
     );
     if (result == deleteKey) {
       await _controller.delete();
-      beamToNamed(widget.returnPath);
+      _leave();
     }
   }
 
@@ -235,6 +256,14 @@ class HabitEditorPageState extends ConsumerState<HabitEditorPage> {
       // transient stream error; only a habit that never arrived gets the
       // shell.
       if (habitAsync.value == null) {
+        // Inside a panel the sheet sizes to its content, so the shell has to
+        // be a bounded placeholder rather than a page-filling scaffold.
+        if (widget.embedded) {
+          return Padding(
+            padding: EdgeInsets.all(tokens.spacing.step8),
+            child: const Center(child: CircularProgressIndicator()),
+          );
+        }
         return EmptyScaffoldWithTitle(messages.habitEditorEditTitle);
       }
     }
@@ -287,6 +316,246 @@ class HabitEditorPageState extends ConsumerState<HabitEditorPage> {
         ? messages.habitEditorCreateTitle
         : messages.habitEditorEditTitle;
 
+    // The two halves of the signals step. On a phone they stack; on desktop
+    // they sit side by side, because the form clamped to the phone column
+    // scrolled a window that could show all of it at once.
+    final identityAndSignals = <Widget>[
+      // The name step stays mounted (offstage) on the
+      // signals step so the form keeps its values.
+      Offstage(
+        offstage: widget.isCreate && onSignalsStep,
+        child: _NameSection(
+          item: item,
+          isCreate: widget.isCreate,
+          onExample: (example) => _applyExample(state, example),
+        ),
+      ),
+      if (onSignalsStep) ...[
+        if (widget.isCreate) ...[
+          Text(
+            messages.habitEditorSignalsHeading,
+            style: tokens.typography.styles.heading.heading2.copyWith(
+              color: tokens.colors.text.highEmphasis,
+            ),
+          ),
+          SizedBox(height: tokens.spacing.step2),
+          Text(
+            messages.habitEditorSignalsSubtitle,
+            style: tokens.typography.styles.body.bodyMedium.copyWith(
+              color: tokens.colors.text.mediumEmphasis,
+            ),
+          ),
+        ] else
+          SettingsFormSection(
+            title: messages.habitEditorSignalsHeading,
+            children: const [],
+          ),
+        SizedBox(height: tokens.spacing.step4),
+        HabitSignalCard(
+          form: signals,
+          measurablesById: measurablesById,
+          onChanged: _setSignals,
+          onAddSignal: () => _openPicker(state),
+          onChangeComposite: () => _openComposite(state),
+        ),
+      ],
+    ];
+    final settingsAndOptions = <Widget>[
+      if (onSignalsStep) ...[
+        SettingsFormSection(
+          title: messages.habitEditorSectionSettings,
+          children: [
+            SelectCategoryWidget(
+              habitId: habitId,
+            ),
+            SettingsDateTimeField(
+              dateTime: item.activeFrom,
+              labelText: messages.habitActiveFromLabel,
+              setDateTime: _controller.setActiveFrom,
+              mode: CupertinoDatePickerMode.date,
+            ),
+            // Only a daily schedule has a show-from and alert time; the setters
+            // would turn a weekly or monthly habit into a daily one.
+            if (item.habitSchedule is DailyHabitSchedule) ...[
+              SettingsDateTimeField(
+                dateTime: showFrom,
+                labelText: messages.habitShowFromLabel,
+                setDateTime: _controller.setShowFrom,
+                mode: CupertinoDatePickerMode.time,
+              ),
+              SettingsDateTimeField(
+                dateTime: alertAtTime,
+                labelText: messages.habitShowAlertAtLabel,
+                setDateTime: _controller.setAlertAtTime,
+                clear: _controller.clearAlertAtTime,
+                mode: CupertinoDatePickerMode.time,
+              ),
+            ],
+            DesignSystemSelectionRow(
+              key: const ValueKey(
+                'habit-editor-notify',
+              ),
+              title: messages.habitEditorNotifyTitle,
+              subtitle: messages.habitEditorNotifyCaption,
+              type: DesignSystemSelectionRowType.multiSelect,
+              selected: item.autoCompleteNotify,
+              showSelectedBackground: false,
+              onTap: () => _controller.setAutoCompleteNotify(
+                notify: !item.autoCompleteNotify,
+              ),
+            ),
+          ],
+        ),
+        if (!widget.isCreate) ...[
+          SettingsFormSection(
+            title: messages.habitSectionOptionsTitle,
+            children: [
+              FormSwitch(
+                name: 'priority',
+                key: const Key('habit_priority'),
+                semanticsLabel: messages.favoriteLabel,
+                initialValue: item.priority,
+                title: messages.favoriteLabel,
+                icon: LottiIcons.star,
+              ),
+              FormSwitch(
+                name: 'private',
+                initialValue: item.private,
+                title: messages.privateLabel,
+                subtitle: messages.privateSwitchDescription,
+                icon: LottiIcons.lock,
+              ),
+              FormSwitch(
+                name: 'active',
+                key: const Key('habit_active'),
+                initialValue: item.active,
+                title: messages.activeLabel,
+                subtitle: messages.habitActiveSwitchDescription,
+                icon: LottiIcons.visible,
+              ),
+            ],
+          ),
+          SizedBox(height: tokens.spacing.step4),
+          DesignSystemButton(
+            key: const ValueKey('habit-editor-delete'),
+            label: messages.deleteButton,
+            onPressed: _delete,
+            variant: DesignSystemButtonVariant.tertiary,
+            leadingIcon: LottiIcons.delete,
+            fullWidth: true,
+          ),
+        ],
+      ],
+    ];
+    final desktop = isDesktopLayout(context) && onSignalsStep;
+    final formChildren = desktop
+        ? [
+            Row(
+              key: const ValueKey('habit-editor-columns'),
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: identityAndSignals,
+                  ),
+                ),
+                SizedBox(width: tokens.spacing.step6),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: settingsAndOptions,
+                  ),
+                ),
+              ],
+            ),
+          ]
+        : [
+            ...identityAndSignals,
+            if (onSignalsStep) SizedBox(height: tokens.spacing.step5),
+            ...settingsAndOptions,
+          ];
+
+    if (widget.embedded) {
+      // Inside a panel the editor takes the panel's full height: the form
+      // scrolls in the middle only when the window is shorter than it, and
+      // the primary action stays pinned at the foot — a Save the user has to
+      // scroll to find was the complaint that moved the editor off its own
+      // route in the first place.
+      final height =
+          MediaQuery.sizeOf(context).height - kHabitEditorPanelChromeHeight;
+      return AppCommandScope(
+        handlers: {
+          AppCommandId.save: AppCommandHandler(
+            invoke: (_) {
+              if (onSignalsStep) _save();
+            },
+          ),
+        },
+        child: SizedBox(
+          height: height,
+          child: Column(
+            children: [
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: EdgeInsets.fromLTRB(
+                    tokens.spacing.step4,
+                    tokens.spacing.step2,
+                    tokens.spacing.step4,
+                    tokens.spacing.step4,
+                  ),
+                  child: FormBuilder(
+                    key: state.formKey,
+                    autovalidateMode: AutovalidateMode.onUserInteraction,
+                    onChanged: _controller.setDirty,
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        if (widget.isCreate)
+                          Padding(
+                            padding: EdgeInsets.only(
+                              bottom: tokens.spacing.step4,
+                            ),
+                            child: _StepProgress(step: _step),
+                          ),
+                        ...formChildren,
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              Padding(
+                padding: EdgeInsets.fromLTRB(
+                  tokens.spacing.step4,
+                  tokens.spacing.step3,
+                  tokens.spacing.step4,
+                  tokens.spacing.step4,
+                ),
+                child: Row(
+                  children: [
+                    // The wizard's way back to the name step; the route
+                    // version has the app bar's back button for this.
+                    if (widget.isCreate && onSignalsStep) ...[
+                      DesignSystemButton(
+                        key: const ValueKey('habit-editor-back'),
+                        label: messages.habitEditorBack,
+                        onPressed: () => setState(() => _step = _Step.name),
+                        variant: DesignSystemButtonVariant.tertiary,
+                        size: DesignSystemButtonSize.large,
+                      ),
+                      SizedBox(width: tokens.spacing.step3),
+                    ],
+                    Expanded(child: primary),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
     return AppCommandScope(
       handlers: {
         AppCommandId.save: AppCommandHandler(
@@ -307,7 +576,7 @@ class HabitEditorPageState extends ConsumerState<HabitEditorPage> {
                 if (widget.isCreate && _step == _Step.signals) {
                   setState(() => _step = _Step.name);
                 } else {
-                  beamToNamed(widget.returnPath);
+                  _leave();
                 }
               },
             ),
@@ -317,8 +586,12 @@ class HabitEditorPageState extends ConsumerState<HabitEditorPage> {
             child: DetailContentWidth(
               child: Center(
                 child: ConstrainedBox(
-                  constraints: const BoxConstraints(
-                    maxWidth: kActionListContentMaxWidth,
+                  // The name step is a single field and stays a narrow
+                  // column; the signals step spreads over two on desktop.
+                  constraints: BoxConstraints(
+                    maxWidth: desktop
+                        ? kDetailContentMaxWidth
+                        : kActionListContentMaxWidth,
                   ),
                   child: Column(
                     children: [
@@ -337,152 +610,7 @@ class HabitEditorPageState extends ConsumerState<HabitEditorPage> {
                               horizontal: tokens.spacing.step4,
                               vertical: tokens.spacing.step5,
                             ),
-                            children: [
-                              // The name step stays mounted (offstage) on the
-                              // signals step so the form keeps its values.
-                              Offstage(
-                                offstage: widget.isCreate && onSignalsStep,
-                                child: _NameSection(
-                                  item: item,
-                                  isCreate: widget.isCreate,
-                                  onExample: (example) =>
-                                      _applyExample(state, example),
-                                ),
-                              ),
-                              if (onSignalsStep) ...[
-                                if (widget.isCreate) ...[
-                                  Text(
-                                    messages.habitEditorSignalsHeading,
-                                    style: tokens
-                                        .typography
-                                        .styles
-                                        .heading
-                                        .heading2
-                                        .copyWith(
-                                          color:
-                                              tokens.colors.text.highEmphasis,
-                                        ),
-                                  ),
-                                  SizedBox(height: tokens.spacing.step2),
-                                  Text(
-                                    messages.habitEditorSignalsSubtitle,
-                                    style: tokens
-                                        .typography
-                                        .styles
-                                        .body
-                                        .bodyMedium
-                                        .copyWith(
-                                          color:
-                                              tokens.colors.text.mediumEmphasis,
-                                        ),
-                                  ),
-                                ] else
-                                  SettingsFormSection(
-                                    title: messages.habitEditorSignalsHeading,
-                                    children: const [],
-                                  ),
-                                SizedBox(height: tokens.spacing.step4),
-                                HabitSignalCard(
-                                  form: signals,
-                                  measurablesById: measurablesById,
-                                  onChanged: _setSignals,
-                                  onAddSignal: () => _openPicker(state),
-                                  onChangeComposite: () =>
-                                      _openComposite(state),
-                                ),
-                                SizedBox(height: tokens.spacing.step5),
-                                SettingsFormSection(
-                                  title: messages.habitEditorSectionSettings,
-                                  children: [
-                                    SelectCategoryWidget(
-                                      habitId: habitId,
-                                    ),
-                                    SettingsDateTimeField(
-                                      dateTime: item.activeFrom,
-                                      labelText: messages.habitActiveFromLabel,
-                                      setDateTime: _controller.setActiveFrom,
-                                      mode: CupertinoDatePickerMode.date,
-                                    ),
-                                    // Only a daily schedule has a show-from and alert time; the setters
-                                    // would turn a weekly or monthly habit into a daily one.
-                                    if (item.habitSchedule
-                                        is DailyHabitSchedule) ...[
-                                      SettingsDateTimeField(
-                                        dateTime: showFrom,
-                                        labelText: messages.habitShowFromLabel,
-                                        setDateTime: _controller.setShowFrom,
-                                        mode: CupertinoDatePickerMode.time,
-                                      ),
-                                      SettingsDateTimeField(
-                                        dateTime: alertAtTime,
-                                        labelText:
-                                            messages.habitShowAlertAtLabel,
-                                        setDateTime: _controller.setAlertAtTime,
-                                        clear: _controller.clearAlertAtTime,
-                                        mode: CupertinoDatePickerMode.time,
-                                      ),
-                                    ],
-                                    DesignSystemSelectionRow(
-                                      key: const ValueKey(
-                                        'habit-editor-notify',
-                                      ),
-                                      title: messages.habitEditorNotifyTitle,
-                                      subtitle:
-                                          messages.habitEditorNotifyCaption,
-                                      type: DesignSystemSelectionRowType
-                                          .multiSelect,
-                                      selected: item.autoCompleteNotify,
-                                      showSelectedBackground: false,
-                                      onTap: () =>
-                                          _controller.setAutoCompleteNotify(
-                                            notify: !item.autoCompleteNotify,
-                                          ),
-                                    ),
-                                  ],
-                                ),
-                                if (!widget.isCreate) ...[
-                                  SettingsFormSection(
-                                    title: messages.habitSectionOptionsTitle,
-                                    children: [
-                                      FormSwitch(
-                                        name: 'priority',
-                                        key: const Key('habit_priority'),
-                                        semanticsLabel: messages.favoriteLabel,
-                                        initialValue: item.priority,
-                                        title: messages.favoriteLabel,
-                                        icon: LottiIcons.star,
-                                      ),
-                                      FormSwitch(
-                                        name: 'private',
-                                        initialValue: item.private,
-                                        title: messages.privateLabel,
-                                        subtitle:
-                                            messages.privateSwitchDescription,
-                                        icon: LottiIcons.lock,
-                                      ),
-                                      FormSwitch(
-                                        name: 'active',
-                                        key: const Key('habit_active'),
-                                        initialValue: item.active,
-                                        title: messages.activeLabel,
-                                        subtitle: messages
-                                            .habitActiveSwitchDescription,
-                                        icon: LottiIcons.visible,
-                                      ),
-                                    ],
-                                  ),
-                                  SizedBox(height: tokens.spacing.step4),
-                                  DesignSystemButton(
-                                    key: const ValueKey('habit-editor-delete'),
-                                    label: messages.deleteButton,
-                                    onPressed: _delete,
-                                    variant: DesignSystemButtonVariant.tertiary,
-                                    leadingIcon: LottiIcons.delete,
-                                    fullWidth: true,
-                                  ),
-                                ],
-                              ],
-                            ],
+                            children: formChildren,
                           ),
                         ),
                       ),

--- a/lib/features/habits/ui/sheets/habit_completion_sheet.dart
+++ b/lib/features/habits/ui/sheets/habit_completion_sheet.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_linkify/flutter_linkify.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lotti/beamer/locations/habits_location.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/buttons/ds_segmented_toggle.dart';
@@ -16,6 +15,7 @@ import 'package:lotti/features/goals/state/goal_habit_watchers.dart';
 import 'package:lotti/features/goals/state/goal_progress_view.dart';
 import 'package:lotti/features/goals/ui/goal_assessment_widgets.dart';
 import 'package:lotti/features/habits/state/habit_signal_status_controller.dart';
+import 'package:lotti/features/habits/ui/pages/habit_editor_launcher.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_signal_row.dart';
 import 'package:lotti/features/habits/ui/widgets/measurable_quick_record_chips.dart';
 import 'package:lotti/features/keyboard/domain/app_command.dart';
@@ -29,7 +29,6 @@ import 'package:lotti/pages/create/create_measurement_dialog.dart';
 import 'package:lotti/services/dev_logger.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/entities_cache_service.dart';
-import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/date_utils_extension.dart';
 import 'package:lotti/utils/platform.dart';
@@ -281,8 +280,11 @@ class _HabitCompletionSheetState extends ConsumerState<HabitCompletionSheet> {
       }),
       onClose: () => Navigator.pop(context),
       onEdit: () {
+        // The sheet is gone once popped, so the editor opens on the root
+        // navigator's context — which is where the desktop panel lives.
+        final root = Navigator.of(context, rootNavigator: true).context;
         Navigator.pop(context);
-        beamToNamed(HabitsLocation.editPath(widget.habitId));
+        openHabitEditor(root, habitId: widget.habitId);
       },
       onRecord: _save,
     );

--- a/lib/features/habits/ui/widgets/habit_action_row.dart
+++ b/lib/features/habits/ui/widgets/habit_action_row.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lotti/beamer/locations/habits_location.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/categories/domain/category_icon.dart';
 import 'package:lotti/features/categories/ui/widgets/category_icon_compact.dart';
@@ -13,13 +12,13 @@ import 'package:lotti/features/design_system/components/celebration/completion_g
 import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/design_system/theme/ds_surface_elevation.dart';
+import 'package:lotti/features/habits/ui/pages/habit_editor_launcher.dart';
 import 'package:lotti/features/habits/ui/sheets/habit_completion_sheet.dart';
 import 'package:lotti/features/settings/state/celebration_preferences_controller.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/entities_cache_service.dart';
-import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/widgets/charts/habits/dashboard_habits_data.dart';
 
@@ -347,8 +346,7 @@ class _HabitActionRowState extends ConsumerState<HabitActionRow>
                 celebrate: celebrate,
                 history: widget.history,
                 onTapAdd: onTapAdd,
-                onEdit: () =>
-                    beamToNamed(HabitsLocation.editPath(widget.habitId)),
+                onEdit: () => openHabitEditor(context, habitId: widget.habitId),
                 onQuickComplete: () => _recordQuickCompletion(
                   HabitCompletionType.success,
                   habitDefinition,

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2879,6 +2879,7 @@
   "habitDeleteConfirm": "Ano, smazat tento návyk",
   "habitDeleteQuestion": "Chceš tento návyk smazat?",
   "habitEditorAddSignal": "Přidat signál",
+  "habitEditorBack": "Zpět",
   "habitEditorCompositeAll": "Všechny signály",
   "habitEditorCompositeAny": "Libovolný signál",
   "habitEditorCompositeAtLeast": "Alespoň {count} z {total}",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -3136,6 +3136,7 @@
   "habitDeleteConfirm": "Ja, slet denne vane",
   "habitDeleteQuestion": "Vil du slette denne vane?",
   "habitEditorAddSignal": "Tilføj et signal",
+  "habitEditorBack": "Tilbage",
   "habitEditorCompositeAll": "Alle signaler",
   "habitEditorCompositeAny": "Et hvilket som helst signal",
   "habitEditorCompositeAtLeast": "Mindst {count} af {total}",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2872,6 +2872,7 @@
   "habitDeleteConfirm": "Ja, diese Gewohnheit löschen",
   "habitDeleteQuestion": "Möchtest du diese Gewohnheit löschen?",
   "habitEditorAddSignal": "Signal hinzufügen",
+  "habitEditorBack": "Zurück",
   "habitEditorCompositeAll": "Alle Signale",
   "habitEditorCompositeAny": "Ein beliebiges Signal",
   "habitEditorCompositeAtLeast": "Mindestens {count} von {total}",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4319,6 +4319,10 @@
   "habitDeleteConfirm": "Yes, delete this habit",
   "habitDeleteQuestion": "Do you want to delete this habit?",
   "habitEditorAddSignal": "Add a signal",
+  "habitEditorBack": "Back",
+  "@habitEditorBack": {
+    "description": "Returns the create-habit wizard from the signals step to the name step when the editor is hosted in a desktop panel."
+  },
   "habitEditorCompositeAll": "All signals",
   "habitEditorCompositeAny": "Any signal",
   "habitEditorCompositeAtLeast": "At least {count} of {total}",

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -101,6 +101,7 @@
   "habitCategoryHint": "Select a category",
   "habitCategoryLabel": "Category",
   "habitDeleteQuestion": "Do you want to delete this habit?",
+  "habitEditorBack": "Back",
   "habitPriorityLabel": "Priority",
   "habitReflectInGoal": "Reflect on this day in {goal}",
   "habitsCompletedHeader": "Completed",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2872,6 +2872,7 @@
   "habitDeleteConfirm": "Sí, borrar este hábito",
   "habitDeleteQuestion": "¿Quieres borrar este hábito?",
   "habitEditorAddSignal": "Añadir una señal",
+  "habitEditorBack": "Atrás",
   "habitEditorCompositeAll": "Todas las señales",
   "habitEditorCompositeAny": "Cualquier señal",
   "habitEditorCompositeAtLeast": "Al menos {count} de {total}",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2872,6 +2872,7 @@
   "habitDeleteConfirm": "Oui, supprimer cette habitude",
   "habitDeleteQuestion": "Veux-tu supprimer cette habitude ?",
   "habitEditorAddSignal": "Ajouter un signal",
+  "habitEditorBack": "Retour",
   "habitEditorCompositeAll": "Tous les signaux",
   "habitEditorCompositeAny": "N’importe quel signal",
   "habitEditorCompositeAtLeast": "Au moins {count} sur {total}",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -3136,6 +3136,7 @@
   "habitDeleteConfirm": "Sì, elimina questa abitudine",
   "habitDeleteQuestion": "Vuoi eliminare questa abitudine?",
   "habitEditorAddSignal": "Aggiungi un segnale",
+  "habitEditorBack": "Indietro",
   "habitEditorCompositeAll": "Tutti i segnali",
   "habitEditorCompositeAny": "Un segnale qualsiasi",
   "habitEditorCompositeAtLeast": "Almeno {count} su {total}",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -12210,6 +12210,12 @@ abstract class AppLocalizations {
   /// **'Add a signal'**
   String get habitEditorAddSignal;
 
+  /// Returns the create-habit wizard from the signals step to the name step when the editor is hosted in a desktop panel.
+  ///
+  /// In en, this message translates to:
+  /// **'Back'**
+  String get habitEditorBack;
+
   /// No description provided for @habitEditorCompositeAll.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -7296,6 +7296,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get habitEditorAddSignal => 'Přidat signál';
 
   @override
+  String get habitEditorBack => 'Zpět';
+
+  @override
   String get habitEditorCompositeAll => 'Všechny signály';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -7217,6 +7217,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get habitEditorAddSignal => 'Tilføj et signal';
 
   @override
+  String get habitEditorBack => 'Tilbage';
+
+  @override
   String get habitEditorCompositeAll => 'Alle signaler';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -7267,6 +7267,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get habitEditorAddSignal => 'Signal hinzufügen';
 
   @override
+  String get habitEditorBack => 'Zurück';
+
+  @override
   String get habitEditorCompositeAll => 'Alle Signale';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7192,6 +7192,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get habitEditorAddSignal => 'Add a signal';
 
   @override
+  String get habitEditorBack => 'Back';
+
+  @override
   String get habitEditorCompositeAll => 'All signals';
 
   @override
@@ -14311,6 +14314,9 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
 
   @override
   String get habitDeleteQuestion => 'Do you want to delete this habit?';
+
+  @override
+  String get habitEditorBack => 'Back';
 
   @override
   String get habitPriorityLabel => 'Priority';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -7315,6 +7315,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get habitEditorAddSignal => 'Añadir una señal';
 
   @override
+  String get habitEditorBack => 'Atrás';
+
+  @override
   String get habitEditorCompositeAll => 'Todas las señales';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -7328,6 +7328,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get habitEditorAddSignal => 'Ajouter un signal';
 
   @override
+  String get habitEditorBack => 'Retour';
+
+  @override
   String get habitEditorCompositeAll => 'Tous les signaux';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -7307,6 +7307,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get habitEditorAddSignal => 'Aggiungi un segnale';
 
   @override
+  String get habitEditorBack => 'Indietro';
+
+  @override
   String get habitEditorCompositeAll => 'Tutti i segnali';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -7231,6 +7231,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get habitEditorAddSignal => 'Signaal toevoegen';
 
   @override
+  String get habitEditorBack => 'Terug';
+
+  @override
   String get habitEditorCompositeAll => 'Alle signalen';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -7289,6 +7289,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get habitEditorAddSignal => 'Adicionar um sinal';
 
   @override
+  String get habitEditorBack => 'Voltar';
+
+  @override
   String get habitEditorCompositeAll => 'Todos os sinais';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -7346,6 +7346,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get habitEditorAddSignal => 'Adăugați un semnal';
 
   @override
+  String get habitEditorBack => 'Înapoi';
+
+  @override
   String get habitEditorCompositeAll => 'Toate semnalele';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -7226,6 +7226,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get habitEditorAddSignal => 'Lägg till en signal';
 
   @override
+  String get habitEditorBack => 'Tillbaka';
+
+  @override
   String get habitEditorCompositeAll => 'Alla signaler';
 
   @override

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -3135,6 +3135,7 @@
   "habitDeleteConfirm": "Ja, verwijder deze gewoonte",
   "habitDeleteQuestion": "Wilt u deze gewoonte verwijderen?",
   "habitEditorAddSignal": "Signaal toevoegen",
+  "habitEditorBack": "Terug",
   "habitEditorCompositeAll": "Alle signalen",
   "habitEditorCompositeAny": "Eén van de signalen",
   "habitEditorCompositeAtLeast": "Minstens {count} van {total}",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -3135,6 +3135,7 @@
   "habitDeleteConfirm": "Sim, excluir este hábito",
   "habitDeleteQuestion": "Quer eliminar esse hábito?",
   "habitEditorAddSignal": "Adicionar um sinal",
+  "habitEditorBack": "Voltar",
   "habitEditorCompositeAll": "Todos os sinais",
   "habitEditorCompositeAny": "Qualquer sinal",
   "habitEditorCompositeAtLeast": "Pelo menos {count} de {total}",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2872,6 +2872,7 @@
   "habitDeleteConfirm": "Da, ștergeți acest obicei",
   "habitDeleteQuestion": "Doriți să ștergeți acest obicei?",
   "habitEditorAddSignal": "Adăugați un semnal",
+  "habitEditorBack": "Înapoi",
   "habitEditorCompositeAll": "Toate semnalele",
   "habitEditorCompositeAny": "Orice semnal",
   "habitEditorCompositeAtLeast": "Cel puțin {count} din {total}",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -3136,6 +3136,7 @@
   "habitDeleteConfirm": "Ja, radera den här vanan",
   "habitDeleteQuestion": "Vill du ta bort den här vanan?",
   "habitEditorAddSignal": "Lägg till en signal",
+  "habitEditorBack": "Tillbaka",
   "habitEditorCompositeAll": "Alla signaler",
   "habitEditorCompositeAny": "Valfri signal",
   "habitEditorCompositeAtLeast": "Minst {count} av {total}",

--- a/lib/widgets/settings/settings_form_section.dart
+++ b/lib/widgets/settings/settings_form_section.dart
@@ -31,7 +31,11 @@ class SettingsFormSection extends StatelessWidget {
     final spacing = tokens.spacing;
 
     return Padding(
-      padding: EdgeInsets.only(bottom: spacing.sectionGap),
+      // A title-only section labels whatever follows it, so it keeps only
+      // the heading's own spacing rather than a whole section gap.
+      padding: EdgeInsets.only(
+        bottom: children.isEmpty ? 0 : spacing.sectionGap,
+      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -68,25 +72,29 @@ class SettingsFormSection extends StatelessWidget {
               ],
             ),
           ),
-          DecoratedBox(
-            decoration: BoxDecoration(
-              color: tokens.colors.background.level02,
-              borderRadius: BorderRadius.circular(tokens.radii.m),
-              border: Border.all(color: tokens.colors.decorative.level01),
-            ),
-            child: Padding(
-              padding: EdgeInsets.all(spacing.cardPadding),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  for (var i = 0; i < children.length; i++) ...[
-                    if (i > 0) SizedBox(height: spacing.cardItemSpacing),
-                    children[i],
+          // A section with nothing to hold is a heading, not an empty
+          // bordered card: the habit editor titles its signal card this way,
+          // and an empty frame under the title read as a broken control.
+          if (children.isNotEmpty)
+            DecoratedBox(
+              decoration: BoxDecoration(
+                color: tokens.colors.background.level02,
+                borderRadius: BorderRadius.circular(tokens.radii.m),
+                border: Border.all(color: tokens.colors.decorative.level01),
+              ),
+              child: Padding(
+                padding: EdgeInsets.all(spacing.cardPadding),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    for (var i = 0; i < children.length; i++) ...[
+                      if (i > 0) SizedBox(height: spacing.cardItemSpacing),
+                      children[i],
+                    ],
                   ],
-                ],
+                ),
               ),
             ),
-          ),
         ],
       ),
     );

--- a/test/features/habits/ui/pages/habit_editor_launcher_test.dart
+++ b/test/features/habits/ui/pages/habit_editor_launcher_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/habits/state/habit_editor_providers.dart';
+import 'package:lotti/features/habits/ui/pages/habit_editor_launcher.dart';
+import 'package:lotti/features/habits/ui/pages/habit_editor_page.dart';
+import 'package:lotti/features/settings/ui/pages/measurables/measurables_page.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/services/notification_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../mocks/mocks.dart';
+import '../../../../test_data/test_data.dart';
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  setUpAll(() => registerFallbackValue(FakeHabitDefinition()));
+  late TestGetItMocks mocks;
+  String? beamedTo;
+
+  setUp(() async {
+    final cache = MockEntitiesCacheService();
+    final persistence = MockPersistenceLogic();
+    final notifications = MockNotificationService();
+    mocks = await setUpTestGetIt(
+      additionalSetup: () {
+        getIt
+          ..registerSingleton<PersistenceLogic>(persistence)
+          ..registerSingleton<EntitiesCacheService>(cache)
+          ..registerSingleton<NotificationService>(notifications);
+      },
+    );
+    when(
+      () => persistence.upsertEntityDefinition(any()),
+    ).thenAnswer((_) async => 1);
+    when(
+      () => notifications.scheduleHabitNotification(any()),
+    ).thenAnswer((_) async {});
+    when(
+      () => mocks.journalDb.getHabitById(habitFlossing.id),
+    ).thenAnswer((_) async => habitFlossing);
+    when(() => cache.sortedCategories).thenReturn([categoryMindfulness]);
+    when(() => cache.getCategoryById(any())).thenReturn(null);
+    beamedTo = null;
+    beamToNamedOverride = (path) => beamedTo = path;
+  });
+  tearDown(() async {
+    beamToNamedOverride = null;
+    await tearDownTestGetIt();
+  });
+
+  Future<void> pumpLauncher(WidgetTester tester, Size size) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Builder(
+          builder: (context) => Column(
+            children: [
+              TextButton(
+                key: const ValueKey('open-edit'),
+                onPressed: () =>
+                    openHabitEditor(context, habitId: habitFlossing.id),
+                child: const Text('edit'),
+              ),
+              TextButton(
+                key: const ValueKey('open-create'),
+                onPressed: () => openHabitEditor(context),
+                child: const Text('create'),
+              ),
+            ],
+          ),
+        ),
+        mediaQueryData: MediaQueryData(size: size),
+        overrides: [
+          measurableDataTypesStreamProvider.overrideWith(
+            (ref) => Stream.value(const []),
+          ),
+          workoutTypesProvider.overrideWith((ref) async => const []),
+        ],
+      ),
+    );
+  }
+
+  group('on a phone', () {
+    testWidgets('the editor is its own route', (tester) async {
+      await pumpLauncher(tester, const Size(390, 844));
+      await tester.tap(find.byKey(const ValueKey('open-edit')));
+      expect(beamedTo, '/habits/edit/${habitFlossing.id}');
+      await tester.tap(find.byKey(const ValueKey('open-create')));
+      expect(beamedTo, '/habits/create');
+      expect(find.byType(HabitEditorPage), findsNothing);
+    });
+  });
+
+  group('on desktop', () {
+    testWidgets('the editor opens embedded in a side panel over the page, '
+        'and Save closes it', (tester) async {
+      await pumpLauncher(tester, const Size(1400, 900));
+      await tester.tap(find.byKey(const ValueKey('open-edit')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(beamedTo, isNull, reason: 'no navigation on desktop');
+      // A scrim over the page, and the editor inside a sheet on top of it.
+      expect(find.byType(ModalBarrier), findsWidgets);
+      final page = tester.widget<HabitEditorPage>(find.byType(HabitEditorPage));
+      expect(page.embedded, isTrue);
+      expect(find.text('Edit habit'), findsOneWidget);
+      // No scaffold chrome of its own inside the panel.
+      expect(
+        find.descendant(
+          of: find.byType(HabitEditorPage),
+          matching: find.byType(AppBar),
+        ),
+        findsNothing,
+      );
+      // Two phone-width columns fit the 800px panel.
+      expect(
+        find.byKey(const ValueKey('habit-editor-columns')),
+        findsOneWidget,
+      );
+      final panelWidth = tester.getSize(find.byType(HabitEditorPage)).width;
+      expect(panelWidth, lessThanOrEqualTo(kHabitEditorPanelWidth));
+      expect(panelWidth, greaterThan(560));
+
+      // Save is pinned at the panel's foot: reachable without scrolling
+      // even on a window shorter than the form.
+      final primary = find.byKey(const ValueKey('habit-editor-primary'));
+      expect(
+        tester.getRect(primary).bottom,
+        lessThanOrEqualTo(tester.view.physicalSize.height),
+      );
+      await tester.tap(primary);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(find.byType(HabitEditorPage), findsNothing);
+      expect(beamedTo, isNull);
+    });
+
+    testWidgets('the create wizard steps inside the panel and offers Back', (
+      tester,
+    ) async {
+      await pumpLauncher(tester, const Size(1400, 900));
+      await tester.tap(find.byKey(const ValueKey('open-create')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(find.text('New habit'), findsOneWidget);
+      expect(find.byKey(const ValueKey('habit-editor-columns')), findsNothing);
+      await tester.enterText(find.byType(TextField).first, 'Floss');
+      await tester.tap(find.text('Continue'));
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(
+        find.byKey(const ValueKey('habit-editor-columns')),
+        findsOneWidget,
+      );
+      await tester.tap(find.byKey(const ValueKey('habit-editor-back')));
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.byKey(const ValueKey('habit-editor-columns')), findsNothing);
+      expect(find.text('Step 1 of 2'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/habits/ui/pages/habit_editor_launcher_test.dart
+++ b/test/features/habits/ui/pages/habit_editor_launcher_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/habits/state/habit_editor_providers.dart';
 import 'package:lotti/features/habits/ui/pages/habit_editor_launcher.dart';
 import 'package:lotti/features/habits/ui/pages/habit_editor_page.dart';
@@ -162,6 +163,64 @@ void main() {
       await tester.pump(const Duration(milliseconds: 300));
       expect(find.byKey(const ValueKey('habit-editor-columns')), findsNothing);
       expect(find.text('Step 1 of 2'), findsOneWidget);
+    });
+    testWidgets('opened from inside a nested navigator, the panel still '
+        'covers the window and closes without popping the tab', (
+      tester,
+    ) async {
+      const size = Size(1400, 900);
+      tester.view.physicalSize = size;
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          // The desktop tabs each run their own Navigator (Beamer); the
+          // launcher must not push the sheet onto it, or the tab's own
+          // route is what a close pops.
+          Navigator(
+            key: const ValueKey('tab-navigator'),
+            onGenerateRoute: (_) => MaterialPageRoute<void>(
+              builder: (context) => Scaffold(
+                body: TextButton(
+                  key: const ValueKey('open-edit'),
+                  onPressed: () =>
+                      openHabitEditor(context, habitId: habitFlossing.id),
+                  child: const Text('tab route'),
+                ),
+              ),
+            ),
+          ),
+          mediaQueryData: const MediaQueryData(size: size),
+          overrides: [
+            measurableDataTypesStreamProvider.overrideWith(
+              (ref) => Stream.value(const []),
+            ),
+            workoutTypesProvider.overrideWith((ref) async => const []),
+          ],
+        ),
+      );
+      await tester.tap(find.byKey(const ValueKey('open-edit')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(find.byType(HabitEditorPage), findsOneWidget);
+      // On the root navigator: the panel spans the window height and the
+      // scrim is not clipped to the tab.
+      expect(
+        tester.getSize(find.byType(HabitEditorPage)).height,
+        greaterThan(700),
+      );
+
+      final primary = find.byKey(const ValueKey('habit-editor-primary'));
+      await tester.tap(primary);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(find.byType(HabitEditorPage), findsNothing);
+      expect(
+        find.text('tab route'),
+        findsOneWidget,
+        reason: 'the tab route survived',
+      );
     });
   });
 }

--- a/test/features/habits/ui/pages/habit_editor_page_test.dart
+++ b/test/features/habits/ui/pages/habit_editor_page_test.dart
@@ -99,8 +99,9 @@ void main() {
     String? habitId,
     String returnPath = '/habits',
     List<MeasurableDataType>? measurables,
+    Size size = const Size(1200, 1800),
   }) async {
-    tester.view.physicalSize = const Size(1200, 1800);
+    tester.view.physicalSize = size;
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
@@ -111,7 +112,7 @@ void main() {
           platform: TargetPlatform.windows,
           child: HabitEditorPage(habitId: habitId, returnPath: returnPath),
         ),
-        mediaQueryData: const MediaQueryData(size: Size(1200, 1800)),
+        mediaQueryData: MediaQueryData(size: size),
         overrides: [
           measurableDataTypesStreamProvider.overrideWith(
             (ref) => Stream.value(measurables ?? [water]),
@@ -507,6 +508,60 @@ void main() {
       habits.addError(StateError('db hiccup'));
       await tester.pump();
       expect(find.byType(HabitSignalCard), findsOneWidget);
+    });
+  });
+  group('layout', () {
+    testWidgets('on desktop the edit page lays signals and settings out side '
+        'by side, wide enough that nothing needs to scroll', (tester) async {
+      await pumpEditor(tester, habitId: habitFlossing.id);
+      final columns = find.byKey(const ValueKey('habit-editor-columns'));
+      expect(columns, findsOneWidget);
+      // Signals on the left, settings and options on the right.
+      final row = tester.widget<Row>(columns);
+      expect(row.children.length, 3);
+      expect(
+        find.descendant(
+          of: find.byWidget(row.children.first),
+          matching: find.byType(HabitSignalCard),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: find.byWidget(row.children.last),
+          matching: find.byKey(const Key('habit_active')),
+        ),
+        findsOneWidget,
+      );
+      // The whole form fits the window: the scroll view has no overflow.
+      final scrollable = tester.widget<Scrollable>(
+        find.byType(Scrollable).first,
+      );
+      expect(scrollable.controller?.position.maxScrollExtent ?? 0, 0);
+      expect(tester.getSize(columns).width, greaterThan(700));
+    });
+
+    testWidgets('a phone keeps the single column', (tester) async {
+      await pumpEditor(
+        tester,
+        habitId: habitFlossing.id,
+        size: const Size(390, 844),
+      );
+      expect(find.byKey(const ValueKey('habit-editor-columns')), findsNothing);
+      expect(find.byType(HabitSignalCard), findsOneWidget);
+    });
+
+    testWidgets("the create wizard's name step stays a narrow column even on "
+        'desktop', (tester) async {
+      await pumpEditor(tester);
+      expect(find.byKey(const ValueKey('habit-editor-columns')), findsNothing);
+      await tester.enterText(find.byType(TextField).first, 'Floss');
+      await tester.tap(find.text('Continue'));
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(
+        find.byKey(const ValueKey('habit-editor-columns')),
+        findsOneWidget,
+      );
     });
   });
 }

--- a/test/features/habits/ui/pages/habit_editor_page_test.dart
+++ b/test/features/habits/ui/pages/habit_editor_page_test.dart
@@ -563,5 +563,34 @@ void main() {
         findsOneWidget,
       );
     });
+    testWidgets('embedded in a panel, a habit still loading shows a bounded '
+        'placeholder rather than a page-filling shell', (tester) async {
+      when(
+        () => mocks.journalDb.getHabitById('slow'),
+      ).thenAnswer((_) => Completer<HabitDefinition?>().future);
+      tester.view.physicalSize = const Size(1200, 1800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          // Unbounded height, as inside a shrink-wrapping sheet page.
+          SingleChildScrollView(
+            child: HabitEditorPage(habitId: 'slow', onClose: () {}),
+          ),
+          mediaQueryData: const MediaQueryData(size: Size(1200, 1800)),
+          overrides: [
+            measurableDataTypesStreamProvider.overrideWith(
+              (ref) => Stream.value(const []),
+            ),
+            workoutTypesProvider.overrideWith((ref) async => const []),
+          ],
+        ),
+      );
+      await tester.pump();
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(Scaffold), findsNothing);
+      expect(tester.takeException(), isNull);
+    });
   });
 }

--- a/test/widgets/settings/settings_form_section_test.dart
+++ b/test/widgets/settings/settings_form_section_test.dart
@@ -52,4 +52,14 @@ void main() {
     expect(find.text('Color'), findsOneWidget);
     expect(find.text('picker'), findsOneWidget);
   });
+  testWidgets('a section with no children is a heading only, never an empty '
+      'bordered card', (tester) async {
+    await tester.pumpWidget(
+      const WidgetTestBench(
+        child: SettingsFormSection(title: 'Signals', children: []),
+      ),
+    );
+    expect(find.text('Signals'), findsOneWidget);
+    expect(find.byType(DecoratedBox), findsNothing);
+  });
 }


### PR DESCRIPTION
## Summary

On desktop the habit editor was a phone-width column on its own route: two empty gutters, and a form that scrolled although a normal window could show all of it. It now opens as a **side panel over the Habits page**.

- **`openHabitEditor`** (`ui/pages/habit_editor_launcher.dart`) is the one doorway used by the FAB, the row long-press and the completion sheet's pencil. Phone: the existing route. Desktop (`isDesktopLayout`): the same `HabitEditorPage` embedded in a right-anchored `SizedWoltSideSheetType` at `kHabitEditorPanelWidth` (800px), pushed on the root navigator over a scrim; closes on Save/Delete, scrim tap or Escape. Deep links and Settings › Habits still mount the full route.
- **Embedded mode** (`HabitEditorPage.onClose`): no scaffold or app bar; the editor takes the panel's height (window minus the sheet's token-sized nav bar) with the form scrolling in the middle only when the window is shorter than it, and the **action row pinned at the panel's foot**. The create wizard steps inside the panel and carries its own *Back* (new label, all 12 catalogs).
- **Two columns at desktop widths** (`habit-editor-columns`): identity + signals left, Settings + Options right — two phone-width columns, so nothing needs to scroll on a normal window. The wizard's name step stays a single narrow column.
- **Fix:** the empty bordered box under "How do we know it's done?" was a `SettingsFormSection` with no children; a title-only section now renders just its heading.

## Screenshots

| | before (full-page route) | after (side panel) |
|---|---|---|
| desktop (1280×800) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-editor-panel/e25a92dfce7a9407f1c54d9428f9c50bfb941a10/before/habit_editor_panel_desktop_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-editor-panel/e25a92dfce7a9407f1c54d9428f9c50bfb941a10/after/habit_editor_panel_desktop_dark.png) |
| mobile (unchanged) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-editor-panel/e25a92dfce7a9407f1c54d9428f9c50bfb941a10/before/habit_editor_route_mobile_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-editor-panel/e25a92dfce7a9407f1c54d9428f9c50bfb941a10/after/habit_editor_route_mobile_dark.png) |

Captured with the shared test habit. (The desktop "after" is captured over a bare host page; in the app the Habits list sits under the scrim.)

## Tests

`habit_editor_launcher_test` (phone → route; desktop → embedded panel, Save closes it, wizard Back, opened from a nested navigator), editor layout tests (columns on desktop, single column on phones and on the wizard's name step, embedded loading placeholder), `settings_form_section_test` for the title-only section. Analyzer and formatter clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * On desktop, the habit editor now opens in a right-side panel over the Habits page.
  * Desktop editor fields use a side-by-side layout, with accessible Save, Back, scrim, and Escape controls.
  * Phones continue using the full-screen editor.
  * Added localized Back labels across supported languages.

* **Bug Fixes**
  * Removed the empty bordered box beneath the completion guidance heading.

* **Documentation**
  * Updated screenshot guidance to prohibit personal data and require approved fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->