### PR TITLE
fix: restore event photo interactions

### DIFF
--- a/changelog.d/2026-08-30-event-photo-fixes.md
+++ b/changelog.d/2026-08-30-event-photo-fixes.md
@@ -1,0 +1,6 @@
+### Fixed
+- **Event photos now stay current and behave consistently everywhere.** Event
+  cards refresh when photos are linked locally or arrive through sync, photos
+  can be unlinked from an event without deleting them, and the full-screen
+  viewer now downloads the current photo, shows its date, hides its controls on
+  tap, and no longer rotates during pinch gestures.

--- a/knowledge/features/events.md
+++ b/knowledge/features/events.md
@@ -37,7 +37,7 @@ flowchart TD
     DB[(JournalDb + EntitiesCacheService)]
 
     subgraph Overview
-      ESP[eventsOverviewControllerProvider<br/>loadResolvedEventsPage paged] -->|ResolvedEvent page| OP[EventsOverviewPage]
+      ESP[eventsOverviewControllerProvider<br/>EVENT + LINK_CHANGED refresh<br/>loadResolvedEventsPage paged] -->|ResolvedEvent page| OP[EventsOverviewPage]
       OP -->|eventCardDataFromEvent<br/>+ groupEventsIntoSections| OV[EventsOverviewView]
       OV --> CARD[EventCard / EventFeatureCard]
     end
@@ -52,7 +52,7 @@ flowchart TD
     DB --> EC
     OV -->|tap card → /events/:id| DP
     OP -->|New event → createEvent → /events/:id| DP
