### PR TITLE
feat(goals): name untitled criteria after their habit or measurable in FACTS

### DIFF
--- a/changelog.d/2026-08-30-goal-facts-criterion-names.md
+++ b/changelog.d/2026-08-30-goal-facts-criterion-names.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **A goal coach can now name every criterion.** A goal criterion created
+  without a title — older or hand-written goals — reaches the coach under the
+  name of the habit or measurable it tracks, instead of only "the habit".

--- a/changelog.d/2026-08-30-goal-facts-criterion-names.md
+++ b/changelog.d/2026-08-30-goal-facts-criterion-names.md
@@ -1,5 +1,6 @@
 ### Fixed
 
-- **A goal coach can now name every criterion.** A goal criterion created
-  without a title — older or hand-written goals — reaches the coach under the
-  name of the habit or measurable it tracks, instead of only "the habit".
+- **A goal coach can now name a habit or measurable criterion that has no
+  title.** Older or hand-written goals whose criterion was created without a
+  title reach the coach under the name of the habit or measurable it tracks,
+  instead of only "the habit".

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -477,6 +477,16 @@ flowchart TD
 - **Phase B re-derives, never trusts.** The workflow calls the same
   `deriveWakeFacts` Phase A used to arm the escalation and renders every
   number into the FACTS block; the prompt forbids the model to recompute.
+  FACTS names a criterion by its `title` and never by the habit or measurable
+  id behind it — those are UUIDs, and a model handed one writes it into prose.
+  A criterion authored without a title (an older or hand-written spec) is
+  titled after its entity at render time: the workflow collects the habit and
+  data-type ids under the tree (`goalCriterionEntityIds`) and resolves them
+  through the injected `GoalCriterionNameReader` (`GoalRepository.criterionNames`
+  via `goalCriterionNameReaderProvider`; null without a journal stack). The
+  read is contained like the user voice: a failure leaves the criterion
+  unnamed, never fails the wake. Backfilling titles onto specs was rejected —
+  it would write a new spec version per goal to fix a presentation gap.
   For supported health criteria, it explicitly distinguishes the rolling
   `actual` from the timestamped `healthSeries` anchored to
   `evaluation.reference`: when the latest reading is on target for that day,

--- a/lib/features/goals/repository/goal_repository.dart
+++ b/lib/features/goals/repository/goal_repository.dart
@@ -4,6 +4,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/goals/model/goal_checkin_source.dart';
 import 'package:lotti/features/goals/model/goal_entry_ids.dart';
+import 'package:lotti/features/goals/workflow/goal_criterion_names.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/logic/services/metadata_service.dart';
 
@@ -54,6 +55,23 @@ class GoalRepository {
   /// The immutable spec snapshots of [goalId], newest version first.
   Future<List<GoalEntry>> getSpecSnapshots(String goalId) =>
       _journalDb.getSpecSnapshotsForGoal(goalId);
+
+  /// Display names for the habits and measurables a goal's criteria refer
+  /// to, keyed by id — the [GoalCriterionNameReader] the agent workflow
+  /// names an untitled criterion with. An id with no definition behind it
+  /// is simply absent from the result.
+  Future<Map<String, String>> criterionNames(GoalCriterionEntityIds ids) async {
+    final names = <String, String>{};
+    for (final habitId in ids.habitIds) {
+      final habit = await _journalDb.getHabitById(habitId);
+      if (habit != null) names[habitId] = habit.name;
+    }
+    for (final dataTypeId in ids.dataTypeIds) {
+      final dataType = await _journalDb.getMeasurableDataTypeById(dataTypeId);
+      if (dataType != null) names[dataTypeId] = dataType.displayName;
+    }
+    return names;
+  }
 
   /// The check-ins linked to [agentId]'s goal that carry words.
   ///

--- a/lib/features/goals/state/goal_agent_providers.dart
+++ b/lib/features/goals/state/goal_agent_providers.dart
@@ -39,6 +39,7 @@ import 'package:lotti/features/goals/sync/goal_signal_sync_dispatcher.dart';
 import 'package:lotti/features/goals/ui/goal_routes.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_workflow.dart';
+import 'package:lotti/features/goals/workflow/goal_criterion_names.dart';
 import 'package:lotti/features/goals/workflow/goal_tool_dispatcher.dart';
 import 'package:lotti/features/labels/repository/labels_repository.dart';
 import 'package:lotti/features/nudges/logic/nudge_banner_snooze.dart';
@@ -186,6 +187,16 @@ final Provider<GoalCheckInSourceReader?> goalCheckInSourceReaderProvider =
       return repository.checkInSources;
     }, name: 'goalCheckInSourceReaderProvider');
 
