### PR TITLE
fix: distinguish skipped habit days

### DIFF
--- a/changelog.d/2026-08-30-habit-skip-outcomes.md
+++ b/changelog.d/2026-08-30-habit-skip-outcomes.md
@@ -1,5 +1,6 @@
 ### Fixed
 - **Skipped habit days are visible and no longer keep streaks alive.** Habit
   strips now show a clear orange dash for a skip, distinct from both an
-  untouched day and a stronger red missed-day cross, and streaks advance only
-  on successful completions.
+  untouched day and a stronger red missed-day cross. Both outcomes retain a
+  clearly bounded rounded cell, and streaks advance only on successful
+  completions.

--- a/changelog.d/2026-08-30-habit-skip-outcomes.md
+++ b/changelog.d/2026-08-30-habit-skip-outcomes.md
@@ -1,0 +1,4 @@
+### Fixed
+- **Skipped habit days are visible and no longer keep streaks alive.** Habit
+  strips now show an orange cross for a skip, distinct from both an untouched
+  day and a red missed day, and streaks advance only on successful completions.

--- a/changelog.d/2026-08-30-habit-skip-outcomes.md
+++ b/changelog.d/2026-08-30-habit-skip-outcomes.md
@@ -1,4 +1,5 @@
 ### Fixed
 - **Skipped habit days are visible and no longer keep streaks alive.** Habit
-  strips now show an orange cross for a skip, distinct from both an untouched
-  day and a red missed day, and streaks advance only on successful completions.
+  strips now show a clear orange dash for a skip, distinct from both an
+  untouched day and a stronger red missed-day cross, and streaks advance only
+  on successful completions.

--- a/knowledge/architecture/day-indicators.md
+++ b/knowledge/architecture/day-indicators.md
@@ -76,10 +76,9 @@ classDiagram
 - **`DayMarkState` is what the app measured.** `full` means the requirement
   held as of that day; `partial` means the routine was kept while a window
   target was still building (a wash of the kept fill); `skipped` and
-  `missed` are recorded habit outcomes. The strip is a record of what was
-  KEPT, so `skipped`, `missed` and `none` share the neutral fill — which of
-  the three a grey square stands for is said in its tooltip and semantics,
-  never drawn.
+  `missed` are recorded habit outcomes. They share `none`'s neutral fill, but
+  a skipped day carries an orange warning cross and a missed day a red error
+  cross, leaving only an untouched day to carry its weekday.
 - **`DayVerdict` is the user's ruling**, and a recorded verdict outranks the
   measurement wherever both are shown. The enum is persisted by `name` in
   goal assessment records (see [goals](../features/goals.md)), so the names
@@ -123,15 +122,16 @@ flowchart LR
 - **Two fills for a measured day.** A kept day is `interactive.enabled` —
   the handover's `--interactive` square — a partial day its `muted` wash, and
   everything else `background.level03`. No alert hue on a habit square's
-  FILL: a struggling habit is never a wall of red; the missed cross alone
-  wears the error ink.
+  FILL: a struggling habit is never a wall of red or orange; the skip and miss
+  crosses alone wear their warning and error inks.
 - **A square says one thing inside itself, and nothing around it.** A
-  judged day draws its verdict's glyph; a kept day (partial included) the tick, a recorded miss
-  a red cross (`alert.error.glyphOnLevel03` — the ramp step that guarantees
-  the 3:1 graphical floor on the `level03` fill in both themes; the surface
-  ink lands at 2.9:1 there in dark) — the one touch of that family a habit
-  square gets, on a fill that stays neutral, which is what tells a miss from
-  the empty day it shares the fill with; any other dated day its weekday — the first two characters of the
+  judged day draws its verdict's glyph; a kept day (partial included) the tick,
+  a skip an orange cross (`alert.warning.glyphOnLevel03`), and a recorded miss
+  a red cross (`alert.error.glyphOnLevel03`). Those ramp steps guarantee the
+  3:1 graphical floor on the `level03` fill in both themes; the surface ink
+  lands at 2.9:1 there in dark. The fill stays neutral while the glyph tells
+  both recorded non-success outcomes from an empty day; an empty dated day
+  carries its weekday — the first two characters of the
   locale's abbreviation (`dayMarkWeekdayLabel`: `Tu Th Sa Su`, `Di Do Sa
   So`), quiet on the fill. No
   ring, no dot, no caption row above the track. The full date, the outcome's
@@ -206,9 +206,9 @@ view and history — so the habit only contributes the day.
 
 # There is no key
 
-The squares carry their own meaning — kept or not, at a glance — and every
-dated square answers hover or long-press with its day and its outcome or
-verdict. A static key was tried twice — an eleven-entry wrap under
+The squares carry their own meaning — success, skip, miss or empty, at a glance
+— and every dated square answers hover or long-press with its day and its
+outcome or verdict. A static key was tried twice — an eleven-entry wrap under
 a dashboard, then a present-states-only line under the goal's habit squares —
 and a design-review panel rated both as more legend than data. Do not
 reintroduce one; if a mark needs explaining, give the mark a better cue or a

--- a/knowledge/architecture/day-indicators.md
+++ b/knowledge/architecture/day-indicators.md
@@ -76,9 +76,9 @@ classDiagram
 - **`DayMarkState` is what the app measured.** `full` means the requirement
   held as of that day; `partial` means the routine was kept while a window
   target was still building (a wash of the kept fill); `skipped` and
-  `missed` are recorded habit outcomes. They share `none`'s neutral fill, but
-  a skipped day carries an orange warning cross and a missed day a red error
-  cross, leaving only an untouched day to carry its weekday.
+  `missed` are recorded habit outcomes. They use the neutral level-02 outcome
+  fill: a skipped day carries an orange warning dash and a missed day a red
+  error cross, leaving only an untouched level-03 day to carry its weekday.
 - **`DayVerdict` is the user's ruling**, and a recorded verdict outranks the
   measurement wherever both are shown. The enum is persisted by `name` in
   goal assessment records (see [goals](../features/goals.md)), so the names
@@ -119,17 +119,17 @@ flowchart LR
 
 # Invariants
 
-- **Two fills for a measured day.** A kept day is `interactive.enabled` —
+- **Three fills for a measured day.** A kept day is `interactive.enabled` —
   the handover's `--interactive` square — a partial day its `muted` wash, and
-  everything else `background.level03`. No alert hue on a habit square's
-  FILL: a struggling habit is never a wall of red or orange; the skip and miss
-  crosses alone wear their warning and error inks.
+  an untouched day `background.level03`; recorded skip and miss outcomes use
+  `background.level02`. No alert hue on a habit square's FILL: a struggling
+  habit is never a wall of red or orange; only the outcome glyph wears it.
 - **A square says one thing inside itself, and nothing around it.** A
   judged day draws its verdict's glyph; a kept day (partial included) the tick,
-  a skip an orange cross (`alert.warning.glyphOnLevel03`), and a recorded miss
-  a red cross (`alert.error.glyphOnLevel03`). Those ramp steps guarantee the
-  3:1 graphical floor on the `level03` fill in both themes; the surface ink
-  lands at 2.9:1 there in dark. The fill stays neutral while the glyph tells
+  a skip an orange dash (`alert.warning.defaultColor`), and a recorded miss
+  a red cross (`alert.error.defaultColor`). Those saturated ramp steps clear
+  the 3:1 graphical floor on the quieter `level02` fill in both themes. The
+  fill stays neutral while the glyph tells
   both recorded non-success outcomes from an empty day; an empty dated day
   carries its weekday — the first two characters of the
   locale's abbreviation (`dayMarkWeekdayLabel`: `Tu Th Sa Su`, `Di Do Sa

