### PR TITLE
fix: keep habit surfaces clear of bottom navigation

### DIFF
--- a/changelog.d/2026-08-31-habits-bottom-navigation.md
+++ b/changelog.d/2026-08-31-habits-bottom-navigation.md
@@ -1,0 +1,5 @@
+### Fixed
+- **Habit editing and the bottom of the Habits page stay clear of navigation.**
+  Opening a habit editor from the Habits tab now hides the bottom navigation so
+  Save remains reachable, while the dashboard keeps enough space below its
+  final chart to scroll fully above the navigation bar.

--- a/knowledge/features/design_system/component-contracts.md
+++ b/knowledge/features/design_system/component-contracts.md
@@ -505,11 +505,13 @@ contract:
 - `DesignSystemBottomNavigationFabPadding` is the default wrapper for
   screen-level FABs that need to stay above that shell. **Feature pages should use
   the wrapper rather than inventing local bottom offsets.**
-- Scroll surfaces that can reach the bottom edge add `occupiedHeight(context)`
-  to their tokenized footer padding. Terminal routes with their own pinned
-  bottom action instead ask the app shell to slide the bar away; project, goal,
-  habit, people and settings route helpers keep that decision tied to the
-  router state rather than widget timing.
+- Scroll surfaces that can reach the bottom edge leave the outer `SafeArea`'s
+  bottom disabled and add `occupiedHeight(context)` to their tokenized footer
+  padding; that height already includes the system inset, so the page must not
+  consume it twice. Terminal routes with their own pinned bottom action instead
+  ask the app shell to slide the bar away; project, goal, habit, people and
+  settings route helpers keep that decision tied to router state rather than
+  widget timing.
 - `DesignSystemFiveSlotNavBar.contentHeight(context)` owns the slot-row height
   contract. It **scales caption line height with `MediaQuery.textScalerOf` and
   rounds fractional line boxes up to the logical pixel Flutter renders**, so

--- a/knowledge/features/design_system/component-contracts.md
+++ b/knowledge/features/design_system/component-contracts.md
@@ -31,7 +31,7 @@ sources:
   - id: navbar
     resource: ../../../lib/widgets/nav_bar/design_system_bottom_navigation_bar.dart
     title: Bottom navigation shell
-    last_modified: 2026-06-12
+    last_modified: 2026-08-31
   - id: measurement-capture
     resource: ../../../lib/pages/create/create_measurement_dialog.dart
     title: Measurement capture sheet — the hero value field and the box that focuses it
@@ -505,6 +505,11 @@ contract:
 - `DesignSystemBottomNavigationFabPadding` is the default wrapper for
   screen-level FABs that need to stay above that shell. **Feature pages should use
   the wrapper rather than inventing local bottom offsets.**
+- Scroll surfaces that can reach the bottom edge add `occupiedHeight(context)`
+  to their tokenized footer padding. Terminal routes with their own pinned
+  bottom action instead ask the app shell to slide the bar away; project, goal,
+  habit, people and settings route helpers keep that decision tied to the
+  router state rather than widget timing.
 - `DesignSystemFiveSlotNavBar.contentHeight(context)` owns the slot-row height
   contract. It **scales caption line height with `MediaQuery.textScalerOf` and
   rounds fractional line boxes up to the logical pixel Flutter renders**, so

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -335,7 +335,10 @@ The chart's final sliver adds
 `DesignSystemBottomNavigationBar.occupiedHeight(context)` beneath its ordinary
 spacing token on mobile, so at the end of the scroll the chart clears the
 floating navigation bar and any recording indicators above it. Desktop gets
-zero from that helper because its sidebar replaces the bottom bar.
+zero from that helper because its sidebar replaces the bottom bar. The page's
+outer `SafeArea` leaves its bottom disabled because `occupiedHeight` already
+includes the system inset; consuming both would create a second home-indicator
+gap.
 
 Tab rows are **action rows**: icon, name, the handover's history strip —
 the last seven days on a phone and fourteen on a desktop window as squares

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -11,7 +11,7 @@ sources:
   - id: src
     resource: ../../lib/features/habits
     title: Habits feature source
-    last_modified: 2026-08-30
+    last_modified: 2026-08-31
   - id: definitions
     resource: ../../lib/classes/entity_definitions.dart
     title: HabitDefinition
@@ -159,6 +159,11 @@ scaffold or app bar; it takes the panel's height with the form scrolling in
 the middle only when the window is shorter than it and the action row pinned
 at the foot under a hairline; back, save and delete close the panel, and the
 wizard's signals step carries its own *Back*.