+/// Names for the entities a goal's criteria refer to, from the journal —
+/// null without a journal stack, in which case untitled criteria stay
+/// unnamed in FACTS rather than the wake failing.
+final Provider<GoalCriterionNameReader?> goalCriterionNameReaderProvider =
+    Provider<GoalCriterionNameReader?>((ref) {
+      final repository = ref.watch(goalRepositoryProvider);
+      if (repository == null) return null;
+      return repository.criterionNames;
+    }, name: 'goalCriterionNameReaderProvider');
+
 final goalAgentWorkflowProvider = Provider<GoalAgentWorkflow>(
   (ref) => GoalAgentWorkflow(
     repository: ref.watch(agentRepositoryProvider),
@@ -198,6 +209,7 @@ final goalAgentWorkflowProvider = Provider<GoalAgentWorkflow>(
     checkInCompactor: ref.watch(goalCheckInCompactorProvider),
     checkInSourceReader: ref.watch(goalCheckInSourceReaderProvider),
     checkInDigestService: ref.watch(goalCheckInDigestServiceProvider),
+    criterionNameReader: ref.watch(goalCriterionNameReaderProvider),
     domainLogger: ref.watch(domainLoggerProvider),
   ),
   name: 'goalAgentWorkflowProvider',

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -44,6 +44,7 @@ import 'package:lotti/features/goals/service/goal_checkin_compactor.dart';
 import 'package:lotti/features/goals/service/goal_checkin_digest_service.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_strategy.dart';
+import 'package:lotti/features/goals/workflow/goal_criterion_names.dart';
 import 'package:lotti/features/goals/workflow/goal_facts_renderer.dart';
 import 'package:lotti/features/nudges/logic/nudge_banner_snooze.dart';
 import 'package:lotti/features/nudges/model/nudge_entity_view.dart';
@@ -114,6 +115,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
     this._checkInCompactor,
     this._checkInSourceReader,
     this._checkInDigestService,
+    this._criterionNameReader,
     this._domainLogger,
   }) : _chatHistoryService =
            chatHistoryService ?? GoalChatHistoryService(_repository);
@@ -126,6 +128,12 @@ class GoalAgentWorkflow with AgentErrorLogging {
   final AiConfigRepository _aiConfigRepository;
   final GoalChatHistoryService _chatHistoryService;
   final GoalFactsRenderer _factsRenderer;
+
+  /// Names the habits and measurables the criteria refer to, so a criterion
+  /// authored without a title still reaches the model with a readable name.
+  /// Optional: without it such a criterion is named by nothing but its
+  /// `criterionId`, which is where the app stood before the reader existed.
+  final GoalCriterionNameReader? _criterionNameReader;
 
   /// Distills a check-in into the bounded form the agent reads. Optional: the
   /// deterministic tier and the LLM tier both work without it, and a wake with
@@ -465,6 +473,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
           GoalChatHistoryService.toJson(entry),
       ],
       userVoice: userVoice,
+      criterionNames: await _criterionNames(version.criteria),
     );
     var factsBlock = pendingUserMessage == null
         ? renderedFacts
@@ -1220,6 +1229,30 @@ class GoalAgentWorkflow with AgentErrorLogging {
       for (final summary in stored)
         if (live.containsKey(summary.sourceEntryId)) summary,
     ];
