### PR TITLE
chore(release): 1.0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.21]
+### Fixed
+- **Editing a checklist item on desktop no longer shows the correction toast
+  twice.** The undo toast now appears only inside the task details pane while
+  page-level notifications continue to work normally.
+
 ## [1.0.20]
 ### Changed
 - **The day squares under each habit now say which day they are, and open

--- a/changelog.d/2026-08-30-checklist-correction-toast.md
+++ b/changelog.d/2026-08-30-checklist-correction-toast.md
@@ -1,4 +1,0 @@
-### Fixed
-- **Editing a checklist item on desktop no longer shows the correction toast
-  twice.** The undo toast now appears only inside the task details pane while
-  page-level notifications continue to work normally.

--- a/changelog.d/2026-08-30-checklist-correction-toast.md
+++ b/changelog.d/2026-08-30-checklist-correction-toast.md
@@ -1,0 +1,4 @@
+### Fixed
+- **Editing a checklist item on desktop no longer shows the correction toast
+  twice.** The undo toast now appears only inside the task details pane while
+  page-level notifications continue to work normally.

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -40,6 +40,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="1.0.21" date="2026-08-30">
+      <description>
+        <p>Fixed: editing a checklist item on desktop no longer shows the correction toast twice. The undo toast now appears only inside the task details pane while page-level notifications continue to work normally.</p>
+      </description>
+    </release>
     <release version="1.0.20" date="2026-08-30">
       <description>
         <p>Changed: the day squares under each habit now say which day they are, and open that day. Every square carries its weekday (Tu, Th, Sa, Su - in your language) until something is recorded for it, then a tick for a kept day or a red cross for a missed one - so a missed day no longer looks like a day you never looked at. The square itself stays grey, so a rough week is a few red marks rather than a red row: enough to sting, not enough to shout. Tapping a square opens the completion sheet for that day rather than for today, which is what makes catching up on Tuesday from Thursday a one-tap job. The squares are a size larger everywhere, and on a desktop window a row shows the last fourteen days instead of seven.</p>

--- a/knowledge/features/tasks/checklists.md
+++ b/knowledge/features/tasks/checklists.md
@@ -59,12 +59,17 @@ before/after title and the item's category, and the rename surfaces an undo
 affordance. **That before→after pair becomes category-scoped AI guidance** — the
 the checklist feature owns the capture and undo logic.
 
-The pending correction is task-wide UI state, so its toast has exactly one
-listener at the task-details boundary: `CorrectionCaptureToastListener` sits
-immediately below `TaskDetailsPage`'s nested `ScaffoldMessenger`. Individual
-`ChecklistCardWrapper`s never listen for it. This keeps the undo toast inside
-the detail pane on desktop, above the sticky action bar on every platform, and
-prevents one provider update from being dispatched once per checklist card.
+The pending correction is shared UI state, but each editable details surface
+owns exactly one `CorrectionCaptureToastListener`. Task details mounts it
+immediately below its nested `ScaffoldMessenger`; the standalone journal entry
+details page mounts one around its scaffold so checklist edits there retain the
+undo affordance. Individual `ChecklistCardWrapper`s never listen for it.
+
+The app shell keeps inactive tabs mounted with `TickerMode` disabled, so each
+page listener ignores correction updates while its tab is offstage. This keeps
+the active task undo toast inside the detail pane on desktop, above the sticky
+action bar on every platform, without letting an offstage journal page dispatch
+the same provider update through the app-wide messenger.
 
 # The sorting state machine
 

--- a/knowledge/features/tasks/checklists.md
+++ b/knowledge/features/tasks/checklists.md
@@ -5,13 +5,17 @@ description: The checklist subsystem, its celebration and collapse motion contra
 resource: ../../../lib/features/tasks/ui/checklists
 tags: [tasks, checklists, motion, accessibility]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T01:00:00Z }
+generated: { by: codex/gpt-5, at: 2026-08-30T13:12:58Z }
 stale_after: 2027-01-25
 sources:
   - id: ui
     resource: ../../../lib/features/tasks/ui/checklists
     title: Checklist widgets
