### PR TITLE
feat(design-system): alert.glyphOnLevel03 for static glyphs on the mid-grey fill

### DIFF
--- a/assets/design_system/tokens.json
+++ b/assets/design_system/tokens.json
@@ -66,25 +66,29 @@
         "default": { "id": "VariableID:2521:549", "light": "#CC3633", "dark": "#D65E5C" },
         "hover":   { "id": "VariableID:2521:550", "light": "#A32B29", "dark": "#E08684" },
         "pressed": { "id": "VariableID:2521:551", "light": "#7A1F1F", "dark": "#EBB0AE" },
-        "ink":     { "light": "#A32B29", "dark": "#E08684" }
+        "ink":     { "light": "#A32B29", "dark": "#E08684" },
+        "glyphOnLevel03": { "light": "#CC3633", "dark": "#EBB0AE" }
       },
       "success": {
         "default": { "id": "VariableID:2521:552", "light": "#478556", "dark": "#7AB889" },
         "hover":   { "id": "VariableID:2521:553", "light": "#478556", "dark": "#9CC9A6" },
         "pressed": { "id": "VariableID:2521:554", "light": "#366340", "dark": "#BDDBC4" },
-        "ink":     { "light": "#366340", "dark": "#7AB889" }
+        "ink":     { "light": "#366340", "dark": "#7AB889" },
+        "glyphOnLevel03": { "light": "#478556", "dark": "#7AB889" }
       },
       "warning": {
         "default": { "id": "VariableID:2521:555", "light": "#C87005", "dark": "#FBA336" },
         "hover":   { "id": "VariableID:2521:556", "light": "#C87005", "dark": "#FCBA69" },
         "pressed": { "id": "VariableID:2521:557", "light": "#965402", "dark": "#FDD19B" },
-        "ink":     { "light": "#965402", "dark": "#FBA336" }
+        "ink":     { "light": "#965402", "dark": "#FBA336" },
+        "glyphOnLevel03": { "light": "#965402", "dark": "#FBA336" }
       },
       "info": {
         "default": { "id": "VariableID:2521:558", "light": "#1783B5", "dark": "#4AB6E8" },
         "hover":   { "id": "VariableID:2521:559", "light": "#1783B5", "dark": "#77C8EE" },
         "pressed": { "id": "VariableID:2521:560", "light": "#116288", "dark": "#A4DAF4" },
-        "ink":     { "light": "#116288", "dark": "#4AB6E8" }
+        "ink":     { "light": "#116288", "dark": "#4AB6E8" },
+        "glyphOnLevel03": { "light": "#1783B5", "dark": "#4AB6E8" }
       }
     },
     "background": {

--- a/knowledge/architecture/day-indicators.md
+++ b/knowledge/architecture/day-indicators.md
@@ -127,8 +127,8 @@ flowchart LR
   wears the error ink.
 - **A square says one thing inside itself, and nothing around it.** A
   judged day draws its verdict's glyph; a kept day (partial included) the tick, a recorded miss
-  a red cross (`alert.error.pressed` — the ramp's far step, the one that
-  clears the 3:1 graphical floor on `level03` in both themes; the surface
+  a red cross (`alert.error.glyphOnLevel03` — the ramp step that guarantees
+  the 3:1 graphical floor on the `level03` fill in both themes; the surface
   ink lands at 2.9:1 there in dark) — the one touch of that family a habit
   square gets, on a fill that stays neutral, which is what tells a miss from
   the empty day it shares the fill with; any other dated day its weekday — the first two characters of the

--- a/knowledge/features/design_system/tokens-and-theming.md
+++ b/knowledge/features/design_system/tokens-and-theming.md
@@ -142,12 +142,18 @@ call site binds is **a contrast decision, not a taste one**:
 | `defaultColor` | Fills, dots, borders, glyphs, chart series | ≥ 3:1 on `background.level01`/`level02` (WCAG SC 1.4.11) |
 | `hover` / `pressed` | Interaction states of a control already using the tone | Inherits the control's |
 | `ink` | **Any alert-toned text**, and the glyph paired with it | ≥ 4.5:1 (SC 1.4.3) |
+| `glyphOnLevel03` | A static alert-toned glyph on the `background.level03` fill — the mid-grey chip and square fill none of the above is tuned for | ≥ 3:1 on `background.level03` (SC 1.4.11) |
 
 **`ink` is not a fifth hue.** It resolves per brightness to the least-extreme step
 of the same ramp that clears AA — `pressed` in light for success/warning/info,
 `hover` in light and dark for error, `defaultColor` in dark for the rest. Widgets
 used to make that pick by hand with `brightness` branches; **that is now the
-token's job.**
+token's job.** `glyphOnLevel03` is the same idea for the one surface `ink` does
+not cover: `level03` is the mid grey on which no error step reaches AA in dark
+and even the surface ink stops at 2.9:1, so a glyph there (the missed-day
+cross on a habit square) binds this step rather than borrowing `pressed` for
+its contrast — an interaction-state token can be retuned for button feedback
+without anyone thinking of a static indicator.
 
 Two consequences worth stating plainly:
 

--- a/lib/features/design_system/theme/generated/design_tokens.g.dart
+++ b/lib/features/design_system/theme/generated/design_tokens.g.dart
@@ -25,24 +25,28 @@ const DsTokens dsTokensLight = DsTokens(
         hover: Color(0xFFA32B29),
         pressed: Color(0xFF7A1F1F),
         ink: Color(0xFFA32B29),
+        glyphOnLevel03: Color(0xFFCC3633),
       ),
       success: DsColorsAlertSuccess(
         defaultColor: Color(0xFF478556),
         hover: Color(0xFF478556),
         pressed: Color(0xFF366340),
         ink: Color(0xFF366340),
+        glyphOnLevel03: Color(0xFF478556),
       ),
       warning: DsColorsAlertWarning(
         defaultColor: Color(0xFFC87005),
         hover: Color(0xFFC87005),
         pressed: Color(0xFF965402),
         ink: Color(0xFF965402),
+        glyphOnLevel03: Color(0xFF965402),
       ),
       info: DsColorsAlertInfo(
         defaultColor: Color(0xFF1783B5),
         hover: Color(0xFF1783B5),
         pressed: Color(0xFF116288),
         ink: Color(0xFF116288),
+        glyphOnLevel03: Color(0xFF1783B5),
       ),
     ),
     background: DsColorsBackground(
@@ -440,24 +444,28 @@ const DsTokens dsTokensDark = DsTokens(
         hover: Color(0xFFE08684),
         pressed: Color(0xFFEBB0AE),
         ink: Color(0xFFE08684),
+        glyphOnLevel03: Color(0xFFEBB0AE),
       ),
       success: DsColorsAlertSuccess(
         defaultColor: Color(0xFF7AB889),
         hover: Color(0xFF9CC9A6),
         pressed: Color(0xFFBDDBC4),
         ink: Color(0xFF7AB889),
+        glyphOnLevel03: Color(0xFF7AB889),
       ),
       warning: DsColorsAlertWarning(
         defaultColor: Color(0xFFFBA336),
         hover: Color(0xFFFCBA69),
         pressed: Color(0xFFFDD19B),
         ink: Color(0xFFFBA336),
+        glyphOnLevel03: Color(0xFFFBA336),
       ),
       info: DsColorsAlertInfo(
         defaultColor: Color(0xFF4AB6E8),
         hover: Color(0xFF77C8EE),
         pressed: Color(0xFFA4DAF4),
         ink: Color(0xFF4AB6E8),
+        glyphOnLevel03: Color(0xFF4AB6E8),
       ),
     ),
     background: DsColorsBackground(
@@ -970,12 +978,14 @@ class DsColorsAlertError {
   final Color hover;
   final Color pressed;
   final Color ink;
+  final Color glyphOnLevel03;
 
   const DsColorsAlertError({
     required this.defaultColor,
     required this.hover,
     required this.pressed,
     required this.ink,
+    required this.glyphOnLevel03,
   });
 
   DsColorsAlertError copyWith({
@@ -983,12 +993,14 @@ class DsColorsAlertError {
     Color? hover,
     Color? pressed,
     Color? ink,
+    Color? glyphOnLevel03,
   }) {
     return DsColorsAlertError(
       defaultColor: defaultColor ?? this.defaultColor,
       hover: hover ?? this.hover,
       pressed: pressed ?? this.pressed,
       ink: ink ?? this.ink,
+      glyphOnLevel03: glyphOnLevel03 ?? this.glyphOnLevel03,
     );
   }
 
@@ -1002,6 +1014,8 @@ class DsColorsAlertError {
       hover: Color.lerp(hover, other.hover, t) ?? hover,
       pressed: Color.lerp(pressed, other.pressed, t) ?? pressed,
       ink: Color.lerp(ink, other.ink, t) ?? ink,
+      glyphOnLevel03:
+          Color.lerp(glyphOnLevel03, other.glyphOnLevel03, t) ?? glyphOnLevel03,
     );
   }
 
@@ -1014,11 +1028,13 @@ class DsColorsAlertError {
         defaultColor == other.defaultColor &&
         hover == other.hover &&
         pressed == other.pressed &&
-        ink == other.ink;
+        ink == other.ink &&
+        glyphOnLevel03 == other.glyphOnLevel03;
   }
 
   @override
-  int get hashCode => Object.hashAll([defaultColor, hover, pressed, ink]);
+  int get hashCode =>
+      Object.hashAll([defaultColor, hover, pressed, ink, glyphOnLevel03]);
 }
 
 @immutable
@@ -1027,12 +1043,14 @@ class DsColorsAlertSuccess {
   final Color hover;
   final Color pressed;
   final Color ink;
+  final Color glyphOnLevel03;
 
   const DsColorsAlertSuccess({
     required this.defaultColor,
     required this.hover,
     required this.pressed,
     required this.ink,
+    required this.glyphOnLevel03,
   });
 
   DsColorsAlertSuccess copyWith({
@@ -1040,12 +1058,14 @@ class DsColorsAlertSuccess {
     Color? hover,
     Color? pressed,
     Color? ink,
+    Color? glyphOnLevel03,
   }) {
     return DsColorsAlertSuccess(
       defaultColor: defaultColor ?? this.defaultColor,
       hover: hover ?? this.hover,
       pressed: pressed ?? this.pressed,
       ink: ink ?? this.ink,
+      glyphOnLevel03: glyphOnLevel03 ?? this.glyphOnLevel03,
     );
   }
 
@@ -1059,6 +1079,8 @@ class DsColorsAlertSuccess {
       hover: Color.lerp(hover, other.hover, t) ?? hover,
       pressed: Color.lerp(pressed, other.pressed, t) ?? pressed,
       ink: Color.lerp(ink, other.ink, t) ?? ink,
+      glyphOnLevel03:
+          Color.lerp(glyphOnLevel03, other.glyphOnLevel03, t) ?? glyphOnLevel03,
     );
   }
 
@@ -1071,11 +1093,13 @@ class DsColorsAlertSuccess {
         defaultColor == other.defaultColor &&
         hover == other.hover &&
         pressed == other.pressed &&
-        ink == other.ink;
+        ink == other.ink &&
+        glyphOnLevel03 == other.glyphOnLevel03;
   }
 
   @override
-  int get hashCode => Object.hashAll([defaultColor, hover, pressed, ink]);
+  int get hashCode =>
+      Object.hashAll([defaultColor, hover, pressed, ink, glyphOnLevel03]);
 }
 
 @immutable
@@ -1084,12 +1108,14 @@ class DsColorsAlertWarning {
   final Color hover;
   final Color pressed;
   final Color ink;
+  final Color glyphOnLevel03;
 
   const DsColorsAlertWarning({
     required this.defaultColor,
     required this.hover,
     required this.pressed,
     required this.ink,
+    required this.glyphOnLevel03,
   });
 
   DsColorsAlertWarning copyWith({
@@ -1097,12 +1123,14 @@ class DsColorsAlertWarning {
     Color? hover,
     Color? pressed,
     Color? ink,
+    Color? glyphOnLevel03,
   }) {
     return DsColorsAlertWarning(
       defaultColor: defaultColor ?? this.defaultColor,
       hover: hover ?? this.hover,
       pressed: pressed ?? this.pressed,
       ink: ink ?? this.ink,
+      glyphOnLevel03: glyphOnLevel03 ?? this.glyphOnLevel03,
     );
   }
 
@@ -1116,6 +1144,8 @@ class DsColorsAlertWarning {
       hover: Color.lerp(hover, other.hover, t) ?? hover,
       pressed: Color.lerp(pressed, other.pressed, t) ?? pressed,
       ink: Color.lerp(ink, other.ink, t) ?? ink,
+      glyphOnLevel03:
+          Color.lerp(glyphOnLevel03, other.glyphOnLevel03, t) ?? glyphOnLevel03,
     );
   }
 
@@ -1128,11 +1158,13 @@ class DsColorsAlertWarning {
         defaultColor == other.defaultColor &&
         hover == other.hover &&
         pressed == other.pressed &&
-        ink == other.ink;
+        ink == other.ink &&
+        glyphOnLevel03 == other.glyphOnLevel03;
   }
 
   @override
-  int get hashCode => Object.hashAll([defaultColor, hover, pressed, ink]);
+  int get hashCode =>
+      Object.hashAll([defaultColor, hover, pressed, ink, glyphOnLevel03]);
 }
 
 @immutable
@@ -1141,12 +1173,14 @@ class DsColorsAlertInfo {
   final Color hover;
   final Color pressed;
   final Color ink;
+  final Color glyphOnLevel03;
 
   const DsColorsAlertInfo({
     required this.defaultColor,
     required this.hover,
     required this.pressed,
     required this.ink,
+    required this.glyphOnLevel03,
   });
 
   DsColorsAlertInfo copyWith({
@@ -1154,12 +1188,14 @@ class DsColorsAlertInfo {
     Color? hover,
     Color? pressed,
     Color? ink,
+    Color? glyphOnLevel03,
   }) {
     return DsColorsAlertInfo(
       defaultColor: defaultColor ?? this.defaultColor,
       hover: hover ?? this.hover,
       pressed: pressed ?? this.pressed,
       ink: ink ?? this.ink,
+      glyphOnLevel03: glyphOnLevel03 ?? this.glyphOnLevel03,
     );
   }
 
@@ -1173,6 +1209,8 @@ class DsColorsAlertInfo {
       hover: Color.lerp(hover, other.hover, t) ?? hover,
       pressed: Color.lerp(pressed, other.pressed, t) ?? pressed,
       ink: Color.lerp(ink, other.ink, t) ?? ink,
+      glyphOnLevel03:
+          Color.lerp(glyphOnLevel03, other.glyphOnLevel03, t) ?? glyphOnLevel03,
     );
   }
 
@@ -1185,11 +1223,13 @@ class DsColorsAlertInfo {
         defaultColor == other.defaultColor &&
         hover == other.hover &&
         pressed == other.pressed &&
-        ink == other.ink;
+        ink == other.ink &&
+        glyphOnLevel03 == other.glyphOnLevel03;
   }
 
   @override
-  int get hashCode => Object.hashAll([defaultColor, hover, pressed, ink]);
+  int get hashCode =>
+      Object.hashAll([defaultColor, hover, pressed, ink, glyphOnLevel03]);
 }
 
 @immutable

--- a/lib/widgets/day_indicators/day_mark_cell.dart
+++ b/lib/widgets/day_indicators/day_mark_cell.dart
@@ -90,15 +90,13 @@ Widget? dayMarkSquareContent(
       // The one touch of the error family a habit square gets: the cross
       // in red, on the neutral fill. A miss should sting a little, and a bad
       // week should still not be a wall of red — the mark carries the hue,
-      // the square does not. The `pressed` step, not the surface ink: the
-      // fill is `level03`, the mid grey no alert ink was tuned for, and in
-      // dark theme the ink lands at 2.9:1 on it. `pressed` is the ramp's far
-      // step — darkest in light, lightest in dark — and the one that clears
-      // the 3:1 graphical floor on that grey in both themes (4.2:1 dark).
+      // the square does not. `glyphOnLevel03`, not the surface ink: the
+      // fill is `level03`, the mid grey the ink was never tuned for (2.9:1
+      // there in dark), and that step is the ramp's guarantee of 3:1 on it.
       return Icon(
         dayVerdictGlyph(DayVerdict.missed),
         size: glyphSize,
-        color: tokens.colors.alert.error.pressed,
+        color: tokens.colors.alert.error.glyphOnLevel03,
       );
     case DayMarkState.none:
     case DayMarkState.skipped:

--- a/lib/widgets/day_indicators/day_mark_styles.dart
+++ b/lib/widgets/day_indicators/day_mark_styles.dart
@@ -9,9 +9,9 @@ import 'package:lotti/widgets/day_indicators/day_mark.dart';
 /// surface for anything else. A skipped or missed day is not painted in an
 /// alert hue: the strip is a record of what was kept, and a struggling habit
 /// is never a wall of red. A recorded miss is told apart from a day nobody
-/// looked at by the red cross drawn inside the grey (`dayMarkSquareContent`
-/// — the error ramp's `pressed` step, the one that clears 3:1 on `level03`
-/// in both themes), not by its fill; a skip keeps its weekday, and is named by the
+/// looked at by the red cross drawn inside the grey (`dayMarkSquareContent`,
+/// in the error ramp's `glyphOnLevel03` step — its 3:1 guarantee on that
+/// fill), not by its fill; a skip keeps its weekday, and is named by the
 /// tooltip and semantics. A partial day, kept too, draws the tick in the
 /// kept hue on its wash.
 /// `SurfaceAlphas.muted` is the sanctioned "reduced-strength accent" alpha, so

--- a/test/features/design_system/theme/design_tokens_test.dart
+++ b/test/features/design_system/theme/design_tokens_test.dart
@@ -102,27 +102,51 @@ const _uiComponent = 3.0;
 /// The four alert families, flattened — the generated classes are siblings
 /// with no common supertype, so the ramp has to be projected into records to
 /// be iterated over.
-List<({String name, Color defaultColor, Color ink})> _alertFamilies(
-  DsTokens tokens,
-) {
+List<
+  ({
+    String name,
+    Color defaultColor,
+    Color hover,
+    Color pressed,
+    Color ink,
+    Color glyphOnLevel03,
+  })
+>
+_alertFamilies(DsTokens tokens) {
   final alert = tokens.colors.alert;
   return [
     (
       name: 'error',
       defaultColor: alert.error.defaultColor,
+      hover: alert.error.hover,
+      pressed: alert.error.pressed,
       ink: alert.error.ink,
+      glyphOnLevel03: alert.error.glyphOnLevel03,
     ),
     (
       name: 'success',
       defaultColor: alert.success.defaultColor,
+      hover: alert.success.hover,
+      pressed: alert.success.pressed,
       ink: alert.success.ink,
+      glyphOnLevel03: alert.success.glyphOnLevel03,
     ),
     (
       name: 'warning',
       defaultColor: alert.warning.defaultColor,
+      hover: alert.warning.hover,
+      pressed: alert.warning.pressed,
       ink: alert.warning.ink,
+      glyphOnLevel03: alert.warning.glyphOnLevel03,
     ),
-    (name: 'info', defaultColor: alert.info.defaultColor, ink: alert.info.ink),
+    (
+      name: 'info',
+      defaultColor: alert.info.defaultColor,
+      hover: alert.info.hover,
+      pressed: alert.info.pressed,
+      ink: alert.info.ink,
+      glyphOnLevel03: alert.info.glyphOnLevel03,
+    ),
   ];
 }
 
@@ -145,6 +169,40 @@ void main() {
   // the 1.4.11 floor (warning at 2.15:1 on level02) and stayed there until a
   // reviewer read the token file by hand. These assertions are the check that
   // was missing.
+  // `level03` is the surface the ramp above deliberately leaves out: no
+  // error step reaches AA on it in dark, and the surface ink stops at 2.9:1.
+  // A static glyph there — the missed-day cross on a habit square — has its
+  // own step, guaranteed here rather than borrowed from an interaction state.
+  group('alert glyphOnLevel03', () {
+    const themes = [
+      (name: 'light', tokens: dsTokensLight),
+      (name: 'dark', tokens: dsTokensDark),
+    ];
+    for (final theme in themes) {
+      final level03 = theme.tokens.colors.background.level03;
+      for (final family in _alertFamilies(theme.tokens)) {
+        final label = '${theme.name} alert.${family.name}.glyphOnLevel03';
+        test('$label clears the non-text floor on level03', () {
+          final ratio = contrastRatio(family.glyphOnLevel03, level03);
+          expect(
+            ratio,
+            greaterThanOrEqualTo(_uiComponent),
+            reason:
+                '$label ${family.glyphOnLevel03} measures '
+                '${ratio.toStringAsFixed(2)}:1 on level03, below '
+                '$_uiComponent:1',
+          );
+        });
+        test('$label is a step of its own ramp, not a fifth hue', () {
+          expect(
+            family.glyphOnLevel03,
+            isIn([family.defaultColor, family.hover, family.pressed]),
+          );
+        });
+      }
+    }
+  });
+
   group('alert palette contrast', () {
     const themes = [
       (name: 'light', tokens: dsTokensLight),

--- a/test/widgets/day_indicators/day_mark_cell_test.dart
+++ b/test/widgets/day_indicators/day_mark_cell_test.dart
@@ -54,7 +54,7 @@ void main() {
         // marks, never a wall of red.
         final icon = tester.widget<Icon>(find.byType(Icon));
         expect(icon.icon, dayVerdictGlyph(DayVerdict.missed));
-        expect(icon.color, tokens.colors.alert.error.pressed);
+        expect(icon.color, tokens.colors.alert.error.glyphOnLevel03);
         expect(decoration(tester).color, tokens.colors.background.level03);
         expect(icon.size, kDaySquareSize - tokens.spacing.step2);
       } else if (state == DayMarkState.full || state == DayMarkState.partial) {
@@ -90,8 +90,9 @@ void main() {
         greaterThanOrEqualTo(3),
         reason: '$brightness: the cross must read against level03',
       );
-      // Still red: the far step of the error ramp, not a neutral ink.
-      expect(icon.color, tokens.colors.alert.error.pressed);
+      // Still red: the error ramp's own step for this fill, not a neutral
+      // ink and not an interaction state borrowed for its contrast.
+      expect(icon.color, tokens.colors.alert.error.glyphOnLevel03);
     }
   });
 


### PR DESCRIPTION
Follow-up to #4088 (Codex: the missed-day cross bound `alert.error.pressed`, an interaction-state token, for its contrast).

Adds a derived step `glyphOnLevel03` to each alert family in `tokens.json` — no Figma id, like `ink` — resolving per theme to the least-extreme step of the family's own ramp that clears the 3:1 graphical floor on `background.level03`:

| family | light | dark |
|---|---|---|
| error | default (4.09:1) | pressed (4.16:1) |
| success | default (3.57:1) | default (3.31:1) |
| warning | pressed (4.76:1) | default (3.81:1) |
| info | default (3.43:1) | default (3.35:1) |

The missed-day cross binds `alert.error.glyphOnLevel03`. The token contract test (`design_tokens_test.dart`) guarantees the floor in both themes and that the step is a member of its own ramp, not a fifth hue; the day-mark cell test asserts the binding and the ratio. `tokens-and-theming.md` documents the step in the ramp table.

In dark theme the cross resolves to the same colour #4088 shipped (`pressed`). In light it moves from `pressed` (#7A1F1F, the darkest step) to `default` (#CC3633) — the least-extreme step that clears the floor, and the one the ramp contract names for glyphs — so the light pair below is the visible change. No changelog fragment: the 1.0.20 notes already describe the red cross, and this only settles its exact step before the tag.

| Surface | Before | After |
|---|---|---|
| Habits, desktop light | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/alert-glyph-on-level03/890810afd11dda2611387b66f13a8e4f3fad52d3/before/habits_today_desktop_light.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/alert-glyph-on-level03/890810afd11dda2611387b66f13a8e4f3fad52d3/after/habits_today_desktop_light.png) |
| Habits, mobile light | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/alert-glyph-on-level03/890810afd11dda2611387b66f13a8e4f3fad52d3/before/habits_today_mobile_light.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/alert-glyph-on-level03/890810afd11dda2611387b66f13a8e4f3fad52d3/after/habits_today_mobile_light.png) |
| Habits, desktop dark (unchanged) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/alert-glyph-on-level03/890810afd11dda2611387b66f13a8e4f3fad52d3/before/habits_today_desktop_dark.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/alert-glyph-on-level03/890810afd11dda2611387b66f13a8e4f3fad52d3/after/habits_today_desktop_dark.png) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated alert glyph colors for error, success, warning, and information states across light and dark themes.
  * Improved contrast for missed-day indicators on level-03 surfaces.

* **Documentation**
  * Updated design system and day-indicator guidance to describe the new glyph colors and contrast requirements.

* **Tests**
  * Added coverage verifying alert glyph contrast and missed-day indicator styling across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
