### PR TITLE
feat(habits): two signal columns on the desktop completion sheet

### DIFF
--- a/changelog.d/2026-08-30-completion-sheet-columns.md
+++ b/changelog.d/2026-08-30-completion-sheet-columns.md
@@ -1,0 +1,7 @@
+### Changed
+
+- **The desktop completion sheet lays three or more signals out in two
+  columns.** The quick-record chips and sparklines stay in view above the
+  form instead of pushing it below the fold; phones keep the single column.
+  Signal rows now read as cards on the sheet, and a row whose status already
+  says "N so far" no longer repeats the number in a "today:" caption.

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -343,7 +343,15 @@ the old dialog that embedded a whole linked dashboard. It renders **one
 measurable (its three most-logged values, from the same ranking the
 measurement dialog uses, plus *Other* for the full capture), and a two-week
 `SignalSparkline` — above the unchanged form (date, comment, Success / Skip /
-Missed, Record). A **choice measurable** offers every active choice as a chip
+Missed, Record). The rows are cards one elevation step above the sheet
+(`dsCardSurface` on `dsPageSurface`), as the handover draws them. On a
+desktop window a habit with three or more signals lays the rows out **two
+abreast in a wider card** (`kHabitCompletionSheetTwoColumnSignals`,
+`kHabitCompletionSheetWideWidth`), an unpaired last row spanning both
+columns, so the signals stay above the form instead of pushing it below the
+fold; a phone, or fewer signals, keeps the single column. A row whose pill
+already reads "N so far" omits the `today:` caption rather than repeat the
+number. A **choice measurable** offers every active choice as a chip
 instead of suggestions — the set is the vocabulary, not a ranking — records
 one occurrence of the tapped choice (`MeasurableQuickValue`, the number-or-
 choice shape the chips, row and sheet pass around), reports today as *logged*

--- a/lib/features/habits/ui/sheets/habit_completion_sheet.dart
+++ b/lib/features/habits/ui/sheets/habit_completion_sheet.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/buttons/ds_segmented_toggle.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/design_system/theme/ds_surface_elevation.dart';
 import 'package:lotti/features/goals/state/goal_assessment_state.dart';
@@ -34,8 +35,20 @@ import 'package:lotti/utils/date_utils_extension.dart';
 import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/date_time/datetime_field.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
-import 'package:tinycolor2/tinycolor2.dart';
 import 'package:url_launcher/url_launcher.dart';
+
+/// The reviewed width of the completion sheet's card.
+const kHabitCompletionSheetWidth = 500.0;
+
+/// The card's width once the signal rows go two abreast: two of the single
+/// column's signal measures side by side, so each row keeps the chip and
+/// sparkline room it has in the narrow card.
+const kHabitCompletionSheetWideWidth = 900.0;
+
+/// The number of signals from which a desktop sheet lays the rows out in
+/// two columns instead of one — the handover's threshold, where a single
+/// column would stack three sparkline cards above the form.
+const kHabitCompletionSheetTwoColumnSignals = 3;
 
 /// The compact completion sheet: the habit's own signals in view, then the
 /// outcome and Record.
@@ -321,6 +334,40 @@ class _HabitCompletionSheetState extends ConsumerState<HabitCompletionSheet> {
       };
 }
 
+/// The signal rows two abreast, paired top to bottom in reading order. An
+/// unpaired last row spans both columns: a half-width orphan beside an empty
+/// cell read as a hole in the sheet, and a full-width row keeps the grid
+/// reading as rows, so the pairing order is the reading order.
+class _SignalColumns extends StatelessWidget {
+  const _SignalColumns({required this.signals});
+
+  final List<Widget> signals;
+
+  @override
+  Widget build(BuildContext context) {
+    final gap = context.designTokens.spacing.step3;
+    return Column(
+      key: const ValueKey('habit-sheet-signal-columns'),
+      children: [
+        for (var index = 0; index < signals.length; index += 2) ...[
+          if (index > 0) SizedBox(height: gap),
+          if (index + 1 < signals.length)
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(child: signals[index]),
+                SizedBox(width: gap),
+                Expanded(child: signals[index + 1]),
+              ],
+            )
+          else
+            signals[index],
+        ],
+      ],
+    );
+  }
+}
+
 /// The completion-capture card: habit name, optional description, the
 /// signal rows, the date being recorded, an optional note, the outcome
 /// segmented picker and the primary Record action.
