### PR TITLE
fix(habits): count an "Other" entry like a chip and validate before closing the sheet

### DIFF
--- a/changelog.d/2026-08-30-completion-sheet-other-and-validate.md
+++ b/changelog.d/2026-08-30-completion-sheet-other-and-validate.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **A value entered through "Other" in the habit completion sheet now counts
+  like a quick-record chip.** The row shows it as recorded and, when it meets
+  the habit's rule, the outcome flips to Success — previously only the chips
+  did. The sheet also validates its form before closing rather than after.

--- a/changelog.d/2026-08-30-completion-sheet-other-and-validate.md
+++ b/changelog.d/2026-08-30-completion-sheet-other-and-validate.md
@@ -2,5 +2,6 @@
 
 - **A value entered through "Other" in the habit completion sheet now counts
   like a quick-record chip.** The row shows it as recorded and, when it meets
-  the habit's rule, the outcome flips to Success — previously only the chips
-  did. The sheet also validates its form before closing rather than after.
+  the habit's rule and you have not picked an outcome yourself, the outcome
+  flips to Success — previously only the chips did. The sheet also validates
+  its form before closing rather than after.

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -341,7 +341,9 @@ the old dialog that embedded a whole linked dashboard. It renders **one
 `HabitSignalRow` per leaf of the habit's `autoCompleteRule`** — status pill
 ("≥ 500 ml · 250 so far", "any workout · done"), quick-record chips for a
 measurable (its three most-logged values, from the same ranking the
-measurement dialog uses, plus *Other* for the full capture), and a two-week
+measurement dialog uses, plus *Other* for the full capture — whose saved
+entry, when it is for today, counts exactly like a chip tap: the row shows it
+recorded and a rule it meets flips the outcome), and a two-week
 `SignalSparkline` — above the unchanged form (date, comment, Success / Skip /
 Missed, Record). The rows are cards one elevation step above the sheet
 (`dsCardSurface` on `dsPageSurface`), as the handover draws them. On a

--- a/lib/features/habits/ui/sheets/habit_completion_sheet.dart
+++ b/lib/features/habits/ui/sheets/habit_completion_sheet.dart
@@ -172,10 +172,14 @@ class _HabitCompletionSheetState extends ConsumerState<HabitCompletionSheet> {
   }
 
   Future<void> _save() async {
-    _formKey.currentState!.save();
+    // Validate before the sheet goes: a form that fails stays on screen
+    // with its errors painted, rather than closing with nothing written.
+    final form = _formKey.currentState;
+    if (form == null) return;
+    if (!form.validate()) return;
+    form.save();
+    final formData = form.value;
     Navigator.pop(context);
-    if (!(_formKey.currentState?.validate() ?? false)) return;
-    final formData = _formKey.currentState?.value;
     final habitDefinition = getIt<EntitiesCacheService>().getHabitById(
       widget.habitId,
     );
@@ -186,9 +190,31 @@ class _HabitCompletionSheetState extends ConsumerState<HabitCompletionSheet> {
         dateFrom: _started,
         completionType: _outcome,
       ),
-      comment: formData!['comment'] as String,
+      comment: formData['comment'] as String,
       habitDefinition: habitDefinition,
     );