--- a/knowledge/architecture/day-indicators.md
+++ b/knowledge/architecture/day-indicators.md
@@ -77,8 +77,9 @@ classDiagram
   held as of that day; `partial` means the routine was kept while a window
   target was still building (a wash of the kept fill); `skipped` and
   `missed` are recorded habit outcomes. They use the neutral level-02 outcome
-  fill: a skipped day carries an orange warning dash and a missed day a red
-  error cross, leaving only an untouched level-03 day to carry its weekday.
+  fill inside a level-03 hairline: a skipped day carries an orange warning
+  dash and a missed day a red error cross, leaving only an untouched level-03
+  day to carry its weekday.
 - **`DayVerdict` is the user's ruling**, and a recorded verdict outranks the
   measurement wherever both are shown. The enum is persisted by `name` in
   goal assessment records (see [goals](../features/goals.md)), so the names
@@ -122,9 +123,11 @@ flowchart LR
 - **Three fills for a measured day.** A kept day is `interactive.enabled` —
   the handover's `--interactive` square — a partial day its `muted` wash, and
   an untouched day `background.level03`; recorded skip and miss outcomes use
-  `background.level02`. No alert hue on a habit square's FILL: a struggling
-  habit is never a wall of red or orange; only the outcome glyph wears it.
-- **A square says one thing inside itself, and nothing around it.** A
+  `background.level02`, framed by a `background.level03` hairline so the
+  rounded container remains visible on dark cards. No alert hue on a habit
+  square's FILL: a struggling habit is never a wall of red or orange; only the
+  outcome glyph wears it.
+- **A square says one thing inside itself, with no external caption.** A
   judged day draws its verdict's glyph; a kept day (partial included) the tick,
   a skip an orange dash (`alert.warning.defaultColor`), and a recorded miss
   a red cross (`alert.error.defaultColor`). Those saturated ramp steps clear

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -318,7 +318,7 @@ action content stays a comfortable column.
 Tab rows are **action rows**: icon, name, the handover's history strip —
 the last seven days on a phone and fourteen on a desktop window as squares
 (`habitHistoryMarks` with `habitHistoryDays`, read off the state's per-day
-completion sets), a tick on a successful day, an orange cross on a skip, a red
+completion sets), a tick on a successful day, an orange dash on a skip, a red
 cross on a recorded miss, the two-letter weekday on an empty day, each naming
 its date and outcome on hover, and
 each opening the completion sheet **for its own day** on tap; then the flame

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -11,7 +11,7 @@ sources:
   - id: src
     resource: ../../lib/features/habits
     title: Habits feature source
-    last_modified: 2026-08-28
+    last_modified: 2026-08-30
   - id: definitions
     resource: ../../lib/classes/entity_definitions.dart
     title: HabitDefinition
@@ -111,12 +111,11 @@ An unrecognised `completionType` decodes to `null` rather than throwing, so one
 completion type synced from a newer peer cannot take out the whole heatmap.
 
 **`null` is not a synonym for success.** It is the value legacy entries already
-carry, and the consumers treat it as *recorded and streak-extending, but not a
-success*: it counts in `allByDay`, `habitSuccessDays` and the heatmap
-denominator, while staying out of `successfulByDay`, `successfulToday` and the
-heatmap's success numerator. So an unknown type closes the habit for that day
-without contributing to its success rate. That asymmetry predates the
-projection; it is how legacy `null`s have always behaved.
+carry, and consumers treat it as *recorded, but not successful*: it counts in
+`allByDay` and the heatmap denominator, while staying out of streaks,
+`successfulByDay`, `successfulToday` and the heatmap's success numerator. So an
+unknown type closes the habit for that day without contributing to either its
+success rate or its streak.
 
 # What the tab controller derives
 
@@ -126,10 +125,12 @@ From active definitions plus completions in range: `completedToday`,
 `shortStreakCount` (trailing 3 days), `longStreakCount` (trailing 7 days), plus
 chart labels and `minY`.
 
-**Streaks require every day in the window.** `countHabitsWithStreak` counts
-habits whose success-day set covers *every* day — a single missing day
-disqualifies. **Skips and `null`-type completions count toward a streak the same
-as explicit successes; only an explicit `fail`, or a missing day, breaks it.**
+**Streaks require success on every day in the window.**
+`countHabitsWithStreak` counts habits whose explicit success-day set covers
+*every* day — a skip, failure, legacy `null`, or missing day disqualifies it.
+The deep-history current streak follows the same rule, except an open current
+day leaves yesterday's run visible until today resolves. Manual and
+auto-completions are both ordinary `success` records and maintain the streak.
 
 **The controller filters to `habit.active == true` immediately.** Archived habits
 still exist in settings and storage, but the main tab derives only from active
@@ -317,8 +318,9 @@ action content stays a comfortable column.
 Tab rows are **action rows**: icon, name, the handover's history strip —
 the last seven days on a phone and fourteen on a desktop window as squares
 (`habitHistoryMarks` with `habitHistoryDays`, read off the state's per-day
-completion sets), a tick on a kept day, a cross on a recorded miss, the
-two-letter weekday on any other, each naming its date and outcome on hover, and
+completion sets), a tick on a successful day, an orange cross on a skip, a red
+cross on a recorded miss, the two-letter weekday on an empty day, each naming
+its date and outcome on hover, and
 each opening the completion sheet **for its own day** on tap; then the flame
 and the current streak — swipe, and one-tap complete. The dashboard habit
 chart draws the same strip over its own range. Both go through the shared

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -318,8 +318,9 @@ action content stays a comfortable column.
 Tab rows are **action rows**: icon, name, the handover's history strip —
 the last seven days on a phone and fourteen on a desktop window as squares
 (`habitHistoryMarks` with `habitHistoryDays`, read off the state's per-day
-completion sets), a tick on a successful day, an orange dash on a skip, a red
-cross on a recorded miss, the two-letter weekday on an empty day, each naming
+completion sets), a tick on a successful day, an orange dash for a skip and a
+red cross for a recorded miss — both on neutral outlined squares — the
+two-letter weekday on an empty day, each naming
 its date and outcome on hover, and
 each opening the completion sheet **for its own day** on tap; then the flame
 and the current streak — swipe, and one-tap complete. The dashboard habit

