### PR TITLE
feat(day-indicators): key the outcome glyphs and verdict hues wherever day squares wear them

### DIFF
--- a/changelog.d/2026-08-29-day-indicator-legend.md
+++ b/changelog.d/2026-08-29-day-indicator-legend.md
@@ -1,0 +1,6 @@
+### Added
+
+- **Day-square keys now explain everything a square can show.** The key on a
+  goal's first habit card lists the skip dash, the missed cross and the four
+  verdict colours; a goal without habits gets the key under its week strip;
+  and a dashboard with habit cards shows one key after them.

--- a/knowledge/architecture/day-indicators.md
+++ b/knowledge/architecture/day-indicators.md
@@ -168,9 +168,30 @@ knows the day: reflecting on a backfilled day judges that day, not today. The
 reflection sheet itself stays the goal's — it needs the goal's spec, progress
 view and history — so the habit only contributes the day.
 
-# Not yet shared
+# The legend, and where it rides
 
-The remaining item from lotti3-co1 (step 4): a complete legend including the
-verdict hues on habit surfaces, longer spans on the habits page, and the
-explicit decision on proportional cell sizing. Those build on this module and
-are a separate change.
+`DayMarkLegend` keys the measured fills always, and opts into the rest:
+`showAgesOut` (only the goal detail's rolling windows draw that ring),
+`showOutcomes` (the skip dash and missed cross a habit square can carry) and
+`showVerdicts` (the four verdict hues and glyphs). One key per surface, placed
+where a reader meets the squares it explains:
+
+| Surface | Legend |
+| --- | --- |
+| Goal detail, first habit card | outcomes + verdicts + ages-out |
+| Goal detail, a goal with no habit cards | under the whole-goal strip on the week card: verdicts, no ages-out |
+| A dashboard with habit items | once, after the items: outcomes + verdicts |
+
+# Cell sizing is a decision, not a gap
+
+Cells never size proportionally to a value or a count. Every day track sizes
+its columns from `dayTrackMetrics`: one pitch per page derived from the
+available width, the square shrinking with its column down to `IconSizes.xs`
+and never growing past `ControlSizes.iconChipCompact`, and a track that
+still cannot fit pans. A proportional cell (wider for a longer window, taller
+for a bigger number) was considered in the 2026-08-15 audit and rejected: a
+date has to line up down the page across strips, habit squares and metric
+bars, which one grid guarantees and per-cell sizing cannot. Longer spans are
+handled the same way — the habits chart offers 14/30/90 days, the goal detail
+page keys every track to its shared range, and a dashboard strip follows the
+dashboard's range — never by a differently-shaped cell.

--- a/knowledge/features/dashboards.md
+++ b/knowledge/features/dashboards.md
@@ -112,6 +112,11 @@ The other three render only: health and workout data arrive from outside the app
 each health chart schedules on construction — and a habit is completed on its own
 surface.
 
+A dashboard with habit items draws one `DayMarkLegend` after its items (key
+`dashboard-habit-legend`) — outcome glyphs and verdict hues, once per
+dashboard rather than once per habit; see [day
+indicators](../architecture/day-indicators.md).
+
 # Which day a health sample belongs to
 
 `aggregateByType` reduces samples to one observation per day, and the choice of

--- a/lib/features/dashboards/ui/widgets/dashboard_widget.dart
+++ b/lib/features/dashboards/ui/widgets/dashboard_widget.dart
@@ -9,6 +9,7 @@ import 'package:lotti/features/dashboards/ui/widgets/charts/dashboard_survey_cha
 import 'package:lotti/features/dashboards/ui/widgets/charts/dashboard_workout_chart.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/widgets/charts/habits/dashboard_habits_chart.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_legend.dart';
 
 /// Renders a dashboard's ordered list of items as a vertical stack of chart
 /// cards over the shared `[rangeStart, rangeEnd]` window.
@@ -116,6 +117,18 @@ class DashboardWidget extends ConsumerWidget {
             SizedBox(height: tokens.spacing.cardItemSpacing),
             items.whereType<Widget>(),
           ),
+          // One key per dashboard for the habit chains above, not one per
+          // habit: the squares share a vocabulary, and a repeated key would
+          // be more legend than data.
+          if (dashboard.items.any((item) => item is DashboardHabitItem)) ...[
+            SizedBox(height: tokens.spacing.step3),
+            const DayMarkLegend(
+              key: ValueKey('dashboard-habit-legend'),
+              showAgesOut: false,
+              showOutcomes: true,
+              showVerdicts: true,
+            ),
+          ],
           if (dashboard.description.isNotEmpty)
             Padding(
               padding: EdgeInsets.only(top: tokens.spacing.step4),

--- a/lib/features/goals/ui/goal_progress_card.dart
+++ b/lib/features/goals/ui/goal_progress_card.dart
@@ -331,6 +331,14 @@ class GoalThisWeekCard extends StatelessWidget {
           // one dimension, so a leaf goal gets the strip without the tally.
           // Centered under the strip it closes, like every legend and summary
           // line on the cards below it.
+          // A goal without habit cards has no card to carry the day-cell
+          // key, yet its strip still wears the four verdict hues — so the
+          // key rides here, under the only squares such a goal draws. A goal
+          // WITH habit cards keys them once, inside its first habit card.
+          if (progress.habits.isEmpty) ...[
+            SizedBox(height: tokens.spacing.step3),
+            const DayMarkLegend(showAgesOut: false, showVerdicts: true),
+          ],
           if (progress.compositeRule != null) ...[
             SizedBox(height: tokens.spacing.step2),
             SizedBox(
@@ -583,7 +591,10 @@ class _HabitDimensionCard extends StatelessWidget {
             // the card's own bottom edge, and read as the card being cut in
             // two.
             SizedBox(height: tokens.spacing.step2),
-            const DayMarkLegend(),
+            // Everything a habit square on this page can wear: the three
+            // measured fills, the outcome glyphs, the ages-out and today
+            // rings, and the verdict a reflection stamps on a day.
+            const DayMarkLegend(showOutcomes: true, showVerdicts: true),
           ],
         ],
       ),

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2262,6 +2262,7 @@
   "dashboardRemoveChartLabel": "Odebrat graf",
   "dashboardReorderChartLabel": "Změnit pořadí grafu",
   "dashboardTakeSurveyTooltip": "Vyplnit dotazník",
+  "dayMarkLegendJudged": "hodnoceno jako {verdict}",
   "defaultLanguage": "Výchozí jazyk",
   "deleteButton": "Smazat",
   "deleteDeviceLabel": "Odebrat ze synchronizace",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -2502,6 +2502,7 @@
   "dashboardRemoveChartLabel": "Fjern skemaet",
   "dashboardReorderChartLabel": "Omarranger kort",
   "dashboardTakeSurveyTooltip": "Tag en undersøgelse",
+  "dayMarkLegendJudged": "vurderet som {verdict}",
   "defaultLanguage": "Standardsprog",
   "deleteButton": "Slet",
   "deleteDeviceLabel": "Fjern fra synkronisering",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2255,6 +2255,7 @@
   "dashboardRemoveChartLabel": "Diagramm entfernen",
   "dashboardReorderChartLabel": "Diagramm neu anordnen",
   "dashboardTakeSurveyTooltip": "Umfrage ausfüllen",
+  "dayMarkLegendJudged": "beurteilt als {verdict}",
   "defaultLanguage": "Standardsprache",
   "deleteButton": "Löschen",
   "deleteDeviceLabel": "Aus Sync entfernen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2951,6 +2951,15 @@
   "dashboardRemoveChartLabel": "Remove chart",
   "dashboardReorderChartLabel": "Reorder chart",
   "dashboardTakeSurveyTooltip": "Take survey",
+  "dayMarkLegendJudged": "judged {verdict}",
+  "@dayMarkLegendJudged": {
+    "description": "Legend entry for a day the user judged in a reflection; {verdict} is the verdict name (Met, Improving, Mixed, Missed), distinguishing it from a recorded habit outcome of the same name.",
+    "placeholders": {
+      "verdict": {
+        "type": "String"
+      }
+    }
+  },
   "defaultLanguage": "Default Language",
   "deleteButton": "Delete",
   "deleteDeviceLabel": "Remove from sync",

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -63,6 +63,7 @@
   "dashboardNameLabel": "Dashboard name",
   "dashboardNotFound": "Dashboard not found",
   "dashboardPrivateLabel": "Private",
+  "dayMarkLegendJudged": "judged {verdict}",
   "doneButton": "Done",
   "editMenuTitle": "Edit",
   "editorPlaceholder": "Enter notes...",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2255,6 +2255,7 @@
   "dashboardRemoveChartLabel": "Quitar gráfico",
   "dashboardReorderChartLabel": "Reordenar gráfico",
   "dashboardTakeSurveyTooltip": "Responder encuesta",
+  "dayMarkLegendJudged": "valorado como {verdict}",
   "defaultLanguage": "Idioma predeterminado",
   "deleteButton": "Eliminar",
   "deleteDeviceLabel": "Quitar de la sincronización",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2255,6 +2255,7 @@
   "dashboardRemoveChartLabel": "Retirer le graphique",
   "dashboardReorderChartLabel": "Réordonner le graphique",
   "dashboardTakeSurveyTooltip": "Répondre au questionnaire",
+  "dayMarkLegendJudged": "jugé {verdict}",
   "defaultLanguage": "Langue par défaut",
   "deleteButton": "Supprimer",
   "deleteDeviceLabel": "Retirer de la synchronisation",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -2502,6 +2502,7 @@
   "dashboardRemoveChartLabel": "Rimuovi il grafico",
   "dashboardReorderChartLabel": "Grafico di riordino",
   "dashboardTakeSurveyTooltip": "Assumere l'indagine",
+  "dayMarkLegendJudged": "giudicato {verdict}",
   "defaultLanguage": "Lingua di default",
   "deleteButton": "Cancella",
   "deleteDeviceLabel": "Rimuovi dalla sincronizzazione",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -8765,6 +8765,12 @@ abstract class AppLocalizations {
   /// **'Take survey'**
   String get dashboardTakeSurveyTooltip;
 
+  /// Legend entry for a day the user judged in a reflection; {verdict} is the verdict name (Met, Improving, Mixed, Missed), distinguishing it from a recorded habit outcome of the same name.
+  ///
+  /// In en, this message translates to:
+  /// **'judged {verdict}'**
+  String dayMarkLegendJudged(String verdict);
+
   /// No description provided for @defaultLanguage.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -5224,6 +5224,11 @@ class AppLocalizationsCs extends AppLocalizations {
   String get dashboardTakeSurveyTooltip => 'Vyplnit dotazník';
 
   @override
+  String dayMarkLegendJudged(String verdict) {
+    return 'hodnoceno jako $verdict';
+  }
+
+  @override
   String get defaultLanguage => 'Výchozí jazyk';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -5168,6 +5168,11 @@ class AppLocalizationsDa extends AppLocalizations {
   String get dashboardTakeSurveyTooltip => 'Tag en undersøgelse';
 
   @override
+  String dayMarkLegendJudged(String verdict) {
+    return 'vurderet som $verdict';
+  }
+
+  @override
   String get defaultLanguage => 'Standardsprog';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -5206,6 +5206,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dashboardTakeSurveyTooltip => 'Umfrage ausfüllen';
 
   @override
+  String dayMarkLegendJudged(String verdict) {
+    return 'beurteilt als $verdict';
+  }
+
+  @override
   String get defaultLanguage => 'Standardsprache';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5141,6 +5141,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dashboardTakeSurveyTooltip => 'Take survey';
 
   @override
+  String dayMarkLegendJudged(String verdict) {
+    return 'judged $verdict';
+  }
+
+  @override
   String get defaultLanguage => 'Default Language';
 
   @override
@@ -14193,6 +14198,11 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
 
   @override
   String get dashboardPrivateLabel => 'Private';
+
+  @override
+  String dayMarkLegendJudged(String verdict) {
+    return 'judged $verdict';
+  }
 
   @override
   String get doneButton => 'Done';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -5238,6 +5238,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dashboardTakeSurveyTooltip => 'Responder encuesta';
 
   @override
+  String dayMarkLegendJudged(String verdict) {
+    return 'valorado como $verdict';
+  }
+
+  @override
   String get defaultLanguage => 'Idioma predeterminado';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -5255,6 +5255,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dashboardTakeSurveyTooltip => 'Répondre au questionnaire';
 
   @override
+  String dayMarkLegendJudged(String verdict) {
+    return 'jugé $verdict';
+  }
+
+  @override
   String get defaultLanguage => 'Langue par défaut';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -5232,6 +5232,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dashboardTakeSurveyTooltip => 'Assumere l\'indagine';
 
   @override
+  String dayMarkLegendJudged(String verdict) {
+    return 'giudicato $verdict';
+  }
+
+  @override
   String get defaultLanguage => 'Lingua di default';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -5182,6 +5182,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dashboardTakeSurveyTooltip => 'Onderzoek uitvoeren';
 
   @override
+  String dayMarkLegendJudged(String verdict) {
+    return 'beoordeeld als $verdict';
+  }
+
+  @override
   String get defaultLanguage => 'Standaardtaal';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -5216,6 +5216,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get dashboardTakeSurveyTooltip => 'Faça uma pesquisa';
 
   @override
+  String dayMarkLegendJudged(String verdict) {
+    return 'avaliado como $verdict';
+  }
+
+  @override
   String get defaultLanguage => 'Idioma padrão';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -5258,6 +5258,11 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dashboardTakeSurveyTooltip => 'Completați chestionarul';
 
   @override
+  String dayMarkLegendJudged(String verdict) {
+    return 'evaluat ca $verdict';
+  }
+
+  @override
   String get defaultLanguage => 'Limbă implicită';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -5172,6 +5172,11 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dashboardTakeSurveyTooltip => 'Gör en undersökning';
 
   @override
+  String dayMarkLegendJudged(String verdict) {
+    return 'bedömd som $verdict';
+  }
+
+  @override
   String get defaultLanguage => 'Standardspråk';
 
   @override

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -2501,6 +2501,7 @@
   "dashboardRemoveChartLabel": "Grafiek verwijderen",
   "dashboardReorderChartLabel": "Kaart herschikken",
   "dashboardTakeSurveyTooltip": "Onderzoek uitvoeren",
+  "dayMarkLegendJudged": "beoordeeld als {verdict}",
   "defaultLanguage": "Standaardtaal",
   "deleteButton": "Verwijderen",
   "deleteDeviceLabel": "Uit synchronisatie verwijderen",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -2501,6 +2501,7 @@
   "dashboardRemoveChartLabel": "Remover gráfico",
   "dashboardReorderChartLabel": "Reordenar gráfico",
   "dashboardTakeSurveyTooltip": "Faça uma pesquisa",
+  "dayMarkLegendJudged": "avaliado como {verdict}",
   "defaultLanguage": "Idioma padrão",
   "deleteButton": "Excluir",
   "deleteDeviceLabel": "Remover da sincronização",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2255,6 +2255,7 @@
   "dashboardRemoveChartLabel": "Eliminați graficul",
   "dashboardReorderChartLabel": "Reordonați graficul",
   "dashboardTakeSurveyTooltip": "Completați chestionarul",
+  "dayMarkLegendJudged": "evaluat ca {verdict}",
   "defaultLanguage": "Limbă implicită",
   "deleteButton": "Ștergeți",
   "deleteDeviceLabel": "Eliminați din sincronizare",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -2502,6 +2502,7 @@
   "dashboardRemoveChartLabel": "Ta bort diagram",
   "dashboardReorderChartLabel": "Omordning diagram",
   "dashboardTakeSurveyTooltip": "Gör en undersökning",
+  "dayMarkLegendJudged": "bedömd som {verdict}",
   "defaultLanguage": "Standardspråk",
   "deleteButton": "Radera",
   "deleteDeviceLabel": "Ta bort från synkronisering",

--- a/lib/widgets/day_indicators/day_mark_cell.dart
+++ b/lib/widgets/day_indicators/day_mark_cell.dart
@@ -96,7 +96,7 @@ class DayMarkCell extends StatelessWidget {
         ? Center(
             child: Icon(
               dayVerdictGlyph(verdict),
-              size: size * 0.75,
+              size: dayMarkGlyphSize(size),
               // The ink of the fill's OWN family. Painting every glyph in
               // the success ink put a green tick's colour on a red missed
               // cell and an orange mixed one.
@@ -107,7 +107,7 @@ class DayMarkCell extends StatelessWidget {
         ? Center(
             child: Icon(
               stateGlyph,
-              size: size * 0.75,
+              size: dayMarkGlyphSize(size),
               color: dayMarkStateGlyphInk(tokens, state),
             ),
           )

--- a/lib/widgets/day_indicators/day_mark_legend.dart
+++ b/lib/widgets/day_indicators/day_mark_legend.dart
@@ -10,7 +10,23 @@ import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
 /// carry the cells' shape and non-color cues — the partial dot, the dashed
 /// today ring — because a key to a mark that is not on the map is no key.
 class DayMarkLegend extends StatelessWidget {
-  const DayMarkLegend({super.key});
+  const DayMarkLegend({
+    this.showAgesOut = true,
+    this.showOutcomes = false,
+    this.showVerdicts = false,
+    super.key,
+  });
+
+  /// Whether to key the quiet "ages out tonight" outline. Only surfaces
+  /// whose cells can draw it — the goal detail's rolling windows — name it.
+  final bool showAgesOut;
+
+  /// Whether to key the recorded habit outcomes a cell can carry: the skip
+  /// dash and the missed cross.
+  final bool showOutcomes;
+
+  /// Whether to key the four verdict hues and glyphs a judged day wears.
+  final bool showVerdicts;
 
   @override
   Widget build(BuildContext context) {
@@ -21,6 +37,8 @@ class DayMarkLegend extends StatelessWidget {
       bool outlined = false,
       bool dotted = false,
       bool dashed = false,
+      IconData? glyph,
+      Color? glyphInk,
     }) {
       Widget swatch = Container(
         width: IconSizes.xs,
@@ -36,6 +54,10 @@ class DayMarkLegend extends StatelessWidget {
         // cells it keys — at `radii.xs` it was a different shape from both.
         child: dotted
             ? Center(child: partialDayDot(tokens, tokens.spacing.step1))
+            : glyph != null
+            ? Center(
+                child: Icon(glyph, size: IconSizes.xs * 0.75, color: glyphInk),
+              )
             : null,
       );
       if (dashed) {
@@ -94,17 +116,42 @@ class DayMarkLegend extends StatelessWidget {
           ),
           // Quiet outline, matching the ring the cells actually draw — an
           // on-track row must not wear the alarm hue in its key either.
-          item(
-            tokens.colors.text.lowEmphasis,
-            context.messages.goalProgressAgesOut,
-            outlined: true,
-          ),
+          if (showAgesOut)
+            item(
+              tokens.colors.text.lowEmphasis,
+              context.messages.goalProgressAgesOut,
+              outlined: true,
+            ),
           // Dashed, exactly like the today cell — the key must match the map.
           item(
             todayRingInk(tokens),
             context.messages.goalProgressToday,
             dashed: true,
           ),
+          // The outcome glyphs, in the same ink the cells draw them.
+          if (showOutcomes)
+            for (final state in [DayMarkState.skipped, DayMarkState.missed])
+              item(
+                dayMarkStateFill(tokens, state),
+                dayMarkStateLabel(context, state),
+                glyph: dayMarkStateGlyph(state),
+                glyphInk: dayMarkStateGlyphInk(tokens, state),
+              ),
+          // A judged day: its own hue and shape, through the same helpers
+          // the cells use — four fills a reader must be able to tell apart.
+          // "judged Missed" beside "Missed": a recorded outcome and a
+          // verdict can share a name, and the key must not list one word
+          // twice with two different swatches.
+          if (showVerdicts)
+            for (final verdict in DayVerdict.values)
+              item(
+                dayVerdictFill(tokens, verdict),
+                context.messages.dayMarkLegendJudged(
+                  dayVerdictLabel(context, verdict),
+                ),
+                glyph: dayVerdictGlyph(verdict),
+                glyphInk: dayVerdictInk(tokens, verdict),
+              ),
         ],
       ),
     );

--- a/lib/widgets/day_indicators/day_mark_legend.dart
+++ b/lib/widgets/day_indicators/day_mark_legend.dart
@@ -56,7 +56,11 @@ class DayMarkLegend extends StatelessWidget {
             ? Center(child: partialDayDot(tokens, tokens.spacing.step1))
             : glyph != null
             ? Center(
-                child: Icon(glyph, size: IconSizes.xs * 0.75, color: glyphInk),
+                child: Icon(
+                  glyph,
+                  size: dayMarkGlyphSize(IconSizes.xs),
+                  color: glyphInk,
+                ),
               )
             : null,
       );

--- a/lib/widgets/day_indicators/day_mark_styles.dart
+++ b/lib/widgets/day_indicators/day_mark_styles.dart
@@ -220,6 +220,12 @@ Widget? dayCellLetter(
   );
 }
 
+/// The glyph inside a day square, as a fraction of the square: large enough
+/// to read as a shape, small enough to leave the fill visible around it. One
+/// rule for the cells and for the legend swatches that key them, so the key
+/// cannot drift from the map.
+double dayMarkGlyphSize(double cellSize) => cellSize * 0.75;
+
 /// The ink the "today" ring is drawn in, on every surface that draws one —
 /// the habit day cells, the whole-goal strip and the legend swatch that keys
 /// them.

--- a/test/features/dashboards/ui/widgets/dashboard_widget_test.dart
+++ b/test/features/dashboards/ui/widgets/dashboard_widget_test.dart
@@ -186,6 +186,74 @@ void main() {
       },
     );
 
+    group('day-square key', () {
+      DashboardDefinition dashboard(String id, List<DashboardItem> items) =>
+          DashboardDefinition(
+            id: id,
+            name: 'Dashboard',
+            description: '',
+            items: items,
+            createdAt: DateTime(2024, 3, 15),
+            updatedAt: DateTime(2024, 3, 15),
+            vectorClock: null,
+            private: false,
+            version: '',
+            lastReviewed: DateTime(2024, 3, 15),
+            active: true,
+          );
+      Future<void> pump(
+        WidgetTester tester,
+        String id,
+        List<DashboardItem> items,
+      ) async {
+        when(() => mockCache.getHabitById(any())).thenReturn(null);
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            DashboardWidget(
+              dashboardId: id,
+              rangeStart: rangeStart,
+              rangeEnd: rangeEnd,
+            ),
+            overrides: [
+              dashboardByIdProvider(
+                id,
+              ).overrideWith((ref) => dashboard(id, items)),
+            ],
+          ),
+        );
+        await tester.pump();
+      }
+
+      testWidgets('a dashboard with habit items carries one key after them, '
+          'keyed for outcomes and verdicts', (tester) async {
+        await pump(tester, 'with-habits', const [
+          DashboardItem.habitChart(habitId: 'habit-1'),
+          DashboardItem.habitChart(habitId: 'habit-2'),
+        ]);
+        final legend = find.byKey(const ValueKey('dashboard-habit-legend'));
+        expect(legend, findsOneWidget, reason: 'once, not per habit');
+        expect(find.text('judged Improving'), findsOneWidget);
+        expect(find.text('Skip'), findsOneWidget);
+        expect(find.textContaining('ages out'), findsNothing);
+        expect(
+          tester.getRect(legend).top,
+          greaterThanOrEqualTo(
+            tester.getRect(find.byType(DashboardHabitsChart).last).top,
+          ),
+        );
+      });
+
+      testWidgets('a dashboard without habit items carries no key', (
+        tester,
+      ) async {
+        await pump(tester, 'no-habits', const []);
+        expect(
+          find.byKey(const ValueKey('dashboard-habit-legend')),
+          findsNothing,
+        );
+      });
+    });
+
     testWidgets(
       'keys charts by item identity, not range, so stale data cannot cross '
       'items',

--- a/test/features/goals/ui/goal_progress_card_test.dart
+++ b/test/features/goals/ui/goal_progress_card_test.dart
@@ -28,8 +28,10 @@ import 'package:lotti/features/goals/state/goal_progress_view.dart';
 import 'package:lotti/features/goals/ui/goal_progress_card.dart';
 import 'package:lotti/l10n/app_localizations.dart';
 import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_legend.dart';
 import 'package:lotti/widgets/day_indicators/day_mark_strip.dart';
 import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
+import 'package:lotti/widgets/day_indicators/day_track.dart';
 import 'package:lotti/widgets/misc/linked_scroll_group.dart';
 
 import '../../../widget_test_utils.dart';
@@ -741,6 +743,73 @@ void main() {
       legend.bottom,
       lessThan(tester.getRect(cards.at(1)).top),
     );
+  });
+
+  testWidgets("the first habit card's key names the outcome glyphs and the "
+      'verdict hues its squares can wear', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        GoalProgressCard(
+          progress: GoalProgressView(
+            today: today,
+            habits: [
+              GoalHabitProgressView(
+                habitId: 'gym',
+                name: 'Gym',
+                targetCount: 3,
+                days: [
+                  for (var offset = 6; offset >= 0; offset--) day(offset, 0),
+                ],
+                successfulWeeks: 0,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    for (final label in [
+      'Skip',
+      'Missed',
+      'judged Met',
+      'judged Improving',
+      'judged Mixed',
+      'judged Missed',
+    ]) {
+      expect(find.text(label), findsOneWidget, reason: label);
+    }
+    expect(find.textContaining('ages out'), findsOneWidget);
+  });
+
+  testWidgets('a goal without habit cards keys its verdict strip on the '
+      'week card, and a goal with them does not', (tester) async {
+    Future<void> pump(GoalProgressView progress) => tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        GoalThisWeekCard(
+          progress: progress,
+          onReflectDay: (_) {},
+        ),
+      ),
+    );
+    await pump(GoalProgressView(today: today));
+    expect(find.byType(DayMarkLegend), findsOneWidget);
+    expect(find.text('judged Improving'), findsOneWidget);
+    expect(find.textContaining('ages out'), findsNothing);
+
+    await pump(
+      GoalProgressView(
+        today: today,
+        habits: [
+          GoalHabitProgressView(
+            habitId: 'gym',
+            name: 'Gym',
+            targetCount: 3,
+            days: [for (var offset = 6; offset >= 0; offset--) day(offset, 0)],
+            successfulWeeks: 0,
+          ),
+        ],
+      ),
+    );
+    expect(find.byType(DayMarkLegend), findsNothing);
   });
 
   testWidgets('a goal with no composite rule still gets a reflectable week', (
@@ -2497,9 +2566,21 @@ void main() {
     await tester.tap(dayFinder);
     await tester.pumpAndSettle();
     expect(find.byType(DesignSystemContextMenu), findsOneWidget);
-    expect(find.text('Success'), findsOneWidget);
-    expect(find.text('Skip'), findsOneWidget);
-    expect(find.text('Missed'), findsOneWidget);
+    // Scoped to the menu: the first habit card's key names Skip and Missed
+    // too.
+    final menu = find.byType(DesignSystemContextMenu);
+    expect(
+      find.descendant(of: menu, matching: find.text('Success')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: menu, matching: find.text('Skip')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: menu, matching: find.text('Missed')),
+      findsOneWidget,
+    );
     expect(
       find.descendant(
         of: find.byType(DesignSystemContextMenu),
@@ -2507,9 +2588,27 @@ void main() {
       ),
       findsOneWidget,
     );
-    expect(find.byIcon(LottiIcons.confirm), findsOneWidget);
-    expect(find.byIcon(LottiIcons.remove), findsOneWidget);
-    expect(find.byIcon(LottiIcons.close), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(DesignSystemContextMenu),
+        matching: find.byIcon(LottiIcons.confirm),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byType(DayTrack),
+        matching: find.byIcon(LottiIcons.remove),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byType(DesignSystemContextMenu),
+        matching: find.byIcon(LottiIcons.close),
+      ),
+      findsOneWidget,
+    );
     expect(find.byIcon(LottiIcons.radioUnselected), findsOneWidget);
     await tester.tap(find.byKey(const ValueKey('goal-habit-day-missed')));
     await tester.pump();
@@ -2624,7 +2723,13 @@ void main() {
       (cell.decoration! as BoxDecoration).color,
       tokens.colors.background.level03,
     );
-    expect(find.byIcon(LottiIcons.remove), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(DayTrack),
+        matching: find.byIcon(LottiIcons.remove),
+      ),
+      findsOneWidget,
+    );
     expect(
       find.bySemanticsLabel('Aug 11, 2026: Skip'),
       findsOneWidget,
@@ -3293,7 +3398,13 @@ void main() {
       findsOneWidget,
     );
     // The measured miss no longer shows its cross — the ruling replaced it.
-    expect(find.byIcon(LottiIcons.close), findsNothing);
+    expect(
+      find.descendant(
+        of: find.byType(DayTrack),
+        matching: find.byIcon(LottiIcons.close),
+      ),
+      findsNothing,
+    );
     expect(
       find.bySemanticsLabel(RegExp('Aug 10, 2026: Improving')),
       findsOneWidget,
@@ -3339,7 +3450,13 @@ void main() {
       find.byKey(const ValueKey('goal-day-missed-walk-2026-08-10')),
       findsOneWidget,
     );
-    expect(find.byIcon(LottiIcons.close), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(DayTrack),
+        matching: find.byIcon(LottiIcons.close),
+      ),
+      findsOneWidget,
+    );
     // The missed cross OWNS the cell: at the compact size a corner letter
     // collides with the glyph, so the letter yields and the neighbouring
     // plain cells carry the axis.

--- a/test/features/goals/ui/pages/goal_agent_detail_page_test.dart
+++ b/test/features/goals/ui/pages/goal_agent_detail_page_test.dart
@@ -55,6 +55,7 @@ import 'package:lotti/features/nudges/state/nudge_banner_providers.dart';
 import 'package:lotti/features/nudges/ui/nudge_banner_exposure_tracker.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/widgets/charts/habits/habit_completion_rate_chart.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_legend.dart';
 import 'package:lotti/widgets/misc/timespan_segmented_control.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -179,7 +180,16 @@ void main() {
     // the detail surface never displays a percentage.
     expect(find.text('At risk'), findsOneWidget);
     expect(find.text('Trending up'), findsOneWidget);
-    expect(find.byIcon(LottiIcons.trendingUp), findsOneWidget);
+    // The header's arrow — and, since this metric-only goal keys its verdict
+    // strip on the week card, the legend's "judged Improving" glyph.
+    expect(find.byIcon(LottiIcons.trendingUp), findsNWidgets(2));
+    expect(
+      find.descendant(
+        of: find.byType(DayMarkLegend),
+        matching: find.byIcon(LottiIcons.trendingUp),
+      ),
+      findsOneWidget,
+    );
     expect(find.textContaining('% of target'), findsNothing);
     // The metric card (the §4b Signals section) carries the dimension name
     // under its section heading; the old Watching list is gone.

--- a/test/widgets/day_indicators/day_mark_legend_test.dart
+++ b/test/widgets/day_indicators/day_mark_legend_test.dart
@@ -65,4 +65,71 @@ void main() {
       isTrue,
     );
   });
+  testWidgets("outcome and verdict entries are opt-in, keyed with the cells' "
+      'own glyphs and inks', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        const DayMarkLegend(
+          showAgesOut: false,
+          showOutcomes: true,
+          showVerdicts: true,
+        ),
+      ),
+    );
+    final tokens = tester.element(find.byType(DayMarkLegend)).designTokens;
+    expect(find.textContaining('ages out'), findsNothing);
+    for (final label in [
+      'Skip',
+      'Missed',
+      'judged Met',
+      'judged Improving',
+      'judged Mixed',
+      'judged Missed',
+    ]) {
+      expect(find.text(label), findsOneWidget, reason: label);
+    }
+    Icon iconBeside(String label) {
+      // The legend row whose label is [label]; scanning rows sidesteps a
+      // Text ancestor lookup that a Wrap re-parents between frames.
+      final rows = tester.widgetList<Row>(find.byType(Row));
+      for (final row in rows) {
+        final texts = find.descendant(
+          of: find.byWidget(row),
+          matching: find.text(label),
+        );
+        if (texts.evaluate().isEmpty) continue;
+        return tester.widget<Icon>(
+          find.descendant(of: find.byWidget(row), matching: find.byType(Icon)),
+        );
+      }
+      throw StateError('no legend row labelled $label');
+    }
+
+    expect(iconBeside('Skip').icon, dayMarkStateGlyph(DayMarkState.skipped));
+    expect(
+      iconBeside('judged Improving').icon,
+      dayVerdictGlyph(DayVerdict.improving),
+    );
+    expect(
+      iconBeside('judged Improving').color,
+      dayVerdictInk(tokens, DayVerdict.improving),
+    );
+    expect(
+      iconBeside('judged Missed').icon,
+      dayVerdictGlyph(DayVerdict.missed),
+    );
+    expect(
+      iconBeside('judged Missed').color,
+      dayVerdictInk(tokens, DayVerdict.missed),
+    );
+  });
+
+  testWidgets('the default legend keys only the measured states and rings', (
+    tester,
+  ) async {
+    await tester.pumpWidget(makeTestableWidgetNoScroll(const DayMarkLegend()));
+    expect(find.byType(Icon), findsNothing);
+    expect(find.textContaining('judged'), findsNothing);
+    expect(find.text('Skip'), findsNothing);
+  });
 }

--- a/test/widgets/day_indicators/day_mark_legend_test.dart
+++ b/test/widgets/day_indicators/day_mark_legend_test.dart
@@ -106,6 +106,7 @@ void main() {
     }
 
     expect(iconBeside('Skip').icon, dayMarkStateGlyph(DayMarkState.skipped));
+    expect(iconBeside('Skip').size, dayMarkGlyphSize(IconSizes.xs));
     expect(
       iconBeside('judged Improving').icon,
       dayVerdictGlyph(DayVerdict.improving),

--- a/test/widgets/day_indicators/day_mark_styles_test.dart
+++ b/test/widgets/day_indicators/day_mark_styles_test.dart
@@ -175,4 +175,8 @@ void main() {
       );
     },
   );
+  test('the glyph takes three quarters of its square at every size', () {
+    expect(dayMarkGlyphSize(IconSizes.xs), IconSizes.xs * 0.75);
+    expect(dayMarkGlyphSize(28), 21);
+  });
 }


### PR DESCRIPTION
## Summary

Beads lotti3-co1, step 4 — the last step. Since #4071 a habit square can wear a recorded skip/miss and a judged verdict, but the only key on the page named the three measured fills.

- **`DayMarkLegend`** gains `showOutcomes` (skip dash, missed cross) and `showVerdicts` (the four verdict hues with their glyphs, labelled *judged Met/Improving/Mixed/Missed* so a judged miss and a recorded miss are not the same word twice); `showAgesOut` is opt-in, since only the goal detail's rolling windows draw that ring.
- **Where it rides** — one key per surface, where a reader meets the squares: the goal detail's first habit card (everything), a goal *without* habit cards keys its verdict strip on the week card (it had no key at all), and a dashboard with habit items carries one key after them (not one per habit).
- **Cell sizing decision recorded** in the day-indicators concept: one pitch grid from `dayTrackMetrics`, never proportional cells; longer spans are handled by range (habits chart 14/30/90, the goal page's shared span, the dashboard's range), not by cell shape. Nothing left open from the 2026-08-15 audit.
- One new label (`dayMarkLegendJudged`), all 12 catalogs; changelog fragment.

## Screenshots (desktop)

| surface | before | after |
|---|---|---|
| goal detail habit card | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/day-indicator-legend/d912b436980184b0f4d96f2502d2de29484b02de/before/goal_habit_legend_desktop_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/day-indicator-legend/d912b436980184b0f4d96f2502d2de29484b02de/after/goal_habit_legend_desktop_dark.png) |
| metric-only goal week card | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/day-indicator-legend/d912b436980184b0f4d96f2502d2de29484b02de/before/goal_week_legend_desktop_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/day-indicator-legend/d912b436980184b0f4d96f2502d2de29484b02de/after/goal_week_legend_desktop_dark.png) |
| dashboard with habit items | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/day-indicator-legend/d912b436980184b0f4d96f2502d2de29484b02de/before/dashboard_habit_legend_desktop_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/day-indicator-legend/d912b436980184b0f4d96f2502d2de29484b02de/after/dashboard_habit_legend_desktop_dark.png) |

## Tests

Legend entries and inks per flag; goal card key names outcomes and verdicts; week card keys only metric-only goals; dashboard key once with habit items, none without. Existing goal tests that matched "Skip"/"Missed"/glyphs are scoped to the menu or the day track. Analyzer and formatter clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear day-square legends explaining skipped, missed, and verdict states.
  * Legends now appear appropriately on goal views and dashboards, including goals without habit cards.
  * Added localized labels for judged verdicts across supported languages.
  * Improved consistency of glyph sizing in day indicators and legend swatches.

* **Documentation**
  * Updated day-indicator and dashboard documentation to describe legend placement and cell-sizing behavior.

* **Tests**
  * Added coverage for legend content, placement, visibility, localization labels, and glyph sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->