### PR TITLE
feat(sync): scan pairing codes on desktop

### DIFF
--- a/changelog.d/2026-08-29-desktop-qr-scanning.md
+++ b/changelog.d/2026-08-29-desktop-qr-scanning.md
@@ -1,0 +1,5 @@
+### Added
+- **Pair new devices by camera on macOS and Linux.** Phones and tablets can
+  already show the pairing code, and desktop users can now scan it directly
+  with a webcam instead of copying the credential by hand. Manual entry remains
+  available when a camera cannot be used.

--- a/docs/implementation_plans/2026-08-29_phase_a_cross_platform_qr_pairing.md
+++ b/docs/implementation_plans/2026-08-29_phase_a_cross_platform_qr_pairing.md
@@ -42,9 +42,11 @@ Reuse `mobile_scanner` 7.x. It officially supports macOS and is already the
 production Android/iOS scanner, so it preserves identical barcode handling,
 deduplication, bundle validation, and pairing-code confirmation.
 
-The macOS runner already has `com.apple.security.device.camera` in debug and
-release entitlements and `NSCameraUsageDescription` in `Info.plist`. Update the
-usage description so it names QR pairing as well as journal photos.
+The macOS runner already has `com.apple.security.device.camera` in its dedicated
+debug and release entitlements and `NSCameraUsageDescription` in `Info.plist`.
+Add the same capability to `DebugProfile.entitlements`, which signs Profile
+builds, and update the usage description so it names QR pairing as well as
+journal photos.
 
 ### 3. Linux scanner
 

--- a/docs/implementation_plans/2026-08-29_phase_a_cross_platform_qr_pairing.md
+++ b/docs/implementation_plans/2026-08-29_phase_a_cross_platform_qr_pairing.md
@@ -1,6 +1,7 @@
 # Phase A — cross-platform QR pairing
 
-**Status:** implemented; physical-camera acceptance pending
+**Status:** implemented; macOS and Linux webcam scanning confirmed, remaining
+packaging and edge-case acceptance pending
 **Date:** 2026-08-29
 
 ## Codebase findings
@@ -116,8 +117,10 @@ Automated:
 
 Hardware acceptance before calling Phase A complete:
 
-- macOS: grant, deny, retry, scan from phone, and scan from tablet.
-- Linux native: V4L2 webcam scan and no-camera fallback.
+- macOS: webcam scanning confirmed on 2026-08-29; grant denial, retry, and both
+  phone/tablet source coverage remain to be recorded.
+- Linux: webcam scanning confirmed on 2026-08-29; native no-camera fallback and
+  the exact packaging path remain to be recorded.
 - Linux Flatpak: portal grant/deny, PipeWire preview, scan, and relaunch after a
   remembered permission decision.
 - Android phone and tablet: generate a code, keep the whole QR visible without

--- a/docs/implementation_plans/2026-08-29_phase_a_cross_platform_qr_pairing.md
+++ b/docs/implementation_plans/2026-08-29_phase_a_cross_platform_qr_pairing.md
@@ -61,7 +61,7 @@ Create `lib/features/sync/ui/provisioned/desktop_qr_scanner.dart`. It will:
 3. sample frames with deterministic backpressure (never decode two frames at
    once);
 4. convert padded RGBA/BGRA rows to the ARGB pixels ZXing expects;
-5. decode off the UI isolate and emit a payload at most once; and
+5. decode off the UI isolate and emit each distinct payload at most once; and
 6. dispose the stream/controller on every exit path.
 
 Lotti already installs the GStreamer development/runtime packages this plugin
@@ -107,7 +107,7 @@ Automated:
 - Pure frame-decoder tests for BGRA, RGBA, row padding, malformed frames, no QR,
   and a valid QR payload.
 - Widget tests for macOS/Linux scanner-first behavior, Windows manual fallback,
-  scanner-to-manual switching, retry, one-shot delivery, and disposal.
+  scanner-to-manual switching, retry, distinct-payload delivery, and disposal.
 - Existing bundle import/controller tests to prove scanned and pasted payloads
   still share the same validation and pairing confirmation.
 - Targeted analyzer and Flutter tests only for touched source mirrors.

--- a/docs/implementation_plans/2026-08-29_phase_a_cross_platform_qr_pairing.md
+++ b/docs/implementation_plans/2026-08-29_phase_a_cross_platform_qr_pairing.md
@@ -1,0 +1,126 @@
+# Phase A — cross-platform QR pairing
+
+**Status:** implemented; physical-camera acceptance pending
+**Date:** 2026-08-29
+
+## Codebase findings
+
+The current branch already implements the mobile-generation half of the brief:
+
+- `SyncDevicesList` exposes **Add device** without a desktop gate.
+- `ProvisionedSyncPage` renders the configured device roster on mobile, so an
+  Android phone or tablet can reach that action directly.
+- `AddDeviceModal` calls `ProvisioningController.regenerateHandover()` and
+  renders the v2 handover bundle with `QrImageView`; its QR size is constrained
+  by both width and viewport height.
+- The joining flow already scans on Android/iOS with `mobile_scanner`, verifies
+  the independently-derived pairing code, and retains paste/manual entry as a
+  fallback.
+
+The remaining limitation is in `bundle_import_page.dart`: `_manualEntry` starts
+true for every desktop and the camera action is exposed only when `isMobile`.
+
+## Implementation
+
+### 1. Preserve mobile QR generation
+
+No second QR generator is needed. Keep the existing flow in:
+
+- `lib/features/sync/ui/widgets/matrix/sync_devices_list.dart`
+- `lib/features/sync/ui/provisioned/add_device_page.dart`
+- `lib/features/sync/ui/provisioned_sync_page.dart`
+
+Add/retain platform-focused widget coverage proving that a configured Android
+surface exposes Add device and that the resulting sheet contains
+`addDeviceQrImage`. This protects the already-shipped architecture while the
+desktop import path changes.
+
+### 2. macOS scanner
+
+Reuse `mobile_scanner` 7.x. It officially supports macOS and is already the
+production Android/iOS scanner, so it preserves identical barcode handling,
+deduplication, bundle validation, and pairing-code confirmation.
+
+The macOS runner already has `com.apple.security.device.camera` in debug and
+release entitlements and `NSCameraUsageDescription` in `Info.plist`. Update the
+usage description so it names QR pairing as well as journal photos.
+
+### 3. Linux scanner
+
+`mobile_scanner` has no Linux implementation. Add:
+
+- `camera` for the standard `CameraController` API;
+- `camera_desktop` for Linux capture (Camera portal/PipeWire in Flatpak, V4L2
+  outside Flatpak); and
+- `zxing2` for pure-Dart QR decoding from RGBA/BGRA camera frames.
+
+Create `lib/features/sync/ui/provisioned/desktop_qr_scanner.dart`. It will:
+
+1. enumerate webcams and initialize the first available camera without audio;
+2. render the live preview inside the existing tokenized scanner frame;
+3. sample frames with deterministic backpressure (never decode two frames at
+   once);
+4. convert padded RGBA/BGRA rows to the ARGB pixels ZXing expects;
+5. decode off the UI isolate and emit a payload at most once; and
+6. dispose the stream/controller on every exit path.
+
+Lotti already installs the GStreamer development/runtime packages this plugin
+requires in Linux CI, and its runner already links GStreamer. The Flatpak path
+uses the desktop camera portal, so the manifest should not gain broad
+`--device=all` access.
+
+### 4. Import-flow integration and UX
+
+Refactor `bundle_import_page.dart` around a platform capability:
+
+- Android/iOS/macOS/Linux start on the scanner.
+- Windows remains on manual entry for now.
+- **Enter manually** remains available under every scanner.
+- Manual entry shows **Scan the QR instead** only on supported platforms.
+- Permission denial, missing camera, initialization failure, and decode failure
+  stay inline in the existing scanner surface with Retry and manual fallback.
+- Successful desktop scans enter the existing handover review screen; no
+  security checks or credential serialization change.
+
+No new visual constants are required: the current scanner frame, design-system
+tokens, and localized labels are reused.
+
+## Files
+
+- `pubspec.yaml`, `pubspec.lock`
+- `lib/features/sync/ui/provisioned/bundle_import_page.dart`
+- `lib/features/sync/ui/provisioned/desktop_qr_scanner.dart` (new)
+- `macos/Runner/Info.plist`
+- `test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart`
+- `test/features/sync/ui/provisioned/desktop_qr_scanner_test.dart` (new)
+- `test/features/sync/ui/provisioned_sync_page_test.dart` or the existing
+  add-device mirror test, only if the mobile-generation assertion is missing
+- `test/features/sync/ui/sync_manual_screenshots_test.dart`
+- `lib/features/sync/README.md`
+- `knowledge/features/sync/overview.md`
+- one `changelog.d/` fragment
+
+## Verification
+
+Automated:
+
+- Pure frame-decoder tests for BGRA, RGBA, row padding, malformed frames, no QR,
+  and a valid QR payload.
+- Widget tests for macOS/Linux scanner-first behavior, Windows manual fallback,
+  scanner-to-manual switching, retry, one-shot delivery, and disposal.
+- Existing bundle import/controller tests to prove scanned and pasted payloads
+  still share the same validation and pairing confirmation.
+- Targeted analyzer and Flutter tests only for touched source mirrors.
+- Linux debug build to compile/link the new native plugin.
+- Before/after desktop screenshots from the existing sync manual harness.
+
+Hardware acceptance before calling Phase A complete:
+
+- macOS: grant, deny, retry, scan from phone, and scan from tablet.
+- Linux native: V4L2 webcam scan and no-camera fallback.
+- Linux Flatpak: portal grant/deny, PipeWire preview, scan, and relaunch after a
+  remembered permission decision.
+- Android phone and tablet: generate a code, keep the whole QR visible without
+  horizontal clipping, and complete a desktop join.
+
+Phase B must not start until those Phase A acceptance paths are green.

--- a/docs/implementation_plans/2026-08-29_phase_b_play_sync_subscription.md
+++ b/docs/implementation_plans/2026-08-29_phase_b_play_sync_subscription.md
@@ -40,15 +40,17 @@ repository. The client:
 1. creates an authenticated purchase intent bound to a stable Lotti account or
    server-issued entitlement identity before opening Play Billing;
 2. attaches the server-derived obfuscated account/profile identifier to the
-   Billing flow, then sends `purchaseToken`, product id, package name, purchase
-   intent, and a client-generated delivery/claim secret over TLS;
-3. obtains a Play Integrity verdict whose `requestHash` covers a canonical
+   Billing flow;
+3. obtains a signed Play Integrity token whose `requestHash` covers a canonical
    serialization of the purchase-token fingerprint, product/base-plan,
    entitlement id, purchase-intent id, and claim-secret hash;
-4. never treats the local `PurchaseDetails` state as entitlement;
-5. waits for the server to verify and provision, then imports the returned v2
+4. sends the signed Play Integrity token together with `purchaseToken`, product
+   and base-plan ids, package name, entitlement id, purchase-intent id, and a
+   client-generated delivery/claim secret over TLS;
+5. never treats the local `PurchaseDetails` state as entitlement;
+6. waits for the server to verify and provision, then imports the returned v2
    bundle through the existing `ProvisioningController`; and
-6. completes the Play purchase only after the server confirms it has granted
+7. completes the Play purchase only after the server confirms it has granted
    entitlement.
 
 The app must not contain the service's current shared `API_KEYS` value. The
@@ -65,10 +67,14 @@ acceptable.
 ### Server verification
 
 Add a `GooglePlayClient` service using Google service-account credentials and
-the Android Publisher scope. For every client submission and RTDN:
+the Android Publisher scope.
 
-1. verify the authenticated account/purchase intent and the Play Integrity
-   verdict, including exact `requestHash`/nonce matching and replay controls;
+For a client purchase submission:
+
+1. verify the authenticated account and one-time purchase intent, decode and
+   verify the submitted signed Play Integrity token, recompute the canonical
+   request hash from the submitted fields, and require exact
+   `requestHash`/nonce matching with replay controls;
 2. call `purchases.subscriptionsv2.get` for `com.matthiasn.lotti` and the token;
 3. require an allowed product/base-plan line item and a grantable state:
    `ACTIVE`, `IN_GRACE_PERIOD`, or `CANCELED` only while the authoritative
@@ -87,9 +93,15 @@ the Android Publisher scope. For every client submission and RTDN:
 8. acknowledge a new, verified token server-side after the entitlement and
    bundle claim are durably recorded. Renewals do not need acknowledgement.
 
-Never trust RTDN state directly. Verify the Pub/Sub push JWT/audience, decode
-the notification, then re-query `subscriptionsv2.get`; notifications are only a
-signal that authoritative state may have changed.
+For RTDN, do not apply client-only account, purchase-intent, Play Integrity, or
+claim-secret checks: `SubscriptionNotification` does not carry those proofs.
+Instead, verify the Pub/Sub push JWT including issuer, audience, and service
+account identity; decode the notification; resolve its `purchaseToken` through
+the stored token-to-entitlement binding; and call
+`purchases.subscriptionsv2.get` with that notification token before changing
+state. An unknown token cannot create or rebind an entitlement. Never trust the
+notification's state directly: RTDN is only a signal that authoritative Google
+state may have changed.
 
 ## Reliable one-time bundle delivery
 
@@ -249,10 +261,15 @@ Expected additions/changes:
 - Mocked Android Publisher tests for verification, acknowledgement, retryable
   errors, invalid product/package, and token replay.
 - Repository migration/transaction/concurrency tests with unique-token races.
-- Route tests for Pub/Sub JWT failures, malformed notifications, idempotent
-  purchase submission, lost-response retry, claim authorization, stolen-token
-  rebinding attempts, mismatched Integrity request hashes/nonces, and replayed
-  purchase intents.
+- Client-submission route tests for a missing/invalid signed Play Integrity
+  token, server recomputation of the canonical request hash from every submitted
+  field, mismatched hashes/nonces, idempotent submission, lost-response retry,
+  claim authorization, stolen-token rebinding attempts, and replayed purchase
+  intents.
+- RTDN route tests for Pub/Sub JWT issuer/audience/service-account failures,
+  malformed notifications, unknown token bindings, duplicate/out-of-order
+  delivery, and proof that the notification token is re-queried through
+  `purchases.subscriptionsv2.get` before a bound entitlement changes.
 - Token-lineage tests for cancellation before expiry and post-expiry
   resubscription without `linkedPurchaseToken`, including
   `outOfAppPurchaseContext`, stable entitlement reuse, and atomic retirement of