--- a/lib/database/database_data_queries.dart
+++ b/lib/database/database_data_queries.dart
@@ -144,11 +144,11 @@ mixin _JournalDbDataQueries on _$JournalDb, _JournalDbConfigFlags {
   ///
   /// `null` is not a synonym for success. It is the same value legacy entries
   /// written before the field existed already carry, and the consumers treat it
-  /// as **recorded, and streak-extending, but not a success**: it lands in
-  /// `allByDay` and `habitSuccessDays`, and in the heatmap's denominator, while
-  /// staying out of `successfulByDay`, `successfulToday` and the heatmap's
-  /// success numerator. An unknown type therefore closes the habit for the day
-  /// without counting toward its success rate.
+  /// as **recorded, but not a success**: it lands in `allByDay` and the
+  /// heatmap's denominator, while staying out of streaks, `successfulByDay`,
+  /// `successfulToday` and the heatmap's success numerator. An unknown type
+  /// therefore closes the habit for the day without counting toward its
+  /// success rate.
   ///
   /// That split is pre-existing behaviour for legacy `null`s, not something
   /// this projection introduced. Giving unknown types their own sentinel with

--- a/lib/features/habits/README.md
+++ b/lib/features/habits/README.md
@@ -15,7 +15,8 @@ derived from combining the two.
   there when the completion needs detail or a different result.
 - **Shows momentum honestly.** A daily summary with a done count, a "to go"
   caption, and streak badges — where a streak requires *every* day in the window,
-  and only an explicit failure or a missing day breaks it.
+  and only successful completions maintain it; skips, failures and missing past
+  days break it.
 - **Shows the long view.** A full-width consistency heatmap of per-day completion
   intensity across all habits, going back years.
 - **Charts completion rates** over selectable time spans, with day-level

--- a/lib/features/habits/model/habit_completion_record.dart
+++ b/lib/features/habits/model/habit_completion_record.dart
@@ -45,10 +45,9 @@ class HabitCompletionRecord {
   /// before the field existed carry it, and so does any completion type synced
   /// from a newer peer that this build cannot decode.
   ///
-  /// The consumers treat it as **recorded and streak-extending, but not a
-  /// success**: it counts in `allByDay`, `habitSuccessDays` and the heatmap
-  /// denominator, but not in `successfulByDay`, `successfulToday` or the
-  /// heatmap's success numerator.
+  /// Consumers treat it as **recorded, but not successful**: it counts in
+  /// `allByDay` and the heatmap denominator, but not in streaks,
+  /// `successfulByDay`, `successfulToday` or the heatmap's success numerator.
   final HabitCompletionType? completionType;
 
   /// `json_extract(serialized, '$.data.source')` — who wrote the completion.

--- a/lib/features/habits/state/habits_controller.dart
+++ b/lib/features/habits/state/habits_controller.dart
@@ -229,9 +229,7 @@ class HabitsController extends Notifier<HabitsState> {
 
     for (final item in _habitCompletions) {
       if (_habitDefinitionsMap.containsKey(item.habitId) &&
-          (item.completionType == HabitCompletionType.success ||
-              item.completionType == HabitCompletionType.skip ||
-              item.completionType == null)) {
+          item.completionType == HabitCompletionType.success) {
         final day = item.dateFrom.ymd;
         habitSuccessDays.putIfAbsent(item.habitId, () => <String>{}).add(day);
       }

--- a/lib/features/habits/state/heatmap/habit_heatmap_data.dart
+++ b/lib/features/habits/state/heatmap/habit_heatmap_data.dart
@@ -153,10 +153,10 @@ int _weekdayRowIndex(String ymd, int firstDayOfWeekIndex) {
 }
 
 /// Per-habit **current streak**: the number of consecutive days, ending today
-/// (or yesterday, if today isn't recorded yet so a still-pending day doesn't
-/// read as a break), on which the habit was *kept* — a `success`, a `skip`, or
-/// an untyped completion, matching the streak rule used elsewhere (an explicit
-/// `fail` or a missing day ends it). Computed over the heatmap's deep history,
+/// (or yesterday, if today is still open), on which the habit was completed
+/// successfully. A skip, failure, legacy null outcome, or past open/missing day
+/// breaks the run; only an absent/open current day may leave yesterday's run
+/// visible while today is pending. Computed over the heatmap's deep history,
 /// so it isn't capped by the tab's short fetch window. Streaks are per habit,
 /// independent of the category filter.
 Map<String, int> currentStreaksByHabit({
@@ -165,39 +165,42 @@ Map<String, int> currentStreaksByHabit({
   required String todayYmd,
 }) {
   final ids = habitDefinitions.map((h) => h.id).toSet();
-  final keptByHabit = <String, Set<String>>{};
+  final outcomesByHabit = <String, Map<String, HabitCompletionType?>>{};
   for (final item in completions) {
     final id = item.habitId;
     if (!ids.contains(id)) {
       continue;
     }
-    final type = item.completionType;
-    if (type == HabitCompletionType.success ||
-        type == HabitCompletionType.skip ||
-        type == null) {
-      keptByHabit.putIfAbsent(id, () => <String>{}).add(item.dateFrom.ymd);
-    }
+    outcomesByHabit.putIfAbsent(
+      id,
+      () => <String, HabitCompletionType?>{},
+    )[item.dateFrom.ymd] = item.completionType;
   }
 
   return {
     for (final habit in habitDefinitions)
-      habit.id: _streakFromKeptDays(
-        keptByHabit[habit.id] ?? const <String>{},
+      habit.id: _streakFromOutcomes(
+        outcomesByHabit[habit.id] ?? const <String, HabitCompletionType?>{},
         todayYmd,
       ),
   };
 }
 
-int _streakFromKeptDays(Set<String> keptDays, String todayYmd) {
+int _streakFromOutcomes(
+  Map<String, HabitCompletionType?> outcomesByDay,
+  String todayYmd,
+) {
   var cursor = DateTime.parse(todayYmd);
-  if (!keptDays.contains(cursor.ymd)) {
+  final todayOutcome = outcomesByDay[cursor.ymd];
+  if (todayOutcome != HabitCompletionType.success) {
+    final todayIsPending =
+        !outcomesByDay.containsKey(cursor.ymd) ||
+        todayOutcome == HabitCompletionType.open;
+    if (!todayIsPending) return 0;
     cursor = DateTime(cursor.year, cursor.month, cursor.day - 1);
-    if (!keptDays.contains(cursor.ymd)) {
-      return 0;
-    }
   }
   var streak = 0;
-  while (keptDays.contains(cursor.ymd)) {
+  while (outcomesByDay[cursor.ymd] == HabitCompletionType.success) {
     streak++;
     cursor = DateTime(cursor.year, cursor.month, cursor.day - 1);
   }

--- a/lib/features/habits/ui/widgets/habit_completion_card.dart
+++ b/lib/features/habits/ui/widgets/habit_completion_card.dart
@@ -113,7 +113,7 @@ List<DayMark> _historyMarks(List<HabitResult> results) {
   ];
 }
 
-/// The current unbroken run of kept days at the end of [results]: today
+/// The current unbroken run of successful days at the end of [results]: today
 /// still open does not break it, any other non-success day does.
 int _currentStreak(List<HabitResult> results) {
   var streak = 0;

--- a/lib/widgets/day_indicators/day_mark.dart
+++ b/lib/widgets/day_indicators/day_mark.dart
@@ -7,8 +7,8 @@ import 'package:flutter/foundation.dart';
 /// target was still building — rendered as a lighter wash of the same success
 /// hue. [skipped] and [missed] are recorded outcomes a habit day can carry.
 /// A strip records what was KEPT, so they share the neutral fill of [none];
-/// a [missed] square draws a cross inside that fill, a [skipped] one stays
-/// bare, and the label and tooltip name all three (see `dayMarkStateLabel`).
+/// [skipped] and [missed] draw warning- and error-toned crosses inside that
+/// fill, and the label and tooltip name all three (see `dayMarkStateLabel`).
 enum DayMarkState { none, partial, full, skipped, missed }
 
 /// How a day turned out, in the user's own judgement.

--- a/lib/widgets/day_indicators/day_mark.dart
+++ b/lib/widgets/day_indicators/day_mark.dart
@@ -6,9 +6,9 @@ import 'package:flutter/foundation.dart';
 /// did everything within their control (the routine was kept) while a window
 /// target was still building — rendered as a lighter wash of the same success
 /// hue. [skipped] and [missed] are recorded outcomes a habit day can carry.
-/// A strip records what was KEPT, so they share the neutral fill of [none];
-/// [skipped] and [missed] draw warning- and error-toned crosses inside that
-/// fill, and the label and tooltip name all three (see `dayMarkStateLabel`).
+/// A strip records what was KEPT, so they stay on a neutral fill rather than
+/// borrowing an alert fill; [skipped] draws an orange dash and [missed] a red
+/// cross, and the label and tooltip name all three (see `dayMarkStateLabel`).
 enum DayMarkState { none, partial, full, skipped, missed }
 
 /// How a day turned out, in the user's own judgement.

--- a/lib/widgets/day_indicators/day_mark_cell.dart
+++ b/lib/widgets/day_indicators/day_mark_cell.dart
@@ -98,8 +98,16 @@ Widget? dayMarkSquareContent(
         size: glyphSize,
         color: tokens.colors.alert.error.glyphOnLevel03,
       );
-    case DayMarkState.none:
     case DayMarkState.skipped:
+      // A skip is an explicit outcome, not an untouched day. It keeps the
+      // same quiet neutral fill as a miss, but uses the warning family so it
+      // cannot be confused with either an empty weekday cell or the red miss.
+      return Icon(
+        dayVerdictGlyph(DayVerdict.missed),
+        size: glyphSize,
+        color: tokens.colors.alert.warning.glyphOnLevel03,
+      );
+    case DayMarkState.none:
       if (day == null) return null;
       final locale = Localizations.localeOf(context).toLanguageTag();
       // Scaled down into the same inset the glyphs keep, never wrapped or

--- a/lib/widgets/day_indicators/day_mark_cell.dart
+++ b/lib/widgets/day_indicators/day_mark_cell.dart
@@ -161,12 +161,13 @@ class PlaceholderDayCell extends StatelessWidget {
 
 /// One day square, as the habits handover draws it: a small rounded square
 /// filled in the interactive hue when the day was kept and in the neutral
-/// level-03 surface otherwise — a recorded verdict paints its own hue, and an
-/// empty TODAY is the dashed unresolved outline, since the day is not over.
+/// level-03 surface otherwise. A skip or miss keeps its quieter level-02 fill
+/// inside a neutral hairline so the rounded square remains visible, a recorded
+/// verdict paints its own hue, and an empty TODAY is the dashed unresolved
+/// outline, since the day is not over.
 /// Inside it, [dayMarkSquareContent]: the outcome's glyph, or the weekday
-/// while there is none. Nothing is drawn around a square; the full
-/// date, the outcome's name and a verdict's are answered by the tooltip and
-/// the semantics.
+/// while there is none. The full date, the outcome's name and a verdict's are
+/// answered by the tooltip and the semantics.
 ///
 /// Read-only by default. With [onTap] the square keeps its size while the
 /// hit slot around it clears the touch floor, and the cell announces itself
@@ -210,6 +211,9 @@ class DayMarkCell extends StatelessWidget {
               color: verdict == null
                   ? dayMarkStateFill(tokens, mark.state)
                   : dayVerdictFill(tokens, verdict),
+              border: verdict == null
+                  ? dayMarkStateBorder(tokens, mark.state)
+                  : null,
               borderRadius: BorderRadius.circular(tokens.radii.xs),
             ),
             child: dayMarkSquareContent(

--- a/lib/widgets/day_indicators/day_mark_cell.dart
+++ b/lib/widgets/day_indicators/day_mark_cell.dart
@@ -46,8 +46,8 @@ String dayMarkWeekdayLabel(String locale, DateTime day) =>
 /// tick or a cross beside a lettered neighbour is read against that
 /// neighbour's day. The glyphs are the reflections history's own
 /// (`dayVerdictGlyph`), so an outcome is drawn the same way wherever it is
-/// shown. A recorded miss shares the neutral fill with an empty day, and the
-/// red cross is what tells them apart.
+/// shown. Recorded misses and skips use a quieter neutral fill than empty
+/// days; a saturated red cross and orange dash tell the two outcomes apart.
 ///
 /// Null for an undated, unresolved square — a streak chain has nothing to
 /// say inside its cells.
@@ -87,25 +87,21 @@ Widget? dayMarkSquareContent(
         color: tokens.colors.interactive.enabled,
       );
     case DayMarkState.missed:
-      // The one touch of the error family a habit square gets: the cross
-      // in red, on the neutral fill. A miss should sting a little, and a bad
-      // week should still not be a wall of red — the mark carries the hue,
-      // the square does not. `glyphOnLevel03`, not the surface ink: the
-      // fill is `level03`, the mid grey the ink was never tuned for (2.9:1
-      // there in dark), and that step is the ramp's guarantee of 3:1 on it.
+      // The one touch of the error family a habit square gets: a saturated
+      // red cross on the neutral outcome fill. The mark carries the hue so a
+      // bad week still does not become a wall of red.
       return Icon(
         dayVerdictGlyph(DayVerdict.missed),
         size: glyphSize,
-        color: tokens.colors.alert.error.glyphOnLevel03,
+        color: tokens.colors.alert.error.defaultColor,
       );
     case DayMarkState.skipped:
-      // A skip is an explicit outcome, not an untouched day. It keeps the
-      // same quiet neutral fill as a miss, but uses the warning family so it
-      // cannot be confused with either an empty weekday cell or the red miss.
+      // A skip is an explicit outcome, not an untouched day or a miss. The
+      // warning-colored dash distinguishes it by shape as well as hue.
       return Icon(
-        dayVerdictGlyph(DayVerdict.missed),
+        LottiIcons.remove,
         size: glyphSize,
-        color: tokens.colors.alert.warning.glyphOnLevel03,
+        color: tokens.colors.alert.warning.defaultColor,
       );
     case DayMarkState.none:
       if (day == null) return null;

--- a/lib/widgets/day_indicators/day_mark_styles.dart
+++ b/lib/widgets/day_indicators/day_mark_styles.dart
@@ -11,9 +11,8 @@ import 'package:lotti/widgets/day_indicators/day_mark.dart';
 /// is never a wall of red. A recorded miss is told apart from a day nobody
 /// looked at by the red cross drawn inside the grey (`dayMarkSquareContent`,
 /// in the error ramp's `glyphOnLevel03` step — its 3:1 guarantee on that
-/// fill), not by its fill; a skip keeps its weekday, and is named by the
-/// tooltip and semantics. A partial day, kept too, draws the tick in the
-/// kept hue on its wash.
+/// fill), not by its fill; a skip uses the same cross in the warning hue. A
+/// partial day, kept too, draws the tick in the kept hue on its wash.
 /// `SurfaceAlphas.muted` is the sanctioned "reduced-strength accent" alpha, so
 /// no new color token is introduced.
 Color dayMarkStateFill(DsTokens tokens, DayMarkState state) => switch (state) {

--- a/lib/widgets/day_indicators/day_mark_styles.dart
+++ b/lib/widgets/day_indicators/day_mark_styles.dart
@@ -6,13 +6,12 @@ import 'package:lotti/widgets/day_indicators/day_mark.dart';
 /// Shared fill for a measured day: the interactive hue when the day was
 /// kept — the handover's `--interactive` square — a wash of it for a partial
 /// success (routine kept, target still building), and the neutral level-03
-/// surface for anything else. A skipped or missed day is not painted in an
+/// surface for an untouched day. A skipped or missed day is not painted in an
 /// alert hue: the strip is a record of what was kept, and a struggling habit
-/// is never a wall of red. A recorded miss is told apart from a day nobody
-/// looked at by the red cross drawn inside the grey (`dayMarkSquareContent`,
-/// in the error ramp's `glyphOnLevel03` step — its 3:1 guarantee on that
-/// fill), not by its fill; a skip uses the same cross in the warning hue. A
-/// partial day, kept too, draws the tick in the kept hue on its wash.
+/// is never a wall of red. Both use the quieter level-02 neutral fill so the
+/// saturated default alert colors remain crisp: a red cross for miss, an
+/// orange dash for skip. A partial day, kept too, draws the tick in the kept
+/// hue on its wash.
 /// `SurfaceAlphas.muted` is the sanctioned "reduced-strength accent" alpha, so
 /// no new color token is introduced.
 Color dayMarkStateFill(DsTokens tokens, DayMarkState state) => switch (state) {
@@ -20,9 +19,9 @@ Color dayMarkStateFill(DsTokens tokens, DayMarkState state) => switch (state) {
   DayMarkState.partial => tokens.colors.interactive.enabled.withValues(
     alpha: SurfaceAlphas.muted,
   ),
-  DayMarkState.none ||
+  DayMarkState.none => tokens.colors.background.level03,
   DayMarkState.skipped ||
-  DayMarkState.missed => tokens.colors.background.level03,
+  DayMarkState.missed => tokens.colors.background.level02,
 };
 
 /// The localized name of a measured state, shared by every day cell's

--- a/lib/widgets/day_indicators/day_mark_styles.dart
+++ b/lib/widgets/day_indicators/day_mark_styles.dart
@@ -24,6 +24,22 @@ Color dayMarkStateFill(DsTokens tokens, DayMarkState state) => switch (state) {
   DayMarkState.missed => tokens.colors.background.level02,
 };
 
+/// Neutral outline for a recorded non-success outcome.
+///
+/// The outcome fill deliberately stays at level 02 so the saturated warning
+/// and error glyphs clear their contrast floor. On dark cards that surface can
+/// merge with its surroundings, so a level-03 hairline keeps the rounded cell
+/// visible without turning the whole square into an alert-colored block.
+BoxBorder? dayMarkStateBorder(DsTokens tokens, DayMarkState state) =>
+    switch (state) {
+      DayMarkState.skipped || DayMarkState.missed => Border.fromBorderSide(
+        BorderSide(color: tokens.colors.background.level03).copyWith(
+          width: BorderWidths.hairline,
+        ),
+      ),
+      DayMarkState.full || DayMarkState.partial || DayMarkState.none => null,
+    };
+
 /// The localized name of a measured state, shared by every day cell's
 /// semantics and tooltip so a "done" day is called the same thing everywhere.
 String dayMarkStateLabel(BuildContext context, DayMarkState state) =>

--- a/test/database/database_data_queries_test.dart
+++ b/test/database/database_data_queries_test.dart
@@ -285,8 +285,8 @@ void main() {
         () async {
           // Forward compatibility: a newer peer can sync a completion type
           // this build does not know. Decoding to null keeps it in the same
-          // bucket as a legacy entry — recorded and streak-extending, but not
-          // counted as a success — rather than throwing and taking out the
+          // bucket as a legacy entry — recorded, but not counted as a success
+          // or streak day — rather than throwing and taking out the
           // whole heatmap for one unrecognised row.
           const serialized =
               '{"data":{"habitId":"habit-future",'

--- a/test/features/goals/ui/goal_progress_card_test.dart
+++ b/test/features/goals/ui/goal_progress_card_test.dart
@@ -542,8 +542,8 @@ void main() {
     expect(find.text('Improving'), findsOneWidget);
   });
 
-  testWidgets('no square draws a ring, glyph or letter: today, the window '
-      'start and the outcomes are said, not drawn', (tester) async {
+  testWidgets('each square draws only its outcome glyph or weekday: today and '
+      'the window start are said, not drawn', (tester) async {
     final habit = GoalHabitProgressView(
       habitId: 'gym',
       name: 'Gym',
@@ -597,6 +597,7 @@ void main() {
           cell.mark.verdict != null ||
           cell.mark.state == DayMarkState.full ||
           cell.mark.state == DayMarkState.partial ||
+          cell.mark.state == DayMarkState.skipped ||
           cell.mark.state == DayMarkState.missed;
       expect(
         find.descendant(of: self, matching: find.byType(Icon)),
@@ -2677,11 +2678,16 @@ void main() {
       (cell.decoration! as BoxDecoration).color,
       tokens.colors.background.level03,
     );
-    // Nothing is drawn inside the square; the skip is said, not shown.
-    expect(
-      find.descendant(of: find.byType(DayTrack), matching: find.byType(Icon)),
-      findsNothing,
+    final icon = tester.widget<Icon>(
+      find.descendant(
+        of: find.byKey(
+          const ValueKey('goal-habit-day-visual-walk-2026-08-11'),
+        ),
+        matching: find.byType(Icon),
+      ),
     );
+    expect(icon.icon, dayVerdictGlyph(DayVerdict.missed));
+    expect(icon.color, tokens.colors.alert.warning.glyphOnLevel03);
     expect(
       find.bySemanticsLabel('Aug 11, 2026: Skip'),
       findsOneWidget,

--- a/test/features/goals/ui/goal_progress_card_test.dart
+++ b/test/features/goals/ui/goal_progress_card_test.dart
@@ -2676,7 +2676,7 @@ void main() {
     );
     expect(
       (cell.decoration! as BoxDecoration).color,
-      tokens.colors.background.level03,
+      tokens.colors.background.level02,
     );
     final icon = tester.widget<Icon>(
       find.descendant(
@@ -2686,8 +2686,8 @@ void main() {
         matching: find.byType(Icon),
       ),
     );
-    expect(icon.icon, dayVerdictGlyph(DayVerdict.missed));
-    expect(icon.color, tokens.colors.alert.warning.glyphOnLevel03);
+    expect(icon.icon, LottiIcons.remove);
+    expect(icon.color, tokens.colors.alert.warning.defaultColor);
     expect(
       find.bySemanticsLabel('Aug 11, 2026: Skip'),
       findsOneWidget,

--- a/test/features/habits/model/habit_completion_record_test.dart
+++ b/test/features/habits/model/habit_completion_record_test.dart
@@ -48,8 +48,8 @@ void main() {
 
   test('a null completion type is a value, not an absence', () {
     // Null is a real value, not missing data — legacy entries carry it, and so
-    // does any completion type this build cannot decode. (It means "recorded
-    // and streak-extending, but not a success"; see the field docs.) Two
+    // does any completion type this build cannot decode. (It means "recorded,
+    // but not a success or streak day"; see the field docs.) Two
     // null-typed records must therefore compare equal to each other.
     expect(record(completionType: null), record(completionType: null));
   });

--- a/test/features/habits/state/habits_controller_test.dart
+++ b/test/features/habits/state/habits_controller_test.dart
@@ -457,6 +457,35 @@ void main() {
       // Should have at least one short streak (4 days)
       expect(state.shortStreakCount, greaterThanOrEqualTo(1));
     });
+
+    test('a skip prevents a habit from qualifying for a streak', () async {
+      final completions = <JournalEntity>[
+        for (var i = 0; i <= 3; i++)
+          createCompletion(
+            id: 'c$i',
+            habitId: 'habit-1',
+            date: controllerToday.subtract(Duration(days: i)),
+            completionType: i == 1
+                ? HabitCompletionType.skip
+                : HabitCompletionType.success,
+          ),
+      ];
+
+      when(
+        () => mockRepository.getHabitCompletionsInRange(
+          rangeStart: any(named: 'rangeStart'),
+        ),
+      ).thenAnswer((_) async => habitCompletionRecordsFrom(completions));
+
+      container.read(habitsControllerProvider);
+      await pumpEventQueue();
+      definitionsController.add([testHabit1]);
+      await pumpEventQueue();
+
+      final state = container.read(habitsControllerProvider);
+      expect(state.shortStreakCount, 0);
+      expect(state.longStreakCount, 0);
+    });
   });
 
   group('UpdateNotifications stream handling', () {

--- a/test/features/habits/state/heatmap/habit_heatmap_data_test.dart
+++ b/test/features/habits/state/heatmap/habit_heatmap_data_test.dart
@@ -394,7 +394,7 @@ void main() {
           todayYmd: today,
         );
 
-    test('counts consecutive kept days ending today', () {
+    test('counts consecutive successful days ending today', () {
       final result = streaks([
         _completion(habitId: 'h1', date: DateTime(2026, 6, 15)),
         _completion(habitId: 'h1', date: DateTime(2026, 6, 16)),
@@ -421,21 +421,30 @@ void main() {
       expect(result['h1'], 2);
     });
 
-    test('a skip keeps the streak, a fail does not extend it', () {
+    test('a skip breaks a streak between successful days', () {
       final result = streaks([
+        _completion(habitId: 'h1', date: DateTime(2026, 6, 15)),
         _completion(
           habitId: 'h1',
           date: DateTime(2026, 6, 16),
           type: HabitCompletionType.skip,
         ),
+        _completion(habitId: 'h1', date: DateTime(2026, 6, 17)),
+      ]);
+      expect(result['h1'], 1);
+    });
+
+    test('a skip today resets the current streak', () {
+      final result = streaks([
+        _completion(habitId: 'h1', date: DateTime(2026, 6, 15)),
+        _completion(habitId: 'h1', date: DateTime(2026, 6, 16)),
         _completion(
           habitId: 'h1',
           date: DateTime(2026, 6, 17),
-          type: HabitCompletionType.fail,
+          type: HabitCompletionType.skip,
         ),
       ]);
-      // Today is a fail (not kept) → fall back to yesterday's skip → 1.
-      expect(result['h1'], 1);
+      expect(result['h1'], 0);
     });
 
     test('no completions → zero', () {

--- a/test/features/habits/ui/habits_manual_screenshots_test.dart
+++ b/test/features/habits/ui/habits_manual_screenshots_test.dart
@@ -552,7 +552,7 @@ HabitHeatmapData _heatmapData() {
     streaksByHabit: {
       _inspectHabitatSeals.id: 6,
       _penguinRollCall.id: 4,
-      _recalibrateFishFeeder.id: 2,
+      _recalibrateFishFeeder.id: 0,
       _reviewSardineInventory.id: 9,
     },
   );

--- a/test/features/habits/ui/widgets/habit_action_row_test.dart
+++ b/test/features/habits/ui/widgets/habit_action_row_test.dart
@@ -199,12 +199,12 @@ void main() {
               .color!;
       expect(fillAt(0), tokens.colors.interactive.enabled);
       expect(fillAt(1), tokens.colors.background.level03);
-      expect(fillAt(2), tokens.colors.background.level03);
-      expect(fillAt(3), tokens.colors.background.level03);
+      expect(fillAt(2), tokens.colors.background.level02);
+      expect(fillAt(3), tokens.colors.background.level02);
       expect(
         find.descendant(
           of: squares().at(3),
-          matching: find.byIcon(LottiIcons.close),
+          matching: find.byIcon(LottiIcons.remove),
         ),
         findsOneWidget,
       );

--- a/test/features/habits/ui/widgets/habit_action_row_test.dart
+++ b/test/features/habits/ui/widgets/habit_action_row_test.dart
@@ -201,6 +201,13 @@ void main() {
       expect(fillAt(1), tokens.colors.background.level03);
       expect(fillAt(2), tokens.colors.background.level03);
       expect(fillAt(3), tokens.colors.background.level03);
+      expect(
+        find.descendant(
+          of: squares().at(3),
+          matching: find.byIcon(LottiIcons.close),
+        ),
+        findsOneWidget,
+      );
       expect(find.byIcon(LottiIcons.streak), findsNothing);
     });
 

--- a/test/features/habits/ui/widgets/habit_completion_card_test.dart
+++ b/test/features/habits/ui/widgets/habit_completion_card_test.dart
@@ -162,25 +162,25 @@ void main() {
         DayMarkState.skipped,
         DayMarkState.full,
       ]);
-      // The missed day draws the cross, the kept day the tick; the skipped
-      // and the open day keep their weekday letters, named by the summary
-      // and the tooltips.
+      // The missed and skipped days draw crosses in their semantic hues, the
+      // kept day the tick; only the open day keeps its weekday letter.
       Finder glyph(int index, IconData icon) => find.descendant(
         of: find.byType(DayMarkCell).at(index),
         matching: find.byIcon(icon),
       );
       expect(glyph(1, dayVerdictGlyph(DayVerdict.missed)), findsOneWidget);
+      expect(glyph(2, dayVerdictGlyph(DayVerdict.missed)), findsOneWidget);
       expect(glyph(3, dayVerdictGlyph(DayVerdict.met)), findsOneWidget);
       expect(
         find.descendant(
           of: find.byType(DayMarkCell),
           matching: find.byType(Icon),
         ),
-        findsNWidgets(2),
+        findsNWidgets(3),
       );
 
       // The strip's summary is its container's label. The range ends on a
-      // kept day, so it is the streak that is announced.
+      // successful day, so it is the streak that is announced.
       expect(find.bySemanticsLabel(RegExp('1-day streak')), findsOneWidget);
       handle.dispose();
     });
@@ -209,7 +209,7 @@ void main() {
   });
 
   group('current streak', () {
-    testWidgets('counts the trailing kept days, letting an open today ride', (
+    testWidgets('counts trailing successful days, letting an open today ride', (
       tester,
     ) async {
       _results = [

--- a/test/features/habits/ui/widgets/habit_completion_card_test.dart
+++ b/test/features/habits/ui/widgets/habit_completion_card_test.dart
@@ -139,8 +139,8 @@ void main() {
   });
 
   group('history strip', () {
-    testWidgets('draws every in-range day as a shared day-mark cell, with the '
-        'tick and cross as non-color cues', (tester) async {
+    testWidgets('draws every in-range day as a shared day-mark cell, with '
+        'distinct tick, dash and cross cues', (tester) async {
       final handle = tester.ensureSemantics();
       // The open day precedes the success day so `results.last` is success and
       // the trailing button is the done-circle, not another check glyph.
@@ -162,14 +162,14 @@ void main() {
         DayMarkState.skipped,
         DayMarkState.full,
       ]);
-      // The missed and skipped days draw crosses in their semantic hues, the
-      // kept day the tick; only the open day keeps its weekday letter.
+      // The missed day draws a red cross, the skipped day an orange dash, and
+      // the kept day a tick; only the open day keeps its weekday letter.
       Finder glyph(int index, IconData icon) => find.descendant(
         of: find.byType(DayMarkCell).at(index),
         matching: find.byIcon(icon),
       );
       expect(glyph(1, dayVerdictGlyph(DayVerdict.missed)), findsOneWidget);
-      expect(glyph(2, dayVerdictGlyph(DayVerdict.missed)), findsOneWidget);
+      expect(glyph(2, LottiIcons.remove), findsOneWidget);
       expect(glyph(3, dayVerdictGlyph(DayVerdict.met)), findsOneWidget);
       expect(
         find.descendant(

--- a/test/widgets/day_indicators/day_mark_cell_test.dart
+++ b/test/widgets/day_indicators/day_mark_cell_test.dart
@@ -46,10 +46,15 @@ void main() {
         BorderRadius.circular(tokens.radii.xs),
         reason: '$state',
       );
-      expect(decoration(tester).border, isNull, reason: '$state');
+      expect(
+        decoration(tester).border,
+        dayMarkStateBorder(tokens, state),
+        reason: '$state',
+      );
       if (state == DayMarkState.missed || state == DayMarkState.skipped) {
-        // Recorded skips and misses share a neutral outcome fill. Shape and
-        // saturated alert hue distinguish the orange dash from the red cross.
+        // Recorded skips and misses share a neutral outlined outcome square.
+        // Shape and saturated alert hue distinguish the orange dash from the
+        // red cross.
         final icon = tester.widget<Icon>(find.byType(Icon));
         expect(
           icon.icon,
@@ -64,6 +69,14 @@ void main() {
               : tokens.colors.alert.error.defaultColor,
         );
         expect(decoration(tester).color, tokens.colors.background.level02);
+        expect(
+          decoration(tester).border,
+          Border.all(color: tokens.colors.background.level03),
+        );
+        expect(
+          (decoration(tester).border! as Border).top.width,
+          BorderWidths.hairline,
+        );
         expect(icon.size, kDaySquareSize - tokens.spacing.step2);
       } else if (state == DayMarkState.full || state == DayMarkState.partial) {
         expect(
@@ -121,6 +134,11 @@ void main() {
     expect(
       tester.widget<Icon>(find.byType(Icon)).icon,
       dayVerdictGlyph(DayVerdict.met),
+    );
+    expect(
+      decoration(tester).border,
+      isNull,
+      reason: 'the verdict fill replaces the measured outcome treatment',
     );
   });
 

--- a/test/widgets/day_indicators/day_mark_cell_test.dart
+++ b/test/widgets/day_indicators/day_mark_cell_test.dart
@@ -32,7 +32,7 @@ void main() {
       square(tester).decoration! as BoxDecoration;
 
   testWidgets('an undated square is one size at the xs radius, with a glyph '
-      'inside it only for a kept or missed day', (tester) async {
+      'inside it for every recorded outcome', (tester) async {
     for (final state in DayMarkState.values) {
       await pump(tester, DayMarkCell(mark: DayMark(state: state)));
       final tokens = tester.element(find.byType(DayMarkCell)).designTokens;
@@ -47,14 +47,18 @@ void main() {
         reason: '$state',
       );
       expect(decoration(tester).border, isNull, reason: '$state');
-      if (state == DayMarkState.missed) {
-        // A recorded miss and an empty day share the grey; the cross is
-        // what tells them apart. The reflections history's own glyph, in
-        // red — the square itself stays neutral, so a bad week is a few red
-        // marks, never a wall of red.
+      if (state == DayMarkState.missed || state == DayMarkState.skipped) {
+        // Recorded skips, misses and empty days share the grey; the cross is
+        // what tells an outcome apart. Warning orange distinguishes a skip
+        // from an error red miss without turning the square into an alert fill.
         final icon = tester.widget<Icon>(find.byType(Icon));
         expect(icon.icon, dayVerdictGlyph(DayVerdict.missed));
-        expect(icon.color, tokens.colors.alert.error.glyphOnLevel03);
+        expect(
+          icon.color,
+          state == DayMarkState.skipped
+              ? tokens.colors.alert.warning.glyphOnLevel03
+              : tokens.colors.alert.error.glyphOnLevel03,
+        );
         expect(decoration(tester).color, tokens.colors.background.level03);
         expect(icon.size, kDaySquareSize - tokens.spacing.step2);
       } else if (state == DayMarkState.full || state == DayMarkState.partial) {
@@ -71,28 +75,33 @@ void main() {
     }
   });
 
-  testWidgets('the missed cross clears the 3:1 graphical floor on the grey '
-      'square in both themes', (tester) async {
+  testWidgets('the skip and missed crosses clear the 3:1 graphical floor on '
+      'the grey square in both themes', (tester) async {
     for (final brightness in Brightness.values) {
-      await tester.pumpWidget(
-        makeTestableWidgetNoScroll(
-          const Align(
-            alignment: Alignment.topLeft,
-            child: DayMarkCell(mark: DayMark(state: DayMarkState.missed)),
+      for (final state in [DayMarkState.skipped, DayMarkState.missed]) {
+        await tester.pumpWidget(
+          makeTestableWidgetNoScroll(
+            Align(
+              alignment: Alignment.topLeft,
+              child: DayMarkCell(mark: DayMark(state: state)),
+            ),
+            theme: ThemeData(brightness: brightness, useMaterial3: true),
           ),
-          theme: ThemeData(brightness: brightness, useMaterial3: true),
-        ),
-      );
-      final tokens = tester.element(find.byType(DayMarkCell)).designTokens;
-      final icon = tester.widget<Icon>(find.byType(Icon));
-      expect(
-        contrastRatio(icon.color!, decoration(tester).color!),
-        greaterThanOrEqualTo(3),
-        reason: '$brightness: the cross must read against level03',
-      );
-      // Still red: the error ramp's own step for this fill, not a neutral
-      // ink and not an interaction state borrowed for its contrast.
-      expect(icon.color, tokens.colors.alert.error.glyphOnLevel03);
+        );
+        final tokens = tester.element(find.byType(DayMarkCell)).designTokens;
+        final icon = tester.widget<Icon>(find.byType(Icon));
+        expect(
+          contrastRatio(icon.color!, decoration(tester).color!),
+          greaterThanOrEqualTo(3),
+          reason: '$brightness $state: the cross must read against level03',
+        );
+        expect(
+          icon.color,
+          state == DayMarkState.skipped
+              ? tokens.colors.alert.warning.glyphOnLevel03
+              : tokens.colors.alert.error.glyphOnLevel03,
+        );
+      }
     }
   });
 
@@ -242,31 +251,27 @@ void main() {
       'inside itself, quiet on the neutral fill; an undated one carries '
       'nothing', (tester) async {
     final monday = DateTime.utc(2026, 8, 10);
-    for (final state in [DayMarkState.none, DayMarkState.skipped]) {
-      await pump(
-        tester,
-        DayMarkCell(
-          mark: DayMark(state: state, day: monday),
-        ),
-      );
-      final tokens = tester.element(find.byType(DayMarkCell)).designTokens;
-      final letter = find.descendant(
-        of: find.byType(Container),
-        matching: find.text('Mo'),
-      );
-      expect(letter, findsOneWidget, reason: '$state');
-      expect(find.byType(Icon), findsNothing, reason: '$state');
-      expect(
-        tester.widget<Text>(letter).style?.color,
-        tokens.colors.text.lowEmphasis,
-        reason: '$state',
-      );
-      expect(
-        tester.getCenter(letter),
-        tester.getCenter(find.byType(Container)),
-        reason: '$state sits centred in its square',
-      );
-    }
+    await pump(
+      tester,
+      DayMarkCell(
+        mark: DayMark(state: DayMarkState.none, day: monday),
+      ),
+    );
+    final tokens = tester.element(find.byType(DayMarkCell)).designTokens;
+    final letter = find.descendant(
+      of: find.byType(Container),
+      matching: find.text('Mo'),
+    );
+    expect(letter, findsOneWidget);
+    expect(find.byType(Icon), findsNothing);
+    expect(
+      tester.widget<Text>(letter).style?.color,
+      tokens.colors.text.lowEmphasis,
+    );
+    expect(
+      tester.getCenter(letter),
+      tester.getCenter(find.byType(Container)),
+    );
     await pump(
       tester,
       const DayMarkCell(mark: DayMark(state: DayMarkState.none)),

--- a/test/widgets/day_indicators/day_mark_cell_test.dart
+++ b/test/widgets/day_indicators/day_mark_cell_test.dart
@@ -48,18 +48,22 @@ void main() {
       );
       expect(decoration(tester).border, isNull, reason: '$state');
       if (state == DayMarkState.missed || state == DayMarkState.skipped) {
-        // Recorded skips, misses and empty days share the grey; the cross is
-        // what tells an outcome apart. Warning orange distinguishes a skip
-        // from an error red miss without turning the square into an alert fill.
+        // Recorded skips and misses share a neutral outcome fill. Shape and
+        // saturated alert hue distinguish the orange dash from the red cross.
         final icon = tester.widget<Icon>(find.byType(Icon));
-        expect(icon.icon, dayVerdictGlyph(DayVerdict.missed));
+        expect(
+          icon.icon,
+          state == DayMarkState.skipped
+              ? LottiIcons.remove
+              : dayVerdictGlyph(DayVerdict.missed),
+        );
         expect(
           icon.color,
           state == DayMarkState.skipped
-              ? tokens.colors.alert.warning.glyphOnLevel03
-              : tokens.colors.alert.error.glyphOnLevel03,
+              ? tokens.colors.alert.warning.defaultColor
+              : tokens.colors.alert.error.defaultColor,
         );
-        expect(decoration(tester).color, tokens.colors.background.level03);
+        expect(decoration(tester).color, tokens.colors.background.level02);
         expect(icon.size, kDaySquareSize - tokens.spacing.step2);
       } else if (state == DayMarkState.full || state == DayMarkState.partial) {
         expect(
@@ -75,8 +79,8 @@ void main() {
     }
   });
 
-  testWidgets('the skip and missed crosses clear the 3:1 graphical floor on '
-      'the grey square in both themes', (tester) async {
+  testWidgets('the skip dash and missed cross clear the 3:1 graphical floor '
+      'on the neutral outcome square in both themes', (tester) async {
     for (final brightness in Brightness.values) {
       for (final state in [DayMarkState.skipped, DayMarkState.missed]) {
         await tester.pumpWidget(
@@ -93,13 +97,13 @@ void main() {
         expect(
           contrastRatio(icon.color!, decoration(tester).color!),
           greaterThanOrEqualTo(3),
-          reason: '$brightness $state: the cross must read against level03',
+          reason: '$brightness $state: the mark must read against level02',
         );
         expect(
           icon.color,
           state == DayMarkState.skipped
-              ? tokens.colors.alert.warning.glyphOnLevel03
-              : tokens.colors.alert.error.glyphOnLevel03,
+              ? tokens.colors.alert.warning.defaultColor
+              : tokens.colors.alert.error.defaultColor,
         );
       }
     }

--- a/test/widgets/day_indicators/day_mark_styles_test.dart
+++ b/test/widgets/day_indicators/day_mark_styles_test.dart
@@ -46,6 +46,25 @@ void main() {
     }
   });
 
+  testWidgets('only recorded skip and miss states receive an outcome outline', (
+    tester,
+  ) async {
+    final t = await tokens(tester);
+    for (final state in DayMarkState.values) {
+      final border = dayMarkStateBorder(t, state);
+      if (state == DayMarkState.skipped || state == DayMarkState.missed) {
+        expect(
+          border,
+          Border.all(color: t.colors.background.level03),
+          reason: '$state keeps its rounded neutral container visible',
+        );
+        expect((border! as Border).top.width, BorderWidths.hairline);
+      } else {
+        expect(border, isNull, reason: '$state');
+      }
+    }
+  });
+
   testWidgets('every verdict has a distinct fill, shape and surface ink', (
     tester,
   ) async {

--- a/test/widgets/day_indicators/day_mark_styles_test.dart
+++ b/test/widgets/day_indicators/day_mark_styles_test.dart
@@ -22,8 +22,8 @@ void main() {
     return tokens;
   }
 
-  testWidgets('state fills: the interactive hue for a kept day, a wash of it '
-      'for a partial one, the neutral surface for everything else', (
+  testWidgets('state fills separate kept, partial, untouched and recorded '
+      'outcome days without alert-colored fills', (
     tester,
   ) async {
     final t = await tokens(tester);
@@ -33,14 +33,14 @@ void main() {
       dayMarkStateFill(t, DayMarkState.partial),
       kept.withValues(alpha: SurfaceAlphas.muted),
     );
-    for (final state in [
-      DayMarkState.missed,
-      DayMarkState.skipped,
-      DayMarkState.none,
-    ]) {
+    expect(
+      dayMarkStateFill(t, DayMarkState.none),
+      t.colors.background.level03,
+    );
+    for (final state in [DayMarkState.missed, DayMarkState.skipped]) {
       expect(
         dayMarkStateFill(t, state),
-        t.colors.background.level03,
+        t.colors.background.level02,
         reason: '$state is not painted in an alert hue',
       );
     }


### PR DESCRIPTION
## Summary

- render skipped habit days as a saturated orange dash and missed days as a saturated red X on neutral outlined outcome cells across habit, dashboard, and goal-card strips
- make streaks success-only so skips, failures, and legacy null outcomes break rather than preserve a run
- document the consecutive-day streak contract and add regression coverage for skip rendering and mixed success/skip histories

## Investigation

Skip entries were already recorded and mapped to `DayMarkState.skipped`, but the shared day-cell renderer handled `skipped` together with `none`, producing the same faint background and weekday text as an untouched day.

Two streak paths also classified `success`, `skip`, and null completion types as kept days. These streaks are consecutive-day indicators, not the separate rolling/calendar frequency progress shown on goal cards, so only explicit successful completions should maintain them. The dashboard card's local streak calculation was already success-only.

The outcome legend introduced in #4074 was removed in the later design follow-up #4076, and the current day-indicator architecture explicitly omits a key. There is therefore no active legend surface to update; all active outcome strips now share the corrected renderer.

## Verification

- `fvm dart analyze`
- 247 targeted unit/widget tests for the full fix, plus 164 focused tests for the visual refinement
- 17 opt-in screenshot harness tests, publishing five affected surface pairs covering habits mobile/desktop light/dark and dashboard dark
- `make changelog_check`
- `make knowledge_check`
- `git diff --check`

The new regression assertions were first run against the previous production implementation and failed for the expected reasons: skipped cells had no glyph, and streaks crossed skipped days.

## Screenshots

### Habits page — desktop light

| Before | After |
|---|---|
| ![Habits desktop light before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-skip-outcome-borders/b8c4431ed3d3dda4f9ad1d45ad05292c1804393c/before/habits_today_desktop_light.png) | ![Habits desktop light after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-skip-outcome-borders/b8c4431ed3d3dda4f9ad1d45ad05292c1804393c/after/habits_today_desktop_light.png) |

### Habits page — desktop dark

| Before | After |
|---|---|
| ![Habits desktop dark before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-skip-outcome-borders/b8c4431ed3d3dda4f9ad1d45ad05292c1804393c/before/habits_today_desktop_dark.png) | ![Habits desktop dark after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-skip-outcome-borders/b8c4431ed3d3dda4f9ad1d45ad05292c1804393c/after/habits_today_desktop_dark.png) |

### Habits page — mobile light

| Before | After |
|---|---|
| ![Habits mobile light before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-skip-outcome-borders/b8c4431ed3d3dda4f9ad1d45ad05292c1804393c/before/habits_today_mobile_light.png) | ![Habits mobile light after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-skip-outcome-borders/b8c4431ed3d3dda4f9ad1d45ad05292c1804393c/after/habits_today_mobile_light.png) |

### Habits page — mobile dark

| Before | After |
|---|---|
| ![Habits mobile dark before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-skip-outcome-borders/b8c4431ed3d3dda4f9ad1d45ad05292c1804393c/before/habits_today_mobile_dark.png) | ![Habits mobile dark after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-skip-outcome-borders/b8c4431ed3d3dda4f9ad1d45ad05292c1804393c/after/habits_today_mobile_dark.png) |

### Dashboard — dark

| Before | After |
|---|---|
| ![Dashboard dark before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-skip-outcome-borders/b8c4431ed3d3dda4f9ad1d45ad05292c1804393c/before/20_surfaces_dark.png) | ![Dashboard dark after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habit-skip-outcome-borders/b8c4431ed3d3dda4f9ad1d45ad05292c1804393c/after/20_surfaces_dark.png) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Skipped habit days now display a neutral square with an orange dash, while missed days show a red cross.
  - Streaks now count only successful completions; skips, failures, incomplete records, and missing days break consecutive streaks.
  - Current streaks reset when an unsuccessful outcome interrupts successful days.

- **Documentation**
  - Updated habit and day-indicator guidance to explain the revised outcome symbols and streak behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

