### PR TITLE
feat(goals): meet a per-day metric day by its own value or the rolling verdict

### DIFF
--- a/changelog.d/2026-08-30-goal-day-met-by-rolling-average.md
+++ b/changelog.d/2026-08-30-goal-day-met-by-rolling-average.md
@@ -1,0 +1,7 @@
+### Changed
+
+- **A goal day counts as met when either the day's own number reaches the
+  target or the rolling average does.** A 10,000-step day inside a weak week
+  is a met day, and an 8,000-step day inside a week averaging above target is
+  no longer painted as a miss. The goal's overall status is unchanged — it
+  still follows the rolling average.

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -1018,11 +1018,17 @@ flowchart TD
   — the bars, the compact strip cells, the reflection sheet's per-dimension
   marks, and the composite card's met-yesterday tally — shares one policy
   (`GoalMetricProgressView.dayMark`): where the target is a per-day quantity
-  (`dailySumThenAverage` and the point samples) the day's own value decides
-  the mark, so a 12,400-step day beats a 10,000 target even inside a weak
-  week; where the target belongs to the whole period (`sum`, `count`) the
-  mark is the evaluator's verdict for the window ending that day, because a
-  single day's contribution cannot be judged against a period total.
+  (`dailySumThenAverage` and the point samples) the day is met when EITHER
+  its own value clears the target OR the evaluator's verdict for the window
+  ending that day holds — so a 12,400-step day beats a 10,000 target even
+  inside a weak week, and an 8,000-step day inside a week averaging above
+  target is not painted as a miss. Every day has a winnable condition while
+  the average recovers (recovery-door principle); the goal's own status stays
+  average-driven, because day-state and goal-state are deliberately different
+  layers. Where the target belongs to the whole period (`sum`, `count`) the
+  mark is the evaluator's verdict for the window ending that day alone,
+  because a single day's contribution cannot be judged against a period
+  total.
   Composite detail keeps every metric and measurable
   leaf instead of silently collapsing the evidence to the first one. The compact
   strip combines that per-day policy with daily accomplishment: a metric cell

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -1018,11 +1018,13 @@ flowchart TD
   — the bars, the compact strip cells, the reflection sheet's per-dimension
   marks, and the composite card's met-yesterday tally — shares one policy
   (`GoalMetricProgressView.dayMark`): where the target is a per-day quantity
-  (`dailySumThenAverage` and the point samples) the day is met when EITHER
-  its own value clears the target OR the evaluator's verdict for the window
-  ending that day holds — so a 12,400-step day beats a 10,000 target even
-  inside a weak week, and an 8,000-step day inside a week averaging above
-  target is not painted as a miss. Every day has a winnable condition while
+  (`dailySumThenAverage` and the point samples) the day is met by its own
+  value clearing the target — and, for the rolling average only, by the
+  evaluator's verdict for the window ending that day — so a 12,400-step day
+  beats a 10,000 target even inside a weak week, and an 8,000-step day inside
+  a week averaging above target is not painted as a miss. A `max` verdict
+  opens no such door: it says one day in the window reached the target, not
+  that the others did. Every day has a winnable condition while
   the average recovers (recovery-door principle); the goal's own status stays
   average-driven, because day-state and goal-state are deliberately different
   layers. Where the target belongs to the whole period (`sum`, `count`) the

--- a/lib/features/goals/logic/goal_day_verdict.dart
+++ b/lib/features/goals/logic/goal_day_verdict.dart
@@ -25,11 +25,11 @@ GoalDayOutcome goalDayOutcome(GoalProgressView progress, DateTime day) {
     final entry = metric.days
         .where((value) => DateUtils.isSameDay(value.day, day))
         .firstOrNull;
-    // The shared per-day policy: the day's own value where the target is a
-    // per-day quantity (the sheet prints that day's number right beside the
-    // mark), the evaluator's window verdict where the target belongs to the
-    // whole period — a single day's hours cannot be judged against a weekly
-    // total.
+    // The shared per-day policy (`GoalMetricProgressView.dayMark`): a
+    // per-day target is met by the day's own value, or for the rolling
+    // average by the window verdict as of that day; a period total only by
+    // the window verdict — a single day's hours cannot be judged against a
+    // weekly total.
     if (entry != null && metric.dayMark(entry)) met++;
   }
   return (met: met, total: total);

