### PR TITLE
feat(habits): day squares open their own day, show weekday or outcome, 14 days on desktop

### DIFF
--- a/changelog.d/2026-08-30-habit-day-squares.md
+++ b/changelog.d/2026-08-30-habit-day-squares.md
@@ -1,6 +1,7 @@
 ### Changed
 - **The day squares under each habit now say which day they are, and open that day.**
-  Every square carries its weekday letter until something is recorded for it,
+  Every square carries its weekday (Tu, Th, Sa, Su — in your language) until
+  something is recorded for it,
   then a tick for a kept day or a cross for a missed one — so a missed day no
   longer looks like a day you never looked at. Tapping a square opens the
   completion sheet for that day rather than for today, which is what makes

--- a/changelog.d/2026-08-30-habit-day-squares.md
+++ b/changelog.d/2026-08-30-habit-day-squares.md
@@ -8,3 +8,6 @@
   catching up on Tuesday from Thursday a one-tap job. The squares are a size
   larger everywhere, and on a desktop window a row shows the last fourteen
   days instead of seven.
+
+### Fixed
+- **On a narrow goal card, the "N successful days needed to recover" note wrapped beside empty space, and the status caption sat on a line of its own.** The note now takes its whole row, and the status ("Needs attention", "On track") sits at the end of the reading's own line whenever the two fit together.

--- a/changelog.d/2026-08-30-habit-day-squares.md
+++ b/changelog.d/2026-08-30-habit-day-squares.md
@@ -10,4 +10,8 @@
   days instead of seven.
 
 ### Fixed
-- **On a narrow goal card, the "N successful days needed to recover" note wrapped beside empty space, and the status caption sat on a line of its own.** The note now takes its whole row, and the status ("Needs attention", "On track") sits at the end of the reading's own line whenever the two fit together.
+- **On a narrow goal card, the "N successful days needed to recover" note
+  wrapped beside empty space, and the status caption sat on a line of its
+  own.** The note now takes its whole row, and the status ("Needs attention",
+  "On track") sits at the end of the reading's own line whenever the two fit
+  together.

--- a/changelog.d/2026-08-30-habit-day-squares.md
+++ b/changelog.d/2026-08-30-habit-day-squares.md
@@ -1,0 +1,9 @@
+### Changed
+- **The day squares under each habit now say which day they are, and open that day.**
+  Every square carries its weekday letter until something is recorded for it,
+  then a tick for a kept day or a cross for a missed one — so a missed day no
+  longer looks like a day you never looked at. Tapping a square opens the
+  completion sheet for that day rather than for today, which is what makes
+  catching up on Tuesday from Thursday a one-tap job. The squares are a size
+  larger everywhere, and on a desktop window a row shows the last fourteen
+  days instead of seven.

--- a/knowledge/architecture/day-indicators.md
+++ b/knowledge/architecture/day-indicators.md
@@ -125,7 +125,7 @@ flowchart LR
   everything else `background.level03`. No alert hue on a habit square: a
   struggling habit is never a wall of red.
 - **A square says one thing inside itself, and nothing around it.** A
-  judged day draws its verdict's glyph; a kept day the tick, a recorded miss
+  judged day draws its verdict's glyph; a kept day (partial included) the tick, a recorded miss
   the cross (which is what tells a miss from the empty day it shares a fill
   with); any other dated day its one-letter weekday, quiet on the fill. No
   ring, no dot, no caption row above the track. The full date, the outcome's

--- a/knowledge/architecture/day-indicators.md
+++ b/knowledge/architecture/day-indicators.md
@@ -31,9 +31,9 @@ habit's own history strip are **two views of the same day**, and for a while
 they drew it two ways — different fills, different corner radii, one with a
 today ring and one without. The package draws the square the habits design
 handover specifies — an `--interactive` square at radius 3 in a 3px-gap row,
-rendered at `radii.xs` and `spacing.step2` — one icon size larger than the
-handover's 11px so a two-letter weekday fits inside it (`IconSizes.s` on a phone,
-`IconSizes.m` on a desktop window; `daySquareSize`), and both features
+rendered at `radii.xs` and `spacing.step2` — larger than the handover's 11px
+so a two-letter weekday sits inside it (`IconSizes.m` on a phone, one
+`spacing.step1` more on a desktop window; `daySquareSize`), and both features
 consume it. It imports neither `features/goals` nor `features/habits`; each
 feature adapts its own state into the shared model.
 

--- a/knowledge/architecture/day-indicators.md
+++ b/knowledge/architecture/day-indicators.md
@@ -1,17 +1,17 @@
 ---
 type: Architecture
 title: Day indicators — the shared day-mark model and cells
-description: One model (DayMark, DayMarkState, DayVerdict) and one component set (the handover's 11px square at the nearest icon size, the strip, the track geometry) that both goals and habits draw their per-day squares with, so a day looks the same wherever it is judged.
+description: One model (DayMark, DayMarkState, DayVerdict) and one component set (one square per window size with its outcome glyph or weekday letter inside, the strip, the track geometry) that both goals and habits draw their per-day squares with, so a day looks the same wherever it is judged.
 resource: ../../lib/widgets/day_indicators
 tags: [day-indicators, habits, goals, design-system, accessibility]
 status: draft
-generated: { by: claude-code/fable-5, at: 2026-08-29T12:00:00Z }
+generated: { by: claude-code/fable-5, at: 2026-08-30T12:00:00Z }
 stale_after: 2027-02-28
 sources:
   - id: src
     resource: ../../lib/widgets/day_indicators
     title: Day indicators package source
-    last_modified: 2026-08-29
+    last_modified: 2026-08-30
   - id: goal-adapter
     resource: ../../lib/features/goals/ui/goal_day_marks.dart
     title: goalDayMarks — the goal side's adapter
@@ -30,10 +30,12 @@ sources:
 habit's own history strip are **two views of the same day**, and for a while
 they drew it two ways — different fills, different corner radii, one with a
 today ring and one without. The package draws the square the habits design
-handover specifies — an 11px `--interactive` square at radius 3 in a 3px-gap
-row, rendered at `IconSizes.xs`, `radii.xs` and `spacing.step2` — and both
-features consume it. It imports neither `features/goals` nor
-`features/habits`; each feature adapts its own state into the shared model.
+handover specifies — an `--interactive` square at radius 3 in a 3px-gap row,
+rendered at `radii.xs` and `spacing.step2` — one icon size larger than the
+handover's 11px so a weekday letter fits inside it (`IconSizes.s` on a phone,
+`IconSizes.m` on a desktop window; `daySquareSize`), and both features
+consume it. It imports neither `features/goals` nor `features/habits`; each
+feature adapts its own state into the shared model.
 
 # The model
 
@@ -89,24 +91,23 @@ classDiagram
   (`DayMark.pending`) draws as the dashed unresolved outline — the same
   encoding a loading placeholder uses — so an alive streak never ends on the
   grey of a missed day; a kept or judged today is an ordinary square. The
-  tooltip names the date, and a tappable square carries its weekday initial
-  above it inside the hit slot (`DayMarkCell.caption`, `dayCellWithCaption`)
-  because an action has to say which day it acts on.
+  tooltip names the date; the square itself says its weekday
+  (`dayMarkSquareContent`) until it has an outcome to show instead.
 
 # The component set
 
 | Piece | File | Role |
 | --- | --- | --- |
-| Fills, labels, the verdict scheme | `day_mark_styles.dart` | The ONE mapping from state/verdict to token colors. `dayVerdictGlyph` and `dayVerdictSurfaceInk` serve the reflections history and the reflect button, not the squares. |
+| Fills, labels, the verdict scheme | `day_mark_styles.dart` | The ONE mapping from state/verdict to token colors. `dayVerdictGlyph` is drawn inside a judged square and in the reflections history alike; `dayVerdictSurfaceInk` serves the history and the reflect button. |
 | `DayTrack`, `dayTrackMetrics`, `fitOrScrollDayTrack`, `LinkedDayTrackScroller` | `day_track.dart` | Column geometry shared by every day row on a page — one square plus `step2` — and the fit-or-pan policy. |
-| `kDaySquareSize`, `DayMarkCell`, `PlaceholderDayCell` | `day_mark_cell.dart` | One square, nothing inside it. Read-only by default; with `onTap` it becomes a labelled button whose hit slot clears the touch floor while the square keeps its size. |
+| `daySquareSize`, `dayMarkSquareContent`, `DayMarkCell`, `PlaceholderDayCell` | `day_mark_cell.dart` | One square per window size, saying one thing inside itself: the outcome's glyph, or the weekday letter while there is none. Read-only by default; with `onTap` it becomes a labelled button whose hit slot clears the touch floor while the square keeps its size. |
 | `DayMarkStrip` | `day_mark_strip.dart` | A row of squares on the shared track with one semantic summary, and — with `streak` — the handover's flame and count after the last square. |
 
 ```mermaid
 flowchart LR
   GV["GoalProgressView.compactWindow<br/>+ latestRatingsByDay"] --> GA["goalDayMarks()"]
   HR["List&lt;HabitResult&gt;<br/>(dashboard range)"] --> HA["habitCompletionDayMarkState()"]
-  HS["HabitsState.*ByDay<br/>(habits page, last 7 of days)"] --> HM["habitHistoryMarks()"]
+  HS["HabitsState.*ByDay<br/>(habits page, last 7 or 14 of days)"] --> HM["habitHistoryMarks()"]
   GA --> M["List&lt;DayMark&gt;"]
   HA --> M
   HM --> M
@@ -123,10 +124,13 @@ flowchart LR
   the handover's `--interactive` square — a partial day its `muted` wash, and
   everything else `background.level03`. No alert hue on a habit square: a
   struggling habit is never a wall of red.
-- **Nothing is drawn inside or around a square.** No glyph, no ring around
-  a filled square, no dot. The words — weekday and date, outcome, verdict, ages-out — live in
-  the `DsTooltip` and the semantics of every dated square; only a TAPPABLE
-  square adds a one-letter weekday caption above itself.
+- **A square says one thing inside itself, and nothing around it.** A
+  judged day draws its verdict's glyph; a kept day the tick, a recorded miss
+  the cross (which is what tells a miss from the empty day it shares a fill
+  with); any other dated day its one-letter weekday, quiet on the fill. No
+  ring, no dot, no caption row above the track. The full date, the outcome's
+  name and the ages-out fact live in the `DsTooltip` and the semantics of
+  every dated square.
 - **Verdict hues are the goal-assessment layer's.** The whole-goal strip and
   the goal detail's habit rows paint a recorded verdict in its own hue — met
   in the same interactive green a kept day wears, so a card is a baseline
@@ -144,15 +148,19 @@ flowchart LR
 
 - `_ProgressDayCell` in `goal_progress_card.dart` is not a `DayMarkCell`: it
   hosts the outcome menu and the saving spinner. It draws the same
-  `kDaySquareSize` square with the shared styles and the shared state enum,
-  so its squares still match; only its interaction shell is its own. The
-  ages-out fact it used to draw as an outline is a tooltip line now.
-- A tappable track is `TapTargets.minimum` tall with the caption and square
-  centred in it, so the cards drop the `step1` they put above a read-only
-  track — the slot brings its own air.
+  `daySquareSize` square with the shared styles, the shared state enum and
+  `dayMarkSquareContent`, so its squares still match; only its interaction
+  shell is its own. The ages-out fact it used to draw as an outline is a
+  tooltip line now.
+- A tappable track is `TapTargets.minimum` tall with the square centred in
+  it, so the cards drop the `step1` they put above a read-only track — the
+  slot brings its own air.
 - The habits page rows and the dashboard card pass `HabitActionRow.history`
-  (a `List<DayMark>`) plus `currentStreak`; the row renders one
-  `DayMarkStrip(streak:)`. There is no separate streak chain.
+  (a `List<DayMark>`) plus `currentStreak`; the row renders one tappable
+  `DayMarkStrip(streak:)`, and a tap on a square opens the completion sheet
+  for THAT day (`HabitCompletionSheet.show(dateString:)`), never for today.
+  The pages slice `habitHistoryDays(context)` days off the state — seven on
+  a phone, fourteen on a desktop window. There is no separate streak chain.
 - The habit dashboard strip used to drop its oldest days to fit; it now pans
   like every other track. There is no `LinkedScrollGroup` on a dashboard, so
   each card pans alone.
@@ -201,8 +209,8 @@ better tooltip.
 
 Cells never size proportionally to a value or a count, and they never
 shrink or grow: every day track sizes its columns from `dayTrackMetrics` —
-one square, `step2` of air, widened only when scaled text needs the
-weekday caption — and a span that does not fit its width pans. A proportional cell (wider for a longer window, taller
+one square, `step2` of air, widened only when scaled text needs the metric
+bars' weekday axis — and a span that does not fit its width pans. A proportional cell (wider for a longer window, taller
 for a bigger number) was considered in the 2026-08-15 audit and rejected: a
 date has to line up down the page across strips, habit squares and metric
 bars, which one grid guarantees and per-cell sizing cannot. Longer spans are

--- a/knowledge/architecture/day-indicators.md
+++ b/knowledge/architecture/day-indicators.md
@@ -1,7 +1,7 @@
 ---
 type: Architecture
 title: Day indicators — the shared day-mark model and cells
-description: One model (DayMark, DayMarkState, DayVerdict) and one component set (one square per window size with its outcome glyph or weekday letter inside, the strip, the track geometry) that both goals and habits draw their per-day squares with, so a day looks the same wherever it is judged.
+description: One model (DayMark, DayMarkState, DayVerdict) and one component set (one square per window size with its outcome glyph or weekday inside, the strip, the track geometry) that both goals and habits draw their per-day squares with, so a day looks the same wherever it is judged.
 resource: ../../lib/widgets/day_indicators
 tags: [day-indicators, habits, goals, design-system, accessibility]
 status: draft
@@ -32,7 +32,7 @@ they drew it two ways — different fills, different corner radii, one with a
 today ring and one without. The package draws the square the habits design
 handover specifies — an `--interactive` square at radius 3 in a 3px-gap row,
 rendered at `radii.xs` and `spacing.step2` — one icon size larger than the
-handover's 11px so a weekday letter fits inside it (`IconSizes.s` on a phone,
+handover's 11px so a two-letter weekday fits inside it (`IconSizes.s` on a phone,
 `IconSizes.m` on a desktop window; `daySquareSize`), and both features
 consume it. It imports neither `features/goals` nor `features/habits`; each
 feature adapts its own state into the shared model.
@@ -100,7 +100,7 @@ classDiagram
 | --- | --- | --- |
 | Fills, labels, the verdict scheme | `day_mark_styles.dart` | The ONE mapping from state/verdict to token colors. `dayVerdictGlyph` is drawn inside a judged square and in the reflections history alike; `dayVerdictSurfaceInk` serves the history and the reflect button. |
 | `DayTrack`, `dayTrackMetrics`, `fitOrScrollDayTrack`, `LinkedDayTrackScroller` | `day_track.dart` | Column geometry shared by every day row on a page — one square plus `step2` — and the fit-or-pan policy. |
-| `daySquareSize`, `dayMarkSquareContent`, `DayMarkCell`, `PlaceholderDayCell` | `day_mark_cell.dart` | One square per window size, saying one thing inside itself: the outcome's glyph, or the weekday letter while there is none. Read-only by default; with `onTap` it becomes a labelled button whose hit slot clears the touch floor while the square keeps its size. |
+| `daySquareSize`, `dayMarkSquareContent`, `DayMarkCell`, `PlaceholderDayCell` | `day_mark_cell.dart` | One square per window size, saying one thing inside itself: the outcome's glyph, or the two-letter weekday while there is none. Read-only by default; with `onTap` it becomes a labelled button whose hit slot clears the touch floor while the square keeps its size. |
 | `DayMarkStrip` | `day_mark_strip.dart` | A row of squares on the shared track with one semantic summary, and — with `streak` — the handover's flame and count after the last square. |
 
 ```mermaid