--- a/docs/implementation_plans/2026-08-29_phase_b_play_sync_subscription.md
+++ b/docs/implementation_plans/2026-08-29_phase_b_play_sync_subscription.md
@@ -13,7 +13,9 @@ background-task patterns (`RedemptionPoller`, `RetentionScheduler`), audit
 events, admin/client API-key separation, and Synapse admin operations.
 
 The Android application id is `com.matthiasn.lotti`. There is currently no Play
-Billing client or user-account identity layer in the Flutter app.
+Billing client or user-account identity layer in the Flutter app. A stable
+server-side entitlement identity is therefore a launch prerequisite, not
+something a purchase token or claim secret may substitute.
 
 ## Purchase and provisioning flow
 
@@ -35,35 +37,54 @@ a dedicated Pub/Sub topic and authenticated push subscription.
 Add the Flutter `in_app_purchase` plugin behind a small sync-subscription
 repository. The client:
 
-1. queries the two base plans and launches the Play purchase flow;
-2. sends `purchaseToken`, product id, package name, and a client-generated
-   idempotency/claim secret to the provisioner over TLS;
-3. never treats the local `PurchaseDetails` state as entitlement;
-4. waits for the server to verify and provision, then imports the returned v2
+1. creates an authenticated purchase intent bound to a stable Lotti account or
+   server-issued entitlement identity before opening Play Billing;
+2. attaches the server-derived obfuscated account/profile identifier to the
+   Billing flow, then sends `purchaseToken`, product id, package name, purchase
+   intent, and a client-generated delivery/claim secret over TLS;
+3. obtains a Play Integrity verdict whose `requestHash` covers a canonical
+   serialization of the purchase-token fingerprint, product/base-plan,
+   entitlement id, purchase-intent id, and claim-secret hash;
+4. never treats the local `PurchaseDetails` state as entitlement;
+5. waits for the server to verify and provision, then imports the returned v2
    bundle through the existing `ProvisioningController`; and
-5. completes the Play purchase only after the server confirms it has granted
+6. completes the Play purchase only after the server confirms it has granted
    entitlement.
 
 The app must not contain the service's current shared `API_KEYS` value. The
 purchase token is a high-entropy proof presented only over TLS, and the server
-must additionally validate it with Google. Add Play Integrity binding before
-public launch if the endpoint is exposed without an authenticated Lotti account.
+must additionally validate it with Google. The claim secret authorizes delivery
+retries only; it does not prove who owns the purchase. If Lotti still has no
+authenticated account at launch, the provisioner must issue and retain a stable
+entitlement identity plus one-time purchase intent, require its server-derived
+obfuscated identifier in the Play purchase, and validate a Play Integrity
+verdict bound to the exact submission through `requestHash` (or a server nonce
+for the classic API). A public token-plus-claim-secret endpoint is not
+acceptable.
 
 ### Server verification
 
 Add a `GooglePlayClient` service using Google service-account credentials and
 the Android Publisher scope. For every client submission and RTDN:
 
-1. call `purchases.subscriptionsv2.get` for `com.matthiasn.lotti` and the token;
-2. require an allowed product/base-plan line item and a grantable subscription
-   state (`ACTIVE` or `IN_GRACE_PERIOD`);
-3. reject pending, paused, on-hold, expired, revoked, unknown-product, test (in
-   production), and package-mismatch results;
-4. verify `externalAccountIdentifiers` when the client supplied an obfuscated
-   account/profile id;
-5. follow `linkedPurchaseToken` on upgrades, downgrades, and re-signups so one
-   entitlement cannot provision two Matrix accounts; and
-6. acknowledge a new, verified token server-side after the entitlement and
+1. verify the authenticated account/purchase intent and the Play Integrity
+   verdict, including exact `requestHash`/nonce matching and replay controls;
+2. call `purchases.subscriptionsv2.get` for `com.matthiasn.lotti` and the token;
+3. require an allowed product/base-plan line item and a grantable state:
+   `ACTIVE`, `IN_GRACE_PERIOD`, or `CANCELED` only while the authoritative
+   line-item `expiryTime` is still in the future;
+4. reject pending, paused, on-hold, expired, revoked, canceled-at-or-after-
+   expiry, unknown-product, test (in production), and package-mismatch results;
+5. require `externalAccountIdentifiers` to match the server-derived obfuscated
+   identifier for the bound entitlement; a missing or mismatched binding cannot
+   create or move an entitlement;
+6. follow `linkedPurchaseToken` on upgrades, downgrades, and non-lapsed
+   re-signups. For a post-expiry resubscription with no linked token, process
+   `outOfAppPurchaseContext.expiredPurchaseToken` and expired external account
+   identifiers when present, but still require the stable entitlement binding;
+7. atomically attach the new token to that entitlement and mark every linked or
+   replaced token non-grantable before any bundle can be provisioned; and
+8. acknowledge a new, verified token server-side after the entitlement and
    bundle claim are durably recorded. Renewals do not need acknowledgement.
 
 Never trust RTDN state directly. Verify the Pub/Sub push JWT/audience, decode
@@ -78,15 +99,20 @@ credential. Keep the plaintext prohibition, but add short-lived encrypted
 escrow for paid provisioning:
 
 - The client generates a random claim secret and sends only its hash for the
-  server record.
+  server record. This secret protects delivery, never purchase ownership.
 - Store the raw Play token encrypted with a KMS/envelope key and a separate
   SHA-256 token fingerprint for uniqueness/lookups.
-- Store the generated bundle encrypted until the client confirms successful
+- Store the generated bundle encrypted until the server validates successful
   import/password rotation, with a strict TTL and audit trail.
 - Idempotent retries with the same purchase token and claim proof return the
   same pending claim; they never create a second Matrix user.
-- Delete escrow ciphertext immediately after rotation confirmation, or revoke
-  an abandoned unrotated account after the claim TTL.
+- Do not trust a bare `bundle_id` rotation callback. After import, issue a
+  one-time rotation challenge; require the bound Matrix user to publish it in
+  the provisioned non-federated room and verify that the escrowed bootstrap
+  password no longer authenticates before recording rotation.
+- Delete escrow ciphertext only after that proof succeeds. A pre-import
+  confirmation leaves escrow intact, repeated valid confirmations are
+  idempotent, and an abandoned unrotated account is revoked after the claim TTL.
 
 This requires replacing the currently unusable
 `/client/bundles/{bundle_id}/rotated` address with a purchase/claim-scoped
@@ -98,12 +124,14 @@ Add repository migrations and models for:
 
 ### `play_subscriptions`
 
+- stable entitlement id and server-derived obfuscated account/profile id
 - token fingerprint (unique), encrypted token, package name
 - product id, base plan id, latest order id (audit only, never the primary key)
 - verified Play state and normalized entitlement state
 - purchase/start time, current period end, grace deadline
 - acknowledgement state/time
 - linked/replaced token fingerprint
+- out-of-app expired token fingerprint and binding-verification result
 - provisioned `bundle_id` foreign key
 - suspended/unsuspended timestamps
 - last verified time, next reconciliation time, last error
@@ -114,6 +142,13 @@ Add repository migrations and models for:
 - `bundle_id` (unique), claim-secret hash
 - encrypted bundle ciphertext and KMS key metadata
 - expires, first delivered, confirmed, and destroyed timestamps
+
+### `purchase_intents`
+
+- opaque intent id, stable entitlement id, one-time secret hash, requested
+  product/base plan, expiry, consumed timestamp, and replay metadata
+- expected Play Integrity request hash/nonce and the server-derived obfuscated
+  account/profile identifier used to launch Billing
 
 ### Events
 