+  }
+
+  /// The "other value" path: the full capture flow, whose saved entry then
+  /// counts exactly like a chip tap — the row shows it as recorded and a
+  /// rule it satisfies flips the outcome — as long as it was entered for
+  /// the day being recorded.
+  Future<void> _captureMeasurable(MeasurableDataType dataType) async {
+    final saved = await MeasurementCaptureModal.show(
+      context: context,
+      measurableDataType: dataType,
+    );
+    if (saved == null || !mounted) return;
+    if (saved.dateFrom.ymd != clock.now().ymd) return;
+    setState(
+      () => _recorded[dataType.id] = (
+        value: saved.value,
+        choiceId: saved.choiceId,
+      ),
+    );
+    await ref
+        .read(habitSignalStatusProvider(widget.habitId).notifier)
+        .refresh();
   }
 
   Future<void> _recordMeasurable(
@@ -262,10 +288,7 @@ class _HabitCompletionSheetState extends ConsumerState<HabitCompletionSheet> {
                   status: status,
                   recordedValue: _recordedFor(leaf),
                   onRecordMeasurable: _recordMeasurable,
-                  onMoreMeasurable: (dataType) => MeasurementCaptureModal.show(
-                    context: context,
-                    measurableDataType: dataType,
-                  ),
+                  onMoreMeasurable: _captureMeasurable,
                 ),
             ],
       reflections: [

--- a/lib/pages/create/create_measurement_dialog.dart
+++ b/lib/pages/create/create_measurement_dialog.dart
@@ -30,7 +30,11 @@ import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 /// chip per active choice; the rest of the sheet — observed-at, comment,
 /// save — is the same route.
 abstract final class MeasurementCaptureModal {
-  static Future<void> show({
+  /// Opens the capture flow for [measurableDataType] and resolves to the
+  /// measurement that was saved, or null when the flow was dismissed — so a
+  /// host that offered the flow as its "other value" path can treat the
+  /// entry exactly like one of its own quick values.
+  static Future<MeasurementData?> show({
     required BuildContext context,
     required MeasurableDataType measurableDataType,
   }) async {
@@ -53,7 +57,7 @@ abstract final class MeasurementCaptureModal {
     }
 
     try {
-      await ModalUtils.showMultiPageModal<void>(
+      return await ModalUtils.showMultiPageModal<MeasurementData>(
         context: context,
         pageIndexNotifier: draft.pageIndexNotifier,
         modalDecorator: decorateFlow,
@@ -238,10 +242,10 @@ class _MeasurementCaptureDraft {
 
     final errorMessage = modalContext.messages.measurementSaveError;
     saveState.value = (isSaving: true, error: null);
-    final observedAt = measurementDateTime.value;
+    final data = buildData(measurementDateTime.value);
     try {
       final savedEntry = await getIt<PersistenceLogic>().createMeasurementEntry(
-        data: buildData(observedAt),
+        data: data,
         comment: commentController.text,
         private: dataType.private ?? false,
       );
@@ -250,7 +254,7 @@ class _MeasurementCaptureDraft {
         return;
       }
       if (modalContext.mounted) {
-        Navigator.of(modalContext).pop('Saved');
+        Navigator.of(modalContext).pop(data);
       }
     } catch (error, stackTrace) {
       DevLogger.error(

--- a/test/features/habits/ui/sheets/habit_completion_sheet_test.dart
+++ b/test/features/habits/ui/sheets/habit_completion_sheet_test.dart
@@ -221,6 +221,7 @@ void main() {
     when(
       () => persistence.createMeasurementEntry(
         data: any(named: 'data'),
+        comment: any(named: 'comment'),
         private: any(named: 'private'),
       ),
     ).thenAnswer((invocation) async {
@@ -730,6 +731,36 @@ void main() {
       expect(find.text('Water'), findsWidgets);
       expect(tester.takeException(), isNull);
     });
+
+    clockedWidgets(
+      'a value saved through Other counts like a chip tap: the row shows it '
+      'recorded and a rule it meets flips the outcome',
+      (tester) async {
+        await pumpSheet(tester, habitId: waterHabit.id);
+        await tester.tap(find.text('Other'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 450));
+        await tester.enterText(
+          find.byKey(const Key('measurement_value_field')),
+          '600',
+        );
+        await tester.pump();
+        await tester.tap(find.byKey(const Key('measurement_save')));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 450));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(find.byKey(const Key('measurement_value_field')), findsNothing);
+        expect(find.text('≥ 500 ml · done'), findsOneWidget);
+        expect(
+          find.byKey(const ValueKey('habit-sheet-auto-banner')),
+          findsOneWidget,
+        );
+        await tester.tap(find.byKey(const Key('habit_save')));
+        await tester.pump(const Duration(milliseconds: 300));
+        expect(captured().completionType, HabitCompletionType.success);
+      },
+    );
 
     clockedWidgets('a past day shows no signal rows', (tester) async {
       await pumpSheet(tester, habitId: waterHabit.id, dateString: '2024-01-15');

--- a/test/pages/create/create_measurement_dialog_test.dart
+++ b/test/pages/create/create_measurement_dialog_test.dart
@@ -77,6 +77,11 @@ void main() {
 
   tearDown(tearDownTestGetIt);
 
+  // What the last opened capture flow resolved to: the saved measurement,
+  // or null when the flow was dismissed.
+  MeasurementData? flowResult;
+  var flowResolved = false;
+
   Future<void> pumpLauncher(
     WidgetTester tester, {
     DateTime? now,
@@ -100,6 +105,7 @@ void main() {
                 key: _openKey,
                 label: 'Open measurement capture',
                 onPressed: () {
+                  flowResolved = false;
                   unawaited(
                     withClock(
                       Clock.fixed(now ?? _fixedNow),
@@ -107,7 +113,10 @@ void main() {
                         context: context,
                         measurableDataType: dataType ?? measurableWater,
                       ),
-                    ),
+                    ).then((result) {
+                      flowResult = result;
+                      flowResolved = true;
+                    }),
                   );
                 },
               ),
@@ -311,6 +320,9 @@ void main() {
       expect(savedComment, 'After the long run');
       expect(savedPrivate, isFalse);
       expect(find.byKey(_valueKey), findsNothing);
+      // The flow resolves to what it saved, so a host can count the entry.
+      expect(flowResolved, isTrue);
+      expect(flowResult, savedData);
     },
   );
 


### PR DESCRIPTION
Two defects in the completion sheet's record paths, found by the design panel on #4080:

- **"+ Other" never counted as recorded** (lotti3-r7uj). `MeasurementCaptureModal.show` now resolves to the `MeasurementData` it saved (null when dismissed), and the sheet feeds that into `_recorded` and refreshes the signal status exactly as a chip tap does — so the row shows the value as recorded and a rule it satisfies flips the untouched outcome to Success. Entries dated for another day are left alone, matching the chips' today-only semantics.
- **`_save()` popped before validating** (lotti3-t2li). Order is now validate → save → pop → persist, so a failing validator keeps the sheet on screen with its errors painted.

No visual change; no screenshots.

## Tests
- `habit_completion_sheet_test.dart`: drives Other → the capture flow → save 600 ml, asserts the row reads done, the auto banner shows, and Record writes Success (fails with the fix reverted).
- `create_measurement_dialog_test.dart`: the flow resolves to the saved measurement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Values entered through **Other** in the habit completion sheet now count like quick-record chips, updating recorded status and success outcomes when rules are met.
  * Completion forms are validated before the sheet closes, preventing invalid submissions from dismissing it.
* **Documentation**
  * Updated habit guidance to describe the expanded measurement capture flow and its effect on completion status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->