-    last_modified: 2026-07-25
+    last_modified: 2026-08-30
+  - id: task-details
+    resource: ../../../lib/features/tasks/ui/pages/task_details_page.dart
+    title: Task details toast scope
+    last_modified: 2026-08-30
   - id: checklist-feature
     resource: ../../../lib/features/checklist
     title: Correction capture and undo
@@ -54,6 +58,13 @@ fire-and-forget `correctionCaptureService.captureCorrection(...)` with the
 before/after title and the item's category, and the rename surfaces an undo
 affordance. **That before→after pair becomes category-scoped AI guidance** — the
 the checklist feature owns the capture and undo logic.
+
+The pending correction is task-wide UI state, so its toast has exactly one
+listener at the task-details boundary: `CorrectionCaptureToastListener` sits
+immediately below `TaskDetailsPage`'s nested `ScaffoldMessenger`. Individual
+`ChecklistCardWrapper`s never listen for it. This keeps the undo toast inside
+the detail pane on desktop, above the sticky action bar on every platform, and
+prevents one provider update from being dispatched once per checklist card.
 
 # The sorting state machine
 

--- a/lib/features/journal/ui/pages/entry_details_page.dart
+++ b/lib/features/journal/ui/pages/entry_details_page.dart
@@ -21,6 +21,7 @@ import 'package:lotti/features/keyboard/domain/app_command.dart';
 import 'package:lotti/features/keyboard/domain/app_command_handler.dart';
 import 'package:lotti/features/keyboard/ui/app_command_scope.dart';
 import 'package:lotti/features/tasks/state/task_app_bar_controller.dart';
+import 'package:lotti/features/tasks/ui/checklists/correction_undo_snackbar.dart';
 import 'package:lotti/features/tasks/ui/checklists/linked_from_checklist_widget.dart';
 import 'package:lotti/features/tasks/ui/checklists/linked_from_task_widget.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