-    DP -->|edit / add → /journal/:id| LEGACY[Entry detail surface]
+    DP -->|timeline open → /journal/:id<br/>?linkedFromId=:eventId| LEGACY[Entry detail surface<br/>confirmed unlink available]
 ```
 
 Presentational widgets render plain view models; **pages own the glue** — they
@@ -89,8 +89,20 @@ linked photos.
 
 Linked photos render as a compact grid and open into a swipeable, zoomable
 full-screen gallery. The gallery contains each image without changing its aspect
-ratio and participates in the shared mobile image-viewer orientation lifecycle
-described in [shared widgets](../architecture/shared-widgets.md).
+ratio, downloads the currently visible file, shows its capture/file date, hides
+all chrome on a single tap, and keeps pinch zoom/pan while rotation is disabled.
+It participates in the shared mobile image-viewer orientation lifecycle described
+in [shared widgets](../architecture/shared-widgets.md).
+
+The overview controller refreshes its loaded window for both event entity
+notifications and `LINK_CHANGED`. Photo links are separate rows from the event,
+so listening only for `EVENT` leaves fallback covers stale after local linking or
+sync. The merged update stream carries both origins.
+
+Opening a timeline source preserves the event id as `linkedFromId`. The
+standalone journal detail resolves that exact live link and exposes the existing
+confirmed unlink action; once removed, the link notification updates the event
+timeline, gallery, and overview cover without deleting the photo entry.
 
 *Add task* mirrors the linked-tasks flow — create the task linked from the event
 (so the event surfaces under the task's "Linked from"), auto-assign the category's

--- a/knowledge/features/events.md
+++ b/knowledge/features/events.md
@@ -94,15 +94,19 @@ all chrome on a single tap, and keeps pinch zoom/pan while rotation is disabled.
 It participates in the shared mobile image-viewer orientation lifecycle described
 in [shared widgets](../architecture/shared-widgets.md).
 
-The overview controller refreshes its loaded window for both event entity
-notifications and `LINK_CHANGED`. Photo links are separate rows from the event,
-so listening only for `EVENT` leaves fallback covers stale after local linking or
-sync. The merged update stream carries both origins.
+The overview controller refreshes its loaded window for event entity
+notifications and for `LINK_CHANGED` notifications whose endpoint ids include
+an event currently loaded in the overview. Photo links are separate rows from
+the event, so listening only for `EVENT` leaves fallback covers stale after
+local linking or sync; gating by endpoint avoids reloading covers for unrelated
+task and journal links.
 
-Opening a timeline source preserves the event id as `linkedFromId`. The
-standalone journal detail resolves that exact live link and exposes the existing
-confirmed unlink action; once removed, the link notification updates the event
-timeline, gallery, and overview cover without deleting the photo entry.
+Opening a timeline source preserves the event id as `linkedFromId`. Mobile
+passes it into the pushed detail page; desktop mirrors it beside the selected
+entry id into the split pane. The journal detail resolves that exact live link
+and exposes the existing confirmed unlink action; once removed, the link
+notification updates the event timeline, gallery, and overview cover without
+deleting the photo entry.
 
 *Add task* mirrors the linked-tasks flow — create the task linked from the event
 (so the event surfaces under the task's "Linked from"), auto-assign the category's

--- a/lib/beamer/locations/journal_location.dart
+++ b/lib/beamer/locations/journal_location.dart
@@ -24,6 +24,8 @@ class JournalLocation extends BeamLocation<BeamState> {
     // `/journal/:entryId` also greedily matches the `fill_survey` segment, so
     // only a real uuid counts as an entry selection.
     final entryId = isUuid(rawEntryId) ? rawEntryId : null;
+    final rawLinkedFromId = state.queryParameters['linkedFromId'];
+    final linkedFromId = isUuid(rawLinkedFromId) ? rawLinkedFromId : null;
     final navService = getIt<NavService>();
     final isDesktop = navService.isDesktopMode;
 
@@ -49,7 +51,10 @@ class JournalLocation extends BeamLocation<BeamState> {
       if (!isDesktop && entryId != null)
         BeamPage(
           key: ValueKey('journal-$entryId'),
-          child: EntryDetailsPage(itemId: entryId),
+          child: EntryDetailsPage(
+            itemId: entryId,
+            linkedFromId: linkedFromId,
+          ),
         ),
     ];
   }

--- a/lib/beamer/locations/journal_location.dart
+++ b/lib/beamer/locations/journal_location.dart
@@ -37,6 +37,9 @@ class JournalLocation extends BeamLocation<BeamState> {
       scheduleMicrotask(() {
         if (getIt.isRegistered<NavService>() &&
             identical(getIt<NavService>(), navService)) {
+          navService.desktopSelectedEntryLinkedFromId.value = entryId == null
+              ? null
+              : linkedFromId;
           navService.desktopSelectedEntryId.value = entryId;
         }
       });

--- a/lib/features/events/state/event_view_mapping.dart
+++ b/lib/features/events/state/event_view_mapping.dart
@@ -34,6 +34,7 @@ EventTimelineEntry? eventTimelineEntryFor(
   required String timeLabel,
   required String Function(DateTime) formatTime,
   required ImageProvider Function(JournalImage image) imageProviderFor,
+  String Function(JournalImage image)? imagePathFor,
   Widget Function(JournalAudio audio)? audioPlayerFor,
 }) {
   return switch (entity) {
@@ -42,7 +43,14 @@ EventTimelineEntry? eventTimelineEntryFor(
       kind: EventTimelineKind.photo,
       entryId: image.meta.id,
       text: _trimmedNote(image),
-      photos: [EventPhoto(imageProviderFor(image))],
+      photos: [
+        EventPhoto(
+          imageProviderFor(image),
+          filePath: imagePathFor?.call(image),
+          capturedAt: image.data.capturedAt,
+          fileDate: image.meta.dateFrom,
+        ),
+      ],
     ),
     final JournalAudio audio => EventTimelineEntry(
       timeLabel: timeLabel,
@@ -119,6 +127,7 @@ EventDetailData eventDetailDataFromEntities({
   required String fallbackTitle,
   required String Function(DateTime) formatTime,
   required ImageProvider Function(JournalImage image) imageProviderFor,
+  String Function(JournalImage image)? imagePathFor,
   Widget Function(JournalAudio audio)? audioPlayerFor,
   String? categoryName,
 }) {
@@ -160,6 +169,7 @@ EventDetailData eventDetailDataFromEntities({
       timeLabel: formatTime(entity.meta.dateFrom.toLocal()),
       formatTime: formatTime,
       imageProviderFor: imageProviderFor,
+      imagePathFor: imagePathFor,
       audioPlayerFor: audioPlayerFor,
     );
     if (timelineEntry != null) timeline.add(timelineEntry);
@@ -178,7 +188,12 @@ EventDetailData eventDetailDataFromEntities({
   // All linked photos, oldest first, for the gallery grid.
   final photos = [
     for (final image in sorted.whereType<JournalImage>())
-      EventPhoto(imageProviderFor(image)),
+      EventPhoto(
+        imageProviderFor(image),
+        filePath: imagePathFor?.call(image),
+        capturedAt: image.data.capturedAt,
+        fileDate: image.meta.dateFrom,
+      ),
   ];
 
   final note = event.entryText?.plainText.trim();

--- a/lib/features/events/state/events_overview_controller.dart
+++ b/lib/features/events/state/events_overview_controller.dart
@@ -58,8 +58,14 @@ class EventsOverviewController extends AsyncNotifier<EventsOverviewState> {
   @override
   Future<EventsOverviewState> build() async {
     final sub = getIt<UpdateNotifications>().updateStream.listen((affected) {
-      if (affected.contains(eventNotification) ||
-          affected.contains(linkNotification)) {
+      final loadedEventIds = state.value?.events
+          .map((resolved) => resolved.event.meta.id)
+          .toSet();
+      final affectsLoadedEventLink =
+          affected.contains(linkNotification) &&
+          loadedEventIds != null &&
+          affected.any(loadedEventIds.contains);
+      if (affected.contains(eventNotification) || affectsLoadedEventLink) {
         unawaited(_refresh());
       }
     });

--- a/lib/features/events/state/events_overview_controller.dart
+++ b/lib/features/events/state/events_overview_controller.dart
@@ -58,7 +58,8 @@ class EventsOverviewController extends AsyncNotifier<EventsOverviewState> {
   @override
   Future<EventsOverviewState> build() async {
     final sub = getIt<UpdateNotifications>().updateStream.listen((affected) {
-      if (affected.contains(eventNotification)) {
+      if (affected.contains(eventNotification) ||
+          affected.contains(linkNotification)) {
         unawaited(_refresh());
       }
     });

--- a/lib/features/events/ui/model/event_view_data.dart
+++ b/lib/features/events/ui/model/event_view_data.dart
@@ -95,10 +95,27 @@ enum EventTimelineKind { photo, note, audio, timeRecording }
 
 @immutable
 class EventPhoto {
-  const EventPhoto(this.image, {this.cropX = 0.5});
+  const EventPhoto(
+    this.image, {
+    this.cropX = 0.5,
+    this.filePath,
+    this.capturedAt,
+    this.fileDate,
+  });
 
   final ImageProvider image;
   final double cropX;
+
+  /// Original file used by the full-screen viewer's download action.
+  final String? filePath;
+
+  /// Embedded capture timestamp when the source photo supplied one.
+  final DateTime? capturedAt;
+
+  /// Journal/file timestamp used when capture metadata is unavailable.
+  final DateTime? fileDate;
+
+  DateTime? get displayDate => capturedAt ?? fileDate;
 }
 
 /// One item on an event's vertical timeline of linked entries.

--- a/lib/features/events/ui/pages/event_detail_page.dart
+++ b/lib/features/events/ui/pages/event_detail_page.dart
@@ -87,6 +87,8 @@ class EventDetailPage extends ConsumerWidget {
       imageProviderFor: (image) => FileImage(
         File(getFullImagePath(image, documentsDirectory: documentsDirectory)),
       ),
+      imagePathFor: (image) =>
+          getFullImagePath(image, documentsDirectory: documentsDirectory),
       // A voice memo on an event's timeline now plays where it sits, instead
       // of only naming its duration. The app-wide player means starting one
       // beat stops any other.
@@ -209,7 +211,14 @@ class EventDetailPage extends ConsumerWidget {
       onDelete: confirmDelete,
       onAddToTimeline: addLinkedEntry,
       onAddTask: addTask,
-      onOpenTimelineEntry: (entryId) => beamToNamed('/journal/$entryId'),
+      // Preserve the parent event in the route so the standalone entry menu
+      // can offer the existing confirmed unlink action for this exact link.
+      onOpenTimelineEntry: (entryId) => beamToNamed(
+        Uri(
+          path: '/journal/$entryId',
+          queryParameters: {'linkedFromId': eventId},
+        ).toString(),
+      ),
       onOpenTask: (taskId) => beamToNamed('/tasks/$taskId'),
     );
   }

--- a/lib/features/events/ui/widgets/event_photo_gallery.dart
+++ b/lib/features/events/ui/widgets/event_photo_gallery.dart
@@ -1,8 +1,10 @@
-import 'dart:ui';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/events/ui/model/event_view_data.dart';
+import 'package:lotti/features/journal/ui/widgets/entry_image_widget.dart';
+import 'package:lotti/features/journal/util/image_export_service.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/media/image_viewer_orientation_scope.dart';
 import 'package:photo_view/photo_view.dart';
@@ -155,11 +157,13 @@ class EventPhotoGalleryViewer extends StatefulWidget {
   const EventPhotoGalleryViewer({
     required this.photos,
     this.initialIndex = 0,
+    this.imageExporter,
     super.key,
   });
 
   final List<EventPhoto> photos;
   final int initialIndex;
+  final ImageExporter? imageExporter;
 
   @override
   State<EventPhotoGalleryViewer> createState() =>
@@ -171,6 +175,13 @@ class _EventPhotoGalleryViewerState extends State<EventPhotoGalleryViewer> {
     initialPage: widget.initialIndex,
   );
   late int _index = widget.initialIndex;
+  bool _overlaysVisible = true;
+
+  EventPhoto get _currentPhoto => widget.photos[_index];
+
+  void _toggleOverlays() {
+    setState(() => _overlaysVisible = !_overlaysVisible);
+  }
 
   @override
   void dispose() {
@@ -187,20 +198,26 @@ class _EventPhotoGalleryViewerState extends State<EventPhotoGalleryViewer> {
         backgroundColor: Colors.black,
         body: Stack(
           children: [
-            PhotoViewGallery.builder(
-              pageController: _controller,
-              itemCount: widget.photos.length,
-              onPageChanged: (i) => setState(() => _index = i),
-              backgroundDecoration: const BoxDecoration(color: Colors.black),
-              builder: (context, i) => PhotoViewGalleryPageOptions(
-                imageProvider: widget.photos[i].image,
-                minScale: PhotoViewComputedScale.contained,
-                maxScale: PhotoViewComputedScale.covered * 3,
-                heroAttributes: PhotoViewHeroAttributes(tag: 'event_photo_$i'),
+            ImageViewerTapRegion(
+              onSingleTap: _toggleOverlays,
+              child: PhotoViewGallery.builder(
+                pageController: _controller,
+                itemCount: widget.photos.length,
+                // PhotoViewGallery defaults rotation off; do not opt in here.
+                onPageChanged: (i) => setState(() => _index = i),
+                backgroundDecoration: const BoxDecoration(color: Colors.black),
+                builder: (context, i) => PhotoViewGalleryPageOptions(
+                  imageProvider: widget.photos[i].image,
+                  minScale: PhotoViewComputedScale.contained,
+                  maxScale: PhotoViewComputedScale.covered * 3,
+                  heroAttributes: PhotoViewHeroAttributes(
+                    tag: 'event_photo_$i',
+                  ),
+                ),
               ),
             ),
             // Page indicator (e.g. "3 / 12").
-            if (widget.photos.length > 1)
+            if (_overlaysVisible && widget.photos.length > 1)
               Positioned(
                 top: padding.top + tokens.spacing.step3,
                 left: 0,
@@ -228,29 +245,43 @@ class _EventPhotoGalleryViewerState extends State<EventPhotoGalleryViewer> {
                   ),
                 ),
               ),
-            Positioned(
-              right: padding.right,
-              top: padding.top,
-              child: IconButton(
-                tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
-                padding: EdgeInsets.all(tokens.spacing.step6),
-                onPressed: () =>
-                    Navigator.of(context, rootNavigator: true).pop(),
-                icon: Stack(
+            if (_overlaysVisible)
+              Positioned(
+                right: padding.right + tokens.spacing.step3,
+                top: padding.top + tokens.spacing.step3,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
                   children: [
-                    ImageFiltered(
-                      imageFilter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-                      child: const Icon(LottiIcons.close, size: 30),
+                    ImageViewerDownloadButton(
+                      file: _currentPhoto.filePath == null
+                          ? null
+                          : File(_currentPhoto.filePath!),
+                      imageExporter: widget.imageExporter,
+                      logDomain: 'event_photo_gallery',
                     ),
-                    const Icon(
-                      LottiIcons.close,
-                      size: 30,
-                      color: Colors.white,
+                    SizedBox(width: tokens.spacing.step2),
+                    ImageViewerIconButton(
+                      tooltip: MaterialLocalizations.of(
+                        context,
+                      ).closeButtonTooltip,
+                      icon: LottiIcons.close,
+                      onPressed: () =>
+                          Navigator.of(context, rootNavigator: true).pop(),
                     ),
                   ],
                 ),
               ),
-            ),
+            if (_overlaysVisible && _currentPhoto.displayDate != null)
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: padding.bottom + tokens.spacing.step4,
+                child: Center(
+                  child: ImageViewerDateChip(
+                    date: _currentPhoto.displayDate!,
+                  ),
+                ),
+              ),
           ],
         ),
       ),

--- a/lib/features/journal/ui/pages/entry_details_page.dart
+++ b/lib/features/journal/ui/pages/entry_details_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/ai/helpers/automatic_image_analysis_trigger.dart';
 import 'package:lotti/features/ai/state/consts.dart';
@@ -11,6 +12,7 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/design_system/theme/ds_surface_elevation.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/features/journal/state/journal_focus_controller.dart';
+import 'package:lotti/features/journal/state/linked_entries_controller.dart';
 import 'package:lotti/features/journal/ui/mixins/highlight_scroll_mixin.dart';
 import 'package:lotti/features/journal/ui/widgets/create/create_entry_action_button.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_detail_linked_from.dart';
@@ -46,10 +48,16 @@ class EntryDetailsPage extends ConsumerStatefulWidget {
   const EntryDetailsPage({
     required this.itemId,
     this.showBackButton = true,
+    this.linkedFromId,
     super.key,
   });
 
   final String itemId;
+
+  /// Optional source whose outgoing link opened this standalone detail page.
+  /// Keeping it lets the entry overflow menu detach that link without deleting
+  /// the entry itself.
+  final String? linkedFromId;
 
   /// Whether the app bar renders a back affordance.
   ///
@@ -123,6 +131,28 @@ class _EntryDetailsPageState extends ConsumerState<EntryDetailsPage>
     final asyncItem = ref.watch(provider);
     final item = asyncItem.value?.entry;
     final tokens = context.designTokens;
+
+    JournalEntity? linkedFrom;
+    EntryLink? sourceLink;
+    final linkedFromId = widget.linkedFromId;
+    if (linkedFromId != null) {
+      final candidate = ref
+          .watch(entryControllerProvider(linkedFromId))
+          .value
+          ?.entry;
+      final links = ref
+          .watch(linkedEntriesControllerProvider(linkedFromId))
+          .value;
+      if (candidate != null && links != null) {
+        for (final link in links) {
+          if (link.toId == widget.itemId) {
+            linkedFrom = candidate;
+            sourceLink = link;
+            break;
+          }
+        }
+      }
+    }
 
     // Only attempt to scroll after entry data is loaded
     if (asyncItem.hasValue && item != null) {
@@ -202,6 +232,8 @@ class _EntryDetailsPageState extends ConsumerState<EntryDetailsPage>
                                     itemId: widget.itemId,
                                     showTaskDetails: true,
                                     showAiEntry: true,
+                                    linkedFrom: linkedFrom,
+                                    link: sourceLink,
                                   ),
                                   // Linked rows carry only the tight step2
                                   // embedded card inset; pad the sections up

--- a/lib/features/journal/ui/pages/journal_root_page.dart
+++ b/lib/features/journal/ui/pages/journal_root_page.dart
@@ -82,56 +82,61 @@ class JournalRootPage extends ConsumerWidget {
             child: ValueListenableBuilder<String?>(
               valueListenable: getIt<NavService>().desktopSelectedEntryId,
               builder: (context, selectedEntryId, _) {
-                final child = selectedEntryId != null
-                    ? EntryDetailsPage(
-                        key: ValueKey(selectedEntryId),
-                        itemId: selectedEntryId,
-                        // The list stays on screen beside the details, so
-                        // there is nothing to go back to. The details keep
-                        // their own FAB: it creates a linked entry, which the
-                        // list pane's standalone-entry FAB cannot.
-                        showBackButton: false,
-                      )
-                    // Reachable only when the feed itself is empty (or holds
-                    // only tasks/events): the list pane already carries the
-                    // "logbook is empty" message and the create CTA, so this
-                    // pane defers with a quiet forward-pointing hint instead
-                    // of echoing the same title at equal weight.
-                    : Padding(
-                        key: const ValueKey<String>(
-                          'journal-root-empty-detail',
-                        ),
-                        // The list pane's zero-state centers in the viewport
-                        // BELOW its header band; this pane has no header, so
-                        // an equivalent top offset keeps both empty blocks on
-                        // one optical horizon across the split.
-                        padding: EdgeInsets.only(
-                          top:
-                              context.designTokens.spacing.step11 +
-                              context.designTokens.spacing.step6,
-                        ),
-                        child: DesignSystemEmptyState(
-                          icon: LottiIcons.book,
-                          hint: context.messages.logbookNewEntriesHint,
-                        ),
-                      );
+                return ValueListenableBuilder<String?>(
+                  valueListenable:
+                      getIt<NavService>().desktopSelectedEntryLinkedFromId,
+                  builder: (context, linkedFromId, _) {
+                    final child = selectedEntryId != null
+                        ? EntryDetailsPage(
+                            key: ValueKey((selectedEntryId, linkedFromId)),
+                            itemId: selectedEntryId,
+                            linkedFromId: linkedFromId,
+                            // The list stays on screen beside the details, so
+                            // there is nothing to go back to. The details keep
+                            // their own FAB: it creates a linked entry, which
+                            // the list pane's standalone-entry FAB cannot.
+                            showBackButton: false,
+                          )
+                        // Reachable only when the feed itself is empty (or
+                        // holds only tasks/events): the list pane already
+                        // carries the "logbook is empty" message and create
+                        // CTA, so this pane defers with a quiet hint.
+                        : Padding(
+                            key: const ValueKey<String>(
+                              'journal-root-empty-detail',
+                            ),
+                            // The list pane's zero-state centers below its
+                            // header band; this equivalent offset keeps both
+                            // empty blocks on one optical horizon.
+                            padding: EdgeInsets.only(
+                              top:
+                                  context.designTokens.spacing.step11 +
+                                  context.designTokens.spacing.step6,
+                            ),
+                            child: DesignSystemEmptyState(
+                              icon: LottiIcons.book,
+                              hint: context.messages.logbookNewEntriesHint,
+                            ),
+                          );
 
-                return AnimatedSwitcher(
-                  duration: journalDetailSwitchDuration,
-                  switchInCurve: Curves.easeInOutCubic,
-                  switchOutCurve: Curves.easeInOutCubic,
-                  layoutBuilder: (currentChild, previousChildren) {
-                    return Stack(
-                      fit: StackFit.expand,
-                      children: <Widget>[
-                        ...previousChildren.map(
-                          (child) => ExcludeFocus(child: child),
-                        ),
-                        ?currentChild,
-                      ],
+                    return AnimatedSwitcher(
+                      duration: journalDetailSwitchDuration,
+                      switchInCurve: Curves.easeInOutCubic,
+                      switchOutCurve: Curves.easeInOutCubic,
+                      layoutBuilder: (currentChild, previousChildren) {
+                        return Stack(
+                          fit: StackFit.expand,
+                          children: <Widget>[
+                            ...previousChildren.map(
+                              (child) => ExcludeFocus(child: child),
+                            ),
+                            ?currentChild,
+                          ],
+                        );
+                      },
+                      child: child,
                     );
                   },
-                  child: child,
                 );
               },
             ),

--- a/lib/features/journal/ui/widgets/entry_image_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_image_widget.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
@@ -50,7 +52,11 @@ class EntryImageWidget extends ConsumerWidget {
     return GestureDetector(
       onTap: () {
         focusNode.unfocus();
-        showFullscreenImageViewer(context, file: file);
+        showFullscreenImageViewer(
+          context,
+          file: file,
+          date: journalImage.data.capturedAt,
+        );
       },
       child: ColoredBox(
         color: Colors.black,
@@ -89,6 +95,8 @@ void showFullscreenImageViewer(
   required File file,
   Object heroTag = 'entry_img',
   List<File>? gallery,
+  DateTime? date,
+  List<DateTime?>? galleryDates,
   int initialIndex = 0,
 }) {
   Navigator.of(context, rootNavigator: true).push(
@@ -102,6 +110,8 @@ void showFullscreenImageViewer(
             file: file,
             heroTag: heroTag,
             gallery: gallery,
+            date: date,
+            galleryDates: galleryDates,
             initialIndex: initialIndex,
           ),
     ),
@@ -117,6 +127,8 @@ class HeroPhotoViewRouteWrapper extends StatefulWidget {
     this.heroTag = 'entry_img',
     this.imageExporter,
     this.gallery,
+    this.date,
+    this.galleryDates,
     this.initialIndex = 0,
   });
 
@@ -132,6 +144,13 @@ class HeroPhotoViewRouteWrapper extends StatefulWidget {
   /// viewer should allow moving between them. Null (or a single entry) keeps
   /// the single-image behavior. [file] is expected to sit at [initialIndex].
   final List<File>? gallery;
+
+  /// Capture date for [file], falling back to the journal/file date at the
+  /// call site when embedded metadata is unavailable.
+  final DateTime? date;
+
+  /// Dates corresponding to [gallery], in the same display order.
+  final List<DateTime?>? galleryDates;
 
   /// Index of the initially shown image within [gallery]. Only the initial
   /// image participates in the Hero transition — after navigating away, a pop
@@ -150,13 +169,10 @@ class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
   late final PhotoViewController _photoController;
   late final PhotoViewScaleStateController _scaleStateController;
   late final StreamSubscription<PhotoViewControllerValue> _photoSubscription;
-  late final ImageExporter _exporter =
-      widget.imageExporter ?? defaultImageExporter();
-
   double _scale = 1;
   double? _minimumScale;
   Size? _lastSize;
-  bool _isDownloading = false;
+  bool _overlaysVisible = true;
 
   late final List<File> _files =
       (widget.gallery == null || widget.gallery!.isEmpty)
@@ -173,6 +189,14 @@ class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
   bool get _canGoNext => _index < _files.length - 1;
 
   File get _currentFile => _files[_index];
+
+  DateTime? get _currentDate {
+    final galleryDates = widget.galleryDates;
+    if (galleryDates != null && _index < galleryDates.length) {
+      return galleryDates[_index];
+    }
+    return _index == _initialIndex ? widget.date : null;
+  }
 
   void _goToPrevious() => _goTo(_index - 1);
 
@@ -226,6 +250,10 @@ class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
 
   void _close() => Navigator.of(context, rootNavigator: true).pop();
 
+  void _toggleOverlays() {
+    setState(() => _overlaysVisible = !_overlaysVisible);
+  }
+
   void _zoomIn() {
     _setZoom(_scale * _zoomFactor);
   }
@@ -251,54 +279,6 @@ class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
       position: Offset.zero,
       scale: nextScale,
     );
-  }
-
-  Future<void> _downloadImage() async {
-    if (_isDownloading) {
-      return;
-    }
-
-    setState(() => _isDownloading = true);
-    try {
-      final result = await _exporter(_currentFile);
-      if (!mounted) {
-        return;
-      }
-      switch (result.status) {
-        case ImageExportStatus.savedToFile:
-          _showSnackBar(
-            context.messages.imageViewerDownloadSaved(result.savedName ?? ''),
-          );
-        case ImageExportStatus.savedToGallery:
-          _showSnackBar(context.messages.imageViewerDownloadSavedToGallery);
-        case ImageExportStatus.permissionDenied:
-          _showSnackBar(context.messages.imageViewerDownloadPermissionDenied);
-        case ImageExportStatus.cancelled:
-          // User dismissed the save panel; no feedback needed.
-          break;
-      }
-    } on Object catch (error, stackTrace) {
-      getIt<LoggingService>().captureException(
-        error,
-        domain: 'entry_image_widget',
-        subDomain: 'downloadImage',
-        stackTrace: stackTrace,
-      );
-      if (!mounted) {
-        return;
-      }
-      _showSnackBar(context.messages.imageViewerDownloadFailed);
-    } finally {
-      if (mounted) {
-        setState(() => _isDownloading = false);
-      }
-    }
-  }
-
-  void _showSnackBar(String message) {
-    ScaffoldMessenger.of(context)
-      ..hideCurrentSnackBar()
-      ..showSnackBar(SnackBar(content: Text(message)));
   }
 
   @override
@@ -332,35 +312,39 @@ class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
             body: Stack(
               children: [
                 Positioned.fill(
-                  child: PhotoView(
-                    imageProvider: imageProvider,
-                    enableRotation: true,
-                    backgroundDecoration:
-                        widget.backgroundDecoration ??
-                        BoxDecoration(
-                          color: Theme.of(context).colorScheme.scrim,
-                        ),
-                    controller: _photoController,
-                    scaleStateController: _scaleStateController,
-                    // Only the initially opened image flies back to its source
-                    // tile; after navigating, a hero pop would pair the wrong
-                    // image with the tile the viewer was opened from.
-                    heroAttributes: _index == _initialIndex
-                        ? PhotoViewHeroAttributes(tag: widget.heroTag)
-                        : null,
-                    minScale: PhotoViewComputedScale.contained,
-                    maxScale: PhotoViewComputedScale.covered * 4,
-                    initialScale: PhotoViewComputedScale.contained,
-                    strictScale: true,
+                  child: ImageViewerTapRegion(
+                    onSingleTap: _toggleOverlays,
+                    child: PhotoView(
+                      imageProvider: imageProvider,
+                      // PhotoView defaults rotation off; do not opt in here.
+                      backgroundDecoration:
+                          widget.backgroundDecoration ??
+                          BoxDecoration(
+                            color: Theme.of(context).colorScheme.scrim,
+                          ),
+                      controller: _photoController,
+                      scaleStateController: _scaleStateController,
+                      // Only the initially opened image flies back to its
+                      // source tile; after navigating, a hero pop would pair
+                      // the wrong image with the tile the viewer was opened
+                      // from.
+                      heroAttributes: _index == _initialIndex
+                          ? PhotoViewHeroAttributes(tag: widget.heroTag)
+                          : null,
+                      minScale: PhotoViewComputedScale.contained,
+                      maxScale: PhotoViewComputedScale.covered * 4,
+                      initialScale: PhotoViewComputedScale.contained,
+                      strictScale: true,
+                    ),
                   ),
                 ),
-                if (_hasGallery) ...[
+                if (_overlaysVisible && _hasGallery) ...[
                   Positioned(
                     left: padding.left + edge,
                     top: 0,
                     bottom: 0,
                     child: Center(
-                      child: _ImageViewerIconButton(
+                      child: ImageViewerIconButton(
                         tooltip: context.messages.imageViewerPreviousTooltip,
                         icon: LottiIcons.chevronLeft,
                         onPressed: _canGoPrevious ? _goToPrevious : null,
@@ -372,7 +356,7 @@ class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
                     top: 0,
                     bottom: 0,
                     child: Center(
-                      child: _ImageViewerIconButton(
+                      child: ImageViewerIconButton(
                         tooltip: context.messages.imageViewerNextTooltip,
                         icon: LottiIcons.chevronRight,
                         onPressed: _canGoNext ? _goToNext : null,
@@ -388,48 +372,53 @@ class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
                     ),
                   ),
                 ],
-                Positioned(
-                  right: padding.right + edge,
-                  top: padding.top + tokens.spacing.step3,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      _ImageViewerIconButton(
-                        tooltip: _isDownloading
-                            ? context.messages.imageViewerDownloadingTooltip
-                            : context.messages.imageViewerDownloadTooltip,
-                        icon: _isDownloading
-                            ? LottiIcons.pending
-                            : LottiIcons.download,
-                        onPressed: _isDownloading
-                            ? null
-                            : () => unawaited(_downloadImage()),
-                      ),
-                      SizedBox(width: tokens.spacing.step2),
-                      _ImageViewerIconButton(
-                        tooltip: MaterialLocalizations.of(
-                          context,
-                        ).closeButtonTooltip,
-                        icon: LottiIcons.close,
-                        onPressed: _close,
-                      ),
-                    ],
-                  ),
-                ),
-                Positioned(
-                  left: 0,
-                  right: 0,
-                  bottom: padding.bottom + tokens.spacing.step4,
-                  child: Center(
-                    child: _ImageViewerZoomControls(
-                      scale: _scale,
-                      canZoomOut: canZoomOut,
-                      onZoomOut: canZoomOut ? _zoomOut : null,
-                      onZoomReset: _resetZoom,
-                      onZoomIn: _zoomIn,
+                if (_overlaysVisible)
+                  Positioned(
+                    right: padding.right + edge,
+                    top: padding.top + tokens.spacing.step3,
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        ImageViewerDownloadButton(
+                          file: _currentFile,
+                          imageExporter: widget.imageExporter,
+                          logDomain: 'entry_image_widget',
+                        ),
+                        SizedBox(width: tokens.spacing.step2),
+                        ImageViewerIconButton(
+                          tooltip: MaterialLocalizations.of(
+                            context,
+                          ).closeButtonTooltip,
+                          icon: LottiIcons.close,
+                          onPressed: _close,
+                        ),
+                      ],
                     ),
                   ),
-                ),
+                if (_overlaysVisible)
+                  Positioned(
+                    left: 0,
+                    right: 0,
+                    bottom: padding.bottom + tokens.spacing.step4,
+                    child: Center(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (_currentDate != null) ...[
+                            ImageViewerDateChip(date: _currentDate!),
+                            SizedBox(height: tokens.spacing.step2),
+                          ],
+                          _ImageViewerZoomControls(
+                            scale: _scale,
+                            canZoomOut: canZoomOut,
+                            onZoomOut: canZoomOut ? _zoomOut : null,
+                            onZoomReset: _resetZoom,
+                            onZoomIn: _zoomIn,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
               ],
             ),
           ),
@@ -472,11 +461,12 @@ class _ImageViewerCounterChip extends StatelessWidget {
   }
 }
 
-class _ImageViewerIconButton extends StatelessWidget {
-  const _ImageViewerIconButton({
+class ImageViewerIconButton extends StatelessWidget {
+  const ImageViewerIconButton({
     required this.tooltip,
     required this.icon,
     required this.onPressed,
+    super.key,
   });
 
   final String tooltip;
@@ -498,6 +488,197 @@ class _ImageViewerIconButton extends StatelessWidget {
         onPressed: onPressed,
         icon: Icon(icon),
       ),
+    );
+  }
+}
+
+/// Download control shared by the single-photo and event gallery viewers.
+///
+/// It owns the in-flight guard and platform-specific result feedback so both
+/// viewer modes have identical permissions, progress, and error behavior.
+class ImageViewerDownloadButton extends StatefulWidget {
+  const ImageViewerDownloadButton({
+    required this.file,
+    required this.logDomain,
+    this.imageExporter,
+    super.key,
+  });
+
+  final File? file;
+  final String logDomain;
+  final ImageExporter? imageExporter;
+
+  @override
+  State<ImageViewerDownloadButton> createState() =>
+      _ImageViewerDownloadButtonState();
+}
+
+class _ImageViewerDownloadButtonState extends State<ImageViewerDownloadButton> {
+  bool _isDownloading = false;
+
+  Future<void> _downloadImage() async {
+    final file = widget.file;
+    if (_isDownloading || file == null) return;
+
+    setState(() => _isDownloading = true);
+    try {
+      final exporter = widget.imageExporter ?? defaultImageExporter();
+      final result = await exporter(file);
+      if (!mounted) return;
+      switch (result.status) {
+        case ImageExportStatus.savedToFile:
+          _showSnackBar(
+            context.messages.imageViewerDownloadSaved(result.savedName ?? ''),
+          );
+        case ImageExportStatus.savedToGallery:
+          _showSnackBar(context.messages.imageViewerDownloadSavedToGallery);
+        case ImageExportStatus.permissionDenied:
+          _showSnackBar(context.messages.imageViewerDownloadPermissionDenied);
+        case ImageExportStatus.cancelled:
+          break;
+      }
+    } on Object catch (error, stackTrace) {
+      getIt<LoggingService>().captureException(
+        error,
+        domain: widget.logDomain,
+        subDomain: 'downloadImage',
+        stackTrace: stackTrace,
+      );
+      if (mounted) {
+        _showSnackBar(context.messages.imageViewerDownloadFailed);
+      }
+    } finally {
+      if (mounted) setState(() => _isDownloading = false);
+    }
+  }
+
+  void _showSnackBar(String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ImageViewerIconButton(
+      tooltip: _isDownloading
+          ? context.messages.imageViewerDownloadingTooltip
+          : context.messages.imageViewerDownloadTooltip,
+      icon: _isDownloading ? LottiIcons.pending : LottiIcons.download,
+      onPressed: _isDownloading || widget.file == null
+          ? null
+          : () => unawaited(_downloadImage()),
+    );
+  }
+}
+
+/// Locale-aware date chip shared by all full-screen image viewer modes.
+class ImageViewerDateChip extends StatelessWidget {
+  const ImageViewerDateChip({required this.date, super.key});
+
+  final DateTime date;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final locale = Localizations.localeOf(context).toString();
+    return Material(
+      color: Theme.of(context).colorScheme.scrim.withValues(alpha: 0.62),
+      borderRadius: BorderRadius.circular(tokens.radii.badgesPills),
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: tokens.spacing.step4,
+          vertical: tokens.spacing.step2,
+        ),
+        child: Text(
+          DateFormat.yMMMd(locale).format(date.toLocal()),
+          style: tokens.typography.styles.body.bodyMedium.copyWith(
+            color: Colors.white,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Passive tap recognizer for an image canvas.
+///
+/// A [Listener] observes pointers without joining `photo_view`'s gesture arena,
+/// so scale/pan and double-tap zoom keep their native handling. Only a
+/// stationary one-finger tap toggles the chrome; the callback waits through
+/// [kDoubleTapTimeout] and is cancelled by a second tap.
+class ImageViewerTapRegion extends StatefulWidget {
+  const ImageViewerTapRegion({
+    required this.onSingleTap,
+    required this.child,
+    super.key,
+  });
+
+  final VoidCallback onSingleTap;
+  final Widget child;
+
+  @override
+  State<ImageViewerTapRegion> createState() => _ImageViewerTapRegionState();
+}
+
+class _ImageViewerTapRegionState extends State<ImageViewerTapRegion> {
+  final Set<int> _activePointers = {};
+  Offset? _origin;
+  bool _disqualified = false;
+  Timer? _pendingTap;
+
+  void _onPointerDown(PointerDownEvent event) {
+    if (_activePointers.isEmpty) {
+      _origin = event.position;
+      _disqualified = false;
+    }
+    _activePointers.add(event.pointer);
+    if (_activePointers.length > 1) _disqualified = true;
+  }
+
+  void _onPointerMove(PointerMoveEvent event) {
+    final origin = _origin;
+    if (origin != null && (event.position - origin).distance > kTouchSlop) {
+      _disqualified = true;
+    }
+  }
+
+  void _onPointerUp(PointerUpEvent event) {
+    _activePointers.remove(event.pointer);
+    if (_activePointers.isNotEmpty || _disqualified) return;
+
+    final pendingTap = _pendingTap;
+    if (pendingTap?.isActive ?? false) {
+      pendingTap!.cancel();
+      _pendingTap = null;
+      return;
+    }
+    _pendingTap = Timer(kDoubleTapTimeout, () {
+      _pendingTap = null;
+      if (mounted) widget.onSingleTap();
+    });
+  }
+
+  void _onPointerCancel(PointerCancelEvent event) {
+    _activePointers.remove(event.pointer);
+    _disqualified = true;
+  }
+
+  @override
+  void dispose() {
+    _pendingTap?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: _onPointerDown,
+      onPointerMove: _onPointerMove,
+      onPointerUp: _onPointerUp,
+      onPointerCancel: _onPointerCancel,
+      child: widget.child,
     );
   }
 }

--- a/lib/features/tasks/ui/cover_art_background.dart
+++ b/lib/features/tasks/ui/cover_art_background.dart
@@ -128,6 +128,7 @@ class _CoverArtBackgroundState extends ConsumerState<CoverArtBackground>
       context,
       file: file,
       heroTag: heroTag,
+      date: entry.data.capturedAt,
     );
 
     final coverArt = Stack(

--- a/lib/services/nav_service.dart
+++ b/lib/services/nav_service.dart
@@ -258,6 +258,14 @@ class NavService {
     null,
   );
 
+  /// Source entry whose link opened [desktopSelectedEntryId], when present.
+  ///
+  /// Journal routes carry this separately from the selected entry so the
+  /// desktop detail pane can expose link-scoped actions such as unlinking a
+  /// photo from an event without changing row-selection behavior.
+  final ValueNotifier<String?> desktopSelectedEntryLinkedFromId =
+      ValueNotifier<String?>(null);
+
   /// Whether the full-screen Time Analysis surface is active. Written
   /// exclusively by `CalendarLocation` from the URL (`/calendar/time`) —
   /// the URL is the single source of truth; the Daily OS sidebar
@@ -907,6 +915,7 @@ class NavService {
     desktopSelectedProjectId.dispose();
     desktopSelectedDashboardId.dispose();
     desktopSelectedEntryId.dispose();
+    desktopSelectedEntryLinkedFromId.dispose();
     desktopShowTimeAnalysis.dispose();
     desktopShowAiImpact.dispose();
     desktopSelectedSettingsRoute.dispose();

--- a/test/beamer/locations/journal_location_test.dart
+++ b/test/beamer/locations/journal_location_test.dart
@@ -17,21 +17,27 @@ void main() {
     late MockBuildContext mockBuildContext;
     late MockNavService mockNavService;
     late ValueNotifier<String?> desktopSelectedEntryId;
+    late ValueNotifier<String?> desktopSelectedEntryLinkedFromId;
 
     setUp(() async {
       mockBuildContext = MockBuildContext();
       mockNavService = MockNavService();
       desktopSelectedEntryId = ValueNotifier<String?>(null);
+      desktopSelectedEntryLinkedFromId = ValueNotifier<String?>(null);
       when(() => mockNavService.isDesktopMode).thenReturn(false);
       when(
         () => mockNavService.desktopSelectedEntryId,
       ).thenReturn(desktopSelectedEntryId);
+      when(
+        () => mockNavService.desktopSelectedEntryLinkedFromId,
+      ).thenReturn(desktopSelectedEntryLinkedFromId);
       await getIt.reset();
       getIt.registerSingleton<NavService>(mockNavService);
     });
 
     tearDown(() async {
       desktopSelectedEntryId.dispose();
+      desktopSelectedEntryLinkedFromId.dispose();
       await getIt.reset();
     });
 
@@ -160,13 +166,29 @@ void main() {
         expect(pages[0].child, isA<JournalRootPage>());
         await Future<void>.microtask(() {});
         expect(desktopSelectedEntryId.value, entryId);
+        expect(desktopSelectedEntryLinkedFromId.value, isNull);
+      });
+
+      test('preserves linked-from context in the detail pane', () async {
+        final entryId = const Uuid().v4();
+        final eventId = const Uuid().v4();
+        buildPagesFor(
+          Uri.parse('/journal/$entryId?linkedFromId=$eventId'),
+          {'entryId': entryId},
+        );
+
+        await Future<void>.microtask(() {});
+        expect(desktopSelectedEntryId.value, entryId);
+        expect(desktopSelectedEntryLinkedFromId.value, eventId);
       });
 
       test('root route clears the selection', () async {
         desktopSelectedEntryId.value = const Uuid().v4();
+        desktopSelectedEntryLinkedFromId.value = const Uuid().v4();
         buildPagesFor(Uri.parse('/journal'), {});
         await Future<void>.microtask(() {});
         expect(desktopSelectedEntryId.value, isNull);
+        expect(desktopSelectedEntryLinkedFromId.value, isNull);
       });
 
       test('non-uuid entryId clears the selection', () async {
@@ -192,17 +214,23 @@ void main() {
           // microtask run against the still-registered original.
           final replacement = MockNavService();
           final replacementNotifier = ValueNotifier<String?>(null);
+          final replacementLinkedFromNotifier = ValueNotifier<String?>(null);
           addTearDown(replacementNotifier.dispose);
+          addTearDown(replacementLinkedFromNotifier.dispose);
           when(() => replacement.isDesktopMode).thenReturn(true);
           when(
             () => replacement.desktopSelectedEntryId,
           ).thenReturn(replacementNotifier);
+          when(
+            () => replacement.desktopSelectedEntryLinkedFromId,
+          ).thenReturn(replacementLinkedFromNotifier);
           getIt
             ..unregister<NavService>()
             ..registerSingleton<NavService>(replacement);
 
           await Future<void>.microtask(() {});
           expect(replacementNotifier.value, isNull);
+          expect(replacementLinkedFromNotifier.value, isNull);
           expect(desktopSelectedEntryId.value, isNull);
         },
       );

--- a/test/beamer/locations/journal_location_test.dart
+++ b/test/beamer/locations/journal_location_test.dart
@@ -102,6 +102,29 @@ void main() {
         expect(detailsPage.showBackButton, isTrue);
       });
 
+      test('passes a valid linked-from event id into the entry page', () {
+        final entryId = const Uuid().v4();
+        final eventId = const Uuid().v4();
+        final pages = buildPagesFor(
+          Uri.parse('/journal/$entryId?linkedFromId=$eventId'),
+          {'entryId': entryId},
+        );
+
+        final detailsPage = pages[1].child as EntryDetailsPage;
+        expect(detailsPage.linkedFromId, eventId);
+      });
+
+      test('drops an invalid linked-from id', () {
+        final entryId = const Uuid().v4();
+        final pages = buildPagesFor(
+          Uri.parse('/journal/$entryId?linkedFromId=not-an-id'),
+          {'entryId': entryId},
+        );
+
+        final detailsPage = pages[1].child as EntryDetailsPage;
+        expect(detailsPage.linkedFromId, isNull);
+      });
+
       test('does not write the desktop selection notifier', () async {
         final entryId = const Uuid().v4();
         buildPagesFor(Uri.parse('/journal/$entryId'), {'entryId': entryId});

--- a/test/beamer/locations/journal_location_test.dart
+++ b/test/beamer/locations/journal_location_test.dart
@@ -2,6 +2,7 @@ import 'package:beamer/beamer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/beamer/locations/journal_location.dart';
+import 'package:lotti/features/demo/seed/demo_ids.dart';
 import 'package:lotti/features/demo/seed/demo_world.dart';
 import 'package:lotti/features/journal/ui/pages/entry_details_page.dart';
 import 'package:lotti/features/journal/ui/pages/journal_root_page.dart';
@@ -108,9 +109,9 @@ void main() {
         expect(detailsPage.showBackButton, isTrue);
       });
 
-      test('passes a valid linked-from event id into the entry page', () {
+      test('passes a valid demo linked-from event id into the entry page', () {
         final entryId = const Uuid().v4();
-        final eventId = const Uuid().v4();
+        final eventId = demoUuid('event-project-waddle-launch-gala');
         final pages = buildPagesFor(
           Uri.parse('/journal/$entryId?linkedFromId=$eventId'),
           {'entryId': entryId},

--- a/test/features/events/state/event_view_mapping_test.dart
+++ b/test/features/events/state/event_view_mapping_test.dart
@@ -256,17 +256,25 @@ void main() {
     ImageProvider fakeImage(JournalImage image) => const AssetImage('x');
 
     test('maps an image entry to a photo timeline entry', () {
+      final image = testImageEntry.copyWith(
+        data: testImageEntry.data.copyWith(imageFile: 'test.jpg'),
+      );
       final entry = eventTimelineEntryFor(
-        testImageEntry,
+        image,
         timeLabel: '20:15',
         formatTime: fakeClock,
         imageProviderFor: fakeImage,
+        imagePathFor: (image) => '/photos/${image.data.imageFile}',
       );
       expect(entry, isNotNull);
       expect(entry!.kind, EventTimelineKind.photo);
       expect(entry.photos, hasLength(1));
       // Carries the source id so the detail view can open the entry.
-      expect(entry.entryId, testImageEntry.meta.id);
+      expect(entry.entryId, image.meta.id);
+      expect(entry.photos.single.filePath, '/photos/test.jpg');
+      expect(entry.photos.single.capturedAt, image.data.capturedAt);
+      expect(entry.photos.single.fileDate, image.meta.dateFrom);
+      expect(entry.photos.single.displayDate, image.data.capturedAt);
     });
 
     test('maps a point-in-time text entry to a note timeline entry', () {

--- a/test/features/events/state/events_overview_controller_test.dart
+++ b/test/features/events/state/events_overview_controller_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/event_data.dart';
@@ -34,6 +35,33 @@ JournalEvent _event(String id, {String? categoryId = 'cat-1'}) {
     ),
   );
 }
+
+JournalImage _image(String id, DateTime capturedAt) => JournalImage(
+  meta: Metadata(
+    id: id,
+    createdAt: capturedAt,
+    updatedAt: capturedAt,
+    dateFrom: capturedAt,
+    dateTo: capturedAt,
+  ),
+  data: ImageData(
+    capturedAt: capturedAt,
+    imageId: id,
+    imageFile: '$id.jpg',
+    imageDirectory: '/images/2026/',
+  ),
+);
+
+LinkedDbEntry _link(String eventId, String imageId) => LinkedDbEntry(
+  id: 'link-$imageId',
+  fromId: eventId,
+  toId: imageId,
+  type: 'BasicLink',
+  serialized: '{}',
+  hidden: false,
+  createdAt: DateTime(2026, 5, 12),
+  updatedAt: DateTime(2026, 5, 12),
+);
 
 void main() {
   late MockJournalDb db;
@@ -174,6 +202,56 @@ void main() {
     expect(state.events.first.event.meta.id, 'new');
     expect(state.events, hasLength(4));
   });
+
+  test(
+    'link notifications refresh the fallback cover for local and synced photos',
+    () async {
+      final event = _event('e1');
+      final firstPhoto = _image('photo-1', DateTime(2026, 5, 13));
+      final syncedPhoto = _image('photo-2', DateTime(2026, 5, 14));
+      final images = {
+        firstPhoto.meta.id: firstPhoto,
+        syncedPhoto.meta.id: syncedPhoto,
+      };
+      final links = <LinkedDbEntry>[];
+      stubPaged([event]);
+      when(() => db.linksFromIds(any())).thenAnswer(
+        (_) => MockSelectable<LinkedDbEntry>([...links]),
+      );
+      when(() => db.getJournalEntitiesForIds(any())).thenAnswer((
+        invocation,
+      ) async {
+        final ids = invocation.positionalArguments.first as Set<String>;
+        return ids.map((id) => images[id]).whereType<JournalEntity>().toList();
+      });
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      var state = await container.read(eventsOverviewControllerProvider.future);
+      expect(state.events.single.coverImage, isNull);
+
+      // Local photo creation writes a link row rather than updating the event.
+      links.add(_link(event.meta.id, firstPhoto.meta.id));
+      updates.add({event.meta.id, firstPhoto.meta.id, linkNotification});
+      await pumpEventQueue();
+      state = container.read(eventsOverviewControllerProvider).value!;
+      expect(
+        (state.events.single.coverImage! as FileImage).file.path,
+        endsWith('photo-1.jpg'),
+      );
+
+      // Sync uses the same merged UI stream and must replace the cover with
+      // the newer linked photo without an EVENT token or app restart.
+      links.add(_link(event.meta.id, syncedPhoto.meta.id));
+      updates.add({event.meta.id, syncedPhoto.meta.id, linkNotification});
+      await pumpEventQueue();
+      state = container.read(eventsOverviewControllerProvider).value!;
+      expect(
+        (state.events.single.coverImage! as FileImage).file.path,
+        endsWith('photo-2.jpg'),
+      );
+    },
+  );
 
   test(
     'refresh reloads the full window when the loaded page is full',

--- a/test/features/events/state/events_overview_controller_test.dart
+++ b/test/features/events/state/events_overview_controller_test.dart
@@ -253,6 +253,44 @@ void main() {
     },
   );
 
+  test('unrelated link notifications do not reload event covers', () async {
+    final event = _event('e1');
+    final master = [event];
+    stubPaged(master);
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    await container.read(eventsOverviewControllerProvider.future);
+
+    master.insert(0, _event('new'));
+    updates.add({'unrelated-from', 'unrelated-to', linkNotification});
+    await pumpEventQueue();
+    expect(
+      container
+          .read(eventsOverviewControllerProvider)
+          .value!
+          .events
+          .first
+          .event
+          .meta
+          .id,
+      event.meta.id,
+    );
+
+    updates.add({event.meta.id, 'photo-1', linkNotification});
+    await pumpEventQueue();
+    expect(
+      container
+          .read(eventsOverviewControllerProvider)
+          .value!
+          .events
+          .first
+          .event
+          .meta
+          .id,
+      'new',
+    );
+  });
+
   test(
     'refresh reloads the full window when the loaded page is full',
     () async {

--- a/test/features/events/ui/pages/event_detail_page_test.dart
+++ b/test/features/events/ui/pages/event_detail_page_test.dart
@@ -315,7 +315,12 @@ void main() {
       await tester.tap(find.text('test entry text'));
       await tester.pump();
 
-      expect(beamed, ['/journal/${testTextEntry.meta.id}']);
+      expect(
+        beamed,
+        [
+          '/journal/${testTextEntry.meta.id}?linkedFromId=$_eventId',
+        ],
+      );
     });
 
     testWidgets('the category pill picks a category through the controller', (

--- a/test/features/events/ui/pages/events_manual_screenshots_test.dart
+++ b/test/features/events/ui/pages/events_manual_screenshots_test.dart
@@ -26,6 +26,7 @@ import 'package:lotti/classes/event_data.dart';
 import 'package:lotti/classes/event_status.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/agents/state/event_agent_providers.dart';
+import 'package:lotti/features/demo/seed/demo_ids.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/events/state/events_controller.dart';
 import 'package:lotti/features/events/state/events_overview_controller.dart';
@@ -51,7 +52,7 @@ import '../../../categories/test_utils.dart';
 import '../../../daily_os_next/screenshot_harness.dart';
 
 const _subdir = 'events';
-const _detailEventId = 'event-project-waddle-launch-gala';
+final String _detailEventId = demoUuid('event-project-waddle-launch-gala');
 String _t(String en, String de) => manualScreenshotText(en: en, de: de);
 
 AppLocalizations _messages(WidgetTester tester) =>
@@ -426,6 +427,7 @@ void main() {
       documentsDirectory: documentsDirectory,
       world: world,
       extents: const [360],
+      includeRawFileImage: true,
     );
     final platform = device.isPhone
         ? TargetPlatform.android
@@ -514,7 +516,7 @@ void main() {
           tester,
           device: device,
           brightness: brightness,
-          home: const EventDetailPage(eventId: _detailEventId),
+          home: EventDetailPage(eventId: _detailEventId),
           overrides: detailOverrides(),
         );
         expect(find.byType(EventDetailView), findsOneWidget);
@@ -555,7 +557,7 @@ void main() {
           tester,
           device: device,
           brightness: brightness,
-          home: const EventDetailPage(eventId: _detailEventId),
+          home: EventDetailPage(eventId: _detailEventId),
           overrides: detailOverrides(),
         );
         final detail = find.byType(EventDetailView);
@@ -591,6 +593,21 @@ void main() {
           ),
           findsOneWidget,
         );
+        final timelineImages = find.byWidgetPredicate(
+          (widget) => widget is Image && widget.image is FileImage,
+        );
+        expect(timelineImages, findsNWidgets(3));
+        for (var index = 0; index < 3; index++) {
+          final rawImage = find.descendant(
+            of: timelineImages.at(index),
+            matching: find.byType(RawImage),
+          );
+          expect(rawImage, findsOneWidget);
+          expect(
+            tester.renderObject<RenderImage>(rawImage).image,
+            isNotNull,
+          );
+        }
         await captureScreenshot(
           tester,
           'events_timeline_${viewport}_$theme',
@@ -604,7 +621,7 @@ void main() {
             tester,
             device: device,
             brightness: brightness,
-            home: const EventDetailPage(eventId: _detailEventId),
+            home: EventDetailPage(eventId: _detailEventId),
             overrides: detailOverrides(),
           );
           final grid = find.byType(EventPhotoGrid);
@@ -623,6 +640,20 @@ void main() {
           );
           await settleFrames(tester, 8);
           expect(find.byType(EventPhotoGalleryViewer), findsOneWidget);
+          expect(find.byType(CircularProgressIndicator), findsNothing);
+          final viewerImages = find.byWidgetPredicate(
+            (widget) => widget is Image && widget.image is FileImage,
+          );
+          expect(viewerImages, findsWidgets);
+          final rawViewerImage = find.descendant(
+            of: viewerImages.first,
+            matching: find.byType(RawImage),
+          );
+          expect(rawViewerImage, findsOneWidget);
+          expect(
+            tester.renderObject<RenderImage>(rawViewerImage).image,
+            isNotNull,
+          );
           await captureScreenshot(
             tester,
             'events_photo_viewer_mobile_light',

--- a/test/features/events/ui/pages/events_manual_screenshots_test.dart
+++ b/test/features/events/ui/pages/events_manual_screenshots_test.dart
@@ -597,6 +597,39 @@ void main() {
           subdir: _subdir,
         );
       });
+
+      if (device.isPhone && brightness == Brightness.light) {
+        testWidgets('mobile event photo viewer — light', (tester) async {
+          await pumpSurface(
+            tester,
+            device: device,
+            brightness: brightness,
+            home: const EventDetailPage(eventId: _detailEventId),
+            overrides: detailOverrides(),
+          );
+          final grid = find.byType(EventPhotoGrid);
+          await tester.scrollUntilVisible(
+            grid,
+            320,
+            scrollable: find
+                .descendant(
+                  of: find.byType(EventDetailView),
+                  matching: find.byType(Scrollable),
+                )
+                .first,
+          );
+          await tester.tap(
+            find.descendant(of: grid, matching: find.byType(InkWell)).first,
+          );
+          await settleFrames(tester, 8);
+          expect(find.byType(EventPhotoGalleryViewer), findsOneWidget);
+          await captureScreenshot(
+            tester,
+            'events_photo_viewer_mobile_light',
+            subdir: _subdir,
+          );
+        });
+      }
     }
   }
 }

--- a/test/features/events/ui/widgets/event_photo_gallery_test.dart
+++ b/test/features/events/ui/widgets/event_photo_gallery_test.dart
@@ -1,16 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/events/ui/model/event_view_data.dart';
 import 'package:lotti/features/events/ui/widgets/event_photo_gallery.dart';
+import 'package:lotti/features/journal/util/image_export_service.dart';
 import 'package:lotti/utils/platform.dart' as platform;
+import 'package:photo_view/photo_view.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 
 import '../../../../widget_test_utils.dart';
 import '../../test_utils.dart';
 
 List<EventPhoto> _photos(int n) => [
-  for (var i = 0; i < n; i++) EventPhoto(testImage()),
+  for (var i = 0; i < n; i++)
+    EventPhoto(
+      testImage(),
+      filePath: '/tmp/event-photo-$i.png',
+      capturedAt: DateTime(2026, 1, i + 1),
+    ),
 ];
 
 void main() {
@@ -53,7 +61,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 400));
       expect(find.byType(EventPhotoGalleryViewer), findsOneWidget);
 
-      await tester.tap(find.byType(IconButton));
+      await tester.tap(find.byTooltip('Close'));
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
       expect(find.byType(EventPhotoGalleryViewer), findsNothing);
@@ -61,7 +69,7 @@ void main() {
   });
 
   group('EventPhotoGalleryViewer', () {
-    testWidgets('shows a page indicator and close button for many photos', (
+    testWidgets('shows counter, current date, download, and close controls', (
       tester,
     ) async {
       await tester.pumpWidget(
@@ -72,15 +80,110 @@ void main() {
       await tester.pump();
 
       expect(find.text('1 / 5'), findsOneWidget);
-      expect(find.byType(IconButton), findsOneWidget);
+      expect(find.text('Jan 1, 2026'), findsOneWidget);
+      expect(find.byTooltip('Download image'), findsOneWidget);
+      expect(find.byTooltip('Close'), findsOneWidget);
 
       final gallery = tester.widget<PhotoViewGallery>(
         find.byType(PhotoViewGallery),
       );
+      expect(gallery.enableRotation, isFalse);
       gallery.onPageChanged!(3);
       await tester.pump();
 
       expect(find.text('4 / 5'), findsOneWidget);
+      expect(find.text('Jan 4, 2026'), findsOneWidget);
+    });
+
+    testWidgets('download exports the currently visible photo', (tester) async {
+      final exported = <String>[];
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          EventPhotoGalleryViewer(
+            photos: _photos(3),
+            imageExporter: (file) async {
+              exported.add(file.path);
+              return const ImageExportResult.cancelled();
+            },
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final gallery = tester.widget<PhotoViewGallery>(
+        find.byType(PhotoViewGallery),
+      );
+      gallery.onPageChanged!(1);
+      await tester.pump();
+      await tester.tap(find.byTooltip('Download image'));
+      await tester.pump();
+
+      expect(exported, ['/tmp/event-photo-1.png']);
+    });
+
+    testWidgets('single taps hide and restore every overlay control', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          EventPhotoGalleryViewer(photos: _photos(3)),
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.byType(PhotoView));
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.text('1 / 3'), findsNothing);
+      expect(find.text('Jan 1, 2026'), findsNothing);
+      expect(find.byTooltip('Download image'), findsNothing);
+      expect(find.byTooltip('Close'), findsNothing);
+
+      await tester.tap(find.byType(PhotoView));
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.text('1 / 3'), findsOneWidget);
+      expect(find.text('Jan 1, 2026'), findsOneWidget);
+      expect(find.byTooltip('Download image'), findsOneWidget);
+      expect(find.byTooltip('Close'), findsOneWidget);
+    });
+
+    testWidgets('double tap zoom leaves overlays visible', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          EventPhotoGalleryViewer(photos: _photos(2)),
+        ),
+      );
+      await tester.pump();
+
+      final photo = find.byType(PhotoView);
+      await tester.tap(photo);
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tap(photo);
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.byTooltip('Close'), findsOneWidget);
+      expect(find.text('1 / 2'), findsOneWidget);
+    });
+
+    testWidgets('uses the file date when capture metadata is unavailable', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          EventPhotoGalleryViewer(
+            photos: [
+              EventPhoto(
+                testImage(),
+                fileDate: DateTime(2025, 12, 24),
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Dec 24, 2025'), findsOneWidget);
     });
 
     testWidgets('hides the page indicator for a single photo', (tester) async {
@@ -112,7 +215,8 @@ void main() {
         ),
       );
       await tester.pump();
-      final rightWithoutInset = tester.getTopRight(find.byType(IconButton)).dx;
+      final closeButton = find.widgetWithIcon(IconButton, LottiIcons.close);
+      final rightWithoutInset = tester.getTopRight(closeButton).dx;
 
       await tester.pumpWidget(
         makeTestableWidget2(
@@ -121,7 +225,7 @@ void main() {
         ),
       );
       await tester.pump();
-      final rightWithInset = tester.getTopRight(find.byType(IconButton)).dx;
+      final rightWithInset = tester.getTopRight(closeButton).dx;
 
       expect(rightWithInset, rightWithoutInset - rightInset);
     });

--- a/test/features/journal/ui/pages/entry_details_page_test.dart
+++ b/test/features/journal/ui/pages/entry_details_page_test.dart
@@ -45,6 +45,8 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
+import '../../../../helpers/fake_entry_controller.dart';
+import '../../../../helpers/fake_linked_entries_controller.dart';
 import '../../../../helpers/fallbacks.dart';
 import '../../../../helpers/path_provider.dart';
 import '../../../../mocks/mocks.dart';
@@ -222,6 +224,57 @@ void main() {
         AiResponseType.audioSummary,
         AiResponseType.promptGeneration,
       });
+    });
+
+    testWidgets('linked route context exposes the unlink action', (
+      tester,
+    ) async {
+      final parent = testTask;
+      final child = testTextEntry;
+      final link = EntryLink.basic(
+        id: 'event-photo-link',
+        fromId: parent.meta.id,
+        toId: child.meta.id,
+        createdAt: DateTime(2026, 5, 12),
+        updatedAt: DateTime(2026, 5, 12),
+        vectorClock: null,
+      );
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          EntryDetailsPage(
+            itemId: child.meta.id,
+            linkedFromId: parent.meta.id,
+          ),
+          overrides: [
+            entryControllerProvider(
+              child.meta.id,
+            ).overrideWith(() => FakeEntryController(child)),
+            entryControllerProvider(
+              parent.meta.id,
+            ).overrideWith(() => FakeEntryController(parent)),
+            linkedEntriesControllerProvider(parent.meta.id).overrideWith(
+              () => FakeLinkedEntriesController(
+                links: [link],
+                id: parent.meta.id,
+              ),
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      final details = tester
+          .widgetList<EntryDetailsWidget>(find.byType(EntryDetailsWidget))
+          .singleWhere((widget) => widget.itemId == child.meta.id);
+      expect(details.linkedFrom?.meta.id, parent.meta.id);
+      expect(details.link?.id, link.id);
+
+      await tester.tap(find.byIcon(LottiIcons.more));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.text('Unlink'), findsOneWidget);
     });
 
     testWidgets('owns one correction toast listener for editable checklists', (

--- a/test/features/journal/ui/pages/journal_manual_screenshots_test.dart
+++ b/test/features/journal/ui/pages/journal_manual_screenshots_test.dart
@@ -539,10 +539,15 @@ void main() {
     ).thenReturn(null);
     // Desktop cards watch the split view's selection to paint the active row.
     final desktopSelectedEntryId = ValueNotifier<String?>(null);
+    final desktopSelectedEntryLinkedFromId = ValueNotifier<String?>(null);
     addTearDown(desktopSelectedEntryId.dispose);
+    addTearDown(desktopSelectedEntryLinkedFromId.dispose);
     when(
       () => navService.desktopSelectedEntryId,
     ).thenReturn(desktopSelectedEntryId);
+    when(
+      () => navService.desktopSelectedEntryLinkedFromId,
+    ).thenReturn(desktopSelectedEntryLinkedFromId);
     when(
       () => ratingRepository.getRatingForTargetEntry(rehearsalTimer.id),
     ).thenAnswer((_) async => sessionRating);

--- a/test/features/journal/ui/pages/journal_root_page_test.dart
+++ b/test/features/journal/ui/pages/journal_root_page_test.dart
@@ -30,10 +30,12 @@ void main() {
 
   late FakeJournalPageController fakeController;
   late ValueNotifier<String?> selectedEntryId;
+  late ValueNotifier<String?> selectedEntryLinkedFromId;
   late MockNavService mockNavService;
 
   setUp(() async {
     selectedEntryId = ValueNotifier<String?>(null);
+    selectedEntryLinkedFromId = ValueNotifier<String?>(null);
     mockNavService = MockNavService();
     await setUpTestGetIt(
       additionalSetup: () {
@@ -61,6 +63,9 @@ void main() {
         when(
           () => mockNavService.desktopSelectedEntryId,
         ).thenReturn(selectedEntryId);
+        when(
+          () => mockNavService.desktopSelectedEntryLinkedFromId,
+        ).thenReturn(selectedEntryLinkedFromId);
         // Feed rows render through ModernJournalCard, whose task variant
         // resolves the recording indicator through TimeService.
         final mockTimeService = MockTimeService();
@@ -83,6 +88,7 @@ void main() {
   tearDown(() async {
     await tearDownTestGetIt();
     selectedEntryId.dispose();
+    selectedEntryLinkedFromId.dispose();
   });
 
   JournalPageState state() => const JournalPageState();
@@ -162,6 +168,23 @@ void main() {
     expect(detailsPage.showBackButton, isFalse);
 
     // Dispose the tree and flush pending animation timers.
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('desktop detail receives the selected link source', (
+    tester,
+  ) async {
+    selectedEntryLinkedFromId.value = 'event-7';
+    selectedEntryId.value = 'entry-42';
+    await pumpRootPage(tester, size: desktop);
+
+    final detailsPage = tester.widget<EntryDetailsPage>(
+      find.byType(EntryDetailsPage),
+    );
+    expect(detailsPage.itemId, 'entry-42');
+    expect(detailsPage.linkedFromId, 'event-7');
+
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pumpAndSettle();
   });

--- a/test/features/journal/ui/widgets/entry_image_widget_test.dart
+++ b/test/features/journal/ui/widgets/entry_image_widget_test.dart
@@ -327,6 +327,8 @@ void main() {
       ImageExporter? imageExporter,
       MediaQueryData? mediaQueryData,
       List<File>? gallery,
+      DateTime? date,
+      List<DateTime?>? galleryDates,
       int initialIndex = 0,
     }) {
       return ProviderScope(
@@ -350,6 +352,8 @@ void main() {
             backgroundDecoration: backgroundDecoration,
             imageExporter: imageExporter,
             gallery: gallery,
+            date: date,
+            galleryDates: galleryDates,
             initialIndex: initialIndex,
           ),
         ),
@@ -390,6 +394,7 @@ void main() {
         expect(photoView.initialScale, PhotoViewComputedScale.contained);
         expect(photoView.maxScale, PhotoViewComputedScale.covered * 4);
         expect(photoView.strictScale, isTrue);
+        expect(photoView.enableRotation, isFalse);
         expect(photoView.controller, isA<PhotoViewController>());
         expect(
           photoView.scaleStateController,
@@ -413,6 +418,85 @@ void main() {
         expect(zoomOutButton.onPressed, isNull);
       },
     );
+
+    testWidgets('shows the photo date in the viewer overlay', (tester) async {
+      await tester.pumpWidget(
+        buildWrapper(date: DateTime(2026, 2, 3)),
+      );
+      await tester.pump();
+
+      expect(find.text('Feb 3, 2026'), findsOneWidget);
+    });
+
+    testWidgets('single taps hide and restore all viewer chrome', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildWrapper(date: DateTime(2026, 2, 3)),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      final canvasPoint =
+          tester.getCenter(find.byType(PhotoView)) - const Offset(100, 100);
+      await tester.tapAt(canvasPoint);
+      await tester.pump(const Duration(milliseconds: 600));
+      expect(find.byTooltip('Download image'), findsNothing);
+      expect(find.byTooltip('Close'), findsNothing);
+      expect(find.text('Feb 3, 2026'), findsNothing);
+      expect(find.byTooltip('Zoom In'), findsNothing);
+
+      await tester.tapAt(canvasPoint);
+      await tester.pump(const Duration(milliseconds: 600));
+      expect(find.byTooltip('Download image'), findsOneWidget);
+      expect(find.byTooltip('Close'), findsOneWidget);
+      expect(find.text('Feb 3, 2026'), findsOneWidget);
+      expect(find.byTooltip('Zoom In'), findsOneWidget);
+    });
+
+    testWidgets('double tap zoom does not toggle viewer chrome', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildWrapper());
+      await tester.pump();
+
+      final photo = find.byType(PhotoView);
+      await tester.tap(photo);
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tap(photo);
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.byTooltip('Close'), findsOneWidget);
+      expect(find.byTooltip('Zoom In'), findsOneWidget);
+    });
+
+    testWidgets('two-finger gesture keeps photo gestures and chrome active', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildWrapper());
+      await tester.pump();
+      await tester.pump();
+      expect(find.text('100%'), findsOneWidget);
+
+      final center = tester.getCenter(find.byType(PhotoView));
+      final first = await tester.createGesture(pointer: 1);
+      final second = await tester.createGesture(pointer: 2);
+      await first.down(center - const Offset(20, 0));
+      await second.down(center + const Offset(20, 0));
+      await tester.pump();
+      await first.moveTo(center - const Offset(80, 0));
+      await second.moveTo(center + const Offset(80, 0));
+      await tester.pump();
+      await first.up();
+      await second.up();
+      await tester.pump(const Duration(milliseconds: 600));
+
+      expect(find.byTooltip('Close'), findsOneWidget);
+      final photoView = tester.widget<PhotoView>(find.byType(PhotoView));
+      expect(photoView.disableGestures, isNot(isTrue));
+      expect(photoView.enableRotation, isFalse);
+      expect(tester.takeException(), isNull);
+    });
 
     testWidgets('keeps top controls inside the landscape right safe area', (
       tester,
@@ -894,6 +978,28 @@ void main() {
           expect(shownPath(tester), gallery[1].path);
         },
       );
+
+      testWidgets('gallery navigation updates the displayed photo date', (
+        tester,
+      ) async {
+        final gallery = writeGallery();
+        await tester.pumpWidget(
+          buildWrapper(
+            gallery: gallery,
+            galleryDates: [
+              DateTime(2026),
+              DateTime(2026, 2),
+              DateTime(2026, 3),
+            ],
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Jan 1, 2026'), findsOneWidget);
+        _pressIconButton(tester, LottiIcons.chevronRight);
+        await tester.pump();
+        expect(find.text('Feb 1, 2026'), findsOneWidget);
+      });
 
       testWidgets(
         'left/right arrow keys navigate and ignore presses beyond the ends',

--- a/test/features/journal/ui/widgets/entry_image_widget_test.dart
+++ b/test/features/journal/ui/widgets/entry_image_widget_test.dart
@@ -454,6 +454,26 @@ void main() {
       expect(find.byTooltip('Zoom In'), findsOneWidget);
     });
 
+    testWidgets('a cancelled pointer does not toggle chrome and tap recovers', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildWrapper());
+      await tester.pump();
+
+      final canvasPoint = tester.getCenter(find.byType(PhotoView));
+      final gesture = await tester.createGesture();
+      await gesture.down(canvasPoint);
+      await gesture.cancel();
+      await tester.pump(const Duration(milliseconds: 600));
+
+      expect(find.byTooltip('Close'), findsOneWidget);
+
+      await tester.tapAt(canvasPoint);
+      await tester.pump(const Duration(milliseconds: 600));
+
+      expect(find.byTooltip('Close'), findsNothing);
+    });
+
     testWidgets('double tap zoom does not toggle viewer chrome', (
       tester,
     ) async {

--- a/test/features/tasks/ui/cover_art_background_test.dart
+++ b/test/features/tasks/ui/cover_art_background_test.dart
@@ -403,8 +403,9 @@ void main() {
         );
         expect(viewer.file.path, getFullImagePath(image));
         expect(viewer.heroTag, 'task_cover_art_image-1');
+        expect(viewer.date, image.data.capturedAt);
         final photoView = tester.widget<PhotoView>(find.byType(PhotoView));
-        expect(photoView.enableRotation, isTrue);
+        expect(photoView.enableRotation, isFalse);
         expect(find.byIcon(LottiIcons.close), findsOneWidget);
       });
     });

--- a/test/services/nav_service_test.dart
+++ b/test/services/nav_service_test.dart
@@ -591,7 +591,11 @@ void main() {
     group('desktop selected entry id', () {
       test('starts unselected and notifies logbook listeners on change', () {
         final navService = getIt<NavService>();
-        addTearDown(() => navService.desktopSelectedEntryId.value = null);
+        addTearDown(() {
+          navService
+            ..desktopSelectedEntryId.value = null
+            ..desktopSelectedEntryLinkedFromId.value = null;
+        });
         expect(navService.desktopSelectedEntryId.value, isNull);
 
         final seen = <String?>[];
@@ -606,13 +610,30 @@ void main() {
         expect(seen, ['entry-1', null]);
       });
 
+      test('tracks the link source independently from the selected row', () {
+        final navService = getIt<NavService>();
+        addTearDown(() {
+          navService
+            ..desktopSelectedEntryId.value = null
+            ..desktopSelectedEntryLinkedFromId.value = null;
+        });
+
+        navService
+          ..desktopSelectedEntryId.value = 'photo-1'
+          ..desktopSelectedEntryLinkedFromId.value = 'event-1';
+
+        expect(navService.desktopSelectedEntryId.value, 'photo-1');
+        expect(navService.desktopSelectedEntryLinkedFromId.value, 'event-1');
+      });
+
       test('is independent of the task detail selection', () {
         final navService = getIt<NavService>()
           ..resetDesktopTaskDetail('task-a');
         addTearDown(() {
           navService
             ..resetDesktopTaskDetail(null)
-            ..desktopSelectedEntryId.value = null;
+            ..desktopSelectedEntryId.value = null
+            ..desktopSelectedEntryLinkedFromId.value = null;
         });
 
         navService.desktopSelectedEntryId.value = 'entry-1';


### PR DESCRIPTION
## Summary

- refresh event overview cards when photo links change locally or through sync
- restore the confirmed unlink action by retaining the source event when opening timeline photos
- unify single-photo and gallery viewer controls for current-image download, localized dates, and tap-to-toggle chrome
- disable two-finger rotation while preserving pinch zoom, pan, and double-tap zoom
- document the event photo update flow and add a user-facing changelog fragment

## Root causes

- The events overview listened to event notifications but not link notifications, so cover resolution stayed stale when photo associations changed.
- Timeline navigation discarded the parent event ID, which hid the existing unlink menu action and handler.
- The event gallery used a separate viewer implementation without the single-image download/date controls.
- The single-image viewer explicitly opted into PhotoView rotation.

## Validation

- `fvm flutter analyze` on all touched Dart files: zero issues
- 165 targeted tests across the affected files
- regression controls verified the new tests fail with each fix reverted
- `make knowledge_check`
- `make changelog_check`
- before/after screenshot harnesses for overview, timeline, and gallery viewer

## Screenshots

| Surface | Before | After |
| --- | --- | --- |
| Events overview | ![Events overview before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/event-photo-fixes/f7152642cccfa727a3b1a5e031e129026541b079/before/events_overview_mobile_light.png) | ![Events overview after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/event-photo-fixes/f7152642cccfa727a3b1a5e031e129026541b079/after/events_overview_mobile_light.png) |
| Event timeline | ![Event timeline before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/event-photo-fixes/f7152642cccfa727a3b1a5e031e129026541b079/before/events_timeline_mobile_light.png) | ![Event timeline after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/event-photo-fixes/f7152642cccfa727a3b1a5e031e129026541b079/after/events_timeline_mobile_light.png) |
| Photo viewer | ![Photo viewer before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/event-photo-fixes/f7152642cccfa727a3b1a5e031e129026541b079/before/events_photo_viewer_mobile_light.png) | ![Photo viewer after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/event-photo-fixes/f7152642cccfa727a3b1a5e031e129026541b079/after/events_photo_viewer_mobile_light.png) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event photos now show capture or file dates in galleries and full-screen viewers.
  * Added downloading for the currently displayed photo.
  * Tap to hide or restore viewer controls while retaining pinch-to-zoom and panning.
  * Timeline links preserve event context and expose the related unlink action.
* **Bug Fixes**
  * Event covers refresh after linked-photo changes without reloading for unrelated links.
  * Disabled unintended image rotation during viewing.
  * Improved photo date fallback when capture dates are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->