@@ -127,7 +127,9 @@ flowchart LR
 - **A square says one thing inside itself, and nothing around it.** A
   judged day draws its verdict's glyph; a kept day (partial included) the tick, a recorded miss
   the cross (which is what tells a miss from the empty day it shares a fill
-  with); any other dated day its one-letter weekday, quiet on the fill. No
+  with); any other dated day its weekday — the first two characters of the
+  locale's abbreviation (`dayMarkWeekdayLabel`: `Tu Th Sa Su`, `Di Do Sa
+  So`), quiet on the fill. No
   ring, no dot, no caption row above the track. The full date, the outcome's
   name and the ages-out fact live in the `DsTooltip` and the semantics of
   every dated square.
@@ -161,7 +163,8 @@ flowchart LR
   for THAT day (`HabitCompletionSheet.show(dateString:)`), never for today.
   Days after today — a dashboard range can hold them — are declined through
   `DayMarkStrip.isDaySelectable` and drawn read-only, not as buttons that
-  do nothing.
+  do nothing; their taps are swallowed so they cannot fall through to the
+  row body and open today's sheet.
   The pages slice `habitHistoryDays(context)` days off the state — seven on
   a phone, fourteen on a desktop window. There is no separate streak chain.
 - The habit dashboard strip used to drop its oldest days to fit; it now pans

--- a/knowledge/architecture/day-indicators.md
+++ b/knowledge/architecture/day-indicators.md
@@ -161,10 +161,9 @@ flowchart LR
   (a `List<DayMark>`) plus `currentStreak`; the row renders one tappable
   `DayMarkStrip(streak:)`, and a tap on a square opens the completion sheet
   for THAT day (`HabitCompletionSheet.show(dateString:)`), never for today.
-  Days after today — a dashboard range can hold them — are declined through
-  `DayMarkStrip.isDaySelectable` and drawn read-only, not as buttons that
-  do nothing; their taps are swallowed so they cannot fall through to the
-  row body and open today's sheet.
+  Every history span ends today — the page state's by construction, the
+  dashboard's by its range — so no square ever stands for a day that has
+  not happened.
   The pages slice `habitHistoryDays(context)` days off the state — seven on
   a phone, fourteen on a desktop window. There is no separate streak chain.
 - The habit dashboard strip used to drop its oldest days to fit; it now pans

--- a/knowledge/architecture/day-indicators.md
+++ b/knowledge/architecture/day-indicators.md
@@ -159,6 +159,9 @@ flowchart LR
   (a `List<DayMark>`) plus `currentStreak`; the row renders one tappable
   `DayMarkStrip(streak:)`, and a tap on a square opens the completion sheet
   for THAT day (`HabitCompletionSheet.show(dateString:)`), never for today.
+  Days after today — a dashboard range can hold them — are declined through
+  `DayMarkStrip.isDaySelectable` and drawn read-only, not as buttons that
+  do nothing.
   The pages slice `habitHistoryDays(context)` days off the state — seven on
   a phone, fourteen on a desktop window. There is no separate streak chain.
 - The habit dashboard strip used to drop its oldest days to fit; it now pans

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -892,7 +892,11 @@ flowchart TD
   onto a second line, and the block leaves the title row altogether, only
   when the reading is MEASURED not to fit (`goalTextWidth`) — a fixed
   breakpoint stacked the corner away on every phone while the figures
-  occupied a third of the row. The legend entry naming that series wears the hue too
+  occupied a third of the row. Off the title row, the status caption sits on
+  the reading's own row at the trailing edge whenever the two are measured
+  to fit, and drops beneath only when they do not; the habit row's deficit
+  note likewise takes its whole fallback row rather than a capped fraction
+  of it. The legend entry naming that series wears the hue too
   (`DashboardLegendEntry.labelWearsSeriesColor`), since colour is the only
   thing resolving the symbol to a mark on the chart. The target stays in the
   keyed legend entry ("Goal ≤ 88", or a compact "Goal 10K" for steps) rather

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -941,15 +941,14 @@ flowchart TD
   range. The retained snapshot is scoped to the active spec version and only
   promoted from a settled provider value, so a spec reload cannot relabel
   prior-spec evidence. A day track never resizes its
-  squares: `dayTrackMetrics` is one `kDaySquareSize` square plus `step2`
+  squares: `dayTrackMetrics` is one `daySquareSize` square plus `step2`
   per column, and a span wider than the width it was given becomes a
   trailing-anchored (`reverse: true`) scroller joined to one
   `LinkedScrollGroup`, where every track then pans in unison. The habit
   squares and the whole-goal strip carry no label row — a square names its
-  day in its tooltip and semantics, and a tappable one wears its weekday
-  initial above itself inside its slot; only the hand-painted metric bars
-  keep a caption axis (`_WeekdayTrack`, one-letter at this pitch), below
-  the bars. Every tappable element on these cards carries the
+  date in its tooltip and semantics and says its weekday, or its outcome's
+  glyph, inside itself; only the hand-painted metric bars keep a caption
+  axis (`_WeekdayTrack`, one-letter at this pitch), below the bars. Every tappable element on these cards carries the
   design system's `surface.hover` fill on its own transparent `Material` —
   ink painted on the Scaffold's Material sits under the opaque cards and
   never shows, which is why the day grids and rail rows previously had no

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -315,13 +315,15 @@ window width** in its own sliver, so a wide screen shows more history while the
 action content stays a comfortable column.
 
 Tab rows are **action rows**: icon, name, the handover's history strip —
-the last seven days as squares (`habitHistoryMarks`, read off the state's
-per-day completion sets), filled for a kept day and neutral otherwise, each
-naming its day and outcome on hover, then the flame and the current streak —
-swipe, and one-tap complete. The dashboard habit chart draws the same strip
-over its own range. Both go through the shared day-indicator squares ([day
-indicators](../architecture/day-indicators.md)) so they match a goal's habit
-squares. A row
+the last seven days on a phone and fourteen on a desktop window as squares
+(`habitHistoryMarks` with `habitHistoryDays`, read off the state's per-day
+completion sets), a tick on a kept day, a cross on a recorded miss, the
+weekday letter on any other, each naming its date and outcome on hover, and
+each opening the completion sheet **for its own day** on tap; then the flame
+and the current streak — swipe, and one-tap complete. The dashboard habit
+chart draws the same strip over its own range. Both go through the shared
+day-indicator squares ([day indicators](../architecture/day-indicators.md))
+so they match a goal's habit squares. A row
 whose completion today came from the engine wears an **auto** pill and a
 caption naming the signal and the time (`HabitsState.autoCompletedToday` and
 `autoCompletedAt`); tapping it still opens the sheet, because a manual entry

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -318,7 +318,7 @@ Tab rows are **action rows**: icon, name, the handover's history strip —
 the last seven days on a phone and fourteen on a desktop window as squares
 (`habitHistoryMarks` with `habitHistoryDays`, read off the state's per-day
 completion sets), a tick on a kept day, a cross on a recorded miss, the
-weekday letter on any other, each naming its date and outcome on hover, and
+two-letter weekday on any other, each naming its date and outcome on hover, and
 each opening the completion sheet **for its own day** on tap; then the flame
 and the current streak — swipe, and one-tap complete. The dashboard habit
 chart draws the same strip over its own range. Both go through the shared

--- a/lib/features/goals/ui/goal_progress_card.dart
+++ b/lib/features/goals/ui/goal_progress_card.dart
@@ -1347,7 +1347,7 @@ class _WeekdayTrack extends StatelessWidget {
               'goal-habit-weekday-$trackId-'
               '${day.day.toIso8601String().substring(0, 10)}',
             ),
-            width: kDaySquareSize,
+            width: daySquareSize(context),
             child: OverflowBox(
               maxWidth: double.infinity,
               child: Text(
@@ -1478,16 +1478,12 @@ class _HabitProgressRowState extends State<_HabitProgressRow> {
     final noteStyle = tokens.typography.styles.others.caption.copyWith(
       color: tokens.colors.text.mediumEmphasis,
     );
-    final letterFormat = DateFormat.EEEEE(
-      Localizations.localeOf(context).toLanguageTag(),
-    );
-
     Widget cells(DayTrackMetrics metrics) {
       // Interactive rows own a touch-floor-high track so each cell's hit
       // slot meets TapTargets.minimum vertically; read-only rows keep the
       // compact height.
       final trackHeight = widget.onOutcomeSelected == null
-          ? kDaySquareSize
+          ? daySquareSize(context)
           : TapTargets.minimum;
       return DayTrack(
         height: trackHeight,
@@ -1501,9 +1497,6 @@ class _HabitProgressRowState extends State<_HabitProgressRow> {
                 activeDays[index].day,
                 widget.today,
               ),
-              weekdayLetter: widget.onOutcomeSelected == null
-                  ? null
-                  : letterFormat.format(activeDays[index].day),
               verdict:
                   widget.verdictsByDay[DateTime.utc(
                     activeDays[index].day.year,
@@ -1694,7 +1687,6 @@ class _ProgressDayCell extends StatelessWidget {
     required this.enabled,
     required this.onOutcomeSelected,
     required this.today,
-    this.weekdayLetter,
     this.verdict,
   });
 
@@ -1704,9 +1696,6 @@ class _ProgressDayCell extends StatelessWidget {
   /// Whether this is the current day. Empty and unjudged, it draws as the
   /// dashed unresolved outline rather than a past day's neutral fill.
   final bool today;
-
-  /// The weekday initial drawn above a tappable square, inside its slot.
-  final String? weekdayLetter;
 
   /// The user's verdict on this habit for this day, when they recorded one
   /// in the reflection sheet. It decides the fill; the measured outcome is
@@ -1739,19 +1728,29 @@ class _ProgressDayCell extends StatelessWidget {
         verdict == null &&
         dayState == DayMarkState.none &&
         (completionType == null || completionType == HabitCompletionType.open);
+    final size = daySquareSize(context);
     Widget cell = pending
         ? PlaceholderDayCell(
             key: ValueKey('goal-habit-day-visual-$habitId-$dayKey'),
+            day: day.day,
           )
         : Container(
             key: ValueKey('goal-habit-day-visual-$habitId-$dayKey'),
-            width: kDaySquareSize,
-            height: kDaySquareSize,
+            width: size,
+            height: size,
+            alignment: Alignment.center,
             decoration: BoxDecoration(
               color: verdict == null
                   ? dayMarkStateFill(tokens, dayState)
                   : dayVerdictFill(tokens, verdict),
               borderRadius: BorderRadius.circular(tokens.radii.xs),
+            ),
+            child: dayMarkSquareContent(
+              context,
+              state: dayState,
+              verdict: verdict,
+              day: day.day,
+              size: size,
             ),
           );
     if (dayState == DayMarkState.partial) {
@@ -1823,18 +1822,14 @@ class _ProgressDayCell extends StatelessWidget {
           semanticLabel: semanticLabel,
           onSelected: callback,
           child: Center(
-            child: dayCellWithCaption(
-              tokens,
-              saving
-                  ? const SizedBox.square(
-                      dimension: kDaySquareSize,
-                      child: CircularProgressIndicator(
-                        strokeWidth: BorderWidths.emphasis,
-                      ),
-                    )
-                  : cell,
-              weekdayLetter,
-            ),
+            child: saving
+                ? SizedBox.square(
+                    dimension: size,
+                    child: const CircularProgressIndicator(
+                      strokeWidth: BorderWidths.emphasis,
+                    ),
+                  )
+                : cell,
           ),
         ),
       ),
@@ -2348,7 +2343,7 @@ class _MetricProgressSeries extends StatelessWidget {
           // whose Stack expands against its parent, so it needs bounded
           // dimensions or every bar collapses to zero — an invisible chart.
           SizedBox(
-            width: kDaySquareSize,
+            width: daySquareSize(context),
             height: height,
             child: _bar(context, day, maxValue, chrome),
           ),

--- a/lib/features/goals/ui/goal_progress_card.dart
+++ b/lib/features/goals/ui/goal_progress_card.dart
@@ -1210,19 +1210,43 @@ class _DimensionHeader extends StatelessWidget {
       );
     }
 
-    Widget block({required bool alignEnd, required bool inline}) => Column(
-      crossAxisAlignment: alignEnd
-          ? CrossAxisAlignment.end
-          : CrossAxisAlignment.start,
-      children: [
-        readingLine(alignEnd: alignEnd, inline: inline),
-        Text(
-          statusLabel,
-          textAlign: alignEnd ? TextAlign.end : TextAlign.start,
-          style: captionStyle.copyWith(color: statusColor),
-        ),
-      ],
-    );
+    final statusStyle = captionStyle.copyWith(color: statusColor);
+    Widget block({
+      required bool alignEnd,
+      required bool inline,
+      bool statusTrailing = false,
+    }) {
+      final status = Text(
+        statusLabel,
+        textAlign: alignEnd ? TextAlign.end : TextAlign.start,
+        style: statusStyle,
+      );
+      final reading = readingLine(alignEnd: alignEnd, inline: inline);
+      if (statusTrailing) {
+        // Off the corner, the block has the card's whole width, and a verdict
+        // stacked under a reading that fills a fraction of it read as a line
+        // of its own, unattached. On the reading's own row, at the trailing
+        // edge, it sits where the corner puts it — under the figure it
+        // judges — just turned sideways.
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          textBaseline: TextBaseline.alphabetic,
+          children: [
+            // Expanded, not Flexible beside a Spacer: two flex children split
+            // the row in half and ellipsized a reading that had room.
+            Expanded(child: reading),
+            SizedBox(width: tokens.spacing.step4),
+            status,
+          ],
+        );
+      }
+      return Column(
+        crossAxisAlignment: alignEnd
+            ? CrossAxisAlignment.end
+            : CrossAxisAlignment.start,
+        children: [reading, status],
+      );
+    }
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -1302,6 +1326,11 @@ class _DimensionHeader extends StatelessWidget {
             block(
               alignEnd: false,
               inline: inlineWidth <= constraints.maxWidth,
+              statusTrailing:
+                  math.min(inlineWidth, math.max(valueWidth, meanWidth)) +
+                      tokens.spacing.step4 +
+                      goalTextWidth(context, statusLabel, statusStyle) <=
+                  constraints.maxWidth,
             ),
           ],
         );
@@ -1560,24 +1589,13 @@ class _HabitProgressRowState extends State<_HabitProgressRow> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // The stacked fallback: the note flush to the trailing edge under
-            // the corner block it qualifies; bounded so it wraps rather than
-            // overflowing a narrow card.
+            // the corner block it qualifies, with the whole row to itself —
+            // it wraps only when the card is narrower than the sentence, not
+            // at an arbitrary fraction of a row nothing else shares.
             if (note != null && !noteSharesLine) ...[
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Spacer(),
-                  ConstrainedBox(
-                    constraints: BoxConstraints(
-                      maxWidth: constraints.maxWidth * 0.6,
-                    ),
-                    child: Text(
-                      note,
-                      textAlign: TextAlign.end,
-                      style: noteStyle,
-                    ),
-                  ),
-                ],
+              Align(
+                alignment: AlignmentDirectional.centerEnd,
+                child: Text(note, textAlign: TextAlign.end, style: noteStyle),
               ),
               SizedBox(height: tokens.spacing.step2),
             ],

--- a/lib/features/goals/ui/pages/unified_goals_page.dart
+++ b/lib/features/goals/ui/pages/unified_goals_page.dart
@@ -242,7 +242,11 @@ class _UnifiedGoalsPageState extends ConsumerState<UnifiedGoalsPage>
         autoCompleteReason: state.autoCompletedToday[habitDefinition.id],
         autoCompletedAt: state.autoCompletedAt(habitDefinition.id),
         currentStreak: streaks[habitDefinition.id] ?? 0,
-        history: habitHistoryMarks(state, habitDefinition.id),
+        history: habitHistoryMarks(
+          state,
+          habitDefinition.id,
+          count: habitHistoryDays(context),
+        ),
       );
     }
 

--- a/lib/features/habits/state/habits_state.dart
+++ b/lib/features/habits/state/habits_state.dart
@@ -245,7 +245,9 @@ List<String> getHabitDays(int timeSpanDays, {DateTime? now}) {
 
 /// The last [count] of [HabitsState.days] as day marks for one habit — the
 /// dated history strip under a habit row, read straight off the per-day
-/// completion sets the page already holds. A day the habit was kept is
+/// completion sets the page already holds. The rows pass `habitHistoryDays`
+/// for [count] (a week on a phone, two on a desktop window); the default is
+/// the handover's week. A day the habit was kept is
 /// `full`; a recorded skip or miss keeps its own state so the square can name
 /// it; a day with no record is `none`.
 List<DayMark> habitHistoryMarks(

--- a/lib/features/habits/ui/habits_page.dart
+++ b/lib/features/habits/ui/habits_page.dart
@@ -241,7 +241,11 @@ class _HabitsTabPageState extends ConsumerState<HabitsTabPage> {
         autoCompleteReason: state.autoCompletedToday[habitDefinition.id],
         autoCompletedAt: state.autoCompletedAt(habitDefinition.id),
         currentStreak: streaks[habitDefinition.id] ?? 0,
-        history: habitHistoryMarks(state, habitDefinition.id),
+        history: habitHistoryMarks(
+          state,
+          habitDefinition.id,
+          count: habitHistoryDays(context),
+        ),
       );
     }
 

--- a/lib/features/habits/ui/sheets/habit_completion_sheet.dart
+++ b/lib/features/habits/ui/sheets/habit_completion_sheet.dart
@@ -101,6 +101,12 @@ class HabitCompletionSheet extends ConsumerStatefulWidget {
 class _HabitCompletionSheetState extends ConsumerState<HabitCompletionSheet> {
   final _formKey = GlobalKey<FormBuilderState>();
   late DateTime _started;
+
+  /// Whether [_started] was placed on a chosen moment rather than "now" — a
+  /// past day given to the sheet, or a date picked in the field. A reset
+  /// start is saved as an instant (`dateTo == dateFrom`); an un-reset one
+  /// ends when the save happens. A completion backfilled onto Tuesday must
+  /// not span from Tuesday to the moment it was saved on Thursday.
   bool _startReset = false;
 
   /// The outcome the [DsSegmentedToggle] currently selects. Defaults to
@@ -135,6 +141,7 @@ class _HabitCompletionSheetState extends ConsumerState<HabitCompletionSheet> {
     final forToday =
         widget.dateString == null || clock.now().ymd == widget.dateString;
     _started = forToday ? clock.now() : endOfDay();
+    _startReset = !forToday;
   }
 
   /// Opens the day's reflection for one of the goals watching this habit.

--- a/lib/features/habits/ui/widgets/habit_action_row.dart
+++ b/lib/features/habits/ui/widgets/habit_action_row.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -195,15 +194,10 @@ class _HabitActionRowState extends ConsumerState<HabitActionRow>
 
   /// A tap on one of the history squares: the sheet for THAT day, so a
   /// missed Tuesday is recorded on Tuesday rather than on today with the
-  /// date to be corrected by hand.
+  /// date to be corrected by hand. Every history span ends today — the page
+  /// state's by construction, the dashboard's by its range — so there is no
+  /// square for a day that has not happened.
   void _onHistoryDaySelected(DateTime day) => onTapAdd(dateString: day.ymd);
-
-  /// The page state's span ends today, but a dashboard range can run past
-  /// it, and there is nothing to record on a day that has not happened —
-  /// those squares stay read-only rather than becoming buttons that do
-  /// nothing.
-  static bool _isHistoryDaySelectable(DateTime day) =>
-      day.ymd.compareTo(clock.now().ymd) <= 0;
 
   /// Records a one-tap completion for *today* with [completionType] and no
   /// comment — the fast path shared by the trailing check button (success) and
@@ -380,7 +374,6 @@ class _HabitActionRowState extends ConsumerState<HabitActionRow>
                 history: widget.history,
                 onTapAdd: onTapAdd,
                 onHistoryDaySelected: _onHistoryDaySelected,
-                isHistoryDaySelectable: _isHistoryDaySelectable,
                 onEdit: () => openHabitEditor(context, habitId: widget.habitId),
                 onQuickComplete: () => _recordQuickCompletion(
                   HabitCompletionType.success,
@@ -450,7 +443,6 @@ class _HabitCardBody extends StatelessWidget {
     required this.celebrate,
     required this.onTapAdd,
     required this.onHistoryDaySelected,
-    required this.isHistoryDaySelectable,
     required this.onEdit,
     required this.onQuickComplete,
     required this.history,
@@ -471,9 +463,6 @@ class _HabitCardBody extends StatelessWidget {
 
   /// A tap on one of the [history] squares, with that square's day.
   final ValueChanged<DateTime> onHistoryDaySelected;
-
-  /// Which [history] squares are offered as buttons at all.
-  final bool Function(DateTime day) isHistoryDaySelectable;
   final VoidCallback onEdit;
 
   /// One-tap "mark done today" — the trailing check records a success directly
@@ -584,7 +573,6 @@ class _HabitCardBody extends StatelessWidget {
                           marks: history,
                           streak: currentStreak,
                           onDaySelected: onHistoryDaySelected,
-                          isDaySelectable: isHistoryDaySelectable,
                         ),
                       ],
                     ],

--- a/lib/features/habits/ui/widgets/habit_action_row.dart
+++ b/lib/features/habits/ui/widgets/habit_action_row.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -10,6 +11,7 @@ import 'package:lotti/features/design_system/components/celebration/celebration_
 import 'package:lotti/features/design_system/components/celebration/completion_burst.dart';
 import 'package:lotti/features/design_system/components/celebration/completion_glow.dart';
 import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/design_system/theme/ds_surface_elevation.dart';
 import 'package:lotti/features/habits/ui/pages/habit_editor_launcher.dart';
@@ -20,6 +22,7 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/themes/colors.dart';
+import 'package:lotti/utils/date_utils_extension.dart';
 import 'package:lotti/widgets/charts/habits/dashboard_habits_data.dart';
 import 'package:lotti/widgets/day_indicators/day_mark.dart';
 import 'package:lotti/widgets/day_indicators/day_mark_strip.dart';
@@ -33,11 +36,26 @@ double? _stageProgress(double c, double start, double end) {
   return (c - start) / (end - start);
 }
 
+/// How many days a habit row's history strip shows on a desktop window.
+///
+/// A phone card has room for the handover's week; a desktop row has several
+/// times that width, and seven squares left most of it empty. Two weeks is
+/// the span the habits chart also opens on.
+const int kHabitHistoryDaysDesktop = 14;
+
+/// The days a habit row's history strip shows in this window: two weeks on a
+/// desktop-width window, the handover's seven otherwise. The rows' callers
+/// pass it to `habitHistoryMarks` so the state slices the same span the row
+/// draws.
+int habitHistoryDays(BuildContext context) =>
+    isDesktopLayout(context) ? kHabitHistoryDaysDesktop : DateTime.daysPerWeek;
+
 /// The shared habit action row used by the habits tab and the dashboard habit
 /// chart: a swipe-to-record row (right = success, left = missed) whose body
 /// opens the completion dialog on tap, with a category icon, an optional
 /// priority star, the habit name, the handover's history strip — one square
-/// per day of [history], then a flame and [currentStreak] — and a trailing
+/// per day of [history], each opening the completion sheet for its own day,
+/// then a flame and [currentStreak] — and a trailing
 /// one-tap complete button.
 ///
 /// The history is the caller's to supply: the habits tab reads its week off
@@ -173,6 +191,17 @@ class _HabitActionRowState extends ConsumerState<HabitActionRow>
       habitId: widget.habitId,
       dateString: dateString,
     );
+  }
+
+  /// A tap on one of the history squares: the sheet for THAT day, so a
+  /// missed Tuesday is recorded on Tuesday rather than on today with the
+  /// date to be corrected by hand. The page state's span ends today; a
+  /// dashboard range can run past it, and there is nothing to record on a
+  /// day that has not happened.
+  void _onHistoryDaySelected(DateTime day) {
+    final ymd = day.ymd;
+    if (ymd.compareTo(clock.now().ymd) > 0) return;
+    onTapAdd(dateString: ymd);
   }
 
   /// Records a one-tap completion for *today* with [completionType] and no
@@ -349,6 +378,7 @@ class _HabitActionRowState extends ConsumerState<HabitActionRow>
                 celebrate: celebrate,
                 history: widget.history,
                 onTapAdd: onTapAdd,
+                onHistoryDaySelected: _onHistoryDaySelected,
                 onEdit: () => openHabitEditor(context, habitId: widget.habitId),
                 onQuickComplete: () => _recordQuickCompletion(
                   HabitCompletionType.success,
@@ -417,6 +447,7 @@ class _HabitCardBody extends StatelessWidget {
     required this.doneColor,
     required this.celebrate,
     required this.onTapAdd,
+    required this.onHistoryDaySelected,
     required this.onEdit,
     required this.onQuickComplete,
     required this.history,
@@ -434,6 +465,9 @@ class _HabitCardBody extends StatelessWidget {
   final bool celebrate;
   final List<DayMark> history;
   final void Function({String? dateString}) onTapAdd;
+
+  /// A tap on one of the [history] squares, with that square's day.
+  final ValueChanged<DateTime> onHistoryDaySelected;
   final VoidCallback onEdit;
 
   /// One-tap "mark done today" — the trailing check records a success directly
@@ -531,12 +565,20 @@ class _HabitCardBody extends StatelessWidget {
                           overflow: TextOverflow.ellipsis,
                         ),
                       ],
-                      // The handover's history strip: the week's squares,
+                      // The handover's history strip: the span's squares,
                       // then the flame and the streak. Nothing when there is
-                      // neither history nor a run going.
+                      // neither history nor a run going. Each square is the
+                      // door to its own day's sheet, and a tappable track
+                      // brings its own air — the touch-floor slot with the
+                      // weekday initial and the square centred in it — so
+                      // the gap above it is the small one.
                       if (history.isNotEmpty || currentStreak >= 1) ...[
-                        SizedBox(height: tokens.spacing.step3),
-                        DayMarkStrip(marks: history, streak: currentStreak),
+                        SizedBox(height: tokens.spacing.step1),
+                        DayMarkStrip(
+                          marks: history,
+                          streak: currentStreak,
+                          onDaySelected: onHistoryDaySelected,
+                        ),
                       ],
                     ],
                   ),

--- a/lib/features/habits/ui/widgets/habit_action_row.dart
+++ b/lib/features/habits/ui/widgets/habit_action_row.dart
@@ -195,14 +195,15 @@ class _HabitActionRowState extends ConsumerState<HabitActionRow>
 
   /// A tap on one of the history squares: the sheet for THAT day, so a
   /// missed Tuesday is recorded on Tuesday rather than on today with the
-  /// date to be corrected by hand. The page state's span ends today; a
-  /// dashboard range can run past it, and there is nothing to record on a
-  /// day that has not happened.
-  void _onHistoryDaySelected(DateTime day) {
-    final ymd = day.ymd;
-    if (ymd.compareTo(clock.now().ymd) > 0) return;
-    onTapAdd(dateString: ymd);
-  }
+  /// date to be corrected by hand.
+  void _onHistoryDaySelected(DateTime day) => onTapAdd(dateString: day.ymd);
+
+  /// The page state's span ends today, but a dashboard range can run past
+  /// it, and there is nothing to record on a day that has not happened —
+  /// those squares stay read-only rather than becoming buttons that do
+  /// nothing.
+  static bool _isHistoryDaySelectable(DateTime day) =>
+      day.ymd.compareTo(clock.now().ymd) <= 0;
 
   /// Records a one-tap completion for *today* with [completionType] and no
   /// comment — the fast path shared by the trailing check button (success) and
@@ -379,6 +380,7 @@ class _HabitActionRowState extends ConsumerState<HabitActionRow>
                 history: widget.history,
                 onTapAdd: onTapAdd,
                 onHistoryDaySelected: _onHistoryDaySelected,
+                isHistoryDaySelectable: _isHistoryDaySelectable,
                 onEdit: () => openHabitEditor(context, habitId: widget.habitId),
                 onQuickComplete: () => _recordQuickCompletion(
                   HabitCompletionType.success,
@@ -448,6 +450,7 @@ class _HabitCardBody extends StatelessWidget {
     required this.celebrate,
     required this.onTapAdd,
     required this.onHistoryDaySelected,
+    required this.isHistoryDaySelectable,
     required this.onEdit,
     required this.onQuickComplete,
     required this.history,
@@ -468,6 +471,9 @@ class _HabitCardBody extends StatelessWidget {
 
   /// A tap on one of the [history] squares, with that square's day.
   final ValueChanged<DateTime> onHistoryDaySelected;
+
+  /// Which [history] squares are offered as buttons at all.
+  final bool Function(DateTime day) isHistoryDaySelectable;
   final VoidCallback onEdit;
 
   /// One-tap "mark done today" — the trailing check records a success directly
@@ -578,6 +584,7 @@ class _HabitCardBody extends StatelessWidget {
                           marks: history,
                           streak: currentStreak,
                           onDaySelected: onHistoryDaySelected,
+                          isDaySelectable: isHistoryDaySelectable,
                         ),
                       ],
                     ],

--- a/lib/features/habits/ui/widgets/habit_completion_card.dart
+++ b/lib/features/habits/ui/widgets/habit_completion_card.dart
@@ -98,9 +98,9 @@ class _HabitCompletionCardState extends ConsumerState<HabitCompletionCard> {
 }
 
 /// The dashboard range as day marks, oldest first, for the row's history
-/// strip. The strip is read-only: tapping anywhere on the row (or the complete
-/// button) opens the dialog, where any past day can be backfilled via the date
-/// field, so the squares need no tiny, swipe-conflicting tap targets.
+/// strip. Each square opens the completion sheet for its own day; the row
+/// body still opens it for today, and the sheet's date field covers any day
+/// the range does not show.
 List<DayMark> _historyMarks(List<HabitResult> results) {
   final today = clock.now().ymd;
   return [

--- a/lib/widgets/day_indicators/day_mark.dart
+++ b/lib/widgets/day_indicators/day_mark.dart
@@ -45,7 +45,7 @@ class DayMark {
 
   /// The calendar day, at midnight UTC. Null on an undated strip — a loading
   /// placeholder row, or a figure whose cells carry no dates and therefore no
-  /// weekday letters.
+  /// weekdays.
   final DateTime? day;
 
   final DayMarkState state;

--- a/lib/widgets/day_indicators/day_mark.dart
+++ b/lib/widgets/day_indicators/day_mark.dart
@@ -7,8 +7,8 @@ import 'package:flutter/foundation.dart';
 /// target was still building — rendered as a lighter wash of the same success
 /// hue. [skipped] and [missed] are recorded outcomes a habit day can carry.
 /// A strip records what was KEPT, so they share the neutral fill of [none];
-/// the label and tooltip say which of the three a neutral square stands for
-/// (see `dayMarkStateLabel`).
+/// a [missed] square draws a cross inside that fill, a [skipped] one stays
+/// bare, and the label and tooltip name all three (see `dayMarkStateLabel`).
 enum DayMarkState { none, partial, full, skipped, missed }
 
 /// How a day turned out, in the user's own judgement.

--- a/lib/widgets/day_indicators/day_mark_cell.dart
+++ b/lib/widgets/day_indicators/day_mark_cell.dart
@@ -27,12 +27,20 @@ const double kDaySquareSizeDesktop = IconSizes.m;
 double daySquareSize(BuildContext context) =>
     isDesktopLayout(context) ? kDaySquareSizeDesktop : kDaySquareSize;
 
+/// The weekday a day square names: the first two characters of the locale's
+/// abbreviated weekday, so Tuesday and Thursday, Saturday and Sunday can be
+/// told apart — one letter left `T T S S` in English and `D D S S` in German
+/// (`Di Do Sa So`). Locales whose abbreviation is already one character
+/// keep it.
+String dayMarkWeekdayLabel(String locale, DateTime day) =>
+    DateFormat.E(locale).format(day).characters.take(2).toString();
+
 /// What a day square says inside itself: the glyph of a recorded or judged
-/// outcome, or — while the day has none — its weekday initial.
+/// outcome, or — while the day has none — its weekday.
 ///
 /// A row of squares used to say which day was which only on hover, and a
 /// tappable one grew a caption row above itself to say it before the tap.
-/// Drawing the letter inside the unresolved squares answers the question
+/// Drawing the weekday inside the unresolved squares answers the question
 /// where the eye already is, and the resolved squares do not need it: a
 /// tick or a cross beside a lettered neighbour is read against that
 /// neighbour's day. The glyphs are the reflections history's own
@@ -86,16 +94,21 @@ Widget? dayMarkSquareContent(
     case DayMarkState.skipped:
       if (day == null) return null;
       final locale = Localizations.localeOf(context).toLanguageTag();
-      // Scaled down, never wrapped or clipped: the caption size fits the
-      // square at the default text scale, and a raised scale must not push
-      // the letter out of a square that does not grow with it.
-      return FittedBox(
-        fit: BoxFit.scaleDown,
-        child: Text(
-          DateFormat.EEEEE(locale).format(day),
-          maxLines: 1,
-          style: tokens.typography.styles.others.caption.copyWith(
-            color: tokens.colors.text.lowEmphasis,
+      // Scaled down into the same inset the glyphs keep, never wrapped or
+      // clipped: two caption-size letters are wider than the square, and a
+      // raised text scale must not push them out of a square that does not
+      // grow with it. There is no type token below the caption tier, so the
+      // fit is what sets the size.
+      return SizedBox.square(
+        dimension: glyphSize,
+        child: FittedBox(
+          fit: BoxFit.scaleDown,
+          child: Text(
+            dayMarkWeekdayLabel(locale, day),
+            maxLines: 1,
+            style: tokens.typography.styles.others.caption.copyWith(
+              color: tokens.colors.text.lowEmphasis,
+            ),
           ),
         ),
       );
@@ -105,7 +118,7 @@ Widget? dayMarkSquareContent(
 /// A not-yet-resolved day slot — a loading window, or today while it is
 /// still open: same footprint as a real square, dashed outline instead of a
 /// fill, so the silhouette holds without borrowing the empty-day encoding.
-/// A dated one carries its weekday initial like any unresolved square.
+/// A dated one carries its weekday like any unresolved square.
 class PlaceholderDayCell extends StatelessWidget {
   const PlaceholderDayCell({this.day, super.key});
 
@@ -139,7 +152,7 @@ class PlaceholderDayCell extends StatelessWidget {
 /// level-03 surface otherwise — a recorded verdict paints its own hue, and an
 /// empty TODAY is the dashed unresolved outline, since the day is not over.
 /// Inside it, [dayMarkSquareContent]: the outcome's glyph, or the weekday
-/// initial while there is none. Nothing is drawn around a square; the full
+/// while there is none. Nothing is drawn around a square; the full
 /// date, the outcome's name and a verdict's are answered by the tooltip and
 /// the semantics.
 ///

--- a/lib/widgets/day_indicators/day_mark_cell.dart
+++ b/lib/widgets/day_indicators/day_mark_cell.dart
@@ -1,28 +1,130 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
 import 'package:lotti/features/design_system/components/ds_quiet_ink.dart';
 import 'package:lotti/features/design_system/components/tooltips/ds_tooltip.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/widgets/day_indicators/day_mark.dart';
 import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
 
-/// The edge of every day square: the handover's 11px square at the nearest
-/// icon size, one size everywhere it is drawn.
-const double kDaySquareSize = IconSizes.xs;
+/// The edge of a day square on a phone: the smallest square a weekday
+/// letter is still legible in. Every day square on a page is this size or
+/// the desktop size, never anything in between — see [daySquareSize].
+const double kDaySquareSize = IconSizes.s;
+
+/// The edge of a day square on a desktop window: one icon size up.
+///
+/// A desktop row has several times a phone card's width and shows twice the
+/// days; a square sized for the phone reads as a speck there and is a
+/// smaller thing to aim a pointer at than it needs to be.
+const double kDaySquareSizeDesktop = IconSizes.m;
+
+/// The edge of every day square on this page: [kDaySquareSizeDesktop] on a
+/// desktop-width window, [kDaySquareSize] otherwise. One size per page, so
+/// the whole-goal strip, the habit squares and the metric bars keep sharing
+/// one column pitch (see `dayTrackMetrics`).
+double daySquareSize(BuildContext context) =>
+    isDesktopLayout(context) ? kDaySquareSizeDesktop : kDaySquareSize;
+
+/// What a day square says inside itself: the glyph of a recorded or judged
+/// outcome, or — while the day has none — its weekday initial.
+///
+/// A row of squares used to say which day was which only on hover, and a
+/// tappable one grew a caption row above itself to say it before the tap.
+/// Drawing the letter inside the unresolved squares answers the question
+/// where the eye already is, and the resolved squares do not need it: a
+/// tick or a cross beside a lettered neighbour is read against that
+/// neighbour's day. The glyphs are the reflections history's own
+/// (`dayVerdictGlyph`), so an outcome is drawn the same way wherever it is
+/// shown. A recorded miss shares the neutral fill with an empty day, and the
+/// cross is what tells them apart.
+///
+/// Null for an undated, unresolved square — a streak chain has nothing to
+/// say inside its cells.
+Widget? dayMarkSquareContent(
+  BuildContext context, {
+  required DayMarkState state,
+  required DayVerdict? verdict,
+  required DateTime? day,
+  required double size,
+}) {
+  final tokens = context.designTokens;
+  // The glyph is inset by one spacing step so it sits inside the square
+  // rather than on its edge.
+  final glyphSize = size - tokens.spacing.step1;
+  if (verdict != null) {
+    return Icon(
+      dayVerdictGlyph(verdict),
+      size: glyphSize,
+      color: tokens.colors.text.onInteractiveAlert,
+    );
+  }
+  switch (state) {
+    case DayMarkState.full:
+      return Icon(
+        dayVerdictGlyph(DayVerdict.met),
+        size: glyphSize,
+        color: tokens.colors.text.onInteractiveAlert,
+      );
+    case DayMarkState.missed:
+      return Icon(
+        dayVerdictGlyph(DayVerdict.missed),
+        size: glyphSize,
+        color: tokens.colors.text.mediumEmphasis,
+      );
+    case DayMarkState.none:
+    case DayMarkState.partial:
+    case DayMarkState.skipped:
+      if (day == null) return null;
+      final locale = Localizations.localeOf(context).toLanguageTag();
+      // Quiet on the neutral fill; a step louder on the partial wash, where
+      // the low-emphasis ink sinks into the tint.
+      final ink = state == DayMarkState.partial
+          ? tokens.colors.text.mediumEmphasis
+          : tokens.colors.text.lowEmphasis;
+      // Scaled down, never wrapped or clipped: the caption size fits the
+      // square at the default text scale, and a raised scale must not push
+      // the letter out of a square that does not grow with it.
+      return FittedBox(
+        fit: BoxFit.scaleDown,
+        child: Text(
+          DateFormat.EEEEE(locale).format(day),
+          maxLines: 1,
+          style: tokens.typography.styles.others.caption.copyWith(color: ink),
+        ),
+      );
+  }
+}
 
 /// A not-yet-resolved day slot — a loading window, or today while it is
 /// still open: same footprint as a real square, dashed outline instead of a
 /// fill, so the silhouette holds without borrowing the empty-day encoding.
+/// A dated one carries its weekday initial like any unresolved square.
 class PlaceholderDayCell extends StatelessWidget {
-  const PlaceholderDayCell({super.key});
+  const PlaceholderDayCell({this.day, super.key});
+
+  final DateTime? day;
 
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
+    final size = daySquareSize(context);
     return DsDashedBorder(
       color: tokens.colors.text.lowEmphasis,
       radius: tokens.radii.xs,
-      child: const SizedBox.square(dimension: kDaySquareSize),
+      child: SizedBox.square(
+        dimension: size,
+        child: Center(
+          child: dayMarkSquareContent(
+            context,
+            state: DayMarkState.none,
+            verdict: null,
+            day: day,
+            size: size,
+          ),
+        ),
+      ),
     );
   }
 }
@@ -31,18 +133,18 @@ class PlaceholderDayCell extends StatelessWidget {
 /// filled in the interactive hue when the day was kept and in the neutral
 /// level-03 surface otherwise — a recorded verdict paints its own hue, and an
 /// empty TODAY is the dashed unresolved outline, since the day is not over.
-/// Nothing is drawn inside a square and nothing around it; which day it is,
-/// what happened and what the user ruled are answered by the tooltip and the
-/// semantics, not by glyphs, corner letters or rings on a 12px cell.
+/// Inside it, [dayMarkSquareContent]: the outcome's glyph, or the weekday
+/// initial while there is none. Nothing is drawn around a square; the full
+/// date, the outcome's name and a verdict's are answered by the tooltip and
+/// the semantics.
 ///
 /// Read-only by default. With [onTap] the square keeps its size while the
-/// hit slot around it clears the touch floor, the cell announces itself as a
-/// button with [label], and a [caption] letter names the weekday above it.
+/// hit slot around it clears the touch floor, and the cell announces itself
+/// as a button with [label].
 class DayMarkCell extends StatelessWidget {
   const DayMarkCell({
     required this.mark,
     this.onTap,
-    this.caption,
     this.label,
     this.tooltipDay,
     this.tooltipOutcome,
@@ -52,19 +154,13 @@ class DayMarkCell extends StatelessWidget {
   final DayMark mark;
   final VoidCallback? onTap;
 
-  /// A one-letter weekday initial drawn above the square, inside the hit
-  /// slot, on a tappable cell only: an action has to say which day it acts
-  /// on before it is tapped. Ignored without [onTap] — a read-only strip is
-  /// the handover's bare row of squares.
-  final String? caption;
-
   /// Spoken name for a tappable cell. Null on a read-only strip, whose
   /// semantics are carried by the summary above it.
   final String? label;
 
   /// The hover tooltip: the day names the subject, the outcome describes it.
-  /// A read-only cell still answers hover with them — the square cannot tell
-  /// one Tuesday from the next, and the tooltip is where a dated cell reveals
+  /// A read-only cell still answers hover with them — the letter names a
+  /// weekday, not a date, and the tooltip is where a dated cell reveals
   /// which day it stands for.
   final String? tooltipDay;
   final String? tooltipOutcome;
@@ -73,16 +169,25 @@ class DayMarkCell extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final verdict = mark.verdict;
+    final size = daySquareSize(context);
     final Widget cell = mark.pending
-        ? const PlaceholderDayCell()
+        ? PlaceholderDayCell(day: mark.day)
         : Container(
-            width: kDaySquareSize,
-            height: kDaySquareSize,
+            width: size,
+            height: size,
+            alignment: Alignment.center,
             decoration: BoxDecoration(
               color: verdict == null
                   ? dayMarkStateFill(tokens, mark.state)
                   : dayVerdictFill(tokens, verdict),
               borderRadius: BorderRadius.circular(tokens.radii.xs),
+            ),
+            child: dayMarkSquareContent(
+              context,
+              state: mark.state,
+              verdict: verdict,
+              day: mark.day,
+              size: size,
             ),
           );
     final onTap = this.onTap;
@@ -117,31 +222,10 @@ class DayMarkCell extends StatelessWidget {
           focusRing: true,
           builder: (context, highlighted) => ConstrainedBox(
             constraints: const BoxConstraints(minHeight: TapTargets.minimum),
-            child: Center(child: dayCellWithCaption(tokens, cell, caption)),
+            child: Center(child: cell),
           ),
         ),
       ),
     );
   }
-}
-
-/// A day square with its weekday initial above it — the layout every
-/// tappable day cell shares, whether it is a [DayMarkCell] or the goal
-/// card's own outcome-menu cell. Just the square when [caption] is null.
-Widget dayCellWithCaption(DsTokens tokens, Widget square, String? caption) {
-  if (caption == null) return square;
-  return Column(
-    mainAxisSize: MainAxisSize.min,
-    children: [
-      Text(
-        caption,
-        maxLines: 1,
-        style: tokens.typography.styles.others.caption.copyWith(
-          color: tokens.colors.text.lowEmphasis,
-        ),
-      ),
-      SizedBox(height: tokens.spacing.step1),
-      square,
-    ],
-  );
 }

--- a/lib/widgets/day_indicators/day_mark_cell.dart
+++ b/lib/widgets/day_indicators/day_mark_cell.dart
@@ -67,6 +67,15 @@ Widget? dayMarkSquareContent(
         size: glyphSize,
         color: tokens.colors.text.onInteractiveAlert,
       );
+    case DayMarkState.partial:
+      // Kept too — the routine held while a window target was still
+      // building — so the tick, in the kept hue itself: the on-accent ink
+      // sinks into the muted wash.
+      return Icon(
+        dayVerdictGlyph(DayVerdict.met),
+        size: glyphSize,
+        color: tokens.colors.interactive.enabled,
+      );
     case DayMarkState.missed:
       return Icon(
         dayVerdictGlyph(DayVerdict.missed),
@@ -74,15 +83,9 @@ Widget? dayMarkSquareContent(
         color: tokens.colors.text.mediumEmphasis,
       );
     case DayMarkState.none:
-    case DayMarkState.partial:
     case DayMarkState.skipped:
       if (day == null) return null;
       final locale = Localizations.localeOf(context).toLanguageTag();
-      // Quiet on the neutral fill; a step louder on the partial wash, where
-      // the low-emphasis ink sinks into the tint.
-      final ink = state == DayMarkState.partial
-          ? tokens.colors.text.mediumEmphasis
-          : tokens.colors.text.lowEmphasis;
       // Scaled down, never wrapped or clipped: the caption size fits the
       // square at the default text scale, and a raised scale must not push
       // the letter out of a square that does not grow with it.
@@ -91,7 +94,9 @@ Widget? dayMarkSquareContent(
         child: Text(
           DateFormat.EEEEE(locale).format(day),
           maxLines: 1,
-          style: tokens.typography.styles.others.caption.copyWith(color: ink),
+          style: tokens.typography.styles.others.caption.copyWith(
+            color: tokens.colors.text.lowEmphasis,
+          ),
         ),
       );
   }

--- a/lib/widgets/day_indicators/day_mark_cell.dart
+++ b/lib/widgets/day_indicators/day_mark_cell.dart
@@ -8,24 +8,25 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/widgets/day_indicators/day_mark.dart';
 import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
 
-/// The edge of a day square on a phone: the smallest square a weekday
-/// letter is still legible in. Every day square on a page is this size or
-/// the desktop size, never anything in between — see [daySquareSize].
-const double kDaySquareSize = IconSizes.s;
+/// The edge of a day square on a phone: the control-glyph tier, the
+/// smallest square two weekday letters sit inside at a comfortable size.
+/// Every day square on a page is this size or the desktop size, never
+/// anything in between — see [daySquareSize].
+const double kDaySquareSize = IconSizes.m;
 
-/// The edge of a day square on a desktop window: one icon size up.
+/// The edge of every day square on this page: [kDaySquareSize] on a phone,
+/// one spacing step more on a desktop-width window. One size per page, so
+/// the whole-goal strip, the habit squares and the metric bars keep sharing
+/// one column pitch (see `dayTrackMetrics`).
 ///
 /// A desktop row has several times a phone card's width and shows twice the
 /// days; a square sized for the phone reads as a speck there and is a
-/// smaller thing to aim a pointer at than it needs to be.
-const double kDaySquareSizeDesktop = IconSizes.m;
-
-/// The edge of every day square on this page: [kDaySquareSizeDesktop] on a
-/// desktop-width window, [kDaySquareSize] otherwise. One size per page, so
-/// the whole-goal strip, the habit squares and the metric bars keep sharing
-/// one column pitch (see `dayTrackMetrics`).
-double daySquareSize(BuildContext context) =>
-    isDesktopLayout(context) ? kDaySquareSizeDesktop : kDaySquareSize;
+/// smaller thing to aim a pointer at than it needs to be. There is no icon
+/// tier between `m` and `l`, and `l` is a callout glyph, so the desktop
+/// square is the phone square plus the smallest step rather than a tier up.
+double daySquareSize(BuildContext context) => isDesktopLayout(context)
+    ? kDaySquareSize + context.designTokens.spacing.step1
+    : kDaySquareSize;
 
 /// The weekday a day square names: the first two characters of the locale's
 /// abbreviated weekday, so Tuesday and Thursday, Saturday and Sunday can be
@@ -58,9 +59,10 @@ Widget? dayMarkSquareContent(
   required double size,
 }) {
   final tokens = context.designTokens;
-  // The glyph is inset by one spacing step so it sits inside the square
-  // rather than on its edge.
-  final glyphSize = size - tokens.spacing.step1;
+  // The content is inset by two spacing steps so it sits inside the square
+  // rather than filling it: at one step, two caption letters filled the
+  // square edge to edge and read larger than the square they were in.
+  final glyphSize = size - tokens.spacing.step2;
   if (verdict != null) {
     return Icon(
       dayVerdictGlyph(verdict),

--- a/lib/widgets/day_indicators/day_mark_strip.dart
+++ b/lib/widgets/day_indicators/day_mark_strip.dart
@@ -22,7 +22,6 @@ class DayMarkStrip extends StatelessWidget {
     this.placeholder = false,
     this.streak,
     this.onDaySelected,
-    this.isDaySelectable,
     this.scrollGroup,
     super.key,
   });
@@ -46,12 +45,6 @@ class DayMarkStrip extends StatelessWidget {
   /// Opens the day's reflection. Null leaves the strip a read-only figure —
   /// which is what the list rows want, since a tap there navigates.
   final ValueChanged<DateTime>? onDaySelected;
-
-  /// Which days a tappable strip actually offers as buttons. A day it
-  /// declines is drawn as a read-only cell — hover still names it, but it is
-  /// no button, no keyboard stop and no click cursor — rather than as a
-  /// button whose tap does nothing. Null offers every dated day.
-  final bool Function(DateTime day)? isDaySelectable;
 
   /// Joins the page's unison day-track scrolling when the strip renders a
   /// span longer than a week.
@@ -99,22 +92,11 @@ class DayMarkStrip extends StatelessWidget {
       if (day == null) return DayMarkCell(mark: mark);
       final dayName = dayFormat.format(day);
       final outcome = outcomeOf(mark);
-      final readOnly = DayMarkCell(
-        mark: mark,
-        tooltipDay: dayName,
-        tooltipOutcome: outcome,
-      );
-      if (onDaySelected == null) return readOnly;
-      if (isDaySelectable?.call(day) == false) {
-        // Declined, not merely inert: a tap on it must not fall through to
-        // whatever the strip sits in — a habit row's body opens today's
-        // sheet, and a tap on Wednesday's square that opened today's sheet
-        // is the confusion the dated squares exist to end. The detector
-        // swallows the tap; hover still reaches the tooltip.
-        return GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: () {},
-          child: readOnly,
+      if (onDaySelected == null) {
+        return DayMarkCell(
+          mark: mark,
+          tooltipDay: dayName,
+          tooltipOutcome: outcome,
         );
       }
       // Colour is the only thing separating these squares, and it does not

--- a/lib/widgets/day_indicators/day_mark_strip.dart
+++ b/lib/widgets/day_indicators/day_mark_strip.dart
@@ -99,11 +99,22 @@ class DayMarkStrip extends StatelessWidget {
       if (day == null) return DayMarkCell(mark: mark);
       final dayName = dayFormat.format(day);
       final outcome = outcomeOf(mark);
-      if (onDaySelected == null || isDaySelectable?.call(day) == false) {
-        return DayMarkCell(
-          mark: mark,
-          tooltipDay: dayName,
-          tooltipOutcome: outcome,
+      final readOnly = DayMarkCell(
+        mark: mark,
+        tooltipDay: dayName,
+        tooltipOutcome: outcome,
+      );
+      if (onDaySelected == null) return readOnly;
+      if (isDaySelectable?.call(day) == false) {
+        // Declined, not merely inert: a tap on it must not fall through to
+        // whatever the strip sits in — a habit row's body opens today's
+        // sheet, and a tap on Wednesday's square that opened today's sheet
+        // is the confusion the dated squares exist to end. The detector
+        // swallows the tap; hover still reaches the tooltip.
+        return GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: () {},
+          child: readOnly,
         );
       }
       // Colour is the only thing separating these squares, and it does not

--- a/lib/widgets/day_indicators/day_mark_strip.dart
+++ b/lib/widgets/day_indicators/day_mark_strip.dart
@@ -12,8 +12,8 @@ import 'package:lotti/widgets/misc/linked_scroll_group.dart';
 
 /// A row of day squares, as the habits handover draws it: one small square
 /// per day on the page's shared column pitch, and — for a habit with a run
-/// going — a flame and the streak count after the last square. The squares
-/// carry no labels of their own; each dated square names its day and outcome
+/// going — a flame and the streak count after the last square. Each square
+/// says its outcome or its weekday inside itself, names its date and outcome
 /// on hover and to a screen reader, and the strip publishes one concise
 /// summary. A tappable strip publishes each day as its own button as well.
 class DayMarkStrip extends StatelessWidget {
@@ -55,7 +55,8 @@ class DayMarkStrip extends StatelessWidget {
     final streak = this.streak ?? 0;
     if (marks.isEmpty && streak <= 0) return const SizedBox.shrink();
     // Always measured: even a seven-square row outgrows a phone card once a
-    // raised text scale widens the shared pitch for the weekday captions.
+    // raised text scale widens the shared pitch for the weekday axis a goal
+    // page draws on it.
     return LayoutBuilder(
       builder: (context, constraints) => _build(
         context,
@@ -76,11 +77,8 @@ class DayMarkStrip extends StatelessWidget {
       'A tappable strip needs dated marks to name the cell that was tapped.',
     );
     final metrics = dayTrackMetrics(context);
+    final squareSize = daySquareSize(context);
     final dayFormat = DateFormat.MMMEd(locale);
-    // A tappable square carries its weekday initial above it, inside the hit
-    // slot: the one surface where a square is an action is the one surface
-    // that has to say which day the action is for before it is tapped.
-    final letterFormat = DateFormat.EEEEE(locale);
 
     String outcomeOf(DayMark mark) => switch (mark.verdict) {
       final verdict? => dayVerdictLabel(context, verdict),
@@ -108,7 +106,6 @@ class DayMarkStrip extends StatelessWidget {
       // every cell is individually actionable.
       return DayMarkCell(
         mark: mark,
-        caption: letterFormat.format(day),
         label: context.messages.goalProgressHabitDaySemantics(
           dayName,
           outcome,
@@ -125,7 +122,7 @@ class DayMarkStrip extends StatelessWidget {
     // those do not fit a phone card — so a tappable slot takes the full pitch
     // horizontally and clears the floor vertically.
     final squares = DayTrack(
-      height: onDaySelected == null ? kDaySquareSize : TapTargets.minimum,
+      height: onDaySelected == null ? squareSize : TapTargets.minimum,
       pitch: metrics.pitch,
       children: [
         for (var index = 0; index < marks.length; index++) cellAt(index),
@@ -141,7 +138,7 @@ class DayMarkStrip extends StatelessWidget {
     final tailWidth = streak <= 0
         ? 0.0
         : tokens.spacing.step2 +
-              kDaySquareSize +
+              squareSize +
               tokens.spacing.step1 +
               _textWidth(context, '$streak', countStyle);
     final fitted = availableWidth == null
@@ -169,7 +166,7 @@ class DayMarkStrip extends StatelessWidget {
               SizedBox(width: tokens.spacing.step2),
               Icon(
                 LottiIcons.streak,
-                size: kDaySquareSize,
+                size: squareSize,
                 color: tokens.colors.text.mediumEmphasis,
               ),
               SizedBox(width: tokens.spacing.step1),

--- a/lib/widgets/day_indicators/day_mark_strip.dart
+++ b/lib/widgets/day_indicators/day_mark_strip.dart
@@ -22,6 +22,7 @@ class DayMarkStrip extends StatelessWidget {
     this.placeholder = false,
     this.streak,
     this.onDaySelected,
+    this.isDaySelectable,
     this.scrollGroup,
     super.key,
   });
@@ -45,6 +46,12 @@ class DayMarkStrip extends StatelessWidget {
   /// Opens the day's reflection. Null leaves the strip a read-only figure —
   /// which is what the list rows want, since a tap there navigates.
   final ValueChanged<DateTime>? onDaySelected;
+
+  /// Which days a tappable strip actually offers as buttons. A day it
+  /// declines is drawn as a read-only cell — hover still names it, but it is
+  /// no button, no keyboard stop and no click cursor — rather than as a
+  /// button whose tap does nothing. Null offers every dated day.
+  final bool Function(DateTime day)? isDaySelectable;
 
   /// Joins the page's unison day-track scrolling when the strip renders a
   /// span longer than a week.
@@ -92,7 +99,7 @@ class DayMarkStrip extends StatelessWidget {
       if (day == null) return DayMarkCell(mark: mark);
       final dayName = dayFormat.format(day);
       final outcome = outcomeOf(mark);
-      if (onDaySelected == null) {
+      if (onDaySelected == null || isDaySelectable?.call(day) == false) {
         return DayMarkCell(
           mark: mark,
           tooltipDay: dayName,

--- a/lib/widgets/day_indicators/day_mark_styles.dart
+++ b/lib/widgets/day_indicators/day_mark_styles.dart
@@ -10,7 +10,7 @@ import 'package:lotti/widgets/day_indicators/day_mark.dart';
 /// alert hue: the strip is a record of what was kept, and a struggling habit
 /// is never a wall of red. A recorded miss is told apart from a day nobody
 /// looked at by the cross drawn inside the grey (`dayMarkSquareContent`),
-/// not by its fill; a skip keeps its weekday letter, and is named by the
+/// not by its fill; a skip keeps its weekday, and is named by the
 /// tooltip and semantics. A partial day, kept too, draws the tick in the
 /// kept hue on its wash.
 /// `SurfaceAlphas.muted` is the sanctioned "reduced-strength accent" alpha, so

--- a/lib/widgets/day_indicators/day_mark_styles.dart
+++ b/lib/widgets/day_indicators/day_mark_styles.dart
@@ -7,8 +7,11 @@ import 'package:lotti/widgets/day_indicators/day_mark.dart';
 /// kept — the handover's `--interactive` square — a wash of it for a partial
 /// success (routine kept, target still building), and the neutral level-03
 /// surface for anything else. A skipped or missed day is not painted in an
-/// alert hue: the strip is a record of what was kept, and the tooltip and
-/// semantics say which of the other three the grey stands for.
+/// alert hue: the strip is a record of what was kept, and a struggling habit
+/// is never a wall of red. A recorded miss is told apart from a day nobody
+/// looked at by the cross drawn inside the grey (`dayMarkSquareContent`),
+/// not by its fill; a skip keeps its weekday letter, and is named by the
+/// tooltip and semantics.
 /// `SurfaceAlphas.muted` is the sanctioned "reduced-strength accent" alpha, so
 /// no new color token is introduced.
 Color dayMarkStateFill(DsTokens tokens, DayMarkState state) => switch (state) {
@@ -72,9 +75,9 @@ Color dayVerdictSurfaceInk(DsTokens tokens, DayVerdict verdict) =>
 ///
 /// The reflections history and the reflect button name a verdict by shape as
 /// well as hue: a tick for met, a rising arrow for improving, a half-filled
-/// circle for mixed, a cross for missed. The day squares themselves carry no
-/// glyph — at 12px there is no room for one — and say the verdict in their
-/// tooltip and semantics instead.
+/// circle for mixed, a cross for missed. A day square draws the same glyph
+/// inside its verdict fill (`dayMarkSquareContent`), and the tick and the
+/// cross double as the marks of a measured kept and missed day.
 IconData dayVerdictGlyph(DayVerdict verdict) => switch (verdict) {
   DayVerdict.met => LottiIcons.confirm,
   DayVerdict.improving => LottiIcons.trendingUp,

--- a/lib/widgets/day_indicators/day_mark_styles.dart
+++ b/lib/widgets/day_indicators/day_mark_styles.dart
@@ -11,7 +11,8 @@ import 'package:lotti/widgets/day_indicators/day_mark.dart';
 /// is never a wall of red. A recorded miss is told apart from a day nobody
 /// looked at by the cross drawn inside the grey (`dayMarkSquareContent`),
 /// not by its fill; a skip keeps its weekday letter, and is named by the
-/// tooltip and semantics.
+/// tooltip and semantics. A partial day, kept too, draws the tick in the
+/// kept hue on its wash.
 /// `SurfaceAlphas.muted` is the sanctioned "reduced-strength accent" alpha, so
 /// no new color token is introduced.
 Color dayMarkStateFill(DsTokens tokens, DayMarkState state) => switch (state) {

--- a/lib/widgets/day_indicators/day_track.dart
+++ b/lib/widgets/day_indicators/day_track.dart
@@ -8,7 +8,7 @@ import 'package:lotti/widgets/misc/linked_scroll_group.dart';
 
 /// The geometry one day track draws on: the column pitch, whether the weekday
 /// captions still fit at full length, and how tall a caption row has to be.
-/// The square inside each column is always [kDaySquareSize].
+/// The square inside each column is always [daySquareSize] for the window.
 ///
 /// The caption height rides along so a caption track does not re-measure
 /// the same seven strings the pitch was already derived from.
@@ -58,13 +58,14 @@ typedef DayTrackMetrics = ({
 /// scroll. A reader cannot follow a day across the page unless the columns
 /// line up.
 ///
-/// The square never changes size — the handover draws one square — so a span
-/// that does not fit its width scrolls (see [fitOrScrollDayTrack]) rather
-/// than shrinking. At raised text scales the pitch widens to hold the weekday
+/// The square never sizes to its content — the handover draws one square,
+/// one size up on a desktop window (see [daySquareSize]) — so a span that
+/// does not fit its width scrolls (see [fitOrScrollDayTrack]) rather than
+/// shrinking. At raised text scales the pitch widens to hold the weekday
 /// caption, which is what keeps the axis readable rather than merely aligned.
 DayTrackMetrics dayTrackMetrics(BuildContext context) {
   final tokens = context.designTokens;
-  final defaultPitch = kDaySquareSize + tokens.spacing.step2;
+  final defaultPitch = daySquareSize(context) + tokens.spacing.step2;
   final label = _weekdayLabelMetrics(context);
   final labelWidth = label.width;
   final expandedPitch = labelWidth + tokens.spacing.step2;

--- a/test/features/goals/ui/goal_progress_card_test.dart
+++ b/test/features/goals/ui/goal_progress_card_test.dart
@@ -596,6 +596,7 @@ void main() {
       final resolved =
           cell.mark.verdict != null ||
           cell.mark.state == DayMarkState.full ||
+          cell.mark.state == DayMarkState.partial ||
           cell.mark.state == DayMarkState.missed;
       expect(
         find.descendant(of: self, matching: find.byType(Icon)),

--- a/test/features/goals/ui/goal_progress_card_test.dart
+++ b/test/features/goals/ui/goal_progress_card_test.dart
@@ -2902,7 +2902,7 @@ void main() {
       // No full-word label row above the squares; an unresolved square
       // carries its weekday initial inside itself.
       expect(find.text('Wed'), findsNothing);
-      final letterFormat = DateFormat.EEEEE('en');
+      String letterFormat(DateTime day) => dayMarkWeekdayLabel('en', day);
       final tokens = tester.element(find.byType(GoalProgressCard)).designTokens;
       final expectedPitch = kDaySquareSize + tokens.spacing.step2;
       double? previousCenter;
@@ -2925,7 +2925,7 @@ void main() {
         );
         final letter = find.descendant(
           of: visualCell,
-          matching: find.text(letterFormat.format(date)),
+          matching: find.text(letterFormat(date)),
         );
         final glyph = find.descendant(
           of: visualCell,

--- a/test/features/goals/ui/goal_progress_card_test.dart
+++ b/test/features/goals/ui/goal_progress_card_test.dart
@@ -582,34 +582,57 @@ void main() {
     );
     // The only outline anywhere is today's open square, once per track.
     expect(find.byType(DsDashedBorder), findsNWidgets(2));
-    // The tappable whole-goal strip names each day above its square and
-    // draws nothing else; the read-only habit track draws the bare squares.
-    expect(
+    // Every square says exactly one thing inside itself — its outcome's
+    // glyph, or its weekday letter while it has none — and nothing above
+    // or around it, on the tappable whole-goal strip and the read-only
+    // habit track alike.
+    for (final cell in tester.widgetList<DayMarkCell>(
       find.descendant(
         of: find.byType(DayMarkStrip),
-        matching: find.byType(Icon),
+        matching: find.byType(DayMarkCell),
       ),
-      findsNothing,
-    );
-    expect(
-      find.descendant(
-        of: find.byType(DayMarkStrip),
-        matching: find.byType(Text),
-      ),
-      findsNWidgets(7),
-    );
+    )) {
+      final self = find.byWidget(cell);
+      final resolved =
+          cell.mark.verdict != null ||
+          cell.mark.state == DayMarkState.full ||
+          cell.mark.state == DayMarkState.missed;
+      expect(
+        find.descendant(of: self, matching: find.byType(Icon)),
+        resolved ? findsOneWidget : findsNothing,
+        reason: '${cell.mark.day}',
+      );
+      expect(
+        find.descendant(of: self, matching: find.byType(Text)),
+        resolved ? findsNothing : findsOneWidget,
+        reason: '${cell.mark.day}',
+      );
+    }
     final habitTrack = find.descendant(
       of: find.byType(GoalProgressCard),
       matching: find.byType(DayTrack),
     );
-    expect(
-      find.descendant(of: habitTrack, matching: find.byType(Icon)),
-      findsNothing,
+    final habitSquares = find.descendant(
+      of: habitTrack,
+      matching: find.byWidgetPredicate(
+        (widget) =>
+            widget.key is ValueKey<String> &&
+            (widget.key! as ValueKey<String>).value.startsWith(
+              'goal-habit-day-visual-',
+            ),
+      ),
     );
-    expect(
-      find.descendant(of: habitTrack, matching: find.byType(Text)),
-      findsNothing,
-    );
+    expect(habitSquares, findsNWidgets(7));
+    for (var index = 0; index < 7; index++) {
+      final square = habitSquares.at(index);
+      final icons = find.descendant(of: square, matching: find.byType(Icon));
+      final letters = find.descendant(of: square, matching: find.byType(Text));
+      expect(
+        icons.evaluate().length + letters.evaluate().length,
+        1,
+        reason: 'square $index says one thing',
+      );
+    }
     final tokens = tester.element(find.byType(GoalProgressCard)).designTokens;
     final visual = tester.widget<Container>(
       find.byKey(ValueKey('goal-habit-day-visual-gym-${dayKey(6)}')),
@@ -2875,8 +2898,8 @@ void main() {
         ),
       );
 
-      // No full-word label row above the squares; a tappable square carries
-      // its weekday initial above it, inside its own slot.
+      // No full-word label row above the squares; an unresolved square
+      // carries its weekday initial inside itself.
       expect(find.text('Wed'), findsNothing);
       final letterFormat = DateFormat.EEEEE('en');
       final tokens = tester.element(find.byType(GoalProgressCard)).designTokens;
@@ -2899,18 +2922,23 @@ void main() {
             TapTargets.minimum,
           ),
         );
-        expect(
-          find.descendant(of: visualCell, matching: find.byType(Text)),
-          findsNothing,
-          reason: '$key draws nothing inside its square',
+        final letter = find.descendant(
+          of: visualCell,
+          matching: find.text(letterFormat.format(date)),
+        );
+        final glyph = find.descendant(
+          of: visualCell,
+          matching: find.byType(Icon),
         );
         expect(
-          find.descendant(
-            of: cell,
-            matching: find.text(letterFormat.format(date)),
-          ),
-          findsOneWidget,
-          reason: '$key names its weekday above the square',
+          letter.evaluate().length + glyph.evaluate().length,
+          1,
+          reason: '$key says its weekday or its outcome, inside the square',
+        );
+        expect(
+          find.descendant(of: cell, matching: find.byType(Text)),
+          letter.evaluate().isEmpty ? findsNothing : findsOneWidget,
+          reason: '$key draws nothing above the square',
         );
         final center = tester.getCenter(cell).dx;
         if (previousCenter != null) {

--- a/test/features/goals/ui/goal_progress_card_test.dart
+++ b/test/features/goals/ui/goal_progress_card_test.dart
@@ -4190,6 +4190,45 @@ void main() {
       lessThanOrEqualTo(stackedPeriod.top),
       reason: 'a narrow card keeps the note on its own line above the period',
     );
+
+    // Measured, not guessed (test glyphs are a full em wide): at 556 the
+    // corner block no longer fits beside the identity and drops below the
+    // title row, while the reading and the status caption still fit one
+    // row, and the note has its own row but not the period line.
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Center(child: SizedBox(width: 556, child: card())),
+      ),
+    );
+    final roomyPeriod = tester.getRect(find.text(periodText));
+    final roomyNote = tester.getRect(find.text(noteText));
+    expect(roomyNote.bottom, lessThanOrEqualTo(roomyPeriod.top));
+    // With the row to itself the note takes the row: it used to be capped
+    // at a fraction of the card and wrapped beside empty space.
+    expect(
+      roomyNote.height,
+      closeTo(roomyPeriod.height, 1),
+      reason: 'one line, not wrapped',
+    );
+    // And the status caption, its corner gone, sits on the reading's own
+    // row at the trailing edge rather than on a line of its own, without
+    // costing the reading any of its width.
+    final readingFinder = find.textContaining('rolling 7 days');
+    final reading = tester.getRect(readingFinder);
+    final readingText = tester.widget<Text>(readingFinder);
+    final readingInk = goalTextWidth(
+      tester.element(readingFinder),
+      readingText.data!,
+      readingText.style!,
+    );
+    final status = tester.getRect(find.text('Needs attention'));
+    expect(status.top, closeTo(reading.top, reading.height));
+    expect(status.left, greaterThan(reading.left + readingInk));
+    expect(
+      reading.width,
+      greaterThanOrEqualTo(readingInk),
+      reason: 'the reading is not ellipsized to make room for the status',
+    );
   });
 
   testWidgets('a reflect label too long to share the title row drops to its '

--- a/test/features/habits/ui/habits_manual_screenshots_test.dart
+++ b/test/features/habits/ui/habits_manual_screenshots_test.dart
@@ -524,7 +524,8 @@ HabitsState _habitsState() {
       days[3]: {_recalibrateFishFeeder.id},
     },
     failedByDay: {
-      days[8]: {_reviewSardineInventory.id},
+      days[9]: {_reviewSardineInventory.id},
+      days[10]: {_recalibrateFishFeeder.id},
     },
     allByDay: {for (final day in days) day: allIds},
     shortStreakCount: 2,

--- a/test/features/habits/ui/sheets/habit_completion_sheet_test.dart
+++ b/test/features/habits/ui/sheets/habit_completion_sheet_test.dart
@@ -389,14 +389,15 @@ void main() {
       }
     });
 
-    clockedWidgets('a past dateString records at the end of that day', (
-      tester,
-    ) async {
+    clockedWidgets('a past dateString records an instant at the end of that '
+        'day, not a span reaching the moment it was saved', (tester) async {
       await pumpSheet(tester, dateString: '2024-01-15');
       expect(find.text('2024-01-15 23:59'), findsOneWidget);
       await tester.tap(find.byKey(const Key('habit_save')));
       await tester.pump(const Duration(milliseconds: 300));
-      expect(captured().dateFrom, DateTime(2024, 1, 15, 23, 59, 59));
+      final data = captured();
+      expect(data.dateFrom, DateTime(2024, 1, 15, 23, 59, 59));
+      expect(data.dateTo, data.dateFrom);
     });
 
     clockedWidgets('picking a date moves the recorded start', (tester) async {

--- a/test/features/habits/ui/widgets/habit_action_row_test.dart
+++ b/test/features/habits/ui/widgets/habit_action_row_test.dart
@@ -1,4 +1,3 @@
-import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/misc.dart';
@@ -227,51 +226,6 @@ void main() {
       expect(sheet.habitId, habitFlossing.id);
       expect(sheet.dateString, '2026-08-07');
       expect(DateTime.parse(sheet.dateString!), friday);
-      handle.dispose();
-    });
-
-    testWidgets('a square for a day after today is not a button at all', (
-      tester,
-    ) async {
-      final handle = tester.ensureSemantics();
-      await withClock(Clock.fixed(today), () async {
-        final tomorrow = today.add(const Duration(days: 1));
-        await pumpRow(
-          tester,
-          history: [
-            DayMark(day: today, state: DayMarkState.none, isToday: true),
-            DayMark(day: tomorrow, state: DayMarkState.none),
-          ],
-        );
-        // Read-only: no activation callback, no semantic button, no ink.
-        final future = find.byWidgetPredicate(
-          (widget) => widget is DayMarkCell && widget.mark.day == tomorrow,
-        );
-        expect(tester.widget<DayMarkCell>(future).onTap, isNull);
-        expect(find.bySemanticsLabel(RegExp('Wed, Aug 12')), findsNothing);
-        expect(
-          find.descendant(of: future, matching: find.byType(InkWell)),
-          findsNothing,
-        );
-        // And a tap on it does not fall through to the row body, which
-        // would open TODAY's sheet under a square that says Wednesday.
-        await tester.tap(future);
-        await tester.pump(const Duration(milliseconds: 300));
-        expect(find.byType(HabitCompletionSheet), findsNothing);
-        await tester.tap(
-          find.byWidgetPredicate(
-            (widget) => widget is DayMarkCell && widget.mark.day == today,
-          ),
-        );
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
-        expect(
-          tester
-              .widget<HabitCompletionSheet>(find.byType(HabitCompletionSheet))
-              .dateString,
-          '2026-08-11',
-        );
-      });
       handle.dispose();
     });
 

--- a/test/features/habits/ui/widgets/habit_action_row_test.dart
+++ b/test/features/habits/ui/widgets/habit_action_row_test.dart
@@ -213,8 +213,11 @@ void main() {
       // Tuesday: the sheet must open on that Friday, not on today.
       final friday = today.subtract(const Duration(days: 4));
       expect(find.text('F'), findsOneWidget);
+      expect(find.bySemanticsLabel(RegExp('Fri, Aug 7')), findsOneWidget);
       await tester.tap(
-        find.bySemanticsLabel(RegExp('Fri, Aug 7')),
+        find.byWidgetPredicate(
+          (widget) => widget is DayMarkCell && widget.mark.day == friday,
+        ),
       );
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
@@ -227,26 +230,34 @@ void main() {
       handle.dispose();
     });
 
-    testWidgets('a square for a day after today opens nothing', (
+    testWidgets('a square for a day after today is not a button at all', (
       tester,
     ) async {
       final handle = tester.ensureSemantics();
       await withClock(Clock.fixed(today), () async {
+        final tomorrow = today.add(const Duration(days: 1));
         await pumpRow(
           tester,
           history: [
             DayMark(day: today, state: DayMarkState.none, isToday: true),
-            DayMark(
-              day: today.add(const Duration(days: 1)),
-              state: DayMarkState.none,
-            ),
+            DayMark(day: tomorrow, state: DayMarkState.none),
           ],
         );
-        await tester.tap(find.bySemanticsLabel(RegExp('Wed, Aug 12')));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
-        expect(find.byType(HabitCompletionSheet), findsNothing);
-        await tester.tap(find.bySemanticsLabel(RegExp('Tue, Aug 11')));
+        // Read-only: no activation callback, no semantic button, no ink.
+        final future = find.byWidgetPredicate(
+          (widget) => widget is DayMarkCell && widget.mark.day == tomorrow,
+        );
+        expect(tester.widget<DayMarkCell>(future).onTap, isNull);
+        expect(find.bySemanticsLabel(RegExp('Wed, Aug 12')), findsNothing);
+        expect(
+          find.descendant(of: future, matching: find.byType(InkWell)),
+          findsNothing,
+        );
+        await tester.tap(
+          find.byWidgetPredicate(
+            (widget) => widget is DayMarkCell && widget.mark.day == today,
+          ),
+        );
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
         expect(

--- a/test/features/habits/ui/widgets/habit_action_row_test.dart
+++ b/test/features/habits/ui/widgets/habit_action_row_test.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/misc.dart';
@@ -202,6 +203,90 @@ void main() {
       expect(fillAt(2), tokens.colors.background.level03);
       expect(fillAt(3), tokens.colors.background.level03);
       expect(find.byIcon(LottiIcons.streak), findsNothing);
+    });
+
+    testWidgets('a square opens the completion sheet for ITS day, and the '
+        'weekday initials say which day each square is', (tester) async {
+      final handle = tester.ensureSemantics();
+      await pumpRow(tester, history: week(List.filled(7, DayMarkState.none)));
+      // Four days back from the last square, on a strip that ends on a
+      // Tuesday: the sheet must open on that Friday, not on today.
+      final friday = today.subtract(const Duration(days: 4));
+      expect(find.text('F'), findsOneWidget);
+      await tester.tap(
+        find.bySemanticsLabel(RegExp('Fri, Aug 7')),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      final sheet = tester.widget<HabitCompletionSheet>(
+        find.byType(HabitCompletionSheet),
+      );
+      expect(sheet.habitId, habitFlossing.id);
+      expect(sheet.dateString, '2026-08-07');
+      expect(DateTime.parse(sheet.dateString!), friday);
+      handle.dispose();
+    });
+
+    testWidgets('a square for a day after today opens nothing', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await withClock(Clock.fixed(today), () async {
+        await pumpRow(
+          tester,
+          history: [
+            DayMark(day: today, state: DayMarkState.none, isToday: true),
+            DayMark(
+              day: today.add(const Duration(days: 1)),
+              state: DayMarkState.none,
+            ),
+          ],
+        );
+        await tester.tap(find.bySemanticsLabel(RegExp('Wed, Aug 12')));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+        expect(find.byType(HabitCompletionSheet), findsNothing);
+        await tester.tap(find.bySemanticsLabel(RegExp('Tue, Aug 11')));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+        expect(
+          tester
+              .widget<HabitCompletionSheet>(find.byType(HabitCompletionSheet))
+              .dateString,
+          '2026-08-11',
+        );
+      });
+      handle.dispose();
+    });
+
+    testWidgets('the strip shows a week on a phone and two on a desktop '
+        'window', (tester) async {
+      late int phoneDays;
+      late int desktopDays;
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Builder(
+            builder: (context) {
+              phoneDays = habitHistoryDays(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Builder(
+            builder: (context) {
+              desktopDays = habitHistoryDays(context);
+              return const SizedBox.shrink();
+            },
+          ),
+          mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+        ),
+      );
+      expect(phoneDays, 7);
+      expect(desktopDays, kHabitHistoryDaysDesktop);
+      expect(kHabitHistoryDaysDesktop, 14);
     });
 
     testWidgets('no history and no streak draws no strip', (tester) async {

--- a/test/features/habits/ui/widgets/habit_action_row_test.dart
+++ b/test/features/habits/ui/widgets/habit_action_row_test.dart
@@ -212,7 +212,7 @@ void main() {
       // Four days back from the last square, on a strip that ends on a
       // Tuesday: the sheet must open on that Friday, not on today.
       final friday = today.subtract(const Duration(days: 4));
-      expect(find.text('F'), findsOneWidget);
+      expect(find.text('Fr'), findsOneWidget);
       expect(find.bySemanticsLabel(RegExp('Fri, Aug 7')), findsOneWidget);
       await tester.tap(
         find.byWidgetPredicate(
@@ -253,6 +253,11 @@ void main() {
           find.descendant(of: future, matching: find.byType(InkWell)),
           findsNothing,
         );
+        // And a tap on it does not fall through to the row body, which
+        // would open TODAY's sheet under a square that says Wednesday.
+        await tester.tap(future);
+        await tester.pump(const Duration(milliseconds: 300));
+        expect(find.byType(HabitCompletionSheet), findsNothing);
         await tester.tap(
           find.byWidgetPredicate(
             (widget) => widget is DayMarkCell && widget.mark.day == today,

--- a/test/features/habits/ui/widgets/habit_completion_card_test.dart
+++ b/test/features/habits/ui/widgets/habit_completion_card_test.dart
@@ -13,6 +13,7 @@ import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/widgets/charts/habits/dashboard_habits_data.dart';
 import 'package:lotti/widgets/day_indicators/day_mark.dart';
 import 'package:lotti/widgets/day_indicators/day_mark_cell.dart';
+import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../mocks/mocks.dart';
@@ -139,7 +140,7 @@ void main() {
 
   group('history strip', () {
     testWidgets('draws every in-range day as a shared day-mark cell, with the '
-        'skip dash and missed cross as non-color cues', (tester) async {
+        'tick and cross as non-color cues', (tester) async {
       final handle = tester.ensureSemantics();
       // The open day precedes the success day so `results.last` is success and
       // the trailing button is the done-circle, not another check glyph.
@@ -161,18 +162,25 @@ void main() {
         DayMarkState.skipped,
         DayMarkState.full,
       ]);
-      // Nothing is drawn inside a square: the state is the fill, the words
-      // are in the summary and the tooltips.
+      // The missed day draws the cross, the kept day the tick; the skipped
+      // and the open day keep their weekday letters, named by the summary
+      // and the tooltips.
+      Finder glyph(int index, IconData icon) => find.descendant(
+        of: find.byType(DayMarkCell).at(index),
+        matching: find.byIcon(icon),
+      );
+      expect(glyph(1, dayVerdictGlyph(DayVerdict.missed)), findsOneWidget);
+      expect(glyph(3, dayVerdictGlyph(DayVerdict.met)), findsOneWidget);
       expect(
         find.descendant(
           of: find.byType(DayMarkCell),
           matching: find.byType(Icon),
         ),
-        findsNothing,
+        findsNWidgets(2),
       );
 
-      // A read-only strip publishes one summary. The range ends on a kept
-      // day, so it is the streak that is announced.
+      // The strip's summary is its container's label. The range ends on a
+      // kept day, so it is the streak that is announced.
       expect(find.bySemanticsLabel(RegExp('1-day streak')), findsOneWidget);
       handle.dispose();
     });

--- a/test/widgets/day_indicators/day_mark_cell_test.dart
+++ b/test/widgets/day_indicators/day_mark_cell_test.dart
@@ -210,7 +210,7 @@ void main() {
     handle.dispose();
   });
 
-  testWidgets('an unresolved dated square carries its weekday initial '
+  testWidgets('an unresolved dated square carries its two-letter weekday '
       'inside itself, quiet on the neutral fill; an undated one carries '
       'nothing', (tester) async {
     final monday = DateTime.utc(2026, 8, 10);
@@ -224,7 +224,7 @@ void main() {
       final tokens = tester.element(find.byType(DayMarkCell)).designTokens;
       final letter = find.descendant(
         of: find.byType(Container),
-        matching: find.text('M'),
+        matching: find.text('Mo'),
       );
       expect(letter, findsOneWidget, reason: '$state');
       expect(find.byType(Icon), findsNothing, reason: '$state');
@@ -260,7 +260,7 @@ void main() {
     var icon = tester.widget<Icon>(find.byType(Icon));
     expect(icon.icon, dayVerdictGlyph(DayVerdict.met));
     expect(icon.color, tokens.colors.text.onInteractiveAlert);
-    expect(find.text('M'), findsNothing);
+    expect(find.text('Mo'), findsNothing);
     // A partial day was kept too; its tick wears the kept hue on the wash.
     await pump(
       tester,
@@ -272,7 +272,7 @@ void main() {
     icon = tester.widget<Icon>(find.byType(Icon));
     expect(icon.icon, dayVerdictGlyph(DayVerdict.met));
     expect(icon.color, tokens.colors.interactive.enabled);
-    expect(find.text('M'), findsNothing);
+    expect(find.text('Mo'), findsNothing);
     for (final verdict in DayVerdict.values) {
       await pump(
         tester,
@@ -288,11 +288,38 @@ void main() {
       icon = tester.widget<Icon>(find.byType(Icon));
       expect(icon.icon, dayVerdictGlyph(verdict), reason: '$verdict');
       expect(icon.color, tokens.colors.text.onInteractiveAlert);
-      expect(find.text('M'), findsNothing, reason: '$verdict');
+      expect(find.text('Mo'), findsNothing, reason: '$verdict');
     }
   });
 
-  testWidgets('a dated open today keeps its letter inside the dashed '
+  testWidgets('the weekday is the first two characters of the localized '
+      'abbreviation', (tester) async {
+    final tuesday = DateTime.utc(2026, 8, 11);
+    final thursday = DateTime.utc(2026, 8, 13);
+    final saturday = DateTime.utc(2026, 8, 15);
+    final sunday = DateTime.utc(2026, 8, 16);
+    expect(
+      [
+        tuesday,
+        thursday,
+        saturday,
+        sunday,
+      ].map((day) => dayMarkWeekdayLabel('en', day)).toList(),
+      ['Tu', 'Th', 'Sa', 'Su'],
+    );
+    expect(
+      [
+        tuesday,
+        thursday,
+        saturday,
+        sunday,
+      ].map((day) => dayMarkWeekdayLabel('de', day)).toList(),
+      ['Di', 'Do', 'Sa', 'So'],
+    );
+    expect(dayMarkWeekdayLabel('ja', tuesday), '火');
+  });
+
+  testWidgets('a dated open today keeps its weekday inside the dashed '
       'outline', (tester) async {
     await pump(
       tester,
@@ -307,7 +334,7 @@ void main() {
     expect(
       find.descendant(
         of: find.byType(DsDashedBorder),
-        matching: find.text('M'),
+        matching: find.text('Mo'),
       ),
       findsOneWidget,
     );

--- a/test/widgets/day_indicators/day_mark_cell_test.dart
+++ b/test/widgets/day_indicators/day_mark_cell_test.dart
@@ -54,7 +54,7 @@ void main() {
         expect(icon.icon, dayVerdictGlyph(DayVerdict.missed));
         expect(icon.color, tokens.colors.text.mediumEmphasis);
         expect(icon.size, kDaySquareSize - tokens.spacing.step1);
-      } else if (state == DayMarkState.full) {
+      } else if (state == DayMarkState.full || state == DayMarkState.partial) {
         expect(
           tester.widget<Icon>(find.byType(Icon)).icon,
           dayVerdictGlyph(DayVerdict.met),
@@ -211,14 +211,10 @@ void main() {
   });
 
   testWidgets('an unresolved dated square carries its weekday initial '
-      'inside itself, quiet on the neutral fill and a step louder on the '
-      'partial wash; an undated one carries nothing', (tester) async {
+      'inside itself, quiet on the neutral fill; an undated one carries '
+      'nothing', (tester) async {
     final monday = DateTime.utc(2026, 8, 10);
-    for (final state in [
-      DayMarkState.none,
-      DayMarkState.skipped,
-      DayMarkState.partial,
-    ]) {
+    for (final state in [DayMarkState.none, DayMarkState.skipped]) {
       await pump(
         tester,
         DayMarkCell(
@@ -234,9 +230,7 @@ void main() {
       expect(find.byType(Icon), findsNothing, reason: '$state');
       expect(
         tester.widget<Text>(letter).style?.color,
-        state == DayMarkState.partial
-            ? tokens.colors.text.mediumEmphasis
-            : tokens.colors.text.lowEmphasis,
+        tokens.colors.text.lowEmphasis,
         reason: '$state',
       );
       expect(
@@ -266,6 +260,18 @@ void main() {
     var icon = tester.widget<Icon>(find.byType(Icon));
     expect(icon.icon, dayVerdictGlyph(DayVerdict.met));
     expect(icon.color, tokens.colors.text.onInteractiveAlert);
+    expect(find.text('M'), findsNothing);
+    // A partial day was kept too; its tick wears the kept hue on the wash.
+    await pump(
+      tester,
+      DayMarkCell(
+        mark: DayMark(state: DayMarkState.partial, day: monday),
+      ),
+    );
+    tokens = tester.element(find.byType(DayMarkCell)).designTokens;
+    icon = tester.widget<Icon>(find.byType(Icon));
+    expect(icon.icon, dayVerdictGlyph(DayVerdict.met));
+    expect(icon.color, tokens.colors.interactive.enabled);
     expect(find.text('M'), findsNothing);
     for (final verdict in DayVerdict.values) {
       await pump(

--- a/test/widgets/day_indicators/day_mark_cell_test.dart
+++ b/test/widgets/day_indicators/day_mark_cell_test.dart
@@ -53,7 +53,7 @@ void main() {
         final icon = tester.widget<Icon>(find.byType(Icon));
         expect(icon.icon, dayVerdictGlyph(DayVerdict.missed));
         expect(icon.color, tokens.colors.text.mediumEmphasis);
-        expect(icon.size, kDaySquareSize - tokens.spacing.step1);
+        expect(icon.size, kDaySquareSize - tokens.spacing.step2);
       } else if (state == DayMarkState.full || state == DayMarkState.partial) {
         expect(
           tester.widget<Icon>(find.byType(Icon)).icon,
@@ -84,7 +84,7 @@ void main() {
   });
 
   testWidgets('on a desktop window the square and the placeholder are one '
-      'icon size up', (tester) async {
+      'spacing step up', (tester) async {
     for (final cell in [
       const DayMarkCell(mark: DayMark(state: DayMarkState.full)),
       const PlaceholderDayCell(),
@@ -95,13 +95,13 @@ void main() {
           mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
         ),
       );
+      final tokens = tester.element(find.byWidget(cell)).designTokens;
       expect(
         tester.getSize(find.byWidget(cell)),
-        const Size.square(kDaySquareSizeDesktop),
+        Size.square(kDaySquareSize + tokens.spacing.step1),
         reason: '$cell',
       );
     }
-    expect(kDaySquareSizeDesktop, greaterThan(kDaySquareSize));
   });
 
   testWidgets('the measured state decides the fill', (tester) async {

--- a/test/widgets/day_indicators/day_mark_cell_test.dart
+++ b/test/widgets/day_indicators/day_mark_cell_test.dart
@@ -30,8 +30,8 @@ void main() {
   BoxDecoration decoration(WidgetTester tester) =>
       square(tester).decoration! as BoxDecoration;
 
-  testWidgets('the square is the handover square: one size, the xs radius, '
-      'nothing inside it', (tester) async {
+  testWidgets('an undated square is one size at the xs radius, with a glyph '
+      'inside it only for a kept or missed day', (tester) async {
     for (final state in DayMarkState.values) {
       await pump(tester, DayMarkCell(mark: DayMark(state: state)));
       final tokens = tester.element(find.byType(DayMarkCell)).designTokens;
@@ -46,11 +46,62 @@ void main() {
         reason: '$state',
       );
       expect(decoration(tester).border, isNull, reason: '$state');
-      expect(square(tester).child, isNull, reason: '$state');
-      expect(find.byType(Icon), findsNothing, reason: '$state');
+      if (state == DayMarkState.missed) {
+        // A recorded miss and an empty day share the grey; the cross is
+        // what tells them apart. The reflections history's own glyph, in
+        // the quiet ink, inset one step so it sits inside the square.
+        final icon = tester.widget<Icon>(find.byType(Icon));
+        expect(icon.icon, dayVerdictGlyph(DayVerdict.missed));
+        expect(icon.color, tokens.colors.text.mediumEmphasis);
+        expect(icon.size, kDaySquareSize - tokens.spacing.step1);
+      } else if (state == DayMarkState.full) {
+        expect(
+          tester.widget<Icon>(find.byType(Icon)).icon,
+          dayVerdictGlyph(DayVerdict.met),
+        );
+      } else {
+        expect(square(tester).child, isNull, reason: '$state');
+        expect(find.byType(Icon), findsNothing, reason: '$state');
+      }
       expect(find.byType(Text), findsNothing, reason: '$state');
       expect(find.byType(DsDashedBorder), findsNothing, reason: '$state');
     }
+  });
+
+  testWidgets('a verdict paints over a measured miss with its own glyph', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      const DayMarkCell(
+        mark: DayMark(state: DayMarkState.missed, verdict: DayVerdict.met),
+      ),
+    );
+    expect(
+      tester.widget<Icon>(find.byType(Icon)).icon,
+      dayVerdictGlyph(DayVerdict.met),
+    );
+  });
+
+  testWidgets('on a desktop window the square and the placeholder are one '
+      'icon size up', (tester) async {
+    for (final cell in [
+      const DayMarkCell(mark: DayMark(state: DayMarkState.full)),
+      const PlaceholderDayCell(),
+    ]) {
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Align(alignment: Alignment.topLeft, child: cell),
+          mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+        ),
+      );
+      expect(
+        tester.getSize(find.byWidget(cell)),
+        const Size.square(kDaySquareSizeDesktop),
+        reason: '$cell',
+      );
+    }
+    expect(kDaySquareSizeDesktop, greaterThan(kDaySquareSize));
   });
 
   testWidgets('the measured state decides the fill', (tester) async {
@@ -159,38 +210,101 @@ void main() {
     handle.dispose();
   });
 
-  testWidgets('a caption rides above a tappable square, inside the slot, and '
-      'is ignored on a read-only cell', (tester) async {
+  testWidgets('an unresolved dated square carries its weekday initial '
+      'inside itself, quiet on the neutral fill and a step louder on the '
+      'partial wash; an undated one carries nothing', (tester) async {
+    final monday = DateTime.utc(2026, 8, 10);
+    for (final state in [
+      DayMarkState.none,
+      DayMarkState.skipped,
+      DayMarkState.partial,
+    ]) {
+      await pump(
+        tester,
+        DayMarkCell(
+          mark: DayMark(state: state, day: monday),
+        ),
+      );
+      final tokens = tester.element(find.byType(DayMarkCell)).designTokens;
+      final letter = find.descendant(
+        of: find.byType(Container),
+        matching: find.text('M'),
+      );
+      expect(letter, findsOneWidget, reason: '$state');
+      expect(find.byType(Icon), findsNothing, reason: '$state');
+      expect(
+        tester.widget<Text>(letter).style?.color,
+        state == DayMarkState.partial
+            ? tokens.colors.text.mediumEmphasis
+            : tokens.colors.text.lowEmphasis,
+        reason: '$state',
+      );
+      expect(
+        tester.getCenter(letter),
+        tester.getCenter(find.byType(Container)),
+        reason: '$state sits centred in its square',
+      );
+    }
+    await pump(
+      tester,
+      const DayMarkCell(mark: DayMark(state: DayMarkState.none)),
+    );
+    expect(find.byType(Text), findsNothing);
+    expect(find.byType(Icon), findsNothing);
+  });
+
+  testWidgets('a kept day draws the tick and a verdict its own glyph, in the '
+      'on-accent ink, instead of the letter', (tester) async {
+    final monday = DateTime.utc(2026, 8, 10);
     await pump(
       tester,
       DayMarkCell(
-        mark: const DayMark(state: DayMarkState.full),
-        caption: 'M',
-        onTap: () {},
+        mark: DayMark(state: DayMarkState.full, day: monday),
       ),
     );
-    final tokens = tester.element(find.byType(DayMarkCell)).designTokens;
-    expect(find.text('M'), findsOneWidget);
-    expect(
-      tester.widget<Text>(find.text('M')).style?.color,
-      tokens.colors.text.lowEmphasis,
-    );
-    expect(
-      tester.getBottomLeft(find.text('M')).dy,
-      lessThanOrEqualTo(tester.getTopLeft(find.byType(Container)).dy),
-    );
-    expect(
-      tester.getSize(find.byType(DayMarkCell)).height,
-      greaterThanOrEqualTo(TapTargets.minimum),
-    );
+    var tokens = tester.element(find.byType(DayMarkCell)).designTokens;
+    var icon = tester.widget<Icon>(find.byType(Icon));
+    expect(icon.icon, dayVerdictGlyph(DayVerdict.met));
+    expect(icon.color, tokens.colors.text.onInteractiveAlert);
+    expect(find.text('M'), findsNothing);
+    for (final verdict in DayVerdict.values) {
+      await pump(
+        tester,
+        DayMarkCell(
+          mark: DayMark(
+            state: DayMarkState.none,
+            day: monday,
+            verdict: verdict,
+          ),
+        ),
+      );
+      tokens = tester.element(find.byType(DayMarkCell)).designTokens;
+      icon = tester.widget<Icon>(find.byType(Icon));
+      expect(icon.icon, dayVerdictGlyph(verdict), reason: '$verdict');
+      expect(icon.color, tokens.colors.text.onInteractiveAlert);
+      expect(find.text('M'), findsNothing, reason: '$verdict');
+    }
+  });
+
+  testWidgets('a dated open today keeps its letter inside the dashed '
+      'outline', (tester) async {
     await pump(
       tester,
-      const DayMarkCell(
-        mark: DayMark(state: DayMarkState.full),
-        caption: 'M',
+      DayMarkCell(
+        mark: DayMark(
+          state: DayMarkState.none,
+          day: DateTime.utc(2026, 8, 10),
+          isToday: true,
+        ),
       ),
     );
-    expect(find.text('M'), findsNothing);
+    expect(
+      find.descendant(
+        of: find.byType(DsDashedBorder),
+        matching: find.text('M'),
+      ),
+      findsOneWidget,
+    );
   });
 
   testWidgets('a read-only dated cell still answers hover with its day and '

--- a/test/widgets/day_indicators/day_mark_strip_test.dart
+++ b/test/widgets/day_indicators/day_mark_strip_test.dart
@@ -40,7 +40,9 @@ void main() {
           .color!;
 
   testWidgets('a read-only strip reports the number of successful days once '
-      'in semantics and draws nothing but the squares', (tester) async {
+      'in semantics and draws the squares with their kept ticks', (
+    tester,
+  ) async {
     final handle = tester.ensureSemantics();
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
@@ -54,8 +56,16 @@ void main() {
       findsOneWidget,
     );
     expect(find.byType(DayMarkCell), findsNWidgets(7));
-    expect(find.byType(Icon), findsNothing);
+    // Undated marks carry no weekday letter; the kept days carry the tick.
     expect(find.byType(Text), findsNothing);
+    expect(find.byType(Icon), findsNWidgets(2));
+    expect(
+      find.descendant(
+        of: find.byType(DayMarkCell).first,
+        matching: find.byIcon(dayVerdictGlyph(DayVerdict.met)),
+      ),
+      findsOneWidget,
+    );
     // The last mark is today and it is empty: "not yet", the dashed
     // unresolved outline, never a past day's grey.
     expect(find.byType(DsDashedBorder), findsOneWidget);
@@ -182,15 +192,28 @@ void main() {
       find.bySemanticsLabel(cell(4, 'done · target not met yet')),
       findsOneWidget,
     );
-    // An action says which day it acts on: a weekday initial rides above
-    // every tappable square, inside its slot.
+    // An action says which day it acts on: every square that has no
+    // outcome yet carries its weekday initial inside itself; the kept
+    // days (six and one back) carry the tick instead.
     for (var daysBack = 6; daysBack >= 0; daysBack--) {
-      final letter = DateFormat.EEEEE().format(
-        today.subtract(Duration(days: daysBack)),
+      final day = today.subtract(Duration(days: daysBack));
+      final letter = DateFormat.EEEEE().format(day);
+      final cell = find.byWidgetPredicate(
+        (widget) => widget is DayMarkCell && widget.mark.day == day,
       );
-      expect(find.text(letter), findsWidgets, reason: letter);
+      final kept = daysBack == 6 || daysBack == 1;
+      expect(
+        find.descendant(of: cell, matching: find.text(letter)),
+        kept ? findsNothing : findsOneWidget,
+        reason: letter,
+      );
+      expect(
+        find.descendant(of: cell, matching: find.byType(Icon)),
+        kept ? findsOneWidget : findsNothing,
+        reason: letter,
+      );
     }
-    expect(find.byType(Text), findsNWidgets(7));
+    expect(find.byType(Text), findsNWidgets(5));
     handle.dispose();
   });
 

--- a/test/widgets/day_indicators/day_mark_strip_test.dart
+++ b/test/widgets/day_indicators/day_mark_strip_test.dart
@@ -56,9 +56,10 @@ void main() {
       findsOneWidget,
     );
     expect(find.byType(DayMarkCell), findsNWidgets(7));
-    // Undated marks carry no weekday letter; the kept days carry the tick.
+    // Undated marks carry no weekday letter; the kept days — the partial
+    // one included — carry the tick.
     expect(find.byType(Text), findsNothing);
-    expect(find.byType(Icon), findsNWidgets(2));
+    expect(find.byType(Icon), findsNWidgets(3));
     expect(
       find.descendant(
         of: find.byType(DayMarkCell).first,
@@ -194,14 +195,15 @@ void main() {
     );
     // An action says which day it acts on: every square that has no
     // outcome yet carries its weekday initial inside itself; the kept
-    // days (six and one back) carry the tick instead.
+    // days (six, four and one back — four is the partial one) carry the
+    // tick instead.
     for (var daysBack = 6; daysBack >= 0; daysBack--) {
       final day = today.subtract(Duration(days: daysBack));
       final letter = DateFormat.EEEEE().format(day);
       final cell = find.byWidgetPredicate(
         (widget) => widget is DayMarkCell && widget.mark.day == day,
       );
-      final kept = daysBack == 6 || daysBack == 1;
+      final kept = daysBack == 6 || daysBack == 4 || daysBack == 1;
       expect(
         find.descendant(of: cell, matching: find.text(letter)),
         kept ? findsNothing : findsOneWidget,
@@ -213,7 +215,7 @@ void main() {
         reason: letter,
       );
     }
-    expect(find.byType(Text), findsNWidgets(5));
+    expect(find.byType(Text), findsNWidgets(4));
     handle.dispose();
   });
 

--- a/test/widgets/day_indicators/day_mark_strip_test.dart
+++ b/test/widgets/day_indicators/day_mark_strip_test.dart
@@ -251,40 +251,6 @@ void main() {
     expect(verdicts, isNot(contains(fillAt(tester, 0))));
   });
 
-  testWidgets('a day the caller declines is drawn read-only inside a '
-      'tappable strip', (tester) async {
-    final handle = tester.ensureSemantics();
-    final tapped = <DateTime>[];
-    await tester.pumpWidget(
-      makeTestableWidgetNoScroll(
-        DayMarkStrip(
-          marks: goalDayMarks(states: week, lastDay: today),
-          onDaySelected: tapped.add,
-          isDaySelectable: (day) => day != today,
-        ),
-      ),
-    );
-    expect(find.bySemanticsLabel(cell(0, 'No entry')), findsNothing);
-    expect(find.bySemanticsLabel(cell(1, 'done · target met')), findsOneWidget);
-    final todayCell = find.byWidgetPredicate(
-      (widget) => widget is DayMarkCell && widget.mark.day == today,
-    );
-    expect(tester.widget<DayMarkCell>(todayCell).onTap, isNull);
-    expect(
-      tester
-          .widget<DsTooltip>(
-            find.descendant(of: todayCell, matching: find.byType(DsTooltip)),
-          )
-          .title,
-      DateFormat.MMMEd().format(today),
-      reason: 'hover still names the day',
-    );
-    await tester.tap(todayCell, warnIfMissed: false);
-    await tester.tap(find.bySemanticsLabel(cell(1, 'done · target met')));
-    expect(tapped, [today.subtract(const Duration(days: 1))]);
-    handle.dispose();
-  });
-
   testWidgets('tapping does not change the pitch, only the slot height', (
     tester,
   ) async {

--- a/test/widgets/day_indicators/day_mark_strip_test.dart
+++ b/test/widgets/day_indicators/day_mark_strip_test.dart
@@ -199,7 +199,7 @@ void main() {
     // tick instead.
     for (var daysBack = 6; daysBack >= 0; daysBack--) {
       final day = today.subtract(Duration(days: daysBack));
-      final letter = DateFormat.EEEEE().format(day);
+      final letter = dayMarkWeekdayLabel('en', day);
       final cell = find.byWidgetPredicate(
         (widget) => widget is DayMarkCell && widget.mark.day == day,
       );

--- a/test/widgets/day_indicators/day_mark_strip_test.dart
+++ b/test/widgets/day_indicators/day_mark_strip_test.dart
@@ -249,6 +249,40 @@ void main() {
     expect(verdicts, isNot(contains(fillAt(tester, 0))));
   });
 
+  testWidgets('a day the caller declines is drawn read-only inside a '
+      'tappable strip', (tester) async {
+    final handle = tester.ensureSemantics();
+    final tapped = <DateTime>[];
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        DayMarkStrip(
+          marks: goalDayMarks(states: week, lastDay: today),
+          onDaySelected: tapped.add,
+          isDaySelectable: (day) => day != today,
+        ),
+      ),
+    );
+    expect(find.bySemanticsLabel(cell(0, 'No entry')), findsNothing);
+    expect(find.bySemanticsLabel(cell(1, 'done · target met')), findsOneWidget);
+    final todayCell = find.byWidgetPredicate(
+      (widget) => widget is DayMarkCell && widget.mark.day == today,
+    );
+    expect(tester.widget<DayMarkCell>(todayCell).onTap, isNull);
+    expect(
+      tester
+          .widget<DsTooltip>(
+            find.descendant(of: todayCell, matching: find.byType(DsTooltip)),
+          )
+          .title,
+      DateFormat.MMMEd().format(today),
+      reason: 'hover still names the day',
+    );
+    await tester.tap(todayCell, warnIfMissed: false);
+    await tester.tap(find.bySemanticsLabel(cell(1, 'done · target met')));
+    expect(tapped, [today.subtract(const Duration(days: 1))]);
+    handle.dispose();
+  });
+
   testWidgets('tapping does not change the pitch, only the slot height', (
     tester,
   ) async {

--- a/test/widgets/day_indicators/day_track_test.dart
+++ b/test/widgets/day_indicators/day_track_test.dart
@@ -64,6 +64,26 @@ void main() {
     expect(metrics.labelHeight, greaterThanOrEqualTo(IconSizes.s));
   });
 
+  testWidgets('a desktop window keys the pitch to the larger square', (
+    tester,
+  ) async {
+    late DayTrackMetrics metrics;
+    late DsTokens tokens;
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Builder(
+          builder: (context) {
+            tokens = context.designTokens;
+            metrics = dayTrackMetrics(context);
+            return const SizedBox.shrink();
+          },
+        ),
+        mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+      ),
+    );
+    expect(metrics.pitch, kDaySquareSizeDesktop + tokens.spacing.step2);
+  });
+
   testWidgets('a raised text scale widens the pitch to hold the caption', (
     tester,
   ) async {

--- a/test/widgets/day_indicators/day_track_test.dart
+++ b/test/widgets/day_indicators/day_track_test.dart
@@ -81,7 +81,10 @@ void main() {
         mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
       ),
     );
-    expect(metrics.pitch, kDaySquareSizeDesktop + tokens.spacing.step2);
+    expect(
+      metrics.pitch,
+      kDaySquareSize + tokens.spacing.step1 + tokens.spacing.step2,
+    );
   });
 
   testWidgets('a raised text scale widens the pitch to hold the caption', (


### PR DESCRIPTION
## What changed

The day squares under each habit row (habits page, unified goals page, dashboard habit cards) and on the goal cards:

- **Tapping a square opens the completion sheet for that day**, not for today. Days after today (possible on a dashboard range) open nothing.
- **Each square says one thing inside itself**: its two-letter weekday (localized: Tu/Th/Sa/Su, Di/Do/Sa/So) until something is recorded, then a tick for a kept day or a cross for a recorded miss. A judged day on a goal card draws its verdict's glyph. A missed day no longer looks identical to a day nobody logged (fill stays neutral — no wall of red).
- **The caption row above tappable tracks is gone** — the letter inside the square replaces it, so the habit rows stay as compact as before even though every square is now a button.
- **Squares are larger**: 18px on a phone, 20px on a desktop window (`daySquareSize`). One size per page, so goal-page tracks keep sharing one pitch.
- **Desktop rows show 14 days** instead of 7 (`habitHistoryDays`); phones keep the week.

Shared package: `lib/widgets/day_indicators` (`dayMarkSquareContent`, `daySquareSize`, `DayMarkCell` without `caption`), consumed by `HabitActionRow`, the habit pages and `_ProgressDayCell` on the goal card. Docs: `knowledge/architecture/day-indicators.md`, `knowledge/features/habits.md`, `knowledge/features/goals.md`. Changelog fragment included.

Also, on a narrow goal card: the "N successful days needed to recover" note takes its whole row instead of wrapping at 60% of it, and the status caption sits at the end of the reading line when the corner block has dropped below the title (see goal card mobile).

## Screenshots

| Surface | Before | After |
|---|---|---|
| Habits, desktop dark | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-strip-days/74da6dc1da495c1c7bd7000f62af84e955dfe871/before/habits_today_desktop_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-strip-days/8d1448958da3060826f45d405e63f173eda230c4/after/habits_today_desktop_dark.png) |
| Habits, desktop light | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-strip-days/74da6dc1da495c1c7bd7000f62af84e955dfe871/before/habits_today_desktop_light.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-strip-days/8d1448958da3060826f45d405e63f173eda230c4/after/habits_today_desktop_light.png) |
| Habits, mobile dark | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-strip-days/74da6dc1da495c1c7bd7000f62af84e955dfe871/before/habits_today_mobile_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-strip-days/8d1448958da3060826f45d405e63f173eda230c4/after/habits_today_mobile_dark.png) |
| Habits, mobile light | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-strip-days/74da6dc1da495c1c7bd7000f62af84e955dfe871/before/habits_today_mobile_light.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-strip-days/8d1448958da3060826f45d405e63f173eda230c4/after/habits_today_mobile_light.png) |
| Goal card, desktop dark | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-strip-days/74da6dc1da495c1c7bd7000f62af84e955dfe871/before/goal_card_desktop_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-strip-days/8d1448958da3060826f45d405e63f173eda230c4/after/goal_card_desktop_dark.png) |
| Goal card, mobile dark | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-strip-days/74da6dc1da495c1c7bd7000f62af84e955dfe871/before/goal_card_mobile_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-strip-days/8d1448958da3060826f45d405e63f173eda230c4/after/goal_card_mobile_dark.png) |

After shots are from the latest commit (two-letter weekdays); before shots are from main.

Fixtures: penguin demo world and synthetic test data only.

## Tests

Updated/added in `test/widgets/day_indicators/*`, `habit_action_row_test.dart` (square tap opens the sheet for its date; future day opens nothing; 7/14 by layout), `habit_completion_card_test.dart`, `goal_progress_card_test.dart`. Goal detail/unified page suites pass unchanged.