+
+On mobile, the `/habits/create` and `/habits/edit/:habitId` routes are terminal
+editor surfaces: the app shell keeps its navigation bar mounted for the exit
+animation but slides it fully off-screen, so the editor's pinned Continue or
+Save action owns the bottom edge. Returning to `/habits` restores the bar.
 
 The panel's layout came out of a design-review-panel loop (baseline 5.0 →
 7.2). On the edit path at desktop widths the form is two columns weighted
@@ -324,9 +329,13 @@ capped at **1100 px**: once the window exceeds that plus side padding, horizonta
 padding becomes `(width - 1100) / 2`, and below it the padding is one spacing
 step.
 
-**Between the list and the chart, the consistency heatmap breaks out to the full
-window width** in its own sliver, so a wide screen shows more history while the
-action content stays a comfortable column.
+The consistency heatmap and completion chart each occupy their own sliver but
+share the same centred width and horizontal padding as the reading content.
+The chart's final sliver adds
+`DesignSystemBottomNavigationBar.occupiedHeight(context)` beneath its ordinary
+spacing token on mobile, so at the end of the scroll the chart clears the
+floating navigation bar and any recording indicators above it. Desktop gets
+zero from that helper because its sidebar replaces the bottom bar.
 
 Tab rows are **action rows**: icon, name, the handover's history strip —
 the last seven days on a phone and fourteen on a desktop window as squares

--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -10,6 +10,7 @@ import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_builder_validators/localization/l10n.dart';
 import 'package:lotti/beamer/locations/goals_location.dart';
+import 'package:lotti/beamer/locations/habits_location.dart';
 import 'package:lotti/beamer/locations/projects_location.dart';
 import 'package:lotti/beamer/locations/relationships_location.dart';
 import 'package:lotti/beamer/locations/settings_location.dart';
@@ -247,6 +248,22 @@ bool goalsRouteHidesBottomNav(BeamLocation<dynamic>? location) {
   };
 }
 
+/// True when the Habits beamer location points at the create or edit route.
+///
+/// The list root keeps the bar because it is the tab surface. The editor owns
+/// the bottom edge with its pinned primary action, so the floating navigation
+/// pill slides away instead of covering Save or Continue.
+bool habitsRouteHidesBottomNav(BeamLocation<dynamic>? location) {
+  if (location is! HabitsLocation) return false;
+  final segments = location.state.uri.pathSegments;
+  if (segments.isEmpty || segments.first != 'habits') return false;
+  return switch (segments.length) {
+    2 => segments[1] == 'create',
+    3 => segments[1] == 'edit' && segments[2].isNotEmpty,
+    _ => false,
+  };
+}
+
 /// True when the PEOPLE beamer location points at one person's own pages —
 /// their detail page (`/people/<id>`) or their agent chat
 /// (`/people/<id>/chat`).
@@ -392,6 +409,7 @@ class _AppScreenState extends ConsumerState<AppScreen> {
     navService.projectsDelegate,
     navService.settingsDelegate,
     navService.goalsDelegate,
+    navService.habitsDelegate,
     navService.relationshipsDelegate,
   ]);
 
@@ -713,13 +731,15 @@ class _AppScreenState extends ConsumerState<AppScreen> {
           Beamer(routerDelegate: navService.settingsDelegate),
         ];
 
-        // Listen to the tasks, projects, settings, goals and relationships
+        // Listen to the tasks, projects, settings, goals, habits and
+        // relationships
         // delegates so the mobile shell rebuilds when their routes change
         // (push to / pop from task, project, goal or person details, into /
         // out of settings entity editors). That's how we know whether to
         // hide the mobile bottom nav. See [_isTaskDetailRoute],
         // [projectsRouteHidesBottomNav], [settingsRouteHidesBottomNav],
