### PR TITLE
feat(day-indicators): draw the habit day squares to the design handover

### DIFF
--- a/changelog.d/2026-08-29-habit-day-squares-handover.md
+++ b/changelog.d/2026-08-29-habit-day-squares-handover.md
@@ -1,0 +1,6 @@
+### Changed
+
+- **The habits list shows each habit's last seven days.** Every row carries a
+  week of squares under the name — kept days filled — followed by the flame
+  and the current streak, replacing the chain of identical squares that only
+  repeated the streak count.

--- a/changelog.d/2026-08-29-shared-day-indicators.md
+++ b/changelog.d/2026-08-29-shared-day-indicators.md
@@ -1,7 +1,10 @@
 ### Changed
 
-- **Habit day squares on dashboard habit cards now speak the same language as
-  goal day cells.** The success fill, a dash for skipped and a cross for missed
-  days as non-color cues, and a dashed ring on today match the goal pages; a
-  range longer than the card can hold pans back through the chain, anchored on
+- **Habit day squares look the same everywhere.** Dashboard habit cards, the
+  habits list and a goal's habit rows all draw one small square per day, as
+  the habits design intends: filled when the habit was kept, neutral otherwise,
+  with the flame and streak count after the week on the habits list. Hovering
+  or long-pressing a square names its day and outcome; on a goal page, where a
+  square can be tapped to record an outcome, its weekday sits above it. A
+  range longer than a card can hold pans back through the days, anchored on
   today, instead of silently dropping its oldest days.

--- a/knowledge/architecture/day-indicators.md
+++ b/knowledge/architecture/day-indicators.md
@@ -1,7 +1,7 @@
 ---
 type: Architecture
 title: Day indicators — the shared day-mark model and cells
