### PR TITLE
chore(flatpak): pin the manifest's Flutter SDK to 3.47.2

### DIFF
--- a/flatpak/com.matthiasn.lotti.flatpak-flutter.yml
+++ b/flatpak/com.matthiasn.lotti.flatpak-flutter.yml
@@ -157,7 +157,7 @@ modules:
       # Flutter SDK - inside lotti module as flatpak-flutter expects
       - type: git
         url: https://github.com/flutter/flutter.git
-        tag: 3.47.1
+        tag: 3.47.2
         dest: flutter
         disable-lfs: true
       - type: script


### PR DESCRIPTION
3f5b9ab9e bumped `.fvmrc` to 3.47.2 but the Flathub manifest still tagged 3.47.1, so the Flutter pin guard fails on main and on every open PR. Sets the manifest tag to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Flutter SDK version used for Flatpak builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->