@@ -361,11 +408,19 @@ class _CompletionForm extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
+    // Desktop with three or more signals: two columns, so the signals stay
+    // in view above the form instead of pushing it below the fold. A phone
+    // never has the width; two signals do not earn the wider card.
+    final twoColumns =
+        isDesktopLayout(context) &&
+        signals.length >= kHabitCompletionSheetTwoColumnSignals;
 
     return Card(
       margin: EdgeInsets.zero,
       elevation: 0,
-      color: dsCardSurface(context),
+      // The canvas step, as the handover draws the sheet: the signal rows
+      // sit on it as cards, and are only visible as cells because of it.
+      color: dsPageSurface(context),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(
           top: Radius.circular(tokens.radii.xl),
@@ -374,12 +429,16 @@ class _CompletionForm extends StatelessWidget {
       ),
       child: ConstrainedBox(
         constraints: BoxConstraints(
-          maxWidth: 500,
+          maxWidth: twoColumns
+              ? kHabitCompletionSheetWideWidth
+              : kHabitCompletionSheetWidth,
           minWidth: isMobile ? MediaQuery.of(context).size.width : 250,
         ),
         child: SingleChildScrollView(
+          // One horizontal inset, the same the signal cards use inside,
+          // so the grid, the fields and Record share their margins.
           padding: EdgeInsets.fromLTRB(
-            tokens.spacing.step6,
+            tokens.spacing.step4,
             tokens.spacing.step4,
             tokens.spacing.step4,
             tokens.spacing.step5,
@@ -419,10 +478,16 @@ class _CompletionForm extends StatelessWidget {
                 ),
                 if (habitDefinition.description.isNotEmpty)
                   HabitDescription(habitDefinition),
-                for (final signal in signals) ...[
-                  SizedBox(height: tokens.spacing.step3),
-                  signal,
-                ],
+                if (twoColumns) ...[
+                  // A section gap on each side of the grid: the signals are
+                  // one tier, the completion record below them the next.
+                  SizedBox(height: tokens.spacing.step4),
+                  _SignalColumns(signals: signals),
+                ] else
+                  for (final signal in signals) ...[
+                    SizedBox(height: tokens.spacing.step3),
+                    signal,
+                  ],
                 if (reflections.isNotEmpty) ...[
                   SizedBox(height: tokens.spacing.step3),
                   // The goals' own judgement of this day, reachable from the
@@ -555,15 +620,18 @@ class HabitDescription extends StatelessWidget {
       }
     }
 
+    final tokens = context.designTokens;
+    final style = tokens.typography.styles.body.bodyMedium.copyWith(
+      color: tokens.colors.text.mediumEmphasis,
+    );
     return Padding(
-      padding: EdgeInsets.only(top: context.designTokens.spacing.step2),
+      padding: EdgeInsets.only(top: tokens.spacing.step2),
       child: Linkify(
         onOpen: onOpen,
         text: '${habitDefinition?.description}',
-        style: habitCompletionHeaderStyle.copyWith(fontSize: fontSizeMedium),
-        linkStyle: habitCompletionHeaderStyle.copyWith(
-          fontSize: fontSizeMedium,
-          color: Theme.of(context).primaryColor.darken(25),
+        style: style,
+        linkStyle: style.copyWith(
+          color: tokens.colors.interactive.enabled,
           decoration: TextDecoration.none,
         ),
       ),

--- a/lib/features/habits/ui/sheets/habit_completion_sheet.dart
+++ b/lib/features/habits/ui/sheets/habit_completion_sheet.dart
@@ -410,10 +410,13 @@ class _CompletionForm extends StatelessWidget {
     final messages = context.messages;
     // Desktop with three or more signals: two columns, so the signals stay
     // in view above the form instead of pushing it below the fold. A phone
-    // never has the width; two signals do not earn the wider card.
+    // never has the width; two signals do not earn the wider card; and a
+    // raised text scale keeps the single column — a half-width cell has no
+    // room for a title beside a status pill grown to twice its size.
     final twoColumns =
         isDesktopLayout(context) &&
-        signals.length >= kHabitCompletionSheetTwoColumnSignals;
+        signals.length >= kHabitCompletionSheetTwoColumnSignals &&
+        MediaQuery.textScalerOf(context).scale(1) <= 1;
 
     return Card(
       margin: EdgeInsets.zero,

--- a/lib/features/habits/ui/widgets/habit_signal_row.dart
+++ b/lib/features/habits/ui/widgets/habit_signal_row.dart
@@ -87,6 +87,10 @@ class HabitSignalRow extends StatelessWidget {
             '${_format(todayValue, locale)} $unit'.trim(),
           );
 
+    // A pill that already reads "N so far" carries today's value; the
+    // caption would only repeat the same number one line lower.
+    final showToday = !_pillCarriesValue(leaf);
+
     return Container(
       key: ValueKey('habit-signal-row-${_leafKey(rule)}'),
       decoration: BoxDecoration(
@@ -147,13 +151,20 @@ class HabitSignalRow extends StatelessWidget {
                     onMore: () => onMoreMeasurable(measurable),
                   ),
                 ),
-                SizedBox(width: tokens.spacing.step3),
-                Text(todayText, style: captionStyle),
+                if (showToday) ...[
+                  SizedBox(width: tokens.spacing.step3),
+                  Text(todayText, style: captionStyle),
+                ],
               ],
             ),
-          ] else ...[
+          ] else if (showToday) ...[
+            // The same slot as beside the chips — trailing — so the today
+            // value sits in one place in every row, chips or not.
             SizedBox(height: tokens.spacing.step2),
-            Text(todayText, style: captionStyle),
+            Align(
+              alignment: AlignmentDirectional.centerEnd,
+              child: Text(todayText, style: captionStyle),
+            ),
           ],
           SizedBox(height: tokens.spacing.step3),
           SignalSparkline(values: _series()),
@@ -198,6 +209,21 @@ class HabitSignalRow extends StatelessWidget {
       };
 
   /// "any entry · done", "6,000 steps · 4,120 so far", "any workout · not yet".
+  /// Whether the status pill states today's value itself — the "so far"
+  /// wording of an unmet threshold rule with a reading.
+  bool _pillCarriesValue(HabitLeafVerdict leaf) {
+    if (leaf.satisfied || leaf.value == null) return false;
+    return switch (leaf.rule) {
+      AutoCompleteRuleMeasurable(:final minimum, :final maximum) ||
+      AutoCompleteRuleHealth(:final minimum, :final maximum) ||
+      AutoCompleteRuleWorkout(
+        :final minimum,
+        :final maximum,
+      ) => minimum != null || maximum != null,
+      _ => false,
+    };
+  }
+
   String _ruleStatus(
     AppLocalizations messages,
     HabitLeafVerdict leaf,

--- a/lib/features/habits/ui/widgets/habit_signal_row.dart
+++ b/lib/features/habits/ui/widgets/habit_signal_row.dart
@@ -122,19 +122,23 @@ class HabitSignalRow extends StatelessWidget {
                 ),
               ),
               SizedBox(width: tokens.spacing.step2),
-              DsPill(
-                key: ValueKey('habit-signal-pill-${_leafKey(rule)}'),
-                variant: DsPillVariant.tinted,
-                shape: DsPillShape.tag,
-                color: pillColor,
-                leading: leaf.satisfied
-                    ? Icon(
-                        LottiIcons.confirm,
-                        size: IconSizes.xs,
-                        color: pillColor,
-                      )
-                    : null,
-                label: _ruleStatus(messages, leaf, unit, locale),
+              // Flexible, so a long localized status at a raised text scale
+              // ellipsizes inside the pill instead of overflowing the row.
+              Flexible(
+                child: DsPill(
+                  key: ValueKey('habit-signal-pill-${_leafKey(rule)}'),
+                  variant: DsPillVariant.tinted,
+                  shape: DsPillShape.tag,
+                  color: pillColor,
+                  leading: leaf.satisfied
+                      ? Icon(
+                          LottiIcons.confirm,
+                          size: IconSizes.xs,
+                          color: pillColor,
+                        )
+                      : null,
+                  label: _ruleStatus(messages, leaf, unit, locale),
+                ),
               ),
             ],
           ),

--- a/test/features/habits/ui/sheets/habit_completion_sheet_test.dart
+++ b/test/features/habits/ui/sheets/habit_completion_sheet_test.dart
@@ -259,6 +259,7 @@ void main() {
     String? dateString,
     List<Override> overrides = const [],
     Size viewport = const Size(800, 1400),
+    double textScale = 1,
   }) async {
     tester.view.physicalSize = viewport;
     tester.view.devicePixelRatio = 1.0;
@@ -289,7 +290,10 @@ void main() {
             ),
           ),
         ),
-        mediaQueryData: MediaQueryData(size: viewport),
+        mediaQueryData: MediaQueryData(
+          size: viewport,
+          textScaler: TextScaler.linear(textScale),
+        ),
         overrides: [
           measurableSuggestionsControllerProvider(
             'water',
@@ -535,6 +539,25 @@ void main() {
         kHabitCompletionSheetWidth,
       );
     });
+
+    clockedWidgets(
+      'a raised text scale keeps three signals stacked on a desktop window: '
+      'a half-width cell cannot hold a title beside a doubled status pill',
+      (tester) async {
+        await pumpSheet(
+          tester,
+          habitId: tripleHabit.id,
+          viewport: const Size(kDesktopBreakpoint, 2400),
+          textScale: 2,
+        );
+        expect(find.byKey(columnsKey), findsNothing);
+        expect(
+          tester.getSize(find.byType(Card)).width,
+          kHabitCompletionSheetWidth,
+        );
+        expect(tester.takeException(), isNull);
+      },
+    );
 
     clockedWidgets('one signal on a desktop window keeps the narrow card', (
       tester,

--- a/test/features/habits/ui/sheets/habit_completion_sheet_test.dart
+++ b/test/features/habits/ui/sheets/habit_completion_sheet_test.dart
@@ -19,6 +19,7 @@ import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/dashboards/state/measurables_controller.dart';
 import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/goals/state/goal_assessment_state.dart';
 import 'package:lotti/features/goals/state/goal_habit_watchers.dart';
 import 'package:lotti/features/goals/state/goal_progress_view.dart';
@@ -108,6 +109,41 @@ class _ChoiceStatus extends HabitSignalStatusController {
   Future<void> refresh() async => state = AsyncData(_status());
 }
 
+/// A status for a three-leaf rule — the handover's threshold for the
+/// desktop sheet to lay its signal rows out two abreast.
+class _TripleStatus extends HabitSignalStatusController {
+  _TripleStatus(super.habitId, this.windowOf);
+  final SignalWindow Function() windowOf;
+
+  static const rule = AutoCompleteRule.and(
+    rules: [
+      AutoCompleteRule.measurable(dataTypeId: 'water', minimum: 500),
+      AutoCompleteRule.measurable(dataTypeId: 'hydration'),
+      AutoCompleteRule.measurable(dataTypeId: 'water', minimum: 250),
+    ],
+  );
+
+  HabitSignalStatus _status() {
+    final window = windowOf();
+    return HabitSignalStatus(
+      rule: rule,
+      window: window,
+      verdict: const HabitRuleEvaluator().evaluate(
+        rule: rule,
+        window: window,
+        day: window.end,
+      ),
+      today: window.end,
+    );
+  }
+
+  @override
+  Future<HabitSignalStatus?> build() async => _status();
+
+  @override
+  Future<void> refresh() async => state = AsyncData(_status());
+}
+
 /// [testWidgets] under the fixed sheet clock.
 void clockedWidgets(
   String description,
@@ -142,6 +178,11 @@ void main() {
     name: 'Check hydration',
     autoCompleteRule: _ChoiceStatus.rule,
   );
+  final tripleHabit = habitFlossing.copyWith(
+    id: 'triple-habit',
+    name: 'Three signals',
+    autoCompleteRule: _TripleStatus.rule,
+  );
   var waterToday = <DateTime, num>{};
   var hydrationToday = <DateTime, num>{};
 
@@ -167,6 +208,7 @@ void main() {
       () => cache.getHabitById(hydrationHabit.id),
     ).thenReturn(hydrationHabit);
     when(() => cache.getDataTypeById('hydration')).thenReturn(hydration);
+    when(() => cache.getHabitById(tripleHabit.id)).thenReturn(tripleHabit);
     when(() => cache.getHabitById('missing')).thenReturn(null);
     when(() => cache.getDataTypeById('water')).thenReturn(water);
     when(
@@ -216,8 +258,9 @@ void main() {
     String? habitId,
     String? dateString,
     List<Override> overrides = const [],
+    Size viewport = const Size(800, 1400),
   }) async {
-    tester.view.physicalSize = const Size(800, 1400);
+    tester.view.physicalSize = viewport;
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
@@ -246,6 +289,7 @@ void main() {
             ),
           ),
         ),
+        mediaQueryData: MediaQueryData(size: viewport),
         overrides: [
           measurableSuggestionsControllerProvider(
             'water',
@@ -256,6 +300,9 @@ void main() {
           habitSignalStatusProvider(
             hydrationHabit.id,
           ).overrideWith(() => _ChoiceStatus(hydrationHabit.id, window)),
+          habitSignalStatusProvider(
+            tripleHabit.id,
+          ).overrideWith(() => _TripleStatus(tripleHabit.id, window)),
           ...overrides,
         ],
       ),
@@ -445,6 +492,65 @@ void main() {
   });
 
   group('signals', () {
+    const columnsKey = ValueKey('habit-sheet-signal-columns');
+    List<Rect> signalRects(WidgetTester tester) => [
+      for (final element in find.byType(HabitSignalRow).evaluate())
+        tester.getRect(find.byWidget(element.widget)),
+    ];
+
+    clockedWidgets(
+      'three signals on a desktop window go two abreast in a wider card, '
+      'the unpaired last row spanning both',
+      (tester) async {
+        await pumpSheet(
+          tester,
+          habitId: tripleHabit.id,
+          viewport: const Size(kDesktopBreakpoint, 1400),
+        );
+        expect(find.byKey(columnsKey), findsOneWidget);
+        expect(find.byType(HabitSignalRow), findsNWidgets(3));
+        final rows = signalRects(tester);
+        expect(rows[0].top, rows[1].top, reason: 'first pair shares a line');
+        expect(rows[1].left, greaterThan(rows[0].right));
+        expect(rows[2].top, greaterThan(rows[0].bottom));
+        expect(rows[2].left, rows[0].left);
+        expect(rows[2].right, rows[1].right, reason: 'odd row spans both');
+        expect(
+          tester.getSize(find.byType(Card)).width,
+          kHabitCompletionSheetWideWidth,
+        );
+      },
+    );
+
+    clockedWidgets('three signals on a phone-width window stay stacked', (
+      tester,
+    ) async {
+      await pumpSheet(tester, habitId: tripleHabit.id);
+      expect(find.byKey(columnsKey), findsNothing);
+      final rows = signalRects(tester);
+      expect(rows[1].top, greaterThan(rows[0].bottom));
+      expect(rows[2].top, greaterThan(rows[1].bottom));
+      expect(
+        tester.getSize(find.byType(Card)).width,
+        kHabitCompletionSheetWidth,
+      );
+    });
+
+    clockedWidgets('one signal on a desktop window keeps the narrow card', (
+      tester,
+    ) async {
+      await pumpSheet(
+        tester,
+        habitId: waterHabit.id,
+        viewport: const Size(kDesktopBreakpoint, 1400),
+      );
+      expect(find.byKey(columnsKey), findsNothing);
+      expect(
+        tester.getSize(find.byType(Card)).width,
+        kHabitCompletionSheetWidth,
+      );
+    });
+
     clockedWidgets('a habit without a rule shows no signal rows', (
       tester,
     ) async {

--- a/test/features/habits/ui/widgets/habit_signal_row_test.dart
+++ b/test/features/habits/ui/widgets/habit_signal_row_test.dart
@@ -132,7 +132,8 @@ void main() {
       );
       await tester.pump();
       expect(find.text('≥ 1,000 ml · 750 so far'), findsOneWidget);
-      expect(find.text('today: 750 ml'), findsOneWidget);
+      // The pill already states the reading; the caption would repeat it.
+      expect(find.textContaining('today:'), findsNothing);
 
       await pump(
         tester,


### PR DESCRIPTION
Closes the last open item of the habits handover (§4, compact completion sheet): on desktop, a habit with three or more signals lays its signal rows out two abreast in a wider card, with an unpaired last row spanning both columns. Phones and habits with fewer signals keep the single column.

Along the way, from the design-panel rounds on the new layout:
- signal rows are cards on the sheet's canvas step (`dsCardSurface` on `dsPageSurface`), which is what makes them legible as cells — and matches the handover's bg-02-on-bg-01;
- the sheet's horizontal inset is one value on both sides;
- the description reads from the typography tokens (drops the last `tinycolor` use in the sheet);
- a row whose pill already says "N so far" no longer repeats the number in a "today:" caption.

Beads: lotti3-pmsi.

## Screenshots

| | before | after |
|---|---|---|
| desktop dark | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/completion-sheet-columns-v2/3f5b9ab9e82634d4936e8cf3ab09daee9aa660bb/before/habit_completion_desktop_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/completion-sheet-columns-v2/3f5b9ab9e82634d4936e8cf3ab09daee9aa660bb/after/habit_completion_desktop_dark.png) |
| desktop light | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/completion-sheet-columns-v2/3f5b9ab9e82634d4936e8cf3ab09daee9aa660bb/before/habit_completion_desktop_light.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/completion-sheet-columns-v2/3f5b9ab9e82634d4936e8cf3ab09daee9aa660bb/after/habit_completion_desktop_light.png) |
| mobile dark | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/completion-sheet-columns-v2/3f5b9ab9e82634d4936e8cf3ab09daee9aa660bb/before/habit_completion_mobile_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/completion-sheet-columns-v2/3f5b9ab9e82634d4936e8cf3ab09daee9aa660bb/after/habit_completion_mobile_dark.png) |
| mobile light | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/completion-sheet-columns-v2/3f5b9ab9e82634d4936e8cf3ab09daee9aa660bb/before/habit_completion_mobile_light.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/completion-sheet-columns-v2/3f5b9ab9e82634d4936e8cf3ab09daee9aa660bb/after/habit_completion_mobile_light.png) |

## Tests

- `habit_completion_sheet_test.dart`: three signals on a desktop window go two abreast in the wide card with the last row spanning; the same three on a phone width stay stacked in the narrow card; one signal on desktop keeps the narrow card.
- `habit_signal_row_test.dart`: the "so far" row omits the today caption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Completion sheets with three or more signals now use a two-column layout on desktop.
  * Phones and sheets with fewer signals retain the single-column layout.
  * Quick-record controls and sparklines remain visible above the form.
  * Signal rows are presented as cards with improved spacing and styling.
  * Removed duplicate “today” values when the status pill already shows the amount recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->