### PR TITLE
fix: map Google credential refresh outages

### DIFF
--- a/knowledge/features/sync/overview.md
+++ b/knowledge/features/sync/overview.md
@@ -154,6 +154,10 @@ before it touches Matrix. Pending escrow records the purchase-token fingerprint
 that authorized their current claim secret: only a verified replacement token
 can rebind it, while a second request for the same token must prove the existing
 secret.
+Application Default Credentials refresh failures caused by Google transport or
+credential errors are mapped to the same retryable service-unavailable response
+as transient Publisher API failures, so verification and RTDN callers receive
+HTTP 503 rather than an unclassified server error.
 A linked replacement must grant access before the repository can store it or
 retire the current token. First observations and the same-token path still
 persist denial state so reconciliation can suspend Matrix. Replacement audit

--- a/services/matrix-provisioning-service/README.md
+++ b/services/matrix-provisioning-service/README.md
@@ -107,6 +107,8 @@ Play Integrity verdict bound to the exact request, then queries
 `purchases.subscriptionsv2.get`. Product, base plan, package, release
 certificate, account binding, token lineage and production/test status all
 have to match before the service stores the subscription or provisions Matrix.
+Runtime ADC refresh transport and credential failures are normalized to the
+service's retryable HTTP 503 response rather than exposed as generic failures.
 The repository rejects a linked replacement token that does not grant access
 before changing the current token; first observations and denial transitions
 for an already-bound token remain durable so Matrix suspension can be enforced.

--- a/services/matrix-provisioning-service/src/services/google_play_client.py
+++ b/services/matrix-provisioning-service/src/services/google_play_client.py
@@ -9,6 +9,7 @@ from urllib.parse import quote
 
 import google.auth
 import httpx
+from google.auth.exceptions import RefreshError, TransportError
 from google.auth.transport.requests import Request
 
 from ..core.exceptions import (
@@ -52,7 +53,10 @@ class GoogleAccessTokenProvider:
         """Return a cached token, refreshing it once when necessary."""
         async with self._lock:
             if not self._credentials.valid:
-                await asyncio.to_thread(self._credentials.refresh, Request())
+                try:
+                    await asyncio.to_thread(self._credentials.refresh, Request())
+                except (TransportError, RefreshError) as exc:
+                    raise GooglePlayUnavailableException("Google credentials unavailable") from exc
             token = self._credentials.token
             if not token:
                 raise GooglePlayUnavailableException(

--- a/services/matrix-provisioning-service/tests/test_google_play_client.py
+++ b/services/matrix-provisioning-service/tests/test_google_play_client.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 
 import httpx
 import pytest
+from google.auth.exceptions import RefreshError, TransportError
 from src.core.exceptions import (
     GooglePlayUnavailableException,
     GooglePlayVerificationException,
@@ -227,6 +228,29 @@ async def test_access_token_provider_refreshes_invalid_credentials_once():
     assert await provider.get_token() == "refreshed-token"
     assert await provider.get_token() == "refreshed-token"
     assert credentials.refresh_count == 1
+
+
+@pytest.mark.parametrize(
+    "refresh_error",
+    [
+        pytest.param(TransportError("metadata unavailable"), id="transport"),
+        pytest.param(RefreshError("credential refresh failed"), id="refresh"),
+    ],
+)
+async def test_access_token_provider_maps_refresh_failures_to_unavailable(refresh_error):
+    class Credentials:
+        valid = False
+        token = None
+
+        def refresh(self, _request):
+            raise refresh_error
+
+    provider = GoogleAccessTokenProvider(Credentials())
+
+    with pytest.raises(GooglePlayUnavailableException, match="credentials unavailable") as caught:
+        await provider.get_token()
+
+    assert caught.value.__cause__ is refresh_error
 
 
 def test_application_default_credentials_use_android_publisher_scope(monkeypatch):


### PR DESCRIPTION
## Summary
- map Google ADC refresh transport and credential failures to `GooglePlayUnavailableException`
- preserve retryable HTTP 503 behavior during Google authentication outages
- document the availability contract for purchase verification and RTDN

## Tests
- `tests/test_google_play_client.py` (30 passed, 100% module coverage)
- Python flake8, isort, black, and Ruff security checks
- `make knowledge_check`
- `make changelog_check`

## Review context
Follow-up to #4077. The regression was run against the prior implementation and failed for both `TransportError` and `RefreshError`.

No changelog fragment: this fixes the subscription backend before that newly merged feature has shipped.