--- a/lib/features/goals/state/goal_progress_view.dart
+++ b/lib/features/goals/state/goal_progress_view.dart
@@ -181,11 +181,12 @@ class GoalMetricProgressView {
 
   /// Whether [day]'s OWN value clears the target.
   ///
-  /// Distinct from [meetsTarget] on purpose. Anywhere a single day's number
-  /// is shown beside a met/missed mark, the mark has to be about that number:
-  /// the reflection sheet printed "122" against a 125 ceiling and crossed it
-  /// out, because the rolling average behind it was still over — contradicting
-  /// the report one card above, which read "today's 122 helps".
+  /// Distinct from [meetsTarget] on purpose: a day that clears the target on
+  /// its own number is met whatever the window says. The reflection sheet
+  /// once printed "122" against a 125 ceiling and crossed it out, because the
+  /// rolling average behind it was still over — contradicting the report one
+  /// card above, which read "today's 122 helps". [dayMark] is the policy the
+  /// surfaces read; this is one of its two doors.
   bool valueMeetsTarget(GoalProgressDay day) =>
       day.isObserved && _meetsTarget(day.value, target, direction);
 
@@ -197,26 +198,35 @@ class GoalMetricProgressView {
     _ => true,
   };
 
+  /// Whether the window verdict as of a day is a second way for that day to
+  /// be met: only for the rolling average, whose verdict says the days
+  /// around it averaged to target. A `max` verdict says one day somewhere
+  /// in the window reached the target, which is no statement about the
+  /// others — letting it through would paint every later short day met.
+  bool get windowVerdictMeetsDay =>
+      aggregation == GoalAggregation.dailySumThenAverage;
+
   /// THE per-day met/missed policy, shared by every surface that marks a
   /// single day (bars, strip cells, the reflection sheet, the composite
   /// tally).
   ///
-  /// Where the target is a per-day quantity, the day is met when EITHER its
-  /// own value clears the target OR the goal's requirement held as of that
-  /// day — the rolling average at or above target. Each day thus has a
-  /// winnable condition even while the average is still recovering (a
-  /// 12,400-step day inside a weak week is a met day), and a short day inside
-  /// a week that is comfortably on target is not painted as a failure. The
-  /// GOAL's status stays average-driven: day-state and goal-state are
-  /// deliberately different layers. Where the target belongs to the whole
-  /// period, only the evaluator's window verdict can judge a day, because a
-  /// single day's contribution cannot be read against a period total.
+  /// Where the target is a per-day quantity, the day's own value clearing
+  /// the target meets it. For the rolling average there is a second door
+  /// ([windowVerdictMeetsDay]): the goal's requirement holding as of that
+  /// day — the average at or above target. Each day thus has a winnable
+  /// condition even while the average is still recovering (a 12,400-step
+  /// day inside a weak week is a met day), and a short day inside a week
+  /// that is comfortably on target is not painted as a failure. The GOAL's
+  /// status stays average-driven: day-state and goal-state are deliberately
+  /// different layers. Where the target belongs to the whole period, only
+  /// the evaluator's window verdict can judge a day, because a single day's
+  /// contribution cannot be read against a period total.
   ///
   /// One policy, or the surfaces contradict each other — a 12,400-step day
   /// inside a weak week rendered muted while the reflection sheet it opens
   /// suggested "met" for the same day.
   bool dayMark(GoalProgressDay day) => targetIsPerDay
-      ? valueMeetsTarget(day) || meetsTarget(day)
+      ? valueMeetsTarget(day) || (windowVerdictMeetsDay && meetsTarget(day))
       : meetsTarget(day);
 }
 