-        // [goalsRouteHidesBottomNav] and [peopleRouteHidesBottomNav].
+        // [goalsRouteHidesBottomNav], [habitsRouteHidesBottomNav] and
+        // [peopleRouteHidesBottomNav].
         return ListenableBuilder(
           listenable: _routeChangeListenable,
           builder: (context, _) => _NudgeBannerTopLane(
@@ -903,10 +923,10 @@ class _AppScreenState extends ConsumerState<AppScreen> {
     // instead of removing it: nothing replaces the bar there, so an instant
     // unmount would read as a jumpy glitch rather than a handoff to a
     // page-owned surface. Project details (`/projects/<id>`) are the same
-    // kind of terminal page and share the motion, as do a goal's own pages
-    // and a person's. See [settingsRouteHidesBottomNav],
+    // kind of terminal page and share the motion, as do a goal's own pages,
+    // a habit editor and a person's. See [settingsRouteHidesBottomNav],
     // [projectsRouteHidesBottomNav], [goalsRouteHidesBottomNav] and
-    // [peopleRouteHidesBottomNav].
+    // [habitsRouteHidesBottomNav] and [peopleRouteHidesBottomNav].
     final slideNavAway =
         (destinations[index].kind == _AppNavigationDestinationKind.settings &&
             settingsRouteHidesBottomNav(
@@ -919,6 +939,10 @@ class _AppScreenState extends ConsumerState<AppScreen> {
         (destinations[index].kind == _AppNavigationDestinationKind.goals &&
             goalsRouteHidesBottomNav(
               navService.goalsDelegate.currentBeamLocation,
+            )) ||
+        (destinations[index].kind == _AppNavigationDestinationKind.habits &&
+            habitsRouteHidesBottomNav(
+              navService.habitsDelegate.currentBeamLocation,
             )) ||
         (destinations[index].kind == _AppNavigationDestinationKind.people &&
             peopleRouteHidesBottomNav(

--- a/lib/features/habits/ui/habits_page.dart
+++ b/lib/features/habits/ui/habits_page.dart
@@ -308,6 +308,10 @@ class _HabitsTabPageState extends ConsumerState<HabitsTabPage> {
         ),
         backgroundColor: dsPageSurface(context),
         body: SafeArea(
+          // The navigation bar's occupied height already includes the system
+          // bottom inset. Leave that edge to the chart footer so the inset is
+          // reserved exactly once.
+          bottom: false,
           child: CustomScrollView(
             controller: _scrollController,
             slivers: <Widget>[

--- a/lib/features/habits/ui/habits_page.dart
+++ b/lib/features/habits/ui/habits_page.dart
@@ -41,6 +41,8 @@ import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
 /// heatmap controller's deep-history `streaksByHabit`. The reading content is
 /// centred on a comfortable column on wide windows; the heatmap band spans the
 /// full width. Scroll activity is reported to the `UserActivityService`.
+/// Its final chart reserves the shell-reported bottom overlay height so it can
+/// scroll completely clear of mobile navigation and recording indicators.
 class HabitsTabPage extends ConsumerStatefulWidget {
   const HabitsTabPage({super.key});
 
@@ -369,7 +371,8 @@ class _HabitsTabPageState extends ConsumerState<HabitsTabPage> {
                   pagePadding,
                   0,
                   pagePadding,
-                  tokens.spacing.step6,
+                  tokens.spacing.step6 +
+                      DesignSystemBottomNavigationBar.occupiedHeight(context),
                 ),
                 sliver: const SliverToBoxAdapter(child: HabitsChartCard()),
               ),

--- a/test/beamer/beamer_app_test.dart
+++ b/test/beamer/beamer_app_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/beamer/beamer_app.dart';
 import 'package:lotti/beamer/locations/goals_location.dart';
+import 'package:lotti/beamer/locations/habits_location.dart';
 import 'package:lotti/beamer/locations/projects_location.dart';
 import 'package:lotti/beamer/locations/relationships_location.dart';
 import 'package:lotti/beamer/locations/settings_location.dart';
@@ -237,6 +238,23 @@ class _TestGoalsLocation extends GoalsLocation {
   }
 }
 
+/// A [HabitsLocation] whose pages are inert stubs: route matching (and
+/// therefore [habitsRouteHidesBottomNav]) behaves exactly like production,
+/// without building the habits dashboard or editor dependency trees.
+class _TestHabitsLocation extends HabitsLocation {
+  _TestHabitsLocation(super.routeInformation);
+
+  @override
+  List<BeamPage> buildPages(BuildContext context, BeamState state) {
+    return [
+      BeamPage(
+        key: ValueKey('test-habits-${state.uri.path}'),
+        child: const SizedBox.shrink(),
+      ),
+    ];
+  }
+}
+
 Future<BeamerDelegate> _createEmptyDelegate(String initialPath) async {
   final delegate = BeamerDelegate(
     setBrowserTabTitle: false,
@@ -264,13 +282,14 @@ Future<void> _stubNavService(
   BeamerDelegate? settingsDelegate,
   BeamerDelegate? projectsDelegate,
   BeamerDelegate? goalsDelegate,
+  BeamerDelegate? habitsDelegate,
   BeamerDelegate? relationshipsDelegate,
 }) async {
   final tasksDelegate = await _createEmptyDelegate('/tasks');
   projectsDelegate ??= await _createEmptyDelegate('/projects');
   relationshipsDelegate ??= await _createEmptyDelegate('/people');
   final calendarDelegate = await _createEmptyDelegate('/calendar');
-  final habitsDelegate = await _createEmptyDelegate('/habits');
+  habitsDelegate ??= await _createEmptyDelegate('/habits');
   final dashboardsDelegate = await _createEmptyDelegate('/dashboards');
   final journalDelegate = await _createEmptyDelegate('/journal');
   final eventsDelegate = await _createEmptyDelegate('/events');
@@ -2804,6 +2823,40 @@ void main() {
     });
   });
 
+  group('habitsRouteHidesBottomNav', () {
+    HabitsLocation habitsLocationFor(String path) =>
+        HabitsLocation(RouteInformation(uri: Uri.parse(path)));
+
+    test('only valid create and edit routes hide the bar', () {
+      expect(habitsRouteHidesBottomNav(null), isFalse);
+      expect(
+        habitsRouteHidesBottomNav(
+          GoalsLocation(RouteInformation(uri: Uri.parse('/habits/create'))),
+        ),
+        isFalse,
+      );
+      expect(habitsRouteHidesBottomNav(habitsLocationFor('/habits')), isFalse);
+      expect(
+        habitsRouteHidesBottomNav(habitsLocationFor('/habits/create')),
+        isTrue,
+      );
+      expect(
+        habitsRouteHidesBottomNav(habitsLocationFor('/habits/edit/habit-1')),
+        isTrue,
+      );
+      expect(
+        habitsRouteHidesBottomNav(habitsLocationFor('/habits/edit')),
+        isFalse,
+      );
+      expect(
+        habitsRouteHidesBottomNav(
+          habitsLocationFor('/habits/edit/habit-1/deep'),
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('AppScreen settings entity-definition nav hiding', () {
     testWidgets(
       'slides the bar away inside an entity editor and back on the list',
@@ -3202,6 +3255,66 @@ void main() {
 
         // Popping back to the unified list slides the bar into place.
         goalsDelegate.beamToNamed('/goals');
+        await tester.pump();
+        expect(slide().offset, Offset.zero);
+        await tester.pump(const Duration(milliseconds: 450));
+      },
+    );
+
+    testWidgets(
+      'slides the bar away inside a Habits editor and back on the list',
+      (tester) async {
+        final mockNavService = MockNavService();
+        final indexController = StreamController<int>.broadcast();
+        addTearDown(indexController.close);
+
+        final habitsDelegate = BeamerDelegate(
+          setBrowserTabTitle: false,
+          initialPath: '/habits',
+          locationBuilder: (routeInformation, _) =>
+              _TestHabitsLocation(routeInformation),
+        );
+        addTearDown(habitsDelegate.dispose);
+        await habitsDelegate.setNewRoutePath(
+          RouteInformation(uri: Uri.parse('/habits')),
+        );
+
+        await _stubNavService(
+          mockNavService,
+          indexStream: indexController.stream,
+          isProjectsEnabled: () => false,
+          isDailyOsEnabled: () => false,
+          isHabitsEnabled: () => true,
+          isDashboardsEnabled: () => false,
+          habitsDelegate: habitsDelegate,
+        );
+        await _registerAppScreenGetIt(mockNavService);
+        addTearDown(tearDownTestGetIt);
+
+        await _pumpAppScreen(tester, navService: mockNavService);
+
+        // Destinations: Tasks, Habits, Journal, Settings.
+        indexController.add(1);
+        await tester.pump();
+
+        AnimatedSlide slide() => tester.widget<AnimatedSlide>(
+          find
+              .ancestor(
+                of: find.byType(DesignSystemBottomNavigationBar),
+                matching: find.byType(AnimatedSlide),
+              )
+              .first,
+        );
+
+        expect(slide().offset, Offset.zero);
+
+        habitsDelegate.beamToNamed('/habits/edit/habit-1');
+        await tester.pump();
+        expect(find.byType(DesignSystemBottomNavigationBar), findsOneWidget);
+        expect(slide().offset, const Offset(0, 1));
+        await tester.pump(const Duration(milliseconds: 450));
+
+        habitsDelegate.beamToNamed('/habits');
         await tester.pump();
         expect(slide().offset, Offset.zero);
         await tester.pump(const Duration(milliseconds: 450));

--- a/test/features/habits/ui/pages/habits_tab_page_test.dart
+++ b/test/features/habits/ui/pages/habits_tab_page_test.dart
@@ -12,6 +12,7 @@ import 'package:lotti/features/habits/state/heatmap/habit_heatmap_controller.dar
 import 'package:lotti/features/habits/state/heatmap/habit_heatmap_data.dart';
 import 'package:lotti/features/habits/ui/habits_page.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_action_row.dart';
+import 'package:lotti/features/habits/ui/widgets/habits_chart_card.dart';
 import 'package:lotti/features/habits/ui/widgets/habits_section_header.dart';
 import 'package:lotti/features/keyboard/ui/app_command_host.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
@@ -22,6 +23,7 @@ import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/utils/device_region.dart';
 import 'package:lotti/widgets/misc/timespan_segmented_control.dart';
+import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../mocks/mocks.dart';
@@ -277,6 +279,39 @@ void main() {
       // overflow at this width; consume it — the point here is that the
       // centred-padding branch is exercised and the page still builds.
       tester.takeException();
+    });
+
+    testWidgets('bottom chart clears the docked navigation bar', (
+      tester,
+    ) async {
+      final testState = HabitsState.initial().copyWith(
+        habitDefinitions: [habitFlossing],
+        openNow: [habitFlossing],
+      );
+
+      await pump(tester, testState);
+
+      final context = tester.element(find.byType(HabitsTabPage));
+      final occupied = DesignSystemBottomNavigationBar.occupiedHeight(context);
+      expect(occupied, greaterThan(0));
+
+      final chartPadding = tester.widget<SliverPadding>(
+        find
+            .ancestor(
+              of: find.byType(HabitsChartCard),
+              matching: find.byType(SliverPadding),
+            )
+            .first,
+      );
+      expect(
+        chartPadding.padding,
+        EdgeInsets.fromLTRB(
+          context.designTokens.spacing.step6,
+          0,
+          context.designTokens.spacing.step6,
+          context.designTokens.spacing.step6 + occupied,
+        ),
+      );
     });
 
     testWidgets('renders an action row for openNow habits', (tester) async {

--- a/test/features/habits/ui/pages/habits_tab_page_test.dart
+++ b/test/features/habits/ui/pages/habits_tab_page_test.dart
@@ -284,16 +284,30 @@ void main() {
     testWidgets('bottom chart clears the docked navigation bar', (
       tester,
     ) async {
+      const mediaQueryData = MediaQueryData(
+        size: Size(400, 800),
+        padding: EdgeInsets.only(bottom: 34),
+      );
       final testState = HabitsState.initial().copyWith(
         habitDefinitions: [habitFlossing],
         openNow: [habitFlossing],
       );
 
-      await pump(tester, testState);
+      await pump(tester, testState, mediaQueryData: mediaQueryData);
 
       final context = tester.element(find.byType(HabitsTabPage));
       final occupied = DesignSystemBottomNavigationBar.occupiedHeight(context);
       expect(occupied, greaterThan(0));
+
+      final safeArea = tester.widget<SafeArea>(
+        find
+            .ancestor(
+              of: find.byType(CustomScrollView),
+              matching: find.byType(SafeArea),
+            )
+            .first,
+      );
+      expect(safeArea.bottom, isFalse);
 
       final chartPadding = tester.widget<SliverPadding>(
         find


### PR DESCRIPTION
## Summary

- slide the mobile bottom navigation away on Habits create/edit routes so the editor primary action stays reachable
- reserve the shell-reported navigation/indicator height beneath the Habits dashboard chart without double-consuming the device safe area
- add route and geometry regressions, update architecture notes, and include a user-facing changelog fragment

## Screenshots

### Habit editor

| Before | After |
|---|---|
| ![Habit editor before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habits-bottom-navigation/482a4ee9190d8ba58a46047c6d6e1d107838ea72/before/habit_editor_step2_mobile_dark.png) | ![Habit editor after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habits-bottom-navigation/482a4ee9190d8ba58a46047c6d6e1d107838ea72/after/habit_editor_step2_mobile_dark.png) |

### Habits dashboard bottom

| Before | After |
|---|---|
| ![Habits dashboard before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habits-bottom-navigation/482a4ee9190d8ba58a46047c6d6e1d107838ea72/before/habits_bottom_mobile_dark.png) | ![Habits dashboard after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/habits-bottom-navigation/482a4ee9190d8ba58a46047c6d6e1d107838ea72/after/habits_bottom_mobile_dark.png) |

## Verification

- `make analyze`
- `fvm flutter test test/features/habits/ui/pages/habits_tab_page_test.dart`
- `fvm flutter test test/beamer/beamer_app_test.dart`
- `make changelog_check`
- `make knowledge_check`

The new Habits route regression was also run with its shell branch removed and failed on the expected nav offset.