@@ -166,6 +167,9 @@ class _EntryDetailsPageState extends ConsumerState<EntryDetailsPage>
           ),
           body: Stack(
             children: [
+              const CorrectionCaptureToastListener(
+                child: SizedBox.shrink(),
+              ),
               CustomScrollView(
                 scrollCacheExtent: const ScrollCacheExtent.pixels(4000),
                 controller: _scrollController,

--- a/lib/features/tasks/ui/checklists/checklist_card_wrapper.dart
+++ b/lib/features/tasks/ui/checklists/checklist_card_wrapper.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/features/checklist/services/correction_capture_service.dart';
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
 import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
 import 'package:lotti/features/journal/repository/app_clipboard_service.dart';
@@ -12,7 +11,6 @@ import 'package:lotti/features/tasks/state/checklist_completion_controller.dart'
 import 'package:lotti/features/tasks/state/checklist_controller.dart';
 import 'package:lotti/features/tasks/state/checklist_item_controller.dart';
 import 'package:lotti/features/tasks/ui/checklists/checklist_card.dart';
-import 'package:lotti/features/tasks/ui/checklists/correction_undo_snackbar.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_detail_section_card.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -24,8 +22,8 @@ import 'package:lotti/utils/platform.dart';
 import 'package:super_drag_and_drop/super_drag_and_drop.dart';
 
 /// Wires a checklist entity to its [ChecklistCard] and handles all
-/// side-effects: provider subscriptions, export/share, correction capture
-/// snackbars, and drop-zone for cross-checklist item moves.
+/// side-effects: provider subscriptions, export/share, and the drop-zone for
+/// cross-checklist item moves.
 ///
 /// Replaces the old `ChecklistWrapper`.
 class ChecklistCardWrapper extends ConsumerWidget {
@@ -101,35 +99,6 @@ class ChecklistCardWrapper extends ConsumerWidget {
           )),
         )
         .value;
-
-    // Show correction-capture toast with undo + countdown.
-    ref.listen<PendingCorrection?>(
-      correctionCaptureProvider,
-      (previous, next) {
-        if (next != null && previous != next) {
-          final captureNotifier = ref.read(correctionCaptureProvider.notifier);
-          final messenger = ScaffoldMessenger.of(context)
-            ..hideCurrentSnackBar();
-          messenger.showSnackBar(
-            SnackBar(
-              content: CorrectionUndoSnackbarContent(
-                pending: next,
-                onUndo: () {
-                  captureNotifier.cancel();
-                  messenger.hideCurrentSnackBar();
-                },
-              ),
-              backgroundColor: Colors.transparent,
-              elevation: 0,
-              padding: EdgeInsets.zero,
-              behavior: SnackBarBehavior.floating,
-              dismissDirection: DismissDirection.down,
-              duration: kCorrectionSaveDelay + const Duration(seconds: 1),
-            ),
-          );
-        }
-      },
-    );
 
     if (checklist == null || completionRate == null) {
       return const SizedBox.shrink();

--- a/lib/features/tasks/ui/checklists/correction_undo_snackbar.dart
+++ b/lib/features/tasks/ui/checklists/correction_undo_snackbar.dart
@@ -1,9 +1,57 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/checklist/services/correction_capture_service.dart';
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+
+/// Owns the single correction-capture toast listener for a task details page.
+///
+/// This belongs immediately below that page's scoped [ScaffoldMessenger].
+/// Keeping the listener at the page boundary prevents one global correction
+/// event from being handled once per checklist card while still resolving the
+/// toast to the task-local messenger rather than the app-wide messenger.
+class CorrectionCaptureToastListener extends ConsumerWidget {
+  const CorrectionCaptureToastListener({
+    required this.child,
+    super.key,
+  });
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen<PendingCorrection?>(
+      correctionCaptureProvider,
+      (previous, next) {
+        if (next == null || previous == next) return;
+
+        final captureNotifier = ref.read(correctionCaptureProvider.notifier);
+        final messenger = ScaffoldMessenger.of(context)..hideCurrentSnackBar();
+        messenger.showSnackBar(
+          SnackBar(
+            content: CorrectionUndoSnackbarContent(
+              pending: next,
+              onUndo: () {
+                captureNotifier.cancel();
+                messenger.hideCurrentSnackBar();
+              },
+            ),
+            backgroundColor: Colors.transparent,
+            elevation: 0,
+            padding: EdgeInsets.zero,
+            behavior: SnackBarBehavior.floating,
+            dismissDirection: DismissDirection.down,
+            duration: kCorrectionSaveDelay + const Duration(seconds: 1),
+          ),
+        );
+      },
+    );
+
+    return child;
+  }
+}
 
 /// SnackBar content that shows a pending text-correction with a countdown
 /// bar and an UNDO action, rendered through [DesignSystemToast] so the

--- a/lib/features/tasks/ui/checklists/correction_undo_snackbar.dart
+++ b/lib/features/tasks/ui/checklists/correction_undo_snackbar.dart
@@ -6,12 +6,15 @@ import 'package:lotti/features/checklist/services/correction_capture_service.dar
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 
-/// Owns the single correction-capture toast listener for a task details page.
+/// Owns one correction-capture toast listener for an editable details page.
 ///
-/// This belongs immediately below that page's scoped [ScaffoldMessenger].
-/// Keeping the listener at the page boundary prevents one global correction
-/// event from being handled once per checklist card while still resolving the
-/// toast to the task-local messenger rather than the app-wide messenger.
+/// Keep this at the page boundary instead of individual checklist cards so a
+/// global correction event is handled once per visible details surface. The
+/// app shell leaves inactive tabs mounted with [TickerMode] disabled, so those
+/// background surfaces must ignore the event. An active task details page
+/// resolves the toast to its nested [ScaffoldMessenger], while an active
+/// journal details page keeps the same undo affordance through the app-level
+/// messenger.
 class CorrectionCaptureToastListener extends ConsumerWidget {
   const CorrectionCaptureToastListener({
     required this.child,
@@ -22,10 +25,12 @@ class CorrectionCaptureToastListener extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final isActiveSurface = TickerMode.valuesOf(context).enabled;
+
     ref.listen<PendingCorrection?>(
       correctionCaptureProvider,
       (previous, next) {
-        if (next == null || previous == next) return;
+        if (!isActiveSurface || next == null || previous == next) return;
 
         final captureNotifier = ref.read(correctionCaptureProvider.notifier);
         final messenger = ScaffoldMessenger.of(context)..hideCurrentSnackBar();

--- a/lib/features/tasks/ui/pages/task_details_page.dart
+++ b/lib/features/tasks/ui/pages/task_details_page.dart
@@ -19,6 +19,7 @@ import 'package:lotti/features/tasks/state/task_app_bar_controller.dart';
 import 'package:lotti/features/tasks/state/task_focus_controller.dart';
 import 'package:lotti/features/tasks/state/task_link_groups_controller.dart';
 import 'package:lotti/features/tasks/ui/checklists/consts.dart';
+import 'package:lotti/features/tasks/ui/checklists/correction_undo_snackbar.dart';
 import 'package:lotti/features/tasks/ui/task_app_bar.dart';
 import 'package:lotti/features/tasks/ui/task_form.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_action_bar.dart';
@@ -688,7 +689,9 @@ class _TaskDetailsPageState extends ConsumerState<TaskDetailsPage>
     // screen / window bottom edge — on mobile the bar would otherwise
     // cover the toast, on desktop it would sit visually detached at the
     // app window's bottom edge.
-    final body = ScaffoldMessenger(child: scaffold);
+    final body = ScaffoldMessenger(
+      child: CorrectionCaptureToastListener(child: scaffold),
+    );
 
     return MediaDropTarget(
       onFiles: (files) => handleDroppedMediaFiles(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.20+4361
+version: 1.0.21+4362
 
 msix_config:
   display_name: LottiApp

--- a/test/features/journal/ui/pages/entry_details_page_test.dart
+++ b/test/features/journal/ui/pages/entry_details_page_test.dart
@@ -27,6 +27,7 @@ import 'package:lotti/features/journal/ui/widgets/linked_entries_with_timer.dart
 import 'package:lotti/features/keyboard/domain/app_command.dart';
 import 'package:lotti/features/keyboard/ui/app_command_controller.dart';
 import 'package:lotti/features/keyboard/ui/app_command_host.dart';
+import 'package:lotti/features/tasks/ui/checklists/correction_undo_snackbar.dart';
 import 'package:lotti/features/tasks/ui/checklists/linked_from_checklist_widget.dart';
 import 'package:lotti/features/tasks/ui/checklists/linked_from_task_widget.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
@@ -221,6 +222,30 @@ void main() {
         AiResponseType.audioSummary,
         AiResponseType.promptGeneration,
       });
+    });
+
+    testWidgets('owns one correction toast listener for editable checklists', (
+      tester,
+    ) async {
+      when(
+        () => mockJournalDb.journalEntityById(testTextEntry.meta.id),
+      ).thenAnswer((_) async => testTextEntry);
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          EntryDetailsPage(itemId: testTextEntry.meta.id),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(
+        find.descendant(
+          of: find.byType(EntryDetailsPage),
+          matching: find.byType(CorrectionCaptureToastListener),
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('save command persists the current text entry', (tester) async {

--- a/test/features/tasks/ui/checklists/checklist_card_wrapper_test.dart
+++ b/test/features/tasks/ui/checklists/checklist_card_wrapper_test.dart
@@ -170,18 +170,9 @@ class _FakeCorrectionCaptureNotifier extends CorrectionCaptureNotifier {
   @override
   PendingCorrection? build() => null;
 
-  bool cancelCalled = false;
-
   // ignore: use_setters_to_change_properties
   void emit(PendingCorrection pending) {
     state = pending;
-  }
-
-  @override
-  bool cancel() {
-    cancelCalled = true;
-    state = null;
-    return true;
   }
 }
 
@@ -477,13 +468,22 @@ void main() {
       },
     );
 
-    // ── Correction capture snackbar ────────────────────────────────────────
+    // ── Correction capture ownership ───────────────────────────────────────
 
-    testWidgets('shows correction undo snackbar on pending correction', (
+    testWidgets('does not dispatch the task-level correction toast', (
       tester,
     ) async {
       final corrNotifier = _FakeCorrectionCaptureNotifier();
       await _pump(tester, correctionNotifier: corrNotifier);
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ChecklistCardWrapper)),
+      );
+      final subscription = container.listen<PendingCorrection?>(
+        correctionCaptureProvider,
+        (_, _) {},
+      );
+      addTearDown(subscription.close);
 
       // Emit a pending correction.
       corrNotifier.emit(
@@ -496,9 +496,9 @@ void main() {
       await tester.pump();
       await tester.pump();
 
-      expect(find.byType(CorrectionUndoSnackbarContent), findsOneWidget);
-      expect(find.textContaining('old text'), findsOneWidget);
-      expect(find.textContaining('new text'), findsOneWidget);
+      expect(find.byType(CorrectionUndoSnackbarContent), findsNothing);
+      expect(find.textContaining('old text'), findsNothing);
+      expect(find.textContaining('new text'), findsNothing);
     });
 
     // ── Completion rate and counts passed through ──────────────────────────
@@ -721,41 +721,6 @@ void main() {
         expect(find.byType(SnackBar), findsOneWidget);
       },
     );
-
-    // ── Correction snackbar Undo button ───────────────────────────────────
-
-    testWidgets('tapping Undo in correction snackbar calls cancel()', (
-      tester,
-    ) async {
-      final corrNotifier = _FakeCorrectionCaptureNotifier();
-      await _pump(tester, correctionNotifier: corrNotifier);
-
-      // Emit a pending correction to trigger the snackbar.
-      corrNotifier.emit(
-        PendingCorrection(
-          before: 'wrong',
-          after: 'right',
-          createdAt: DateTime(2025, 3, 15),
-        ),
-      );
-      await tester.pump();
-      await tester.pump();
-
-      expect(find.byType(CorrectionUndoSnackbarContent), findsOneWidget);
-
-      // Invoke the onUndo callback directly from the widget — the snackbar
-      // floats in an overlay layer and the hit-test offset won't reach it via
-      // a normal tap(), so we extract the callback from the widget tree and
-      // call it programmatically.
-      final content = tester.widget<CorrectionUndoSnackbarContent>(
-        find.byType(CorrectionUndoSnackbarContent),
-      );
-      content.onUndo();
-      await tester.pump();
-
-      // The fake cancel() should have been called.
-      expect(corrNotifier.cancelCalled, isTrue);
-    });
 
     // ── onExpansionChanged wiring ─────────────────────────────────────────
 

--- a/test/features/tasks/ui/checklists/correction_undo_snackbar_test.dart
+++ b/test/features/tasks/ui/checklists/correction_undo_snackbar_test.dart
@@ -5,6 +5,25 @@ import 'package:lotti/features/tasks/ui/checklists/correction_undo_snackbar.dart
 
 import '../../../../test_helper.dart';
 
+class _FakeCorrectionCaptureNotifier extends CorrectionCaptureNotifier {
+  @override
+  PendingCorrection? build() => null;
+
+  bool cancelCalled = false;
+
+  // ignore: use_setters_to_change_properties
+  void emit(PendingCorrection pending) {
+    state = pending;
+  }
+
+  @override
+  bool cancel() {
+    cancelCalled = true;
+    state = null;
+    return true;
+  }
+}
+
 void main() {
   // A fixed expired date used for tests that don't depend on countdown values.
   final expiredDate = DateTime(2024, 3, 15);
@@ -184,6 +203,134 @@ void main() {
 
       // With an expired date, remainingTime is clamped to zero
       expect(find.textContaining('0'), findsOneWidget);
+    });
+  });
+
+  group('CorrectionCaptureToastListener', () {
+    testWidgets(
+      'shows the correction once through the nearest scoped messenger',
+      (tester) async {
+        final notifier = _FakeCorrectionCaptureNotifier();
+        final detailsMessengerKey = GlobalKey<ScaffoldMessengerState>();
+        const listenerChildKey = ValueKey('listener-child');
+
+        await tester.pumpWidget(
+          WidgetTestBench(
+            overrides: [
+              correctionCaptureProvider.overrideWith(() => notifier),
+            ],
+            child: ScaffoldMessenger(
+              key: detailsMessengerKey,
+              child: const Scaffold(
+                body: CorrectionCaptureToastListener(
+                  child: SizedBox(key: listenerChildKey),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final listenerContext = tester.element(
+          find.byKey(listenerChildKey),
+        );
+        expect(
+          ScaffoldMessenger.of(listenerContext),
+          same(detailsMessengerKey.currentState),
+        );
+
+        notifier.emit(
+          PendingCorrection(
+            before: 'Buy bred',
+            after: 'Buy bread',
+            createdAt: expiredDate,
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byType(CorrectionUndoSnackbarContent), findsOneWidget);
+        expect(find.textContaining('Buy bred'), findsOneWidget);
+        expect(find.textContaining('Buy bread'), findsOneWidget);
+      },
+    );
+
+    testWidgets('undo cancels the pending correction', (tester) async {
+      final notifier = _FakeCorrectionCaptureNotifier();
+
+      await tester.pumpWidget(
+        WidgetTestBench(
+          overrides: [
+            correctionCaptureProvider.overrideWith(() => notifier),
+          ],
+          child: const ScaffoldMessenger(
+            child: Scaffold(
+              body: CorrectionCaptureToastListener(
+                child: SizedBox.shrink(),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      notifier.emit(
+        PendingCorrection(
+          before: 'wrong',
+          after: 'right',
+          createdAt: expiredDate,
+        ),
+      );
+      await tester.pump();
+
+      final content = tester.widget<CorrectionUndoSnackbarContent>(
+        find.byType(CorrectionUndoSnackbarContent),
+      );
+      content.onUndo();
+      await tester.pump();
+
+      expect(notifier.cancelCalled, isTrue);
+      expect(find.byType(CorrectionUndoSnackbarContent), findsNothing);
+    });
+
+    testWidgets('does not suppress an independent global toast', (
+      tester,
+    ) async {
+      final notifier = _FakeCorrectionCaptureNotifier();
+      final detailsMessengerKey = GlobalKey<ScaffoldMessengerState>();
+
+      await tester.pumpWidget(
+        WidgetTestBench(
+          overrides: [
+            correctionCaptureProvider.overrideWith(() => notifier),
+          ],
+          child: ScaffoldMessenger(
+            key: detailsMessengerKey,
+            child: const Scaffold(
+              body: CorrectionCaptureToastListener(
+                child: SizedBox.shrink(),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      tester
+          .stateList<ScaffoldMessengerState>(
+            find.byType(ScaffoldMessenger),
+          )
+          .singleWhere((state) => state != detailsMessengerKey.currentState)
+          .showSnackBar(
+            const SnackBar(content: Text('Global action succeeded')),
+          );
+      notifier.emit(
+        PendingCorrection(
+          before: 'Buy bred',
+          after: 'Buy bread',
+          createdAt: expiredDate,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Global action succeeded'), findsOneWidget);
+      expect(find.byType(CorrectionUndoSnackbarContent), findsOneWidget);
     });
   });
 }

--- a/test/features/tasks/ui/checklists/correction_undo_snackbar_test.dart
+++ b/test/features/tasks/ui/checklists/correction_undo_snackbar_test.dart
@@ -290,6 +290,41 @@ void main() {
       expect(find.byType(CorrectionUndoSnackbarContent), findsNothing);
     });
 
+    testWidgets('ignores corrections while its tab is inactive', (
+      tester,
+    ) async {
+      final notifier = _FakeCorrectionCaptureNotifier();
+
+      await tester.pumpWidget(
+        WidgetTestBench(
+          overrides: [
+            correctionCaptureProvider.overrideWith(() => notifier),
+          ],
+          child: const TickerMode(
+            enabled: false,
+            child: ScaffoldMessenger(
+              child: Scaffold(
+                body: CorrectionCaptureToastListener(
+                  child: SizedBox.shrink(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      notifier.emit(
+        PendingCorrection(
+          before: 'Buy bred',
+          after: 'Buy bread',
+          createdAt: expiredDate,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(CorrectionUndoSnackbarContent), findsNothing);
+    });
+
     testWidgets('does not suppress an independent global toast', (
       tester,
     ) async {

--- a/test/features/tasks/ui/pages/task_details_page_test.dart
+++ b/test/features/tasks/ui/pages/task_details_page_test.dart
@@ -25,6 +25,7 @@ import 'package:lotti/features/journal/ui/widgets/entry_detail_linked_from.dart'
 import 'package:lotti/features/journal/ui/widgets/linked_entries_with_timer.dart';
 import 'package:lotti/features/tasks/state/task_focus_controller.dart';
 import 'package:lotti/features/tasks/state/task_link_groups_controller.dart';
+import 'package:lotti/features/tasks/ui/checklists/correction_undo_snackbar.dart';
 import 'package:lotti/features/tasks/ui/header/desktop_task_header_connector.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/linked_tasks_widget.dart';
 import 'package:lotti/features/tasks/ui/pages/task_details_page.dart';
@@ -528,6 +529,13 @@ void main() {
           matching: find.byType(ScaffoldMessenger),
         );
         expect(nestedFinder, findsOneWidget);
+        expect(
+          find.descendant(
+            of: nestedFinder,
+            matching: find.byType(CorrectionCaptureToastListener),
+          ),
+          findsOneWidget,
+        );
 
         final nestedMessengerState = tester.state<ScaffoldMessengerState>(
           nestedFinder,


### PR DESCRIPTION
## [1.0.21]
### Fixed
- **Editing a checklist item on desktop no longer shows the correction toast
  twice.** The undo toast now appears only inside the task details pane while
  page-level notifications continue to work normally.

## Implementation

The app keeps tabs mounted in an `IndexedStack`. A checklist rendered in an inactive Journal tab could therefore retain a generic `ChecklistCardWrapper` listener while the active task details view had its own listener. Both listened to the same global correction-capture provider:

- the active task listener resolved the nested task-details `ScaffoldMessenger`, producing the task-column-width toast
- the background listener resolved the root `ScaffoldMessenger`, producing the full-app-width duplicate

Listener ownership now sits at the task and Journal details page boundaries. Each listener checks the shell's `TickerMode` visibility signal, so only the active surface handles a correction. Task details still resolves through its nested messenger; standalone Journal editing retains its page-level undo notification.

This PR also assembles the release notes, updates Flathub metainfo, and bumps the app to `1.0.21+4362`.

## Verification

- targeted widget tests: 74 passed
- `fvm flutter analyze`: no issues
- `make knowledge_check`: passed
- `make changelog_check`: passed
- strict changelog fragment validation: passed before assembly
- Flathub metainfo XML validation: passed
- regression tests were confirmed to fail before the visibility-aware fix:
  - an inactive tab emitted a correction toast
  - Journal details had no page-level correction listener
- mobile keeps the existing task-details messenger boundary; only listener ownership and inactive-tab gating changed

## Screenshots

Fixture data only; images are staged outside the repository.

| Before | After |
| --- | --- |
| Two notifications: task-column width and full-app width | One notification: task-column width only |
| ![Before: duplicate correction toasts](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/checklist-correction-toast/48d4c6364f3c01039d096abde4fc1f9aabdf8f7e/before/desktop_checklist_correction_toast_before.png) | ![After: scoped correction toast](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/checklist-correction-toast/48d4c6364f3c01039d096abde4fc1f9aabdf8f7e/after/desktop_checklist_correction_toast_after.png) |