--- a/lib/features/goals/state/goal_progress_view.dart
+++ b/lib/features/goals/state/goal_progress_view.dart
@@ -199,14 +199,25 @@ class GoalMetricProgressView {
 
   /// THE per-day met/missed policy, shared by every surface that marks a
   /// single day (bars, strip cells, the reflection sheet, the composite
-  /// tally): the day's own value where the target is a per-day quantity, the
-  /// evaluator's window verdict where the target belongs to the period.
+  /// tally).
+  ///
+  /// Where the target is a per-day quantity, the day is met when EITHER its
+  /// own value clears the target OR the goal's requirement held as of that
+  /// day — the rolling average at or above target. Each day thus has a
+  /// winnable condition even while the average is still recovering (a
+  /// 12,400-step day inside a weak week is a met day), and a short day inside
+  /// a week that is comfortably on target is not painted as a failure. The
+  /// GOAL's status stays average-driven: day-state and goal-state are
+  /// deliberately different layers. Where the target belongs to the whole
+  /// period, only the evaluator's window verdict can judge a day, because a
+  /// single day's contribution cannot be read against a period total.
   ///
   /// One policy, or the surfaces contradict each other — a 12,400-step day
   /// inside a weak week rendered muted while the reflection sheet it opens
   /// suggested "met" for the same day.
-  bool dayMark(GoalProgressDay day) =>
-      targetIsPerDay ? valueMeetsTarget(day) : meetsTarget(day);
+  bool dayMark(GoalProgressDay day) => targetIsPerDay
+      ? valueMeetsTarget(day) || meetsTarget(day)
+      : meetsTarget(day);
 }
 
 class GoalProgressDay {

--- a/lib/features/goals/ui/goal_assessment_widgets.dart
+++ b/lib/features/goals/ui/goal_assessment_widgets.dart
@@ -493,9 +493,10 @@ List<_MeasuredRow> _measuredRows(
             '—',
         met: metric.days
             .where((entry) => DateUtils.isSameDay(entry.day, day))
-            // The shared per-day policy: for a per-day target the mark is
-            // about the number this row prints beside it; for a period-total
-            // criterion it is the evaluator's verdict as of that day, since
+            // The shared per-day policy (`GoalMetricProgressView.dayMark`):
+            // a per-day target is met by the number this row prints beside
+            // it, or for the rolling average by the window verdict as of
+            // that day; a period-total criterion only by that verdict, since
             // one day's hours cannot be judged against a weekly total.
             .map((entry) => entry.isObserved ? metric.dayMark(entry) : null)
             .firstOrNull,

--- a/lib/features/goals/ui/goal_progress_card.dart
+++ b/lib/features/goals/ui/goal_progress_card.dart
@@ -2367,10 +2367,12 @@ class _MetricProgressSeries extends StatelessWidget {
     final date = chrome.dateFormat.format(day.day);
     final number = chrome.number;
     // The shared per-day policy: a bar drawn against a per-day target rule
-    // is judged by the day's own value, so a 12,400-step day beats a 10,000
-    // target even when the trailing week's average is still short. Only a
-    // period-total criterion keeps the evaluator's window verdict, because
-    // no single bar can be read against a whole-period target.
+    // is met by the day's own value OR by the window verdict as of that
+    // day, so a 12,400-step day beats a 10,000 target even when the trailing
+    // week's average is still short, and a short day inside an on-target
+    // week is not a failure. Only a period-total criterion keeps the window
+    // verdict alone, because no single bar can be read against a
+    // whole-period target.
     final met = metric.dayMark(day);
     final status = !day.isObserved
         ? 'missing'

--- a/test/features/goals/state/goal_progress_view_test.dart
+++ b/test/features/goals/state/goal_progress_view_test.dart
@@ -1165,6 +1165,24 @@ void main() {
     );
     expect(shortDayShortWeek.dayMark(shortDayShortWeek.days.single), isFalse);
 
+    // A `max` verdict only says SOME day in the window reached the target,
+    // so it opens no door for the others: a short day stays short.
+    final maxShortDay = GoalMetricProgressView(
+      name: 'Longest walk',
+      target: 10000,
+      aggregation: GoalAggregation.max,
+      days: [
+        GoalProgressDay(
+          day: DateTime.utc(2026, 8, 10),
+          value: 8000,
+          targetSatisfied: true,
+        ),
+      ],
+    );
+    expect(maxShortDay.targetIsPerDay, isTrue);
+    expect(maxShortDay.windowVerdictMeetsDay, isFalse);
+    expect(maxShortDay.dayMark(maxShortDay.days.single), isFalse);
+
     // An unobserved day is never met, whatever the window says.
     final unobserved = GoalMetricProgressView(
       name: 'Steps',

--- a/test/features/goals/state/goal_progress_view_test.dart
+++ b/test/features/goals/state/goal_progress_view_test.dart
@@ -276,9 +276,11 @@ void main() {
 
     expect(view.metric?.days, hasLength(7));
     expect(view.metric?.aggregation, GoalAggregation.dailySumThenAverage);
-    // Per-day policy: the 7,999 day is not full even though the rolling
-    // average of the observed days clears 8,000 — a strip cell is a
-    // statement about that day's own number.
+    // Per-day policy: the 7,999 day is met all the same, because the rolling
+    // average of the observed days (8,333) clears 8,000 as of that day — a
+    // short day inside an on-target week has its winnable condition in the
+    // window verdict. The unobserved days between stay empty: no evidence,
+    // no mark, whatever the average says.
     expect(view.compactWindow, [
       DayMarkState.full,
       DayMarkState.none,
@@ -286,7 +288,7 @@ void main() {
       DayMarkState.none,
       DayMarkState.full,
       DayMarkState.none,
-      DayMarkState.none,
+      DayMarkState.full,
     ]);
   });
 
@@ -1114,8 +1116,8 @@ void main() {
     expect(habit.deficit, 1);
   });
 
-  test('dayMark uses the day value for per-day targets and the window '
-      'verdict for period totals', () {
+  test('dayMark meets a per-day target by the day value OR the window '
+      'verdict, and a period total by the window verdict alone', () {
     final perDay = GoalMetricProgressView(
       name: 'Steps',
       target: 10000,
@@ -1129,6 +1131,54 @@ void main() {
     );
     expect(perDay.dayMark(perDay.days.single), isTrue);
     expect(perDay.targetIsPerDay, isTrue);
+
+    // The other door: a short day inside a week whose rolling average holds
+    // is met by the window verdict as of that day. Day-state, not goal-state.
+    final shortDayGoodWeek = GoalMetricProgressView(
+      name: 'Steps',
+      target: 10000,
+      days: [
+        GoalProgressDay(
+          day: DateTime.utc(2026, 8, 10),
+          value: 8000,
+          targetSatisfied: true,
+        ),
+      ],
+    );
+    expect(
+      shortDayGoodWeek.valueMeetsTarget(shortDayGoodWeek.days.single),
+      isFalse,
+    );
+    expect(shortDayGoodWeek.dayMark(shortDayGoodWeek.days.single), isTrue);
+
+    // Neither door: short day, short week.
+    final shortDayShortWeek = GoalMetricProgressView(
+      name: 'Steps',
+      target: 10000,
+      days: [
+        GoalProgressDay(
+          day: DateTime.utc(2026, 8, 10),
+          value: 8000,
+          targetSatisfied: false,
+        ),
+      ],
+    );
+    expect(shortDayShortWeek.dayMark(shortDayShortWeek.days.single), isFalse);
+
+    // An unobserved day is never met, whatever the window says.
+    final unobserved = GoalMetricProgressView(
+      name: 'Steps',
+      target: 10000,
+      days: [
+        GoalProgressDay(
+          day: DateTime.utc(2026, 8, 10),
+          value: 0,
+          isObserved: false,
+          targetSatisfied: true,
+        ),
+      ],
+    );
+    expect(unobserved.dayMark(unobserved.days.single), isFalse);
 
     final periodTotal = GoalMetricProgressView(
       name: 'Deep work',

--- a/test/features/goals/ui/goal_progress_card_test.dart
+++ b/test/features/goals/ui/goal_progress_card_test.dart
@@ -2291,13 +2291,18 @@ void main() {
             metric: GoalMetricProgressView(
               name: 'Steps',
               target: 10000,
-              // `targetSatisfied` deliberately contradicts each day's own
-              // value: production always populates it with the evaluator's
-              // ROLLING verdict, and this test exists to prove a per-day
-              // target bar ignores that verdict in favour of the day's own
-              // number. Without it, both days took the null-fallback branch
-              // and the test passed against either policy.
+              // `targetSatisfied` is the evaluator's ROLLING verdict as of
+              // each day, set here to pin the per-day policy: a bar is met
+              // by the day's own number OR by that verdict, and short only
+              // when neither holds. Without explicit verdicts every day took
+              // the null-fallback branch and the test passed against any
+              // policy.
               days: [
+                GoalProgressDay(
+                  day: today.subtract(const Duration(days: 2)),
+                  value: 6100,
+                  targetSatisfied: false,
+                ),
                 GoalProgressDay(
                   day: today.subtract(const Duration(days: 1)),
                   value: 12400,
@@ -2335,10 +2340,17 @@ void main() {
     // success family instead — three states, three fills.
     expect(
       barColor('2026-08-11'),
+      dayMarkStateFill(tokens, DayMarkState.full),
+      reason:
+          '5,262 steps fell short of the day target, but the rolling week '
+          'ending that day holds — the other winnable condition',
+    );
+    expect(
+      barColor('2026-08-09'),
       dayMarkStateFill(tokens, DayMarkState.partial),
       reason:
-          '5,262 steps fell short but were still logged — the passing '
-          'rolling verdict must not paint the day green',
+          '6,100 steps fell short on both counts but were still logged — '
+          'measured, not absent, so the muted wash rather than the neutral',
     );
 
     // Seven bars filling a full-width card rendered ~40px slabs. Each one now


### PR DESCRIPTION
Closes lotti3-gr9 (endorsed proposal, 2026-08-15).

For a metric goal judged against a per-day target — steps at 10,000/day on a 7-day rolling average, the health point samples — a day's mark now holds when **either** the day's own value clears the target **or** the evaluator's verdict for the window ending that day holds. Previously only the day's own value counted. So a 10k day inside a bad week is a met day (already true), and an 8k day inside a week averaging above target is no longer painted as a miss (new). The goal's status is untouched; it stays rolling-average-driven — day-state and goal-state are deliberately different layers (recovery-door principle P4).

Period-total criteria (`sum`, `count`) keep the window verdict alone, as before: a single day's contribution cannot be read against a weekly total.

No criterion or wizard change was needed: the policy lives in `GoalMetricProgressView.dayMark`, the one place every surface that marks a metric day reads from (bars, compact strip cells, reflection-sheet marks, the composite met-yesterday tally, `suggestedDayVerdict`).

## Tests
- `goal_progress_view_test.dart`: the dayMark policy test now covers all doors — day value only, window verdict only, neither, and an unobserved day never met whatever the window says; the compact-window projection test's expectation updated (the 7,999 day inside an 8,333-average week is met, unobserved days stay empty).
- `goal_progress_card_test.dart`: the bar-fill test pins the OR (a short day inside an on-target week wears the met fill; a day short on both counts keeps the muted "measured but short" wash).
- Neighbouring goal surfaces (unified card, detail page, day verdict, assessment widgets) unchanged and green.

No visual token change; the same three fills carry the same meanings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily goal indicators now count a day as met when its value reaches the target or, for rolling-average goals, the rolling average meets the requirement.
  * Overall goal status remains based on the rolling average.
  * Period-based goals continue to use their window evaluation.

* **Bug Fixes**
  * Corrected progress bars that incorrectly showed qualifying days as incomplete.
  * Prevented “maximum” evaluations from marking subsequent short days as met.

* **Documentation**
  * Clarified daily indicator and overall status evaluation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->