### PR TITLE
docs(release): align changelog version policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and release versions follow the project policy documented in
+[the release skill](.agents/skills/release/SKILL.md).
 
 ## [1.0.22]
 ### Added


### PR DESCRIPTION
## Summary

- replace the outdated strict Semantic Versioning claim in the changelog preamble
- link to the project release policy, which now defines build-only fixes, patch-by-default user-facing releases, and explicitly requested minor releases

Follow-up to the review discussion on #4096.

## Verification

- release skill validation
- strict changelog validation
- AppStream XML validation
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog to clarify that release versions follow the project’s documented release policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->