+  }
+
+  /// Display names for the entities [criteria] refer to, for the renderer.
+  ///
+  /// Contained like the user voice: names are ADDITIVE context, and a read
+  /// that fails must leave the wake with untitled criteria unnamed, never
+  /// fail the wake itself.
+  Future<Map<String, String>> _criterionNames(GoalCriterion criteria) async {
+    final reader = _criterionNameReader;
+    if (reader == null) return const {};
+    final ids = goalCriterionEntityIds(criteria);
+    if (ids.habitIds.isEmpty && ids.dataTypeIds.isEmpty) return const {};
+    try {
+      return await reader(ids);
+    } catch (error, stackTrace) {
+      _domainLogger?.error(
+        LogDomain.agentWorkflow,
+        error,
+        subDomain: 'goalCriterionNames',
+        message: 'criterion names unavailable; rendering criteria unnamed',
+        stackTrace: stackTrace,
+      );
+      return const {};
+    }
   }
 
   Future<List<Map<String, Object?>>> _userVoiceEntries({

--- a/lib/features/goals/workflow/goal_criterion_names.dart
+++ b/lib/features/goals/workflow/goal_criterion_names.dart
@@ -1,0 +1,44 @@
+import 'package:lotti/classes/goal_criterion.dart';
+
+/// The user-defined entities a criteria tree refers to, by kind.
+typedef GoalCriterionEntityIds = ({
+  Set<String> habitIds,
+  Set<String> dataTypeIds,
+});
+
+/// Resolves display names for the habits and measurables a criteria tree
+/// refers to, keyed by their id.
+///
+/// A function rather than a repository handle, so the agent tier depends on
+/// the shape of the data and not on the journal stack. The FACTS renderer
+/// names a criterion by its title; a criterion authored without one — an
+/// older or hand-written spec — is named after the entity it measures
+/// instead, and this is where that name comes from. Ids missing from the
+/// result simply stay unnamed.
+typedef GoalCriterionNameReader =
+    Future<Map<String, String>> Function(GoalCriterionEntityIds ids);
+
+/// Every habit id and measurable data-type id under [criterion].
+GoalCriterionEntityIds goalCriterionEntityIds(GoalCriterion criterion) {
+  final habitIds = <String>{};
+  final dataTypeIds = <String>{};
+  void visit(GoalCriterion node) {
+    switch (node) {
+      case GoalCriterionHabit(:final habitId):
+        habitIds.add(habitId);
+      case GoalCriterionMeasurable(:final dataTypeId):
+        dataTypeIds.add(dataTypeId);
+      case GoalCriterionAllOf(:final criteria) ||
+          GoalCriterionAnyOf(:final criteria) ||
+          GoalCriterionAtLeastCount(:final criteria):
+        criteria.forEach(visit);
+      case GoalCriterionMetric() ||
+          GoalCriterionCategoryTime() ||
+          GoalCriterionLabelTime():
+        break;
+    }
+  }
+
+  visit(criterion);
+  return (habitIds: habitIds, dataTypeIds: dataTypeIds);
+}

--- a/lib/features/goals/workflow/goal_facts_renderer.dart
+++ b/lib/features/goals/workflow/goal_facts_renderer.dart
@@ -70,6 +70,7 @@ class GoalFactsRenderer {
     List<String> unansweredUserMessages = const [],
     List<Map<String, Object>> recentDialogue = const [],
     List<Map<String, Object?>> userVoice = const [],
+    Map<String, String> criterionNames = const {},
   }) {
     final now = clock.now();
     final active = nudges.where((n) => n.status == NudgeStatus.active).toList();
@@ -141,7 +142,7 @@ class GoalFactsRenderer {
       'goal': {
         'id': version.agentId,
         'statement': version.statement,
-        'criteria': criterionJson(version.criteria),
+        'criteria': criterionJson(version.criteria, names: criterionNames),
       },
       'evaluation': {
         'referenceIsCurrentDay': _isToday(evaluationReference, now),
@@ -784,86 +785,99 @@ String truncateGoalEvidenceText(String text, int tokenBudget) {
 /// A JSON rendering of the criteria tree, mirroring the eval fixtures'
 /// vocabulary: leaves carry their window/target/direction, composites
 /// nest their children under the combinator name.
-Map<String, Object?> criterionJson(GoalCriterion criterion) =>
-    switch (criterion) {
-      GoalCriterionMetric() => {
-        'criterionId': criterion.criterionId,
-        if (criterion.title != null) 'title': criterion.title,
-        'metric': criterion.dataType,
-        'aggregation': criterion.aggregation.name,
-        'window': _windowLabel(criterion.window),
-        'target': criterion.target,
-        'direction': criterion.direction.name,
+///
+/// [names] maps habit ids and measurable data-type ids to display names. A
+/// habit or measurable criterion without a title of its own is titled after
+/// its entity from there, so the model always has a readable name for it —
+/// the raw ids never reach the payload either way.
+Map<String, Object?> criterionJson(
+  GoalCriterion criterion, {
+  Map<String, String> names = const {},
+}) => switch (criterion) {
+  GoalCriterionMetric() => {
+    'criterionId': criterion.criterionId,
+    if (criterion.title != null) 'title': criterion.title,
+    'metric': criterion.dataType,
+    'aggregation': criterion.aggregation.name,
+    'window': _windowLabel(criterion.window),
+    'target': criterion.target,
+    'direction': criterion.direction.name,
+  },
+  GoalCriterionHabit() => {
+    'criterionId': criterion.criterionId,
+    'title': ?(criterion.title ?? names[criterion.habitId]),
+    // No `habit: <habitId>` here, and none below for the measurable's
+    // data type: both are UUIDs in production, `title` already names the
+    // thing, and every tool call references `criterionId` instead. The
+    // evals never surfaced the duplication because their fixtures use
+    // readable slugs ('habit-measure-bp') where the app has UUIDs.
+    'window': _windowLabel(criterion.window),
+    'targetCount': criterion.targetCount,
+  },
+  GoalCriterionMeasurable() => {
+    'criterionId': criterion.criterionId,
+    'title': ?(criterion.title ?? names[criterion.dataTypeId]),
+    'aggregation': criterion.aggregation.name,
+    'window': _windowLabel(criterion.window),
+    'target': criterion.target,
+    'direction': criterion.direction.name,
+  },
+  GoalCriterionCategoryTime() => {
+    'criterionId': criterion.criterionId,
+    if (criterion.title != null) 'title': criterion.title,
+    'categoryTime': criterion.categoryId,
+    'aggregation': criterion.aggregation.name,
+    'window': _windowLabel(criterion.window),
+    'targetHours': criterion.targetHours,
+    'direction': criterion.direction.name,
+    if (criterion.dailyTimeRange case final range?)
+      'dailyTimeRange': {
+        'startMinute': range.startMinute,
+        'endMinute': range.endMinute,
       },
-      GoalCriterionHabit() => {
-        'criterionId': criterion.criterionId,
-        if (criterion.title != null) 'title': criterion.title,
-        // No `habit: <habitId>` here, and none below for the measurable's
-        // data type: both are UUIDs in production, `title` already names the
-        // thing, and every tool call references `criterionId` instead. The
-        // evals never surfaced the duplication because their fixtures use
-        // readable slugs ('habit-measure-bp') where the app has UUIDs.
-        'window': _windowLabel(criterion.window),
-        'targetCount': criterion.targetCount,
+    'evidence': 'tracked Lotti time entries only',
+  },
+  GoalCriterionLabelTime() => {
+    'criterionId': criterion.criterionId,
+    if (criterion.title != null) 'title': criterion.title,
+    'labelTime': criterion.labelId,
+    if (criterion.categoryId != null) 'categoryId': criterion.categoryId,
+    'aggregation': criterion.aggregation.name,
+    'window': _windowLabel(criterion.window),
+    'targetHours': criterion.targetHours,
+    'direction': criterion.direction.name,
+    if (criterion.dailyTimeRange case final range?)
+      'dailyTimeRange': {
+        'startMinute': range.startMinute,
+        'endMinute': range.endMinute,
       },
-      GoalCriterionMeasurable() => {
-        'criterionId': criterion.criterionId,
-        if (criterion.title != null) 'title': criterion.title,
-        'aggregation': criterion.aggregation.name,
-        'window': _windowLabel(criterion.window),
-        'target': criterion.target,
-        'direction': criterion.direction.name,
-      },
-      GoalCriterionCategoryTime() => {
-        'criterionId': criterion.criterionId,
-        if (criterion.title != null) 'title': criterion.title,
-        'categoryTime': criterion.categoryId,
-        'aggregation': criterion.aggregation.name,
-        'window': _windowLabel(criterion.window),
-        'targetHours': criterion.targetHours,
-        'direction': criterion.direction.name,
-        if (criterion.dailyTimeRange case final range?)
-          'dailyTimeRange': {
-            'startMinute': range.startMinute,
-            'endMinute': range.endMinute,
-          },
-        'evidence': 'tracked Lotti time entries only',
-      },
-      GoalCriterionLabelTime() => {
-        'criterionId': criterion.criterionId,
-        if (criterion.title != null) 'title': criterion.title,
-        'labelTime': criterion.labelId,
-        if (criterion.categoryId != null) 'categoryId': criterion.categoryId,
-        'aggregation': criterion.aggregation.name,
-        'window': _windowLabel(criterion.window),
-        'targetHours': criterion.targetHours,
-        'direction': criterion.direction.name,
-        if (criterion.dailyTimeRange case final range?)
-          'dailyTimeRange': {
-            'startMinute': range.startMinute,
-            'endMinute': range.endMinute,
-          },
-        'evidence':
-            'tracked Lotti time entries carrying this label; '
-            'matching entry markdown is supplied in signals',
-      },
-      GoalCriterionAllOf() => {
-        'criterionId': criterion.criterionId,
-        if (criterion.title != null) 'title': criterion.title,
-        'allOf': [for (final c in criterion.criteria) criterionJson(c)],
-      },
-      GoalCriterionAnyOf() => {
-        'criterionId': criterion.criterionId,
-        if (criterion.title != null) 'title': criterion.title,
-        'anyOf': [for (final c in criterion.criteria) criterionJson(c)],
-      },
-      GoalCriterionAtLeastCount() => {
-        'criterionId': criterion.criterionId,
-        if (criterion.title != null) 'title': criterion.title,
-        'atLeast': criterion.successes,
-        'of': [for (final c in criterion.criteria) criterionJson(c)],
-      },
-    };
+    'evidence':
+        'tracked Lotti time entries carrying this label; '
+        'matching entry markdown is supplied in signals',
+  },
+  GoalCriterionAllOf() => {
+    'criterionId': criterion.criterionId,
+    if (criterion.title != null) 'title': criterion.title,
+    'allOf': [
+      for (final c in criterion.criteria) criterionJson(c, names: names),
+    ],
+  },
+  GoalCriterionAnyOf() => {
+    'criterionId': criterion.criterionId,
+    if (criterion.title != null) 'title': criterion.title,
+    'anyOf': [
+      for (final c in criterion.criteria) criterionJson(c, names: names),
+    ],
+  },
+  GoalCriterionAtLeastCount() => {
+    'criterionId': criterion.criterionId,
+    if (criterion.title != null) 'title': criterion.title,
+    'atLeast': criterion.successes,
+    'of': [
+      for (final c in criterion.criteria) criterionJson(c, names: names),
+    ],
+  },
+};
 
 String _windowLabel(GoalWindow window) => switch (window) {
   GoalWindowDay() => 'day',

--- a/test/features/agents/eval/goal/goal_agent_outcome_eval_test.dart
+++ b/test/features/agents/eval/goal/goal_agent_outcome_eval_test.dart
@@ -141,6 +141,7 @@ void main() {
     // quietly grading a different policy row.
     const expectedStatus = {
       'ot_quiet_wake': GoalTrackStatus.onTrack,
+      'ot_untitled_habit_criterion': GoalTrackStatus.onTrack,
       'ot_transition_report': GoalTrackStatus.onTrack,
       'off_track_first_ad': GoalTrackStatus.offTrack,
       'off_track_fresh_ad': GoalTrackStatus.offTrack,
@@ -175,11 +176,28 @@ void main() {
       );
     }
 
+    test('the untitled habit criterion reaches the model named after its '
+        'habit, and its UUID reaches it nowhere', () async {
+      final scenario = goalOutcomeEvalScenarios.singleWhere(
+        (s) => s.id == 'ot_untitled_habit_criterion',
+      );
+      final driven = await drive(scenario);
+      final criteria = (driven.facts['goal']! as Map)['criteria'] as Map;
+      expect(criteria['criterionId'], 'bp-check');
+      expect(criteria['title'], 'Measure blood pressure');
+      expect(
+        jsonEncode(driven.facts),
+        isNot(contains(goalOutcomeEvalUntitledHabitId)),
+        reason: 'a UUID handed to the model ends up in its prose',
+      );
+    });
+
     test('the ad surface is offered only where policy permits one', () async {
       // The production gate, read at the wire rather than mirrored: ad tools
       // ride on eligibility AND the absence of a same-day dismissal.
       const offered = {
         'ot_quiet_wake': false,
+        'ot_untitled_habit_criterion': false,
         'ot_transition_report': false,
         'off_track_first_ad': true,
         'off_track_fresh_ad': true,

--- a/test/features/agents/eval/goal/support/goal_agent_outcome_eval.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_outcome_eval.dart
@@ -138,6 +138,7 @@ class GoalOutcomeEvalScenario {
     this.priorRegisters,
     this.pendingUserMessage,
     this.previousAssistantMessage,
+    this.criterionNames = const {},
     this.triggerTokens = const {
       'goal-escalation:$goalOutcomeEvalPeriodKey',
     },
@@ -166,6 +167,11 @@ class GoalOutcomeEvalScenario {
 
   final String? pendingUserMessage;
   final String? previousAssistantMessage;
+
+  /// What the journal would answer for the habits and measurables the
+  /// criteria refer to, keyed by id — the world's definitions, the way the
+  /// production name reader resolves them.
+  final Map<String, String> criterionNames;
   final Set<String> triggerTokens;
 
   final GoalOutcomeExpectation expectation;
@@ -891,6 +897,10 @@ GoalOutcomeEvalBench buildGoalOutcomeEvalBench({
     conversationRepository: conversationRepository,
     cloudInferenceRepository: cloudInferenceRepository,
     aiConfigRepository: aiConfigRepository,
+    criterionNameReader: (ids) async => {
+      for (final id in ids.habitIds.followedBy(ids.dataTypeIds))
+        id: ?scenario.criterionNames[id],
+    },
   );
 
   return (

--- a/test/features/agents/eval/goal/support/goal_agent_outcome_eval_scenarios.dart
+++ b/test/features/agents/eval/goal/support/goal_agent_outcome_eval_scenarios.dart
@@ -34,6 +34,29 @@ const goalOutcomeEvalSteps = GoalCriterion.metric(
 
 const _statement = 'Average 10,000 steps per day.';
 
+/// A habit id the way the app has them — a UUID, which the model must never
+/// be handed as a name. The readable slugs the rest of the catalog uses
+/// would hide a leak.
+const goalOutcomeEvalUntitledHabitId = '71ca84b0-1f1e-4f5d-9c2e-6b4a1d0c9e01';
+
+/// A habit criterion authored without a title, as an older or hand-written
+/// spec might be. FACTS has to name it after the habit itself.
+const goalOutcomeEvalUntitledHabit = GoalCriterion.habit(
+  criterionId: 'bp-check',
+  habitId: goalOutcomeEvalUntitledHabitId,
+  window: GoalWindow.rollingDays(count: 7),
+  targetCount: 5,
+);
+
+/// The blood-pressure habit kept on every day of the window.
+final _untitledHabitWindow = GoalSignalWindow(
+  habitSuccessesByDay: {
+    goalOutcomeEvalUntitledHabitId: {
+      for (var day = 3; day <= 9; day++) DateTime.utc(2026, 8, day): 1,
+    },
+  },
+);
+
 /// A uniform seven-day window at [perDay] steps. Attainment is then simply
 /// `perDay / 10000`, so a scenario's intended status is legible from the
 /// number alone — and the offline test asserts the derivation agrees.
@@ -97,6 +120,24 @@ final goalOutcomeEvalScenarios = <GoalOutcomeEvalScenario>[
     criteria: goalOutcomeEvalSteps,
     window: _uniform(11000),
     priorRegisters: _yesterday(GoalTrackStatus.onTrack, 1.1),
+    expectation: const GoalOutcomeExpectation(expectsNoOutcome: true),
+  ),
+
+  // ── Untitled criterion: named after its habit, never by its id ─────────
+  // The same quiet wake, on a habit criterion authored without a title. The
+  // offline test reads the FACTS this builds: the criterion must carry the
+  // habit's display name, and the UUID must appear nowhere in the prompt.
+  GoalOutcomeEvalScenario(
+    id: 'ot_untitled_habit_criterion',
+    policyRuleId: 'P2',
+    title: 'Blood pressure',
+    statement: 'Measure blood pressure on 5 of 7 days.',
+    criteria: goalOutcomeEvalUntitledHabit,
+    window: _untitledHabitWindow,
+    priorRegisters: _yesterday(GoalTrackStatus.onTrack, 1),
+    criterionNames: const {
+      goalOutcomeEvalUntitledHabitId: 'Measure blood pressure',
+    },
     expectation: const GoalOutcomeExpectation(expectsNoOutcome: true),
   ),
 

--- a/test/features/goals/repository/goal_repository_test.dart
+++ b/test/features/goals/repository/goal_repository_test.dart
@@ -10,6 +10,7 @@ import 'package:lotti/features/goals/repository/goal_repository.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
+import '../../../test_data/test_data.dart';
 
 void main() {
   final testDate = DateTime(2026, 8, 18, 10, 30);
@@ -122,6 +123,40 @@ void main() {
       // Scoped to the goal: the snapshots ride the subtype index, so an
       // unscoped read would return every goal's history.
       verify(() => mockDb.getSpecSnapshotsForGoal('goal-1')).called(1);
+    });
+  });
+
+  group('criterionNames', () {
+    test('names the habits and measurables it can find and leaves the rest '
+        'out', () async {
+      when(
+        () => mockDb.getHabitById(habitFlossing.id),
+      ).thenAnswer((_) async => habitFlossing);
+      when(
+        () => mockDb.getHabitById('missing-habit'),
+      ).thenAnswer((_) async => null);
+      when(
+        () => mockDb.getMeasurableDataTypeById(measurableWater.id),
+      ).thenAnswer((_) async => measurableWater);
+
+      final names = await repository.criterionNames((
+        habitIds: {habitFlossing.id, 'missing-habit'},
+        dataTypeIds: {measurableWater.id},
+      ));
+
+      expect(names, {
+        habitFlossing.id: habitFlossing.name,
+        measurableWater.id: measurableWater.displayName,
+      });
+    });
+
+    test('empty id sets touch the database not at all', () async {
+      expect(
+        await repository.criterionNames((habitIds: {}, dataTypeIds: {})),
+        isEmpty,
+      );
+      verifyNever(() => mockDb.getHabitById(any()));
+      verifyNever(() => mockDb.getMeasurableDataTypeById(any()));
     });
   });
 

--- a/test/features/goals/state/goal_journal_providers_test.dart
+++ b/test/features/goals/state/goal_journal_providers_test.dart
@@ -51,6 +51,7 @@ void main() {
       expect(c.read(goalMirrorServiceProvider), isNull);
       expect(c.read(goalCheckInNotifierProvider), isNull);
       expect(c.read(goalCheckInSourceReaderProvider), isNull);
+      expect(c.read(goalCriterionNameReaderProvider), isNull);
     });
   });
 
@@ -64,6 +65,7 @@ void main() {
       expect(c.read(goalMirrorServiceProvider), isNotNull);
       expect(c.read(goalCheckInNotifierProvider), isA<GoalCheckInNotifier>());
       expect(c.read(goalCheckInSourceReaderProvider), isNotNull);
+      expect(c.read(goalCriterionNameReaderProvider), isNotNull);
     });
 
     test('the compactor is available wherever inference is', () {

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -29,6 +29,7 @@ import 'package:lotti/features/goals/service/goal_checkin_digest_service.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_contract.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_strategy.dart';
 import 'package:lotti/features/goals/workflow/goal_agent_workflow.dart';
+import 'package:lotti/features/goals/workflow/goal_criterion_names.dart';
 import 'package:lotti/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
@@ -1116,6 +1117,117 @@ void main() {
     expect(sentFacts, isNot(contains('Skipped the lunch walk.')));
     expect(sentFacts, contains('userVoice'));
     expect(sentFacts, contains('walk after lunch tomorrow'));
+  });
+
+  group('criterion names', () {
+    const habitId = '71ca84b0-1f1e-4f5d-9c2e-6b4a1d0c9e01';
+    const untitled = GoalCriterion.allOf(
+      criterionId: 'all',
+      criteria: [
+        GoalCriterion.metric(
+          criterionId: 'steps',
+          dataType: 'cumulative_step_count',
+          window: GoalWindow.rollingDays(count: 7),
+          aggregation: GoalAggregation.dailySumThenAverage,
+          target: 10000,
+        ),
+        // Authored without a title, as an older spec might be.
+        GoalCriterion.habit(
+          criterionId: 'bp',
+          habitId: habitId,
+          window: GoalWindow.rollingDays(count: 7),
+          targetCount: 5,
+        ),
+      ],
+    );
+
+    Future<String?> factsWith(
+      GoalCriterionNameReader? reader, {
+      GoalCriterion criteria = untitled,
+    }) async {
+      stubSpec(criteria: criteria);
+      stubGlmResolution();
+      _stubBadPrior(repository, agentId, now);
+      workflow = GoalAgentWorkflow(
+        repository: repository,
+        syncService: syncService,
+        phaseA: GoalAgentPhaseA(
+          repository: repository,
+          syncService: syncService,
+          signalReader: _FakeReader(),
+        ),
+        conversationRepository: conversationRepository,
+        cloudInferenceRepository: cloudInferenceRepository,
+        aiConfigRepository: aiConfigRepository,
+        criterionNameReader: reader,
+      );
+      String? sentFacts;
+      conversationRepository.sendMessageDelegate =
+          ({
+            required conversationId,
+            required message,
+            required model,
+            required provider,
+            required inferenceRepo,
+            tools,
+            toolChoice,
+            temperature = 0.7,
+            strategy,
+          }) async {
+            sentFacts ??= message;
+            return const InferenceUsage(inputTokens: 10, outputTokens: 5);
+          };
+      await workflow.execute(
+        agentIdentity: identity,
+        runKey: 'run-names',
+        triggerTokens: const {'goal-escalation:2026-08-11'},
+        threadId: 'thread-names',
+      );
+      return sentFacts;
+    }
+
+    test('an untitled criterion reaches the model named after its habit, '
+        'with the id itself kept out of FACTS', () async {
+      GoalCriterionEntityIds? asked;
+      final facts = await factsWith((ids) async {
+        asked = ids;
+        return {habitId: 'Measure blood pressure'};
+      });
+      expect(asked?.habitIds, {habitId});
+      expect(asked?.dataTypeIds, isEmpty);
+      expect(facts, contains('"title": "Measure blood pressure"'));
+      expect(facts, isNot(contains(habitId)));
+    });
+
+    test('a failing name read leaves the criterion unnamed and the wake '
+        'intact', () async {
+      final facts = await factsWith((_) async => throw StateError('db gone'));
+      expect(facts, isNotNull);
+      expect(facts, contains('"criterionId": "bp"'));
+      expect(facts, isNot(contains(habitId)));
+    });
+
+    test(
+      'a spec with no user-defined entities never asks the reader',
+      () async {
+        var asked = false;
+        final facts = await factsWith(
+          (_) async {
+            asked = true;
+            return {};
+          },
+          criteria: const GoalCriterion.metric(
+            criterionId: 'steps',
+            dataType: 'cumulative_step_count',
+            window: GoalWindow.rollingDays(count: 7),
+            aggregation: GoalAggregation.dailySumThenAverage,
+            target: 10000,
+          ),
+        );
+        expect(facts, isNotNull);
+        expect(asked, isFalse);
+      },
+    );
   });
 
   group('hierarchical user voice', () {

--- a/test/features/goals/workflow/goal_criterion_names_test.dart
+++ b/test/features/goals/workflow/goal_criterion_names_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/goal_criterion.dart';
+import 'package:lotti/classes/goal_enums.dart';
+import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/features/goals/workflow/goal_criterion_names.dart';
+
+void main() {
+  test('collects every habit and measurable id under a composite tree, '
+      'once each, and nothing from the other leaf kinds', () {
+    const tree = GoalCriterion.allOf(
+      criterionId: 'all',
+      criteria: [
+        GoalCriterion.habit(
+          criterionId: 'gym',
+          habitId: '71ca84b0-1f1e-4f5d-9c2e-6b4a1d0c9e01',
+          window: GoalWindow.calendarWeek(),
+          targetCount: 3,
+        ),
+        GoalCriterion.anyOf(
+          criterionId: 'either',
+          criteria: [
+            GoalCriterion.measurable(
+              criterionId: 'water',
+              dataTypeId: '0d2f9b6a-3c4e-4a1b-8e7d-5f6a7b8c9d0e',
+              window: GoalWindow.day(),
+              aggregation: GoalAggregation.sum,
+              target: 2000,
+            ),
+            GoalCriterion.atLeastCount(
+              criterionId: 'two',
+              successes: 1,
+              criteria: [
+                // The same habit again: a set, not a list.
+                GoalCriterion.habit(
+                  criterionId: 'gym-again',
+                  habitId: '71ca84b0-1f1e-4f5d-9c2e-6b4a1d0c9e01',
+                  window: GoalWindow.day(),
+                  targetCount: 1,
+                ),
+                GoalCriterion.metric(
+                  criterionId: 'steps',
+                  dataType: 'cumulative_step_count',
+                  window: GoalWindow.day(),
+                  aggregation: GoalAggregation.sum,
+                  target: 1,
+                ),
+                GoalCriterion.categoryTime(
+                  criterionId: 'coding',
+                  categoryId: 'coding-category',
+                  window: GoalWindow.day(),
+                  aggregation: GoalAggregation.sum,
+                  targetHours: 1,
+                ),
+                GoalCriterion.labelTime(
+                  criterionId: 'deep',
+                  labelId: 'deep-label',
+                  window: GoalWindow.day(),
+                  aggregation: GoalAggregation.sum,
+                  targetHours: 1,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    final ids = goalCriterionEntityIds(tree);
+    expect(ids.habitIds, {'71ca84b0-1f1e-4f5d-9c2e-6b4a1d0c9e01'});
+    expect(ids.dataTypeIds, {'0d2f9b6a-3c4e-4a1b-8e7d-5f6a7b8c9d0e'});
+  });
+
+  test('a tree without user-defined entities yields empty sets', () {
+    const tree = GoalCriterion.metric(
+      criterionId: 'steps',
+      dataType: 'cumulative_step_count',
+      window: GoalWindow.rollingDays(count: 7),
+      aggregation: GoalAggregation.dailySumThenAverage,
+      target: 10000,
+    );
+    final ids = goalCriterionEntityIds(tree);
+    expect(ids.habitIds, isEmpty);
+    expect(ids.dataTypeIds, isEmpty);
+  });
+}

--- a/test/features/goals/workflow/goal_facts_renderer_test.dart
+++ b/test/features/goals/workflow/goal_facts_renderer_test.dart
@@ -133,6 +133,7 @@ void main() {
     List<GoalObservationFact> observations = const [],
     List<String> unansweredUserMessages = const [],
     List<Map<String, Object>> recentDialogue = const [],
+    Map<String, String> criterionNames = const {},
   }) {
     final text = withClock(
       fixedClock,
@@ -145,6 +146,7 @@ void main() {
         observations: observations,
         unansweredUserMessages: unansweredUserMessages,
         recentDialogue: recentDialogue,
+        criterionNames: criterionNames,
       ),
     );
     expect(
@@ -1038,6 +1040,56 @@ void main() {
     expect(renderer.trendWorsening(0.5, [0.6]), isFalse);
     expect(renderer.trendWorsening(0.7, [0.6, 0.7]), isFalse);
     expect(renderer.trendWorsening(0.5, [0.5, 0.7]), isFalse);
+  });
+
+  test('an untitled habit or measurable criterion is titled after its entity '
+      'from the names map; a title of its own wins; the ids stay out', () {
+    const habitId = '71ca84b0-1f1e-4f5d-9c2e-6b4a1d0c9e01';
+    const dataTypeId = '0d2f9b6a-3c4e-4a1b-8e7d-5f6a7b8c9d0e';
+    const names = {habitId: 'Measure blood pressure', dataTypeId: 'Water'};
+    const tree = GoalCriterion.allOf(
+      criterionId: 'all',
+      criteria: [
+        GoalCriterion.habit(
+          criterionId: 'bp',
+          habitId: habitId,
+          window: GoalWindow.rollingDays(count: 7),
+          targetCount: 5,
+        ),
+        GoalCriterion.measurable(
+          criterionId: 'water',
+          dataTypeId: dataTypeId,
+          window: GoalWindow.day(),
+          aggregation: GoalAggregation.sum,
+          target: 2000,
+        ),
+        GoalCriterion.habit(
+          criterionId: 'bp-titled',
+          habitId: habitId,
+          title: 'BP check',
+          window: GoalWindow.day(),
+          targetCount: 1,
+        ),
+      ],
+    );
+
+    final children = (criterionJson(tree, names: names)['allOf']! as List)
+        .cast<Map<String, dynamic>>();
+    expect(children[0]['title'], 'Measure blood pressure');
+    expect(children[1]['title'], 'Water');
+    expect(children[2]['title'], 'BP check', reason: 'own title outranks');
+    expect(criterionJson(tree).toString(), isNot(contains(habitId)));
+    expect(criterionJson(tree).toString(), isNot(contains(dataTypeId)));
+    // Without a map an untitled criterion stays untitled, never id-named.
+    final bare = (criterionJson(tree)['allOf']! as List)
+        .cast<Map<String, dynamic>>();
+    expect(bare[0].containsKey('title'), isFalse);
+
+    // And the same through render, which is what the wake calls.
+    final json = renderedJson(criteria: tree, criterionNames: names);
+    final rendered =
+        ((json['goal'] as Map)['criteria'] as Map)['allOf'] as List;
+    expect((rendered[0] as Map)['title'], 'Measure blood pressure');
   });
 
   test('criterionJson renders every composite variant', () {


### PR DESCRIPTION
Closes lotti3-jdc (raised by Codex on #3927).

`criterionJson` emits a criterion's `title` and, since #3927, nothing else identifying — the raw habit / measurable ids are UUIDs the model echoed into prose. A criterion authored without a title (older or hand-written specs) therefore had no name at all.

Resolution at render time, as the issue's design decided (backfilling titles would rewrite a spec version per goal to fix a presentation gap):

- `goalCriterionEntityIds(tree)` collects the habit and data-type ids under a criteria tree.
- `GoalCriterionNameReader` — a function type, so the agent tier depends on the shape of the data rather than the journal stack — is implemented by `GoalRepository.criterionNames` and exposed through `goalCriterionNameReaderProvider` (null without a journal stack, like the check-in source reader).
- `GoalAgentWorkflow` resolves the names before rendering; a failed read is contained like the user voice (logged, criteria stay unnamed, wake proceeds).
- `criterionJson(criterion, names:)` titles an untitled habit/measurable criterion after its entity; an own title wins; ids stay out either way.

## Tests
- New `goal_criterion_names_test.dart`; `criterionNames` on the repository; renderer resolution (own title wins, ids absent, through `render`); workflow: reader asked with the right ids and the name lands in FACTS, a throwing reader leaves the wake intact, a spec without user-defined entities never asks; journal-gated provider null/non-null.
- Outcome eval: new `ot_untitled_habit_criterion` scenario with a UUID-shaped habit id; the offline test asserts the resolved title is in FACTS and the UUID appears nowhere in the prompt.

No visual change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Untitled goal criteria are now shown to the goal coach using the associated habit or measurable name instead of a generic label.
  * Existing criterion titles continue to take precedence.
  * Criterion and entity IDs are no longer exposed in the goal coach’s facts.
  * Missing names or lookup failures are handled gracefully without interrupting goal processing.

* **Documentation**
  * Added guidance describing how criterion names are selected and displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->