### PR TITLE
fix(day-indicators): missed cross clears 3:1 contrast on the grey square in dark theme

### DIFF
--- a/knowledge/architecture/day-indicators.md
+++ b/knowledge/architecture/day-indicators.md
@@ -127,9 +127,11 @@ flowchart LR
   wears the error ink.
 - **A square says one thing inside itself, and nothing around it.** A
   judged day draws its verdict's glyph; a kept day (partial included) the tick, a recorded miss
-  the cross in the error family's surface ink (`dayVerdictSurfaceInk`) — the
-  one touch of that family a habit square gets, on a fill that stays neutral,
-  which is what tells a miss from the empty day it shares the fill with; any other dated day its weekday — the first two characters of the
+  a red cross (`alert.error.pressed` — the ramp's far step, the one that
+  clears the 3:1 graphical floor on `level03` in both themes; the surface
+  ink lands at 2.9:1 there in dark) — the one touch of that family a habit
+  square gets, on a fill that stays neutral, which is what tells a miss from
+  the empty day it shares the fill with; any other dated day its weekday — the first two characters of the
   locale's abbreviation (`dayMarkWeekdayLabel`: `Tu Th Sa Su`, `Di Do Sa
   So`), quiet on the fill. No
   ring, no dot, no caption row above the track. The full date, the outcome's

--- a/lib/widgets/day_indicators/day_mark_cell.dart
+++ b/lib/widgets/day_indicators/day_mark_cell.dart
@@ -47,7 +47,7 @@ String dayMarkWeekdayLabel(String locale, DateTime day) =>
 /// neighbour's day. The glyphs are the reflections history's own
 /// (`dayVerdictGlyph`), so an outcome is drawn the same way wherever it is
 /// shown. A recorded miss shares the neutral fill with an empty day, and the
-/// cross — in the error family's surface ink — is what tells them apart.
+/// red cross is what tells them apart.
 ///
 /// Null for an undated, unresolved square — a streak chain has nothing to
 /// say inside its cells.
@@ -88,13 +88,17 @@ Widget? dayMarkSquareContent(
       );
     case DayMarkState.missed:
       // The one touch of the error family a habit square gets: the cross
-      // in the family's surface ink, on the neutral fill. A miss should
-      // sting a little, and a bad week should still not be a wall of red —
-      // the mark carries the hue, the square does not.
+      // in red, on the neutral fill. A miss should sting a little, and a bad
+      // week should still not be a wall of red — the mark carries the hue,
+      // the square does not. The `pressed` step, not the surface ink: the
+      // fill is `level03`, the mid grey no alert ink was tuned for, and in
+      // dark theme the ink lands at 2.9:1 on it. `pressed` is the ramp's far
+      // step — darkest in light, lightest in dark — and the one that clears
+      // the 3:1 graphical floor on that grey in both themes (4.2:1 dark).
       return Icon(
         dayVerdictGlyph(DayVerdict.missed),
         size: glyphSize,
-        color: dayVerdictSurfaceInk(tokens, DayVerdict.missed),
+        color: tokens.colors.alert.error.pressed,
       );
     case DayMarkState.none:
     case DayMarkState.skipped:

--- a/lib/widgets/day_indicators/day_mark_styles.dart
+++ b/lib/widgets/day_indicators/day_mark_styles.dart
@@ -9,8 +9,9 @@ import 'package:lotti/widgets/day_indicators/day_mark.dart';
 /// surface for anything else. A skipped or missed day is not painted in an
 /// alert hue: the strip is a record of what was kept, and a struggling habit
 /// is never a wall of red. A recorded miss is told apart from a day nobody
-/// looked at by the cross drawn inside the grey in the error family's
-/// surface ink (`dayMarkSquareContent`), not by its fill; a skip keeps its weekday, and is named by the
+/// looked at by the red cross drawn inside the grey (`dayMarkSquareContent`
+/// — the error ramp's `pressed` step, the one that clears 3:1 on `level03`
+/// in both themes), not by its fill; a skip keeps its weekday, and is named by the
 /// tooltip and semantics. A partial day, kept too, draws the tick in the
 /// kept hue on its wash.
 /// `SurfaceAlphas.muted` is the sanctioned "reduced-strength accent" alpha, so

--- a/test/widgets/day_indicators/day_mark_cell_test.dart
+++ b/test/widgets/day_indicators/day_mark_cell_test.dart
@@ -9,6 +9,7 @@ import 'package:lotti/widgets/day_indicators/day_mark.dart';
 import 'package:lotti/widgets/day_indicators/day_mark_cell.dart';
 import 'package:lotti/widgets/day_indicators/day_mark_styles.dart';
 
+import '../../test_utils/wcag_contrast.dart';
 import '../../widget_test_utils.dart';
 
 void main() {
@@ -48,13 +49,12 @@ void main() {
       expect(decoration(tester).border, isNull, reason: '$state');
       if (state == DayMarkState.missed) {
         // A recorded miss and an empty day share the grey; the cross is
-        // what tells them apart. The reflections history's own glyph in the
-        // error family's surface ink — the square itself stays neutral, so
-        // a bad week is a few red marks, never a wall of red.
+        // what tells them apart. The reflections history's own glyph, in
+        // red — the square itself stays neutral, so a bad week is a few red
+        // marks, never a wall of red.
         final icon = tester.widget<Icon>(find.byType(Icon));
         expect(icon.icon, dayVerdictGlyph(DayVerdict.missed));
-        expect(icon.color, dayVerdictSurfaceInk(tokens, DayVerdict.missed));
-        expect(icon.color, tokens.colors.alert.error.ink);
+        expect(icon.color, tokens.colors.alert.error.pressed);
         expect(decoration(tester).color, tokens.colors.background.level03);
         expect(icon.size, kDaySquareSize - tokens.spacing.step2);
       } else if (state == DayMarkState.full || state == DayMarkState.partial) {
@@ -68,6 +68,30 @@ void main() {
       }
       expect(find.byType(Text), findsNothing, reason: '$state');
       expect(find.byType(DsDashedBorder), findsNothing, reason: '$state');
+    }
+  });
+
+  testWidgets('the missed cross clears the 3:1 graphical floor on the grey '
+      'square in both themes', (tester) async {
+    for (final brightness in Brightness.values) {
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          const Align(
+            alignment: Alignment.topLeft,
+            child: DayMarkCell(mark: DayMark(state: DayMarkState.missed)),
+          ),
+          theme: ThemeData(brightness: brightness, useMaterial3: true),
+        ),
+      );
+      final tokens = tester.element(find.byType(DayMarkCell)).designTokens;
+      final icon = tester.widget<Icon>(find.byType(Icon));
+      expect(
+        contrastRatio(icon.color!, decoration(tester).color!),
+        greaterThanOrEqualTo(3),
+        reason: '$brightness: the cross must read against level03',
+      );
+      // Still red: the far step of the error ramp, not a neutral ink.
+      expect(icon.color, tokens.colors.alert.error.pressed);
     }
   });
 


### PR DESCRIPTION
Follow-up to #4087, before the 1.0.20 tag. Codex measured the missed-day cross (`alert.error.ink` on `background.level03`) at 2.9:1 in dark theme — under the 3:1 graphical floor, and the palette contract deliberately excludes `level03` from the alert-ink surfaces for exactly this reason.

The cross now uses `alert.error.pressed`: the ramp's far step — darkest in light, lightest in dark — which clears the floor on that grey in both themes (4.16:1 dark, ~8:1 light). The square stays grey. A test pumps both themes and asserts the ratio with the shared `contrastRatio` helper.

No changelog fragment: introduced and fixed before it shipped; the 1.0.20 notes already describe the red cross.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated missed-day indicators to use a clearer red cross color.
  * Improved visibility of the cross against the grey square in both light and dark themes.
* **Documentation**
  * Updated guidance to describe the revised missed-day indicator color and contrast behavior.
* **Tests**
  * Added coverage confirming the cross maintains the required contrast across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->