-description: One model (DayMark, DayMarkState, DayVerdict) and one component set (the handover's 12px square, the strip, the track geometry) that both goals and habits draw their per-day squares with, so a day looks the same wherever it is judged.
+description: One model (DayMark, DayMarkState, DayVerdict) and one component set (the handover's 11px square at the nearest icon size, the strip, the track geometry) that both goals and habits draw their per-day squares with, so a day looks the same wherever it is judged.
 resource: ../../lib/widgets/day_indicators
 tags: [day-indicators, habits, goals, design-system, accessibility]
 status: draft

--- a/knowledge/architecture/day-indicators.md
+++ b/knowledge/architecture/day-indicators.md
@@ -1,7 +1,7 @@
 ---
 type: Architecture
 title: Day indicators — the shared day-mark model and cells
-description: One model (DayMark, DayMarkState, DayVerdict) and one component set (cells, strip, track geometry, legend) that both goals and habits draw their per-day squares with, so a day looks the same wherever it is judged.
+description: One model (DayMark, DayMarkState, DayVerdict) and one component set (the handover's 12px square, the strip, the track geometry) that both goals and habits draw their per-day squares with, so a day looks the same wherever it is judged.
 resource: ../../lib/widgets/day_indicators
 tags: [day-indicators, habits, goals, design-system, accessibility]
 status: draft
@@ -29,8 +29,10 @@ sources:
 `lib/widgets/day_indicators/` exists because a goal's habit dimension and a
 habit's own history strip are **two views of the same day**, and for a while
 they drew it two ways — different fills, different corner radii, one with a
-today ring and one without. The package promotes the goal side's primitives
-into a module both features consume. It imports neither `features/goals` nor
+today ring and one without. The package draws the square the habits design
+handover specifies — an 11px `--interactive` square at radius 3 in a 3px-gap
+row, rendered at `IconSizes.xs`, `radii.xs` and `spacing.step2` — and both
+features consume it. It imports neither `features/goals` nor
 `features/habits`; each feature adapts its own state into the shared model.
 
 # The model
@@ -42,7 +44,6 @@ classDiagram
     DayMarkState state
     DayVerdict? verdict
     DayVerdictProvenance? verdictProvenance
-    bool isToday
     bool successful
   }
   class DayMarkState {
@@ -72,35 +73,44 @@ classDiagram
 
 - **`DayMarkState` is what the app measured.** `full` means the requirement
   held as of that day; `partial` means the routine was kept while a window
-  target was still building (the lighter wash plus a dot); `skipped` and
-  `missed` are recorded habit outcomes. `missed` is never the grey of `none`:
-  deciding a day was missed and never looking at it are different facts.
+  target was still building (a wash of the kept fill); `skipped` and
+  `missed` are recorded habit outcomes. The strip is a record of what was
+  KEPT, so `skipped`, `missed` and `none` share the neutral fill — which of
+  the three a grey square stands for is said in its tooltip and semantics,
+  never drawn.
 - **`DayVerdict` is the user's ruling**, and a recorded verdict outranks the
   measurement wherever both are shown. The enum is persisted by `name` in
   goal assessment records (see [goals](../features/goals.md)), so the names
   are frozen even though the type moved here.
 - **`day` is nullable** only for undated figures — a loading placeholder or a
-  strip whose cells carry no dates and therefore no weekday letters. A
-  tappable strip asserts that every mark is dated, because a tap must resolve
-  to a day.
-- **`isToday` is explicit.** The goal adapter flags the last cell; the habit
-  card compares each day against `clock.now()`.
+  streak chain, whose squares stand for a count of days. A tappable strip
+  asserts that every mark is dated, because a tap must resolve to a day.
+- **`isToday` marks the open day, not a ring.** An empty, unjudged today
+  (`DayMark.pending`) draws as the dashed unresolved outline — the same
+  encoding a loading placeholder uses — so an alive streak never ends on the
+  grey of a missed day; a kept or judged today is an ordinary square. The
+  tooltip names the date, and a tappable square carries its weekday initial
+  above it inside the hit slot (`DayMarkCell.caption`, `dayCellWithCaption`)
+  because an action has to say which day it acts on.
 
 # The component set
 
 | Piece | File | Role |
 | --- | --- | --- |
-| Fills, glyphs, inks, labels, letter, ring, dot | `day_mark_styles.dart` | The ONE mapping from state/verdict to token colors and shapes. Every cell and every legend swatch goes through it. |
-| `DayTrack`, `dayTrackMetrics`, `fitOrScrollDayTrack`, `LinkedDayTrackScroller` | `day_track.dart` | Column geometry shared by every day row on a page, and the fit-or-pan policy. |
-| `DayMarkCell`, `PlaceholderDayCell` | `day_mark_cell.dart` | One square. Read-only by default; with `onTap` it becomes a labelled button whose hit slot clears the touch floor while the square keeps its size. |
-| `DayMarkStrip` | `day_mark_strip.dart` | A row of cells with one semantic summary; dated strips sit on the shared track, undated ones on a plain row. |
+| Fills, labels, the verdict scheme | `day_mark_styles.dart` | The ONE mapping from state/verdict to token colors. `dayVerdictGlyph` and `dayVerdictSurfaceInk` serve the reflections history and the reflect button, not the squares. |
+| `DayTrack`, `dayTrackMetrics`, `fitOrScrollDayTrack`, `LinkedDayTrackScroller` | `day_track.dart` | Column geometry shared by every day row on a page — one square plus `step2` — and the fit-or-pan policy. |
+| `kDaySquareSize`, `DayMarkCell`, `PlaceholderDayCell` | `day_mark_cell.dart` | One square, nothing inside it. Read-only by default; with `onTap` it becomes a labelled button whose hit slot clears the touch floor while the square keeps its size. |
+| `DayMarkStrip` | `day_mark_strip.dart` | A row of squares on the shared track with one semantic summary, and — with `streak` — the handover's flame and count after the last square. |
 
 ```mermaid
 flowchart LR
   GV["GoalProgressView.compactWindow<br/>+ latestRatingsByDay"] --> GA["goalDayMarks()"]
   HR["List&lt;HabitResult&gt;<br/>(dashboard range)"] --> HA["habitCompletionDayMarkState()"]
+  HS["HabitsState.*ByDay<br/>(habits page, last 7 of days)"] --> HM["habitHistoryMarks()"]
   GA --> M["List&lt;DayMark&gt;"]
   HA --> M
+  HM --> M
+  SC["currentStreak"] --> S
   M --> S["DayMarkStrip"]
   S --> C["DayMarkCell ×N"]
   C --> ST["day_mark_styles"]
@@ -109,15 +119,23 @@ flowchart LR
 
 # Invariants
 
-- **Data never wears the interactive teal.** States use the `alert` families
-  and `background.level03`; the today ring is `text.mediumEmphasis`.
-- **Every non-neutral state has a non-color cue**: the partial dot, the skip
-  dash, the missed cross, a verdict's own glyph. A red-green deficiency can
-  read the strip.
-- **Read-only strips publish one semantics node** (the successful-day count
-  plus any verdicts); tappable strips publish one button per day, each naming
-  its date and outcome.
-- **A verdict outranks a state** for fill, glyph and the success tally.
+- **Two fills for a measured day.** A kept day is `interactive.enabled` —
+  the handover's `--interactive` square — a partial day its `muted` wash, and
+  everything else `background.level03`. No alert hue on a habit square: a
+  struggling habit is never a wall of red.
+- **Nothing is drawn inside or around a square.** No glyph, no ring around
+  a filled square, no dot. The words — weekday and date, outcome, verdict, ages-out — live in
+  the `DsTooltip` and the semantics of every dated square; only a TAPPABLE
+  square adds a one-letter weekday caption above itself.
+- **Verdict hues are the goal-assessment layer's.** The whole-goal strip and
+  the goal detail's habit rows paint a recorded verdict in its own hue — met
+  in the same interactive green a kept day wears, so a card is a baseline
+  plus judgements rather than two greens; the habit dashboard strip and the
+  habits page rows show measured outcomes only.
+- **Read-only strips publish one semantics node** (the successful-day count,
+  or the streak length, plus any verdicts); tappable strips publish one
+  button per day, each naming its date and outcome.
+- **A verdict outranks a state** for the fill and the success tally.
 - **One pitch per page.** Anything that draws days on a goal detail page —
   the whole-goal strip, the habit squares, the metric bars, the page chrome —
   sizes its columns with `dayTrackMetrics` so a date lines up down the page.
@@ -125,9 +143,16 @@ flowchart LR
 # Gotchas
 
 - `_ProgressDayCell` in `goal_progress_card.dart` is not a `DayMarkCell`: it
-  hosts the outcome menu, the saving spinner and the ages-out ring. It draws
-  with the shared styles and the shared state enum, so its squares still
-  match; only its interaction shell is its own.
+  hosts the outcome menu and the saving spinner. It draws the same
+  `kDaySquareSize` square with the shared styles and the shared state enum,
+  so its squares still match; only its interaction shell is its own. The
+  ages-out fact it used to draw as an outline is a tooltip line now.
+- A tappable track is `TapTargets.minimum` tall with the caption and square
+  centred in it, so the cards drop the `step1` they put above a read-only
+  track — the slot brings its own air.
+- The habits page rows and the dashboard card pass `HabitActionRow.history`
+  (a `List<DayMark>`) plus `currentStreak`; the row renders one
+  `DayMarkStrip(streak:)`. There is no separate streak chain.
 - The habit dashboard strip used to drop its oldest days to fit; it now pans
   like every other track. There is no `LinkedScrollGroup` on a dashboard, so
   each card pans alone.
@@ -142,10 +167,9 @@ the user's per-dimension ruling under the goal's criterion id. Habits reach
 those rulings through `lib/features/goals/state/goal_habit_watchers.dart`:
 
 - `goalsWatchingHabitProvider(habitId)` — the active goals whose current spec
-  names the habit, each with the criterion id the habit is filed under.
-- `habitDayVerdictsProvider(habitId)` — the verdict standing for each of the
-  habit's days across every watching goal, keyed by UTC day; when two goals
-  judged one day, the most recently recorded judgement wins.
+  names the habit, each with the criterion id the habit is filed under. It
+  feeds the completion sheet's reflect actions; the habit strips themselves
+  do not paint verdicts.
 - `latestDimensionRatingsByDay` in `goal_assessment_state.dart` is the
   per-dimension sibling of `latestRatingsByDay`, and what the goal detail
   page feeds its own habit cells.
@@ -154,10 +178,7 @@ those rulings through `lib/features/goals/state/goal_habit_watchers.dart`:
 flowchart LR
   A["GoalAssessmentRecord.dimensionRatings[criterionId]"] --> D["latestDimensionRatingsByDay"]
   D --> P["_ProgressDayCell(verdict:)<br/>goal detail habit card"]
-  W["goalsWatchingHabitProvider(habitId)"] --> V["habitDayVerdictsProvider(habitId)"]
-  A --> V
-  V --> H["HabitCompletionCard strip<br/>DayMark(verdict:)"]
-  W --> S["HabitCompletionSheet<br/>Reflect on this day in ‹goal›"]
+  W["goalsWatchingHabitProvider(habitId)"] --> S["HabitCompletionSheet<br/>Reflect on this day in ‹goal›"]
   S --> R["showGoalDayAssessmentSheet(day: the sheet's day)"]
 ```
 
@@ -168,10 +189,9 @@ view and history — so the habit only contributes the day.
 
 # There is no key
 
-The squares carry their own meaning: every non-neutral state has a
-non-color cue (the partial dot, the skip dash, the missed cross, a verdict's
-own glyph), and every cell answers hover or long-press with its day and its
-outcome or verdict. A static key was tried twice — an eleven-entry wrap under
+The squares carry their own meaning — kept or not, at a glance — and every
+dated square answers hover or long-press with its day and its outcome or
+verdict. A static key was tried twice — an eleven-entry wrap under
 a dashboard, then a present-states-only line under the goal's habit squares —
 and a design-review panel rated both as more legend than data. Do not
 reintroduce one; if a mark needs explaining, give the mark a better cue or a
@@ -179,11 +199,10 @@ better tooltip.
 
 # Cell sizing is a decision, not a gap
 
-Cells never size proportionally to a value or a count. Every day track sizes
-its columns from `dayTrackMetrics`: one pitch per page derived from the
-available width, the square shrinking with its column down to `IconSizes.xs`
-and never growing past `ControlSizes.iconChipCompact`, and a track that
-still cannot fit pans. A proportional cell (wider for a longer window, taller
+Cells never size proportionally to a value or a count, and they never
+shrink or grow: every day track sizes its columns from `dayTrackMetrics` —
+one square, `step2` of air, widened only when scaled text needs the
+weekday caption — and a span that does not fit its width pans. A proportional cell (wider for a longer window, taller
 for a bigger number) was considered in the 2026-08-15 audit and rejected: a
 date has to line up down the page across strips, habit squares and metric
 bars, which one grid guarantees and per-cell sizing cannot. Longer spans are

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -930,19 +930,16 @@ flowchart TD
   until that rollback lands; old evidence is never relabelled as the failed
   range. The retained snapshot is scoped to the active spec version and only
   promoted from a settled provider value, so a spec reload cannot relabel
-  prior-spec evidence. A day track FITS before it scrolls:
-  `dayTrackMetrics` narrows the column pitch — and the square inside it
-  — until the whole span fits the width it was given, and only a span that
-  overflows even at the legibility floor becomes a trailing-anchored
-  (`reverse: true`) scroller joined to one `LinkedScrollGroup`, where every
-  track then pans in unison. The habit squares and the whole-goal strip carry their weekday
-  axis INSIDE the cells (`dayCellLetter`: a small bottom-left corner
-  initial that yields to a center mark — verdict glyph, partial dot, missed
-  cross, which collide with it at the compact cell size — and is suppressed
-  below `IconSizes.l`) instead of a label
-  row above the track; only the hand-painted metric bars keep a caption
-  axis (`_WeekdayTrack`), below the bars, since a variable-height bar
-  cannot host a letter. Every tappable element on these cards carries the
+  prior-spec evidence. A day track never resizes its
+  squares: `dayTrackMetrics` is one `kDaySquareSize` square plus `step1`
+  per column, and a span wider than the width it was given becomes a
+  trailing-anchored (`reverse: true`) scroller joined to one
+  `LinkedScrollGroup`, where every track then pans in unison. The habit
+  squares and the whole-goal strip carry no label row — a square names its
+  day in its tooltip and semantics, and a tappable one wears its weekday
+  initial above itself inside its slot; only the hand-painted metric bars
+  keep a caption axis (`_WeekdayTrack`, one-letter at this pitch), below
+  the bars. Every tappable element on these cards carries the
   design system's `surface.hover` fill on its own transparent `Material` —
   ink painted on the Scaffold's Material sits under the opaque cards and
   never shows, which is why the day grids and rail rows previously had no

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -931,7 +931,7 @@ flowchart TD
   range. The retained snapshot is scoped to the active spec version and only
   promoted from a settled provider value, so a spec reload cannot relabel
   prior-spec evidence. A day track never resizes its
-  squares: `dayTrackMetrics` is one `kDaySquareSize` square plus `step1`
+  squares: `dayTrackMetrics` is one `kDaySquareSize` square plus `step2`
   per column, and a span wider than the width it was given becomes a
   trailing-anchored (`reverse: true`) scroller joined to one
   `LinkedScrollGroup`, where every track then pans in unison. The habit

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -314,14 +314,14 @@ step.
 window width** in its own sliver, so a wide screen shows more history while the
 action content stays a comfortable column.
 
-Tab rows are lean **action rows**: icon, name, swipe, one-tap complete — **no
-per-row history**. Per-day history reads from the heatmap instead. The older
-per-row history strip survives only inside the dashboard habit chart, drawn
-with the shared day-indicator cells ([day
-indicators](../architecture/day-indicators.md)) so it matches a goal's habit
-squares: success fill, skip dash, missed cross, dashed ring on today — and,
-for a day a watching goal's reflection judged, that verdict's fill and glyph
-(`habitDayVerdictsProvider`). A row
+Tab rows are **action rows**: icon, name, the handover's history strip —
+the last seven days as squares (`habitHistoryMarks`, read off the state's
+per-day completion sets), filled for a kept day and neutral otherwise, each
+naming its day and outcome on hover, then the flame and the current streak —
+swipe, and one-tap complete. The dashboard habit chart draws the same strip
+over its own range. Both go through the shared day-indicator squares ([day
+indicators](../architecture/day-indicators.md)) so they match a goal's habit
+squares. A row
 whose completion today came from the engine wears an **auto** pill and a
 caption naming the signal and the time (`HabitsState.autoCompletedToday` and
 `autoCompletedAt`); tapping it still opens the sheet, because a manual entry

--- a/lib/features/goals/README.md
+++ b/lib/features/goals/README.md
@@ -118,10 +118,10 @@ only pan when even the narrowest column overflows, so a fortnight no longer
 opens with its first days cut off the left edge. A leading gutter is reserved
 only where a value axis is actually drawn.
 A completed day whose window target was not yet met renders as a lighter
-partial-success wash with a full-strength inner dot (day states wear the
-success family; the interactive teal stays tap-only), each square carries its
-concrete date in tooltip and outcome-menu header, and a blank habit day with
-a name-matching data observation recorded today offers a one-tap check-off.
+wash of the kept fill; nothing is drawn inside a square. Each tappable square
+carries its weekday initial above it and its concrete date in tooltip and
+outcome-menu header, and a blank habit day with a name-matching data
+observation recorded today offers a one-tap check-off.
 On the detail page the banner CTA opens a one-tap logging sheet
 (`GoalLogTodaySheet`) instead of navigating to the page it is on.
 On phones a goal's own pages — detail, chat, and the create and edit wizards —

--- a/lib/features/goals/state/goal_habit_watchers.dart
+++ b/lib/features/goals/state/goal_habit_watchers.dart
@@ -2,10 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:lotti/classes/goal_criterion.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
-import 'package:lotti/features/goals/model/goal_assessment.dart';
 import 'package:lotti/features/goals/state/goal_agent_providers.dart';
-import 'package:lotti/features/goals/state/goal_assessment_state.dart';
-import 'package:lotti/widgets/day_indicators/day_mark.dart';
 
 /// One active goal that watches a habit: the goal's identity, the spec
 /// version currently in force, and the id of the criterion inside that spec
@@ -67,47 +64,3 @@ goalsWatchingHabitProvider = FutureProvider.autoDispose
       }
       return watchers;
     }, name: 'goalsWatchingHabitProvider');
-
-/// The verdict standing for each of the habit's days across every goal that
-/// watches it, keyed by UTC day.
-///
-/// A habit shared by two goals can be judged twice for one day. The most
-/// recently recorded judgement wins — the same rule `latestAssessmentsByDay`
-/// applies to one goal's own revisions — so the habit's squares show the user's latest word on
-/// that day rather than one goal's older one.
-final FutureProviderFamily<Map<DateTime, DayVerdict>, String>
-habitDayVerdictsProvider = FutureProvider.autoDispose
-    .family<Map<DateTime, DayVerdict>, String>((ref, habitId) async {
-      final watchers = await ref.watch(
-        goalsWatchingHabitProvider(habitId).future,
-      );
-      final latest = <DateTime, GoalAssessmentRecord>{};
-      final verdicts = <DateTime, DayVerdict>{};
-      for (final watcher in watchers) {
-        final records = await ref.watch(
-          goalAssessmentHistoryProvider(watcher.identity.agentId).future,
-        );
-        final byDay = latestAssessmentsByDay(
-          records,
-          specVersionId: watcher.spec.id,
-        );
-        for (final entry in byDay.entries) {
-          final verdict = entry.value.dimensionRatings[watcher.criterionId];
-          if (verdict == null) continue;
-          final held = latest[entry.key];
-          // The same tie-break `latestAssessmentsByDay` applies within one
-          // goal: equal timestamps fall back to the higher record id, so two
-          // devices iterating the goals in different orders agree.
-          final record = entry.value;
-          final wins =
-              held == null ||
-              record.createdAt.isAfter(held.createdAt) ||
-              (record.createdAt == held.createdAt &&
-                  record.id.compareTo(held.id) > 0);
-          if (!wins) continue;
-          latest[entry.key] = entry.value;
-          verdicts[entry.key] = verdict;
-        }
-      }
-      return verdicts;
-    }, name: 'habitDayVerdictsProvider');

--- a/lib/features/goals/ui/goal_progress_card.dart
+++ b/lib/features/goals/ui/goal_progress_card.dart
@@ -17,7 +17,6 @@ import 'package:lotti/features/design_system/components/buttons/design_system_bu
 import 'package:lotti/features/design_system/components/callouts/design_system_inline_callout.dart';
 import 'package:lotti/features/design_system/components/cards/design_system_section_card.dart';
 import 'package:lotti/features/design_system/components/context_menus/design_system_context_menu.dart';
-import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
 import 'package:lotti/features/design_system/components/ds_quiet_ink.dart';
 import 'package:lotti/features/design_system/components/tooltips/ds_tooltip.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -31,6 +30,7 @@ import 'package:lotti/features/goals/ui/goal_day_marks.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/charts/utils.dart';
 import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_cell.dart';
 import 'package:lotti/widgets/day_indicators/day_mark_strip.dart';
 import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
 import 'package:lotti/widgets/day_indicators/day_track.dart';
@@ -314,8 +314,10 @@ class GoalThisWeekCard extends StatelessWidget {
           ),
           // step1: the date line labels the strip directly beneath it, the
           // same pairing the habit cards use. A step3 gap made it read as
-          // floating between the strip and the title row above.
-          SizedBox(height: tokens.spacing.step1),
+          // floating between the strip and the title row above. A tappable
+          // strip brings its own air: its touch-floor slot is taller than
+          // the squares it centres.
+          if (onReflectDay == null) SizedBox(height: tokens.spacing.step1),
           // On the card's own rail. It used to be inset by a chart's y-axis
           // gutter so it would line up with plots on other cards — but this
           // card draws no plot, so the gutter was 52px of nothing between the
@@ -1345,7 +1347,7 @@ class _WeekdayTrack extends StatelessWidget {
               'goal-habit-weekday-$trackId-'
               '${day.day.toIso8601String().substring(0, 10)}',
             ),
-            width: metrics.cellSize,
+            width: kDaySquareSize,
             child: OverflowBox(
               maxWidth: double.infinity,
               child: Text(
@@ -1476,8 +1478,6 @@ class _HabitProgressRowState extends State<_HabitProgressRow> {
     final noteStyle = tokens.typography.styles.others.caption.copyWith(
       color: tokens.colors.text.mediumEmphasis,
     );
-    // Weekday initials live INSIDE the squares (see [dayCellLetter]);
-    // the separate label row above the track is gone.
     final letterFormat = DateFormat.EEEEE(
       Localizations.localeOf(context).toLanguageTag(),
     );
@@ -1487,7 +1487,7 @@ class _HabitProgressRowState extends State<_HabitProgressRow> {
       // slot meets TapTargets.minimum vertically; read-only rows keep the
       // compact height.
       final trackHeight = widget.onOutcomeSelected == null
-          ? metrics.cellSize
+          ? kDaySquareSize
           : TapTargets.minimum;
       return DayTrack(
         height: trackHeight,
@@ -1497,21 +1497,22 @@ class _HabitProgressRowState extends State<_HabitProgressRow> {
             _ProgressDayCell(
               day: activeDays[index],
               habitId: habit.habitId,
-              size: metrics.cellSize,
+              today: DateUtils.isSameDay(
+                activeDays[index].day,
+                widget.today,
+              ),
+              weekdayLetter: widget.onOutcomeSelected == null
+                  ? null
+                  : letterFormat.format(activeDays[index].day),
               verdict:
                   widget.verdictsByDay[DateTime.utc(
                     activeDays[index].day.year,
                     activeDays[index].day.month,
                     activeDays[index].day.day,
                   )],
-              weekdayLetter: letterFormat.format(activeDays[index].day),
-              today: DateUtils.isSameDay(
-                activeDays[index].day,
-                widget.today,
-              ),
-              // The ring marks the WINDOW's first day — with the page's
-              // shared span rendering extra history, the list head can be a
-              // blank day weeks before the window.
+              // The WINDOW's first day — with the page's shared span
+              // rendering extra history, the list head can be a blank day
+              // weeks before the window.
               agingOut:
                   index == _windowStartIndex(habit, activeDays) &&
                   habit.oldestSuccessAgesOutTonight,
@@ -1528,19 +1529,12 @@ class _HabitProgressRowState extends State<_HabitProgressRow> {
       );
     }
 
-    // Just the squares: their weekday initials ride inside the cells.
+    // The squares alone; the date axis is the tooltip on each of them.
     Widget track(DayTrackMetrics metrics) => cells(metrics);
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        // The track is sized to the width it actually has, so a fortnight of
-        // days fits the card instead of opening scrolled past its own first
-        // day.
-        final metrics = dayTrackMetrics(
-          context,
-          dayCount: activeDays.length,
-          availableWidth: constraints.maxWidth,
-        );
+        final metrics = dayTrackMetrics(context);
         final contentWidth = metrics.pitch * activeDays.length;
         final periodLine = _periodLabel(context, activeDays);
         // The deficit note shares the period line whenever everything on it
@@ -1630,8 +1624,11 @@ class _HabitProgressRowState extends State<_HabitProgressRow> {
                   ),
                   // step1, not step2: the window line LABELS the squares, so
                   // it has to read as attached to them rather than floating
-                  // midway between them and the header block above.
-                  SizedBox(height: tokens.spacing.step1),
+                  // midway between them and the header block above. A
+                  // tappable track brings its own air: its touch-floor slot
+                  // is taller than the square it centres.
+                  if (widget.onOutcomeSelected == null)
+                    SizedBox(height: tokens.spacing.step1),
                   // Labels and squares pan as one unit, and only where even
                   // the narrowest column overflows.
                   fitOrScrollDayTrack(
@@ -1692,12 +1689,11 @@ class _ProgressDayCell extends StatelessWidget {
   const _ProgressDayCell({
     required this.day,
     required this.habitId,
-    required this.today,
     required this.agingOut,
     required this.saving,
     required this.enabled,
     required this.onOutcomeSelected,
-    this.size = ControlSizes.iconChipCompact,
+    required this.today,
     this.weekdayLetter,
     this.verdict,
   });
@@ -1705,20 +1701,20 @@ class _ProgressDayCell extends StatelessWidget {
   final GoalProgressDay day;
   final String habitId;
 
-  /// The user's verdict on this habit for this day, when they recorded one
-  /// in the reflection sheet. It decides the fill and the glyph; the measured
-  /// outcome is only what the app observed.
-  final DayVerdict? verdict;
+  /// Whether this is the current day. Empty and unjudged, it draws as the
+  /// dashed unresolved outline rather than a past day's neutral fill.
+  final bool today;
 
-  /// One-letter weekday initial nested in the square — the day axis, now
-  /// that the label row above the track is gone. Outranked by the stronger
-  /// marks (missed cross, skipped dash, partial dot).
+  /// The weekday initial drawn above a tappable square, inside its slot.
   final String? weekdayLetter;
 
-  /// Edge of the square. Shrinks with the track's column pitch so a long span
-  /// fits the card instead of scrolling past its own first day.
-  final double size;
-  final bool today;
+  /// The user's verdict on this habit for this day, when they recorded one
+  /// in the reflection sheet. It decides the fill; the measured outcome is
+  /// only what the app observed.
+  final DayVerdict? verdict;
+
+  /// Whether this is the window's oldest kept day and it ages out tonight.
+  /// Said in the tooltip and the semantics, not drawn on the square.
   final bool agingOut;
   final bool saving;
   final bool enabled;
@@ -1727,114 +1723,49 @@ class _ProgressDayCell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final hit = day.hasValue;
     final completionType = day.habitCompletionType;
     final missed = completionType == HabitCompletionType.fail;
     // A completed day is a partial success (lighter wash) while the habit's
     // own window target was not yet met as of that day; a null verdict from
     // older projections keeps the established full-strength rendering.
     final dayState = goalProgressDayMarkState(day);
-    // The square's own edge; the interactive slot around it is larger.
-    final visualDimension = size;
-    final glyphSize = math.min(IconSizes.xs, visualDimension * 0.6);
-    // Ages-out is a quiet outline, not the page's alarm hue: an on-track
-    // habit must never wear warning orange. Today-and-done rings in the
-    // success family — the cell is data, not a control.
-    final border = agingOut
-        ? Border.all(
-            color: tokens.colors.text.lowEmphasis,
-            width: BorderWidths.emphasis,
-          )
-        : today && hit
-        ? Border.all(
-            color: tokens.colors.alert.success.defaultColor,
-            width: BorderWidths.emphasis,
-          )
-        : null;
-    // The glyph scales with the square it sits in, so a squeezed column
-    // does not paint a 12px cross onto a 14px cell.
-    // A recorded verdict outranks the measured outcome for fill and glyph,
-    // exactly as on the whole-goal strip: the measurement is evidence, the
+    // A recorded verdict outranks the measured outcome for the fill, exactly
+    // as on the whole-goal strip: the measurement is evidence, the
     // reflection is the user's ruling on the day.
     final verdict = this.verdict;
-    final stateGlyph = verdict == null ? dayMarkStateGlyph(dayState) : null;
-    final Widget? centerMark = verdict != null
-        ? Center(
-            child: Icon(
-              dayVerdictGlyph(verdict),
-              size: glyphSize,
-              color: dayVerdictInk(tokens, verdict),
-            ),
+    final dayKey = day.day.toIso8601String().substring(0, 10);
+    final pending =
+        today &&
+        verdict == null &&
+        dayState == DayMarkState.none &&
+        (completionType == null || completionType == HabitCompletionType.open);
+    Widget cell = pending
+        ? PlaceholderDayCell(
+            key: ValueKey('goal-habit-day-visual-$habitId-$dayKey'),
           )
-        : stateGlyph != null
-        ? Center(
-            child: Icon(
-              stateGlyph,
-              size: glyphSize,
-              color: dayMarkStateGlyphInk(tokens, dayState),
+        : Container(
+            key: ValueKey('goal-habit-day-visual-$habitId-$dayKey'),
+            width: kDaySquareSize,
+            height: kDaySquareSize,
+            decoration: BoxDecoration(
+              color: verdict == null
+                  ? dayMarkStateFill(tokens, dayState)
+                  : dayVerdictFill(tokens, verdict),
+              borderRadius: BorderRadius.circular(tokens.radii.xs),
             ),
-          )
-        : dayState == DayMarkState.partial
-        ? Center(child: partialDayDot(tokens, tokens.spacing.step2))
-        : null;
-    // The corner weekday tag renders only when the center is empty: at the
-    // compact cell size a cross, dash or dot and a corner letter collide,
-    // and the mark is the rarer, more meaningful of the two — neighbouring
-    // plain cells keep carrying the axis.
-    final letterTag = centerMark != null
-        ? null
-        : dayCellLetter(
-            tokens,
-            letter: weekdayLetter,
-            cellSize: visualDimension,
-            filled: verdict != null || dayState == DayMarkState.full,
           );
-    Widget cell = Container(
-      key: ValueKey(
-        'goal-habit-day-visual-$habitId-'
-        '${day.day.toIso8601String().substring(0, 10)}',
-      ),
-      width: visualDimension,
-      height: visualDimension,
-      decoration: BoxDecoration(
-        color: verdict == null
-            ? dayMarkStateFill(tokens, dayState)
-            : dayVerdictFill(tokens, verdict),
-        borderRadius: BorderRadius.circular(dayCellRadius(tokens)),
-        border: border,
-      ),
-      child: centerMark == null && letterTag == null
-          ? null
-          : Stack(
-              children: [?centerMark, ?letterTag],
-            ),
-    );
     if (dayState == DayMarkState.partial) {
       cell = KeyedSubtree(
-        key: ValueKey(
-          'goal-day-partial-$habitId-'
-          '${day.day.toIso8601String().substring(0, 10)}',
-        ),
+        key: ValueKey('goal-day-partial-$habitId-$dayKey'),
         child: cell,
       );
     }
     if (missed) {
       cell = KeyedSubtree(
-        key: ValueKey(
-          'goal-day-missed-$habitId-'
-          '${day.day.toIso8601String().substring(0, 10)}',
-        ),
+        key: ValueKey('goal-day-missed-$habitId-$dayKey'),
         child: cell,
       );
     }
-    final decoratedCell = !today || hit
-        ? cell
-        : DsDashedBorder(
-            color: todayRingInk(tokens),
-            strokeWidth: BorderWidths.emphasis,
-            radius: dayCellRadius(tokens),
-            child: cell,
-          );
     final locale = Localizations.localeOf(context).toLanguageTag();
     final date = DateFormat.yMMMd(locale).format(day.day);
     final menuDate = DateFormat.MMMEd(locale).format(day.day);
@@ -1847,10 +1778,15 @@ class _ProgressDayCell extends StatelessWidget {
       null => context.messages.goalProgressHabitDayNoEntry,
     };
     // Spoken and hovered as the verdict where one stands, the measurement
-    // otherwise — the cell must say what it shows.
-    final outcome = verdict == null
+    // otherwise — the cell must say what it shows. The ages-out fact rides
+    // along: the square has no room to draw it.
+    final ruling = verdict == null
         ? measured
         : dayVerdictLabel(context, verdict);
+    final outcome = [
+      ruling,
+      if (agingOut) context.messages.goalProgressAgesOut,
+    ].join(' · ');
     final semanticLabel = context.messages.goalProgressHabitDaySemantics(
       date,
       outcome,
@@ -1864,7 +1800,7 @@ class _ProgressDayCell extends StatelessWidget {
           title: menuDate,
           message: outcome,
           preferBelow: false,
-          child: decoratedCell,
+          child: cell,
         ),
       );
     }
@@ -1873,35 +1809,32 @@ class _ProgressDayCell extends StatelessWidget {
       button: true,
       enabled: enabled && !saving,
       excludeSemantics: true,
-      // The visual stays at the compact chip size; the hit slot meets the
-      // design system's touch floor vertically and fills the track pitch
-      // horizontally — invisible ergonomics, unchanged rhythm.
+      // The square stays small; the hit slot meets the design system's touch
+      // floor vertically and fills the track pitch horizontally — invisible
+      // ergonomics, unchanged rhythm.
       child: SizedBox.expand(
-        key: ValueKey(
-          'goal-habit-day-$habitId-'
-          '${day.day.toIso8601String().substring(0, 10)}',
-        ),
+        key: ValueKey('goal-habit-day-$habitId-$dayKey'),
         child: _HabitDayOutcomeMenu(
           enabled: enabled && !saving,
           currentOutcome: completionType,
-          headerKey: ValueKey(
-            'goal-habit-day-date-$habitId-'
-            '${day.day.toIso8601String().substring(0, 10)}',
-          ),
+          headerKey: ValueKey('goal-habit-day-date-$habitId-$dayKey'),
           menuDate: menuDate,
           outcomeLabel: outcome,
           semanticLabel: semanticLabel,
           onSelected: callback,
           child: Center(
-            child: saving
-                ? SizedBox.square(
-                    dimension: visualDimension,
-                    child: Padding(
-                      padding: EdgeInsets.all(tokens.spacing.step2),
-                      child: const CircularProgressIndicator(),
-                    ),
-                  )
-                : decoratedCell,
+            child: dayCellWithCaption(
+              tokens,
+              saving
+                  ? const SizedBox.square(
+                      dimension: kDaySquareSize,
+                      child: CircularProgressIndicator(
+                        strokeWidth: BorderWidths.emphasis,
+                      ),
+                    )
+                  : cell,
+              weekdayLetter,
+            ),
           ),
         ),
       ),
@@ -2282,11 +2215,7 @@ class _MetricProgressSeries extends StatelessWidget {
           constraints.maxWidth - kChartLeftAxisWidth,
           0,
         );
-        final metrics = dayTrackMetrics(
-          context,
-          dayCount: metric.days.length,
-          availableWidth: plotWidth,
-        );
+        final metrics = dayTrackMetrics(context);
         final contentWidth = metrics.pitch * metric.days.length;
         final track = _track(context, axis.max, metrics);
         return Column(
@@ -2419,7 +2348,7 @@ class _MetricProgressSeries extends StatelessWidget {
           // whose Stack expands against its parent, so it needs bounded
           // dimensions or every bar collapses to zero — an invisible chart.
           SizedBox(
-            width: metrics.cellSize,
+            width: kDaySquareSize,
             height: height,
             child: _bar(context, day, maxValue, chrome),
           ),
@@ -2686,9 +2615,7 @@ class _CategoryBandSeries extends StatelessWidget {
                           color: _startsInBand(session.dateFrom, range)
                               ? tokens.colors.alert.warning.defaultColor
                               : tokens.colors.interactive.enabled,
-                          borderRadius: BorderRadius.circular(
-                            dayCellRadius(tokens),
-                          ),
+                          borderRadius: BorderRadius.circular(tokens.radii.xs),
                         ),
                       ),
                     ),

--- a/lib/features/goals/ui/pages/goal_agent_detail_page.dart
+++ b/lib/features/goals/ui/pages/goal_agent_detail_page.dart
@@ -116,7 +116,7 @@ class _GoalAgentDetailPageState extends ConsumerState<GoalAgentDetailPage>
   }) {
     if (_rangePicked) return;
     final tokens = context.designTokens;
-    final pitch = dayTrackMetrics(context, dayCount: 1).pitch;
+    final pitch = dayTrackMetrics(context).pitch;
     final contentWidth =
         math.min(
           kUnifiedGoalsContentMaxWidth,

--- a/lib/features/goals/ui/pages/unified_goals_page.dart
+++ b/lib/features/goals/ui/pages/unified_goals_page.dart
@@ -242,6 +242,7 @@ class _UnifiedGoalsPageState extends ConsumerState<UnifiedGoalsPage>
         autoCompleteReason: state.autoCompletedToday[habitDefinition.id],
         autoCompletedAt: state.autoCompletedAt(habitDefinition.id),
         currentStreak: streaks[habitDefinition.id] ?? 0,
+        history: habitHistoryMarks(state, habitDefinition.id),
       );
     }
 

--- a/lib/features/habits/state/habits_state.dart
+++ b/lib/features/habits/state/habits_state.dart
@@ -7,6 +7,7 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/habits/model/habit_completion_record.dart';
 import 'package:lotti/utils/date_utils_extension.dart';
 import 'package:lotti/widgets/charts/utils.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
 
 part 'habits_state.freezed.dart';
 
@@ -240,6 +241,36 @@ List<String> getHabitDays(int timeSpanDays, {DateTime? now}) {
     rangeEnd: currentTime,
   )..sort();
   return days;
+}
+
+/// The last [count] of [HabitsState.days] as day marks for one habit — the
+/// dated history strip under a habit row, read straight off the per-day
+/// completion sets the page already holds. A day the habit was kept is
+/// `full`; a recorded skip or miss keeps its own state so the square can name
+/// it; a day with no record is `none`.
+List<DayMark> habitHistoryMarks(
+  HabitsState state,
+  String habitId, {
+  int count = DateTime.daysPerWeek,
+}) {
+  final days = state.days;
+  final start = max(0, days.length - count);
+  // The state's span ends on the day it was built for, which is today.
+  final today = days.isEmpty ? null : days.last;
+  return [
+    for (final ymd in days.sublist(start))
+      DayMark(
+        day: DateTime.parse(ymd),
+        isToday: ymd == today,
+        state: state.successfulByDay[ymd]?.contains(habitId) ?? false
+            ? DayMarkState.full
+            : state.skippedByDay[ymd]?.contains(habitId) ?? false
+            ? DayMarkState.skipped
+            : state.failedByDay[ymd]?.contains(habitId) ?? false
+            ? DayMarkState.missed
+            : DayMarkState.none,
+      ),
+  ];
 }
 
 extension HabitsStateAutoCompletion on HabitsState {

--- a/lib/features/habits/ui/habits_page.dart
+++ b/lib/features/habits/ui/habits_page.dart
@@ -241,6 +241,7 @@ class _HabitsTabPageState extends ConsumerState<HabitsTabPage> {
         autoCompleteReason: state.autoCompletedToday[habitDefinition.id],
         autoCompletedAt: state.autoCompletedAt(habitDefinition.id),
         currentStreak: streaks[habitDefinition.id] ?? 0,
+        history: habitHistoryMarks(state, habitDefinition.id),
       );
     }
 

--- a/lib/features/habits/ui/widgets/habit_action_row.dart
+++ b/lib/features/habits/ui/widgets/habit_action_row.dart
@@ -21,6 +21,8 @@ import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/widgets/charts/habits/dashboard_habits_data.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_strip.dart';
 
 /// The 0→1 progress of a celebration beat whose window is `[start, end]` within
 /// the shared timeline [c], or `null` when [c] is outside that window so the
@@ -34,20 +36,21 @@ double? _stageProgress(double c, double start, double end) {
 /// The shared habit action row used by the habits tab and the dashboard habit
 /// chart: a swipe-to-record row (right = success, left = missed) whose body
 /// opens the completion dialog on tap, with a category icon, an optional
-/// priority star, the habit name, an optional [history] slot and a trailing
+/// priority star, the habit name, the handover's history strip — one square
+/// per day of [history], then a flame and [currentStreak] — and a trailing
 /// one-tap complete button.
 ///
-/// Whether to show per-day history is the caller's concern: the habits tab
-/// passes none (history lives in the consistency heatmap), while the dashboard
-/// card injects its strip. [completedToday] is supplied by the caller too — the
-/// tab derives it from the controller's `successfulToday` bucket, the dashboard
-/// card from its latest in-range result — so the row stays presentational.
+/// The history is the caller's to supply: the habits tab reads its week off
+/// `HabitsState` (`habitHistoryMarks`), the dashboard card off its own range.
+/// [completedToday] is supplied by the caller too — the tab derives it from
+/// the controller's `successfulToday` bucket, the dashboard card from its
+/// latest in-range result — so the row stays presentational.
 class HabitActionRow extends ConsumerStatefulWidget {
   const HabitActionRow({
     required this.habitId,
     required this.completedToday,
     this.currentStreak = 0,
-    this.history,
+    this.history = const [],
     this.autoCompleted = false,
     this.autoCompleteReason,
     this.autoCompletedAt,
@@ -60,14 +63,14 @@ class HabitActionRow extends ConsumerStatefulWidget {
   /// trailing button's two modes.
   final bool completedToday;
 
-  /// This habit's current consecutive-day streak. Rendered under the name as a
-  /// chain of green boxes (one per kept day, capped) plus a flame + count once
-  /// it reaches 1 — the per-habit "don't break the chain" signal the combined
-  /// heatmap can't give.
+  /// This habit's current consecutive-day streak, drawn as a flame and the
+  /// count after the history squares once it reaches 1 — the per-habit
+  /// "don't break the chain" signal the combined heatmap can't give.
   final int currentStreak;
 
-  /// Optional per-day history shown under the name (the dashboard card's strip).
-  final Widget? history;
+  /// The per-day history under the name, oldest first. Empty draws no
+  /// squares; the streak tail still shows when there is a run going.
+  final List<DayMark> history;
 
   /// Whether today's completion was written by the auto-completion engine —
   /// shows the "auto" pill and, with [autoCompleteReason], the caption naming
@@ -416,7 +419,7 @@ class _HabitCardBody extends StatelessWidget {
     required this.onTapAdd,
     required this.onEdit,
     required this.onQuickComplete,
-    this.history,
+    required this.history,
   });
 
   final HabitDefinition habitDefinition;
@@ -427,10 +430,9 @@ class _HabitCardBody extends StatelessWidget {
   final int currentStreak;
   final Color doneColor;
 
-  /// Whether habit-completion celebrations are enabled — gates the streak
-  /// chain's grow-in pop when a kept day extends the chain.
+  /// Whether habit-completion celebrations are enabled.
   final bool celebrate;
-  final Widget? history;
+  final List<DayMark> history;
   final void Function({String? dateString}) onTapAdd;
   final VoidCallback onEdit;
 
@@ -529,16 +531,12 @@ class _HabitCardBody extends StatelessWidget {
                           overflow: TextOverflow.ellipsis,
                         ),
                       ],
-                      // The current streak as a chain of green boxes — the
-                      // visible "don't break the chain". Empty when there's no
-                      // run going.
-                      if (currentStreak >= 1) ...[
+                      // The handover's history strip: the week's squares,
+                      // then the flame and the streak. Nothing when there is
+                      // neither history nor a run going.
+                      if (history.isNotEmpty || currentStreak >= 1) ...[
                         SizedBox(height: tokens.spacing.step3),
-                        _StreakChain(count: currentStreak, animate: celebrate),
-                      ],
-                      if (history != null) ...[
-                        SizedBox(height: tokens.spacing.step3),
-                        history!,
+                        DayMarkStrip(marks: history, streak: currentStreak),
                       ],
                     ],
                   ),
@@ -564,136 +562,6 @@ class _HabitCardBody extends StatelessWidget {
               ],
             ),
           ),
-        ),
-      ),
-    );
-  }
-}
-
-/// The current streak rendered as a chain of small green rounded boxes — the
-/// visible "don't break the chain" the combined heatmap can't surface per habit.
-///
-/// Only the *current unbroken run* is shown: when the streak breaks it resets to
-/// empty (a habit with no streak shows nothing), and there are no red or gap
-/// cells — a kept day is green, that's all, so a struggling habit is never a
-/// wall of failure. The chain caps at 30 boxes and fits to the available
-/// width (older boxes drop first); a trailing flame + count gives the exact
-/// length, including runs past the cap. The streak is announced once via a
-/// semantics label, so screen readers don't read each box.
-///
-/// When the streak grows the newest (rightmost) box pops in (a brief scale +
-/// fade), so extending the chain on completion reads as a small reward; the rest
-/// of the chain is static. Reduced motion skips the pop.
-class _StreakChain extends StatefulWidget {
-  const _StreakChain({required this.count, this.animate = true});
-
-  final int count;
-
-  /// Whether the newest box pops in when the streak grows. False mirrors
-  /// reduced motion (the chain still updates, just without the pop).
-  final bool animate;
-
-  @override
-  State<_StreakChain> createState() => _StreakChainState();
-}
-
-class _StreakChainState extends State<_StreakChain>
-    with SingleTickerProviderStateMixin {
-  static const _cap = 30;
-  static const _box = 14.0;
-
-  late final AnimationController _grow = AnimationController(
-    vsync: this,
-    duration: const Duration(milliseconds: 420),
-    value: 1, // rest = newest box at full size
-  );
-
-  @override
-  void didUpdateWidget(_StreakChain oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.count > oldWidget.count &&
-        widget.animate &&
-        !(MediaQuery.maybeOf(context)?.disableAnimations ?? false)) {
-      _grow.forward(from: 0);
-    }
-  }
-
-  @override
-  void dispose() {
-    _grow.dispose();
-    super.dispose();
-  }
-
-  Widget _boxWidget(BuildContext context, {required bool newest}) {
-    final tokens = context.designTokens;
-    final box = Container(
-      width: _box,
-      height: _box,
-      decoration: BoxDecoration(
-        color: successColor,
-        borderRadius: BorderRadius.circular(tokens.radii.xs),
-      ),
-    );
-    if (!newest) return box;
-    return AnimatedBuilder(
-      animation: _grow,
-      builder: (context, child) => Opacity(
-        opacity: _grow.value.clamp(0.0, 1.0),
-        // easeOutBack overshoots past full then settles — a little pop.
-        child: Transform.scale(
-          scale: Curves.easeOutBack.transform(_grow.value),
-          child: child,
-        ),
-      ),
-      child: box,
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    final gap = tokens.spacing.step1;
-
-    return Semantics(
-      label: context.messages.habitStreakDaysSemantic(widget.count),
-      child: ExcludeSemantics(
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            // Reserve room for the trailing flame + count, then fit as many
-            // boxes as the width allows (capped), newest kept.
-            const reserve = 48.0;
-            final avail = (constraints.maxWidth - reserve).clamp(
-              0.0,
-              double.infinity,
-            );
-            final fits = (avail / (_box + gap)).floor();
-            var shown = widget.count < _cap ? widget.count : _cap;
-            if (shown > fits) shown = fits < 0 ? 0 : fits;
-
-            return Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                for (var i = 0; i < shown; i++) ...[
-                  if (i > 0) SizedBox(width: gap),
-                  _boxWidget(context, newest: i == shown - 1),
-                ],
-                SizedBox(width: tokens.spacing.step2),
-                Icon(
-                  LottiIcons.streak,
-                  size: tokens.spacing.step5,
-                  color: tokens.colors.interactive.enabled,
-                ),
-                SizedBox(width: tokens.spacing.step1),
-                Text(
-                  '${widget.count}',
-                  style: tokens.typography.styles.body.bodySmall.copyWith(
-                    color: tokens.colors.text.highEmphasis,
-                    fontWeight: tokens.typography.weight.semiBold,
-                  ),
-                ),
-              ],
-            );
-          },
         ),
       ),
     );

--- a/lib/features/habits/ui/widgets/habit_completion_card.dart
+++ b/lib/features/habits/ui/widgets/habit_completion_card.dart
@@ -91,6 +91,7 @@ class _HabitCompletionCardState extends ConsumerState<HabitCompletionCard> {
     return HabitActionRow(
       habitId: habitDefinition.id,
       completedToday: completedToday,
+      currentStreak: _currentStreak(results),
       history: _historyMarks(results),
     );
   }
@@ -110,6 +111,24 @@ List<DayMark> _historyMarks(List<HabitResult> results) {
         isToday: result.dayString == today,
       ),
   ];
+}
+
+/// The current unbroken run of kept days at the end of [results]: today
+/// still open does not break it, any other non-success day does.
+int _currentStreak(List<HabitResult> results) {
+  var streak = 0;
+  var index = results.length - 1;
+  if (index >= 0 &&
+      results[index].completionType == HabitCompletionType.open &&
+      results[index].dayString == clock.now().ymd) {
+    index--;
+  }
+  while (index >= 0 &&
+      results[index].completionType == HabitCompletionType.success) {
+    streak++;
+    index--;
+  }
+  return streak;
 }
 
 /// The shared day-mark state a recorded habit outcome renders as.

--- a/lib/features/habits/ui/widgets/habit_completion_card.dart
+++ b/lib/features/habits/ui/widgets/habit_completion_card.dart
@@ -2,7 +2,6 @@ import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/features/goals/state/goal_habit_watchers.dart';
 import 'package:lotti/features/habits/state/habit_completion_controller.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_action_row.dart';
 import 'package:lotti/get_it.dart';
@@ -10,7 +9,6 @@ import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/utils/date_utils_extension.dart';
 import 'package:lotti/widgets/charts/habits/dashboard_habits_data.dart';
 import 'package:lotti/widgets/day_indicators/day_mark.dart';
-import 'package:lotti/widgets/day_indicators/day_mark_strip.dart';
 
 /// A habit row that carries its own per-day completion history strip — used by
 /// the dashboard habit chart, where seeing the chain over the dashboard's range
@@ -18,9 +16,9 @@ import 'package:lotti/widgets/day_indicators/day_mark_strip.dart';
 ///
 /// Wraps the shared [HabitActionRow] (swipe + quick-complete + dialog), adding
 /// the range-keyed [habitCompletionControllerProvider] watch that feeds the
-/// [_HistoryStrip] and derives the done-state from the latest in-range result.
-/// The habits tab does NOT use this card — it renders [HabitActionRow] directly
-/// (history lives in the consistency heatmap).
+/// row's history squares and derives the done-state from the latest in-range
+/// result. The habits tab does NOT use this card — it renders [HabitActionRow]
+/// directly with the week read off `HabitsState`.
 class HabitCompletionCard extends ConsumerStatefulWidget {
   const HabitCompletionCard({
     required this.habitId,
@@ -90,57 +88,28 @@ class _HabitCompletionCardState extends ConsumerState<HabitCompletionCard> {
           HabitCompletionType.skip,
         }.contains(results.last.completionType);
 
-    // A day the user judged in a watching goal's reflection wears that
-    // verdict here too: the strip shows the user's ruling, not only the
-    // measurement. Empty until the goals resolve, and empty for a habit no
-    // goal watches — the strip is complete either way.
-    final verdicts =
-        ref.watch(habitDayVerdictsProvider(habitDefinition.id)).value ??
-        const <DateTime, DayVerdict>{};
-
     return HabitActionRow(
       habitId: habitDefinition.id,
       completedToday: completedToday,
-      history: _HistoryStrip(results: results, verdictsByDay: verdicts),
+      history: _historyMarks(results),
     );
   }
 }
 
-/// The per-day completion history strip — a compact "don't break the chain"
-/// calendar drawn with the shared day-indicator cells, so a habit's chain here
-/// wears exactly the language a goal's habit dimension does: the success fill,
-/// the skip dash and missed cross as non-color cues, the dashed ring on today.
-///
-/// The strip is read-only: it's a glanceable record, not a control. Tapping
-/// anywhere on the row (or the complete button) opens the dialog, where any
-/// past day can be backfilled via the date field — so the strip needs no tiny,
-/// swipe-conflicting per-cell tap targets. A range longer than the width can
-/// hold pans, anchored on today, like every other day track.
-class _HistoryStrip extends StatelessWidget {
-  const _HistoryStrip({required this.results, this.verdictsByDay = const {}});
-
-  final List<HabitResult> results;
-
-  /// The user's verdicts on this habit's days, keyed by UTC day.
-  final Map<DateTime, DayVerdict> verdictsByDay;
-
-  @override
-  Widget build(BuildContext context) {
-    final today = clock.now().ymd;
-    return DayMarkStrip(
-      marks: [
-        for (final result in results)
-          if (DateTime.parse(result.dayString) case final day)
-            DayMark(
-              day: day,
-              state: habitCompletionDayMarkState(result.completionType),
-              verdict:
-                  verdictsByDay[DateTime.utc(day.year, day.month, day.day)],
-              isToday: result.dayString == today,
-            ),
-      ],
-    );
-  }
+/// The dashboard range as day marks, oldest first, for the row's history
+/// strip. The strip is read-only: tapping anywhere on the row (or the complete
+/// button) opens the dialog, where any past day can be backfilled via the date
+/// field, so the squares need no tiny, swipe-conflicting tap targets.
+List<DayMark> _historyMarks(List<HabitResult> results) {
+  final today = clock.now().ymd;
+  return [
+    for (final result in results)
+      DayMark(
+        day: DateTime.parse(result.dayString),
+        state: habitCompletionDayMarkState(result.completionType),
+        isToday: result.dayString == today,
+      ),
+  ];
 }
 
 /// The shared day-mark state a recorded habit outcome renders as.

--- a/lib/widgets/day_indicators/day_mark.dart
+++ b/lib/widgets/day_indicators/day_mark.dart
@@ -5,9 +5,10 @@ import 'package:flutter/foundation.dart';
 /// [full] means the requirement held as of that day; [partial] means the user
 /// did everything within their control (the routine was kept) while a window
 /// target was still building — rendered as a lighter wash of the same success
-/// hue. [skipped] and [missed] are recorded outcomes a habit day can carry:
-/// deciding a day was missed and never looking at it are different facts, so
-/// [missed] is never the neutral grey of [none].
+/// hue. [skipped] and [missed] are recorded outcomes a habit day can carry.
+/// A strip records what was KEPT, so they share the neutral fill of [none];
+/// the label and tooltip say which of the three a neutral square stands for
+/// (see `dayMarkStateLabel`).
 enum DayMarkState { none, partial, full, skipped, missed }
 
 /// How a day turned out, in the user's own judgement.

--- a/lib/widgets/day_indicators/day_mark.dart
+++ b/lib/widgets/day_indicators/day_mark.dart
@@ -26,7 +26,7 @@ enum DayVerdict { met, improving, mixed, missed }
 enum DayVerdictProvenance { ratedByUser, suggestedAndAccepted }
 
 /// One day on a day-indicator surface: the measured [state], the user's
-/// [verdict] where one was recorded, and whether the cell stands for today.
+/// [verdict] where one was recorded, and whether the day is still open.
 ///
 /// A recorded verdict outranks the measured state wherever both are shown. The
 /// measurement is evidence about a day; the reflection is the user's ruling on
@@ -50,7 +50,15 @@ class DayMark {
   final DayMarkState state;
   final DayVerdict? verdict;
   final DayVerdictProvenance? verdictProvenance;
+
+  /// Whether the mark stands for the current day. An empty today is drawn as
+  /// "not yet" — the dashed unresolved outline — rather than as the neutral
+  /// fill a past day nobody kept wears, so a streak that is alive does not
+  /// look broken at its last square.
   final bool isToday;
+
+  /// An empty current day: nothing recorded, nothing ruled, still open.
+  bool get pending => isToday && state == DayMarkState.none && verdict == null;
 
   /// Whether the day counts toward a "successful days" tally: a verdict of
   /// [DayVerdict.met] where one exists, otherwise any measured state that is

--- a/lib/widgets/day_indicators/day_mark_cell.dart
+++ b/lib/widgets/day_indicators/day_mark_cell.dart
@@ -6,64 +6,66 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/widgets/day_indicators/day_mark.dart';
 import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
 
-/// A not-yet-resolved day slot: same footprint as a real cell, dashed
-/// outline instead of a fill, so the silhouette holds without borrowing the
-/// empty-week encoding.
-class PlaceholderDayCell extends StatelessWidget {
-  const PlaceholderDayCell({this.size = IconSizes.xs, super.key});
+/// The edge of every day square: the handover's 11px square at the nearest
+/// icon size, one size everywhere it is drawn.
+const double kDaySquareSize = IconSizes.xs;
 
-  final double size;
+/// A not-yet-resolved day slot — a loading window, or today while it is
+/// still open: same footprint as a real square, dashed outline instead of a
+/// fill, so the silhouette holds without borrowing the empty-day encoding.
+class PlaceholderDayCell extends StatelessWidget {
+  const PlaceholderDayCell({super.key});
 
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    return Padding(
-      padding: EdgeInsets.all(tokens.spacing.step1),
-      child: DsDashedBorder(
-        color: tokens.colors.text.lowEmphasis,
-        radius: dayCellRadius(tokens),
-        child: SizedBox(width: size, height: size),
-      ),
+    return DsDashedBorder(
+      color: tokens.colors.text.lowEmphasis,
+      radius: tokens.radii.xs,
+      child: const SizedBox.square(dimension: kDaySquareSize),
     );
   }
 }
 
-/// One day square: the measured state's fill, the recorded verdict's fill and
-/// glyph where one outranks it, the partial dot or outcome glyph as the
-/// non-color cue, a corner weekday letter when nothing stronger claims the
-/// center, and the dashed ring on today.
+/// One day square, as the habits handover draws it: a small rounded square
+/// filled in the interactive hue when the day was kept and in the neutral
+/// level-03 surface otherwise — a recorded verdict paints its own hue, and an
+/// empty TODAY is the dashed unresolved outline, since the day is not over.
+/// Nothing is drawn inside a square and nothing around it; which day it is,
+/// what happened and what the user ruled are answered by the tooltip and the
+/// semantics, not by glyphs, corner letters or rings on a 12px cell.
 ///
 /// Read-only by default. With [onTap] the square keeps its size while the
-/// hit slot around it clears the touch floor, and the cell announces itself
-/// as a button with [label].
+/// hit slot around it clears the touch floor, the cell announces itself as a
+/// button with [label], and a [caption] letter names the weekday above it.
 class DayMarkCell extends StatelessWidget {
   const DayMarkCell({
     required this.mark,
-    this.size = IconSizes.xs,
     this.onTap,
+    this.caption,
     this.label,
     this.tooltipDay,
     this.tooltipOutcome,
-    this.weekdayLetter,
     super.key,
   });
 
   final DayMark mark;
-  final double size;
   final VoidCallback? onTap;
 
-  /// One-letter weekday initial nested in the cell, replacing the label row
-  /// that used to run above the strip. Null on strips without dates.
-  final String? weekdayLetter;
+  /// A one-letter weekday initial drawn above the square, inside the hit
+  /// slot, on a tappable cell only: an action has to say which day it acts
+  /// on before it is tapped. Ignored without [onTap] — a read-only strip is
+  /// the handover's bare row of squares.
+  final String? caption;
 
   /// Spoken name for a tappable cell. Null on a read-only strip, whose
   /// semantics are carried by the summary above it.
   final String? label;
 
-  /// The same fact split for the hover tooltip: the day names the subject,
-  /// the outcome describes it. A read-only cell still answers hover with
-  /// them — the corner letter cannot tell one Tuesday from the next, and the
-  /// tooltip is where a dated cell reveals which day it stands for.
+  /// The hover tooltip: the day names the subject, the outcome describes it.
+  /// A read-only cell still answers hover with them — the square cannot tell
+  /// one Tuesday from the next, and the tooltip is where a dated cell reveals
+  /// which day it stands for.
   final String? tooltipDay;
   final String? tooltipOutcome;
 
@@ -71,110 +73,35 @@ class DayMarkCell extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final verdict = mark.verdict;
-    final state = mark.state;
-    // The dot is the measured-partial cue; a recorded verdict wears its own
-    // glyph instead. Either way the cell says something a reader who cannot
-    // separate the hues can still act on.
-    final showsPartialDot = verdict == null && state == DayMarkState.partial;
-    final stateGlyph = verdict == null ? dayMarkStateGlyph(state) : null;
-    final Widget? centerMark = showsPartialDot
-        ? Center(
-            child: partialDayDot(
-              tokens,
-              // The dot has to stay legible inside the square it marks, so
-              // it scales with it rather than sitting at one fixed size.
-              size <= IconSizes.xs
-                  ? tokens.spacing.step1
-                  : tokens.spacing.step2,
+    final Widget cell = mark.pending
+        ? const PlaceholderDayCell()
+        : Container(
+            width: kDaySquareSize,
+            height: kDaySquareSize,
+            decoration: BoxDecoration(
+              color: verdict == null
+                  ? dayMarkStateFill(tokens, mark.state)
+                  : dayVerdictFill(tokens, verdict),
+              borderRadius: BorderRadius.circular(tokens.radii.xs),
             ),
-          )
-        : verdict != null
-        // The verdict's own shape at every size. Collapsing the three
-        // non-met verdicts into one dot on the list's 12px cells left
-        // Improving, Mixed and Missed distinguishable by hue alone —
-        // which is the one thing the shapes exist to avoid.
-        ? Center(
-            child: Icon(
-              dayVerdictGlyph(verdict),
-              size: dayMarkGlyphSize(size),
-              // The ink of the fill's OWN family. Painting every glyph in
-              // the success ink put a green tick's colour on a red missed
-              // cell and an orange mixed one.
-              color: dayVerdictInk(tokens, verdict),
-            ),
-          )
-        : stateGlyph != null
-        ? Center(
-            child: Icon(
-              stateGlyph,
-              size: dayMarkGlyphSize(size),
-              color: dayMarkStateGlyphInk(tokens, state),
-            ),
-          )
-        : null;
-    // The corner weekday tag renders only when the center is empty: at the
-    // compact cell size a glyph and a corner letter collide, and the glyph
-    // is the rarer, more meaningful mark — neighbouring plain cells keep
-    // carrying the axis.
-    final letterTag = centerMark != null
-        ? null
-        : dayCellLetter(
-            tokens,
-            letter: weekdayLetter,
-            cellSize: size,
-            filled: verdict != null || state == DayMarkState.full,
           );
-    final cell = Container(
-      width: size,
-      height: size,
-      decoration: BoxDecoration(
-        color: verdict == null
-            ? dayMarkStateFill(tokens, state)
-            : dayVerdictFill(tokens, verdict),
-        borderRadius: BorderRadius.circular(dayCellRadius(tokens)),
-      ),
-      child: centerMark == null && letterTag == null
-          ? null
-          : Stack(
-              children: [?centerMark, ?letterTag],
-            ),
-    );
-    // Every cell shares one outer footprint; today only adds the dashed
-    // ring inside it, so the strip's rhythm never bulges at the last cell.
-    final padded = Padding(
-      padding: EdgeInsets.all(tokens.spacing.step1),
-      child: cell,
-    );
-    final decorated = mark.isToday
-        ? DsDashedBorder(
-            color: todayRingInk(tokens),
-            strokeWidth: BorderWidths.emphasis,
-            radius: dayCellRadius(tokens),
-            child: padded,
-          )
-        : padded;
     final onTap = this.onTap;
     if (onTap == null) {
       final tooltipDay = this.tooltipDay;
-      if (tooltipDay == null) return decorated;
+      if (tooltipDay == null) return cell;
       return DsTooltip(
         title: tooltipDay,
         message: tooltipOutcome ?? '',
         preferBelow: false,
-        child: decorated,
+        child: cell,
       );
     }
     // The square keeps its size; the hit slot around it takes the full height
-    // of the touch floor and whatever width the row can spare. Growing the
-    // square itself to 48px would make the strip shout over the habit rows it
-    // is meant to summarise.
-    // No hover fill: the hit slot is far larger than the square it serves,
-    // so Material's overlay drew a phantom button bulging around the cell.
-    // The cell is a data readout — hover answers with the styled tooltip
-    // naming the day and its outcome, not with a fill on the data itself.
-    // `excludeSemantics` drops the ink well's own node, so the activation
-    // action has to be published here or the button a reader hears has
-    // nothing to activate.
+    // of the touch floor and whatever width the row can spare. No hover fill:
+    // the slot is far larger than the square it serves, and Material's
+    // overlay drew a phantom button bulging around the cell. Hover answers
+    // with the tooltip instead. `excludeSemantics` drops the ink well's own
+    // node, so the activation action is published here.
     return Semantics(
       label: label,
       button: true,
@@ -189,13 +116,32 @@ class DayMarkCell extends StatelessWidget {
           borderRadius: BorderRadius.circular(tokens.radii.s),
           focusRing: true,
           builder: (context, highlighted) => ConstrainedBox(
-            constraints: const BoxConstraints(
-              minHeight: TapTargets.minimum,
-            ),
-            child: Center(child: decorated),
+            constraints: const BoxConstraints(minHeight: TapTargets.minimum),
+            child: Center(child: dayCellWithCaption(tokens, cell, caption)),
           ),
         ),
       ),
     );
   }
+}
+
+/// A day square with its weekday initial above it — the layout every
+/// tappable day cell shares, whether it is a [DayMarkCell] or the goal
+/// card's own outcome-menu cell. Just the square when [caption] is null.
+Widget dayCellWithCaption(DsTokens tokens, Widget square, String? caption) {
+  if (caption == null) return square;
+  return Column(
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      Text(
+        caption,
+        maxLines: 1,
+        style: tokens.typography.styles.others.caption.copyWith(
+          color: tokens.colors.text.lowEmphasis,
+        ),
+      ),
+      SizedBox(height: tokens.spacing.step1),
+      square,
+    ],
+  );
 }

--- a/lib/widgets/day_indicators/day_mark_strip.dart
+++ b/lib/widgets/day_indicators/day_mark_strip.dart
@@ -8,14 +8,17 @@ import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
 import 'package:lotti/widgets/day_indicators/day_track.dart';
 import 'package:lotti/widgets/misc/linked_scroll_group.dart';
 
-/// A row of day cells — the seven-cell picture on each goal row, the
-/// completion chain on a dashboard habit card. It is intentionally unlabeled
-/// visually, but exposes one concise semantic summary; a tappable strip
-/// publishes each day as its own button as well.
+/// A row of day squares, as the habits handover draws it: one small square
+/// per day on the page's shared column pitch, and — for a habit with a run
+/// going — a flame and the streak count after the last square. The squares
+/// carry no labels of their own; each dated square names its day and outcome
+/// on hover and to a screen reader, and the strip publishes one concise
+/// summary. A tappable strip publishes each day as its own button as well.
 class DayMarkStrip extends StatelessWidget {
   const DayMarkStrip({
     required this.marks,
     this.placeholder = false,
+    this.streak,
     this.onDaySelected,
     this.scrollGroup,
     super.key,
@@ -33,6 +36,10 @@ class DayMarkStrip extends StatelessWidget {
   /// it.
   final bool placeholder;
 
+  /// The current unbroken run, shown as a flame and the count after the
+  /// squares. Null or zero draws no tail.
+  final int? streak;
+
   /// Opens the day's reflection. Null leaves the strip a read-only figure —
   /// which is what the list rows want, since a tap there navigates.
   final ValueChanged<DateTime>? onDaySelected;
@@ -43,12 +50,10 @@ class DayMarkStrip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // The full span, not a seven-day cap: on the detail page the strip
-    // follows the page's shared range like every other day track (the list
-    // rows keep passing seven-day windows).
-    if (marks.isEmpty) return const SizedBox.shrink();
-    // Only the extended span needs to know the width it has to fit into; the
-    // seven-cell list rows keep their authored pitch and their scale-down fit.
+    final streak = this.streak ?? 0;
+    if (marks.isEmpty && streak <= 0) return const SizedBox.shrink();
+    // Only a span longer than a week can outgrow its row; the seven-square
+    // list rows are narrower than any card and need no measuring.
     if (marks.length <= 7) return _build(context, availableWidth: null);
     return LayoutBuilder(
       builder: (context, constraints) => _build(
@@ -69,18 +74,12 @@ class DayMarkStrip extends StatelessWidget {
       onDaySelected == null || placeholder || dated,
       'A tappable strip needs dated marks to name the cell that was tapped.',
     );
-    final metrics = dayTrackMetrics(
-      context,
-      dayCount: marks.length,
-      availableWidth: availableWidth,
-    );
-    final resolvedCellSize = metrics.cellSize;
-
-    // One-letter weekday initials, nested inside the cells themselves — the
-    // separate label row above the strip spent a full row on what a letter
-    // per node now carries. Dateless strips render no letters.
-    final letterFormat = DateFormat.EEEEE(locale);
+    final metrics = dayTrackMetrics(context);
     final dayFormat = DateFormat.MMMEd(locale);
+    // A tappable square carries its weekday initial above it, inside the hit
+    // slot: the one surface where a square is an action is the one surface
+    // that has to say which day the action is for before it is tapped.
+    final letterFormat = DateFormat.EEEEE(locale);
 
     String outcomeOf(DayMark mark) => switch (mark.verdict) {
       final verdict? => dayVerdictLabel(context, verdict),
@@ -88,39 +87,27 @@ class DayMarkStrip extends StatelessWidget {
     };
 
     Widget cellAt(int index) {
-      if (placeholder) return PlaceholderDayCell(size: resolvedCellSize);
+      if (placeholder) return const PlaceholderDayCell();
       final mark = marks[index];
       final day = mark.day;
-      final letter = day == null ? null : letterFormat.format(day);
-      if (day == null) {
-        return DayMarkCell(
-          mark: mark,
-          size: resolvedCellSize,
-          weekdayLetter: letter,
-        );
-      }
+      if (day == null) return DayMarkCell(mark: mark);
       final dayName = dayFormat.format(day);
       final outcome = outcomeOf(mark);
       if (onDaySelected == null) {
-        // Read-only, but still dated: hover names the day and its outcome,
-        // because the corner letter cannot tell one Tuesday from the next.
         return DayMarkCell(
           mark: mark,
-          size: resolvedCellSize,
-          weekdayLetter: letter,
           tooltipDay: dayName,
           tooltipOutcome: outcome,
         );
       }
-      // Colour and an inner dot are the only thing separating these cells,
-      // and neither reaches a screen reader. Each day therefore announces its
-      // own state, not just its date — the strip's summary gives a count and
-      // cannot say WHICH days went well, which is exactly what a reader needs
-      // once every cell is individually actionable.
+      // Colour is the only thing separating these squares, and it does not
+      // reach a screen reader. Each day therefore announces its own state,
+      // not just its date — the strip's summary gives a count and cannot say
+      // WHICH days went well, which is exactly what a reader needs once
+      // every cell is individually actionable.
       return DayMarkCell(
         mark: mark,
-        size: resolvedCellSize,
-        weekdayLetter: letter,
+        caption: letterFormat.format(day),
         label: context.messages.goalProgressHabitDaySemantics(
           dayName,
           outcome,
@@ -131,31 +118,46 @@ class DayMarkStrip extends StatelessWidget {
       );
     }
 
-    // On the page's shared seven-column track when it carries dates, so the
-    // whole-goal week lines up column-for-column with the habit squares and
-    // the metric bars below it. Three grids for one week meant a reader
-    // could not follow a Wednesday down the page.
-    //
-    // The pitch is narrower than the 48px touch floor — seven of those do not
-    // fit a phone card — so, exactly as the habit cells already do, the slot
-    // takes the full pitch horizontally and clears the floor vertically.
-    final row = !dated
-        ? Row(
+    // The squares sit on the page's shared column track so the whole-goal
+    // week lines up column-for-column with the habit squares and the metric
+    // bars below it. The pitch is narrower than the touch floor — seven of
+    // those do not fit a phone card — so a tappable slot takes the full pitch
+    // horizontally and clears the floor vertically.
+    final squares = DayTrack(
+      height: onDaySelected == null ? kDaySquareSize : TapTargets.minimum,
+      pitch: metrics.pitch,
+      children: [
+        for (var index = 0; index < marks.length; index++) cellAt(index),
+      ],
+    );
+    final streak = this.streak ?? 0;
+    final row = streak <= 0
+        ? squares
+        : Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              for (var index = 0; index < marks.length; index++) ...[
-                if (index > 0) SizedBox(width: tokens.spacing.step1),
-                cellAt(index),
-              ],
-            ],
-          )
-        : DayTrack(
-            height: onDaySelected == null
-                ? resolvedCellSize + tokens.spacing.step2
-                : TapTargets.minimum,
-            pitch: metrics.pitch,
-            children: [
-              for (var index = 0; index < marks.length; index++) cellAt(index),
+              squares,
+              // Text-grade separation from the chain, so the flame reads as
+              // the count's icon rather than one more cell. Flame and count
+              // share the handover's medium-emphasis ink — the flame in the
+              // kept hue read as one more kept day — and the flame sits at
+              // the square's own size so square, glyph and numeral share one
+              // optical line. The count is the one fact the strip states in
+              // words, so it takes the handover's 13px tier at the nearest
+              // token, not the caption size of the annotations around it.
+              SizedBox(width: tokens.spacing.step2),
+              Icon(
+                LottiIcons.streak,
+                size: kDaySquareSize,
+                color: tokens.colors.text.mediumEmphasis,
+              ),
+              SizedBox(width: tokens.spacing.step1),
+              Text(
+                '$streak',
+                style: tokens.typography.styles.body.bodySmall.copyWith(
+                  color: tokens.colors.text.mediumEmphasis,
+                ),
+              ),
             ],
           );
 
@@ -171,61 +173,38 @@ class DayMarkStrip extends StatelessWidget {
               dayVerdictLabel(context, verdict),
             ),
     ].join(', ');
-
-    return Semantics(
-      label: placeholder
-          ? context.messages.goalProgressStripLoading
-          : [
-              // Counted with the verdicts applied. Taken from the measured
+    final summary = placeholder
+        ? context.messages.goalProgressStripLoading
+        : [
+            if (streak > 0)
+              context.messages.habitStreakDaysSemantic(streak)
+            else
+              // Counted with the verdicts applied: taken from the measured
               // states alone, the strip could announce "1 successful day"
-              // and name that same date as Missed in the next breath, while
-              // the cell itself correctly showed the verdict.
+              // and name that same date as Missed in the next breath.
               context.messages.goalProgressCompactSemantics(
                 marks.where((mark) => mark.successful).length,
               ),
-              if (verdictSummary.isNotEmpty) verdictSummary,
-            ].join('. '),
-      // A tappable strip publishes each day as its own button, so the summary
-      // above becomes the container's label rather than the whole story.
-      // The scale-down FittedBox is the overflow bound: the track (and the
-      // dateless placeholder Row) size themselves to `pitch * days`, and on
-      // a 320px phone a list row's column is a few pixels narrower than
-      // seven full-size cells. Everywhere with room, the fit is identity.
-      // An extended span goes through the page's shared fit-or-scroll policy
-      // instead — by WIDTH, like every other track. Wrapping it by day count
-      // put a span that fits into a trailing-anchored scroller, which is what
-      // opened it with its first days cut off the left edge.
-      child: availableWidth != null
-          ? fitOrScrollDayTrack(
-              // The dateless Row is not on the track: each cell carries its
-              // own step1 padding and the cells are separated by step1, so
-              // its width has to be measured from that geometry or a span
-              // that "fits" overflows the card by a gap per cell.
-              contentWidth: dated
-                  ? metrics.pitch * marks.length
-                  : marks.length *
-                            (resolvedCellSize + 2 * tokens.spacing.step1) +
-                        (marks.length - 1) * tokens.spacing.step1,
-              availableWidth: availableWidth,
-              group: scrollGroup,
-              child: row,
-            )
-          : onDaySelected == null
-          ? ExcludeSemantics(
-              child: FittedBox(
-                fit: BoxFit.scaleDown,
-                alignment: AlignmentDirectional.centerStart,
-                child: row,
-              ),
-            )
-          : Align(
-              alignment: AlignmentDirectional.centerStart,
-              child: FittedBox(
-                fit: BoxFit.scaleDown,
-                alignment: AlignmentDirectional.centerStart,
-                child: row,
-              ),
-            ),
+            if (verdictSummary.isNotEmpty) verdictSummary,
+          ].join('. ');
+
+    // An extended span goes through the page's shared fit-or-scroll policy —
+    // by WIDTH, like every other track. Wrapping it by day count put a span
+    // that fits into a trailing-anchored scroller, which is what opened it
+    // with its first days cut off the left edge. A tappable strip publishes
+    // each day as its own button, so the summary becomes the container's
+    // label rather than the whole story.
+    final content = availableWidth == null
+        ? Align(alignment: AlignmentDirectional.centerStart, child: row)
+        : fitOrScrollDayTrack(
+            contentWidth: metrics.pitch * marks.length,
+            availableWidth: availableWidth,
+            group: scrollGroup,
+            child: row,
+          );
+    return Semantics(
+      label: summary,
+      child: onDaySelected == null ? ExcludeSemantics(child: content) : content,
     );
   }
 }

--- a/lib/widgets/day_indicators/day_mark_strip.dart
+++ b/lib/widgets/day_indicators/day_mark_strip.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -52,9 +54,8 @@ class DayMarkStrip extends StatelessWidget {
   Widget build(BuildContext context) {
     final streak = this.streak ?? 0;
     if (marks.isEmpty && streak <= 0) return const SizedBox.shrink();
-    // Only a span longer than a week can outgrow its row; the seven-square
-    // list rows are narrower than any card and need no measuring.
-    if (marks.length <= 7) return _build(context, availableWidth: null);
+    // Always measured: even a seven-square row outgrows a phone card once a
+    // raised text scale widens the shared pitch for the weekday captions.
     return LayoutBuilder(
       builder: (context, constraints) => _build(
         context,
@@ -131,12 +132,32 @@ class DayMarkStrip extends StatelessWidget {
       ],
     );
     final streak = this.streak ?? 0;
-    final row = streak <= 0
+    final countStyle = tokens.typography.styles.body.bodySmall.copyWith(
+      color: tokens.colors.text.mediumEmphasis,
+    );
+    // The tail never scrolls away with the squares: the count is the one
+    // fact the strip states in words, so the squares fit or pan in whatever
+    // width is left beside it.
+    final tailWidth = streak <= 0
+        ? 0.0
+        : tokens.spacing.step2 +
+              kDaySquareSize +
+              tokens.spacing.step1 +
+              _textWidth(context, '$streak', countStyle);
+    final fitted = availableWidth == null
         ? squares
+        : fitOrScrollDayTrack(
+            contentWidth: metrics.pitch * marks.length,
+            availableWidth: math.max(0, availableWidth - tailWidth),
+            group: scrollGroup,
+            child: squares,
+          );
+    final row = streak <= 0
+        ? fitted
         : Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              squares,
+              Flexible(child: fitted),
               // Text-grade separation from the chain, so the flame reads as
               // the count's icon rather than one more cell. Flame and count
               // share the handover's medium-emphasis ink — the flame in the
@@ -152,12 +173,7 @@ class DayMarkStrip extends StatelessWidget {
                 color: tokens.colors.text.mediumEmphasis,
               ),
               SizedBox(width: tokens.spacing.step1),
-              Text(
-                '$streak',
-                style: tokens.typography.styles.body.bodySmall.copyWith(
-                  color: tokens.colors.text.mediumEmphasis,
-                ),
-              ),
+              Text('$streak', style: countStyle),
             ],
           );
 
@@ -194,17 +210,21 @@ class DayMarkStrip extends StatelessWidget {
     // with its first days cut off the left edge. A tappable strip publishes
     // each day as its own button, so the summary becomes the container's
     // label rather than the whole story.
-    final content = availableWidth == null
-        ? Align(alignment: AlignmentDirectional.centerStart, child: row)
-        : fitOrScrollDayTrack(
-            contentWidth: metrics.pitch * marks.length,
-            availableWidth: availableWidth,
-            group: scrollGroup,
-            child: row,
-          );
+    final content = Align(
+      alignment: AlignmentDirectional.centerStart,
+      child: row,
+    );
     return Semantics(
       label: summary,
       child: onDaySelected == null ? ExcludeSemantics(child: content) : content,
     );
   }
 }
+
+double _textWidth(BuildContext context, String text, TextStyle style) =>
+    (TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+      maxLines: 1,
+    )..layout()).width;

--- a/lib/widgets/day_indicators/day_mark_styles.dart
+++ b/lib/widgets/day_indicators/day_mark_styles.dart
@@ -3,81 +3,23 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/day_indicators/day_mark.dart';
 
-/// The corner radius every day cell shares.
-///
-/// The whole-goal strip once drew its squares at `radii.xs` while the habit
-/// squares — the identical footprint, one card below — drew theirs at
-/// `radii.s`. Same instrument, same week, two shapes.
-double dayCellRadius(DsTokens tokens) => tokens.radii.s;
-
-/// Where the weekday initial sits inside a day cell, and how big it gets.
-///
-/// Deliberately NOT an extension on `DsTokens`. Hanging these off the token
-/// object put feature-specific geometry into the canonical token API, where
-/// every caller in the app would see `tokens.letterInsetStart` offered
-/// alongside real exported tokens — which is a bigger claim than "these
-/// three numbers live in one place" was ever meant to make.
-///
-/// Proportions of the cell rather than absolute lengths: the cell itself is
-/// sized by `dayTrackMetrics` from the available width, so a fixed inset that
-/// looked right on a fortnight track would crowd the corner on a ninety-day
-/// one. They are geometry, not spacing — there is no design-system token for
-/// "a fraction of a cell" — so they live here, named and in ONE place, rather
-/// than as bare numbers inside the widget.
-///
-/// [DayCellLetter.scaleBox] is a ceiling, not a size: the rendered letter is
-/// `min(fontSize, cellSize * scaleBox)`, because the glyph is fitted with
-/// [BoxFit.scaleDown] and that never scales UP. The box therefore governs
-/// small cells while the style's own size caps large ones.
-abstract final class DayCellLetter {
-  /// Inset from the cell's leading edge.
-  static const double insetStart = 0.18;
-
-  /// Inset from the cell's bottom edge.
-  static const double insetBottom = 0.14;
-
-  /// Ceiling on the letter's height, as a fraction of the cell.
-  static const double scaleBox = 0.38;
-}
-
-/// Shared fill for a measured day: the full-strength success hue when the
-/// requirement held as of that day, a lighter wash of the same hue for a
-/// partial success (routine kept, target still building), the error hue for a
-/// recorded miss, neutral for a skip or an empty day. `SurfaceAlphas.muted`
-/// is the sanctioned "reduced-strength accent" alpha, so no new color token
-/// is introduced. Data-that-happened wears the `alert` families; the
-/// interactive teal stays strictly for things the user can tap.
+/// Shared fill for a measured day: the interactive hue when the day was
+/// kept — the handover's `--interactive` square — a wash of it for a partial
+/// success (routine kept, target still building), and the neutral level-03
+/// surface for anything else. A skipped or missed day is not painted in an
+/// alert hue: the strip is a record of what was kept, and the tooltip and
+/// semantics say which of the other three the grey stands for.
+/// `SurfaceAlphas.muted` is the sanctioned "reduced-strength accent" alpha, so
+/// no new color token is introduced.
 Color dayMarkStateFill(DsTokens tokens, DayMarkState state) => switch (state) {
-  DayMarkState.full => tokens.colors.alert.success.defaultColor,
-  DayMarkState.partial => tokens.colors.alert.success.defaultColor.withValues(
+  DayMarkState.full => tokens.colors.interactive.enabled,
+  DayMarkState.partial => tokens.colors.interactive.enabled.withValues(
     alpha: SurfaceAlphas.muted,
   ),
-  DayMarkState.missed => tokens.colors.alert.error.defaultColor,
-  DayMarkState.none || DayMarkState.skipped => tokens.colors.background.level03,
+  DayMarkState.none ||
+  DayMarkState.skipped ||
+  DayMarkState.missed => tokens.colors.background.level03,
 };
-
-/// The non-color cue a recorded outcome carries: a cross for a miss, a dash
-/// for a skip. Null for the states whose cue is the fill (or the partial dot).
-IconData? dayMarkStateGlyph(DayMarkState state) => switch (state) {
-  DayMarkState.missed => LottiIcons.close,
-  DayMarkState.skipped => LottiIcons.remove,
-  DayMarkState.none || DayMarkState.partial || DayMarkState.full => null,
-};
-
-/// The ink a state glyph is drawn in, on top of that state's own fill.
-///
-/// The missed cross sits on the saturated error fill, so it takes the
-/// design system's on-alert ink — the family's own `ink` is tuned for a
-/// neutral surface and all but vanishes on its own hue. The skip dash sits
-/// on a neutral fill and keeps the medium-emphasis text ink.
-Color dayMarkStateGlyphInk(DsTokens tokens, DayMarkState state) =>
-    switch (state) {
-      DayMarkState.missed => tokens.colors.text.onInteractiveAlert,
-      DayMarkState.none ||
-      DayMarkState.partial ||
-      DayMarkState.full ||
-      DayMarkState.skipped => tokens.colors.text.mediumEmphasis,
-    };
 
 /// The localized name of a measured state, shared by every day cell's
 /// semantics and tooltip so a "done" day is called the same thing everywhere.
@@ -94,40 +36,30 @@ String dayMarkStateLabel(BuildContext context, DayMarkState state) =>
 /// measured: a reflection is a statement about the day, and the measurement is
 /// only evidence toward one.
 ///
-/// Four distinct hues, all existing alert tokens, and the same three the
-/// reflections-history pill has always used — extended with the blue a
-/// restarting agent wears for [DayVerdict.improving], which is progress that
-/// is not yet arrival. Sharing one scheme is the point: the strip and the
-/// history are two views of the same verdict, and a day filed as missed must
-/// not be grey in one place and red in another.
+/// A day judged met wears the same interactive hue a measured kept day
+/// wears — one green for "good" on every track, so a card that mixes judged
+/// and measured days is a baseline plus judgements, not two greens. The
+/// three other verdicts take the alert families the reflections history has
+/// always used, extended with the blue a restarting agent wears for
+/// [DayVerdict.improving], which is progress that is not yet arrival. Sharing
+/// one scheme is the point: the strip and the history are two views of the
+/// same verdict, and a day filed as missed must not be grey in one place and
+/// red in another.
 ///
 /// Notably [DayVerdict.missed] is not the neutral grey a day with no data
 /// wears. Deciding a day was missed and never looking at it are different
 /// facts, and the strip has to be able to say which.
 Color dayVerdictFill(DsTokens tokens, DayVerdict verdict) => switch (verdict) {
-  DayVerdict.met => tokens.colors.alert.success.defaultColor,
+  DayVerdict.met => tokens.colors.interactive.enabled,
   DayVerdict.improving => tokens.colors.alert.info.defaultColor,
   DayVerdict.mixed => tokens.colors.alert.warning.defaultColor,
   DayVerdict.missed => tokens.colors.alert.error.defaultColor,
 };
 
-/// The ink a verdict glyph is drawn in, on top of that verdict's own fill.
-///
-/// One high-contrast ink for every verdict rather than each family's own:
-/// the families' inks are tuned to sit on a NEUTRAL surface, so a success ink
-/// on a success fill is green on green and the glyph all but disappears —
-/// which defeats the point of having a shape at all, since the shape exists
-/// for readers who cannot separate the hues. `onInteractiveAlert` is the
-/// design system's ink for exactly this: text over a saturated alert fill.
-Color dayVerdictInk(DsTokens tokens, DayVerdict verdict) =>
-    tokens.colors.text.onInteractiveAlert;
-
 /// The verdict's ink for a glyph drawn on an ordinary card surface.
 ///
-/// Distinct from [dayVerdictInk], which is for a glyph sitting on that
-/// verdict's own saturated fill. Using the on-alert ink here paints
-/// near-background on background; using this one on a fill would be its own
-/// hue on itself.
+/// The family's own ink, tuned for a neutral surface — not the on-alert ink,
+/// which would paint near-background on background.
 Color dayVerdictSurfaceInk(DsTokens tokens, DayVerdict verdict) =>
     switch (verdict) {
       DayVerdict.met => tokens.colors.alert.success.ink,
@@ -138,11 +70,11 @@ Color dayVerdictSurfaceInk(DsTokens tokens, DayVerdict verdict) =>
 
 /// The glyph that names a recorded verdict without relying on its hue.
 ///
-/// Four fills that differ only by colour are four fills a red-green colour
-/// deficiency cannot tell apart, and the strip's whole job is to be read at a
-/// glance. Each verdict therefore carries a shape as well: a tick for met, a
-/// rising arrow for improving, a half-filled circle for mixed, a cross for
-/// missed.
+/// The reflections history and the reflect button name a verdict by shape as
+/// well as hue: a tick for met, a rising arrow for improving, a half-filled
+/// circle for mixed, a cross for missed. The day squares themselves carry no
+/// glyph — at 12px there is no room for one — and say the verdict in their
+/// tooltip and semantics instead.
 IconData dayVerdictGlyph(DayVerdict verdict) => switch (verdict) {
   DayVerdict.met => LottiIcons.confirm,
   DayVerdict.improving => LottiIcons.trendingUp,
@@ -159,92 +91,3 @@ String dayVerdictLabel(BuildContext context, DayVerdict verdict) =>
       DayVerdict.mixed => context.messages.goalAssessmentMixed,
       DayVerdict.missed => context.messages.goalAssessmentMissed,
     };
-
-/// The weekday's one-letter initial, tucked into the bottom-left corner of
-/// its own day cell.
-///
-/// Replaces the separate label row that used to run above every track: one
-/// letter per node keeps the weekday axis without spending a full row on it.
-/// A quiet corner tag rather than a centered label. It yields entirely to
-/// the marks that outrank it — a verdict glyph, the partial dot, the missed
-/// cross — because at the compact cell size a corner letter and a center
-/// glyph collide; the rarer mark wins and neighbouring plain cells keep
-/// carrying the axis. Scaled down with the cell (never up past the
-/// `bodySmall` size), and null when the cell is too small to hold a legible
-/// letter — a squeezed ninety-day track drops the letters rather than
-/// painting mush.
-///
-/// Ink follows the fill so the letter stays readable on both states: the
-/// on-alert ink over a saturated fill, medium emphasis over the neutral and
-/// washed fills. Returns a [PositionedDirectional]; the cell hosts it in a
-/// [Stack].
-Widget? dayCellLetter(
-  DsTokens tokens, {
-  required String? letter,
-  required double cellSize,
-  required bool filled,
-}) {
-  if (letter == null || cellSize < IconSizes.l) return null;
-  return PositionedDirectional(
-    // Off the corner, not in it. The letter reads better with a little air
-    // under and behind it than pinned to the rounded rect's inner angle —
-    // but it stays an annotation, so it moves TOWARD the center rather than
-    // to it.
-    start: cellSize * DayCellLetter.insetStart,
-    bottom: cellSize * DayCellLetter.insetBottom,
-    child: SizedBox(
-      // The scale bound: the glyph shrinks into this box, so the letter
-      // stays a small corner annotation at every cell size instead of
-      // competing with the mark in the center. The effective size is
-      // `min(fontSize, this height)` — `scaleDown` never scales UP — so
-      // raising the letter one step means raising BOTH: the box governs the
-      // small cells, the style's own size caps the large ones.
-      height: cellSize * DayCellLetter.scaleBox,
-      child: FittedBox(
-        fit: BoxFit.scaleDown,
-        child: Text(
-          letter,
-          maxLines: 1,
-          // One step up the type scale from caption (12 → 14), so a cell
-          // roomy enough to show the letter at full size shows it a step
-          // larger too.
-          style: tokens.typography.styles.body.bodySmall.copyWith(
-            color: filled
-                ? tokens.colors.text.onInteractiveAlert
-                : tokens.colors.text.mediumEmphasis,
-            height: 1,
-          ),
-        ),
-      ),
-    ),
-  );
-}
-
-/// The glyph inside a day square, as a fraction of the square: large enough
-/// to read as a shape, small enough to leave the fill visible around it. One
-/// rule for the cells and for the legend swatches that key them, so the key
-/// cannot drift from the map.
-double dayMarkGlyphSize(double cellSize) => cellSize * 0.75;
-
-/// The ink the "today" ring is drawn in, on every surface that draws one —
-/// the habit day cells, the whole-goal strip and the legend swatch that keys
-/// them.
-///
-/// Medium emphasis rather than low: at `radii.xs` on a dark surface a
-/// hairline in the low-emphasis ink is a rumour, not a ring. It still has to
-/// stay quieter than a day's own fill, which is the thing the cell is
-/// actually reporting — so it lifts one step and takes the emphasis stroke,
-/// rather than becoming an accent.
-Color todayRingInk(DsTokens tokens) => tokens.colors.text.mediumEmphasis;
-
-/// The non-color cue for a partial day: a full-strength dot inside the
-/// lighter wash, so full/partial/none survive without a legend (the list
-/// rows carry none) and for color-blind readers.
-Widget partialDayDot(DsTokens tokens, double diameter) => Container(
-  width: diameter,
-  height: diameter,
-  decoration: BoxDecoration(
-    shape: BoxShape.circle,
-    color: tokens.colors.alert.success.ink,
-  ),
-);

--- a/lib/widgets/day_indicators/day_track.dart
+++ b/lib/widgets/day_indicators/day_track.dart
@@ -3,17 +3,17 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_cell.dart';
 import 'package:lotti/widgets/misc/linked_scroll_group.dart';
 
-/// The geometry one day track draws on: the column pitch, the square inside
-/// each column, whether the weekday captions still fit at full length, and
-/// how tall a caption row has to be.
+/// The geometry one day track draws on: the column pitch, whether the weekday
+/// captions still fit at full length, and how tall a caption row has to be.
+/// The square inside each column is always [kDaySquareSize].
 ///
 /// The caption height rides along so a caption track does not re-measure
 /// the same seven strings the pitch was already derived from.
 typedef DayTrackMetrics = ({
   double pitch,
-  double cellSize,
   bool narrowLabels,
   double labelHeight,
 });
@@ -48,12 +48,9 @@ typedef DayTrackMetrics = ({
   return (width: width, height: height);
 }
 
-/// The narrowest column a day is still legible in — a 12px square with a
-/// hairline of air either side. Below this a track scrolls instead of
-/// shrinking further.
-double _minimumDayPitch(DsTokens tokens) => IconSizes.xs + tokens.spacing.step2;
-
-/// The column pitch every day row on a page shares.
+/// The column pitch every day row on a page shares: one day square and
+/// `step2` of air — the handover's 3px gap on an 11px square, at the nearest
+/// tokens.
 ///
 /// One pitch, one origin, one width: the whole-goal verdict strip, the habit
 /// squares and the metric bars all draw the SAME week, and drawn on three
@@ -61,51 +58,26 @@ double _minimumDayPitch(DsTokens tokens) => IconSizes.xs + tokens.spacing.step2;
 /// scroll. A reader cannot follow a day across the page unless the columns
 /// line up.
 ///
-/// Wide enough for the weekday label at raised text scales, which is what
-/// makes the axis readable rather than merely aligned — and, when
-/// [availableWidth] is known, narrow enough that a span longer than a week
-/// still FITS. A fourteen-day track at the authored pitch is wider than a
-/// phone card, and the trailing-edge scroller that resulted opened with the
-/// first days of the span cut in half off the left edge.
-DayTrackMetrics dayTrackMetrics(
-  BuildContext context, {
-  required int dayCount,
-  double? availableWidth,
-}) {
+/// The square never changes size — the handover draws one square — so a span
+/// that does not fit its width scrolls (see [fitOrScrollDayTrack]) rather
+/// than shrinking. At raised text scales the pitch widens to hold the weekday
+/// caption, which is what keeps the axis readable rather than merely aligned.
+DayTrackMetrics dayTrackMetrics(BuildContext context) {
   final tokens = context.designTokens;
-  final defaultPitch = ControlSizes.iconChipCompact + tokens.spacing.step2;
+  final defaultPitch = kDaySquareSize + tokens.spacing.step2;
   final label = _weekdayLabelMetrics(context);
   final labelWidth = label.width;
-  final expandedPitch = labelWidth + tokens.spacing.step1;
+  final expandedPitch = labelWidth + tokens.spacing.step2;
   final textScaledUp = MediaQuery.textScalerOf(context).scale(1) > 1;
-  var pitch = textScaledUp && expandedPitch > defaultPitch
+  final pitch = textScaledUp && expandedPitch > defaultPitch
       ? expandedPitch
       : defaultPitch;
-  if (availableWidth != null && availableWidth > 0 && dayCount > 0) {
-    // Floored, so `pitch * days` can never round up past the width it was
-    // derived from and reintroduce a one-pixel scroller.
-    final fitted = (availableWidth / dayCount).floorToDouble();
-    if (fitted < pitch) {
-      pitch = math.max(fitted, _minimumDayPitch(tokens));
-    }
-  }
   return (
     pitch: pitch,
     labelHeight: math.max(IconSizes.s, label.height),
-    // The square shrinks with its column, or neighbouring cells would touch
-    // and the track would read as one bar — but it never GROWS past the
-    // authored chip size: spreading the span means wider gutters between
-    // same-sized nodes, not inflated squares.
-    cellSize: math.min(
-      ControlSizes.iconChipCompact,
-      math.max(IconSizes.xs, pitch - tokens.spacing.step2),
-    ),
-    // "Mon" needs its own width; a SQUEEZED column takes the one-letter form
-    // rather than letting neighbouring captions overlap into mush. Only a
-    // squeezed one: at the authored pitch the captions are centered and
-    // overhang their cell into the gap by design, which is the established
-    // rendering and stays untouched.
-    narrowLabels: pitch < defaultPitch && pitch < labelWidth,
+    // "Mon" does not fit a 16px column; the captions take the one-letter
+    // form unless the pitch has been widened past the full caption.
+    narrowLabels: pitch < labelWidth,
   );
 }
 

--- a/test/features/goals/state/goal_habit_watchers_test.dart
+++ b/test/features/goals/state/goal_habit_watchers_test.dart
@@ -7,11 +7,8 @@ import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
-import 'package:lotti/features/goals/model/goal_assessment.dart';
 import 'package:lotti/features/goals/state/goal_agent_providers.dart';
-import 'package:lotti/features/goals/state/goal_assessment_state.dart';
 import 'package:lotti/features/goals/state/goal_habit_watchers.dart';
-import 'package:lotti/widgets/day_indicators/day_mark.dart';
 
 void main() {
   const window = GoalWindow.rollingDays(count: 7);
@@ -78,26 +75,9 @@ void main() {
     buffer: null,
   );
 
-  GoalAssessmentRecord record({
-    required String id,
-    required String specVersionId,
-    required DateTime day,
-    required DateTime createdAt,
-    Map<String, DayVerdict> dimensions = const {},
-  }) => GoalAssessmentRecord(
-    id: id,
-    day: day,
-    specVersionId: specVersionId,
-    rating: DayVerdict.mixed,
-    createdAt: createdAt,
-    provenance: DayVerdictProvenance.ratedByUser,
-    dimensionRatings: dimensions,
-  );
-
   ProviderContainer container({
     required List<AgentIdentityEntity> agents,
     required Map<String, GoalSpecVersionEntity?> specs,
-    Map<String, List<GoalAssessmentRecord>> history = const {},
   }) {
     final c = ProviderContainer(
       overrides: [
@@ -106,10 +86,6 @@ void main() {
           goalAgentHealthProvider(
             entry.key,
           ).overrideWith((ref) async => health(entry.value)),
-        for (final id in specs.keys)
-          goalAssessmentHistoryProvider(
-            id,
-          ).overrideWith((ref) async => history[id] ?? const []),
       ],
     );
     addTearDown(c.dispose);
@@ -200,138 +176,5 @@ void main() {
       final watchers = await c.read(goalsWatchingHabitProvider('floss').future);
       expect(watchers.map((w) => w.identity.agentId), ['g2']);
     });
-  });
-
-  group('habitDayVerdictsProvider', () {
-    final day = DateTime.utc(2026, 8, 10);
-
-    test('a habit no goal watches has no verdicts', () async {
-      final c = container(
-        agents: [identity('g1')],
-        specs: {'g1': spec('g1', walking)},
-      );
-      expect(await c.read(habitDayVerdictsProvider('floss').future), isEmpty);
-    });
-
-    test('reads the habit dimension out of the latest record per day, '
-        'scoped to the spec in force', () async {
-      final c = container(
-        agents: [identity('g1')],
-        specs: {'g1': spec('g1', flossing)},
-        history: {
-          'g1': [
-            record(
-              id: 'old',
-              specVersionId: 'g1:spec',
-              day: day,
-              createdAt: DateTime(2026, 8, 10, 20),
-              dimensions: {'c-floss': DayVerdict.missed},
-            ),
-            record(
-              id: 'revised',
-              specVersionId: 'g1:spec',
-              day: day,
-              createdAt: DateTime(2026, 8, 10, 21),
-              dimensions: {'c-floss': DayVerdict.improving},
-            ),
-            record(
-              id: 'retired-spec',
-              specVersionId: 'g1:spec-v0',
-              day: day.subtract(const Duration(days: 1)),
-              createdAt: DateTime(2026, 8, 9, 21),
-              dimensions: {'c-floss': DayVerdict.met},
-            ),
-            record(
-              id: 'untouched-row',
-              specVersionId: 'g1:spec',
-              day: day.subtract(const Duration(days: 2)),
-              createdAt: DateTime(2026, 8, 8, 21),
-            ),
-          ],
-        },
-      );
-      expect(await c.read(habitDayVerdictsProvider('floss').future), {
-        day: DayVerdict.improving,
-      });
-    });
-
-    test('equal timestamps across goals break by record id, whichever goal '
-        'is iterated first', () async {
-      for (final order in [
-        ['g1', 'g2'],
-        ['g2', 'g1'],
-      ]) {
-        final c = container(
-          agents: [for (final id in order) identity(id)],
-          specs: {'g1': spec('g1', flossing), 'g2': spec('g2', flossing)},
-          history: {
-            'g1': [
-              record(
-                id: 'a-lower',
-                specVersionId: 'g1:spec',
-                day: day,
-                createdAt: DateTime(2026, 8, 10, 21),
-                dimensions: {'c-floss': DayVerdict.missed},
-              ),
-            ],
-            'g2': [
-              record(
-                id: 'b-higher',
-                specVersionId: 'g2:spec',
-                day: day,
-                createdAt: DateTime(2026, 8, 10, 21),
-                dimensions: {'c-floss': DayVerdict.met},
-              ),
-            ],
-          },
-        );
-        expect(
-          await c.read(habitDayVerdictsProvider('floss').future),
-          {day: DayVerdict.met},
-          reason: 'order $order',
-        );
-      }
-    });
-
-    test(
-      'across two watching goals the most recent judgement of a day wins',
-      () async {
-        final c = container(
-          agents: [identity('g1'), identity('g2')],
-          specs: {'g1': spec('g1', flossing), 'g2': spec('g2', flossing)},
-          history: {
-            'g1': [
-              record(
-                id: 'g1-day',
-                specVersionId: 'g1:spec',
-                day: day,
-                createdAt: DateTime(2026, 8, 10, 22),
-                dimensions: {'c-floss': DayVerdict.met},
-              ),
-              record(
-                id: 'g1-earlier-day',
-                specVersionId: 'g1:spec',
-                day: day.subtract(const Duration(days: 1)),
-                createdAt: DateTime(2026, 8, 9, 22),
-                dimensions: {'c-floss': DayVerdict.mixed},
-              ),
-            ],
-            'g2': [
-              record(
-                id: 'g2-day',
-                specVersionId: 'g2:spec',
-                day: day,
-                createdAt: DateTime(2026, 8, 10, 21),
-                dimensions: {'c-floss': DayVerdict.missed},
-              ),
-            ],
-          },
-        );
-        expect(await c.read(habitDayVerdictsProvider('floss').future), {
-          day: DayVerdict.met,
-          day.subtract(const Duration(days: 1)): DayVerdict.mixed,
-        });
-      },
-    );
   });
 }

--- a/test/features/goals/ui/goal_day_marks_test.dart
+++ b/test/features/goals/ui/goal_day_marks_test.dart
@@ -24,7 +24,6 @@ void main() {
       DayMarkState.partial,
       DayMarkState.full,
     ]);
-    expect(marks.map((m) => m.isToday), [false, false, true]);
   });
 
   test('verdicts line up by UTC day even when the last day is local', () {
@@ -52,7 +51,6 @@ void main() {
     );
     expect(marks.every((m) => m.day == null), isTrue);
     expect(marks.every((m) => m.verdict == null), isTrue);
-    expect(marks.last.isToday, isTrue);
   });
 
   test('an empty window yields no marks', () {

--- a/test/features/goals/ui/goal_progress_card_test.dart
+++ b/test/features/goals/ui/goal_progress_card_test.dart
@@ -20,6 +20,7 @@ import 'package:lotti/features/design_system/components/callouts/design_system_i
 import 'package:lotti/features/design_system/components/cards/design_system_section_card.dart';
 import 'package:lotti/features/design_system/components/context_menus/design_system_context_menu.dart';
 import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
+import 'package:lotti/features/design_system/components/tooltips/ds_tooltip.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
 import 'package:lotti/features/goals/model/goal_assessment.dart';
@@ -28,6 +29,7 @@ import 'package:lotti/features/goals/state/goal_progress_view.dart';
 import 'package:lotti/features/goals/ui/goal_progress_card.dart';
 import 'package:lotti/l10n/app_localizations.dart';
 import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_cell.dart';
 import 'package:lotti/widgets/day_indicators/day_mark_strip.dart';
 import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
 import 'package:lotti/widgets/day_indicators/day_track.dart';
@@ -37,10 +39,12 @@ import '../../../widget_test_utils.dart';
 
 void main() {
   final today = DateTime.utc(2026, 8, 11);
-  GoalProgressDay day(int offset, num value) => GoalProgressDay(
-    day: today.subtract(Duration(days: offset)),
-    value: value,
-  );
+  GoalProgressDay day(int offset, num value, {HabitCompletionType? type}) =>
+      GoalProgressDay(
+        day: today.subtract(Duration(days: offset)),
+        value: value,
+        habitCompletionType: type,
+      );
 
   /// The `yyyy-MM-dd` fragment the day-cell keys are built from.
   String dayKey(int offset) =>
@@ -450,16 +454,26 @@ void main() {
           ),
         )
         .firstWhere((container) => container.decoration is BoxDecoration);
+    // Today itself is the dashed open square on both tracks; yesterday is a
+    // filled one, so it is the one to compare decorations on.
     final habitCell = tester.widget<Container>(
-      find.byKey(ValueKey('goal-habit-day-visual-walk-${dayKey(0)}')),
+      find.byKey(ValueKey('goal-habit-day-visual-walk-${dayKey(1)}')),
     );
     final stripRect = tester.getRect(
       find.byWidget(stripCell),
     );
     final habitRect = tester.getRect(
-      find.byKey(ValueKey('goal-habit-day-visual-walk-${dayKey(0)}')),
+      find.byKey(ValueKey('goal-habit-day-visual-walk-${dayKey(1)}')),
     );
     expect(stripRect.size, habitRect.size);
+    expect(
+      find.descendant(
+        of: find.byKey(ValueKey('goal-habit-day-visual-walk-${dayKey(0)}')),
+        matching: find.byType(DsDashedBorder),
+      ),
+      findsOneWidget,
+      reason: 'today, still open, is the dashed square',
+    );
     expect(
       (habitCell.decoration! as BoxDecoration).borderRadius,
       (stripCell.decoration! as BoxDecoration).borderRadius,
@@ -528,21 +542,23 @@ void main() {
     expect(find.text('Improving'), findsOneWidget);
   });
 
-  testWidgets('the today ring is drawn in one ink and one stroke on every '
-      'surface that draws one', (
-    tester,
-  ) async {
-    // Each ring-producing surface has to be MOUNTED, or the test grades an
-    // empty set: the whole-goal strip lives on GoalThisWeekCard, not on
-    // GoalProgressCard, and the strip's cell only draws its ring on a day
-    // with no recorded verdict of its own.
+  testWidgets('no square draws a ring, glyph or letter: today, the window '
+      'start and the outcomes are said, not drawn', (tester) async {
     final habit = GoalHabitProgressView(
       habitId: 'gym',
       name: 'Gym',
-      targetCount: 3,
-      days: [for (var offset = 6; offset >= 0; offset--) day(offset, 0)],
+      // At its rate with the one success on the window's first day, so that
+      // success ages out tonight.
+      targetCount: 1,
+      days: [
+        day(6, 1, type: HabitCompletionType.success),
+        day(5, 0, type: HabitCompletionType.fail),
+        day(4, 0, type: HabitCompletionType.skip),
+        for (var offset = 3; offset >= 0; offset--) day(offset, 0),
+      ],
       successfulWeeks: 0,
     );
+    expect(habit.oldestSuccessAgesOutTonight, isTrue);
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
         SingleChildScrollView(
@@ -564,31 +580,55 @@ void main() {
         ),
       ),
     );
-
-    final tokens = tester.element(find.byType(GoalProgressCard)).designTokens;
-    Iterable<DsDashedBorder> ringsIn(Finder host) =>
-        tester.widgetList<DsDashedBorder>(
-          find.descendant(of: host, matching: find.byType(DsDashedBorder)),
-        );
-
-    // Named per surface rather than swept as one bag: a bare
-    // `byType(DsDashedBorder)` passed while the strip was never mounted at
-    // all, and would keep passing if it stopped being mounted again.
-    final stripRings = ringsIn(find.byType(DayMarkStrip));
-    final cardRings = ringsIn(find.byType(GoalProgressCard));
-    expect(stripRings, hasLength(1), reason: 'the strip marks today once');
+    // The only outline anywhere is today's open square, once per track.
+    expect(find.byType(DsDashedBorder), findsNWidgets(2));
+    // The tappable whole-goal strip names each day above its square and
+    // draws nothing else; the read-only habit track draws the bare squares.
     expect(
-      cardRings,
-      hasLength(1),
-      reason: "the habit card's today cell, drawn inside the square",
+      find.descendant(
+        of: find.byType(DayMarkStrip),
+        matching: find.byType(Icon),
+      ),
+      findsNothing,
     );
-
-    // A hairline in the low-emphasis ink is a rumour on a dark screen.
-    for (final ring in [...stripRings, ...cardRings]) {
-      expect(ring.color, todayRingInk(tokens));
-      expect(ring.strokeWidth, BorderWidths.emphasis);
-    }
-    expect(todayRingInk(tokens), tokens.colors.text.mediumEmphasis);
+    expect(
+      find.descendant(
+        of: find.byType(DayMarkStrip),
+        matching: find.byType(Text),
+      ),
+      findsNWidgets(7),
+    );
+    final habitTrack = find.descendant(
+      of: find.byType(GoalProgressCard),
+      matching: find.byType(DayTrack),
+    );
+    expect(
+      find.descendant(of: habitTrack, matching: find.byType(Icon)),
+      findsNothing,
+    );
+    expect(
+      find.descendant(of: habitTrack, matching: find.byType(Text)),
+      findsNothing,
+    );
+    final tokens = tester.element(find.byType(GoalProgressCard)).designTokens;
+    final visual = tester.widget<Container>(
+      find.byKey(ValueKey('goal-habit-day-visual-gym-${dayKey(6)}')),
+    );
+    final decoration = visual.decoration! as BoxDecoration;
+    expect(decoration.border, isNull);
+    expect(decoration.borderRadius, BorderRadius.circular(tokens.radii.xs));
+    expect(
+      tester.getSize(find.byWidget(visual)),
+      const Size.square(kDaySquareSize),
+    );
+    // The ages-out fact rides the tooltip and the semantics instead.
+    final tooltip = tester.widget<DsTooltip>(
+      find.ancestor(
+        of: find.byWidget(visual),
+        matching: find.byType(DsTooltip),
+      ),
+    );
+    expect(tooltip.message, 'Success · ages out tonight');
   });
 
   testWidgets('a card closing on a check-off callout keeps its full foot, '
@@ -745,9 +785,8 @@ void main() {
       reason: 'dead space sits between the day targets',
     );
 
-    // The square itself matches the habit day squares below it — the whole
-    // goal used to render at IconSizes.xs against their iconChipCompact,
-    // less than half the size, on the same screen.
+    // The square itself is the one handover square, the same on the
+    // whole-goal strip and on the habit rows below it.
     final square = tester.widget<Container>(
       find
           .descendant(
@@ -756,10 +795,7 @@ void main() {
           )
           .first,
     );
-    expect(
-      square.constraints!.maxWidth,
-      ControlSizes.iconChipCompact,
-    );
+    expect(square.constraints!.maxWidth, kDaySquareSize);
   });
 
   testWidgets('metric card renders seven bars in the same rolling frame', (
@@ -2128,36 +2164,22 @@ void main() {
     expect(find.text('2× · calendar month'), findsNothing);
     expect(find.textContaining('· calendar month'), findsOneWidget);
     expect(find.textContaining('/ 6'), findsNothing);
-    // A month of days narrows its columns to fit rather than panning, so the
-    // first of the month is on screen with the last.
-    expect(
-      find.byWidgetPredicate(
-        (widget) =>
-            widget is SingleChildScrollView &&
-            widget.scrollDirection == Axis.horizontal,
-      ),
-      findsNothing,
-    );
+    // Every day of the month is on the track, first to last; the square
+    // never shrinks, so a month wider than the card pans, anchored on today.
     expect(
       find.byKey(const ValueKey('goal-habit-day-walk-2026-08-01')),
       findsOneWidget,
     );
-
-    const todayKey = ValueKey('goal-habit-day-walk-2026-08-11');
     const finalDayKey = ValueKey('goal-habit-day-walk-2026-08-31');
+    // Only today's open square is dashed; the month's remaining days are
+    // plain empty squares, not "not yet".
+    expect(find.byType(DsDashedBorder), findsOneWidget);
     expect(
       find.descendant(
-        of: find.byKey(todayKey),
+        of: find.byKey(const ValueKey('goal-habit-day-walk-2026-08-11')),
         matching: find.byType(DsDashedBorder),
       ),
       findsOneWidget,
-    );
-    expect(
-      find.descendant(
-        of: find.byKey(finalDayKey),
-        matching: find.byType(DsDashedBorder),
-      ),
-      findsNothing,
     );
     await tester.ensureVisible(find.byKey(finalDayKey));
     await tester.tap(find.byKey(finalDayKey));
@@ -2270,7 +2292,7 @@ void main() {
       tester
           .getSize(find.byKey(const ValueKey('goal-metric-bar-2026-08-11')))
           .width,
-      ControlSizes.iconChipCompact,
+      kDaySquareSize,
     );
   });
 
@@ -2558,12 +2580,10 @@ void main() {
       (cell.decoration! as BoxDecoration).color,
       tokens.colors.background.level03,
     );
+    // Nothing is drawn inside the square; the skip is said, not shown.
     expect(
-      find.descendant(
-        of: find.byType(DayTrack),
-        matching: find.byIcon(LottiIcons.remove),
-      ),
-      findsOneWidget,
+      find.descendant(of: find.byType(DayTrack), matching: find.byType(Icon)),
+      findsNothing,
     );
     expect(
       find.bySemanticsLabel('Aug 11, 2026: Skip'),
@@ -2661,17 +2681,15 @@ void main() {
     final fullCell = tester.widget<Container>(
       find.byKey(const ValueKey('goal-habit-day-visual-walk-2026-08-08')),
     );
-    // Day states wear the success family — the interactive teal is
-    // reserved for tappable controls.
+    // The handover's interactive square for a kept day, a wash of it for
+    // a day that was kept while the window target was still building.
     expect(
       (partialCell.decoration! as BoxDecoration).color,
-      tokens.colors.alert.success.defaultColor.withValues(
-        alpha: SurfaceAlphas.muted,
-      ),
+      tokens.colors.interactive.enabled.withValues(alpha: SurfaceAlphas.muted),
     );
     expect(
       (fullCell.decoration! as BoxDecoration).color,
-      tokens.colors.alert.success.defaultColor,
+      tokens.colors.interactive.enabled,
     );
   });
 
@@ -2755,8 +2773,8 @@ void main() {
   });
 
   testWidgets(
-    'weekday initials nest inside the day cells on the compact interactive '
-    'grid — no separate label row',
+    'the day squares sit on the shared pitch with no label row and nothing '
+    'inside them',
     (
       tester,
     ) async {
@@ -2784,12 +2802,12 @@ void main() {
         ),
       );
 
-      // The full-word label row above the squares is gone; the axis is the
-      // one-letter initial nested inside each cell.
+      // No full-word label row above the squares; a tappable square carries
+      // its weekday initial above it, inside its own slot.
       expect(find.text('Wed'), findsNothing);
       final letterFormat = DateFormat.EEEEE('en');
       final tokens = tester.element(find.byType(GoalProgressCard)).designTokens;
-      final expectedPitch = ControlSizes.iconChipCompact + tokens.spacing.step2;
+      final expectedPitch = kDaySquareSize + tokens.spacing.step2;
       double? previousCenter;
       for (var offset = 6; offset >= 0; offset--) {
         final date = today.subtract(Duration(days: offset));
@@ -2798,10 +2816,7 @@ void main() {
         final visualCell = find.byKey(
           ValueKey('goal-habit-day-visual-walk-$key'),
         );
-        expect(
-          tester.getSize(visualCell),
-          const Size.square(ControlSizes.iconChipCompact),
-        );
+        expect(tester.getSize(visualCell), const Size.square(kDaySquareSize));
         // The interactive slot fills the track pitch horizontally and
         // meets the design system's touch floor vertically.
         expect(
@@ -2812,12 +2827,17 @@ void main() {
           ),
         );
         expect(
+          find.descendant(of: visualCell, matching: find.byType(Text)),
+          findsNothing,
+          reason: '$key draws nothing inside its square',
+        );
+        expect(
           find.descendant(
-            of: visualCell,
+            of: cell,
             matching: find.text(letterFormat.format(date)),
           ),
           findsOneWidget,
-          reason: '$key carries its weekday initial inside the cell',
+          reason: '$key names its weekday above the square',
         );
         final center = tester.getCenter(cell).dx;
         if (previousCenter != null) {
@@ -3049,7 +3069,7 @@ void main() {
       expect(
         tester.getSize(find.byKey(dayKey)),
         Size(
-          ControlSizes.iconChipCompact +
+          kDaySquareSize +
               tester
                   .element(find.byType(GoalProgressCard))
                   .designTokens
@@ -3226,19 +3246,9 @@ void main() {
         tester.widget<Container>(visual).decoration! as BoxDecoration;
     expect(decoration.color, dayVerdictFill(tokens, DayVerdict.improving));
     expect(
-      find.descendant(
-        of: visual,
-        matching: find.byIcon(dayVerdictGlyph(DayVerdict.improving)),
-      ),
-      findsOneWidget,
-    );
-    // The measured miss no longer shows its cross — the ruling replaced it.
-    expect(
-      find.descendant(
-        of: find.byType(DayTrack),
-        matching: find.byIcon(LottiIcons.close),
-      ),
-      findsNothing,
+      decoration.color,
+      isNot(dayMarkStateFill(tokens, DayMarkState.missed)),
+      reason: 'the ruling replaced the measured miss',
     );
     expect(
       find.bySemanticsLabel(RegExp('Aug 10, 2026: Improving')),
@@ -3247,9 +3257,10 @@ void main() {
     handle.dispose();
   });
 
-  testWidgets('a recorded miss is visibly distinct from an empty day', (
+  testWidgets('a recorded miss is told apart from an empty day', (
     tester,
   ) async {
+    final handle = tester.ensureSemantics();
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
         GoalProgressCard(
@@ -3285,26 +3296,18 @@ void main() {
       find.byKey(const ValueKey('goal-day-missed-walk-2026-08-10')),
       findsOneWidget,
     );
+    // A recorded miss and an empty day share the neutral fill — the strip
+    // is a record of what was KEPT — so the difference is said: the missed
+    // day names its outcome in the semantics and the tooltip.
     expect(
-      find.descendant(
-        of: find.byType(DayTrack),
-        matching: find.byIcon(LottiIcons.close),
-      ),
+      find.bySemanticsLabel(RegExp('Aug 10, 2026: Missed')),
       findsOneWidget,
     );
-    // The missed cross OWNS the cell: at the compact size a corner letter
-    // collides with the glyph, so the letter yields and the neighbouring
-    // plain cells carry the axis.
     expect(
-      find.descendant(
-        of: find.byKey(
-          const ValueKey('goal-habit-day-visual-walk-2026-08-10'),
-        ),
-        matching: find.text('M'),
-      ),
-      findsNothing,
-      reason: 'the mark outranks the weekday initial in one small cell',
+      find.bySemanticsLabel(RegExp('Aug 9, 2026: No entry')),
+      findsOneWidget,
     );
+    handle.dispose();
   });
 
   testWidgets('a failed completion save clears the busy state and reports it', (

--- a/test/features/goals/ui/goal_progress_card_test.dart
+++ b/test/features/goals/ui/goal_progress_card_test.dart
@@ -827,6 +827,67 @@ void main() {
     expect(find.text('Today'), findsNothing);
   });
 
+  testWidgets('a raised text scale gives the metric bars full weekday '
+      'captions on a pitch widened to hold them', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(1.01)),
+          child: SingleChildScrollView(
+            child: GoalProgressCard(
+              progress: GoalProgressView(
+                today: today,
+                metric: GoalMetricProgressView(
+                  name: 'Daily steps',
+                  target: 8000,
+                  days: [
+                    for (var index = 0; index < 7; index++)
+                      day(6 - index, 9000),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    // Wide enough for "Tue", so the one-letter fallback is not used.
+    expect(find.text('Tue'), findsOneWidget);
+    expect(find.text('T'), findsNothing);
+  });
+
+  testWidgets('a today recorded as open, not merely empty, is still the '
+      'dashed open square', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        GoalProgressCard(
+          progress: GoalProgressView(
+            today: today,
+            habits: [
+              GoalHabitProgressView(
+                habitId: 'walk',
+                name: 'Walk',
+                targetCount: 3,
+                days: [
+                  for (var offset = 6; offset >= 1; offset--) day(offset, 0),
+                  day(0, 0, type: HabitCompletionType.open),
+                ],
+                successfulWeeks: 0,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(ValueKey('goal-habit-day-visual-walk-${dayKey(0)}')),
+        matching: find.byType(DsDashedBorder),
+      ),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('a point-sample health header quotes the latest reading, not '
       'the period average', (tester) async {
     await tester.pumpWidget(
@@ -2895,7 +2956,7 @@ void main() {
       );
 
       final tokens = tester.element(find.byType(GoalProgressCard)).designTokens;
-      final defaultPitch = ControlSizes.iconChipCompact + tokens.spacing.step2;
+      final defaultPitch = kDaySquareSize + tokens.spacing.step2;
       double? previousCellCenter;
       for (var offset = 6; offset >= 0; offset--) {
         final date = today

--- a/test/features/goals/ui/pages/goal_agent_detail_page_test.dart
+++ b/test/features/goals/ui/pages/goal_agent_detail_page_test.dart
@@ -55,6 +55,7 @@ import 'package:lotti/features/nudges/state/nudge_banner_providers.dart';
 import 'package:lotti/features/nudges/ui/nudge_banner_exposure_tracker.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/widgets/charts/habits/habit_completion_rate_chart.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_cell.dart';
 import 'package:lotti/widgets/misc/timespan_segmented_control.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -2502,7 +2503,7 @@ void main() {
     final tokens = tester
         .element(find.byType(GoalAgentDetailPage))
         .designTokens;
-    final pitch = ControlSizes.iconChipCompact + tokens.spacing.step2;
+    final pitch = kDaySquareSize + tokens.spacing.step2;
     final contentWidth =
         math.min(
           kUnifiedGoalsContentMaxWidth,

--- a/test/features/habits/state/habits_state_test.dart
+++ b/test/features/habits/state/habits_state_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/habits/model/habit_completion_record.dart';
 import 'package:lotti/features/habits/state/habits_state.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
 
 void main() {
   group('HabitsState', () {
@@ -242,6 +243,73 @@ void main() {
 
       // 1 from definitions + 2 extra from allByDay
       expect(result, 3);
+    });
+  });
+
+  group('habitHistoryMarks', () {
+    final state = HabitsState.initial().copyWith(
+      days: [
+        for (var day = 1; day <= 10; day++)
+          '2026-08-${day.toString().padLeft(2, '0')}',
+      ],
+      successfulByDay: {
+        '2026-08-04': {'floss', 'walk'},
+        '2026-08-09': {'floss'},
+        '2026-08-10': {'walk'},
+      },
+      skippedByDay: {
+        '2026-08-06': {'floss'},
+      },
+      failedByDay: {
+        '2026-08-08': {'floss'},
+        '2026-08-10': {'floss'},
+      },
+    );
+
+    test('reads the last seven days off the per-day sets, oldest first', () {
+      final marks = habitHistoryMarks(state, 'floss');
+      expect(marks.map((m) => m.day), [
+        for (var day = 4; day <= 10; day++) DateTime(2026, 8, day),
+      ]);
+      expect(marks.map((m) => m.state), [
+        DayMarkState.full,
+        DayMarkState.none,
+        DayMarkState.skipped,
+        DayMarkState.none,
+        DayMarkState.missed,
+        DayMarkState.full,
+        DayMarkState.missed,
+      ]);
+      expect(marks.every((m) => m.verdict == null), isTrue);
+      // The span's last day is the day the state was built for.
+      expect(marks.map((m) => m.isToday), [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+      ]);
+    });
+
+    test('another habit reads its own days out of the same sets', () {
+      expect(habitHistoryMarks(state, 'walk', count: 3).map((m) => m.state), [
+        DayMarkState.none,
+        DayMarkState.none,
+        DayMarkState.full,
+      ]);
+    });
+
+    test('a shorter state yields what it has', () {
+      final short = state.copyWith(days: ['2026-08-09', '2026-08-10']);
+      expect(habitHistoryMarks(short, 'floss'), hasLength(2));
+      expect(habitHistoryMarks(state.copyWith(days: []), 'floss'), isEmpty);
+      // A fresh state already carries its default span of days, all empty.
+      expect(
+        habitHistoryMarks(HabitsState.initial(), 'floss').map((m) => m.state),
+        everyElement(DayMarkState.none),
+      );
     });
   });
 

--- a/test/features/habits/ui/widgets/habit_action_row_test.dart
+++ b/test/features/habits/ui/widgets/habit_action_row_test.dart
@@ -17,6 +17,9 @@ import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/themes/colors.dart';
+import 'package:lotti/widgets/day_indicators/day_mark.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_cell.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_strip.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../mocks/mocks.dart';
@@ -83,7 +86,7 @@ void main() {
     String? autoCompleteReason,
     String? autoCompletedAt,
     int currentStreak = 0,
-    Widget? history,
+    List<DayMark> history = const [],
     bool reduceMotion = false,
     List<Override> extraOverrides = const [],
   }) async {
@@ -152,69 +155,85 @@ void main() {
     }
   });
 
-  group('history slot', () {
-    testWidgets('renders the history widget when provided', (tester) async {
+  group('history strip', () {
+    final today = DateTime(2026, 8, 11);
+    List<DayMark> week(List<DayMarkState> states) => [
+      for (var i = 0; i < states.length; i++)
+        DayMark(
+          day: today.subtract(Duration(days: states.length - 1 - i)),
+          state: states[i],
+        ),
+    ];
+    Finder squares() => find.byType(DayMarkCell);
+
+    testWidgets('draws one dated square per history day under the name, kept '
+        'days in the interactive fill', (tester) async {
       await pumpRow(
         tester,
-        history: const SizedBox(key: Key('history-slot')),
+        history: week(const [
+          DayMarkState.full,
+          DayMarkState.none,
+          DayMarkState.missed,
+          DayMarkState.skipped,
+          DayMarkState.none,
+          DayMarkState.full,
+          DayMarkState.full,
+        ]),
       );
-      expect(find.byKey(const Key('history-slot')), findsOneWidget);
+      expect(squares(), findsNWidgets(7));
+      expect(
+        tester.getTopLeft(squares().first).dy,
+        greaterThan(tester.getBottomLeft(find.text(habitFlossing.name)).dy),
+      );
+      final tokens = tester.element(find.byType(HabitActionRow)).designTokens;
+      Color fillAt(int index) =>
+          (tester
+                      .widget<Container>(
+                        find.descendant(
+                          of: squares().at(index),
+                          matching: find.byType(Container),
+                        ),
+                      )
+                      .decoration!
+                  as BoxDecoration)
+              .color!;
+      expect(fillAt(0), tokens.colors.interactive.enabled);
+      expect(fillAt(1), tokens.colors.background.level03);
+      expect(fillAt(2), tokens.colors.background.level03);
+      expect(fillAt(3), tokens.colors.background.level03);
+      expect(find.byIcon(LottiIcons.streak), findsNothing);
     });
 
-    testWidgets('omits history when none is supplied', (tester) async {
+    testWidgets('no history and no streak draws no strip', (tester) async {
       await pumpRow(tester);
-      expect(find.byKey(const Key('history-slot')), findsNothing);
-      // The body still renders without a history slot.
+      expect(find.byType(DayMarkStrip), findsNothing);
       expect(find.text(habitFlossing.name), findsOneWidget);
     });
-  });
 
-  group('streak chain', () {
-    Finder greenBoxes() => find.byWidgetPredicate(
-      (w) =>
-          w is Container &&
-          w.decoration is BoxDecoration &&
-          (w.decoration! as BoxDecoration).color == successColor,
-    );
+    testWidgets('the streak rides the strip as a flame and the exact count', (
+      tester,
+    ) async {
+      await pumpRow(
+        tester,
+        history: week(List.filled(7, DayMarkState.full)),
+        currentStreak: 41,
+      );
+      expect(squares(), findsNWidgets(7));
+      expect(find.byIcon(LottiIcons.streak), findsOneWidget);
+      expect(find.text('41'), findsOneWidget);
+      expect(
+        tester.getTopLeft(find.byIcon(LottiIcons.streak)).dx,
+        greaterThan(tester.getTopRight(squares().last).dx),
+      );
+    });
 
-    testWidgets('shows one green box per kept day, plus the flame + count', (
+    testWidgets('a streak with no history still shows its tail', (
       tester,
     ) async {
       await pumpRow(tester, currentStreak: 3);
+      expect(squares(), findsNothing);
       expect(find.byIcon(LottiIcons.streak), findsOneWidget);
       expect(find.text('3'), findsOneWidget);
-      expect(greenBoxes(), findsNWidgets(3));
-    });
-
-    testWidgets('shows nothing when there is no current streak', (
-      tester,
-    ) async {
-      await pumpRow(tester);
-      expect(find.byIcon(LottiIcons.streak), findsNothing);
-      expect(greenBoxes(), findsNothing);
-    });
-
-    testWidgets('a long streak keeps the true count but caps the chain', (
-      tester,
-    ) async {
-      await pumpRow(tester, currentStreak: 41);
-      // The flame count is always the real length...
-      expect(find.text('41'), findsOneWidget);
-      // ...but the chain is capped (and never exceeds 30 boxes).
-      final boxes = greenBoxes().evaluate().length;
-      expect(boxes, greaterThan(0));
-      expect(boxes, lessThanOrEqualTo(30));
-    });
-
-    testWidgets('extends with a new box when the streak grows', (tester) async {
-      await pumpRow(tester, currentStreak: 5);
-      expect(greenBoxes(), findsNWidgets(5));
-
-      // Grow in place → the chain gains a box (which pops in); let it settle.
-      await pumpRow(tester, currentStreak: 6);
-      await tester.pump(const Duration(milliseconds: 500));
-      expect(greenBoxes(), findsNWidgets(6));
-      expect(find.text('6'), findsOneWidget);
     });
   });
 

--- a/test/features/habits/ui/widgets/habit_completion_card_test.dart
+++ b/test/features/habits/ui/widgets/habit_completion_card_test.dart
@@ -1,10 +1,8 @@
-import 'package:clock/clock.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
-import 'package:lotti/features/goals/state/goal_habit_watchers.dart';
 import 'package:lotti/features/habits/state/habit_completion_controller.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_action_row.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_completion_card.dart';
@@ -83,11 +81,7 @@ void main() {
 
   /// Pumps a [HabitCompletionCard] for [habit] with the family overridden to
   /// serve [_results].
-  Future<void> pumpCard(
-    WidgetTester tester, {
-    HabitDefinition? habit,
-    Map<DateTime, DayVerdict> verdicts = const {},
-  }) async {
+  Future<void> pumpCard(WidgetTester tester, {HabitDefinition? habit}) async {
     final definition = habit ?? habitFlossing;
     await tester.pumpWidget(
       makeTestableWidgetWithScaffold(
@@ -100,9 +94,6 @@ void main() {
           habitCompletionControllerProvider.overrideWith2(
             (_) => _FakeController(),
           ),
-          habitDayVerdictsProvider(
-            definition.id,
-          ).overrideWith((ref) async => verdicts),
         ],
       ),
     );
@@ -169,8 +160,15 @@ void main() {
         DayMarkState.skipped,
         DayMarkState.full,
       ]);
-      expect(find.byIcon(LottiIcons.close), findsOneWidget); // fail cell
-      expect(find.byIcon(LottiIcons.remove), findsOneWidget); // skip cell
+      // Nothing is drawn inside a square: the state is the fill, the words
+      // are in the summary and the tooltips.
+      expect(
+        find.descendant(
+          of: find.byType(DayMarkCell),
+          matching: find.byType(Icon),
+        ),
+        findsNothing,
+      );
 
       // A read-only strip publishes one summary, counted from the marks: the
       // success day is the only one that counts.
@@ -192,9 +190,7 @@ void main() {
       ];
       await pumpCard(tester);
 
-      expect(find.byIcon(LottiIcons.close), findsNothing);
-      expect(find.byIcon(LottiIcons.remove), findsNothing);
-      // No success cell, and the not-done button is a hollow "+" — so the strip
+      // No success cell, and the not-done button is a hollow "+" — so the card
       // shows no check glyph at all.
       expect(find.byIcon(LottiIcons.confirm), findsNothing);
       expect(find.byIcon(LottiIcons.add), findsOneWidget);
@@ -203,64 +199,6 @@ void main() {
         findsOneWidget,
       );
       handle.dispose();
-    });
-
-    testWidgets("only the cell for the clock's today wears the dashed ring", (
-      tester,
-    ) async {
-      _results = [
-        _result(DateTime(2024, 3, 14), HabitCompletionType.success),
-        _result(_rangeEnd, HabitCompletionType.open),
-      ];
-      await withClock(Clock.fixed(_rangeEnd.add(const Duration(hours: 9))), () {
-        return pumpCard(tester);
-      });
-
-      final marks = tester
-          .widgetList<DayMarkCell>(find.byType(DayMarkCell))
-          .map((cell) => cell.mark.isToday)
-          .toList();
-      expect(marks, [false, true]);
-      expect(find.byType(DsDashedBorder), findsOneWidget);
-    });
-
-    testWidgets("a day outside the clock's today wears no ring", (
-      tester,
-    ) async {
-      _results = _last(HabitCompletionType.success);
-      await withClock(Clock.fixed(DateTime(2024, 3, 20)), () {
-        return pumpCard(tester);
-      });
-      expect(find.byType(DsDashedBorder), findsNothing);
-    });
-  });
-
-  group('goal verdicts on the strip', () {
-    testWidgets('a day a watching goal judged wears that verdict, the rest '
-        'keep their measured state', (tester) async {
-      _results = [
-        _result(DateTime(2024, 3, 13), HabitCompletionType.fail),
-        _result(DateTime(2024, 3, 14), HabitCompletionType.success),
-        _result(_rangeEnd, HabitCompletionType.open),
-      ];
-      await pumpCard(
-        tester,
-        verdicts: {DateTime.utc(2024, 3, 13): DayVerdict.improving},
-      );
-      // One extra frame: the verdicts resolve after the results.
-      await tester.pump();
-      final marks = tester
-          .widgetList<DayMarkCell>(find.byType(DayMarkCell))
-          .map((cell) => (cell.mark.state, cell.mark.verdict))
-          .toList();
-      expect(marks, [
-        (DayMarkState.missed, DayVerdict.improving),
-        (DayMarkState.full, null),
-        (DayMarkState.none, null),
-      ]);
-      // The ruling replaces the measured cross with its own glyph.
-      expect(find.byIcon(LottiIcons.close), findsNothing);
-      expect(find.byIcon(LottiIcons.trendingUp), findsOneWidget);
     });
   });
 

--- a/test/features/habits/ui/widgets/habit_completion_card_test.dart
+++ b/test/features/habits/ui/widgets/habit_completion_card_test.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
@@ -170,12 +171,9 @@ void main() {
         findsNothing,
       );
 
-      // A read-only strip publishes one summary, counted from the marks: the
-      // success day is the only one that counts.
-      expect(
-        find.bySemanticsLabel(RegExp('1 successful day')),
-        findsOneWidget,
-      );
+      // A read-only strip publishes one summary. The range ends on a kept
+      // day, so it is the streak that is announced.
+      expect(find.bySemanticsLabel(RegExp('1-day streak')), findsOneWidget);
       handle.dispose();
     });
 
@@ -199,6 +197,47 @@ void main() {
         findsOneWidget,
       );
       handle.dispose();
+    });
+  });
+
+  group('current streak', () {
+    testWidgets('counts the trailing kept days, letting an open today ride', (
+      tester,
+    ) async {
+      _results = [
+        _result(DateTime(2024, 3, 11), HabitCompletionType.fail),
+        _result(DateTime(2024, 3, 12), HabitCompletionType.success),
+        _result(DateTime(2024, 3, 13), HabitCompletionType.success),
+        _result(DateTime(2024, 3, 14), HabitCompletionType.success),
+        _result(_rangeEnd, HabitCompletionType.open),
+      ];
+      await withClock(Clock.fixed(_rangeEnd.add(const Duration(hours: 9))), () {
+        return pumpCard(tester);
+      });
+      expect(row(tester).currentStreak, 3);
+      expect(find.text('3'), findsOneWidget);
+    });
+
+    testWidgets('a past open day or a skip breaks the run', (tester) async {
+      _results = [
+        _result(DateTime(2024, 3, 13), HabitCompletionType.success),
+        _result(DateTime(2024, 3, 14), HabitCompletionType.skip),
+        _result(_rangeEnd, HabitCompletionType.success),
+      ];
+      await pumpCard(tester);
+      expect(row(tester).currentStreak, 1);
+    });
+
+    testWidgets('an open day that is not today breaks the run', (tester) async {
+      _results = [
+        _result(DateTime(2024, 3, 14), HabitCompletionType.success),
+        _result(_rangeEnd, HabitCompletionType.open),
+      ];
+      await withClock(Clock.fixed(DateTime(2024, 3, 20)), () {
+        return pumpCard(tester);
+      });
+      expect(row(tester).currentStreak, 0);
+      expect(find.byIcon(LottiIcons.streak), findsNothing);
     });
   });
 

--- a/test/widgets/day_indicators/day_mark_cell_test.dart
+++ b/test/widgets/day_indicators/day_mark_cell_test.dart
@@ -27,102 +27,89 @@ void main() {
         .first,
   );
 
-  testWidgets('a verdict outranks the state for fill and glyph', (
-    tester,
-  ) async {
+  BoxDecoration decoration(WidgetTester tester) =>
+      square(tester).decoration! as BoxDecoration;
+
+  testWidgets('the square is the handover square: one size, the xs radius, '
+      'nothing inside it', (tester) async {
+    for (final state in DayMarkState.values) {
+      await pump(tester, DayMarkCell(mark: DayMark(state: state)));
+      final tokens = tester.element(find.byType(DayMarkCell)).designTokens;
+      expect(
+        tester.getSize(find.byType(DayMarkCell)),
+        const Size.square(kDaySquareSize),
+        reason: '$state',
+      );
+      expect(
+        decoration(tester).borderRadius,
+        BorderRadius.circular(tokens.radii.xs),
+        reason: '$state',
+      );
+      expect(decoration(tester).border, isNull, reason: '$state');
+      expect(square(tester).child, isNull, reason: '$state');
+      expect(find.byType(Icon), findsNothing, reason: '$state');
+      expect(find.byType(Text), findsNothing, reason: '$state');
+      expect(find.byType(DsDashedBorder), findsNothing, reason: '$state');
+    }
+  });
+
+  testWidgets('the measured state decides the fill', (tester) async {
+    for (final state in DayMarkState.values) {
+      await pump(tester, DayMarkCell(mark: DayMark(state: state)));
+      final tokens = tester.element(find.byType(DayMarkCell)).designTokens;
+      expect(
+        decoration(tester).color,
+        dayMarkStateFill(tokens, state),
+        reason: '$state',
+      );
+    }
+  });
+
+  testWidgets('an open today is the dashed unresolved square, and answers '
+      'hover and taps like any other', (tester) async {
+    var taps = 0;
+    await pump(
+      tester,
+      DayMarkCell(
+        mark: const DayMark(state: DayMarkState.none, isToday: true),
+        label: 'Tue, Aug 11: No entry',
+        tooltipDay: 'Tue, Aug 11',
+        tooltipOutcome: 'No entry',
+        onTap: () => taps++,
+      ),
+    );
+    expect(find.byType(PlaceholderDayCell), findsOneWidget);
+    expect(find.byType(DsDashedBorder), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(DayMarkCell),
+        matching: find.byType(Container),
+      ),
+      findsNothing,
+      reason: 'no fill under the outline',
+    );
+    await tester.tap(find.byType(DayMarkCell));
+    expect(taps, 1);
+    // A kept today is an ordinary filled square.
+    await pump(
+      tester,
+      const DayMarkCell(mark: DayMark(state: DayMarkState.full, isToday: true)),
+    );
+    expect(find.byType(DsDashedBorder), findsNothing);
+  });
+
+  testWidgets('a verdict outranks the state for the fill', (tester) async {
     await pump(
       tester,
       const DayMarkCell(
         mark: DayMark(state: DayMarkState.none, verdict: DayVerdict.mixed),
-        size: 28,
-        weekdayLetter: 'M',
       ),
     );
     final tokens = tester.element(find.byType(DayMarkCell)).designTokens;
+    expect(decoration(tester).color, dayVerdictFill(tokens, DayVerdict.mixed));
     expect(
-      (square(tester).decoration! as BoxDecoration).color,
-      dayVerdictFill(tokens, DayVerdict.mixed),
-    );
-    expect(find.byIcon(dayVerdictGlyph(DayVerdict.mixed)), findsOneWidget);
-    expect(
-      find.text('M'),
-      findsNothing,
-      reason: 'the glyph outranks the letter',
-    );
-  });
-
-  testWidgets('a plain full cell carries the weekday letter; a partial one '
-      'carries the dot instead', (tester) async {
-    await pump(
-      tester,
-      const DayMarkCell(
-        mark: DayMark(state: DayMarkState.full),
-        size: 28,
-        weekdayLetter: 'T',
-      ),
-    );
-    expect(find.text('T'), findsOneWidget);
-    expect(find.byType(Icon), findsNothing);
-
-    await pump(
-      tester,
-      const DayMarkCell(
-        mark: DayMark(state: DayMarkState.partial),
-        size: 28,
-        weekdayLetter: 'T',
-      ),
-    );
-    expect(find.text('T'), findsNothing);
-    // The dot is the innermost Container inside the cell.
-    final dot = find
-        .descendant(
-          of: find.byType(DayMarkCell),
-          matching: find.byType(Container),
-        )
-        .last;
-    expect(
-      (tester.widget<Container>(dot).decoration! as BoxDecoration).shape,
-      BoxShape.circle,
-    );
-  });
-
-  testWidgets('recorded outcomes show their shape without a verdict', (
-    tester,
-  ) async {
-    await pump(
-      tester,
-      const DayMarkCell(mark: DayMark(state: DayMarkState.missed), size: 20),
-    );
-    expect(find.byIcon(LottiIcons.close), findsOneWidget);
-    await pump(
-      tester,
-      const DayMarkCell(mark: DayMark(state: DayMarkState.skipped), size: 20),
-    );
-    expect(find.byIcon(LottiIcons.remove), findsOneWidget);
-  });
-
-  testWidgets('today wears the dashed ring inside the shared footprint', (
-    tester,
-  ) async {
-    await pump(
-      tester,
-      const DayMarkCell(mark: DayMark(state: DayMarkState.none), size: 20),
-    );
-    final plain = tester.getSize(find.byType(DayMarkCell));
-    expect(find.byType(DsDashedBorder), findsNothing);
-
-    await pump(
-      tester,
-      const DayMarkCell(
-        mark: DayMark(state: DayMarkState.none, isToday: true),
-        size: 20,
-      ),
-    );
-    expect(find.byType(DsDashedBorder), findsOneWidget);
-    expect(
-      tester.getSize(find.byType(DayMarkCell)),
-      plain,
-      reason: 'the ring never bulges the rhythm',
+      decoration(tester).color,
+      isNot(dayMarkStateFill(tokens, DayMarkState.none)),
     );
   });
 
@@ -134,7 +121,6 @@ void main() {
       tester,
       DayMarkCell(
         mark: const DayMark(state: DayMarkState.full),
-        size: 20,
         label: 'Mon, Aug 10: done',
         tooltipDay: 'Mon, Aug 10',
         tooltipOutcome: 'done',
@@ -145,6 +131,12 @@ void main() {
       tester.getSize(find.byType(DayMarkCell)).height,
       greaterThanOrEqualTo(TapTargets.minimum),
     );
+    expect(
+      tester.getSize(find.byType(Container)),
+      const Size.square(kDaySquareSize),
+      reason: 'the hit slot grows, the square does not',
+    );
+    expect(find.byType(Text), findsNothing, reason: 'no caption asked for');
     final tooltip = tester.widget<DsTooltip>(find.byType(DsTooltip));
     expect(tooltip.title, 'Mon, Aug 10');
     expect(tooltip.message, 'done');
@@ -167,6 +159,40 @@ void main() {
     handle.dispose();
   });
 
+  testWidgets('a caption rides above a tappable square, inside the slot, and '
+      'is ignored on a read-only cell', (tester) async {
+    await pump(
+      tester,
+      DayMarkCell(
+        mark: const DayMark(state: DayMarkState.full),
+        caption: 'M',
+        onTap: () {},
+      ),
+    );
+    final tokens = tester.element(find.byType(DayMarkCell)).designTokens;
+    expect(find.text('M'), findsOneWidget);
+    expect(
+      tester.widget<Text>(find.text('M')).style?.color,
+      tokens.colors.text.lowEmphasis,
+    );
+    expect(
+      tester.getBottomLeft(find.text('M')).dy,
+      lessThanOrEqualTo(tester.getTopLeft(find.byType(Container)).dy),
+    );
+    expect(
+      tester.getSize(find.byType(DayMarkCell)).height,
+      greaterThanOrEqualTo(TapTargets.minimum),
+    );
+    await pump(
+      tester,
+      const DayMarkCell(
+        mark: DayMark(state: DayMarkState.full),
+        caption: 'M',
+      ),
+    );
+    expect(find.text('M'), findsNothing);
+  });
+
   testWidgets('a read-only dated cell still answers hover with its day and '
       'outcome, without becoming a button', (tester) async {
     final handle = tester.ensureSemantics();
@@ -174,7 +200,6 @@ void main() {
       tester,
       const DayMarkCell(
         mark: DayMark(state: DayMarkState.full),
-        size: 20,
         tooltipDay: 'Tue, Aug 11',
         tooltipOutcome: 'done',
       ),
@@ -194,26 +219,19 @@ void main() {
   testWidgets('an undated read-only cell carries no tooltip', (tester) async {
     await pump(
       tester,
-      const DayMarkCell(mark: DayMark(state: DayMarkState.full), size: 20),
+      const DayMarkCell(mark: DayMark(state: DayMarkState.full)),
     );
     expect(find.byType(DsTooltip), findsNothing);
   });
 
-  testWidgets('a placeholder cell is a dashed outline at the cell size', (
+  testWidgets('a placeholder cell is a dashed outline at the square size', (
     tester,
   ) async {
-    await pump(tester, const PlaceholderDayCell(size: 18));
+    await pump(tester, const PlaceholderDayCell());
     expect(find.byType(DsDashedBorder), findsOneWidget);
     expect(
-      tester.getSize(
-        find
-            .descendant(
-              of: find.byType(DsDashedBorder),
-              matching: find.byType(SizedBox),
-            )
-            .first,
-      ),
-      const Size(18, 18),
+      tester.getSize(find.byType(PlaceholderDayCell)),
+      const Size.square(kDaySquareSize),
     );
   });
 }

--- a/test/widgets/day_indicators/day_mark_strip_test.dart
+++ b/test/widgets/day_indicators/day_mark_strip_test.dart
@@ -15,59 +15,115 @@ import '../../widget_test_utils.dart';
 
 void main() {
   final today = DateTime.utc(2026, 8, 11);
+  const week = [
+    DayMarkState.full,
+    DayMarkState.none,
+    DayMarkState.partial,
+    DayMarkState.none,
+    DayMarkState.none,
+    DayMarkState.full,
+    DayMarkState.none,
+  ];
 
-  testWidgets('compact strip reports the number of successful days once in '
-      'semantics', (tester) async {
+  String cell(int daysBack, String outcome) =>
+      '${DateFormat.MMMEd().format(today.subtract(Duration(days: daysBack)))}'
+      ': $outcome';
+
+  Finder squares() => find.descendant(
+    of: find.byType(DayMarkCell),
+    matching: find.byType(Container),
+  );
+
+  Color fillAt(WidgetTester tester, int index) =>
+      (tester.widget<Container>(squares().at(index)).decoration!
+              as BoxDecoration)
+          .color!;
+
+  testWidgets('a read-only strip reports the number of successful days once '
+      'in semantics and draws nothing but the squares', (tester) async {
     final handle = tester.ensureSemantics();
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
-        DayMarkStrip(
-          marks: goalDayMarks(
-            states: const [
-              DayMarkState.full,
-              DayMarkState.none,
-              DayMarkState.partial,
-              DayMarkState.none,
-              DayMarkState.none,
-              DayMarkState.full,
-              DayMarkState.none,
-            ],
-          ),
-        ),
+        DayMarkStrip(marks: goalDayMarks(states: week)),
       ),
     );
-
     expect(
       find.bySemanticsLabel(
         '3 successful days in the trailing seven-day window',
       ),
       findsOneWidget,
     );
+    expect(find.byType(DayMarkCell), findsNWidgets(7));
+    expect(find.byType(Icon), findsNothing);
+    expect(find.byType(Text), findsNothing);
+    // The last mark is today and it is empty: "not yet", the dashed
+    // unresolved outline, never a past day's grey.
+    expect(find.byType(DsDashedBorder), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(DayMarkCell).last,
+        matching: find.byType(DsDashedBorder),
+      ),
+      findsOneWidget,
+    );
     handle.dispose();
   });
 
-  testWidgets('compact strip outlines the last cell as today when short', (
-    tester,
-  ) async {
-    await tester.pumpWidget(
-      makeTestableWidgetNoScroll(
-        DayMarkStrip(
-          marks: goalDayMarks(
-            states: const [
-              DayMarkState.none,
-              DayMarkState.full,
-              DayMarkState.none,
+  testWidgets('today is dashed only while it is still open', (tester) async {
+    for (final (state, verdict, dashed) in [
+      (DayMarkState.none, null, true),
+      (DayMarkState.full, null, false),
+      (DayMarkState.skipped, null, false),
+      (DayMarkState.none, DayVerdict.missed, false),
+    ]) {
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          DayMarkStrip(
+            marks: [
+              DayMark(
+                day: today,
+                state: state,
+                verdict: verdict,
+                isToday: true,
+              ),
             ],
           ),
         ),
-      ),
-    );
-
-    expect(find.byType(DsDashedBorder), findsOneWidget);
+      );
+      expect(
+        find.byType(DsDashedBorder),
+        dashed ? findsOneWidget : findsNothing,
+        reason: '$state / $verdict',
+      );
+    }
   });
 
-  testWidgets('a read-only strip announces its verdicts and marks non-met '
-      'days with a shape', (tester) async {
+  testWidgets('the squares sit on the shared column pitch with one step of '
+      'air between them', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Align(
+          alignment: Alignment.topLeft,
+          child: DayMarkStrip(marks: goalDayMarks(states: week)),
+        ),
+      ),
+    );
+    final tokens = tester.element(find.byType(DayMarkStrip)).designTokens;
+    final pitch = kDaySquareSize + tokens.spacing.step2;
+    for (var index = 0; index < 7; index++) {
+      final rect = tester.getRect(find.byType(DayMarkCell).at(index));
+      expect(rect.size, const Size.square(kDaySquareSize), reason: '$index');
+      expect(rect.center.dx, pitch * index + pitch / 2, reason: '$index');
+    }
+    expect(
+      tester.getSize(find.byType(DayTrack)),
+      Size(pitch * 7, kDaySquareSize),
+    );
+  });
+
+  testWidgets('a read-only strip announces its verdicts in the summary', (
+    tester,
+  ) async {
     final handle = tester.ensureSemantics();
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
@@ -83,26 +139,13 @@ void main() {
         ),
       ),
     );
-
     // A read-only strip publishes one summary rather than seven nodes, so the
     // verdicts have to reach it there — otherwise the list announced a
     // measured day count while showing four verdict hues.
     final label = tester.getSemantics(find.byType(DayMarkStrip)).label;
-    expect(label, contains('Met'));
-    expect(label, contains('Missed'));
-
-    // Each verdict keeps its OWN shape even on the list's 12px cells.
-    // Collapsing the three non-met verdicts into one dot left Improving,
-    // Mixed and Missed separable by hue alone, which is the single thing the
-    // shapes exist to prevent.
-    expect(
-      find.byIcon(dayVerdictGlyph(DayVerdict.met)),
-      findsOneWidget,
-    );
-    expect(
-      find.byIcon(dayVerdictGlyph(DayVerdict.missed)),
-      findsOneWidget,
-    );
+    expect(label, startsWith('1 successful day'));
+    expect(label, contains(cell(2, 'Met')));
+    expect(label, contains(cell(1, 'Missed')));
     handle.dispose();
   });
 
@@ -113,56 +156,42 @@ void main() {
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
         DayMarkStrip(
-          marks: goalDayMarks(
-            states: const [
-              DayMarkState.full,
-              DayMarkState.none,
-              DayMarkState.partial,
-              DayMarkState.none,
-              DayMarkState.none,
-              DayMarkState.full,
-              DayMarkState.none,
-            ],
-            lastDay: today,
-          ),
+          marks: goalDayMarks(states: week, lastDay: today),
           onDaySelected: tapped.add,
         ),
       ),
     );
-
     // The oldest cell is six days back and the last one is today. Tapping a
     // *past* day is the point: before this, the only way to reflect on a day
-    // was the "Reflect on today" row, so a day could never be closed off
-    // once it had passed.
-    String cell(int daysBack, String outcome) =>
-        '${DateFormat.MMMEd().format(today.subtract(Duration(days: daysBack)))}'
-        ': $outcome';
-
+    // was the "Reflect on today" row.
     await tester.tap(find.bySemanticsLabel(cell(6, 'done · target met')));
     await tester.tap(find.bySemanticsLabel(cell(0, 'No entry')));
-
     expect(tapped, [today.subtract(const Duration(days: 6)), today]);
-
-    // Colour and an inner dot are the only visual difference between these
-    // cells, and neither reaches a screen reader. Each day names its own
-    // state; the strip's summary only gives a count and cannot say which
-    // days went well.
+    // Colour is the only visual difference between these cells, and it does
+    // not reach a screen reader. Each day names its own state.
     expect(
       find.bySemanticsLabel(cell(4, 'done · target not met yet')),
       findsOneWidget,
     );
+    // An action says which day it acts on: a weekday initial rides above
+    // every tappable square, inside its slot.
+    for (var daysBack = 6; daysBack >= 0; daysBack--) {
+      final letter = DateFormat.EEEEE().format(
+        today.subtract(Duration(days: daysBack)),
+      );
+      expect(find.text(letter), findsWidgets, reason: letter);
+    }
+    expect(find.byType(Text), findsNWidgets(7));
     handle.dispose();
   });
 
   testWidgets('a recorded verdict outranks the measured state, and each '
       'verdict has its own colour', (tester) async {
-    final handle = tester.ensureSemantics();
-    final week = List.filled(7, DayMarkState.none);
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
         DayMarkStrip(
           marks: goalDayMarks(
-            states: week,
+            states: List.filled(7, DayMarkState.none),
             lastDay: today,
             verdictsByDay: {
               today.subtract(const Duration(days: 3)): DayVerdict.met,
@@ -175,107 +204,30 @@ void main() {
         ),
       ),
     );
-
     final tokens = tester.element(find.byType(DayMarkStrip)).designTokens;
-    final cells = find.descendant(
-      of: find.byType(DayMarkStrip),
-      matching: find.byType(Container),
-    );
-    Color fillAt(int index) =>
-        (tester.widget<Container>(cells.at(index)).decoration! as BoxDecoration)
-            .color!;
-
-    // Every measured day here is `none` — grey. The user's own verdict is what
-    // decides the colour, because the measurement is evidence about a day and
-    // the reflection is their ruling on it.
-    expect(fillAt(0), dayMarkStateFill(tokens, DayMarkState.none));
-    expect(
-      fillAt(3),
-      dayVerdictFill(tokens, DayVerdict.met),
-    );
-    expect(
-      fillAt(4),
-      dayVerdictFill(tokens, DayVerdict.improving),
-    );
-    expect(
-      fillAt(5),
-      dayVerdictFill(tokens, DayVerdict.mixed),
-    );
-    expect(
-      fillAt(6),
-      dayVerdictFill(tokens, DayVerdict.missed),
-    );
-
-    // The verdict is what a screen reader hears too, not just what the eye
-    // sees — the colour is the only visual difference between these cells.
-    expect(
-      find.bySemanticsLabel(
-        '${DateFormat.MMMEd().format(
-          today.subtract(const Duration(days: 2)),
-        )}: Improving',
-      ),
-      findsOneWidget,
-    );
-
-    // Colour alone is not enough: four fills that differ only by hue are four
-    // fills a red-green deficiency cannot separate, and reading the week at a
-    // glance is the strip's entire job. Each verdict wears a shape too.
-    for (final rating in DayVerdict.values) {
-      expect(
-        find.byIcon(dayVerdictGlyph(rating)),
-        findsOneWidget,
-        reason: '${rating.name} has no shape of its own',
-      );
-      // Two inks per verdict, for two backgrounds. On its own saturated fill
-      // the glyph takes the on-alert ink; on a plain card — the reflect row —
-      // it takes its family's ink, because the on-alert ink is near-invisible
-      // there by design.
-      expect(
-        dayVerdictSurfaceInk(tokens, rating),
-        isNot(dayVerdictInk(tokens, rating)),
-        reason: '${rating.name} uses one ink for both surfaces',
-      );
-    }
-    expect(
-      {
-        for (final rating in DayVerdict.values) dayVerdictGlyph(rating),
-      },
-      hasLength(DayVerdict.values.length),
-      reason: 'two verdicts share a glyph',
-    );
-
+    expect(fillAt(tester, 0), dayMarkStateFill(tokens, DayMarkState.none));
+    expect(fillAt(tester, 3), dayVerdictFill(tokens, DayVerdict.met));
+    expect(fillAt(tester, 4), dayVerdictFill(tokens, DayVerdict.improving));
+    expect(fillAt(tester, 5), dayVerdictFill(tokens, DayVerdict.mixed));
+    expect(fillAt(tester, 6), dayVerdictFill(tokens, DayVerdict.missed));
     // All four are distinguishable, and none of them is the grey of a day
-    // nobody looked at — "I decided this was missed" and "no data" are
-    // different facts and the strip has to be able to say which.
-    final verdicts = {fillAt(3), fillAt(4), fillAt(5), fillAt(6)};
+    // nobody looked at.
+    final verdicts = {for (var i = 3; i < 7; i++) fillAt(tester, i)};
     expect(verdicts, hasLength(4));
-    expect(
-      verdicts,
-      isNot(contains(dayMarkStateFill(tokens, DayMarkState.none))),
-    );
-    handle.dispose();
+    expect(verdicts, isNot(contains(fillAt(tester, 0))));
   });
 
-  testWidgets('a read-only strip hugs its cells while a tappable one spans '
-      'the measure', (tester) async {
-    const week = [
-      DayMarkState.full,
-      DayMarkState.none,
-      DayMarkState.partial,
-      DayMarkState.none,
-      DayMarkState.none,
-      DayMarkState.full,
-      DayMarkState.none,
-    ];
+  testWidgets('tapping does not change the pitch, only the slot height', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
         SizedBox(
           width: 400,
           child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              DayMarkStrip(
-                marks: goalDayMarks(states: week),
-              ),
+              DayMarkStrip(marks: goalDayMarks(states: week)),
               DayMarkStrip(
                 marks: goalDayMarks(states: week, lastDay: today),
                 onDaySelected: (_) {},
@@ -285,29 +237,19 @@ void main() {
         ),
       ),
     );
-
-    final cells = find.descendant(
+    final tracks = tester.widgetList<DayTrack>(find.byType(DayTrack)).toList();
+    expect(tracks[0].pitch, tracks[1].pitch);
+    expect(tracks[0].height, kDaySquareSize);
+    expect(tracks[1].height, TapTargets.minimum);
+    final slots = find.descendant(
       of: find.byType(DayMarkStrip).at(1),
       matching: find.byType(InkWell),
     );
-    var covered = 0.0;
-    for (var index = 0; index < 7; index++) {
-      covered += tester.getSize(cells.at(index)).width;
-    }
-    // Both strips sit on the page's shared seven-column track now, so the
-    // week lines up with the habit squares and the metric bars rather than
-    // being a third grid. Tapping does not change the pitch: the cells are
-    // the same width either way, and the span is seven of them.
-    final readOnlyCells = find.descendant(
-      of: find.byType(DayMarkStrip).at(0),
-      matching: find.byType(Padding),
-    );
+    expect(tester.getSize(slots.first).width, tracks[1].pitch);
     expect(
-      tester.getSize(cells.at(0)).width,
-      moreOrLessEquals(covered / 7, epsilon: 1),
-      reason: 'the tappable cells do not sit on an even pitch',
+      tester.getSize(slots.first).height,
+      greaterThanOrEqualTo(TapTargets.minimum),
     );
-    expect(readOnlyCells, findsWidgets);
   });
 
   testWidgets('a placeholder strip keeps the silhouette without borrowing the '
@@ -315,80 +257,21 @@ void main() {
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
         DayMarkStrip(
-          marks: goalDayMarks(
-            states: const [
-              DayMarkState.none,
-              DayMarkState.none,
-              DayMarkState.none,
-            ],
-          ),
+          marks: goalDayMarks(states: List.filled(3, DayMarkState.none)),
           placeholder: true,
         ),
       ),
     );
-
-    // Dashed outlines, never the filled grey a genuinely-empty week wears:
-    // "no data yet" and "nothing happened" must not share an encoding.
     expect(find.byType(DsDashedBorder), findsNWidgets(3));
-    final outlined = tester.getSize(
-      find
-          .descendant(
-            of: find.byType(DsDashedBorder).first,
-            matching: find.byType(SizedBox),
-          )
-          .first,
+    expect(find.byType(DayMarkCell), findsNothing);
+    expect(
+      tester.getSize(find.byType(PlaceholderDayCell).first),
+      const Size.square(kDaySquareSize),
     );
-    expect(outlined.width, ControlSizes.iconChipCompact);
-    expect(outlined.height, ControlSizes.iconChipCompact);
   });
 
-  testWidgets('the partial-day dot scales with the square it marks', (
-    tester,
-  ) async {
-    // The square's size is derived from the width the track has to fit into,
-    // so a squeezed strip is how a small cell is produced.
-    Future<double> dotWidth({
-      required double width,
-      required int dayCount,
-    }) async {
-      await tester.pumpWidget(
-        makeTestableWidgetNoScroll(
-          Align(
-            alignment: Alignment.topLeft,
-            child: SizedBox(
-              width: width,
-              child: DayMarkStrip(
-                marks: goalDayMarks(
-                  states: List.filled(dayCount, DayMarkState.partial),
-                ),
-              ),
-            ),
-          ),
-        ),
-      );
-      // The dot is the innermost Container inside the cell.
-      return tester
-          .getSize(
-            find
-                .descendant(
-                  of: find.byType(DayMarkStrip),
-                  matching: find.byType(Container),
-                )
-                .last,
-          )
-          .width;
-    }
-
-    final compact = await dotWidth(width: 200, dayCount: 30);
-    final large = await dotWidth(width: 760, dayCount: 8);
-    // A dot fixed at the compact size vanishes inside the 28px square the
-    // detail page uses, and the partial state is the one that has no colour
-    // of its own to fall back on.
-    expect(large, greaterThan(compact));
-  });
-
-  testWidgets('a habit-outcome strip draws the skip dash and missed cross, '
-      'names each state, and counts only the kept days', (tester) async {
+  testWidgets('a habit-outcome strip names each state and counts only the '
+      'kept days', (tester) async {
     final handle = tester.ensureSemantics();
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
@@ -406,18 +289,12 @@ void main() {
               day: today.subtract(const Duration(days: 1)),
               state: DayMarkState.missed,
             ),
-            DayMark(day: today, state: DayMarkState.none, isToday: true),
+            DayMark(day: today, state: DayMarkState.none),
           ],
           onDaySelected: (_) {},
         ),
       ),
     );
-
-    expect(find.byIcon(LottiIcons.remove), findsOneWidget);
-    expect(find.byIcon(LottiIcons.close), findsOneWidget);
-    String cell(int daysBack, String outcome) =>
-        '${DateFormat.MMMEd().format(today.subtract(Duration(days: daysBack)))}'
-        ': $outcome';
     expect(find.bySemanticsLabel(cell(2, 'Skip')), findsOneWidget);
     expect(find.bySemanticsLabel(cell(1, 'Missed')), findsOneWidget);
     expect(
@@ -444,50 +321,80 @@ void main() {
         .widgetList<DsTooltip>(find.byType(DsTooltip))
         .map((t) => '${t.title}: ${t.message}')
         .toList();
-    final yesterday = DateFormat.MMMEd().format(
-      today.subtract(const Duration(days: 1)),
-    );
-    expect(tooltips, [
-      '$yesterday: done · target met',
-      '${DateFormat.MMMEd().format(today)}: Skip',
-    ]);
+    expect(tooltips, [cell(1, 'done · target met'), cell(0, 'Skip')]);
   });
 
-  testWidgets('an explicit today flag places the ring, not the last slot', (
-    tester,
-  ) async {
+  testWidgets('a streak draws the flame and the exact count after the '
+      'squares, and is announced as a streak', (tester) async {
+    final handle = tester.ensureSemantics();
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
-        DayMarkStrip(
-          marks: [
-            DayMark(
-              day: today.subtract(const Duration(days: 1)),
-              state: DayMarkState.full,
-              isToday: true,
-            ),
-            DayMark(day: today, state: DayMarkState.none),
-          ],
+        Align(
+          alignment: Alignment.topLeft,
+          child: DayMarkStrip(
+            marks: List.filled(5, const DayMark(state: DayMarkState.full)),
+            streak: 12,
+          ),
         ),
       ),
     );
-    final ringed = find.ancestor(
-      of: find.byType(DayMarkCell).first,
-      matching: find.byType(DsDashedBorder),
-    );
-    expect(find.byType(DsDashedBorder), findsOneWidget);
-    expect(ringed, findsNothing, reason: 'the ring is inside the cell');
+    final tokens = tester.element(find.byType(DayMarkStrip)).designTokens;
+    expect(find.byIcon(LottiIcons.streak), findsOneWidget);
+    // Flame and count in the handover's medium-emphasis ink: a flame in
+    // the kept hue read as one more kept day.
     expect(
-      tester.widget<DayMarkCell>(find.byType(DayMarkCell).first).mark.isToday,
-      isTrue,
+      tester.widget<Icon>(find.byIcon(LottiIcons.streak)).color,
+      tokens.colors.text.mediumEmphasis,
+    );
+    expect(find.text('12'), findsOneWidget);
+    final count = tester.widget<Text>(find.text('12')).style;
+    expect(count?.color, tokens.colors.text.mediumEmphasis);
+    expect(
+      count?.fontSize,
+      tokens.typography.styles.body.bodySmall.fontSize,
+      reason: 'the count is text, not fine print',
+    );
+    // Tail after the last square, in reading order.
+    expect(
+      tester.getTopLeft(find.byIcon(LottiIcons.streak)).dx,
+      greaterThan(tester.getTopRight(find.byType(DayMarkCell).last).dx),
     );
     expect(
-      tester.widget<DayMarkCell>(find.byType(DayMarkCell).last).mark.isToday,
-      isFalse,
+      tester.getTopLeft(find.text('12')).dx,
+      greaterThan(tester.getTopRight(find.byIcon(LottiIcons.streak)).dx),
     );
+    // step2 after the last column, which itself ends in half the pitch's
+    // air — text-grade separation from the chain, not one more cell gap.
+    final pitch = dayTrackMetrics(
+      tester.element(find.byType(DayMarkStrip)),
+    ).pitch;
+    expect(
+      tester.getTopLeft(find.byIcon(LottiIcons.streak)).dx -
+          tester.getTopRight(find.byType(DayMarkCell).last).dx,
+      tokens.spacing.step2 + (pitch - kDaySquareSize) / 2,
+    );
+    expect(
+      tester.widget<Icon>(find.byIcon(LottiIcons.streak)).size,
+      kDaySquareSize,
+    );
+    expect(find.bySemanticsLabel('12-day streak'), findsOneWidget);
+    expect(find.bySemanticsLabel(RegExp('successful day')), findsNothing);
+    handle.dispose();
   });
 
-  testWidgets('a span longer than a week fits its width and shrinks the '
-      'cells rather than scrolling', (tester) async {
+  testWidgets('a zero streak draws no tail', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        DayMarkStrip(marks: goalDayMarks(states: week), streak: 0),
+      ),
+    );
+    expect(find.byIcon(LottiIcons.streak), findsNothing);
+    expect(find.byType(Text), findsNothing);
+  });
+
+  testWidgets('a fortnight fits a phone card without scrolling', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
         Align(
@@ -505,13 +412,13 @@ void main() {
       ),
     );
     expect(find.byType(LinkedDayTrackScroller), findsNothing);
-    expect(find.byType(DayTrack), findsOneWidget);
     expect(tester.getSize(find.byType(DayTrack)).width, lessThanOrEqualTo(320));
     expect(find.byType(DayMarkCell), findsNWidgets(14));
   });
 
-  testWidgets('a span that cannot fit even at the narrowest pitch pans, '
-      'anchored on today', (tester) async {
+  testWidgets('a span wider than its measure pans, anchored on today', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
         Align(
@@ -535,31 +442,7 @@ void main() {
       ),
     );
     expect(scroller.reverse, isTrue);
-  });
-
-  testWidgets('a dateless span longer than a week is measured with its gaps, '
-      'so a fit never overflows the card', (tester) async {
-    // 12 undated cells: on the Row branch each cell is padded and the cells
-    // are gapped, so `pitch * count` underestimates the row; at this width
-    // that underestimate used to declare a fit and overflow by ~11 gaps.
-    await tester.pumpWidget(
-      makeTestableWidgetNoScroll(
-        Align(
-          alignment: Alignment.topLeft,
-          child: SizedBox(
-            width: 300,
-            child: DayMarkStrip(
-              marks: goalDayMarks(states: List.filled(12, DayMarkState.none)),
-            ),
-          ),
-        ),
-      ),
-    );
     expect(tester.takeException(), isNull);
-    expect(find.byType(DayTrack), findsNothing, reason: 'undated → Row');
-    // The honest measure says it does not fit, so the row pans instead of
-    // being handed back unwrapped to overflow the card.
-    expect(find.byType(LinkedDayTrackScroller), findsOneWidget);
   });
 
   testWidgets('an empty strip renders nothing', (tester) async {

--- a/test/widgets/day_indicators/day_mark_strip_test.dart
+++ b/test/widgets/day_indicators/day_mark_strip_test.dart
@@ -142,7 +142,16 @@ void main() {
     // A read-only strip publishes one summary rather than seven nodes, so the
     // verdicts have to reach it there — otherwise the list announced a
     // measured day count while showing four verdict hues.
-    final label = tester.getSemantics(find.byType(DayMarkStrip)).label;
+    final label = tester
+        .getSemantics(
+          find
+              .descendant(
+                of: find.byType(DayMarkStrip),
+                matching: find.byType(Semantics),
+              )
+              .first,
+        )
+        .label;
     expect(label, startsWith('1 successful day'));
     expect(label, contains(cell(2, 'Met')));
     expect(label, contains(cell(1, 'Missed')));

--- a/test/widgets/day_indicators/day_mark_styles_test.dart
+++ b/test/widgets/day_indicators/day_mark_styles_test.dart
@@ -22,56 +22,28 @@ void main() {
     return tokens;
   }
 
-  testWidgets('state fills: success family for kept days, error for a miss, '
-      'neutral for skip and empty', (tester) async {
-    final t = await tokens(tester);
-    final success = t.colors.alert.success.defaultColor;
-    expect(dayMarkStateFill(t, DayMarkState.full), success);
-    expect(
-      dayMarkStateFill(t, DayMarkState.partial),
-      success.withValues(alpha: SurfaceAlphas.muted),
-    );
-    expect(
-      dayMarkStateFill(t, DayMarkState.missed),
-      t.colors.alert.error.defaultColor,
-    );
-    expect(
-      dayMarkStateFill(t, DayMarkState.skipped),
-      t.colors.background.level03,
-    );
-    expect(
-      dayMarkStateFill(t, DayMarkState.none),
-      t.colors.background.level03,
-    );
-    // Data never wears the interactive teal.
-    for (final state in DayMarkState.values) {
-      expect(dayMarkStateFill(t, state), isNot(t.colors.interactive.enabled));
-    }
-  });
-
-  testWidgets('only recorded outcomes carry a state glyph, in their own ink', (
+  testWidgets('state fills: the interactive hue for a kept day, a wash of it '
+      'for a partial one, the neutral surface for everything else', (
     tester,
   ) async {
     final t = await tokens(tester);
-    expect(dayMarkStateGlyph(DayMarkState.missed), LottiIcons.close);
-    expect(dayMarkStateGlyph(DayMarkState.skipped), LottiIcons.remove);
+    final kept = t.colors.interactive.enabled;
+    expect(dayMarkStateFill(t, DayMarkState.full), kept);
+    expect(
+      dayMarkStateFill(t, DayMarkState.partial),
+      kept.withValues(alpha: SurfaceAlphas.muted),
+    );
     for (final state in [
+      DayMarkState.missed,
+      DayMarkState.skipped,
       DayMarkState.none,
-      DayMarkState.partial,
-      DayMarkState.full,
     ]) {
-      expect(dayMarkStateGlyph(state), isNull);
+      expect(
+        dayMarkStateFill(t, state),
+        t.colors.background.level03,
+        reason: '$state is not painted in an alert hue',
+      );
     }
-    // On the saturated error fill the cross takes the on-alert ink; the
-    // family's own ink is ~1.4:1 against its own hue.
-    expect(
-      dayMarkStateGlyphInk(t, DayMarkState.missed),
-      t.colors.text.onInteractiveAlert,
-    );
-    expect(
-      dayMarkStateGlyphInk(t, DayMarkState.skipped),
-      t.colors.text.mediumEmphasis,
-    );
   });
 
   testWidgets('every verdict has a distinct fill, shape and surface ink', (
@@ -91,17 +63,21 @@ void main() {
       DayVerdict.values.length,
     );
     expect(
-      dayVerdictFill(t, DayVerdict.met),
-      dayMarkStateFill(t, DayMarkState.full),
-      reason: 'met and measured-full are the same green',
-    );
-    expect(
       dayVerdictFill(t, DayVerdict.missed),
       isNot(dayMarkStateFill(t, DayMarkState.none)),
       reason: 'a judged miss is never the empty-day grey',
     );
-    for (final verdict in DayVerdict.values) {
-      expect(dayVerdictInk(t, verdict), t.colors.text.onInteractiveAlert);
+    expect(
+      dayVerdictFill(t, DayVerdict.met),
+      dayMarkStateFill(t, DayMarkState.full),
+      reason: 'one green for good on every track',
+    );
+    for (final verdict in DayVerdict.values.where((v) => v != DayVerdict.met)) {
+      expect(
+        dayVerdictFill(t, verdict),
+        isNot(dayMarkStateFill(t, DayMarkState.full)),
+        reason: 'a non-met verdict is never mistaken for a kept day',
+      );
     }
   });
 
@@ -127,56 +103,5 @@ void main() {
     expect(dayVerdictLabel(ctx, DayVerdict.improving), 'Improving');
     expect(dayVerdictLabel(ctx, DayVerdict.mixed), 'Mixed');
     expect(dayVerdictLabel(ctx, DayVerdict.missed), 'Missed');
-  });
-
-  testWidgets('the corner letter yields on cells too small to hold it and '
-      'follows the fill for ink', (tester) async {
-    final t = await tokens(tester);
-    expect(
-      dayCellLetter(t, letter: 'M', cellSize: IconSizes.xs, filled: false),
-      isNull,
-    );
-    expect(
-      dayCellLetter(t, letter: null, cellSize: IconSizes.l, filled: false),
-      isNull,
-    );
-    final tag = dayCellLetter(t, letter: 'M', cellSize: 28, filled: true);
-    expect(tag, isA<PositionedDirectional>());
-    await tester.pumpWidget(
-      makeTestableWidgetNoScroll(
-        SizedBox.square(dimension: 28, child: Stack(children: [tag!])),
-      ),
-    );
-    final text = tester.widget<Text>(find.text('M'));
-    expect(text.style?.color, t.colors.text.onInteractiveAlert);
-    final positioned = tester.widget<PositionedDirectional>(
-      find.byType(PositionedDirectional),
-    );
-    expect(positioned.start, 28 * DayCellLetter.insetStart);
-    expect(positioned.bottom, 28 * DayCellLetter.insetBottom);
-  });
-
-  testWidgets(
-    'the today ring and partial dot draw in quiet, non-interactive ink',
-    (
-      tester,
-    ) async {
-      final t = await tokens(tester);
-      expect(todayRingInk(t), t.colors.text.mediumEmphasis);
-      expect(dayCellRadius(t), t.radii.s);
-      await tester.pumpWidget(
-        makeTestableWidgetNoScroll(Center(child: partialDayDot(t, 6))),
-      );
-      final dot = tester.widget<Container>(find.byType(Container));
-      expect(tester.getSize(find.byType(Container)), const Size(6, 6));
-      expect(
-        (dot.decoration! as BoxDecoration).color,
-        t.colors.alert.success.ink,
-      );
-    },
-  );
-  test('the glyph takes three quarters of its square at every size', () {
-    expect(dayMarkGlyphSize(IconSizes.xs), IconSizes.xs * 0.75);
-    expect(dayMarkGlyphSize(28), 21);
   });
 }

--- a/test/widgets/day_indicators/day_mark_test.dart
+++ b/test/widgets/day_indicators/day_mark_test.dart
@@ -77,6 +77,30 @@ void main() {
     expect(a.toString(), contains('DayMarkState.full'));
   });
 
+  test('only an empty, unjudged today is pending', () {
+    expect(
+      const DayMark(state: DayMarkState.none, isToday: true).pending,
+      isTrue,
+    );
+    expect(const DayMark(state: DayMarkState.none).pending, isFalse);
+    expect(
+      const DayMark(state: DayMarkState.full, isToday: true).pending,
+      isFalse,
+    );
+    expect(
+      const DayMark(state: DayMarkState.skipped, isToday: true).pending,
+      isFalse,
+    );
+    expect(
+      const DayMark(
+        state: DayMarkState.none,
+        verdict: DayVerdict.missed,
+        isToday: true,
+      ).pending,
+      isFalse,
+    );
+  });
+
   test('verdict names are the persisted wire format and must not change', () {
     expect(DayVerdict.values.map((v) => v.name), [
       'met',

--- a/test/widgets/day_indicators/day_track_test.dart
+++ b/test/widgets/day_indicators/day_track_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_cell.dart';
 import 'package:lotti/widgets/day_indicators/day_track.dart';
 import 'package:lotti/widgets/misc/linked_scroll_group.dart';
 
@@ -43,44 +44,24 @@ void main() {
     expect(tester.getSize(find.byType(DayTrack)), Size.zero);
   });
 
-  testWidgets('metrics keep the authored pitch when the span fits and shrink '
-      'toward the floor when it does not', (tester) async {
-    late DayTrackMetrics roomy;
-    late DayTrackMetrics squeezed;
-    late DayTrackMetrics floored;
+  testWidgets('metrics are one square and step2 of air, with one-letter '
+      'captions, at every span', (tester) async {
+    late DayTrackMetrics metrics;
     late DsTokens tokens;
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
         Builder(
           builder: (context) {
             tokens = context.designTokens;
-            roomy = dayTrackMetrics(context, dayCount: 7, availableWidth: 1000);
-            squeezed = dayTrackMetrics(
-              context,
-              dayCount: 14,
-              availableWidth: 320,
-            );
-            floored = dayTrackMetrics(
-              context,
-              dayCount: 90,
-              availableWidth: 320,
-            );
+            metrics = dayTrackMetrics(context);
             return const SizedBox.shrink();
           },
         ),
       ),
     );
-    final authored = ControlSizes.iconChipCompact + tokens.spacing.step2;
-    expect(roomy.pitch, authored);
-    expect(roomy.cellSize, ControlSizes.iconChipCompact);
-    expect(roomy.narrowLabels, isFalse);
-    expect(squeezed.pitch, lessThan(authored));
-    expect(squeezed.pitch * 14, lessThanOrEqualTo(320));
-    expect(squeezed.cellSize, squeezed.pitch - tokens.spacing.step2);
-    expect(floored.pitch, IconSizes.xs + tokens.spacing.step2);
-    expect(floored.cellSize, IconSizes.xs);
-    expect(floored.narrowLabels, isTrue);
-    expect(roomy.labelHeight, greaterThanOrEqualTo(IconSizes.s));
+    expect(metrics.pitch, kDaySquareSize + tokens.spacing.step2);
+    expect(metrics.narrowLabels, isTrue, reason: '"Mon" does not fit 16px');
+    expect(metrics.labelHeight, greaterThanOrEqualTo(IconSizes.s));
   });
 
   testWidgets('a raised text scale widens the pitch to hold the caption', (
@@ -92,14 +73,14 @@ void main() {
       makeTestableWidgetNoScroll(
         Builder(
           builder: (context) {
-            normal = dayTrackMetrics(context, dayCount: 7);
+            normal = dayTrackMetrics(context);
             return MediaQuery(
               data: MediaQuery.of(
                 context,
               ).copyWith(textScaler: const TextScaler.linear(2.5)),
               child: Builder(
                 builder: (context) {
-                  scaled = dayTrackMetrics(context, dayCount: 7);
+                  scaled = dayTrackMetrics(context);
                   return const SizedBox.shrink();
                 },
               ),


### PR DESCRIPTION
## What

Rebuilds the habit day squares to the Claude Design habits handover ("Habit row": a history strip of 11px squares, radius 3, plus flame and streak count in medium-emphasis text; the prototype is a flex row, gap 3px, each square filled `--interactive`).

- **One square, everywhere.** `kDaySquareSize` (`IconSizes.xs`), `radii.xs`, `spacing.step2` gap. Kept day = `interactive.enabled`, partial = its muted wash, everything else the neutral `background.level03`. Today while still open is the module's dashed "unresolved" outline, so a live streak never ends on the grey of a missed day.
- **Nothing inside or around a square.** The weekday letters, outcome/verdict glyphs, today ring, partial dot and the shrinking cell sizes are gone. Weekday+date, outcome, verdict and ages-out are the tooltip's and the semantics'. A *tappable* square (goal detail) carries its weekday initial above it, inside the 48px hit slot.
- **Habits list rows show the real week**: `habitHistoryMarks` reads the last seven days off `HabitsState`'s per-day completion sets; the flame + current streak follow the squares. The separate 14px streak chain is deleted. `HabitActionRow.history` is now a `List<DayMark>`.
- **Verdict hues stay on the goal-assessment layer.** `met` now paints the same interactive green a kept day wears (one green for "good"); improving/mixed/missed keep their alert hues. The habit strips no longer paint verdicts, so `habitDayVerdictsProvider` is removed (`goalsWatchingHabitProvider` stays for the completion sheet's reflect actions).
- `dayTrackMetrics` is one square + `step2` per column (widened only for scaled-text captions); spans that do not fit pan instead of shrinking.

Part of lotti3-co1 (unify Habits and Goals day indicators).

## Design review

Ran the design-review panel against the handover three times (experts / personas): baseline of the previous squares **3.0 / 2.8** → round 1 **6.33 / 6.0** → round 2 **6.67 / 6.2** → round 3 **6.75 / 6.0**. Applied between rounds: the gap (step1→step2), one green for met/kept, flame in medium-emphasis ink at the square size, count on `bodySmall`, real dated history on the list rows, weekday captions in the tappable slot, dashed today-open. Deliberately not applied: glyphs back inside the squares, hover fills on read-only strips, bigger squares — none of these are in the handover. Follow-up worth its own PR: collapse `_ProgressDayCell` (goal detail's outcome-menu cell) onto `DayMarkCell`.

## Screenshots

| Surface | Before | After |
|---|---|---|
| Habits list, phone | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-squares-handover/d3844f7d159d295f872ccf8baa5ae381aed4fee9/before/habits_today_mobile_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-squares-handover/d3844f7d159d295f872ccf8baa5ae381aed4fee9/after/habits_today_mobile_dark.png) |
| Habits list, desktop | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-squares-handover/d3844f7d159d295f872ccf8baa5ae381aed4fee9/before/habits_today_desktop_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-squares-handover/d3844f7d159d295f872ccf8baa5ae381aed4fee9/after/habits_today_desktop_dark.png) |
| Dashboard habit card | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-squares-handover/d3844f7d159d295f872ccf8baa5ae381aed4fee9/before/dashboard_habit_phone.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-squares-handover/d3844f7d159d295f872ccf8baa5ae381aed4fee9/after/dashboard_habit_phone.png) |
| Goal detail habit cards, phone | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-squares-handover/d3844f7d159d295f872ccf8baa5ae381aed4fee9/before/goal_card_phone.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-squares-handover/d3844f7d159d295f872ccf8baa5ae381aed4fee9/after/goal_card_phone.png) |
| Goal detail habit cards, desktop | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-squares-handover/d3844f7d159d295f872ccf8baa5ae381aed4fee9/before/goal_card_desktop.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-day-squares-handover/d3844f7d159d295f872ccf8baa5ae381aed4fee9/after/goal_card_desktop.png) |

Fixtures: penguin demo world and `test/test_data` only. (The habits-list fixture paints every day kept; the dashboard/goal captures use synthetic mixed weeks.)

## Tests

Rewrote `test/widgets/day_indicators/*` for the new contract (square geometry, fills, caption, pending today, streak tail, pitch, fit-or-pan), added `habitHistoryMarks` tests, and updated the goal card / detail page / action row / completion card suites. Docs: `knowledge/architecture/day-indicators.md`, `knowledge/features/{habits,goals}.md`, `lib/features/goals/README.md`; two `changelog.d` fragments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seven-day history strips to habit rows and dashboard habit cards.
  * Unified day-square styling across habits and goals with filled kept days and neutral incomplete days.
  * Added weekday captions for tappable goal squares, hover/long-press details, and accessibility descriptions.
  * Preserved square sizing while enabling synchronized panning for longer date ranges.
  * Added flame and current-streak summaries to habit history strips.

* **Improvements**
  * Simplified day indicators by removing embedded icons, letters, dots, and rings.
  * Updated partial-day and skipped/missed-day visual treatments for clearer status recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->