@@ -139,7 +174,10 @@ pending -> active -> grace -> suspended -> active
 active  -> canceled_active -> suspended/expired at entitlement end
 ```
 
-- `ACTIVE`, including voluntary cancellation before period end: keep sync.
+- `ACTIVE`: keep sync.
+- `CANCELED` with a future authoritative `expiryTime`: keep sync as
+  `canceled_active`; suspend when that timestamp is reached. A canceled result
+  whose `expiryTime` is already past loses entitlement immediately.
 - `IN_GRACE_PERIOD`: keep sync through the Play-configured three-day deadline.
 - `ON_HOLD`, `PAUSED`, `EXPIRED`, or revoked: remove entitlement immediately
   once the authoritative Google response says access is no longer valid.
@@ -192,6 +230,9 @@ Expected additions/changes:
 - TLS only, strict request sizes, schema validation, rate limits, replay-safe
   idempotency, redacted structured logs, and no permissive CORS on client APIs.
 - Authenticated Pub/Sub push with issuer/audience/email verification.
+- Mandatory stable account/entitlement binding for purchase submission and
+  restoration; Play Integrity `requestHash`/nonce validation must bind every
+  security-relevant request field and reject replays.
 - Least-privilege Google Play and Synapse service accounts.
 - Constant-time claim-secret verification and encryption key separation.
 - Metrics/alerts for verification failures, unacknowledged purchases nearing
@@ -202,15 +243,23 @@ Expected additions/changes:
 
 ## Testing
 
-- Pure state-table tests for every Play state, cancellation, grace boundary,
-  recovery, linked tokens, out-of-order/duplicate RTDN, and exact UTC deadlines.
+- Pure state-table tests for every Play state, cancellation before and after
+  `expiryTime`, grace boundary, recovery, linked tokens, out-of-order/duplicate
+  RTDN, and exact UTC deadlines.
 - Mocked Android Publisher tests for verification, acknowledgement, retryable
   errors, invalid product/package, and token replay.
 - Repository migration/transaction/concurrency tests with unique-token races.
 - Route tests for Pub/Sub JWT failures, malformed notifications, idempotent
-  purchase submission, lost-response retry, and claim authorization.
+  purchase submission, lost-response retry, claim authorization, stolen-token
+  rebinding attempts, mismatched Integrity request hashes/nonces, and replayed
+  purchase intents.
+- Token-lineage tests for cancellation before expiry and post-expiry
+  resubscription without `linkedPurchaseToken`, including
+  `outOfAppPurchaseContext`, stable entitlement reuse, and atomic retirement of
+  the replaced token.
 - Bundle lifecycle tests proving a network retry provisions exactly one account
-  and confirmed rotation destroys escrow.
+  and only server-validated rotation destroys escrow; cover pre-import and
+  repeated rotation confirmations explicitly.
 - Synapse integration tests proving suspend blocks sync sends and unsuspend
   restores them without replacing devices/room membership.
 - Google Play license-tester scenarios for initial purchase, pending payment,
@@ -219,3 +268,15 @@ Expected additions/changes:
 
 No Phase B code should be merged until Phase A's macOS/Linux camera acceptance
 is complete.
+
+## Primary references
+
+- Google Play Billing security and purchase attribution:
+  <https://developer.android.com/google/play/billing/security>
+- Subscription cancellation, expiry, and entitlement lifecycle:
+  <https://developer.android.com/google/play/billing/lifecycle/subscriptions>
+- `purchases.subscriptionsv2`, including external identifiers and
+  `outOfAppPurchaseContext`:
+  <https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2>
+- Play Integrity request content binding:
+  <https://developer.android.com/google/play/integrity/standard>

--- a/docs/implementation_plans/2026-08-29_phase_b_play_sync_subscription.md
+++ b/docs/implementation_plans/2026-08-29_phase_b_play_sync_subscription.md
@@ -1,0 +1,221 @@
+# Phase B — Google Play SYNC subscription provisioning
+
+**Status:** plan only; blocked on Phase A acceptance
+**Date:** 2026-08-29
+
+## Existing service to extend
+
+`services/matrix-provisioning-service` is already a FastAPI service backed by a
+SQLite repository. `BundleService` provisions a Matrix account plus encrypted,
+non-federated sync room through `services/shared/matrix`, stores only a bundle
+fingerprint, and returns the live credential once. The service already has
+background-task patterns (`RedemptionPoller`, `RetentionScheduler`), audit
+events, admin/client API-key separation, and Synapse admin operations.
+
+The Android application id is `com.matthiasn.lotti`. There is currently no Play
+Billing client or user-account identity layer in the Flutter app.
+
+## Purchase and provisioning flow
+
+### Play Console
+
+Create one subscription product (for example `lotti_sync`) with monthly and
+annual auto-renewing base plans. Configure the displayed prices in Play Console
+(approximately USD 4.99/month and 44.99/year); the backend validates product and
+base-plan IDs, not a hard-coded currency amount. Configure the Play grace period
+to exactly three days so Google and Lotti have one entitlement deadline rather
+than two overlapping grace calculations.
+
+Enable the Google Play Developer API, grant a least-privilege service account
+access to the Lotti app, and connect Real-time Developer Notifications (RTDN) to
+a dedicated Pub/Sub topic and authenticated push subscription.
+
+### Android client
+
+Add the Flutter `in_app_purchase` plugin behind a small sync-subscription
+repository. The client:
+
+1. queries the two base plans and launches the Play purchase flow;
+2. sends `purchaseToken`, product id, package name, and a client-generated
+   idempotency/claim secret to the provisioner over TLS;
+3. never treats the local `PurchaseDetails` state as entitlement;
+4. waits for the server to verify and provision, then imports the returned v2
+   bundle through the existing `ProvisioningController`; and
+5. completes the Play purchase only after the server confirms it has granted
+   entitlement.
+
+The app must not contain the service's current shared `API_KEYS` value. The
+purchase token is a high-entropy proof presented only over TLS, and the server
+must additionally validate it with Google. Add Play Integrity binding before
+public launch if the endpoint is exposed without an authenticated Lotti account.
+
+### Server verification
+
+Add a `GooglePlayClient` service using Google service-account credentials and
+the Android Publisher scope. For every client submission and RTDN:
+
+1. call `purchases.subscriptionsv2.get` for `com.matthiasn.lotti` and the token;
+2. require an allowed product/base-plan line item and a grantable subscription
+   state (`ACTIVE` or `IN_GRACE_PERIOD`);
+3. reject pending, paused, on-hold, expired, revoked, unknown-product, test (in
+   production), and package-mismatch results;
+4. verify `externalAccountIdentifiers` when the client supplied an obfuscated
+   account/profile id;
+5. follow `linkedPurchaseToken` on upgrades, downgrades, and re-signups so one
+   entitlement cannot provision two Matrix accounts; and
+6. acknowledge a new, verified token server-side after the entitlement and
+   bundle claim are durably recorded. Renewals do not need acknowledgement.
+
+Never trust RTDN state directly. Verify the Pub/Sub push JWT/audience, decode
+the notification, then re-query `subscriptionsv2.get`; notifications are only a
+signal that authoritative state may have changed.
+
+## Reliable one-time bundle delivery
+
+The current return-once bundle rule is unsafe for a paid network request: a
+dropped response after provisioning would consume the purchase but lose the
+credential. Keep the plaintext prohibition, but add short-lived encrypted
+escrow for paid provisioning:
+
+- The client generates a random claim secret and sends only its hash for the
+  server record.
+- Store the raw Play token encrypted with a KMS/envelope key and a separate
+  SHA-256 token fingerprint for uniqueness/lookups.
+- Store the generated bundle encrypted until the client confirms successful
+  import/password rotation, with a strict TTL and audit trail.
+- Idempotent retries with the same purchase token and claim proof return the
+  same pending claim; they never create a second Matrix user.
+- Delete escrow ciphertext immediately after rotation confirmation, or revoke
+  an abandoned unrotated account after the claim TTL.
+
+This requires replacing the currently unusable
+`/client/bundles/{bundle_id}/rotated` address with a purchase/claim-scoped
+rotation endpoint or adding the bundle id to a backward-compatible v3 bundle.
+
+## Data model
+
+Add repository migrations and models for:
+
+### `play_subscriptions`
+
+- token fingerprint (unique), encrypted token, package name
+- product id, base plan id, latest order id (audit only, never the primary key)
+- verified Play state and normalized entitlement state
+- purchase/start time, current period end, grace deadline
+- acknowledgement state/time
+- linked/replaced token fingerprint
+- provisioned `bundle_id` foreign key
+- suspended/unsuspended timestamps
+- last verified time, next reconciliation time, last error
+- created/updated timestamps
+
+### `bundle_claims`
+
+- `bundle_id` (unique), claim-secret hash
+- encrypted bundle ciphertext and KMS key metadata
+- expires, first delivered, confirmed, and destroyed timestamps
+
+### Events
+
+Extend `BundleEventType` (or add a subscription event table) for verified,
+acknowledged, renewed, grace-entered, suspended, recovered, expired, revoked,
+claim-delivered, and claim-destroyed transitions. Do not store tokens, bundle
+plaintext, authorization headers, or Google credentials in event detail/logs.
+
+SQLite remains acceptable only for the current single-instance deployment:
+enable WAL, foreign keys, busy timeout, explicit transactions, and unique
+constraints. A multi-replica/HA deployment must move the repository interface
+to PostgreSQL before adding workers; local SQLite cannot coordinate duplicate
+RTDN processing across hosts safely.
+
+## Expiry and three-day grace
+
+Normalize Google states into a small entitlement state machine:
+
+```text
+pending -> active -> grace -> suspended -> active
+                    |          |
+                    +--------> expired
+active  -> canceled_active -> suspended/expired at entitlement end
+```
+
+- `ACTIVE`, including voluntary cancellation before period end: keep sync.
+- `IN_GRACE_PERIOD`: keep sync through the Play-configured three-day deadline.
+- `ON_HOLD`, `PAUSED`, `EXPIRED`, or revoked: remove entitlement immediately
+  once the authoritative Google response says access is no longer valid.
+- Recovery/renewal: restore entitlement idempotently.
+
+Use RTDN for prompt transitions plus a periodic reconciliation worker for
+missed/out-of-order notifications and deadline enforcement. Compare UTC
+timestamps supplied by Google; never infer expiry from local receipt time.
+
+## Enforcing sync access
+
+Do **not** deactivate expired Matrix accounts: Synapse deactivation removes
+devices, E2EE keys, tokens, room membership, and other account state, making a
+normal subscription recovery destructive.
+
+Extend `services/shared/matrix/admin_client.py` with reversible account
+suspension and query methods. At entitlement loss, suspend the Matrix user;
+Synapse then rejects message sends, joins, invites, and profile changes, which
+stops Lotti's cross-device replication while preserving the account and room.
+On renewal/recovery, unsuspend it. Record desired and observed suspension state
+so retries converge after Synapse outages.
+
+Before launch, verify the deployed Synapse version supports the suspension API
+and add an end-to-end test showing that a suspended account cannot send a sync
+event. If stronger read/login denial is required, use a Synapse authorization
+module tied to the entitlement store; do not approximate it by password reset
+or device deletion, both of which break recoverability.
+
+## Service files
+
+Expected additions/changes:
+
+- `services/matrix-provisioning-service/src/core/models.py`
+- `services/matrix-provisioning-service/src/core/constants.py`
+- `services/matrix-provisioning-service/src/api/routes.py`
+- `services/matrix-provisioning-service/src/services/provisioning_repository.py`
+- `services/matrix-provisioning-service/src/services/bundle_service.py`
+- new `google_play_client.py`, `subscription_service.py`,
+  `subscription_reconciler.py`, and `bundle_claim_service.py`
+- `services/matrix-provisioning-service/src/container.py`, `src/main.py`
+- `services/shared/matrix/admin_client.py`
+- dependency/configuration/Docker/README updates
+- mirrored unit, route, repository, scheduler, and integration tests
+- Flutter billing repository/controller/UI and localized catalog changes
+
+## Security and operations
+
+- Secret Manager/KMS-mounted Google credentials; never a JSON key in the image
+  or repository. Rotate service and envelope keys.
+- TLS only, strict request sizes, schema validation, rate limits, replay-safe
+  idempotency, redacted structured logs, and no permissive CORS on client APIs.
+- Authenticated Pub/Sub push with issuer/audience/email verification.
+- Least-privilege Google Play and Synapse service accounts.
+- Constant-time claim-secret verification and encryption key separation.
+- Metrics/alerts for verification failures, unacknowledged purchases nearing
+  Google's three-day refund deadline, RTDN lag, reconciliation drift, escrow
+  age, and failed suspend/unsuspend operations.
+- Backups and tested restore for subscription/audit data; encrypted token and
+  bundle fields excluded from ordinary support exports.
+
+## Testing
+
+- Pure state-table tests for every Play state, cancellation, grace boundary,
+  recovery, linked tokens, out-of-order/duplicate RTDN, and exact UTC deadlines.
+- Mocked Android Publisher tests for verification, acknowledgement, retryable
+  errors, invalid product/package, and token replay.
+- Repository migration/transaction/concurrency tests with unique-token races.
+- Route tests for Pub/Sub JWT failures, malformed notifications, idempotent
+  purchase submission, lost-response retry, and claim authorization.
+- Bundle lifecycle tests proving a network retry provisions exactly one account
+  and confirmed rotation destroys escrow.
+- Synapse integration tests proving suspend blocks sync sends and unsuspend
+  restores them without replacing devices/room membership.
+- Google Play license-tester scenarios for initial purchase, pending payment,
+  renewal, cancellation, three-day grace, account hold, expiry, refund/revoke,
+  upgrade/downgrade, reinstall, and RTDN redelivery.
+
+No Phase B code should be merged until Phase A's macOS/Linux camera acceptance
+is complete.

--- a/knowledge/features/sync/overview.md
+++ b/knowledge/features/sync/overview.md
@@ -146,7 +146,8 @@ stateDiagram-v2
     Ready --> SendingMessages: Send message history (opens ReSyncModal)
   }
   state "New device" as New {
-    [*] --> Scanning: mobile opens the camera
+    [*] --> Scanning: Android, iOS, macOS, or Linux opens the camera
+    [*] --> Manual: Windows opens manual entry
     Scanning --> Manual: enter code manually
     Manual --> Scanning: scan with camera
     Scanning --> Decoded: handover barcode decodes
@@ -172,11 +173,17 @@ Five properties are deliberate:
   that sheet is open — it used to render unconditionally at the bottom of the
   status page on desktop. It is hidden until revealed, and the sheet states
   that the code unlocks the account. "Never ambient" is about *display*, not
-  secrecy: *Copy pairing code* puts it on the clipboard by design, because a
-  desktop joining a desktop has no camera. See the check-code bullet below for
-  what that means for the threat model.
+  secrecy: *Copy pairing code* puts it on the clipboard by design, both as a
+  fallback when camera access is unavailable and as the primary Windows path.
+  See the check-code bullet below for what that means for the threat model.
 - **Add device is not platform-gated.** Any paired device can present a code,
   so a surviving phone can onboard a replacement for a dead desktop.
+- **Camera scanning follows platform capability.** Android, iOS, and macOS use
+  `mobile_scanner`; Linux streams webcam frames through the standard camera API
+  backed by `camera_desktop` and decodes QR payloads in a worker isolate with
+  `zxing2`. Only one Linux frame is decoded at a time and intervening frames are
+  skipped to keep the UI responsive. Camera denial or absence leaves manual
+  entry available, and Windows stays manual-only until it gets a scanner.
 - **Both devices warn, and the warning touches the credential.** The inviting
   side keeps a lock-badged `DesignSystemInlineCallout` (the design-system
   component the sync-local callout was promoted into) glued directly under

--- a/lib/features/sync/README.md
+++ b/lib/features/sync/README.md
@@ -38,8 +38,9 @@ merge of two users' work.
   and it says plainly that it unlocks the account — it can also be copied as
   text, so it is treated as a credential throughout: let your own new device
   scan it, but never keep a screenshot or send it through chat or email. The
-  joining device opens straight into the camera, with manual entry as the
-  fallback, and finishes on a screen naming what is still outstanding: the
+  joining device opens straight into the camera on Android, iOS, macOS, and
+  Linux, with manual entry as the fallback (and the primary path on Windows),
+  then finishes on a screen naming what is still outstanding: the
   emoji ceremony, plus the settings and message-history pushes that only the
   other device can send. Both transfers stay beside the pairing code and remain
   disabled until that exact new device's Matrix verification ceremony succeeds

--- a/lib/features/sync/ui/provisioned/bundle_import_page.dart
+++ b/lib/features/sync/ui/provisioned/bundle_import_page.dart
@@ -14,6 +14,7 @@ import 'package:lotti/features/settings/state/manual_language_controller.dart';
 import 'package:lotti/features/sync/models/pairing_check_code.dart';
 import 'package:lotti/features/sync/state/bundle_decode_error.dart';
 import 'package:lotti/features/sync/state/provisioning_controller.dart';
+import 'package:lotti/features/sync/ui/provisioned/desktop_qr_scanner.dart';
 import 'package:lotti/features/sync/ui/widgets/matrix/pairing_check_code_view.dart';
 import 'package:lotti/features/sync/ui/widgets/sync_well.dart';
 import 'package:lotti/features/sync/ui/widgets/sync_wizard_progress_track.dart';
@@ -57,10 +58,13 @@ class _BundleImportWidgetState extends ConsumerState<BundleImportWidget> {
   String? _errorText;
   SyncProvisioningBundle? _decodedBundle;
 
-  /// Mobile opens straight into the camera: scanning is the path a new phone
-  /// is actually here for, and a base64 field is a poor first impression.
-  /// Desktop has no usable camera, so it starts on the manual field.
-  late bool _manualEntry = isDesktop;
+  /// Every platform with a supported camera backend opens straight into the
+  /// scanner. Windows stays on manual entry until its camera path is added.
+  late bool _manualEntry = !_scannerSupported;
+
+  bool get _scannerSupported => isMobile || isMacOS || isLinux;
+
+  bool get _usesLinuxScanner => !isMobile && isLinux;
 
   /// Payloads the user explicitly declined. The rejected QR is usually still
   /// on the other device's screen, so without this the very next camera frame
@@ -167,7 +171,10 @@ class _BundleImportWidgetState extends ConsumerState<BundleImportWidget> {
   }
 
   void _handleBarcode(BarcodeCapture barcodes) {
-    final code = barcodes.barcodes.firstOrNull?.rawValue;
+    _handleScannedCode(barcodes.barcodes.firstOrNull?.rawValue);
+  }
+
+  void _handleScannedCode(String? code) {
     if (code == null || code.isEmpty || code == _lastScannedCode) return;
     if (_rejectedCodes.contains(code)) {
       // Silently ignoring it left the camera looking alive and permanently
@@ -243,7 +250,7 @@ class _BundleImportWidgetState extends ConsumerState<BundleImportWidget> {
           _lastScannedCode = null;
           _errorText = null;
           _textController.clear();
-          if (isDesktop) _manualEntry = true;
+          _manualEntry = !_scannerSupported;
         });
       }
     });
@@ -296,7 +303,7 @@ class _BundleImportWidgetState extends ConsumerState<BundleImportWidget> {
                         onImport: () =>
                             _importBundle(_textController.text.trim()),
                         onPaste: _pasteFromClipboard,
-                        onUseCamera: isMobile
+                        onUseCamera: _scannerSupported
                             ? () => _setManualEntry(manual: false)
                             : null,
                       )
@@ -305,6 +312,8 @@ class _BundleImportWidgetState extends ConsumerState<BundleImportWidget> {
                         key: ValueKey('scanner_$_scannerGeneration'),
                         controller: _ensureScannerController(),
                         onDetect: _handleBarcode,
+                        onDesktopDetect: _handleScannedCode,
+                        usesLinuxScanner: _usesLinuxScanner,
                         errorText: _errorText,
                         onEnterManually: () => _setManualEntry(manual: true),
                         onRetryCamera: _restartScanner,
@@ -456,15 +465,19 @@ class _ScannerView extends StatefulWidget {
   const _ScannerView({
     required this.controller,
     required this.onDetect,
+    required this.onDesktopDetect,
     required this.onEnterManually,
     required this.onRetryCamera,
+    required this.usesLinuxScanner,
     super.key,
     this.errorText,
   });
 
   final MobileScannerController controller;
   final void Function(BarcodeCapture) onDetect;
+  final ValueChanged<String> onDesktopDetect;
   final VoidCallback onEnterManually;
+  final bool usesLinuxScanner;
 
   /// Rebuilds the scanner after the user grants permission out of band —
   /// without it, "Allow it in system settings" is an instruction with no way
@@ -481,7 +494,7 @@ class _ScannerViewState extends State<_ScannerView> {
   void initState() {
     super.initState();
     // Nothing to start when the preview is a stand-in.
-    if (scannerPreviewOverride == null) {
+    if (scannerPreviewOverride == null && !widget.usesLinuxScanner) {
       // After the first frame, not during initState: `MobileScanner` is a
       // child, so it has not mounted or called `attach()` yet. Starting here
       // would leave the controller waiting on its attachment timeout instead
@@ -495,7 +508,7 @@ class _ScannerViewState extends State<_ScannerView> {
   @override
   void dispose() {
     // Best effort: the controller belongs to the page, which disposes it.
-    if (scannerPreviewOverride == null) {
+    if (scannerPreviewOverride == null && !widget.usesLinuxScanner) {
       unawaited(widget.controller.stop().catchError((Object _) {}));
     }
     super.dispose();
@@ -554,15 +567,24 @@ class _ScannerViewState extends State<_ScannerView> {
                     fit: StackFit.expand,
                     children: [
                       scannerPreviewOverride?.call(context, side) ??
-                          MobileScanner(
-                            controller: widget.controller,
-                            onDetect: widget.onDetect,
-                            errorBuilder: (context, error) =>
-                                _CameraUnavailable(
-                                  message: messages.syncPairCameraDenied,
-                                  onRetry: widget.onRetryCamera,
-                                ),
-                          ),
+                          (widget.usesLinuxScanner
+                              ? DesktopQrScanner(
+                                  onDetect: widget.onDesktopDetect,
+                                  unavailableBuilder: (context) =>
+                                      _CameraUnavailable(
+                                        message: messages.syncPairCameraDenied,
+                                        onRetry: widget.onRetryCamera,
+                                      ),
+                                )
+                              : MobileScanner(
+                                  controller: widget.controller,
+                                  onDetect: widget.onDetect,
+                                  errorBuilder: (context, error) =>
+                                      _CameraUnavailable(
+                                        message: messages.syncPairCameraDenied,
+                                        onRetry: widget.onRetryCamera,
+                                      ),
+                                )),
                       // The pairing moment's frame: accent corner brackets
                       // marking where the code should land. Decorative and
                       // input-transparent.

--- a/lib/features/sync/ui/provisioned/bundle_import_page.dart
+++ b/lib/features/sync/ui/provisioned/bundle_import_page.dart
@@ -250,7 +250,10 @@ class _BundleImportWidgetState extends ConsumerState<BundleImportWidget> {
           _lastScannedCode = null;
           _errorText = null;
           _textController.clear();
-          _manualEntry = !_scannerSupported;
+          // A reset clears the submitted code, not the input mode the user
+          // explicitly selected. Unsupported platforms still require manual
+          // entry, while scanner-capable platforms preserve camera/manual.
+          if (!_scannerSupported) _manualEntry = true;
         });
       }
     });

--- a/lib/features/sync/ui/provisioned/desktop_qr_scanner.dart
+++ b/lib/features/sync/ui/provisioned/desktop_qr_scanner.dart
@@ -115,6 +115,7 @@ abstract interface class DesktopQrCamera {
   Future<void> start({
     required bool Function() shouldCaptureFrame,
     required ValueChanged<DesktopQrFrame> onFrame,
+    required ValueChanged<Object> onError,
   });
 
   Future<void> dispose();
@@ -135,6 +136,7 @@ class _DesktopQrScannerState extends State<DesktopQrScanner> {
   DesktopQrCamera? _camera;
   bool _unavailable = false;
   bool _decoding = false;
+  bool _handlingCameraFailure = false;
   String? _lastDetectedPayload;
   int _framesToSkip = 0;
 
@@ -157,30 +159,42 @@ class _DesktopQrScannerState extends State<DesktopQrScanner> {
       await camera.start(
         shouldCaptureFrame: _shouldCaptureFrame,
         onFrame: _onFrame,
+        onError: _onCameraError,
       );
     } on Exception catch (error, stackTrace) {
-      final failedCamera = _camera;
-      _camera = null;
-      if (failedCamera != null) {
-        try {
-          await failedCamera.dispose();
-        } on Exception catch (disposeError, disposeStackTrace) {
-          DevLogger.error(
-            name: 'DesktopQrScanner',
-            message: 'Failed to dispose desktop camera after startup error',
-            error: disposeError,
-            stackTrace: disposeStackTrace,
-          );
-        }
-      }
-      DevLogger.error(
-        name: 'DesktopQrScanner',
-        message: 'Desktop camera initialization failed',
-        error: error,
-        stackTrace: stackTrace,
-      );
-      if (mounted) setState(() => _unavailable = true);
+      await _handleCameraFailure(error, stackTrace);
     }
+  }
+
+  void _onCameraError(Object error) {
+    unawaited(_handleCameraFailure(error, StackTrace.current));
+  }
+
+  Future<void> _handleCameraFailure(Object error, StackTrace stackTrace) async {
+    if (_handlingCameraFailure || _unavailable) return;
+    _handlingCameraFailure = true;
+    final failedCamera = _camera;
+    _camera = null;
+    if (failedCamera != null) {
+      try {
+        await failedCamera.dispose();
+      } on Exception catch (disposeError, disposeStackTrace) {
+        DevLogger.error(
+          name: 'DesktopQrScanner',
+          message: 'Failed to dispose desktop camera after camera error',
+          error: disposeError,
+          stackTrace: disposeStackTrace,
+        );
+      }
+    }
+    DevLogger.error(
+      name: 'DesktopQrScanner',
+      message: 'Desktop camera failed',
+      error: error,
+      stackTrace: stackTrace,
+    );
+    if (mounted) setState(() => _unavailable = true);
+    _handlingCameraFailure = false;
   }
 
   bool _shouldCaptureFrame() {
@@ -246,6 +260,7 @@ class _CameraDesktopQrCamera implements DesktopQrCamera {
   _CameraDesktopQrCamera(this._controller);
 
   final CameraController _controller;
+  VoidCallback? _cameraErrorListener;
 
   static Future<_CameraDesktopQrCamera> create() async {
     final cameras = await availableCameras();
@@ -274,27 +289,48 @@ class _CameraDesktopQrCamera implements DesktopQrCamera {
   Future<void> start({
     required bool Function() shouldCaptureFrame,
     required ValueChanged<DesktopQrFrame> onFrame,
-  }) {
-    return _controller.startImageStream((image) {
-      if (image.planes.isEmpty || !shouldCaptureFrame()) return;
-      final plane = image.planes.first;
-      onFrame(
-        DesktopQrFrame(
-          // The native buffer is reused, so decoding must own a copy.
-          bytes: Uint8List.fromList(plane.bytes),
-          width: image.width,
-          height: image.height,
-          bytesPerRow: plane.bytesPerRow,
-          channelOrder: image.format.raw == 'RGBA'
-              ? DesktopQrChannelOrder.rgba
-              : DesktopQrChannelOrder.bgra,
-        ),
-      );
-    });
+    required ValueChanged<Object> onError,
+  }) async {
+    void cameraErrorListener() {
+      final description = _controller.value.errorDescription;
+      if (description != null) {
+        onError(CameraException('camera_error', description));
+      }
+    }
+
+    _cameraErrorListener = cameraErrorListener;
+    _controller.addListener(cameraErrorListener);
+    try {
+      await _controller.startImageStream((image) {
+        if (image.planes.isEmpty || !shouldCaptureFrame()) return;
+        final plane = image.planes.first;
+        onFrame(
+          DesktopQrFrame(
+            // The native buffer is reused, so decoding must own a copy.
+            bytes: Uint8List.fromList(plane.bytes),
+            width: image.width,
+            height: image.height,
+            bytesPerRow: plane.bytesPerRow,
+            channelOrder: image.format.raw == 'RGBA'
+                ? DesktopQrChannelOrder.rgba
+                : DesktopQrChannelOrder.bgra,
+          ),
+        );
+      });
+    } on Exception {
+      _controller.removeListener(cameraErrorListener);
+      _cameraErrorListener = null;
+      rethrow;
+    }
   }
 
   @override
   Future<void> dispose() async {
+    final cameraErrorListener = _cameraErrorListener;
+    if (cameraErrorListener != null) {
+      _controller.removeListener(cameraErrorListener);
+      _cameraErrorListener = null;
+    }
     if (_controller.value.isStreamingImages) {
       try {
         await _controller.stopImageStream();

--- a/lib/features/sync/ui/provisioned/desktop_qr_scanner.dart
+++ b/lib/features/sync/ui/provisioned/desktop_qr_scanner.dart
@@ -159,6 +159,20 @@ class _DesktopQrScannerState extends State<DesktopQrScanner> {
         onFrame: _onFrame,
       );
     } on Exception catch (error, stackTrace) {
+      final failedCamera = _camera;
+      _camera = null;
+      if (failedCamera != null) {
+        try {
+          await failedCamera.dispose();
+        } on Exception catch (disposeError, disposeStackTrace) {
+          DevLogger.error(
+            name: 'DesktopQrScanner',
+            message: 'Failed to dispose desktop camera after startup error',
+            error: disposeError,
+            stackTrace: disposeStackTrace,
+          );
+        }
+      }
       DevLogger.error(
         name: 'DesktopQrScanner',
         message: 'Desktop camera initialization failed',

--- a/lib/features/sync/ui/provisioned/desktop_qr_scanner.dart
+++ b/lib/features/sync/ui/provisioned/desktop_qr_scanner.dart
@@ -126,6 +126,11 @@ typedef DesktopQrCameraFactory = Future<DesktopQrCamera> Function();
 @visibleForTesting
 DesktopQrCameraFactory? desktopQrCameraFactoryOverride;
 
+/// Creates the production Linux camera adapter through a testable seam.
+@visibleForTesting
+Future<DesktopQrCamera> createDesktopQrCamera() =>
+    _CameraDesktopQrCamera.create();
+
 class _DesktopQrScannerState extends State<DesktopQrScanner> {
   DesktopQrCamera? _camera;
   bool _unavailable = false;
@@ -143,7 +148,7 @@ class _DesktopQrScannerState extends State<DesktopQrScanner> {
     try {
       final camera =
           await (desktopQrCameraFactoryOverride?.call() ??
-              _CameraDesktopQrCamera.create());
+              createDesktopQrCamera());
       if (!mounted) {
         await camera.dispose();
         return;

--- a/lib/features/sync/ui/provisioned/desktop_qr_scanner.dart
+++ b/lib/features/sync/ui/provisioned/desktop_qr_scanner.dart
@@ -110,7 +110,12 @@ class DesktopQrScanner extends StatefulWidget {
 abstract interface class DesktopQrCamera {
   Widget buildPreview();
 
-  Future<void> start(ValueChanged<DesktopQrFrame> onFrame);
+  /// Starts the stream, consulting [shouldCaptureFrame] before copying a
+  /// native camera buffer into a Dart-owned [DesktopQrFrame].
+  Future<void> start({
+    required bool Function() shouldCaptureFrame,
+    required ValueChanged<DesktopQrFrame> onFrame,
+  });
 
   Future<void> dispose();
 }
@@ -125,7 +130,7 @@ class _DesktopQrScannerState extends State<DesktopQrScanner> {
   DesktopQrCamera? _camera;
   bool _unavailable = false;
   bool _decoding = false;
-  bool _detected = false;
+  String? _lastDetectedPayload;
   int _framesToSkip = 0;
 
   @override
@@ -144,7 +149,10 @@ class _DesktopQrScannerState extends State<DesktopQrScanner> {
         return;
       }
       setState(() => _camera = camera);
-      await camera.start(_onFrame);
+      await camera.start(
+        shouldCaptureFrame: _shouldCaptureFrame,
+        onFrame: _onFrame,
+      );
     } on Exception catch (error, stackTrace) {
       DevLogger.error(
         name: 'DesktopQrScanner',
@@ -156,24 +164,33 @@ class _DesktopQrScannerState extends State<DesktopQrScanner> {
     }
   }
 
-  void _onFrame(DesktopQrFrame frame) {
-    if (_detected || _decoding) return;
+  bool _shouldCaptureFrame() {
+    if (_decoding) return false;
     if (_framesToSkip > 0) {
       _framesToSkip--;
-      return;
+      return false;
     }
     // Decode roughly every fifth delivered frame. This is deterministic,
     // needs no Timer, and keeps backpressure independent of decoder latency.
     _framesToSkip = 4;
     _decoding = true;
+    return true;
+  }
+
+  void _onFrame(DesktopQrFrame frame) {
     unawaited(_decode(frame));
   }
 
   Future<void> _decode(DesktopQrFrame frame) async {
     try {
       final payload = await widget.decoder(frame);
-      if (!mounted || payload == null || payload.isEmpty || _detected) return;
-      _detected = true;
+      if (!mounted ||
+          payload == null ||
+          payload.isEmpty ||
+          payload == _lastDetectedPayload) {
+        return;
+      }
+      _lastDetectedPayload = payload;
       widget.onDetect(payload);
     } on Exception catch (error, stackTrace) {
       DevLogger.error(
@@ -235,9 +252,12 @@ class _CameraDesktopQrCamera implements DesktopQrCamera {
   Widget buildPreview() => CameraPreview(_controller);
 
   @override
-  Future<void> start(ValueChanged<DesktopQrFrame> onFrame) {
+  Future<void> start({
+    required bool Function() shouldCaptureFrame,
+    required ValueChanged<DesktopQrFrame> onFrame,
+  }) {
     return _controller.startImageStream((image) {
-      if (image.planes.isEmpty) return;
+      if (image.planes.isEmpty || !shouldCaptureFrame()) return;
       final plane = image.planes.first;
       onFrame(
         DesktopQrFrame(

--- a/lib/features/sync/ui/provisioned/desktop_qr_scanner.dart
+++ b/lib/features/sync/ui/provisioned/desktop_qr_scanner.dart
@@ -1,0 +1,269 @@
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:camera/camera.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/components/spinners/design_system_spinner.dart';
+import 'package:lotti/services/dev_logger.dart';
+import 'package:zxing2/qrcode.dart';
+
+/// Channel order used by a desktop camera's packed four-byte image plane.
+enum DesktopQrChannelOrder { rgba, bgra }
+
+/// A sendable, decoder-ready copy of one desktop camera frame.
+@immutable
+class DesktopQrFrame {
+  const DesktopQrFrame({
+    required this.bytes,
+    required this.width,
+    required this.height,
+    required this.bytesPerRow,
+    required this.channelOrder,
+  });
+
+  final Uint8List bytes;
+  final int width;
+  final int height;
+  final int bytesPerRow;
+  final DesktopQrChannelOrder channelOrder;
+}
+
+/// Decodes a QR payload from a packed RGBA/BGRA desktop camera frame.
+///
+/// Camera rows may contain alignment padding, so pixels are walked using
+/// [DesktopQrFrame.bytesPerRow] rather than treating the plane as tightly
+/// packed. Malformed frames and frames without a QR code return null.
+String? decodeDesktopQrFrame(DesktopQrFrame frame) {
+  const bytesPerPixel = 4;
+  if (frame.width <= 0 ||
+      frame.height <= 0 ||
+      frame.bytesPerRow < frame.width * bytesPerPixel) {
+    return null;
+  }
+
+  final requiredBytes =
+      (frame.height - 1) * frame.bytesPerRow + frame.width * bytesPerPixel;
+  if (frame.bytes.length < requiredBytes) return null;
+
+  final pixels = Int32List(frame.width * frame.height);
+  for (var y = 0; y < frame.height; y++) {
+    final rowStart = y * frame.bytesPerRow;
+    for (var x = 0; x < frame.width; x++) {
+      final offset = rowStart + x * bytesPerPixel;
+      final (red, green, blue) = switch (frame.channelOrder) {
+        DesktopQrChannelOrder.rgba => (
+          frame.bytes[offset],
+          frame.bytes[offset + 1],
+          frame.bytes[offset + 2],
+        ),
+        DesktopQrChannelOrder.bgra => (
+          frame.bytes[offset + 2],
+          frame.bytes[offset + 1],
+          frame.bytes[offset],
+        ),
+      };
+      pixels[y * frame.width + x] = (0xFF000000 | red << 16 | green << 8 | blue)
+          .toSigned(32);
+    }
+  }
+
+  try {
+    final source = RGBLuminanceSource(frame.width, frame.height, pixels);
+    final bitmap = BinaryBitmap(HybridBinarizer(source));
+    return QRCodeReader().decode(bitmap).text;
+  } on ReaderException {
+    return null;
+  }
+}
+
+typedef DesktopQrUnavailableBuilder = Widget Function(BuildContext context);
+typedef DesktopQrDecoder = Future<String?> Function(DesktopQrFrame frame);
+
+/// Linux webcam preview and QR decoder.
+///
+/// `mobile_scanner` covers Android, iOS, and macOS but has no Linux plugin.
+/// This widget uses the standard camera API, backed by `camera_desktop`, then
+/// decodes copied RGBA/BGRA frames off the UI isolate with ZXing.
+class DesktopQrScanner extends StatefulWidget {
+  const DesktopQrScanner({
+    required this.onDetect,
+    required this.unavailableBuilder,
+    super.key,
+    this.decoder = _decodeOffUiIsolate,
+  });
+
+  final ValueChanged<String> onDetect;
+  final DesktopQrUnavailableBuilder unavailableBuilder;
+  final DesktopQrDecoder decoder;
+
+  static Future<String?> _decodeOffUiIsolate(DesktopQrFrame frame) =>
+      Isolate.run(() => decodeDesktopQrFrame(frame));
+
+  @override
+  State<DesktopQrScanner> createState() => _DesktopQrScannerState();
+}
+
+/// Narrow camera seam used by the widget tests; production uses
+/// [_CameraDesktopQrCamera].
+@visibleForTesting
+abstract interface class DesktopQrCamera {
+  Widget buildPreview();
+
+  Future<void> start(ValueChanged<DesktopQrFrame> onFrame);
+
+  Future<void> dispose();
+}
+
+typedef DesktopQrCameraFactory = Future<DesktopQrCamera> Function();
+
+/// Test-only factory override for a native Linux webcam.
+@visibleForTesting
+DesktopQrCameraFactory? desktopQrCameraFactoryOverride;
+
+class _DesktopQrScannerState extends State<DesktopQrScanner> {
+  DesktopQrCamera? _camera;
+  bool _unavailable = false;
+  bool _decoding = false;
+  bool _detected = false;
+  int _framesToSkip = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_initialize());
+  }
+
+  Future<void> _initialize() async {
+    try {
+      final camera =
+          await (desktopQrCameraFactoryOverride?.call() ??
+              _CameraDesktopQrCamera.create());
+      if (!mounted) {
+        await camera.dispose();
+        return;
+      }
+      setState(() => _camera = camera);
+      await camera.start(_onFrame);
+    } on Exception catch (error, stackTrace) {
+      DevLogger.error(
+        name: 'DesktopQrScanner',
+        message: 'Desktop camera initialization failed',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      if (mounted) setState(() => _unavailable = true);
+    }
+  }
+
+  void _onFrame(DesktopQrFrame frame) {
+    if (_detected || _decoding) return;
+    if (_framesToSkip > 0) {
+      _framesToSkip--;
+      return;
+    }
+    // Decode roughly every fifth delivered frame. This is deterministic,
+    // needs no Timer, and keeps backpressure independent of decoder latency.
+    _framesToSkip = 4;
+    _decoding = true;
+    unawaited(_decode(frame));
+  }
+
+  Future<void> _decode(DesktopQrFrame frame) async {
+    try {
+      final payload = await widget.decoder(frame);
+      if (!mounted || payload == null || payload.isEmpty || _detected) return;
+      _detected = true;
+      widget.onDetect(payload);
+    } on Exception catch (error, stackTrace) {
+      DevLogger.error(
+        name: 'DesktopQrScanner',
+        message: 'Desktop QR decode failed',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    } finally {
+      _decoding = false;
+    }
+  }
+
+  @override
+  void dispose() {
+    final camera = _camera;
+    _camera = null;
+    if (camera != null) unawaited(camera.dispose());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_unavailable) return widget.unavailableBuilder(context);
+    final camera = _camera;
+    if (camera == null) {
+      return const Center(child: DesignSystemSpinner());
+    }
+    return camera.buildPreview();
+  }
+}
+
+class _CameraDesktopQrCamera implements DesktopQrCamera {
+  _CameraDesktopQrCamera(this._controller);
+
+  final CameraController _controller;
+
+  static Future<_CameraDesktopQrCamera> create() async {
+    final cameras = await availableCameras();
+    if (cameras.isEmpty) {
+      throw CameraException('no_camera', 'No webcam is available');
+    }
+    final controller = CameraController(
+      cameras.first,
+      ResolutionPreset.medium,
+      enableAudio: false,
+      imageFormatGroup: ImageFormatGroup.bgra8888,
+    );
+    try {
+      await controller.initialize();
+    } on Exception {
+      await controller.dispose();
+      rethrow;
+    }
+    return _CameraDesktopQrCamera(controller);
+  }
+
+  @override
+  Widget buildPreview() => CameraPreview(_controller);
+
+  @override
+  Future<void> start(ValueChanged<DesktopQrFrame> onFrame) {
+    return _controller.startImageStream((image) {
+      if (image.planes.isEmpty) return;
+      final plane = image.planes.first;
+      onFrame(
+        DesktopQrFrame(
+          // The native buffer is reused, so decoding must own a copy.
+          bytes: Uint8List.fromList(plane.bytes),
+          width: image.width,
+          height: image.height,
+          bytesPerRow: plane.bytesPerRow,
+          channelOrder: image.format.raw == 'RGBA'
+              ? DesktopQrChannelOrder.rgba
+              : DesktopQrChannelOrder.bgra,
+        ),
+      );
+    });
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_controller.value.isStreamingImages) {
+      try {
+        await _controller.stopImageStream();
+      } on CameraException {
+        // Disposal must still release the controller after a native stream
+        // already stopped itself.
+      }
+    }
+    await _controller.dispose();
+  }
+}

--- a/lib/features/sync/ui/provisioned/desktop_qr_scanner.dart
+++ b/lib/features/sync/ui/provisioned/desktop_qr_scanner.dart
@@ -176,16 +176,7 @@ class _DesktopQrScannerState extends State<DesktopQrScanner> {
     final failedCamera = _camera;
     _camera = null;
     if (failedCamera != null) {
-      try {
-        await failedCamera.dispose();
-      } on Exception catch (disposeError, disposeStackTrace) {
-        DevLogger.error(
-          name: 'DesktopQrScanner',
-          message: 'Failed to dispose desktop camera after camera error',
-          error: disposeError,
-          stackTrace: disposeStackTrace,
-        );
-      }
+      await _disposeCamera(failedCamera);
     }
     DevLogger.error(
       name: 'DesktopQrScanner',
@@ -195,6 +186,19 @@ class _DesktopQrScannerState extends State<DesktopQrScanner> {
     );
     if (mounted) setState(() => _unavailable = true);
     _handlingCameraFailure = false;
+  }
+
+  Future<void> _disposeCamera(DesktopQrCamera camera) async {
+    try {
+      await camera.dispose();
+    } on Exception catch (error, stackTrace) {
+      DevLogger.error(
+        name: 'DesktopQrScanner',
+        message: 'Failed to dispose desktop camera',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   bool _shouldCaptureFrame() {
@@ -241,7 +245,7 @@ class _DesktopQrScannerState extends State<DesktopQrScanner> {
   void dispose() {
     final camera = _camera;
     _camera = null;
-    if (camera != null) unawaited(camera.dispose());
+    if (camera != null) unawaited(_disposeCamera(camera));
     super.dispose();
   }
 

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <audio_decoder/audio_decoder_plugin.h>
 #include <audioplayers_linux/audioplayers_linux_plugin.h>
+#include <camera_desktop/camera_desktop_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_onnxruntime/flutter_onnxruntime_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
@@ -29,6 +30,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) audioplayers_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "AudioplayersLinuxPlugin");
   audioplayers_linux_plugin_register_with_registrar(audioplayers_linux_registrar);
+  g_autoptr(FlPluginRegistrar) camera_desktop_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "CameraDesktopPlugin");
+  camera_desktop_plugin_register_with_registrar(camera_desktop_registrar);
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   audio_decoder
   audioplayers_linux
+  camera_desktop
   file_selector_linux
   flutter_onnxruntime
   flutter_secure_storage_linux

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import audio_decoder
 import audio_session
 import audioplayers_darwin
+import camera_desktop
 import connectivity_plus
 import device_info_plus
 import file_selector_macos
@@ -43,6 +44,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioDecoderPlugin.register(with: registry.registrar(forPlugin: "AudioDecoderPlugin"))
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
+  CameraDesktopPlugin.register(with: registry.registrar(forPlugin: "CameraDesktopPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -12,6 +12,8 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -55,7 +55,7 @@
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Record audio notes</string>
 	<key>NSCameraUsageDescription</key>
-	<string>Allow camera access to attach photos to journal entries</string>
+	<string>Allow camera access to scan sync QR codes and attach photos to journal entries</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Import photos and videos</string>
 	<key>NSPrincipalClass</key>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -290,7 +290,7 @@ packages:
     source: hosted
     version: "1.2.1"
   camera_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: camera_platform_interface
       sha256: "4524ca6eb4176b066864036ad4fe02c3e4863e63b77eadc21a5bf56824f43498"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -257,6 +257,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  camera:
+    dependency: "direct main"
+    description:
+      name: camera
+      sha256: "4142a19a38e388d3bab444227636610ba88982e36dff4552d5191a86f65dc437"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.4"
+  camera_android_camerax:
+    dependency: transitive
+    description:
+      name: camera_android_camerax
+      sha256: "8516fe308bc341a5067fb1a48edff0ddfa57c0d3cdcc9dbe7ceca3ba119e2577"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.30"
+  camera_avfoundation:
+    dependency: transitive
+    description:
+      name: camera_avfoundation
+      sha256: "11b4aee2f5e5e038982e152b4a342c749b414aa27857899d20f4323e94cb5f0b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.23+2"
+  camera_desktop:
+    dependency: "direct main"
+    description:
+      name: camera_desktop
+      sha256: bea6ba51ecfa1afa24c543f26a66f10ca9f43ce8525207de7675ebcb4402d66f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  camera_platform_interface:
+    dependency: transitive
+    description:
+      name: camera_platform_interface
+      sha256: "4524ca6eb4176b066864036ad4fe02c3e4863e63b77eadc21a5bf56824f43498"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.13.1"
+  camera_web:
+    dependency: transitive
+    description:
+      name: camera_web
+      sha256: "081441bd2f92b5841aa70ff4d6eddfe34078d97f9d085cc9e0f9d0102f145925"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+5"
   canonical_json:
     dependency: transitive
     description:
@@ -3347,6 +3395,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  zxing2:
+    dependency: "direct main"
+    description:
+      name: zxing2
+      sha256: "2677c49a3b9ca9457cb1d294fd4bd5041cac6aab8cdb07b216ba4e98945c684f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.4"
 sdks:
   dart: ">=3.12.0 <4.0.0"
   flutter: ">=3.47.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,8 @@ dependencies:
   audio_decoder: ^0.8.1
   beamer: ^1.5.2
   cached_network_image: ^3.2.0
+  camera: ^0.11.3
+  camera_desktop: ^1.2.1
   clock: ^1.1.1
   collection: ^1.18.0
   connectivity_plus: ^7.0.0
@@ -126,6 +128,7 @@ dependencies:
   widgetbook: ^3.7.1
   window_manager: ^0.5.0
   wolt_modal_sheet: ^0.11.0
+  zxing2: ^0.2.4
 
 dependency_overrides:
   # json_serializable >=6.13.2 requires analyzer >=10, while

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -154,6 +154,7 @@ dev_dependencies:
   arb_utils: ^0.11.0
   archive: ^4.0.7
   build_runner: ^2.5.4
+  camera_platform_interface: any
   cross_file: any
   dart_style: ^3.0.1
   drift_dev: ^2.16.0

--- a/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
@@ -3,12 +3,14 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart'
     hide isLinux, isMacOS, isWindows;
 import 'package:lotti/classes/config.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/sync/state/provisioning_controller.dart';
 import 'package:lotti/features/sync/ui/provisioned/bundle_import_page.dart';
 import 'package:lotti/features/sync/ui/provisioned/desktop_qr_scanner.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -321,6 +323,51 @@ void main() {
 
         expect(find.byType(MobileScanner), findsOneWidget);
         expect(find.byType(TextField), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'a provisioning reset preserves manual mode on scanner platforms',
+      (tester) async {
+        final camera = _FakeDesktopCamera();
+        desktopQrCameraFactoryOverride = () async => camera;
+        isWindows = false;
+        isLinux = true;
+
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            SingleChildScrollView(
+              child: BundleImportWidget(pageIndexNotifier: pageIndexNotifier),
+            ),
+            overrides: defaultOverrides(),
+          ),
+        );
+        await tester.pump();
+
+        final manualEntry = find.byKey(
+          const Key('bundle_import_enter_manually'),
+        );
+        await tester.ensureVisible(manualEntry);
+        await tester.tap(manualEntry);
+        await tester.pump();
+        expect(find.byType(TextField), findsOneWidget);
+
+        await tester.enterText(find.byType(TextField), validBase64);
+        await tester.pump();
+        final context = tester.element(find.byType(BundleImportWidget));
+        await tester.tap(
+          find.text(context.messages.provisionedSyncImportButton),
+        );
+        await tester.pumpAndSettle();
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(BundleImportWidget)),
+        );
+        container.read(provisioningControllerProvider.notifier).reset();
+        await tester.pumpAndSettle();
+
+        expect(find.byType(TextField), findsOneWidget);
+        expect(find.byType(DesktopQrScanner), findsNothing);
       },
     );
   });

--- a/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
@@ -852,7 +852,10 @@ class _FakeDesktopCamera implements DesktopQrCamera {
   Future<void> dispose() async {}
 
   @override
-  Future<void> start(ValueChanged<DesktopQrFrame> onFrame) async {
+  Future<void> start({
+    required bool Function() shouldCaptureFrame,
+    required ValueChanged<DesktopQrFrame> onFrame,
+  }) async {
     started = true;
   }
 }

--- a/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
@@ -891,6 +891,7 @@ class _FakeDesktopCamera implements DesktopQrCamera {
   Future<void> start({
     required bool Function() shouldCaptureFrame,
     required ValueChanged<DesktopQrFrame> onFrame,
+    required ValueChanged<Object> onError,
   }) async {
     started = true;
   }

--- a/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
@@ -225,6 +225,42 @@ void main() {
       expect(camera.started, isTrue);
     });
 
+    testWidgets(
+      'Linux camera failure keeps retry and manual recovery visible',
+      (
+        tester,
+      ) async {
+        desktopQrCameraFactoryOverride = () async =>
+            throw const FormatException('no camera');
+        isWindows = false;
+        isLinux = true;
+
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            SingleChildScrollView(
+              child: BundleImportWidget(pageIndexNotifier: pageIndexNotifier),
+            ),
+            overrides: defaultOverrides(),
+          ),
+        );
+        await tester.pump();
+
+        final context = tester.element(find.byType(BundleImportWidget));
+        expect(
+          find.text(context.messages.syncPairCameraDenied),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const Key('bundle_import_camera_retry')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const Key('bundle_import_enter_manually')),
+          findsOneWidget,
+        );
+      },
+    );
+
     testWidgets('hides import form after successful import', (tester) async {
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(

--- a/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart
@@ -4,11 +4,13 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/misc.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test/flutter_test.dart'
+    hide isLinux, isMacOS, isWindows;
 import 'package:lotti/classes/config.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/sync/ui/provisioned/bundle_import_page.dart';
+import 'package:lotti/features/sync/ui/provisioned/desktop_qr_scanner.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/utils/platform.dart';
@@ -46,6 +48,24 @@ void main() {
   });
 
   setUp(() {
+    final wasDesktop = isDesktop;
+    final wasMobile = isMobile;
+    final wasWindows = isWindows;
+    final wasLinux = isLinux;
+    final wasMacOS = isMacOS;
+    isDesktop = true;
+    isMobile = false;
+    isWindows = true;
+    isLinux = false;
+    isMacOS = false;
+    addTearDown(() {
+      isDesktop = wasDesktop;
+      isMobile = wasMobile;
+      isWindows = wasWindows;
+      isLinux = wasLinux;
+      isMacOS = wasMacOS;
+    });
+
     mockMatrixService = MockMatrixService();
     mockLoggingService = MockLoggingService();
     pageIndexNotifier = ValueNotifier(0);
@@ -84,6 +104,7 @@ void main() {
   });
 
   tearDown(() async {
+    desktopQrCameraFactoryOverride = null;
     pageIndexNotifier.dispose();
     await tearDownTestGetIt();
   });
@@ -141,18 +162,9 @@ void main() {
       );
     });
 
-    testWidgets('desktop stays on manual entry with no camera', (
+    testWidgets('Windows stays on manual entry until its scanner is added', (
       tester,
     ) async {
-      final wasDesktop = isDesktop;
-      final wasMobile = isMobile;
-      isDesktop = true;
-      isMobile = false;
-      addTearDown(() {
-        isDesktop = wasDesktop;
-        isMobile = wasMobile;
-      });
-
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
           SingleChildScrollView(
@@ -166,6 +178,51 @@ void main() {
       expect(find.byIcon(LottiIcons.scanQr), findsNothing);
       expect(find.byType(MobileScanner), findsNothing);
       expect(find.byType(TextField), findsOneWidget);
+    });
+
+    testWidgets('macOS opens the existing mobile scanner immediately', (
+      tester,
+    ) async {
+      setUpMacOsScanner();
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          SingleChildScrollView(
+            child: BundleImportWidget(pageIndexNotifier: pageIndexNotifier),
+          ),
+          overrides: defaultOverrides(),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(MobileScanner), findsOneWidget);
+      expect(find.byType(TextField), findsNothing);
+      final context = tester.element(find.byType(BundleImportWidget));
+      expect(find.text(context.messages.syncPairScanTitle), findsOneWidget);
+    });
+
+    testWidgets('Linux opens the desktop camera scanner immediately', (
+      tester,
+    ) async {
+      final camera = _FakeDesktopCamera();
+      desktopQrCameraFactoryOverride = () async => camera;
+      isWindows = false;
+      isLinux = true;
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          SingleChildScrollView(
+            child: BundleImportWidget(pageIndexNotifier: pageIndexNotifier),
+          ),
+          overrides: defaultOverrides(),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(DesktopQrScanner), findsOneWidget);
+      expect(find.byType(MobileScanner), findsNothing);
+      expect(find.byType(TextField), findsNothing);
+      expect(camera.started, isTrue);
     });
 
     testWidgets('hides import form after successful import', (tester) async {
@@ -782,5 +839,20 @@ class _GatedStartScanner extends FakeMethodChannelMobileScanner {
     started = true;
     await gate.future;
     return super.start(startOptions);
+  }
+}
+
+class _FakeDesktopCamera implements DesktopQrCamera {
+  bool started = false;
+
+  @override
+  Widget buildPreview() => const ColoredBox(color: Colors.green);
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<void> start(ValueChanged<DesktopQrFrame> onFrame) async {
+    started = true;
   }
 }

--- a/test/features/sync/ui/provisioned/bundle_import_page_test.dart
+++ b/test/features/sync/ui/provisioned/bundle_import_page_test.dart
@@ -4,7 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test/flutter_test.dart'
+    hide isLinux, isMacOS, isWindows;
 import 'package:lotti/classes/config.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -63,6 +64,24 @@ void main() {
   });
 
   setUp(() {
+    final wasDesktop = isDesktop;
+    final wasMobile = isMobile;
+    final wasWindows = isWindows;
+    final wasLinux = isLinux;
+    final wasMacOS = isMacOS;
+    isDesktop = true;
+    isMobile = false;
+    isWindows = true;
+    isLinux = false;
+    isMacOS = false;
+    addTearDown(() {
+      isDesktop = wasDesktop;
+      isMobile = wasMobile;
+      isWindows = wasWindows;
+      isLinux = wasLinux;
+      isMacOS = wasMacOS;
+    });
+
     mockMatrixService = MockMatrixService();
     mockLoggingService = MockLoggingService();
     mockOnboardingSyncService = MockOnboardingSyncService();

--- a/test/features/sync/ui/provisioned/bundle_import_page_test_helpers.dart
+++ b/test/features/sync/ui/provisioned/bundle_import_page_test_helpers.dart
@@ -1,7 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test/flutter_test.dart'
+    hide isLinux, isMacOS, isWindows;
 import 'package:lotti/utils/platform.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:mobile_scanner/src/method_channel/mobile_scanner_method_channel.dart';
@@ -61,14 +62,31 @@ class FakeMethodChannelMobileScanner extends MethodChannelMobileScanner {
 void setUpMobileScanner() {
   final wasDesktop = isDesktop;
   final wasMobile = isMobile;
+  final wasWindows = isWindows;
+  final wasLinux = isLinux;
+  final wasMacOS = isMacOS;
   isDesktop = false;
   isMobile = true;
+  isWindows = false;
+  isLinux = false;
+  isMacOS = false;
   addTearDown(() {
     isDesktop = wasDesktop;
     isMobile = wasMobile;
+    isWindows = wasWindows;
+    isLinux = wasLinux;
+    isMacOS = wasMacOS;
   });
 
   final fakePlatform = FakeMethodChannelMobileScanner();
   MobileScannerPlatform.instance = fakePlatform;
   addTearDown(fakePlatform.disposeControllers);
+}
+
+/// Pins the platform flags to macOS while reusing the mobile_scanner fake.
+void setUpMacOsScanner() {
+  setUpMobileScanner();
+  isDesktop = true;
+  isMobile = false;
+  isMacOS = true;
 }

--- a/test/features/sync/ui/provisioned/desktop_qr_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/desktop_qr_scanner_test.dart
@@ -1,0 +1,208 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/sync/ui/provisioned/desktop_qr_scanner.dart';
+import 'package:lotti/services/dev_logger.dart';
+import 'package:zxing2/qrcode.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    DevLogger.suppressOutput = true;
+    DevLogger.clear();
+  });
+
+  tearDown(() {
+    desktopQrCameraFactoryOverride = null;
+    DevLogger.suppressOutput = false;
+    DevLogger.clear();
+  });
+
+  group('decodeDesktopQrFrame', () {
+    for (final order in DesktopQrChannelOrder.values) {
+      test('decodes ${order.name} data with padded rows', () {
+        const payload = 'lotti-sync-handover-v2';
+        final frame = _qrFrame(payload, order: order, rowPadding: 12);
+
+        expect(decodeDesktopQrFrame(frame), payload);
+      });
+    }
+
+    test('returns null for a malformed frame', () {
+      expect(
+        decodeDesktopQrFrame(
+          DesktopQrFrame(
+            bytes: Uint8List(3),
+            width: 20,
+            height: 20,
+            bytesPerRow: 80,
+            channelOrder: DesktopQrChannelOrder.rgba,
+          ),
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null when the frame has no QR code', () {
+      expect(
+        decodeDesktopQrFrame(
+          DesktopQrFrame(
+            bytes: Uint8List.fromList(List.filled(40 * 40 * 4, 0xFF)),
+            width: 40,
+            height: 40,
+            bytesPerRow: 40 * 4,
+            channelOrder: DesktopQrChannelOrder.rgba,
+          ),
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('DesktopQrScanner', () {
+    testWidgets('shows a preview and emits the decoded payload once', (
+      tester,
+    ) async {
+      final camera = _FakeDesktopQrCamera();
+      desktopQrCameraFactoryOverride = () async => camera;
+      final detected = <String>[];
+
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          DesktopQrScanner(
+            onDetect: detected.add,
+            unavailableBuilder: (_) => const Text('Camera unavailable'),
+            decoder: (_) async => 'pairing-code',
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byKey(const Key('desktop_camera_preview')), findsOneWidget);
+      expect(camera.started, isTrue);
+
+      camera.emit(_blankFrame());
+      await tester.pump();
+      camera.emit(_blankFrame());
+      await tester.pump();
+
+      expect(detected, ['pairing-code']);
+    });
+
+    testWidgets('shows the fallback when camera initialization fails', (
+      tester,
+    ) async {
+      desktopQrCameraFactoryOverride = () async =>
+          throw const FormatException('no camera');
+
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          DesktopQrScanner(
+            onDetect: (_) {},
+            unavailableBuilder: (_) => const Text('Camera unavailable'),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Camera unavailable'), findsOneWidget);
+    });
+
+    testWidgets('disposes the camera when removed', (tester) async {
+      final camera = _FakeDesktopQrCamera();
+      desktopQrCameraFactoryOverride = () async => camera;
+
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          DesktopQrScanner(
+            onDetect: (_) {},
+            unavailableBuilder: (_) => const Text('Camera unavailable'),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+
+      expect(camera.disposed, isTrue);
+    });
+  });
+}
+
+DesktopQrFrame _blankFrame() => DesktopQrFrame(
+  bytes: Uint8List.fromList(List.filled(4, 0xFF)),
+  width: 1,
+  height: 1,
+  bytesPerRow: 4,
+  channelOrder: DesktopQrChannelOrder.rgba,
+);
+
+DesktopQrFrame _qrFrame(
+  String payload, {
+  required DesktopQrChannelOrder order,
+  required int rowPadding,
+}) {
+  const quietZone = 4;
+  const scale = 7;
+  final matrix = Encoder.encode(payload, ErrorCorrectionLevel.h).matrix!;
+  final width = (matrix.width + quietZone * 2) * scale;
+  final height = (matrix.height + quietZone * 2) * scale;
+  final bytesPerRow = width * 4 + rowPadding;
+  final bytes = Uint8List(bytesPerRow * height)
+    ..fillRange(0, bytesPerRow * height, 0xFF);
+
+  for (var moduleY = 0; moduleY < matrix.height; moduleY++) {
+    for (var moduleX = 0; moduleX < matrix.width; moduleX++) {
+      if (matrix.get(moduleX, moduleY) != 1) continue;
+      final startX = (moduleX + quietZone) * scale;
+      final startY = (moduleY + quietZone) * scale;
+      for (var y = startY; y < startY + scale; y++) {
+        for (var x = startX; x < startX + scale; x++) {
+          final offset = y * bytesPerRow + x * 4;
+          bytes[offset] = 0;
+          bytes[offset + 1] = 0;
+          bytes[offset + 2] = 0;
+          bytes[offset + 3] = 0xFF;
+        }
+      }
+    }
+  }
+
+  return DesktopQrFrame(
+    bytes: bytes,
+    width: width,
+    height: height,
+    bytesPerRow: bytesPerRow,
+    channelOrder: order,
+  );
+}
+
+class _FakeDesktopQrCamera implements DesktopQrCamera {
+  ValueChanged<DesktopQrFrame>? _onFrame;
+  bool started = false;
+  bool disposed = false;
+
+  @override
+  Widget buildPreview() => const ColoredBox(
+    key: Key('desktop_camera_preview'),
+    color: Colors.green,
+  );
+
+  void emit(DesktopQrFrame frame) => _onFrame?.call(frame);
+
+  @override
+  Future<void> start(ValueChanged<DesktopQrFrame> onFrame) async {
+    started = true;
+    _onFrame = onFrame;
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposed = true;
+    _onFrame = null;
+  }
+}

--- a/test/features/sync/ui/provisioned/desktop_qr_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/desktop_qr_scanner_test.dart
@@ -150,6 +150,54 @@ void main() {
       expect(find.text('Camera unavailable'), findsOneWidget);
     });
 
+    testWidgets('disposes the camera before reporting stream start failure', (
+      tester,
+    ) async {
+      final camera = _FakeDesktopQrCamera(
+        startError: const FormatException('stream unavailable'),
+      );
+      desktopQrCameraFactoryOverride = () async => camera;
+
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          DesktopQrScanner(
+            onDetect: (_) {},
+            unavailableBuilder: (_) => const Text('Camera unavailable'),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(camera.started, isTrue);
+      expect(camera.disposed, isTrue);
+      expect(find.text('Camera unavailable'), findsOneWidget);
+      expect(find.byKey(const Key('desktop_camera_preview')), findsNothing);
+    });
+
+    testWidgets('keeps fallback usable when failed camera disposal throws', (
+      tester,
+    ) async {
+      final camera = _FakeDesktopQrCamera(
+        startError: const FormatException('stream unavailable'),
+        disposeError: const FormatException('dispose failed'),
+      );
+      desktopQrCameraFactoryOverride = () async => camera;
+
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          DesktopQrScanner(
+            onDetect: (_) {},
+            unavailableBuilder: (_) => const Text('Camera unavailable'),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(camera.disposed, isTrue);
+      expect(find.text('Camera unavailable'), findsOneWidget);
+    });
+
     testWidgets('disposes a camera created after the scanner is removed', (
       tester,
     ) async {
@@ -401,6 +449,10 @@ DesktopQrFrame _qrFrame(
 }
 
 class _FakeDesktopQrCamera implements DesktopQrCamera {
+  _FakeDesktopQrCamera({this.startError, this.disposeError});
+
+  final Exception? startError;
+  final Exception? disposeError;
   bool Function()? _shouldCaptureFrame;
   ValueChanged<DesktopQrFrame>? _onFrame;
   bool started = false;
@@ -427,6 +479,8 @@ class _FakeDesktopQrCamera implements DesktopQrCamera {
     required ValueChanged<DesktopQrFrame> onFrame,
   }) async {
     started = true;
+    final error = startError;
+    if (error != null) throw error;
     _shouldCaptureFrame = shouldCaptureFrame;
     _onFrame = onFrame;
   }
@@ -436,6 +490,8 @@ class _FakeDesktopQrCamera implements DesktopQrCamera {
     disposed = true;
     _shouldCaptureFrame = null;
     _onFrame = null;
+    final error = disposeError;
+    if (error != null) throw error;
   }
 }
 

--- a/test/features/sync/ui/provisioned/desktop_qr_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/desktop_qr_scanner_test.dart
@@ -325,6 +325,7 @@ void main() {
       await camera.start(
         shouldCaptureFrame: () => admitFrame,
         onFrame: decodedFrames.add,
+        onError: (_) {},
       );
 
       expect(platform.streaming, isTrue);
@@ -364,6 +365,7 @@ void main() {
       await camera.start(
         shouldCaptureFrame: () => false,
         onFrame: (_) {},
+        onError: (_) {},
       );
       expect(platform.streaming, isTrue);
 
@@ -371,6 +373,34 @@ void main() {
 
       expect(platform.streamCancelled, isTrue);
       expect(platform.disposedCameraIds, [7]);
+    });
+
+    testWidgets('shows the fallback after a running camera reports an error', (
+      tester,
+    ) async {
+      final platform = _FakeCameraPlatform();
+      CameraPlatform.instance = platform;
+
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          DesktopQrScanner(
+            onDetect: (_) {},
+            unavailableBuilder: (_) => const Text('Camera disconnected'),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(platform.streaming, isTrue);
+      expect(find.byType(CameraPreview), findsOneWidget);
+
+      platform.emitError('camera disconnected');
+      await tester.pump();
+
+      expect(platform.streamCancelled, isTrue);
+      expect(platform.disposedCameraIds, [7]);
+      expect(find.text('Camera disconnected'), findsOneWidget);
+      expect(find.byType(CameraPreview), findsNothing);
     });
   });
 }
@@ -477,6 +507,7 @@ class _FakeDesktopQrCamera implements DesktopQrCamera {
   Future<void> start({
     required bool Function() shouldCaptureFrame,
     required ValueChanged<DesktopQrFrame> onFrame,
+    required ValueChanged<Object> onError,
   }) async {
     started = true;
     final error = startError;
@@ -538,6 +569,9 @@ class _FakeCameraPlatform extends CameraPlatform {
   final disposedCameraIds = <int>[];
 
   void emit(CameraImageData image) => _frames.add(image);
+
+  void emitError(String description) =>
+      _errors.add(CameraErrorEvent(7, description));
 
   @override
   Future<List<CameraDescription>> availableCameras() async => cameras;

--- a/test/features/sync/ui/provisioned/desktop_qr_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/desktop_qr_scanner_test.dart
@@ -375,6 +375,35 @@ void main() {
       expect(platform.disposedCameraIds, [7]);
     });
 
+    test('removes its error listener when stream startup fails', () async {
+      final platform = _FakeCameraPlatform(throwOnStreamListen: true);
+      CameraPlatform.instance = platform;
+      final errors = <Object>[];
+
+      final camera = await createDesktopQrCamera();
+      await expectLater(
+        camera.start(
+          shouldCaptureFrame: () => false,
+          onFrame: (_) {},
+          onError: errors.add,
+        ),
+        throwsA(
+          isA<CameraException>().having(
+            (error) => error.code,
+            'code',
+            'stream_start_failed',
+          ),
+        ),
+      );
+
+      platform.emitError('late camera error');
+      await Future<void>.value();
+      expect(errors, isEmpty);
+
+      await camera.dispose();
+      expect(platform.disposedCameraIds, [7]);
+    });
+
     testWidgets('shows the fallback after a running camera reports an error', (
       tester,
     ) async {
@@ -536,6 +565,7 @@ class _FakeCameraPlatform extends CameraPlatform {
       ),
     ],
     this.throwOnInitialize = false,
+    this.throwOnStreamListen = false,
     this.throwOnStreamCancel = false,
   }) {
     _frames = StreamController<CameraImageData>(
@@ -553,6 +583,7 @@ class _FakeCameraPlatform extends CameraPlatform {
 
   final List<CameraDescription> cameras;
   final bool throwOnInitialize;
+  final bool throwOnStreamListen;
   final bool throwOnStreamCancel;
   final _initialized = StreamController<CameraInitializedEvent>.broadcast(
     sync: true,
@@ -627,7 +658,12 @@ class _FakeCameraPlatform extends CameraPlatform {
   Stream<CameraImageData> onStreamedFrameAvailable(
     int cameraId, {
     CameraImageStreamOptions? options,
-  }) => _frames.stream;
+  }) {
+    if (throwOnStreamListen) {
+      throw PlatformException(code: 'stream_start_failed');
+    }
+    return _frames.stream;
+  }
 
   @override
   Widget buildPreview(int cameraId) => const ColoredBox(

--- a/test/features/sync/ui/provisioned/desktop_qr_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/desktop_qr_scanner_test.dart
@@ -64,34 +64,50 @@ void main() {
   });
 
   group('DesktopQrScanner', () {
-    testWidgets('shows a preview and emits the decoded payload once', (
-      tester,
-    ) async {
-      final camera = _FakeDesktopQrCamera();
-      desktopQrCameraFactoryOverride = () async => camera;
-      final detected = <String>[];
+    testWidgets(
+      'copies one frame in five and continues after a different payload',
+      (tester) async {
+        final camera = _FakeDesktopQrCamera();
+        desktopQrCameraFactoryOverride = () async => camera;
+        final detected = <String>[];
+        var decodeCount = 0;
 
-      await tester.pumpWidget(
-        makeTestableWidget2(
-          DesktopQrScanner(
-            onDetect: detected.add,
-            unavailableBuilder: (_) => const Text('Camera unavailable'),
-            decoder: (_) async => 'pairing-code',
+        await tester.pumpWidget(
+          makeTestableWidget2(
+            DesktopQrScanner(
+              onDetect: detected.add,
+              unavailableBuilder: (_) => const Text('Camera unavailable'),
+              decoder: (_) async {
+                decodeCount++;
+                return decodeCount == 1 ? 'not-a-bundle' : 'pairing-code';
+              },
+            ),
           ),
-        ),
-      );
-      await tester.pump();
+        );
+        await tester.pump();
 
-      expect(find.byKey(const Key('desktop_camera_preview')), findsOneWidget);
-      expect(camera.started, isTrue);
+        expect(find.byKey(const Key('desktop_camera_preview')), findsOneWidget);
+        expect(camera.started, isTrue);
 
-      camera.emit(_blankFrame());
-      await tester.pump();
-      camera.emit(_blankFrame());
-      await tester.pump();
+        camera.emit(_blankFrame());
+        await tester.pump();
+        for (var i = 0; i < 4; i++) {
+          camera.emit(_blankFrame());
+        }
+        camera.emit(_blankFrame());
+        await tester.pump();
+        for (var i = 0; i < 4; i++) {
+          camera.emit(_blankFrame());
+        }
+        camera.emit(_blankFrame());
+        await tester.pump();
 
-      expect(detected, ['pairing-code']);
-    });
+        expect(detected, ['not-a-bundle', 'pairing-code']);
+        expect(camera.emittedFrames, 11);
+        expect(camera.capturedFrames, 3);
+        expect(decodeCount, 3);
+      },
+    );
 
     testWidgets('shows the fallback when camera initialization fails', (
       tester,
@@ -182,9 +198,12 @@ DesktopQrFrame _qrFrame(
 }
 
 class _FakeDesktopQrCamera implements DesktopQrCamera {
+  bool Function()? _shouldCaptureFrame;
   ValueChanged<DesktopQrFrame>? _onFrame;
   bool started = false;
   bool disposed = false;
+  int emittedFrames = 0;
+  int capturedFrames = 0;
 
   @override
   Widget buildPreview() => const ColoredBox(
@@ -192,17 +211,27 @@ class _FakeDesktopQrCamera implements DesktopQrCamera {
     color: Colors.green,
   );
 
-  void emit(DesktopQrFrame frame) => _onFrame?.call(frame);
+  void emit(DesktopQrFrame frame) {
+    emittedFrames++;
+    if (!(_shouldCaptureFrame?.call() ?? false)) return;
+    capturedFrames++;
+    _onFrame?.call(frame);
+  }
 
   @override
-  Future<void> start(ValueChanged<DesktopQrFrame> onFrame) async {
+  Future<void> start({
+    required bool Function() shouldCaptureFrame,
+    required ValueChanged<DesktopQrFrame> onFrame,
+  }) async {
     started = true;
+    _shouldCaptureFrame = shouldCaptureFrame;
     _onFrame = onFrame;
   }
 
   @override
   Future<void> dispose() async {
     disposed = true;
+    _shouldCaptureFrame = null;
     _onFrame = null;
   }
 }

--- a/test/features/sync/ui/provisioned/desktop_qr_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/desktop_qr_scanner_test.dart
@@ -274,6 +274,30 @@ void main() {
 
       expect(camera.disposed, isTrue);
     });
+
+    testWidgets('contains camera disposal failures when removed', (
+      tester,
+    ) async {
+      final camera = _FakeDesktopQrCamera(
+        disposeError: const FormatException('release failed'),
+      );
+      desktopQrCameraFactoryOverride = () async => camera;
+
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          DesktopQrScanner(
+            onDetect: (_) {},
+            unavailableBuilder: (_) => const Text('Camera unavailable'),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+
+      expect(camera.disposed, isTrue);
+      expect(tester.takeException(), isNull);
+    });
   });
 
   group('production camera adapter', () {

--- a/test/features/sync/ui/provisioned/desktop_qr_scanner_test.dart
+++ b/test/features/sync/ui/provisioned/desktop_qr_scanner_test.dart
@@ -1,6 +1,9 @@
-import 'dart:typed_data';
+import 'dart:async';
 
+import 'package:camera/camera.dart' show CameraPreview;
+import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/sync/ui/provisioned/desktop_qr_scanner.dart';
 import 'package:lotti/services/dev_logger.dart';
@@ -11,12 +14,16 @@ import '../../../../widget_test_utils.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  late CameraPlatform originalCameraPlatform;
+
   setUp(() {
+    originalCameraPlatform = CameraPlatform.instance;
     DevLogger.suppressOutput = true;
     DevLogger.clear();
   });
 
   tearDown(() {
+    CameraPlatform.instance = originalCameraPlatform;
     desktopQrCameraFactoryOverride = null;
     DevLogger.suppressOutput = false;
     DevLogger.clear();
@@ -60,6 +67,21 @@ void main() {
         ),
         isNull,
       );
+    });
+
+    test('decodes outside the UI isolate', () async {
+      const payload = 'decoded-off-ui-isolate';
+      final frame = _qrFrame(
+        payload,
+        order: DesktopQrChannelOrder.rgba,
+        rowPadding: 4,
+      );
+      final scanner = DesktopQrScanner(
+        onDetect: (_) {},
+        unavailableBuilder: (_) => const SizedBox.shrink(),
+      );
+
+      expect(await scanner.decoder(frame), payload);
     });
   });
 
@@ -128,6 +150,64 @@ void main() {
       expect(find.text('Camera unavailable'), findsOneWidget);
     });
 
+    testWidgets('disposes a camera created after the scanner is removed', (
+      tester,
+    ) async {
+      final cameraCompleter = Completer<DesktopQrCamera>();
+      final camera = _FakeDesktopQrCamera();
+      desktopQrCameraFactoryOverride = () => cameraCompleter.future;
+
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          DesktopQrScanner(
+            onDetect: (_) {},
+            unavailableBuilder: (_) => const Text('Camera unavailable'),
+          ),
+        ),
+      );
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      cameraCompleter.complete(camera);
+      await tester.pump();
+
+      expect(camera.started, isFalse);
+      expect(camera.disposed, isTrue);
+    });
+
+    testWidgets('recovers after the decoder throws', (tester) async {
+      final camera = _FakeDesktopQrCamera();
+      desktopQrCameraFactoryOverride = () async => camera;
+      final detected = <String>[];
+      var decodeCount = 0;
+
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          DesktopQrScanner(
+            onDetect: detected.add,
+            unavailableBuilder: (_) => const Text('Camera unavailable'),
+            decoder: (_) async {
+              decodeCount++;
+              if (decodeCount == 1) throw const FormatException('bad frame');
+              return 'recovered-payload';
+            },
+          ),
+        ),
+      );
+      await tester.pump();
+
+      camera.emit(_blankFrame());
+      await tester.pump();
+      for (var i = 0; i < 4; i++) {
+        camera.emit(_blankFrame());
+      }
+      camera.emit(_blankFrame());
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(detected, ['recovered-payload']);
+      expect(decodeCount, 2);
+    });
+
     testWidgets('disposes the camera when removed', (tester) async {
       final camera = _FakeDesktopQrCamera();
       desktopQrCameraFactoryOverride = () async => camera;
@@ -147,6 +227,104 @@ void main() {
       expect(camera.disposed, isTrue);
     });
   });
+
+  group('production camera adapter', () {
+    testWidgets('shows the fallback when no webcam exists', (tester) async {
+      final platform = _FakeCameraPlatform(cameras: const []);
+      CameraPlatform.instance = platform;
+
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          DesktopQrScanner(
+            onDetect: (_) {},
+            unavailableBuilder: (_) => const Text('No webcam'),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('No webcam'), findsOneWidget);
+      expect(platform.createCalls, 0);
+    });
+
+    test('disposes the controller when initialization fails', () async {
+      final platform = _FakeCameraPlatform(throwOnInitialize: true);
+      CameraPlatform.instance = platform;
+
+      await expectLater(
+        createDesktopQrCamera(),
+        throwsA(
+          isA<CameraException>().having(
+            (error) => error.code,
+            'code',
+            'initialization_failed',
+          ),
+        ),
+      );
+
+      expect(platform.disposedCameraIds, [7]);
+      expect(platform.requestedImageFormat, ImageFormatGroup.bgra8888);
+    });
+
+    test('copies admitted RGBA and BGRA frames before decoding', () async {
+      final platform = _FakeCameraPlatform();
+      CameraPlatform.instance = platform;
+      final decodedFrames = <DesktopQrFrame>[];
+      var admitFrame = false;
+
+      final camera = await createDesktopQrCamera();
+      expect(camera.buildPreview(), isA<CameraPreview>());
+      await camera.start(
+        shouldCaptureFrame: () => admitFrame,
+        onFrame: decodedFrames.add,
+      );
+
+      expect(platform.streaming, isTrue);
+      expect(platform.requestedResolution, ResolutionPreset.medium);
+      expect(platform.requestedAudio, isFalse);
+
+      platform
+        ..emit(_cameraImageWithoutPlanes())
+        ..emit(_cameraImage(Uint8List(4), rawFormat: 'RGBA'));
+      expect(decodedFrames, isEmpty);
+
+      admitFrame = true;
+      final rgbaBytes = Uint8List.fromList([1, 2, 3, 4]);
+      platform.emit(_cameraImage(rgbaBytes, rawFormat: 'RGBA'));
+      rgbaBytes[0] = 99;
+      final bgraBytes = Uint8List.fromList([5, 6, 7, 8]);
+      platform.emit(_cameraImage(bgraBytes, rawFormat: 'BGRA'));
+      bgraBytes[0] = 88;
+
+      expect(decodedFrames, hasLength(2));
+      expect(decodedFrames.first.channelOrder, DesktopQrChannelOrder.rgba);
+      expect(decodedFrames.first.bytes, [1, 2, 3, 4]);
+      expect(decodedFrames.last.channelOrder, DesktopQrChannelOrder.bgra);
+      expect(decodedFrames.last.bytes, [5, 6, 7, 8]);
+
+      await camera.dispose();
+
+      expect(platform.streamCancelled, isTrue);
+      expect(platform.disposedCameraIds, [7]);
+    });
+
+    test('still disposes when the native stream already stopped', () async {
+      final platform = _FakeCameraPlatform(throwOnStreamCancel: true);
+      CameraPlatform.instance = platform;
+
+      final camera = await createDesktopQrCamera();
+      await camera.start(
+        shouldCaptureFrame: () => false,
+        onFrame: (_) {},
+      );
+      expect(platform.streaming, isTrue);
+
+      await expectLater(camera.dispose(), completes);
+
+      expect(platform.streamCancelled, isTrue);
+      expect(platform.disposedCameraIds, [7]);
+    });
+  });
 }
 
 DesktopQrFrame _blankFrame() => DesktopQrFrame(
@@ -155,6 +333,31 @@ DesktopQrFrame _blankFrame() => DesktopQrFrame(
   height: 1,
   bytesPerRow: 4,
   channelOrder: DesktopQrChannelOrder.rgba,
+);
+
+CameraImageData _cameraImage(
+  Uint8List bytes, {
+  required Object rawFormat,
+}) => CameraImageData(
+  format: CameraImageFormat(ImageFormatGroup.bgra8888, raw: rawFormat),
+  planes: [
+    CameraImagePlane(
+      bytes: bytes,
+      bytesPerRow: 4,
+      bytesPerPixel: 4,
+      height: 1,
+      width: 1,
+    ),
+  ],
+  height: 1,
+  width: 1,
+);
+
+CameraImageData _cameraImageWithoutPlanes() => const CameraImageData(
+  format: CameraImageFormat(ImageFormatGroup.bgra8888, raw: 'BGRA'),
+  planes: [],
+  height: 1,
+  width: 1,
 );
 
 DesktopQrFrame _qrFrame(
@@ -233,5 +436,117 @@ class _FakeDesktopQrCamera implements DesktopQrCamera {
     disposed = true;
     _shouldCaptureFrame = null;
     _onFrame = null;
+  }
+}
+
+class _FakeCameraPlatform extends CameraPlatform {
+  _FakeCameraPlatform({
+    this.cameras = const [
+      CameraDescription(
+        name: 'webcam',
+        lensDirection: CameraLensDirection.external,
+        sensorOrientation: 0,
+      ),
+    ],
+    this.throwOnInitialize = false,
+    this.throwOnStreamCancel = false,
+  }) {
+    _frames = StreamController<CameraImageData>(
+      sync: true,
+      onListen: () => streaming = true,
+      onCancel: () async {
+        streamCancelled = true;
+        streaming = false;
+        if (throwOnStreamCancel) {
+          throw PlatformException(code: 'stream_already_stopped');
+        }
+      },
+    );
+  }
+
+  final List<CameraDescription> cameras;
+  final bool throwOnInitialize;
+  final bool throwOnStreamCancel;
+  final _initialized = StreamController<CameraInitializedEvent>.broadcast(
+    sync: true,
+  );
+  final _errors = StreamController<CameraErrorEvent>.broadcast(sync: true);
+  late final StreamController<CameraImageData> _frames;
+
+  int createCalls = 0;
+  bool streaming = false;
+  bool streamCancelled = false;
+  bool? requestedAudio;
+  ResolutionPreset? requestedResolution;
+  ImageFormatGroup? requestedImageFormat;
+  final disposedCameraIds = <int>[];
+
+  void emit(CameraImageData image) => _frames.add(image);
+
+  @override
+  Future<List<CameraDescription>> availableCameras() async => cameras;
+
+  @override
+  Future<int> createCameraWithSettings(
+    CameraDescription cameraDescription,
+    MediaSettings mediaSettings,
+  ) async {
+    createCalls++;
+    requestedAudio = mediaSettings.enableAudio;
+    requestedResolution = mediaSettings.resolutionPreset;
+    return 7;
+  }
+
+  @override
+  Future<void> initializeCamera(
+    int cameraId, {
+    ImageFormatGroup imageFormatGroup = ImageFormatGroup.unknown,
+  }) async {
+    requestedImageFormat = imageFormatGroup;
+    if (throwOnInitialize) {
+      throw PlatformException(code: 'initialization_failed');
+    }
+    _initialized.add(
+      CameraInitializedEvent(
+        cameraId,
+        640,
+        480,
+        ExposureMode.auto,
+        false,
+        FocusMode.auto,
+        false,
+      ),
+    );
+  }
+
+  @override
+  Stream<CameraInitializedEvent> onCameraInitialized(int cameraId) =>
+      _initialized.stream;
+
+  @override
+  Stream<CameraErrorEvent> onCameraError(int cameraId) => _errors.stream;
+
+  @override
+  Stream<DeviceOrientationChangedEvent> onDeviceOrientationChanged() =>
+      const Stream.empty();
+
+  @override
+  bool supportsImageStreaming() => true;
+
+  @override
+  Stream<CameraImageData> onStreamedFrameAvailable(
+    int cameraId, {
+    CameraImageStreamOptions? options,
+  }) => _frames.stream;
+
+  @override
+  Widget buildPreview(int cameraId) => const ColoredBox(
+    key: Key('native_camera_preview'),
+    color: Colors.blue,
+  );
+
+  @override
+  Future<void> dispose(int cameraId) async {
+    disposedCameraIds.add(cameraId);
   }
 }

--- a/test/features/sync/ui/provisioned/provisioned_sync_modal_test.dart
+++ b/test/features/sync/ui/provisioned/provisioned_sync_modal_test.dart
@@ -18,6 +18,7 @@ void main() {
   late MockMatrixClient mockClient;
 
   setUp(() {
+    scannerPreviewOverride = (context, side) => const SizedBox.shrink();
     mockMatrixService = MockMatrixService();
     mockClient = MockMatrixClient();
 
@@ -33,6 +34,8 @@ void main() {
       ),
     );
   });
+
+  tearDown(() => scannerPreviewOverride = null);
 
   Future<void> pumpEmptyState(WidgetTester tester) {
     return tester.pumpWidget(

--- a/test/features/sync/ui/sync_manual_screenshots_test.dart
+++ b/test/features/sync/ui/sync_manual_screenshots_test.dart
@@ -500,6 +500,7 @@ class _ManualSyncMaintenanceController extends SyncMaintenanceController {
 
 enum _SyncSurface {
   hub,
+  scanner,
   provisioned,
   addDevice,
   paired,
@@ -518,6 +519,7 @@ enum _SyncSurface {
 extension on _SyncSurface {
   String get id => switch (this) {
     _SyncSurface.hub => 'hub',
+    _SyncSurface.scanner => 'scanner',
     _SyncSurface.provisioned => 'provisioned',
     _SyncSurface.addDevice => 'add_device',
     _SyncSurface.paired => 'paired',
@@ -535,6 +537,7 @@ extension on _SyncSurface {
 
   String get route => switch (this) {
     _SyncSurface.hub => '/settings/sync',
+    _SyncSurface.scanner => '/settings/sync/provisioned',
     _SyncSurface.provisioned => '/settings/sync/provisioned',
     _SyncSurface.addDevice => '/settings/sync/provisioned',
     _SyncSurface.paired => '/settings/sync/provisioned',
@@ -558,6 +561,7 @@ extension on _SyncSurface {
 
   Widget mobilePage() => switch (this) {
     _SyncSurface.hub => const SettingsMobileBranchPage(branchId: 'sync'),
+    _SyncSurface.scanner => const ProvisionedSyncPage(),
     _SyncSurface.provisioned => const ProvisionedSyncPage(),
     _SyncSurface.addDevice => const ProvisionedSyncPage(),
     _SyncSurface.paired => const ProvisionedSyncPage(),
@@ -944,6 +948,9 @@ void main() {
     _SyncSurface surface,
   ) async {
     switch (surface) {
+      case _SyncSurface.scanner:
+        await tester.tap(find.byKey(const Key('sync_setup_cta')));
+        await settleFrames(tester, 10);
       case _SyncSurface.provisioned:
         await openBundleImport(tester);
         await settleFrames(tester, 8);
@@ -1039,6 +1046,13 @@ void main() {
       case _SyncSurface.hub:
         expect(find.text(messages.provisionedSyncTitle), findsWidgets);
         expect(find.text(messages.settingsMaintenanceTitle), findsWidgets);
+      case _SyncSurface.scanner:
+        expect(find.byType(BundleImportWidget), findsOneWidget);
+        expect(find.text(messages.syncPairScanTitle), findsOneWidget);
+        expect(
+          find.byKey(const Key('bundle_import_enter_manually')),
+          findsOneWidget,
+        );
       case _SyncSurface.provisioned:
         // A fresh CLI bundle establishes this account's first device. With no
         // peer available for comparison, it skips the check-code review and

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <audio_decoder/audio_decoder_plugin_c_api.h>
 #include <audioplayers_windows/audioplayers_windows_plugin.h>
+#include <camera_desktop/camera_desktop_plugin.h>
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_onnxruntime/flutter_onnxruntime_plugin.h>
@@ -32,6 +33,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("AudioDecoderPluginCApi"));
   AudioplayersWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AudioplayersWindowsPlugin"));
+  CameraDesktopPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("CameraDesktopPlugin"));
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FileSelectorWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   audio_decoder
   audioplayers_windows
+  camera_desktop
   connectivity_plus
   file_selector_windows
   flutter_onnxruntime


### PR DESCRIPTION
## Summary

- open the pairing scanner immediately on macOS and Linux while preserving the existing Android/iOS scanner-first flow and mobile Add device QR generation
- reuse `mobile_scanner` on macOS with the required sandbox camera entitlement; add `camera_desktop` plus off-UI-isolate `zxing2` decoding for padded RGBA/BGRA Linux webcam frames
- keep Windows and camera-error cases on the existing localized manual-entry fallback
- document both the completed Phase A approach and the gated Phase B Google Play subscription/backend plan

## Verification

- `fvm dart analyze`
- `fvm flutter test test/features/sync/ui/provisioned/desktop_qr_scanner_test.dart test/features/sync/ui/provisioned/bundle_import_page_scanner_test.dart test/features/sync/ui/provisioned/bundle_import_page_test.dart test/features/sync/ui/provisioned/provisioned_sync_modal_test.dart test/features/sync/ui/provisioned/add_device_page_test.dart test/features/sync/ui/provisioned_sync_page_test.dart`
- `fvm flutter build linux --debug`
- `make knowledge_check`
- `make changelog_check`
- opt-in sync scanner screenshot harness in light and dark themes
- regression proof: macOS/Linux route tests fail with the old mobile-only capability gate; the Linux scanner test also fails with the old stop-after-first-payload behavior and verifies capture-side frame admission before buffer copies
- production camera adapter tests cover device absence, initialization cleanup, RGBA/BGRA buffer ownership, capture admission, isolate decoding, and stream teardown through `camera_platform_interface`

## Screenshots

| Theme | Before | After |
| --- | --- | --- |
| Light | ![Manual pairing code entry before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/desktop-qr-scanning/622d8ce267a230547f4a9360dd79a78fcbe434b6/before/sync_scanner_desktop_light.png) | ![Desktop QR scanner after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/desktop-qr-scanning/622d8ce267a230547f4a9360dd79a78fcbe434b6/after/sync_scanner_desktop_light.png) |
| Dark | ![Manual pairing code entry before in dark theme](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/desktop-qr-scanning/622d8ce267a230547f4a9360dd79a78fcbe434b6/before/sync_scanner_desktop_dark.png) | ![Desktop QR scanner after in dark theme](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/desktop-qr-scanning/622d8ce267a230547f4a9360dd79a78fcbe434b6/after/sync_scanner_desktop_dark.png) |

## Acceptance boundary

Targeted tests, the full analyzer, and the Linux debug build are green. Codecov reports every modified coverable line covered, with 99.27% project coverage. Webcam scanning has been confirmed on macOS and Linux; permission-denial/no-camera cases and the Flatpak/PipeWire packaging path remain deployment checks. Phase B is plan-only and intentionally not implemented in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added webcam-based QR code scanning for device pairing on Linux and macOS.
  - Android, iOS, macOS, and Linux now open directly to QR scanning when supported.
  - Manual credential entry remains available as a fallback and is the primary Windows pairing method.

- **Bug Fixes**
  - Improved recovery when camera access is unavailable, initialization fails, or scanning cannot proceed.

- **Documentation**
  - Updated pairing instructions and feature documentation with platform-specific scanning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
