### PR TITLE
feat(plaza): project plaza prototype M0 — live widget facades on a 3D street

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -50,6 +50,13 @@ ignore:
   # (`flutter run -t .../dev_main.dart`): a `runApp` harness with no logic to
   # unit-test, not shipped in the app.
   - "lib/features/knowledge_graph/dev_main.dart"
+  # Dev-only standalone entrypoint for the project-plaza prototype harness
+  # (same pattern as the knowledge-graph one above), plus its flutter_scene
+  # scene layer: `Scene()` requires a live Flutter GPU context at
+  # construction and throws on the headless Linux CI runner, so this code
+  # can only be exercised by running the real harness.
+  - "lib/features/plaza/dev_main.dart"
+  - "lib/features/plaza/scene/**"
   # Integration glue that embeds the app's real task/entry detail widgets
   # (TaskForm / EntryDetailsWidget) in the graph's side panel. Those widgets
   # carry their own extensive tests and pull the whole app's provider/getIt

--- a/lib/features/plaza/data/demo_world_projection.dart
+++ b/lib/features/plaza/data/demo_world_projection.dart
@@ -1,0 +1,97 @@
+/// Projects the penguin demo world into plaza tasks.
+///
+/// The plaza's "small project" preset uses real task surfaces — titles,
+/// states, checklists and links from [ManualDemoWorld.penguinLogistics] —
+/// instead of synthetic filler, per the fixture policy (demo world only,
+/// never user data).
+library;
+
+import 'package:lotti/classes/checklist_item_data.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/demo/seed/demo_world.dart';
+import 'package:lotti/features/plaza/domain/plaza_task.dart';
+
+/// Fallback category color when the demo category has none.
+const _fallbackColor = 0xFF5C9DFF;
+
+/// Builds the plaza task list from the Project Waddle demo world.
+List<PlazaTask> plazaTasksFromDemoWorld({DateTime? now}) {
+  final world = ManualDemoWorld.penguinLogistics(now: now);
+
+  final categoryColors = <String, int>{
+    for (final category in world.categories)
+      category.id: _parseHexColor(category.color) ?? _fallbackColor,
+  };
+
+  // Checklist items per task, resolved through the checklist layer.
+  final itemById = <String, ChecklistItemData>{
+    for (final item in world.checklistItems) item.meta.id: item.data,
+  };
+  final itemsByTask = <String, List<ChecklistItemData>>{};
+  for (final checklist in world.checklists) {
+    for (final taskId in checklist.data.linkedTasks) {
+      final items = itemsByTask.putIfAbsent(taskId, () => []);
+      for (final itemId in checklist.data.linkedChecklistItems) {
+        final item = itemById[itemId];
+        if (item != null && !item.isArchived) items.add(item);
+      }
+    }
+  }
+
+  final taskIds = {for (final task in world.tasks) task.meta.id};
+  final linksByTask = <String, Set<String>>{};
+  for (final link in world.links) {
+    if (taskIds.contains(link.fromId) && taskIds.contains(link.toId)) {
+      linksByTask.putIfAbsent(link.fromId, () => {}).add(link.toId);
+    }
+  }
+
+  return [
+    for (final task in world.tasks)
+      _project(
+        task: task,
+        items: itemsByTask[task.meta.id] ?? const [],
+        links: linksByTask[task.meta.id] ?? const {},
+        categoryColor: categoryColors[task.meta.categoryId] ?? _fallbackColor,
+      ),
+  ];
+}
+
+PlazaTask _project({
+  required Task task,
+  required List<ChecklistItemData> items,
+  required Set<String> links,
+  required int categoryColor,
+}) {
+  final checked = items.where((i) => i.isChecked).length;
+  return PlazaTask(
+    id: task.meta.id,
+    createdAt: task.meta.createdAt,
+    title: task.data.title,
+    state: _mapStatus(task.data.status),
+    due: task.data.due,
+    progress: items.isEmpty ? 0 : checked / items.length,
+    checklistItems: items.length,
+    linkedTaskIds: links.toList()..sort(),
+    categoryColor: categoryColor,
+    deleted: task.meta.deletedAt != null,
+  );
+}
+
+PlazaTaskState _mapStatus(TaskStatus status) {
+  return switch (status) {
+    TaskOpen() || TaskGroomed() => PlazaTaskState.open,
+    TaskInProgress() => PlazaTaskState.inProgress,
+    TaskBlocked() || TaskOnHold() => PlazaTaskState.blocked,
+    TaskDone() => PlazaTaskState.done,
+    TaskRejected() => PlazaTaskState.cancelled,
+  };
+}
+
+int? _parseHexColor(String? hex) {
+  if (hex == null) return null;
+  var value = hex.replaceFirst('#', '');
+  if (value.length == 6) value = 'FF$value';
+  return int.tryParse(value, radix: 16);
+}

--- a/lib/features/plaza/data/demo_world_projection.dart
+++ b/lib/features/plaza/data/demo_world_projection.dart
@@ -9,6 +9,7 @@ library;
 import 'package:lotti/classes/checklist_item_data.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/demo/media/demo_media_asset.dart';
 import 'package:lotti/features/demo/seed/demo_world.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 
@@ -65,9 +66,19 @@ PlazaTask _project({
   required int categoryColor,
 }) {
   final checked = items.where((i) => i.isChecked).length;
+  // Demo cover art lives in the public immutable R2 catalog; the harness
+  // loads it straight over HTTP, no hydrator or app storage involved.
+  final cover = demoMediaAssets
+      .where((asset) => asset.taskId == task.meta.id && asset.isCover)
+      .firstOrNull;
   return PlazaTask(
     id: task.meta.id,
     createdAt: task.meta.createdAt,
+    coverImageUrl: cover?.uri.toString(),
+    openChecklistItems: [
+      for (final item in items)
+        if (!item.isChecked) item.title,
+    ].take(8).toList(),
     title: task.data.title,
     state: _mapStatus(task.data.status),
     due: task.data.due,

--- a/lib/features/plaza/data/demo_world_projection.dart
+++ b/lib/features/plaza/data/demo_world_projection.dart
@@ -80,7 +80,7 @@ PlazaTask _project({
         if (!item.isChecked) item.title,
     ].take(8).toList(),
     title: task.data.title,
-    state: _mapStatus(task.data.status),
+    state: mapTaskStatusToPlazaState(task.data.status),
     due: task.data.due,
     progress: items.isEmpty ? 0 : checked / items.length,
     checklistItems: items.length,
@@ -90,7 +90,11 @@ PlazaTask _project({
   );
 }
 
-PlazaTaskState _mapStatus(TaskStatus status) {
+/// Maps the app's task status union onto the plaza's surface states.
+///
+/// Public so every arm is directly testable — the demo world does not
+/// exercise all of them.
+PlazaTaskState mapTaskStatusToPlazaState(TaskStatus status) {
   return switch (status) {
     TaskOpen() || TaskGroomed() => PlazaTaskState.open,
     TaskInProgress() => PlazaTaskState.inProgress,

--- a/lib/features/plaza/dev_main.dart
+++ b/lib/features/plaza/dev_main.dart
@@ -214,6 +214,11 @@ class _PlazaHarnessState extends State<_PlazaHarness> {
   void _applyKnobs() {
     _lod.dispose();
     setState(() => _loadPreset(_preset));
+    // _loadPreset replaces the camera; keep the scripted walk going if a
+    // benchmark phase is mid-flight.
+    if (_benchMode && !_benchDone) {
+      _camera.autoForward = 1;
+    }
   }
 
   void _onTick(Duration elapsed, double dt) {

--- a/lib/features/plaza/dev_main.dart
+++ b/lib/features/plaza/dev_main.dart
@@ -22,6 +22,7 @@ import 'package:flutter_scene/scene.dart' hide FlyCameraController;
 import 'package:lotti/features/plaza/data/demo_world_projection.dart';
 import 'package:lotti/features/plaza/domain/plaza_generator.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
+import 'package:lotti/features/plaza/domain/street_layout.dart';
 import 'package:lotti/features/plaza/scene/facade_lod_manager.dart';
 import 'package:lotti/features/plaza/scene/plaza_scene.dart';
 import 'package:lotti/features/plaza/ui/debug_overlay.dart';
@@ -80,6 +81,7 @@ class _PlazaHarnessState extends State<_PlazaHarness> {
   late FacadeLodManager _lod;
   late FlyCameraController _camera;
   final FacadeLodConfig _config = FacadeLodConfig();
+  final PlazaLayoutKnobs _knobs = PlazaLayoutKnobs();
   final PlazaHarnessStats _stats = PlazaHarnessStats();
 
   Camera? _frameCamera;
@@ -177,6 +179,12 @@ class _PlazaHarnessState extends State<_PlazaHarness> {
     _sceneController = PlazaSceneController(
       tasks: preset.load(),
       projectSeed: 1337,
+      layout: StreetLayout(
+        projectSeed: 1337,
+        roadWidth: _knobs.roadWidth,
+        pxPerMeter: _knobs.pxPerMeter,
+        maxBuildingHeight: _knobs.maxHeight,
+      ),
     );
     _lod = FacadeLodManager(
       buildings: _sceneController.buildings,
@@ -194,6 +202,12 @@ class _PlazaHarnessState extends State<_PlazaHarness> {
       final next = (_preset.index + 1) % _HarnessPreset.values.length;
       _loadPreset(_HarnessPreset.values[next]);
     });
+  }
+
+  /// Rebuilds the scene with the current layout knobs, keeping the preset.
+  void _applyKnobs() {
+    _lod.dispose();
+    setState(() => _loadPreset(_preset));
   }
 
   void _onTick(Duration elapsed, double dt) {
@@ -259,9 +273,11 @@ class _PlazaHarnessState extends State<_PlazaHarness> {
                     child: PlazaDebugOverlay(
                       stats: _stats,
                       config: _config,
+                      knobs: _knobs,
                       presetLabel: _preset.label,
                       onCyclePreset: _cyclePreset,
-                      onConfigChanged: () {},
+                      onConfigChanged: () => setState(() {}),
+                      onKnobsApplied: _applyKnobs,
                       onToggleOverhead: _camera.toggleOverhead,
                     ),
                   ),

--- a/lib/features/plaza/dev_main.dart
+++ b/lib/features/plaza/dev_main.dart
@@ -1,0 +1,271 @@
+/// Standalone dev entrypoint for the project plaza prototype (M0 perf
+/// spike): a street of task buildings with live widget facades, surface
+/// LOD, and a debug overlay for finding the live-widget ceiling.
+///
+/// Run it directly (Flutter GPU must be enabled):
+///   fvm flutter run --enable-flutter-gpu \
+///       -t lib/features/plaza/dev_main.dart -d linux
+///   fvm flutter run --enable-flutter-gpu \
+///       -t lib/features/plaza/dev_main.dart -d macos
+///
+/// This is a developer harness only — it is not part of the shipping app.
+///
+/// Benchmark mode: launch with `PLAZA_BENCH=1` in the environment and the
+/// harness auto-walks the street through a fixed set of LOD configurations,
+/// printing an fps table (`PLAZA_BENCH` lines) to stdout.
+library;
+
+import 'dart:io' show Platform;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_scene/scene.dart' hide FlyCameraController;
+import 'package:lotti/features/plaza/data/demo_world_projection.dart';
+import 'package:lotti/features/plaza/domain/plaza_generator.dart';
+import 'package:lotti/features/plaza/domain/plaza_task.dart';
+import 'package:lotti/features/plaza/scene/facade_lod_manager.dart';
+import 'package:lotti/features/plaza/scene/plaza_scene.dart';
+import 'package:lotti/features/plaza/ui/debug_overlay.dart';
+import 'package:lotti/features/plaza/ui/fly_camera_controller.dart';
+
+void main() => runApp(const PlazaDevApp());
+
+/// The datasets the harness can cycle through. `demo` projects real task
+/// surfaces from the penguin demo world; the rest are synthetic presets.
+enum _HarnessPreset {
+  demo('waddle'),
+  small('20'),
+  medium('80'),
+  large('300');
+
+  const _HarnessPreset(this.label);
+
+  final String label;
+
+  List<PlazaTask> load() => switch (this) {
+    demo => plazaTasksFromDemoWorld(),
+    small => generatePlazaTasks(preset: PlazaPreset.small),
+    medium => generatePlazaTasks(preset: PlazaPreset.medium),
+    large => generatePlazaTasks(preset: PlazaPreset.large),
+  };
+}
+
+class PlazaDevApp extends StatelessWidget {
+  const PlazaDevApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData.dark(useMaterial3: true),
+      home: const _PlazaHarness(),
+    );
+  }
+}
+
+class _PlazaHarness extends StatefulWidget {
+  const _PlazaHarness();
+
+  @override
+  State<_PlazaHarness> createState() => _PlazaHarnessState();
+}
+
+class _PlazaHarnessState extends State<_PlazaHarness> {
+  _HarnessPreset _preset = _HarnessPreset.large;
+  late PlazaSceneController _sceneController;
+  late FacadeLodManager _lod;
+  late FlyCameraController _camera;
+  final FacadeLodConfig _config = FacadeLodConfig();
+  final PlazaHarnessStats _stats = PlazaHarnessStats();
+
+  Camera? _frameCamera;
+
+  // Rolling frame-time window.
+  final List<double> _frameMs = [];
+  double _statsAge = 0;
+
+  // --- Benchmark mode (PLAZA_BENCH=1) ---
+  static final bool _benchMode = Platform.environment['PLAZA_BENCH'] == '1';
+  static const _benchPhaseSeconds = 14.0;
+  static const _benchWarmupSeconds = 4.0;
+  // (label, nearCap, midCap, nearDistance, midDistance, forceAllLive).
+  // The saturated phases stretch the distance thresholds so the caps are
+  // the binding limit, not the walkway geometry.
+  static const _benchPhases = <(String, int, int, double, double, bool)>[
+    ('far-only    (no widgets)', 0, 0, 35, 140, false),
+    ('default     (12 live / 60 static)', 12, 60, 35, 140, false),
+    ('sat-live-30 (30 live, saturated)', 30, 0, 4000, 4000, false),
+    ('sat-live-60 (60 live, saturated)', 60, 0, 4000, 4000, false),
+    ('all-static  (292 hosted, no capture)', 0, 300, 4000, 4000, false),
+    ('all-live    (every facade live)', 0, 0, 35, 140, true),
+  ];
+  int _benchPhase = 0;
+  double _benchClock = 0;
+  final List<double> _benchSamples = [];
+  bool _benchDone = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPreset(_preset);
+    if (_benchMode) {
+      _applyBenchPhase(0);
+    }
+  }
+
+  void _applyBenchPhase(int phase) {
+    final (label, nearCap, midCap, nearDist, midDist, allLive) =
+        _benchPhases[phase];
+    _config
+      ..nearCap = nearCap
+      ..midCap = midCap
+      ..nearDistance = nearDist
+      ..midDistance = midDist
+      ..forceAllLive = allLive;
+    _camera
+      ..reset(
+        position: _sceneController.frontierEye,
+        yaw: _sceneController.frontierYaw,
+      )
+      ..autoForward = 1;
+    _benchClock = 0;
+    _benchSamples.clear();
+    debugPrint('PLAZA_BENCH phase $phase start: $label');
+  }
+
+  void _benchTick(double dt) {
+    if (_benchDone) return;
+    _benchClock += dt;
+    if (_benchClock > _benchWarmupSeconds && dt > 0) {
+      _benchSamples.add(dt * 1000);
+    }
+    if (_benchClock < _benchPhaseSeconds) return;
+
+    final avg =
+        _benchSamples.fold<double>(0, (a, b) => a + b) / _benchSamples.length;
+    final worst = _benchSamples.reduce((a, b) => a > b ? a : b);
+    final sorted = [..._benchSamples]..sort();
+    final p99 =
+        sorted[(sorted.length * 0.99).floor().clamp(0, sorted.length - 1)];
+    final (label, _, _, _, _, _) = _benchPhases[_benchPhase];
+    debugPrint(
+      'PLAZA_BENCH result | $label | '
+      '${(1000 / avg).toStringAsFixed(1)} fps avg | '
+      '${avg.toStringAsFixed(1)} ms avg | '
+      '${p99.toStringAsFixed(1)} ms p99 | '
+      '${worst.toStringAsFixed(1)} ms worst | '
+      'live ${_lod.stats.near} static ${_lod.stats.mid} '
+      'captures ${_lod.stats.captures}',
+    );
+
+    if (_benchPhase + 1 < _benchPhases.length) {
+      _benchPhase++;
+      _applyBenchPhase(_benchPhase);
+    } else {
+      _benchDone = true;
+      _camera.autoForward = 0;
+      debugPrint('PLAZA_BENCH done');
+    }
+  }
+
+  void _loadPreset(_HarnessPreset preset) {
+    _preset = preset;
+    _sceneController = PlazaSceneController(
+      tasks: preset.load(),
+      projectSeed: 1337,
+    );
+    _lod = FacadeLodManager(
+      buildings: _sceneController.buildings,
+      config: _config,
+    );
+    _camera = FlyCameraController(
+      position: _sceneController.frontierEye,
+      yaw: _sceneController.frontierYaw,
+    );
+  }
+
+  void _cyclePreset() {
+    _lod.dispose();
+    setState(() {
+      final next = (_preset.index + 1) % _HarnessPreset.values.length;
+      _loadPreset(_HarnessPreset.values[next]);
+    });
+  }
+
+  void _onTick(Duration elapsed, double dt) {
+    if (_benchMode) _benchTick(dt);
+    _camera.update(dt);
+    final camera = _camera.camera();
+    _frameCamera = camera;
+    _lod.update(camera.position);
+
+    if (dt > 0) {
+      _frameMs.add(dt * 1000);
+      if (_frameMs.length > 120) _frameMs.removeAt(0);
+    }
+    _statsAge += dt;
+    if (_statsAge >= 0.25 && _frameMs.isNotEmpty) {
+      _statsAge = 0;
+      final sum = _frameMs.fold<double>(0, (a, b) => a + b);
+      final avg = sum / _frameMs.length;
+      _stats
+        ..fps = 1000 / avg
+        ..avgFrameMs = avg
+        ..worstFrameMs = _frameMs.reduce((a, b) => a > b ? a : b)
+        ..buildings = _sceneController.buildings.length
+        ..near = _lod.stats.near
+        ..mid = _lod.stats.mid
+        ..far = _lod.stats.far
+        ..captures = _lod.stats.captures
+        ..lastCaptureMs = _lod.stats.lastCapture.inMicroseconds / 1000
+        ..promotions = _lod.stats.promotions
+        ..publish();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF06070C),
+      body: Focus(
+        autofocus: true,
+        onKeyEvent: (node, event) => _camera.handleKeyEvent(event)
+            ? KeyEventResult.handled
+            : KeyEventResult.ignored,
+        child: Listener(
+          onPointerMove: (event) {
+            if (event.buttons != 0) {
+              _camera.addLookDelta(event.delta.dx, event.delta.dy);
+            }
+          },
+          child: Stack(
+            children: [
+              Positioned.fill(
+                child: SceneView(
+                  _sceneController.scene,
+                  cameraBuilder: (_) => _frameCamera ?? _camera.camera(),
+                  onTick: _onTick,
+                ),
+              ),
+              SafeArea(
+                child: Align(
+                  alignment: Alignment.topRight,
+                  child: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: PlazaDebugOverlay(
+                      stats: _stats,
+                      config: _config,
+                      presetLabel: _preset.label,
+                      onCyclePreset: _cyclePreset,
+                      onConfigChanged: () {},
+                      onToggleOverhead: _camera.toggleOverhead,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/plaza/dev_main.dart
+++ b/lib/features/plaza/dev_main.dart
@@ -113,6 +113,12 @@ class _PlazaHarnessState extends State<_PlazaHarness> {
   @override
   void initState() {
     super.initState();
+    if (_benchMode) {
+      // The bench phases assume the 300-task workload (their labels and
+      // saturation caps are sized for it), so the preset override is
+      // ignored in benchmark mode.
+      _preset = _HarnessPreset.large;
+    }
     _loadPreset(_preset);
     if (_benchMode) {
       _applyBenchPhase(0);

--- a/lib/features/plaza/dev_main.dart
+++ b/lib/features/plaza/dev_main.dart
@@ -70,7 +70,12 @@ class _PlazaHarness extends StatefulWidget {
 }
 
 class _PlazaHarnessState extends State<_PlazaHarness> {
-  _HarnessPreset _preset = _HarnessPreset.large;
+  // Boots on the 300-task perf preset; override with PLAZA_PRESET=demo
+  // (or small/medium/large) to start elsewhere, e.g. on the penguin world.
+  _HarnessPreset _preset = _HarnessPreset.values.firstWhere(
+    (p) => p.name == Platform.environment['PLAZA_PRESET'],
+    orElse: () => _HarnessPreset.large,
+  );
   late PlazaSceneController _sceneController;
   late FacadeLodManager _lod;
   late FlyCameraController _camera;

--- a/lib/features/plaza/domain/plaza_generator.dart
+++ b/lib/features/plaza/domain/plaza_generator.dart
@@ -129,6 +129,11 @@ List<PlazaTask> generatePlazaTasks({
     } else {
       progress = rng.nextInt(checklistItems + 1) / checklistItems;
     }
+    final openCount = checklistItems - (progress * checklistItems).round();
+    final openItems = [
+      for (var n = 0; n < openCount; n++)
+        '${_verbs[rng.nextInt(_verbs.length)]} ${_objects[rng.nextInt(_objects.length)]}',
+    ];
 
     final links = <String>[];
     if (rng.nextDouble() < 0.25 && i > 0) {
@@ -150,6 +155,7 @@ List<PlazaTask> generatePlazaTasks({
             : null,
         progress: progress,
         checklistItems: checklistItems,
+        openChecklistItems: openItems,
         linkedTaskIds: links,
         categoryColor: _categoryColors[rng.nextInt(_categoryColors.length)],
         deleted: rng.nextDouble() < 0.03,

--- a/lib/features/plaza/domain/plaza_generator.dart
+++ b/lib/features/plaza/domain/plaza_generator.dart
@@ -1,0 +1,167 @@
+/// Seeded synthetic task generator for the plaza prototype.
+///
+/// Pure Dart. Presets model a small project (20), a real one (80), and an
+/// unreasonably large one (300). Output is fully reproducible from the seed.
+library;
+
+import 'dart:math' as math;
+
+import 'package:lotti/features/plaza/domain/plaza_task.dart';
+
+/// Dataset sizes the harness can switch between.
+enum PlazaPreset {
+  small(20),
+  medium(80),
+  large(300);
+
+  const PlazaPreset(this.taskCount);
+
+  final int taskCount;
+}
+
+const _verbs = [
+  'Fix',
+  'Ship',
+  'Design',
+  'Review',
+  'Refactor',
+  'Investigate',
+  'Document',
+  'Migrate',
+  'Benchmark',
+  'Localize',
+  'Wire up',
+  'Stabilize',
+  'Prototype',
+  'Deprecate',
+  'Instrument',
+  'Untangle',
+  'Rebuild',
+  'Audit',
+  'Polish',
+];
+
+const _objects = [
+  'sync conflict banner',
+  'habit streak math',
+  'audio recorder',
+  'task header',
+  'checklist drag handles',
+  'calendar day view',
+  'search index',
+  'AI summary',
+  'settings import',
+  'onboarding flow',
+  'theme tokens',
+  'entry linking',
+  'export pipeline',
+  'notification wake',
+  'attachment previews',
+  'dashboards',
+  'time tracking rollup',
+  'category picker',
+  'vector clock merge',
+  'transcription queue',
+];
+
+const _tails = [
+  '', '', '', '', // Most titles are short.
+  'on Linux', 'for the mobile layout', 'before the release',
+  'after the schema change', 'so the board stops lying',
+  'without breaking offline sync, including the edge case where two devices edit the same entry inside one sync window',
+];
+
+const _categoryColors = [
+  0xFF5C9DFF, // work — blue
+  0xFFB588F2, // writing — purple
+  0xFF63C99A, // health — green
+  0xFFE8B44F, // learning — amber
+  0xFFE87C6C, // home — coral
+  0xFF6ECBD8, // admin — teal
+];
+
+/// Generates a reproducible task list for [preset] from [seed].
+List<PlazaTask> generatePlazaTasks({
+  required PlazaPreset preset,
+  int seed = 42,
+}) {
+  final rng = math.Random(seed);
+  final count = preset.taskCount;
+  final tasks = <PlazaTask>[];
+  final start = DateTime(2026, 3, 2, 9);
+
+  // A few hub tasks collect most links (plausible link-graph density).
+  final hubCount = math.max(1, count ~/ 25);
+  final hubs = <int>{};
+  while (hubs.length < hubCount) {
+    hubs.add(rng.nextInt(count));
+  }
+
+  var cursor = start;
+  for (var i = 0; i < count; i++) {
+    // Bursty creation: sometimes many in a day, sometimes a quiet week.
+    cursor = cursor.add(
+      rng.nextDouble() < 0.6
+          ? Duration(minutes: 20 + rng.nextInt(400))
+          : Duration(days: 1 + rng.nextInt(9), hours: rng.nextInt(8)),
+    );
+
+    final roll = rng.nextDouble();
+    final PlazaTaskState state;
+    if (roll < 0.32) {
+      state = PlazaTaskState.open;
+    } else if (roll < 0.52) {
+      state = PlazaTaskState.inProgress;
+    } else if (roll < 0.60) {
+      state = PlazaTaskState.blocked;
+    } else if (roll < 0.94) {
+      state = PlazaTaskState.done;
+    } else {
+      state = PlazaTaskState.cancelled;
+    }
+
+    final checklistItems = rng.nextDouble() < 0.45 ? 2 + rng.nextInt(9) : 0;
+    final double progress;
+    if (checklistItems == 0) {
+      progress = 0;
+    } else if (state == PlazaTaskState.done) {
+      progress = 1;
+    } else {
+      progress = rng.nextInt(checklistItems + 1) / checklistItems;
+    }
+
+    final links = <String>[];
+    if (rng.nextDouble() < 0.25 && i > 0) {
+      // Mostly link to a hub, occasionally to a random earlier task.
+      final target = rng.nextDouble() < 0.7
+          ? hubs.elementAt(rng.nextInt(hubs.length))
+          : rng.nextInt(i);
+      if (target != i) links.add('plaza-$seed-$target');
+    }
+
+    tasks.add(
+      PlazaTask(
+        id: 'plaza-$seed-$i',
+        createdAt: cursor,
+        title: _title(rng),
+        state: state,
+        due: rng.nextDouble() < 0.3
+            ? cursor.add(Duration(days: 2 + rng.nextInt(30)))
+            : null,
+        progress: progress,
+        checklistItems: checklistItems,
+        linkedTaskIds: links,
+        categoryColor: _categoryColors[rng.nextInt(_categoryColors.length)],
+        deleted: rng.nextDouble() < 0.03,
+      ),
+    );
+  }
+  return tasks;
+}
+
+String _title(math.Random rng) {
+  final verb = _verbs[rng.nextInt(_verbs.length)];
+  final object = _objects[rng.nextInt(_objects.length)];
+  final tail = _tails[rng.nextInt(_tails.length)];
+  return tail.isEmpty ? '$verb the $object' : '$verb the $object $tail';
+}

--- a/lib/features/plaza/domain/plaza_task.dart
+++ b/lib/features/plaza/domain/plaza_task.dart
@@ -39,6 +39,8 @@ class PlazaTask {
     required this.linkedTaskIds,
     required this.categoryColor,
     this.due,
+    this.coverImageUrl,
+    this.openChecklistItems = const [],
     this.deleted = false,
   });
 
@@ -59,6 +61,14 @@ class PlazaTask {
 
   /// ARGB, kept as an int so this layer stays Flutter-free.
   final int categoryColor;
+
+  /// Cover art for the facade, when the task has any (display only).
+  final String? coverImageUrl;
+
+  /// Titles of the still-open checklist items, shown on the facade.
+  /// Drives building height together with the title (content-sized
+  /// facades, no filler).
+  final List<String> openChecklistItems;
 
   /// Deleted tasks leave a fenced empty lot; the street never closes up.
   final bool deleted;

--- a/lib/features/plaza/domain/plaza_task.dart
+++ b/lib/features/plaza/domain/plaza_task.dart
@@ -1,0 +1,65 @@
+/// Domain model for the project plaza prototype.
+///
+/// Pure Dart on purpose: the layout and generator layers depend only on this
+/// file, so they can be unit-tested without Flutter and lifted out wholesale
+/// if the prototype graduates.
+library;
+
+/// Lifecycle state of a task as the plaza renders it.
+enum PlazaTaskState {
+  /// Not started.
+  open,
+
+  /// Actively being worked.
+  inProgress,
+
+  /// Waiting on something else.
+  blocked,
+
+  /// Finished — green and quiet, lights off.
+  done,
+
+  /// Abandoned without completion.
+  cancelled,
+}
+
+/// One task, projected into plaza terms.
+///
+/// Placement depends on `(createdAt, id)` alone — merge-stable under sync
+/// (see the spec's invariant: nothing ever moves). Everything else drives
+/// the surface only.
+class PlazaTask {
+  const PlazaTask({
+    required this.id,
+    required this.createdAt,
+    required this.title,
+    required this.state,
+    required this.progress,
+    required this.checklistItems,
+    required this.linkedTaskIds,
+    required this.categoryColor,
+    this.due,
+    this.deleted = false,
+  });
+
+  /// Placement tiebreak within a week bucket.
+  final String id;
+
+  /// Placement input: bucketed by week, ordered within the bucket.
+  final DateTime createdAt;
+
+  final String title;
+  final PlazaTaskState state;
+  final DateTime? due;
+
+  /// 0..1 for checklist-bearing tasks; 0 when [checklistItems] is 0.
+  final double progress;
+  final int checklistItems;
+  final List<String> linkedTaskIds;
+
+  /// ARGB, kept as an int so this layer stays Flutter-free.
+  final int categoryColor;
+
+  /// Deleted tasks leave a fenced empty lot; the street never closes up.
+  final bool deleted;
+}

--- a/lib/features/plaza/domain/street_layout.dart
+++ b/lib/features/plaza/domain/street_layout.dart
@@ -74,7 +74,8 @@ class PlotPlacement {
   /// Building footprint away from the road.
   final double depth;
 
-  /// Building height. Deterministic per task id, surface-independent.
+  /// Building height. Content-driven: sized to the facade's cover art,
+  /// title and open checklist items (see [StreetLayout.heightFor]).
   final double height;
 }
 
@@ -165,10 +166,36 @@ class StreetLayout {
     return 0.5 + t;
   }
 
-  /// Deterministic building height for a task id (independent of state).
-  double heightFor(String taskId) {
-    final t = ((stableHash(taskId) >> 16) & 0xFFFF) / 0xFFFF;
-    return 6.0 + 9.0 * t * t;
+  /// Logical pixels per world meter on a facade texture. Must match the
+  /// scale the scene layer uses for facade widget layout sizes.
+  static const facadePxPerMeter = 56.0;
+
+  /// Content-driven building height: the facade is sized to exactly fit
+  /// the cover art, the wrapped title, the meta rows and the open
+  /// checklist items — no filler. Mirrors the facade widget's layout
+  /// metrics; still a pure function of merged task data, so it stays
+  /// identical on every device.
+  double heightFor(PlazaTask task, double buildingWidth) {
+    final facadeWidthPx = buildingWidth * 0.92 * facadePxPerMeter;
+    final innerPx = facadeWidthPx - 48; // horizontal text padding
+
+    var px = 10.0; // category bar
+    if (task.coverImageUrl != null) {
+      px += facadeWidthPx * 9 / 16; // full-bleed 16:9 cover
+    }
+    px += 48; // text-section vertical padding
+    // Title wrap estimate at 44px w700 (~0.53em average advance).
+    final charsPerLine = (innerPx / (44 * 0.53)).floor().clamp(6, 200);
+    final lines = (task.title.length / charsPerLine).ceil().clamp(1, 6);
+    px += lines * 44 * 1.15 + 16;
+    if (task.due != null || task.linkedTaskIds.isNotEmpty) {
+      px += 43; // meta row
+    }
+    px += task.openChecklistItems.length.clamp(0, 8) * 46; // item rows
+    px += 44; // state row
+
+    final facadeHeight = px / facadePxPerMeter;
+    return (facadeHeight / 0.88).clamp(3.5, 22.0);
   }
 
   /// Start of the week containing [time] (Monday 00:00).
@@ -312,7 +339,7 @@ class StreetLayout {
               heading + (side == PlotSide.left ? math.pi / 2 : -math.pi / 2),
           width: buildingWidth,
           depth: plotDepth * 0.8,
-          height: heightFor(task.id),
+          height: heightFor(task, buildingWidth),
         );
         cursor += slot;
       }

--- a/lib/features/plaza/domain/street_layout.dart
+++ b/lib/features/plaza/domain/street_layout.dart
@@ -179,18 +179,20 @@ class StreetLayout {
     final facadeWidthPx = buildingWidth * 0.92 * facadePxPerMeter;
     final innerPx = facadeWidthPx - 48; // horizontal text padding
 
-    var px = 10.0; // category bar
-    if (task.coverImageUrl != null) {
-      px += facadeWidthPx * 9 / 16; // full-bleed 16:9 cover
-    }
-    px += 48; // text-section vertical padding
+    // Shopfront order: title block high, full-bleed cover at mid-height,
+    // checklist and state at street level (mirrors the facade widget).
+    var px = 10.0 + 24 + 18; // category bar + title-section padding
     // Title wrap estimate at 44px w700 (~0.53em average advance).
     final charsPerLine = (innerPx / (44 * 0.53)).floor().clamp(6, 200);
     final lines = (task.title.length / charsPerLine).ceil().clamp(1, 6);
-    px += lines * 44 * 1.15 + 16;
+    px += lines * 44 * 1.15;
     if (task.due != null || task.linkedTaskIds.isNotEmpty) {
-      px += 43; // meta row
+      px += 16 + 43; // meta row
     }
+    if (task.coverImageUrl != null) {
+      px += facadeWidthPx * 9 / 16; // full-bleed 16:9 cover
+    }
+    px += 48; // bottom-section padding
     px += task.openChecklistItems.length.clamp(0, 8) * 46; // item rows
     px += 44; // state row
 

--- a/lib/features/plaza/domain/street_layout.dart
+++ b/lib/features/plaza/domain/street_layout.dart
@@ -125,7 +125,7 @@ class StreetPlan {
 class StreetLayout {
   StreetLayout({
     required this.projectSeed,
-    this.roadWidth = 8,
+    this.roadWidth = 16,
     this.groupLength = 46,
     this.gapLength = 7,
     this.plotDepth = 8,
@@ -168,7 +168,7 @@ class StreetLayout {
 
   /// Logical pixels per world meter on a facade texture. Must match the
   /// scale the scene layer uses for facade widget layout sizes.
-  static const facadePxPerMeter = 56.0;
+  static const facadePxPerMeter = 90.0;
 
   /// Content-driven building height: the facade is sized to exactly fit
   /// the cover art, the wrapped title, the meta rows and the open
@@ -197,7 +197,7 @@ class StreetLayout {
     px += 44; // state row
 
     final facadeHeight = px / facadePxPerMeter;
-    return (facadeHeight / 0.88).clamp(3.5, 22.0);
+    return (facadeHeight / 0.88).clamp(2.5, 12.0);
   }
 
   /// Start of the week containing [time] (Monday 00:00).

--- a/lib/features/plaza/domain/street_layout.dart
+++ b/lib/features/plaza/domain/street_layout.dart
@@ -168,7 +168,7 @@ class StreetLayout {
   /// Deterministic building height for a task id (independent of state).
   double heightFor(String taskId) {
     final t = ((stableHash(taskId) >> 16) & 0xFFFF) / 0xFFFF;
-    return 3.0 + 5.0 * t * t;
+    return 6.0 + 9.0 * t * t;
   }
 
   /// Start of the week containing [time] (Monday 00:00).

--- a/lib/features/plaza/domain/street_layout.dart
+++ b/lib/features/plaza/domain/street_layout.dart
@@ -125,7 +125,9 @@ class StreetPlan {
 class StreetLayout {
   StreetLayout({
     required this.projectSeed,
-    this.roadWidth = 16,
+    this.roadWidth = 25,
+    this.pxPerMeter = 90,
+    this.maxBuildingHeight = 12,
     this.groupLength = 46,
     this.gapLength = 7,
     this.plotDepth = 8,
@@ -166,9 +168,13 @@ class StreetLayout {
     return 0.5 + t;
   }
 
-  /// Logical pixels per world meter on a facade texture. Must match the
-  /// scale the scene layer uses for facade widget layout sizes.
-  static const facadePxPerMeter = 90.0;
+  /// Logical pixels per world meter on a facade texture — bigger means
+  /// shorter buildings for the same content. The scene layer sizes facade
+  /// widget subtrees with the same value.
+  final double pxPerMeter;
+
+  /// Cap on content-driven building height, world meters.
+  final double maxBuildingHeight;
 
   /// Content-driven building height: the facade is sized to exactly fit
   /// the cover art, the wrapped title, the meta rows and the open
@@ -176,7 +182,7 @@ class StreetLayout {
   /// metrics; still a pure function of merged task data, so it stays
   /// identical on every device.
   double heightFor(PlazaTask task, double buildingWidth) {
-    final facadeWidthPx = buildingWidth * 0.92 * facadePxPerMeter;
+    final facadeWidthPx = buildingWidth * 0.92 * pxPerMeter;
     final innerPx = facadeWidthPx - 48; // horizontal text padding
 
     // Shopfront order: title block high, full-bleed cover at mid-height,
@@ -196,8 +202,8 @@ class StreetLayout {
     px += task.openChecklistItems.length.clamp(0, 8) * 46; // item rows
     px += 44; // state row
 
-    final facadeHeight = px / facadePxPerMeter;
-    return (facadeHeight / 0.88).clamp(2.5, 12.0);
+    final facadeHeight = px / pxPerMeter;
+    return (facadeHeight / 0.88).clamp(2.5, maxBuildingHeight);
   }
 
   /// Start of the week containing [time] (Monday 00:00).

--- a/lib/features/plaza/domain/street_layout.dart
+++ b/lib/features/plaza/domain/street_layout.dart
@@ -206,9 +206,14 @@ class StreetLayout {
     return (facadeHeight / 0.88).clamp(2.5, maxBuildingHeight);
   }
 
-  /// Start of the week containing [time] (Monday 00:00).
+  /// Start of the UTC week containing [time] (Monday 00:00 UTC).
+  ///
+  /// Weeks are anchored in UTC so every device derives the same bucket from
+  /// the same instant regardless of its local time zone or DST — the local
+  /// calendar would break the merge-stable placement invariant.
   static DateTime weekStart(DateTime time) {
-    final day = DateTime(time.year, time.month, time.day);
+    final utc = time.toUtc();
+    final day = DateTime.utc(utc.year, utc.month, utc.day);
     return day.subtract(Duration(days: day.weekday - DateTime.monday));
   }
 
@@ -246,8 +251,10 @@ class StreetLayout {
 
     final anchor = epoch ?? weekStart(ordered.first.createdAt);
 
+    // A task older than an explicit epoch lands in bucket zero rather than
+    // being silently dropped to a negative bucket the street never renders.
     int bucketOf(PlazaTask task) =>
-        task.createdAt.difference(anchor).inDays ~/ 7;
+        math.max(0, task.createdAt.difference(anchor).inDays ~/ 7);
 
     final byBucket = <int, List<PlazaTask>>{};
     for (final task in ordered) {
@@ -328,9 +335,11 @@ class StreetLayout {
         final task = sideTasks[i];
         final slot = usable * weights[i] / totalWeight;
         final centerAlong = cursor + slot / 2;
-        final buildingWidth = (slot * 0.82).clamp(
-          minBuildingWidth,
-          maxBuildingWidth,
+        // Never wider than 95% of the slot: in a crowded week the minimum
+        // width yields to the slot so neighbors cannot intersect.
+        final buildingWidth = math.min(
+          slot * 0.95,
+          (slot * 0.82).clamp(minBuildingWidth, maxBuildingWidth),
         );
 
         final sideSign = side == PlotSide.left ? -1.0 : 1.0;

--- a/lib/features/plaza/domain/street_layout.dart
+++ b/lib/features/plaza/domain/street_layout.dart
@@ -249,7 +249,9 @@ class StreetLayout {
         return byDate != 0 ? byDate : a.id.compareTo(b.id);
       });
 
-    final anchor = epoch ?? weekStart(ordered.first.createdAt);
+    // Normalize even an explicit epoch to its UTC week start, so a Tuesday
+    // or local-time anchor cannot shift the Monday-aligned bucket grid.
+    final anchor = weekStart(epoch ?? ordered.first.createdAt);
 
     // A task older than an explicit epoch lands in bucket zero rather than
     // being silently dropped to a negative bucket the street never renders.

--- a/lib/features/plaza/domain/street_layout.dart
+++ b/lib/features/plaza/domain/street_layout.dart
@@ -1,0 +1,321 @@
+/// Deterministic, merge-stable street layout for the project plaza.
+///
+/// Pure Dart, no Flutter dependency.
+///
+/// Placement must survive sync: Lotti is local-first with concurrent task
+/// creation on multiple devices, so there is no global creation order.
+/// Placement is therefore a pure function of data that merges identically
+/// everywhere — `createdAt`, with `id` as tiebreak — bucketed by week:
+///
+/// - One bucket = one week of the project's life; one plot group per bucket.
+/// - Within a bucket, tasks subdivide the plot group ordered by
+///   `(createdAt, id)`, alternating sides.
+/// - A late-syncing task can only jostle its siblings inside one bucket —
+///   a bounded blast radius of a single plot group, never the street.
+/// - Empty weeks collapse to a short gap: a visible pause, not a hike.
+///   (Known edge: a task syncing into a previously *empty* week widens that
+///   gap into a plot group and shifts everything downstream. Accepted for
+///   the prototype; the M2 invariant test documents it.)
+/// - The road's course (bends) is a function of the project seed and the
+///   bucket index alone, never of task data.
+library;
+
+import 'dart:math' as math;
+
+import 'package:lotti/features/plaza/domain/plaza_task.dart';
+
+/// Stable 32-bit FNV-1a hash of [input].
+///
+/// `String.hashCode` is not guaranteed stable across VM versions, and plot
+/// rhythm must never change under the user's feet, so we hash explicitly.
+int stableHash(String input) {
+  var hash = 0x811c9dc5;
+  for (final unit in input.codeUnits) {
+    hash ^= unit;
+    hash = (hash * 0x01000193) & 0xFFFFFFFF;
+  }
+  return hash;
+}
+
+/// Which side of the road a plot sits on.
+enum PlotSide { left, right }
+
+/// A placed plot: world-space position and orientation for one task.
+class PlotPlacement {
+  const PlotPlacement({
+    required this.taskId,
+    required this.bucketIndex,
+    required this.side,
+    required this.x,
+    required this.z,
+    required this.facingRadians,
+    required this.width,
+    required this.depth,
+    required this.height,
+  });
+
+  final String taskId;
+
+  /// The week bucket (plot group) this task belongs to.
+  final int bucketIndex;
+
+  final PlotSide side;
+
+  /// Plot center, world space (y is always ground level).
+  final double x;
+  final double z;
+
+  /// Rotation about +Y such that the facade faces the road.
+  final double facingRadians;
+
+  /// Building footprint along the road.
+  final double width;
+
+  /// Building footprint away from the road.
+  final double depth;
+
+  /// Building height. Deterministic per task id, surface-independent.
+  final double height;
+}
+
+/// One straight run of road: a plot group (week) or a collapsed gap.
+class RoadSegment {
+  const RoadSegment({
+    required this.bucketIndex,
+    required this.startX,
+    required this.startZ,
+    required this.headingRadians,
+    required this.length,
+    required this.isGap,
+  });
+
+  final int bucketIndex;
+  final double startX;
+  final double startZ;
+
+  /// Direction of travel, radians about +Y (0 = +Z).
+  final double headingRadians;
+  final double length;
+
+  /// True for a collapsed empty week.
+  final bool isGap;
+}
+
+/// The output of [StreetLayout.plan].
+class StreetPlan {
+  const StreetPlan({
+    required this.epoch,
+    required this.segments,
+    required this.placements,
+  });
+
+  /// Start of week zero.
+  final DateTime epoch;
+
+  /// One segment per week bucket, in order, gaps included.
+  final List<RoadSegment> segments;
+
+  /// One placement per (non-filtered) task, keyed by task id.
+  final Map<String, PlotPlacement> placements;
+}
+
+/// Lays out the street. All knobs are deterministic tuning inputs; nothing
+/// here consults wall-clock time or unseeded randomness.
+class StreetLayout {
+  StreetLayout({
+    required this.projectSeed,
+    this.roadWidth = 8,
+    this.groupLength = 46,
+    this.gapLength = 7,
+    this.plotDepth = 8,
+    this.sideMargin = 2,
+    this.minBuildingWidth = 2.5,
+    this.maxBuildingWidth = 12,
+    this.bendEveryBuckets = 3,
+    this.maxBendRadians = math.pi / 5,
+  });
+
+  final int projectSeed;
+  final double roadWidth;
+
+  /// Road length one non-empty week occupies.
+  final double groupLength;
+
+  /// Road length a collapsed empty week occupies.
+  final double gapLength;
+
+  final double plotDepth;
+
+  /// Unbuilt strip at each end of a plot group, per side.
+  final double sideMargin;
+
+  /// Buildings never get thinner than this, however busy the week.
+  final double minBuildingWidth;
+
+  /// Nor wider than this, however quiet.
+  final double maxBuildingWidth;
+
+  /// Roughly every Nth bucket boundary bends the road (hash-decided).
+  final int bendEveryBuckets;
+  final double maxBendRadians;
+
+  /// Deterministic relative width factor for a task id (0.5 .. 1.5).
+  double widthFactorFor(String taskId) {
+    final t = (stableHash(taskId) & 0xFFFF) / 0xFFFF;
+    return 0.5 + t;
+  }
+
+  /// Deterministic building height for a task id (independent of state).
+  double heightFor(String taskId) {
+    final t = ((stableHash(taskId) >> 16) & 0xFFFF) / 0xFFFF;
+    return 3.0 + 5.0 * t * t;
+  }
+
+  /// Start of the week containing [time] (Monday 00:00).
+  static DateTime weekStart(DateTime time) {
+    final day = DateTime(time.year, time.month, time.day);
+    return day.subtract(Duration(days: day.weekday - DateTime.monday));
+  }
+
+  /// The signed bend applied *after* bucket [bucketIndex], purely from the
+  /// project seed and the bucket index.
+  double bendAfter(int bucketIndex) {
+    final roll = stableHash('$projectSeed:bend:$bucketIndex');
+    if (roll % bendEveryBuckets != 0) return 0;
+    final t = ((roll >> 8) & 0xFFFF) / 0xFFFF;
+    return (t * 2 - 1) * maxBendRadians;
+  }
+
+  /// Plans the street for [tasks].
+  ///
+  /// [epoch] anchors week zero; it defaults to the Monday of the earliest
+  /// `createdAt`. Pass a fixed project epoch when one exists — the default
+  /// shifts if a task older than all known ones syncs in.
+  ///
+  /// Input order is irrelevant: tasks are sorted by `(createdAt, id)`
+  /// internally, so shuffled arrival produces an identical street.
+  StreetPlan plan(List<PlazaTask> tasks, {DateTime? epoch}) {
+    if (tasks.isEmpty) {
+      return StreetPlan(
+        epoch: epoch ?? DateTime(2000),
+        segments: const [],
+        placements: const {},
+      );
+    }
+
+    final ordered = [...tasks]
+      ..sort((a, b) {
+        final byDate = a.createdAt.compareTo(b.createdAt);
+        return byDate != 0 ? byDate : a.id.compareTo(b.id);
+      });
+
+    final anchor = epoch ?? weekStart(ordered.first.createdAt);
+
+    int bucketOf(PlazaTask task) =>
+        task.createdAt.difference(anchor).inDays ~/ 7;
+
+    final byBucket = <int, List<PlazaTask>>{};
+    for (final task in ordered) {
+      byBucket.putIfAbsent(bucketOf(task), () => []).add(task);
+    }
+    final lastBucket = byBucket.keys.reduce(math.max);
+
+    final segments = <RoadSegment>[];
+    final placements = <String, PlotPlacement>{};
+
+    var x = 0.0;
+    var z = 0.0;
+    var heading = 0.0; // Start heading +Z.
+
+    for (var bucket = 0; bucket <= lastBucket; bucket++) {
+      final weekTasks = byBucket[bucket];
+      final isGap = weekTasks == null;
+      final length = isGap ? gapLength : groupLength;
+
+      segments.add(
+        RoadSegment(
+          bucketIndex: bucket,
+          startX: x,
+          startZ: z,
+          headingRadians: heading,
+          length: length,
+          isGap: isGap,
+        ),
+      );
+
+      if (weekTasks != null) {
+        _placeBucket(
+          weekTasks,
+          bucket: bucket,
+          startX: x,
+          startZ: z,
+          heading: heading,
+          into: placements,
+        );
+      }
+
+      x += math.sin(heading) * length;
+      z += math.cos(heading) * length;
+      heading += bendAfter(bucket);
+    }
+
+    return StreetPlan(
+      epoch: anchor,
+      segments: segments,
+      placements: placements,
+    );
+  }
+
+  void _placeBucket(
+    List<PlazaTask> weekTasks, {
+    required int bucket,
+    required double startX,
+    required double startZ,
+    required double heading,
+    required Map<String, PlotPlacement> into,
+  }) {
+    final sinH = math.sin(heading);
+    final cosH = math.cos(heading);
+    final usable = groupLength - 2 * sideMargin;
+
+    for (final side in PlotSide.values) {
+      final sideTasks = <PlazaTask>[
+        for (var i = 0; i < weekTasks.length; i++)
+          if ((i.isEven) == (side == PlotSide.left)) weekTasks[i],
+      ];
+      if (sideTasks.isEmpty) continue;
+
+      final weights = [for (final t in sideTasks) widthFactorFor(t.id)];
+      final totalWeight = weights.reduce((a, b) => a + b);
+
+      var cursor = sideMargin;
+      for (var i = 0; i < sideTasks.length; i++) {
+        final task = sideTasks[i];
+        final slot = usable * weights[i] / totalWeight;
+        final centerAlong = cursor + slot / 2;
+        final buildingWidth = (slot * 0.82).clamp(
+          minBuildingWidth,
+          maxBuildingWidth,
+        );
+
+        final sideSign = side == PlotSide.left ? -1.0 : 1.0;
+        final lateral = sideSign * (roadWidth / 2 + plotDepth / 2);
+        // Lateral axis is the road's right-hand normal.
+        into[task.id] = PlotPlacement(
+          taskId: task.id,
+          bucketIndex: bucket,
+          side: side,
+          x: startX + sinH * centerAlong + cosH * lateral,
+          z: startZ + cosH * centerAlong - sinH * lateral,
+          // Facade faces the road.
+          facingRadians:
+              heading + (side == PlotSide.left ? math.pi / 2 : -math.pi / 2),
+          width: buildingWidth,
+          depth: plotDepth * 0.8,
+          height: heightFor(task.id),
+        );
+        cursor += slot;
+      }
+    }
+  }
+}

--- a/lib/features/plaza/scene/facade_lod_manager.dart
+++ b/lib/features/plaza/scene/facade_lod_manager.dart
@@ -1,0 +1,187 @@
+import 'package:flutter_scene/scene.dart';
+import 'package:lotti/features/plaza/scene/plaza_scene.dart';
+import 'package:lotti/features/plaza/ui/facade_widget.dart';
+import 'package:vector_math/vector_math.dart' show Vector3;
+
+/// Surface tier of one facade (spec §9):
+/// near = live interactive widget, mid = widget captured once (manual
+/// policy, re-captured only on task change), far = color block only.
+enum FacadeTier { far, mid, near }
+
+/// Tuning knobs the debug overlay exposes while hunting the M0 ceiling.
+class FacadeLodConfig {
+  FacadeLodConfig({
+    this.nearCap = 12,
+    this.midCap = 60,
+    this.nearDistance = 35,
+    this.midDistance = 140,
+    this.forceAllLive = false,
+  });
+
+  /// Hard cap on simultaneous live (every-frame) widget surfaces.
+  int nearCap;
+
+  /// Hard cap on hosted-but-static (manual-capture) widget surfaces.
+  int midCap;
+
+  double nearDistance;
+  double midDistance;
+
+  /// Stress mode: every facade becomes a live widget, caps ignored.
+  /// This is the naive version whose ceiling M0 exists to find.
+  bool forceAllLive;
+}
+
+/// Live counters for the debug overlay.
+class FacadeLodStats {
+  int near = 0;
+  int mid = 0;
+  int far = 0;
+  int captures = 0;
+  Duration lastCapture = Duration.zero;
+  int promotions = 0;
+}
+
+class _FacadeSurface {
+  WidgetComponent? component;
+  FacadeTier tier = FacadeTier.far;
+  bool captured = false;
+}
+
+/// Assigns each building facade a tier from camera distance, with sticky
+/// hysteresis so surfaces don't thrash at tier boundaries, and hard caps
+/// enforced by construction (evict by distance).
+class FacadeLodManager {
+  FacadeLodManager({required this.buildings, required this.config})
+    : _surfaces = [for (final _ in buildings) _FacadeSurface()];
+
+  final List<PlazaBuilding> buildings;
+  final FacadeLodConfig config;
+  final List<_FacadeSurface> _surfaces;
+  final FacadeLodStats stats = FacadeLodStats();
+
+  /// Sticky factor: a surface already at a tier ranks as if 15% closer.
+  static const _hysteresis = 0.85;
+
+  void update(Vector3 cameraPosition) {
+    final n = buildings.length;
+    final distances = List<double>.filled(n, 0);
+    final order = List<int>.generate(n, (i) => i);
+    for (var i = 0; i < n; i++) {
+      final d = buildings[i].facadeCenter.distanceTo(cameraPosition);
+      final tier = _surfaces[i].tier;
+      distances[i] = tier == FacadeTier.far ? d : d * _hysteresis;
+    }
+    order.sort((a, b) => distances[a].compareTo(distances[b]));
+
+    var nearLeft = config.forceAllLive ? n : config.nearCap;
+    var midLeft = config.forceAllLive ? 0 : config.midCap;
+
+    for (final i in order) {
+      final d = distances[i];
+      FacadeTier target;
+      if (config.forceAllLive) {
+        target = FacadeTier.near;
+      } else if (nearLeft > 0 && d < config.nearDistance) {
+        target = FacadeTier.near;
+      } else if (midLeft > 0 && d < config.midDistance) {
+        target = FacadeTier.mid;
+      } else {
+        target = FacadeTier.far;
+      }
+      if (target == FacadeTier.near) nearLeft--;
+      if (target == FacadeTier.mid) midLeft--;
+      _apply(i, target);
+    }
+
+    _refreshStats();
+  }
+
+  void _apply(int index, FacadeTier target) {
+    final surface = _surfaces[index];
+    if (surface.tier == target) {
+      // Mid surfaces capture once; keep asking until the first capture
+      // lands (the host attaches a frame after the component does).
+      if (target == FacadeTier.mid && !surface.captured) {
+        final controller = surface.component?.controller;
+        if (controller != null) {
+          if (controller.texture != null) {
+            surface.captured = true;
+          } else {
+            controller.requestCapture();
+          }
+        }
+      }
+      return;
+    }
+
+    final building = buildings[index];
+    final existing = surface.component;
+    if (existing != null) {
+      building.facadeAnchor.removeComponent(existing);
+      surface.component = null;
+    }
+
+    if (target != FacadeTier.far) {
+      final interactive = target == FacadeTier.near;
+      final component = WidgetComponent(
+        child: FacadeWidget(
+          task: building.task,
+          interactive: interactive,
+        ),
+        size: building.widgetSize,
+        worldHeight: building.facadeWorldHeight,
+        update: interactive
+            ? WidgetUpdatePolicy.everyFrame
+            : WidgetUpdatePolicy.manual,
+      );
+      building.facadeAnchor.addComponent(component);
+      surface.component = component;
+      stats.promotions++;
+    }
+    surface
+      ..tier = target
+      ..captured = false;
+  }
+
+  void _refreshStats() {
+    var near = 0;
+    var mid = 0;
+    var captures = 0;
+    var lastCapture = Duration.zero;
+    for (final surface in _surfaces) {
+      switch (surface.tier) {
+        case FacadeTier.near:
+          near++;
+        case FacadeTier.mid:
+          mid++;
+        case FacadeTier.far:
+          break;
+      }
+      final controller = surface.component?.controller;
+      if (controller != null) {
+        captures += controller.captureCount;
+        if (controller.lastCaptureDuration > lastCapture) {
+          lastCapture = controller.lastCaptureDuration;
+        }
+      }
+    }
+    stats
+      ..near = near
+      ..mid = mid
+      ..far = buildings.length - near - mid
+      ..captures = captures
+      ..lastCapture = lastCapture;
+  }
+
+  /// Detaches every widget surface (used when tearing a scene down).
+  void dispose() {
+    for (var i = 0; i < buildings.length; i++) {
+      final component = _surfaces[i].component;
+      if (component != null) {
+        buildings[i].facadeAnchor.removeComponent(component);
+        _surfaces[i].component = null;
+      }
+    }
+  }
+}

--- a/lib/features/plaza/scene/facade_lod_manager.dart
+++ b/lib/features/plaza/scene/facade_lod_manager.dart
@@ -158,9 +158,12 @@ class FacadeLodManager {
           building.facadeWorldWidth,
           building.facadeWorldHeight,
         ),
+        // Static facades re-capture on a slow interval rather than once:
+        // negligible amortized cost, and late-arriving content (network
+        // cover art) still shows up without change-tracking plumbing.
         update: interactive
             ? WidgetUpdatePolicy.everyFrame
-            : WidgetUpdatePolicy.manual,
+            : const WidgetUpdatePolicy.interval(Duration(seconds: 3)),
       );
       building.facadeAnchor.addComponent(component);
       surface.component = component;

--- a/lib/features/plaza/scene/facade_lod_manager.dart
+++ b/lib/features/plaza/scene/facade_lod_manager.dart
@@ -1,7 +1,31 @@
+import 'dart:typed_data';
+
 import 'package:flutter_scene/scene.dart';
 import 'package:lotti/features/plaza/scene/plaza_scene.dart';
 import 'package:lotti/features/plaza/ui/facade_widget.dart';
 import 'package:vector_math/vector_math.dart' show Vector3;
+
+/// A facade quad for a [WidgetComponent], wound counter-clockwise.
+///
+/// flutter_scene 0.23 flipped the engine's front-face convention to CCW and
+/// regenerated its primitives, but `WidgetComponent`'s built-in quad still
+/// winds CW (byte-identical to 0.20), so the default surface is back-face
+/// culled and widget textures never show. Same vertex data as upstream's
+/// quad, triangles reversed. Drop when the upstream quad is fixed.
+Geometry _facadeQuad(double width, double height) {
+  final hw = width / 2;
+  final hh = height / 2;
+  return MeshGeometry.fromArrays(
+    positions: Float32List.fromList([
+      hw, -hh, 0, //
+      -hw, -hh, 0, //
+      -hw, hh, 0, //
+      hw, hh, 0, //
+    ]),
+    texCoords: Float32List.fromList([0, 1, 1, 1, 1, 0, 0, 0]),
+    indices: [3, 1, 0, 2, 1, 3],
+  );
+}
 
 /// Surface tier of one facade (spec §9):
 /// near = live interactive widget, mid = widget captured once (manual
@@ -130,7 +154,10 @@ class FacadeLodManager {
           interactive: interactive,
         ),
         size: building.widgetSize,
-        worldHeight: building.facadeWorldHeight,
+        geometry: _facadeQuad(
+          building.facadeWorldWidth,
+          building.facadeWorldHeight,
+        ),
         update: interactive
             ? WidgetUpdatePolicy.everyFrame
             : WidgetUpdatePolicy.manual,

--- a/lib/features/plaza/scene/plaza_scene.dart
+++ b/lib/features/plaza/scene/plaza_scene.dart
@@ -17,6 +17,7 @@ class PlazaBuilding {
     required this.facadeCenter,
     required this.facadeWorldWidth,
     required this.facadeWorldHeight,
+    required this.pxPerMeter,
   });
 
   final PlazaTask task;
@@ -35,11 +36,14 @@ class PlazaBuilding {
   final double facadeWorldWidth;
   final double facadeWorldHeight;
 
-  /// Logical layout size for the facade widget subtree. Uses the same
-  /// px-per-meter scale the layout's content-height estimate assumes.
+  /// Pixels per world meter for this building's facade texture, from the
+  /// layout that placed it (the content-height estimate uses the same).
+  final double pxPerMeter;
+
+  /// Logical layout size for the facade widget subtree.
   Size get widgetSize => Size(
-    facadeWorldWidth * StreetLayout.facadePxPerMeter,
-    facadeWorldHeight * StreetLayout.facadePxPerMeter,
+    facadeWorldWidth * pxPerMeter,
+    facadeWorldHeight * pxPerMeter,
   );
 }
 
@@ -52,8 +56,9 @@ class PlazaSceneController {
   PlazaSceneController({
     required List<PlazaTask> tasks,
     required int projectSeed,
-  }) : layout = StreetLayout(projectSeed: projectSeed) {
-    plan = layout.plan(tasks);
+    StreetLayout? layout,
+  }) : layout = layout ?? StreetLayout(projectSeed: projectSeed) {
+    plan = this.layout.plan(tasks);
     _build(tasks);
   }
 
@@ -191,6 +196,7 @@ class PlazaSceneController {
         ),
         facadeWorldWidth: facadeW,
         facadeWorldHeight: facadeH,
+        pxPerMeter: layout.pxPerMeter,
       ),
     );
   }

--- a/lib/features/plaza/scene/plaza_scene.dart
+++ b/lib/features/plaza/scene/plaza_scene.dart
@@ -35,14 +35,12 @@ class PlazaBuilding {
   final double facadeWorldWidth;
   final double facadeWorldHeight;
 
-  /// Logical layout size for the facade widget subtree.
-  Size get widgetSize {
-    const pxPerMeter = 56.0;
-    return Size(
-      facadeWorldWidth * pxPerMeter,
-      facadeWorldHeight * pxPerMeter,
-    );
-  }
+  /// Logical layout size for the facade widget subtree. Uses the same
+  /// px-per-meter scale the layout's content-height estimate assumes.
+  Size get widgetSize => Size(
+    facadeWorldWidth * StreetLayout.facadePxPerMeter,
+    facadeWorldHeight * StreetLayout.facadePxPerMeter,
+  );
 }
 
 /// Builds and owns the plaza [Scene]: ground, road, buildings, dusk light.

--- a/lib/features/plaza/scene/plaza_scene.dart
+++ b/lib/features/plaza/scene/plaza_scene.dart
@@ -1,0 +1,242 @@
+import 'dart:math' as math;
+import 'dart:ui' show Size;
+
+import 'package:flutter_scene/scene.dart';
+import 'package:lotti/features/plaza/domain/plaza_task.dart';
+import 'package:lotti/features/plaza/domain/street_layout.dart';
+import 'package:vector_math/vector_math.dart' hide Colors;
+
+/// One building in the plaza: geometry handles plus everything the facade
+/// LOD manager needs to promote/demote its surface.
+class PlazaBuilding {
+  PlazaBuilding({
+    required this.task,
+    required this.placement,
+    required this.node,
+    required this.facadeAnchor,
+    required this.facadeCenter,
+    required this.facadeWorldWidth,
+    required this.facadeWorldHeight,
+  });
+
+  final PlazaTask task;
+  final PlotPlacement placement;
+
+  /// The building root (box mesh), attached to the scene.
+  final Node node;
+
+  /// Child node on the street-facing wall; the LOD manager attaches
+  /// [WidgetComponent]s here.
+  final Node facadeAnchor;
+
+  /// World-space center of the facade, for camera-distance ranking.
+  final Vector3 facadeCenter;
+
+  final double facadeWorldWidth;
+  final double facadeWorldHeight;
+
+  /// Logical layout size for the facade widget subtree.
+  Size get widgetSize {
+    const pxPerMeter = 56.0;
+    return Size(
+      facadeWorldWidth * pxPerMeter,
+      facadeWorldHeight * pxPerMeter,
+    );
+  }
+}
+
+/// Builds and owns the plaza [Scene]: ground, road, buildings, dusk light.
+///
+/// Registration is deliberately register-neutral and unlit (spec §8): the
+/// scene defaults to dusk so luminance contrast — the attention mechanism —
+/// has somewhere to live, and M0 measures widget-surface cost, not PBR cost.
+class PlazaSceneController {
+  PlazaSceneController({
+    required List<PlazaTask> tasks,
+    required int projectSeed,
+  }) : layout = StreetLayout(projectSeed: projectSeed) {
+    plan = layout.plan(tasks);
+    _build(tasks);
+  }
+
+  final StreetLayout layout;
+  late final StreetPlan plan;
+  final Scene scene = Scene();
+  final List<PlazaBuilding> buildings = [];
+
+  /// Where the plaza opens without a specific task: at the frontier (the
+  /// newest buildings), looking back down the street (spec §10).
+  late final Vector3 frontierEye;
+  late final double frontierYaw;
+
+  static Vector4 _rgba(int argb, {double alpha = 1, double dim = 1}) {
+    return Vector4(
+      ((argb >> 16) & 0xFF) / 255 * dim,
+      ((argb >> 8) & 0xFF) / 255 * dim,
+      (argb & 0xFF) / 255 * dim,
+      alpha,
+    );
+  }
+
+  void _build(List<PlazaTask> tasks) {
+    final byId = {for (final t in tasks) t.id: t};
+
+    // Ground: one big dark slab under everything.
+    final groundCenter = _planCenter();
+    scene.add(
+      Node(
+        localTransform: Matrix4.translation(
+          Vector3(groundCenter.x, -0.06, groundCenter.z),
+        ),
+        mesh: Mesh(
+          CuboidGeometry(Vector3(4000, 0.1, 4000)),
+          UnlitMaterial()..baseColorFactor = Vector4(0.045, 0.05, 0.065, 1),
+        ),
+      ),
+    );
+
+    // Road: one slab per segment; collapsed gap weeks read darker.
+    for (final segment in plan.segments) {
+      final midAlong = segment.length / 2;
+      final mid = Vector3(
+        segment.startX + math.sin(segment.headingRadians) * midAlong,
+        0,
+        segment.startZ + math.cos(segment.headingRadians) * midAlong,
+      );
+      final shade = segment.isGap ? 0.06 : 0.09;
+      scene.add(
+        Node(
+          localTransform: Matrix4.translation(mid)
+            ..rotateY(segment.headingRadians),
+          mesh: Mesh(
+            CuboidGeometry(
+              Vector3(layout.roadWidth, 0.08, segment.length + 0.4),
+            ),
+            UnlitMaterial()
+              ..baseColorFactor = Vector4(shade, shade, shade * 1.2, 1),
+          ),
+        ),
+      );
+    }
+
+    for (final placement in plan.placements.values) {
+      final task = byId[placement.taskId];
+      if (task == null) continue;
+      if (task.deleted) {
+        _buildEmptyLot(placement);
+      } else {
+        _buildBuilding(task, placement);
+      }
+    }
+
+    _computeFrontierSpawn();
+  }
+
+  void _buildBuilding(PlazaTask task, PlotPlacement placement) {
+    final w = placement.width;
+    final h = placement.height;
+    final d = placement.depth;
+
+    // Walls: dark, faintly tinted by category so blocks read apart at dusk.
+    final wall = UnlitMaterial()
+      ..baseColorFactor =
+          _rgba(task.categoryColor, dim: 0.10) + Vector4(0.05, 0.05, 0.06, 0);
+
+    final node = Node(
+      localTransform: Matrix4.translation(
+        Vector3(placement.x, h / 2, placement.z),
+      )..rotateY(placement.facingRadians),
+      mesh: Mesh(CuboidGeometry(Vector3(w, h, d)), wall),
+    );
+
+    final facadeW = w * 0.92;
+    final facadeH = h * 0.88;
+
+    // Far-tier surface: an always-present color block on the facade —
+    // state as color, no text (spec §9 LOD "far").
+    final farColor = switch (task.state) {
+      PlazaTaskState.done => Vector4(0.10, 0.28, 0.19, 1),
+      PlazaTaskState.cancelled => Vector4(0.10, 0.11, 0.13, 1),
+      PlazaTaskState.blocked => Vector4(0.36, 0.16, 0.13, 1),
+      PlazaTaskState.inProgress => Vector4(0.13, 0.22, 0.40, 1),
+      PlazaTaskState.open => Vector4(0.16, 0.17, 0.21, 1),
+    };
+    node.add(
+      Node(
+        localTransform: Matrix4.translation(Vector3(0, 0, d / 2 + 0.02)),
+        mesh: Mesh(
+          CuboidGeometry(Vector3(facadeW, facadeH, 0.02)),
+          UnlitMaterial()..baseColorFactor = farColor,
+        ),
+      ),
+    );
+
+    // Anchor for the live/mid widget surface, in front of the color block.
+    final facadeAnchor = Node(
+      localTransform: Matrix4.translation(Vector3(0, 0, d / 2 + 0.09)),
+    );
+    node.add(facadeAnchor);
+
+    scene.add(node);
+
+    final facing = placement.facingRadians;
+    buildings.add(
+      PlazaBuilding(
+        task: task,
+        placement: placement,
+        node: node,
+        facadeAnchor: facadeAnchor,
+        facadeCenter: Vector3(
+          placement.x + math.sin(facing) * (d / 2),
+          h / 2,
+          placement.z + math.cos(facing) * (d / 2),
+        ),
+        facadeWorldWidth: facadeW,
+        facadeWorldHeight: facadeH,
+      ),
+    );
+  }
+
+  void _buildEmptyLot(PlotPlacement placement) {
+    // Fenced empty lot: foundations visible, street never closes up.
+    scene.add(
+      Node(
+        localTransform: Matrix4.translation(
+          Vector3(placement.x, 0.25, placement.z),
+        )..rotateY(placement.facingRadians),
+        mesh: Mesh(
+          CuboidGeometry(Vector3(placement.width, 0.5, placement.depth)),
+          UnlitMaterial()..baseColorFactor = Vector4(0.07, 0.07, 0.08, 1),
+        ),
+      ),
+    );
+  }
+
+  Vector3 _planCenter() {
+    if (plan.segments.isEmpty) return Vector3.zero();
+    var sumX = 0.0;
+    var sumZ = 0.0;
+    for (final s in plan.segments) {
+      sumX += s.startX;
+      sumZ += s.startZ;
+    }
+    return Vector3(sumX / plan.segments.length, 0, sumZ / plan.segments.length);
+  }
+
+  void _computeFrontierSpawn() {
+    if (plan.segments.isEmpty) {
+      frontierEye = Vector3(0, 1.7, -6);
+      frontierYaw = 0;
+      return;
+    }
+    final last = plan.segments.last;
+    final endAlong = last.length;
+    frontierEye = Vector3(
+      last.startX + math.sin(last.headingRadians) * endAlong,
+      1.7,
+      last.startZ + math.cos(last.headingRadians) * endAlong,
+    );
+    // Look back down the street: history one turn away, not in the way.
+    frontierYaw = last.headingRadians + math.pi;
+  }
+}

--- a/lib/features/plaza/ui/debug_overlay.dart
+++ b/lib/features/plaza/ui/debug_overlay.dart
@@ -87,10 +87,15 @@ class PlazaDebugOverlay extends StatelessWidget {
                       ),
                     ),
                     const Spacer(),
-                    Text(
-                      '${stats.avgFrameMs.toStringAsFixed(1)} ms avg\n'
-                      '${stats.worstFrameMs.toStringAsFixed(1)} ms worst',
-                      textAlign: TextAlign.right,
+                    Flexible(
+                      child: FittedBox(
+                        fit: BoxFit.scaleDown,
+                        child: Text(
+                          '${stats.avgFrameMs.toStringAsFixed(1)} ms avg\n'
+                          '${stats.worstFrameMs.toStringAsFixed(1)} ms worst',
+                          textAlign: TextAlign.right,
+                        ),
+                      ),
                     ),
                   ],
                 ),
@@ -170,13 +175,14 @@ class PlazaDebugOverlay extends StatelessWidget {
                   ],
                 ),
                 const SizedBox(height: 4),
-                Row(
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 4,
                   children: [
                     OutlinedButton(
                       onPressed: onCyclePreset,
                       child: const Text('preset'),
                     ),
-                    const SizedBox(width: 8),
                     OutlinedButton(
                       onPressed: onToggleOverhead,
                       child: const Text('overhead'),

--- a/lib/features/plaza/ui/debug_overlay.dart
+++ b/lib/features/plaza/ui/debug_overlay.dart
@@ -138,7 +138,7 @@ class PlazaDebugOverlay extends StatelessWidget {
                 ),
                 const SizedBox(height: 4),
                 const Text(
-                  'WASD walk · drag look · shift sprint',
+                  'WASD walk · space stop/go · drag look · shift sprint',
                   style: TextStyle(color: Color(0xFF6B7280)),
                 ),
               ],

--- a/lib/features/plaza/ui/debug_overlay.dart
+++ b/lib/features/plaza/ui/debug_overlay.dart
@@ -17,24 +17,38 @@ class PlazaHarnessStats extends ChangeNotifier {
   void publish() => notifyListeners();
 }
 
+/// World-scale tuning knobs. Changing one rebuilds the scene (they are
+/// layout inputs, not surface state), so sliders apply on release.
+class PlazaLayoutKnobs {
+  double pxPerMeter = 90;
+  double roadWidth = 25;
+  double maxHeight = 12;
+}
+
 /// The M0 instrumentation and knobs: frame time, tier counts, capture
 /// stats, plus the levers used to find the live-widget ceiling.
 class PlazaDebugOverlay extends StatelessWidget {
   const PlazaDebugOverlay({
     required this.stats,
     required this.config,
+    required this.knobs,
     required this.presetLabel,
     required this.onCyclePreset,
     required this.onConfigChanged,
+    required this.onKnobsApplied,
     required this.onToggleOverhead,
     super.key,
   });
 
   final PlazaHarnessStats stats;
   final FacadeLodConfig config;
+  final PlazaLayoutKnobs knobs;
   final String presetLabel;
   final VoidCallback onCyclePreset;
   final VoidCallback onConfigChanged;
+
+  /// Fired when a layout slider is released — the scene rebuilds.
+  final VoidCallback onKnobsApplied;
   final VoidCallback onToggleOverhead;
 
   @override
@@ -110,6 +124,39 @@ class PlazaDebugOverlay extends StatelessWidget {
                     onConfigChanged();
                   },
                 ),
+                _slider(
+                  label: 'px/m ${knobs.pxPerMeter.round()}',
+                  value: knobs.pxPerMeter,
+                  min: 40,
+                  max: 160,
+                  onChanged: (v) {
+                    knobs.pxPerMeter = v;
+                    onConfigChanged();
+                  },
+                  onChangeEnd: (_) => onKnobsApplied(),
+                ),
+                _slider(
+                  label: 'road ${knobs.roadWidth.round()} m',
+                  value: knobs.roadWidth,
+                  min: 6,
+                  max: 50,
+                  onChanged: (v) {
+                    knobs.roadWidth = v;
+                    onConfigChanged();
+                  },
+                  onChangeEnd: (_) => onKnobsApplied(),
+                ),
+                _slider(
+                  label: 'max h ${knobs.maxHeight.round()} m',
+                  value: knobs.maxHeight,
+                  min: 4,
+                  max: 25,
+                  onChanged: (v) {
+                    knobs.maxHeight = v;
+                    onConfigChanged();
+                  },
+                  onChangeEnd: (_) => onKnobsApplied(),
+                ),
                 Row(
                   children: [
                     const Expanded(child: Text('ALL LIVE (stress)')),
@@ -154,6 +201,8 @@ class PlazaDebugOverlay extends StatelessWidget {
     required double value,
     required double max,
     required ValueChanged<double> onChanged,
+    double min = 0,
+    ValueChanged<double>? onChangeEnd,
   }) {
     return Row(
       children: [
@@ -165,9 +214,11 @@ class PlazaDebugOverlay extends StatelessWidget {
               thumbShape: RoundSliderThumbShape(enabledThumbRadius: 6),
             ),
             child: Slider(
-              value: value.clamp(0, max),
+              value: value.clamp(min, max),
+              min: min,
               max: max,
               onChanged: onChanged,
+              onChangeEnd: onChangeEnd,
             ),
           ),
         ),

--- a/lib/features/plaza/ui/debug_overlay.dart
+++ b/lib/features/plaza/ui/debug_overlay.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/plaza/scene/facade_lod_manager.dart';
+
+/// Rolling frame stats published by the harness a few times a second.
+class PlazaHarnessStats extends ChangeNotifier {
+  double fps = 0;
+  double avgFrameMs = 0;
+  double worstFrameMs = 0;
+  int buildings = 0;
+  int near = 0;
+  int mid = 0;
+  int far = 0;
+  int captures = 0;
+  double lastCaptureMs = 0;
+  int promotions = 0;
+
+  void publish() => notifyListeners();
+}
+
+/// The M0 instrumentation and knobs: frame time, tier counts, capture
+/// stats, plus the levers used to find the live-widget ceiling.
+class PlazaDebugOverlay extends StatelessWidget {
+  const PlazaDebugOverlay({
+    required this.stats,
+    required this.config,
+    required this.presetLabel,
+    required this.onCyclePreset,
+    required this.onConfigChanged,
+    required this.onToggleOverhead,
+    super.key,
+  });
+
+  final PlazaHarnessStats stats;
+  final FacadeLodConfig config;
+  final String presetLabel;
+  final VoidCallback onCyclePreset;
+  final VoidCallback onConfigChanged;
+  final VoidCallback onToggleOverhead;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: stats,
+      builder: (context, _) {
+        final good = stats.fps >= 55;
+        return Container(
+          width: 280,
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: const Color(0xE6101218),
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: DefaultTextStyle(
+            style: const TextStyle(
+              color: Color(0xFFD6DAE3),
+              fontSize: 12,
+              fontFamily: 'monospace',
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      '${stats.fps.toStringAsFixed(0)} fps',
+                      style: TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                        color: good
+                            ? const Color(0xFF63C99A)
+                            : const Color(0xFFE87C6C),
+                      ),
+                    ),
+                    const Spacer(),
+                    Text(
+                      '${stats.avgFrameMs.toStringAsFixed(1)} ms avg\n'
+                      '${stats.worstFrameMs.toStringAsFixed(1)} ms worst',
+                      textAlign: TextAlign.right,
+                    ),
+                  ],
+                ),
+                const Divider(color: Color(0xFF2A2E38)),
+                Text('buildings ${stats.buildings}   preset $presetLabel'),
+                Text(
+                  'live ${stats.near}   static ${stats.mid}   '
+                  'far ${stats.far}',
+                ),
+                Text(
+                  'captures ${stats.captures}   '
+                  'last ${stats.lastCaptureMs.toStringAsFixed(1)} ms   '
+                  'promos ${stats.promotions}',
+                ),
+                const Divider(color: Color(0xFF2A2E38)),
+                _slider(
+                  label: 'live cap ${config.nearCap}',
+                  value: config.nearCap.toDouble(),
+                  max: 100,
+                  onChanged: (v) {
+                    config.nearCap = v.round();
+                    onConfigChanged();
+                  },
+                ),
+                _slider(
+                  label: 'static cap ${config.midCap}',
+                  value: config.midCap.toDouble(),
+                  max: 300,
+                  onChanged: (v) {
+                    config.midCap = v.round();
+                    onConfigChanged();
+                  },
+                ),
+                Row(
+                  children: [
+                    const Expanded(child: Text('ALL LIVE (stress)')),
+                    Switch(
+                      value: config.forceAllLive,
+                      onChanged: (v) {
+                        config.forceAllLive = v;
+                        onConfigChanged();
+                      },
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                Row(
+                  children: [
+                    OutlinedButton(
+                      onPressed: onCyclePreset,
+                      child: const Text('preset'),
+                    ),
+                    const SizedBox(width: 8),
+                    OutlinedButton(
+                      onPressed: onToggleOverhead,
+                      child: const Text('overhead'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                const Text(
+                  'WASD walk · drag look · shift sprint',
+                  style: TextStyle(color: Color(0xFF6B7280)),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _slider({
+    required String label,
+    required double value,
+    required double max,
+    required ValueChanged<double> onChanged,
+  }) {
+    return Row(
+      children: [
+        SizedBox(width: 110, child: Text(label)),
+        Expanded(
+          child: SliderTheme(
+            data: const SliderThemeData(
+              trackHeight: 2,
+              thumbShape: RoundSliderThumbShape(enabledThumbRadius: 6),
+            ),
+            child: Slider(
+              value: value.clamp(0, max),
+              max: max,
+              onChanged: onChanged,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/plaza/ui/facade_widget.dart
+++ b/lib/features/plaza/ui/facade_widget.dart
@@ -39,11 +39,11 @@ String _shortDate(DateTime date) => '${_months[date.month - 1]} ${date.day}';
 
 /// The live signage on one building facade.
 ///
-/// Content-packed, no filler: the building's height is sized to this very
-/// layout (see `StreetLayout.heightFor`), so the column stacks cover art
-/// (full 16:9), title, meta, open checklist items, and the state chip with
-/// nothing artificial in between. A scale-down fit absorbs the estimate
-/// error rather than overflowing.
+/// Content-packed, no filler, ordered like a shopfront: the title reads
+/// high like a sign, the cover art hangs at mid-height near eye level, and
+/// the checklist and state chip sit at street level. The building's height
+/// is sized to this very layout (see `StreetLayout.heightFor`); a
+/// scale-down fit absorbs the estimate error rather than overflowing.
 ///
 /// On the near tier the checklist checkboxes are live — the proof that
 /// interactive widgets on meshes matter (spec §11).
@@ -65,6 +65,12 @@ class FacadeWidget extends StatefulWidget {
 
 class _FacadeWidgetState extends State<FacadeWidget> {
   final Set<int> _ticked = {};
+
+  static const _metaStyle = TextStyle(
+    color: FacadeStyle.textDim,
+    fontSize: 26,
+    fontWeight: FontWeight.w600,
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -103,10 +109,50 @@ class _FacadeWidgetState extends State<FacadeWidget> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Container(height: 10, color: Color(task.categoryColor)),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(24, 24, 24, 18),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            task.title,
+                            maxLines: 6,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: dimText,
+                              fontSize: 44,
+                              height: 1.15,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          if (task.due != null ||
+                              task.linkedTaskIds.isNotEmpty) ...[
+                            const SizedBox(height: 16),
+                            Row(
+                              children: [
+                                if (task.due != null)
+                                  Text(
+                                    'due ${_shortDate(task.due!)}',
+                                    style: _metaStyle,
+                                  ),
+                                const Spacer(),
+                                if (task.linkedTaskIds.isNotEmpty)
+                                  Text(
+                                    'links ${task.linkedTaskIds.length}',
+                                    style: _metaStyle,
+                                  ),
+                              ],
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
                     if (task.coverImageUrl != null)
-                      // The demo covers are 16:9; a matching full-bleed
-                      // frame shows the whole image, edge to edge,
-                      // uncropped and undistorted.
+                      // Full-bleed 16:9 frame: the demo covers are 16:9,
+                      // so the whole image shows, edge to edge, uncropped
+                      // and undistorted — hung below the title so it sits
+                      // near eye level, not at the top of a tower.
                       AspectRatio(
                         aspectRatio: 16 / 9,
                         child: Opacity(
@@ -125,45 +171,6 @@ class _FacadeWidgetState extends State<FacadeWidget> {
                         mainAxisSize: MainAxisSize.min,
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Text(
-                            task.title,
-                            maxLines: 6,
-                            overflow: TextOverflow.ellipsis,
-                            style: TextStyle(
-                              color: dimText,
-                              fontSize: 44,
-                              height: 1.15,
-                              fontWeight: FontWeight.w700,
-                            ),
-                          ),
-                          const SizedBox(height: 16),
-                          if (task.due != null ||
-                              task.linkedTaskIds.isNotEmpty) ...[
-                            Row(
-                              children: [
-                                if (task.due != null)
-                                  Text(
-                                    'due ${_shortDate(task.due!)}',
-                                    style: const TextStyle(
-                                      color: FacadeStyle.textDim,
-                                      fontSize: 26,
-                                      fontWeight: FontWeight.w600,
-                                    ),
-                                  ),
-                                const Spacer(),
-                                if (task.linkedTaskIds.isNotEmpty)
-                                  Text(
-                                    'links ${task.linkedTaskIds.length}',
-                                    style: const TextStyle(
-                                      color: FacadeStyle.textDim,
-                                      fontSize: 26,
-                                      fontWeight: FontWeight.w600,
-                                    ),
-                                  ),
-                              ],
-                            ),
-                            const SizedBox(height: 12),
-                          ],
                           for (final (index, item)
                               in task.openChecklistItems.take(8).indexed)
                             SizedBox(

--- a/lib/features/plaza/ui/facade_widget.dart
+++ b/lib/features/plaza/ui/facade_widget.dart
@@ -30,11 +30,23 @@ abstract final class FacadeStyle {
   };
 }
 
+const _months = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', //
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+String _shortDate(DateTime date) => '${_months[date.month - 1]} ${date.day}';
+
 /// The live signage on one building facade.
 ///
-/// Designed to read at distance: state as color and light, progress as a
-/// filled portion of the facade, title auto-scaled. The checkbox on the
-/// near tier exists to prove interactive widgets on meshes work (spec §11).
+/// Content-packed, no filler: the building's height is sized to this very
+/// layout (see `StreetLayout.heightFor`), so the column stacks cover art
+/// (full 16:9), title, meta, open checklist items, and the state chip with
+/// nothing artificial in between. A scale-down fit absorbs the estimate
+/// error rather than overflowing.
+///
+/// On the near tier the checklist checkboxes are live — the proof that
+/// interactive widgets on meshes matter (spec §11).
 class FacadeWidget extends StatefulWidget {
   const FacadeWidget({
     required this.task,
@@ -44,7 +56,7 @@ class FacadeWidget extends StatefulWidget {
 
   final PlazaTask task;
 
-  /// Near-tier facades get a live checkbox; mid-tier captures stay passive.
+  /// Near-tier facades get live checkboxes; static captures stay passive.
   final bool interactive;
 
   @override
@@ -52,7 +64,7 @@ class FacadeWidget extends StatefulWidget {
 }
 
 class _FacadeWidgetState extends State<FacadeWidget> {
-  bool _demoTicked = false;
+  final Set<int> _ticked = {};
 
   @override
   Widget build(BuildContext context) {
@@ -61,6 +73,7 @@ class _FacadeWidgetState extends State<FacadeWidget> {
     final stateColor = FacadeStyle.stateColor(state);
     final quiet =
         state == PlazaTaskState.done || state == PlazaTaskState.cancelled;
+    final dimText = quiet ? FacadeStyle.textDim : FacadeStyle.text;
 
     return Material(
       color: state == PlazaTaskState.done
@@ -79,91 +92,162 @@ class _FacadeWidgetState extends State<FacadeWidget> {
                 child: ColoredBox(color: stateColor.withValues(alpha: 0.18)),
               ),
             ),
-          Padding(
-            padding: const EdgeInsets.all(24),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Container(height: 10, color: Color(task.categoryColor)),
-                const SizedBox(height: 20),
-                Expanded(
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: Text(
-                      task.title,
-                      maxLines: 5,
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(
-                        color: quiet ? FacadeStyle.textDim : FacadeStyle.text,
-                        fontSize: 44,
-                        height: 1.15,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 16),
-                Row(
+          LayoutBuilder(
+            builder: (context, constraints) => FittedBox(
+              fit: BoxFit.scaleDown,
+              alignment: Alignment.topCenter,
+              child: SizedBox(
+                width: constraints.maxWidth,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 14,
-                        vertical: 8,
-                      ),
-                      decoration: BoxDecoration(
-                        color: stateColor.withValues(alpha: quiet ? 0.25 : 1),
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: Text(
-                        FacadeStyle.stateLabel(state),
-                        style: TextStyle(
-                          color: quiet ? stateColor : Colors.black,
-                          fontSize: 24,
-                          fontWeight: FontWeight.w800,
-                          letterSpacing: 1.5,
-                        ),
-                      ),
-                    ),
-                    const Spacer(),
-                    if (task.checklistItems > 0)
-                      Text(
-                        '${(task.progress * task.checklistItems).round()}'
-                        '/${task.checklistItems}',
-                        style: const TextStyle(
-                          color: FacadeStyle.textDim,
-                          fontSize: 28,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                  ],
-                ),
-                if (widget.interactive && !quiet) ...[
-                  const SizedBox(height: 12),
-                  Row(
-                    children: [
-                      Transform.scale(
-                        scale: 1.6,
-                        child: Checkbox(
-                          value: _demoTicked,
-                          activeColor: stateColor,
-                          onChanged: (v) =>
-                              setState(() => _demoTicked = v ?? false),
-                        ),
-                      ),
-                      const SizedBox(width: 8),
-                      const Expanded(
-                        child: Text(
-                          'Tick me from the street',
-                          style: TextStyle(
-                            color: FacadeStyle.textDim,
-                            fontSize: 24,
+                    Container(height: 10, color: Color(task.categoryColor)),
+                    if (task.coverImageUrl != null)
+                      // The demo covers are 16:9; a matching full-bleed
+                      // frame shows the whole image, edge to edge,
+                      // uncropped and undistorted.
+                      AspectRatio(
+                        aspectRatio: 16 / 9,
+                        child: Opacity(
+                          opacity: quiet ? 0.45 : 1,
+                          child: Image.network(
+                            task.coverImageUrl!,
+                            width: double.infinity,
+                            fit: BoxFit.cover,
+                            errorBuilder: (_, _, _) => const SizedBox(),
                           ),
                         ),
                       ),
-                    ],
-                  ),
-                ],
-              ],
+                    Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            task.title,
+                            maxLines: 6,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: dimText,
+                              fontSize: 44,
+                              height: 1.15,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                          if (task.due != null ||
+                              task.linkedTaskIds.isNotEmpty) ...[
+                            Row(
+                              children: [
+                                if (task.due != null)
+                                  Text(
+                                    'due ${_shortDate(task.due!)}',
+                                    style: const TextStyle(
+                                      color: FacadeStyle.textDim,
+                                      fontSize: 26,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                const Spacer(),
+                                if (task.linkedTaskIds.isNotEmpty)
+                                  Text(
+                                    'links ${task.linkedTaskIds.length}',
+                                    style: const TextStyle(
+                                      color: FacadeStyle.textDim,
+                                      fontSize: 26,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                              ],
+                            ),
+                            const SizedBox(height: 12),
+                          ],
+                          for (final (index, item)
+                              in task.openChecklistItems.take(8).indexed)
+                            SizedBox(
+                              height: 46,
+                              child: Row(
+                                children: [
+                                  SizedBox(
+                                    width: 40,
+                                    child: Checkbox(
+                                      value: _ticked.contains(index),
+                                      activeColor: stateColor,
+                                      onChanged: widget.interactive && !quiet
+                                          ? (v) => setState(() {
+                                              if (v ?? false) {
+                                                _ticked.add(index);
+                                              } else {
+                                                _ticked.remove(index);
+                                              }
+                                            })
+                                          : null,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 10),
+                                  Expanded(
+                                    child: Text(
+                                      item,
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: TextStyle(
+                                        color: _ticked.contains(index)
+                                            ? FacadeStyle.textDim
+                                            : dimText,
+                                        fontSize: 26,
+                                        decoration: _ticked.contains(index)
+                                            ? TextDecoration.lineThrough
+                                            : null,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          Row(
+                            children: [
+                              Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 14,
+                                  vertical: 8,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: stateColor.withValues(
+                                    alpha: quiet ? 0.25 : 1,
+                                  ),
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                                child: Text(
+                                  FacadeStyle.stateLabel(state),
+                                  style: TextStyle(
+                                    color: quiet ? stateColor : Colors.black,
+                                    fontSize: 24,
+                                    fontWeight: FontWeight.w800,
+                                    letterSpacing: 1.5,
+                                  ),
+                                ),
+                              ),
+                              const Spacer(),
+                              if (task.checklistItems > 0)
+                                Text(
+                                  '${(task.progress * task.checklistItems).round()}'
+                                  '/${task.checklistItems}',
+                                  style: const TextStyle(
+                                    color: FacadeStyle.textDim,
+                                    fontSize: 28,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             ),
           ),
         ],

--- a/lib/features/plaza/ui/facade_widget.dart
+++ b/lib/features/plaza/ui/facade_widget.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/plaza/domain/plaza_task.dart';
+
+/// Dev-harness palette for facade signage.
+///
+/// The plaza is 3D scene content rendered inside the prototype harness, not
+/// app chrome; like `knowledge_graph/ui/graph_style.dart` it keeps a local
+/// palette instead of design-system tokens. If the prototype graduates, this
+/// gets rebased onto the token pipeline.
+abstract final class FacadeStyle {
+  static const background = Color(0xFF14161C);
+  static const backgroundDone = Color(0xFF10201A);
+  static const text = Color(0xFFECEFF4);
+  static const textDim = Color(0xFF8B92A1);
+
+  static Color stateColor(PlazaTaskState state) => switch (state) {
+    PlazaTaskState.open => const Color(0xFF8B92A1),
+    PlazaTaskState.inProgress => const Color(0xFF5C9DFF),
+    PlazaTaskState.blocked => const Color(0xFFE87C6C),
+    PlazaTaskState.done => const Color(0xFF63C99A),
+    PlazaTaskState.cancelled => const Color(0xFF565B66),
+  };
+
+  static String stateLabel(PlazaTaskState state) => switch (state) {
+    PlazaTaskState.open => 'OPEN',
+    PlazaTaskState.inProgress => 'IN PROGRESS',
+    PlazaTaskState.blocked => 'BLOCKED',
+    PlazaTaskState.done => 'DONE',
+    PlazaTaskState.cancelled => 'CANCELLED',
+  };
+}
+
+/// The live signage on one building facade.
+///
+/// Designed to read at distance: state as color and light, progress as a
+/// filled portion of the facade, title auto-scaled. The checkbox on the
+/// near tier exists to prove interactive widgets on meshes work (spec §11).
+class FacadeWidget extends StatefulWidget {
+  const FacadeWidget({
+    required this.task,
+    required this.interactive,
+    super.key,
+  });
+
+  final PlazaTask task;
+
+  /// Near-tier facades get a live checkbox; mid-tier captures stay passive.
+  final bool interactive;
+
+  @override
+  State<FacadeWidget> createState() => _FacadeWidgetState();
+}
+
+class _FacadeWidgetState extends State<FacadeWidget> {
+  bool _demoTicked = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final task = widget.task;
+    final state = task.state;
+    final stateColor = FacadeStyle.stateColor(state);
+    final quiet =
+        state == PlazaTaskState.done || state == PlazaTaskState.cancelled;
+
+    return Material(
+      color: state == PlazaTaskState.done
+          ? FacadeStyle.backgroundDone
+          : FacadeStyle.background,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          // Progress reads as a filled portion of the whole facade.
+          if (task.checklistItems > 0)
+            Align(
+              alignment: Alignment.bottomCenter,
+              child: FractionallySizedBox(
+                heightFactor: task.progress.clamp(0.0, 1.0),
+                widthFactor: 1,
+                child: ColoredBox(color: stateColor.withValues(alpha: 0.18)),
+              ),
+            ),
+          Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(height: 10, color: Color(task.categoryColor)),
+                const SizedBox(height: 20),
+                Expanded(
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      task.title,
+                      maxLines: 5,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: quiet ? FacadeStyle.textDim : FacadeStyle.text,
+                        fontSize: 44,
+                        height: 1.15,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 14,
+                        vertical: 8,
+                      ),
+                      decoration: BoxDecoration(
+                        color: stateColor.withValues(alpha: quiet ? 0.25 : 1),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        FacadeStyle.stateLabel(state),
+                        style: TextStyle(
+                          color: quiet ? stateColor : Colors.black,
+                          fontSize: 24,
+                          fontWeight: FontWeight.w800,
+                          letterSpacing: 1.5,
+                        ),
+                      ),
+                    ),
+                    const Spacer(),
+                    if (task.checklistItems > 0)
+                      Text(
+                        '${(task.progress * task.checklistItems).round()}'
+                        '/${task.checklistItems}',
+                        style: const TextStyle(
+                          color: FacadeStyle.textDim,
+                          fontSize: 28,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                  ],
+                ),
+                if (widget.interactive && !quiet) ...[
+                  const SizedBox(height: 12),
+                  Row(
+                    children: [
+                      Transform.scale(
+                        scale: 1.6,
+                        child: Checkbox(
+                          value: _demoTicked,
+                          activeColor: stateColor,
+                          onChanged: (v) =>
+                              setState(() => _demoTicked = v ?? false),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      const Expanded(
+                        child: Text(
+                          'Tick me from the street',
+                          style: TextStyle(
+                            color: FacadeStyle.textDim,
+                            fontSize: 24,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/plaza/ui/fly_camera_controller.dart
+++ b/lib/features/plaza/ui/fly_camera_controller.dart
@@ -1,0 +1,156 @@
+import 'dart:math' as math;
+
+import 'package:flutter/services.dart';
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart' show Vector3;
+
+/// First-person walk camera with an animated overhead search mode.
+///
+/// Eye height ~1.7 m, WASD/arrows + drag-look on desktop. The overhead
+/// toggle blends smoothly — transitions are animated, never cut (spec §10).
+class FlyCameraController {
+  FlyCameraController({
+    required Vector3 position,
+    required this._yaw,
+  }) : _position = Vector3.copy(position);
+
+  static const _eyeHeight = 1.7;
+  static const _walkSpeed = 12.0;
+  static const _sprintFactor = 3.0;
+  static const _overheadHeight = 90.0;
+  static const _overheadBack = 40.0;
+
+  final Vector3 _position;
+  double _yaw;
+  double _pitch = 0;
+  final Set<LogicalKeyboardKey> _pressed = {};
+
+  double _overheadBlend = 0;
+  bool _overhead = false;
+
+  /// Scripted forward input (benchmark mode): -1..1, applied when no key is
+  /// pressed.
+  double autoForward = 0;
+
+  Vector3 get position => _position;
+  bool get overhead => _overhead;
+
+  /// Feed key events from the harness. Returns true when handled.
+  bool handleKeyEvent(KeyEvent event) {
+    final key = event.logicalKey;
+    final tracked = {
+      LogicalKeyboardKey.keyW,
+      LogicalKeyboardKey.keyA,
+      LogicalKeyboardKey.keyS,
+      LogicalKeyboardKey.keyD,
+      LogicalKeyboardKey.arrowUp,
+      LogicalKeyboardKey.arrowDown,
+      LogicalKeyboardKey.arrowLeft,
+      LogicalKeyboardKey.arrowRight,
+      LogicalKeyboardKey.shiftLeft,
+      LogicalKeyboardKey.shiftRight,
+    };
+    if (!tracked.contains(key)) return false;
+    if (event is KeyDownEvent || event is KeyRepeatEvent) {
+      _pressed.add(key);
+    } else if (event is KeyUpEvent) {
+      _pressed.remove(key);
+    }
+    return true;
+  }
+
+  /// Mouse-drag look, in logical pixels.
+  void addLookDelta(double dx, double dy) {
+    _yaw -= dx * 0.0035;
+    _pitch = (_pitch - dy * 0.0035).clamp(-1.35, 1.35);
+  }
+
+  void toggleOverhead() => _overhead = !_overhead;
+
+  /// Jump to a pose (used on preset change / locator entry).
+  void reset({required Vector3 position, required double yaw}) {
+    _position.setFrom(position);
+    _yaw = yaw;
+    _pitch = 0;
+  }
+
+  bool _down(LogicalKeyboardKey a, LogicalKeyboardKey b) =>
+      _pressed.contains(a) || _pressed.contains(b);
+
+  /// Advance one frame.
+  void update(double dt) {
+    var forwardInput =
+        (_down(LogicalKeyboardKey.keyW, LogicalKeyboardKey.arrowUp)
+            ? 1.0
+            : 0.0) -
+        (_down(LogicalKeyboardKey.keyS, LogicalKeyboardKey.arrowDown)
+            ? 1.0
+            : 0.0);
+    if (forwardInput == 0) forwardInput = autoForward;
+    final strafeInput =
+        (_down(LogicalKeyboardKey.keyD, LogicalKeyboardKey.arrowRight)
+            ? 1.0
+            : 0.0) -
+        (_down(LogicalKeyboardKey.keyA, LogicalKeyboardKey.arrowLeft)
+            ? 1.0
+            : 0.0);
+
+    if (forwardInput != 0 || strafeInput != 0) {
+      var speed = _walkSpeed;
+      if (_down(LogicalKeyboardKey.shiftLeft, LogicalKeyboardKey.shiftRight)) {
+        speed *= _sprintFactor;
+      }
+      // Overhead mode pans faster: it is the search mode.
+      speed *= 1 + _overheadBlend * 4;
+      final sinY = math.sin(_yaw);
+      final cosY = math.cos(_yaw);
+      _position
+        ..x += (sinY * forwardInput + cosY * strafeInput) * speed * dt
+        ..z += (cosY * forwardInput - sinY * strafeInput) * speed * dt;
+    }
+    _position.y = _eyeHeight;
+
+    final target = _overhead ? 1.0 : 0.0;
+    final rate = dt * 2.2;
+    _overheadBlend =
+        _overheadBlend + (target - _overheadBlend).clamp(-rate, rate);
+  }
+
+  /// The camera for this frame.
+  Camera camera() {
+    final sinY = math.sin(_yaw);
+    final cosY = math.cos(_yaw);
+    final cosP = math.cos(_pitch);
+    final forward = Vector3(sinY * cosP, math.sin(_pitch), cosY * cosP);
+
+    // Smoothstep the blend so both ends ease.
+    final t = _overheadBlend * _overheadBlend * (3 - 2 * _overheadBlend);
+
+    final groundEye = _position;
+    final overheadEye = Vector3(
+      _position.x - sinY * _overheadBack,
+      _overheadHeight,
+      _position.z - cosY * _overheadBack,
+    );
+    final eye = Vector3(
+      groundEye.x + (overheadEye.x - groundEye.x) * t,
+      groundEye.y + (overheadEye.y - groundEye.y) * t,
+      groundEye.z + (overheadEye.z - groundEye.z) * t,
+    );
+
+    final groundTarget = groundEye + forward * 10;
+    // Overhead looks at the walker's spot, tracking the street.
+    final overheadTarget = Vector3(_position.x, 0, _position.z);
+    final lookAt = Vector3(
+      groundTarget.x + (overheadTarget.x - groundTarget.x) * t,
+      groundTarget.y + (overheadTarget.y - groundTarget.y) * t,
+      groundTarget.z + (overheadTarget.z - groundTarget.z) * t,
+    );
+
+    return PerspectiveCamera(
+      position: eye,
+      target: lookAt,
+      fovFar: 2500,
+    );
+  }
+}

--- a/lib/features/plaza/ui/fly_camera_controller.dart
+++ b/lib/features/plaza/ui/fly_camera_controller.dart
@@ -16,7 +16,7 @@ class FlyCameraController {
   }) : _position = Vector3.copy(position);
 
   // Slightly above head height so tall content-sized facades read well.
-  static const _eyeHeight = 4.5;
+  static const _eyeHeight = 5.0;
   static const _walkSpeed = 12.0;
   static const _sprintFactor = 3.0;
   static const _overheadHeight = 90.0;

--- a/lib/features/plaza/ui/fly_camera_controller.dart
+++ b/lib/features/plaza/ui/fly_camera_controller.dart
@@ -6,15 +6,17 @@ import 'package:vector_math/vector_math.dart' show Vector3;
 
 /// First-person walk camera with an animated overhead search mode.
 ///
-/// Eye height ~1.7 m, WASD/arrows + drag-look on desktop. The overhead
-/// toggle blends smoothly — transitions are animated, never cut (spec §10).
+/// WASD/arrows + drag-look on desktop; space toggles auto-walk. The
+/// overhead toggle blends smoothly — transitions are animated, never cut
+/// (spec §10).
 class FlyCameraController {
   FlyCameraController({
     required Vector3 position,
     required this._yaw,
   }) : _position = Vector3.copy(position);
 
-  static const _eyeHeight = 1.7;
+  // Slightly above head height so tall content-sized facades read well.
+  static const _eyeHeight = 4.5;
   static const _walkSpeed = 12.0;
   static const _sprintFactor = 3.0;
   static const _overheadHeight = 90.0;
@@ -38,6 +40,15 @@ class FlyCameraController {
   /// Feed key events from the harness. Returns true when handled.
   bool handleKeyEvent(KeyEvent event) {
     final key = event.logicalKey;
+    if (key == LogicalKeyboardKey.space) {
+      if (event is KeyDownEvent) {
+        // Stop/play: toggle auto-walk. Also clears any stuck movement key
+        // (a key-up lost to a focus change would otherwise walk forever).
+        autoForward = autoForward == 0 ? 1 : 0;
+        _pressed.clear();
+      }
+      return true;
+    }
     final tracked = {
       LogicalKeyboardKey.keyW,
       LogicalKeyboardKey.keyA,
@@ -79,6 +90,13 @@ class FlyCameraController {
 
   /// Advance one frame.
   void update(double dt) {
+    // A key-up lost to a focus change (clicking the overlay, panning)
+    // would leave a movement key latched and the camera walking forever;
+    // reconcile with the hardware's actual pressed set every frame.
+    _pressed.removeWhere(
+      (key) => !HardwareKeyboard.instance.logicalKeysPressed.contains(key),
+    );
+
     var forwardInput =
         (_down(LogicalKeyboardKey.keyW, LogicalKeyboardKey.arrowUp)
             ? 1.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -386,7 +386,7 @@ packages:
     source: hosted
     version: "1.1.3"
   code_assets:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: code_assets
       sha256: cfd4f5f575a49c5f10ca856e9846073f1e6c3ee94912377eea5f6cefc5272941
@@ -537,6 +537,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.7"
+  data_assets:
+    dependency: transitive
+    description:
+      name: data_assets
+      sha256: "8bfdbf25ec8a0f4b5a3c993042c4ab9996ba354f0b03d40f4e360f3730d71cae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.0"
   dbus:
     dependency: "direct main"
     description:
@@ -884,6 +892,19 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.3.0+2"
+  flutter_gpu:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_gpu_shaders:
+    dependency: transitive
+    description:
+      name: flutter_gpu_shaders
+      sha256: "1e8c5438c24e79629f5688c7b5dfd2b7cf09b36b443a806bc8c083cd8c04644a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.2"
   flutter_image_compress:
     dependency: "direct main"
     description:
@@ -1145,6 +1166,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.12.0"
+  flutter_scene:
+    dependency: "direct main"
+    description:
+      name: flutter_scene
+      sha256: "1cc32b5ed0d05296c1f7958e63168a750c05c2373d6769ad9b9eaa973b2f97fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.23.0"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -1950,7 +1979,7 @@ packages:
     source: hosted
     version: "0.8.0"
   native_toolchain_c:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: native_toolchain_c
       sha256: "9d233b6f2d9c52e1a2b5fbe70451d2c10ac674d3bb419d0ec8de14989d437c26"
@@ -2518,6 +2547,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.6"
+  scene:
+    dependency: transitive
+    description:
+      name: scene
+      sha256: f14dd23ea3858041b644ec4824eca5cae817b42aca03c5ed2efcf1afa003d554
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   scope:
     dependency: transitive
     description:
@@ -3156,7 +3193,7 @@ packages:
     source: hosted
     version: "1.3.0"
   vector_math:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: vector_math
       sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
@@ -3395,6 +3432,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.4"
+  yaml_edit:
+    dependency: transitive
+    description:
+      name: yaml_edit
+      sha256: "07c9e63ba42519745182b88ca12264a7ba2484d8239958778dfe4d44fe760488"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.4"
   zxing2:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,6 +67,7 @@ dependencies:
   flutter_quill_extensions: ^11.0.0
   flutter_rating: ^2.0.2
   flutter_riverpod: ^3.1.0
+  flutter_scene: ^0.23.0
   flutter_secure_storage: ^10.0.0
   flutter_svg: ^2.2.4
   flutter_vodozemac: ^0.7.1
@@ -124,6 +125,7 @@ dependencies:
   tinycolor2: ^3.0.0
   url_launcher: ^6.1.2
   uuid: ^4.3.3
+  vector_math: ^2.4.2
   wechat_assets_picker: ^10.1.0
   widgetbook: ^3.7.1
   window_manager: ^0.5.0
@@ -131,6 +133,12 @@ dependencies:
   zxing2: ^0.2.4
 
 dependency_overrides:
+  # flutter_scene 0.23 pins code_assets ^1.2.1, which would downgrade the
+  # native-assets toolchain for everyone else. Its build hook compiles fine
+  # against 2.x (verified by a full Linux build), so keep the toolchain
+  # current. Re-check on every flutter_scene bump.
+  code_assets: ^2.0.0
+  native_toolchain_c: 0.19.4
   # json_serializable >=6.13.2 requires analyzer >=10, while
   # objectbox_generator 5.x currently caps analyzer below 11.
   analyzer_plugin: '>=0.14.0 <0.14.5'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -133,15 +133,15 @@ dependencies:
   zxing2: ^0.2.4
 
 dependency_overrides:
-  # flutter_scene 0.23 pins code_assets ^1.2.1, which would downgrade the
-  # native-assets toolchain for everyone else. Its build hook compiles fine
-  # against 2.x (verified by a full Linux build), so keep the toolchain
-  # current. Re-check on every flutter_scene bump.
-  code_assets: ^2.0.0
-  native_toolchain_c: 0.19.4
   # json_serializable >=6.13.2 requires analyzer >=10, while
   # objectbox_generator 5.x currently caps analyzer below 11.
   analyzer_plugin: '>=0.14.0 <0.14.5'
+  # flutter_scene 0.23 pins code_assets ^1.2.1, which would downgrade the
+  # native-assets toolchain for everyone else. Its build hook compiles fine
+  # against 2.x (verified by a full Linux build), so keep the toolchain
+  # current (with the matching native_toolchain_c below). Re-check on every
+  # flutter_scene bump.
+  code_assets: ^2.0.0
   # health >=13.2.0 requires device_info_plus ^12.1.0, while
   # super_native_extensions 0.9.1 still caps it below 12.0.0.
   device_info_plus: ^12.1.0
@@ -151,6 +151,8 @@ dependency_overrides:
   flutter_onnxruntime:
     path: third_party/flutter_onnxruntime
   intl: ^0.20.3
+  # Partner of the code_assets override above (0.19.4 needs code_assets 2.x).
+  native_toolchain_c: 0.19.4
   # Downgrade to avoid objective_c.framework malformed bundle issue (ITMS-90291)
   # See: https://github.com/flutter/flutter/issues/178915
   path_provider_foundation: 2.5.1

--- a/test/features/plaza/data/demo_world_projection_test.dart
+++ b/test/features/plaza/data/demo_world_projection_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/demo/media/demo_media_asset.dart';
 import 'package:lotti/features/plaza/data/demo_world_projection.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
@@ -72,6 +73,62 @@ void main() {
       for (final task in covered) {
         expect(task.coverImageUrl, startsWith(demoMediaPublicBaseUrl));
       }
+    });
+
+    test('every task status arm maps to a plaza state', () {
+      final now = DateTime.utc(2026, 7, 17);
+      expect(
+        mapTaskStatusToPlazaState(
+          TaskStatus.open(id: 'a', createdAt: now, utcOffset: 0),
+        ),
+        PlazaTaskState.open,
+      );
+      expect(
+        mapTaskStatusToPlazaState(
+          TaskStatus.groomed(id: 'b', createdAt: now, utcOffset: 0),
+        ),
+        PlazaTaskState.open,
+      );
+      expect(
+        mapTaskStatusToPlazaState(
+          TaskStatus.inProgress(id: 'c', createdAt: now, utcOffset: 0),
+        ),
+        PlazaTaskState.inProgress,
+      );
+      expect(
+        mapTaskStatusToPlazaState(
+          TaskStatus.blocked(
+            id: 'd',
+            createdAt: now,
+            utcOffset: 0,
+            reason: 'ice',
+          ),
+        ),
+        PlazaTaskState.blocked,
+      );
+      expect(
+        mapTaskStatusToPlazaState(
+          TaskStatus.onHold(
+            id: 'e',
+            createdAt: now,
+            utcOffset: 0,
+            reason: 'ice',
+          ),
+        ),
+        PlazaTaskState.blocked,
+      );
+      expect(
+        mapTaskStatusToPlazaState(
+          TaskStatus.done(id: 'f', createdAt: now, utcOffset: 0),
+        ),
+        PlazaTaskState.done,
+      );
+      expect(
+        mapTaskStatusToPlazaState(
+          TaskStatus.rejected(id: 'g', createdAt: now, utcOffset: 0),
+        ),
+        PlazaTaskState.cancelled,
+      );
     });
 
     test('projection is reproducible under the fixed clock', () {

--- a/test/features/plaza/data/demo_world_projection_test.dart
+++ b/test/features/plaza/data/demo_world_projection_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/demo/media/demo_media_asset.dart';
+import 'package:lotti/features/plaza/data/demo_world_projection.dart';
+import 'package:lotti/features/plaza/domain/plaza_task.dart';
+
+void main() {
+  // The demo world is deterministic under a fixed clock, so project once.
+  final tasks = plazaTasksFromDemoWorld(now: DateTime(2026, 7, 17, 10, 30));
+
+  group('plazaTasksFromDemoWorld', () {
+    test('projects every penguin task with a unique id and a title', () {
+      expect(tasks, isNotEmpty);
+      expect(tasks.map((t) => t.id).toSet(), hasLength(tasks.length));
+      for (final task in tasks) {
+        expect(task.title.trim(), isNotEmpty);
+      }
+    });
+
+    test('maps a realistic mix of states', () {
+      final states = tasks.map((t) => t.state).toSet();
+      expect(states, contains(PlazaTaskState.done));
+      expect(states, contains(PlazaTaskState.inProgress));
+      expect(states.length, greaterThanOrEqualTo(3));
+    });
+
+    test('checklist progress matches the open-item projection', () {
+      var withItems = 0;
+      for (final task in tasks) {
+        expect(task.progress, inInclusiveRange(0, 1));
+        if (task.checklistItems == 0) {
+          expect(task.openChecklistItems, isEmpty);
+          continue;
+        }
+        withItems++;
+        expect(task.openChecklistItems.length, lessThanOrEqualTo(8));
+        if (task.checklistItems <= 8) {
+          // Below the display cap, open items and progress must agree.
+          final open =
+              task.checklistItems -
+              (task.progress * task.checklistItems).round();
+          expect(task.openChecklistItems, hasLength(open));
+        }
+        for (final item in task.openChecklistItems) {
+          expect(item.trim(), isNotEmpty);
+        }
+      }
+      expect(withItems, greaterThan(0));
+    });
+
+    test('links reference only other projected tasks, sorted', () {
+      final ids = tasks.map((t) => t.id).toSet();
+      var linked = 0;
+      for (final task in tasks) {
+        if (task.linkedTaskIds.isEmpty) continue;
+        linked++;
+        expect(
+          task.linkedTaskIds,
+          containsAllInOrder(
+            [...task.linkedTaskIds]..sort(),
+          ),
+        );
+        for (final target in task.linkedTaskIds) {
+          expect(ids, contains(target));
+        }
+      }
+      expect(linked, greaterThan(0));
+    });
+
+    test('cover art resolves to the public immutable R2 catalog', () {
+      final covered = tasks.where((t) => t.coverImageUrl != null).toList();
+      expect(covered, isNotEmpty);
+      for (final task in covered) {
+        expect(task.coverImageUrl, startsWith(demoMediaPublicBaseUrl));
+      }
+    });
+
+    test('projection is reproducible under the fixed clock', () {
+      final again = plazaTasksFromDemoWorld(now: DateTime(2026, 7, 17, 10, 30));
+      expect(again.length, tasks.length);
+      for (var i = 0; i < tasks.length; i++) {
+        expect(again[i].id, tasks[i].id);
+        expect(again[i].createdAt, tasks[i].createdAt);
+        expect(again[i].state, tasks[i].state);
+        expect(again[i].progress, tasks[i].progress);
+      }
+    });
+  });
+}

--- a/test/features/plaza/domain/plaza_generator_test.dart
+++ b/test/features/plaza/domain/plaza_generator_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/plaza/domain/plaza_generator.dart';
+import 'package:lotti/features/plaza/domain/plaza_task.dart';
+
+void main() {
+  group('generatePlazaTasks', () {
+    test('presets produce their advertised task counts', () {
+      expect(generatePlazaTasks(preset: PlazaPreset.small), hasLength(20));
+      expect(generatePlazaTasks(preset: PlazaPreset.medium), hasLength(80));
+      expect(generatePlazaTasks(preset: PlazaPreset.large), hasLength(300));
+    });
+
+    test('same seed reproduces the identical dataset', () {
+      final a = generatePlazaTasks(preset: PlazaPreset.medium, seed: 7);
+      final b = generatePlazaTasks(preset: PlazaPreset.medium, seed: 7);
+      for (var i = 0; i < a.length; i++) {
+        expect(b[i].id, a[i].id);
+        expect(b[i].title, a[i].title);
+        expect(b[i].state, a[i].state);
+        expect(b[i].createdAt, a[i].createdAt);
+        expect(b[i].progress, a[i].progress);
+        expect(b[i].linkedTaskIds, a[i].linkedTaskIds);
+        expect(b[i].openChecklistItems, a[i].openChecklistItems);
+      }
+    });
+
+    test('different seeds produce different datasets', () {
+      final a = generatePlazaTasks(preset: PlazaPreset.small, seed: 1);
+      final b = generatePlazaTasks(preset: PlazaPreset.small, seed: 2);
+      expect(
+        a.map((t) => t.title).join(),
+        isNot(b.map((t) => t.title).join()),
+      );
+    });
+
+    test('creation times are strictly increasing (placement input)', () {
+      final tasks = generatePlazaTasks(preset: PlazaPreset.large);
+      for (var i = 1; i < tasks.length; i++) {
+        expect(tasks[i].createdAt.isAfter(tasks[i - 1].createdAt), isTrue);
+      }
+    });
+
+    test('the large preset exercises every state and some deletions', () {
+      final tasks = generatePlazaTasks(preset: PlazaPreset.large);
+      final states = tasks.map((t) => t.state).toSet();
+      expect(states, containsAll(PlazaTaskState.values));
+      expect(tasks.any((t) => t.deleted), isTrue);
+      expect(tasks.any((t) => t.linkedTaskIds.isNotEmpty), isTrue);
+    });
+
+    test('checklist bookkeeping is internally consistent', () {
+      for (final task in generatePlazaTasks(preset: PlazaPreset.large)) {
+        expect(task.progress, inInclusiveRange(0, 1));
+        if (task.checklistItems == 0) {
+          expect(task.progress, 0);
+          expect(task.openChecklistItems, isEmpty);
+        } else {
+          if (task.state == PlazaTaskState.done) {
+            expect(task.progress, 1);
+          }
+          final open =
+              task.checklistItems -
+              (task.progress * task.checklistItems).round();
+          expect(task.openChecklistItems, hasLength(open));
+        }
+      }
+    });
+
+    test('links point at tasks that exist in the same dataset', () {
+      final tasks = generatePlazaTasks(preset: PlazaPreset.large);
+      final ids = tasks.map((t) => t.id).toSet();
+      for (final task in tasks) {
+        for (final target in task.linkedTaskIds) {
+          expect(ids, contains(target));
+          expect(target, isNot(task.id));
+        }
+      }
+    });
+  });
+}

--- a/test/features/plaza/domain/street_layout_test.dart
+++ b/test/features/plaza/domain/street_layout_test.dart
@@ -242,6 +242,32 @@ void main() {
       expect(plan.placements['anchor']!.bucketIndex, 0);
     });
 
+    test('an empty project plans an empty street', () {
+      final plan = layout.plan([]);
+      expect(plan.segments, isEmpty);
+      expect(plan.placements, isEmpty);
+    });
+
+    test('meta rows and cover art add height, checklist items stack more', () {
+      final bare = _task('t', DateTime.utc(2026, 3, 2, 9));
+      final withMeta = PlazaTask(
+        id: 't',
+        createdAt: bare.createdAt,
+        title: bare.title,
+        state: bare.state,
+        progress: 0,
+        checklistItems: 3,
+        openChecklistItems: const ['a', 'b', 'c'],
+        linkedTaskIds: const ['other'],
+        categoryColor: 0xFF5C9DFF,
+        due: DateTime.utc(2026, 4, 2),
+        coverImageUrl: 'https://example.invalid/cover.webp',
+      );
+      final plain = layout.heightFor(bare, 8);
+      final loaded = layout.heightFor(withMeta, 8);
+      expect(loaded, greaterThan(plain));
+    });
+
     test('weekStart anchors to Monday 00:00 UTC', () {
       expect(
         StreetLayout.weekStart(DateTime.utc(2026, 9, 3, 15, 30)), // Thursday.

--- a/test/features/plaza/domain/street_layout_test.dart
+++ b/test/features/plaza/domain/street_layout_test.dart
@@ -21,7 +21,7 @@ PlazaTask _task(String id, DateTime createdAt) {
 /// some empty ones.
 List<PlazaTask> _dataset({int count = 60, int seed = 7}) {
   final rng = Random(seed);
-  var cursor = DateTime(2026, 3, 2, 9);
+  var cursor = DateTime.utc(2026, 3, 2, 9);
   return [
     for (var i = 0; i < count; i++)
       _task(
@@ -90,34 +90,35 @@ void main() {
   });
 
   group('the invariant: nothing ever moves', () {
-    test('appending tasks in later weeks never changes existing placements',
-        () {
-      final tasks = _dataset();
-      final before = layout.plan(tasks);
-
-      final lastCreated = tasks
-          .map((t) => t.createdAt)
-          .reduce((a, b) => a.isAfter(b) ? a : b);
-      final grown = [
-        ...tasks,
-        for (var i = 0; i < 25; i++)
-          _task('new-$i', lastCreated.add(Duration(days: 7 + i * 2))),
-      ];
-      final after = layout.plan(grown, epoch: before.epoch);
-
-      for (final id in before.placements.keys) {
-        expect(
-          after.placements[id],
-          _samePlacementAs(before.placements[id]!),
-          reason: 'appending later tasks moved $id',
-        );
-      }
-      // And the street did grow.
-      expect(after.segments.length, greaterThan(before.segments.length));
-    });
-
     test(
-        'a late-syncing task jostles only its own bucket — '
+      'appending tasks in later weeks never changes existing placements',
+      () {
+        final tasks = _dataset();
+        final before = layout.plan(tasks);
+
+        final lastCreated = tasks
+            .map((t) => t.createdAt)
+            .reduce((a, b) => a.isAfter(b) ? a : b);
+        final grown = [
+          ...tasks,
+          for (var i = 0; i < 25; i++)
+            _task('new-$i', lastCreated.add(Duration(days: 7 + i * 2))),
+        ];
+        final after = layout.plan(grown, epoch: before.epoch);
+
+        for (final id in before.placements.keys) {
+          expect(
+            after.placements[id],
+            _samePlacementAs(before.placements[id]!),
+            reason: 'appending later tasks moved $id',
+          );
+        }
+        // And the street did grow.
+        expect(after.segments.length, greaterThan(before.segments.length));
+      },
+    );
+
+    test('a late-syncing task jostles only its own bucket — '
         'every other placement is bit-identical', () {
       final tasks = _dataset();
       final before = layout.plan(tasks);
@@ -146,7 +147,8 @@ void main() {
           expect(
             after.placements[id],
             _samePlacementAs(b),
-            reason: 'late syncer in bucket $touchedBucket moved $id '
+            reason:
+                'late syncer in bucket $touchedBucket moved $id '
                 'in bucket ${b.bucketIndex}',
           );
         }
@@ -166,13 +168,12 @@ void main() {
   });
 
   group('street structure', () {
-    test('empty weeks collapse to gap segments, busy weeks to plot groups',
-        () {
+    test('empty weeks collapse to gap segments, busy weeks to plot groups', () {
       final tasks = [
-        _task('w0-a', DateTime(2026, 3, 2, 10)),
-        _task('w0-b', DateTime(2026, 3, 3, 10)),
+        _task('w0-a', DateTime.utc(2026, 3, 2, 10)),
+        _task('w0-b', DateTime.utc(2026, 3, 3, 10)),
         // Weeks 1 and 2 empty.
-        _task('w3-a', DateTime(2026, 3, 24, 10)),
+        _task('w3-a', DateTime.utc(2026, 3, 24, 10)),
       ];
       final plan = layout.plan(tasks);
 
@@ -184,10 +185,9 @@ void main() {
     });
 
     test('within a week, tasks alternate sides in (createdAt, id) order', () {
-      final base = DateTime(2026, 3, 2, 9);
+      final base = DateTime.utc(2026, 3, 2, 9);
       final tasks = [
-        for (var i = 0; i < 5; i++)
-          _task('t$i', base.add(Duration(hours: i))),
+        for (var i = 0; i < 5; i++) _task('t$i', base.add(Duration(hours: i))),
       ];
       final plan = layout.plan(tasks);
 
@@ -198,29 +198,63 @@ void main() {
       expect(plan.placements['t4']!.side, PlotSide.left);
     });
 
-    test('building widths stay within bounds however busy the week', () {
-      final base = DateTime(2026, 3, 2, 9);
+    test('crowded weeks never overlap neighboring buildings', () {
+      final base = DateTime.utc(2026, 3, 2, 9);
       final crowded = [
         for (var i = 0; i < 40; i++)
           _task('busy-$i', base.add(Duration(minutes: i))),
       ];
       final plan = layout.plan(crowded);
       for (final placement in plan.placements.values) {
-        expect(
-          placement.width,
-          inInclusiveRange(layout.minBuildingWidth, layout.maxBuildingWidth),
-        );
+        expect(placement.width, lessThanOrEqualTo(layout.maxBuildingWidth));
+        expect(placement.width, greaterThan(0));
+      }
+      // Same bucket, same side: neighbors must not intersect along the road.
+      for (final side in PlotSide.values) {
+        final sidePlacements =
+            plan.placements.values
+                .where((p) => p.side == side && p.bucketIndex == 0)
+                .toList()
+              ..sort((a, b) => a.z.compareTo(b.z));
+        for (var i = 1; i < sidePlacements.length; i++) {
+          final a = sidePlacements[i - 1];
+          final b = sidePlacements[i];
+          final centerGap = (b.z - a.z).abs();
+          expect(
+            centerGap + 1e-9,
+            greaterThanOrEqualTo((a.width + b.width) / 2),
+            reason: 'buildings ${a.taskId} and ${b.taskId} overlap',
+          );
+        }
       }
     });
 
-    test('weekStart anchors to Monday 00:00', () {
+    test('a task older than an explicit epoch lands in bucket zero', () {
+      final tasks = [
+        _task('anchor', DateTime.utc(2026, 3, 9, 10)),
+        _task('straggler', DateTime.utc(2026, 2, 2, 10)),
+      ];
+      final plan = layout.plan(
+        tasks,
+        epoch: StreetLayout.weekStart(DateTime.utc(2026, 3, 9)),
+      );
+      expect(plan.placements['straggler']!.bucketIndex, 0);
+      expect(plan.placements['anchor']!.bucketIndex, 0);
+    });
+
+    test('weekStart anchors to Monday 00:00 UTC', () {
       expect(
-        StreetLayout.weekStart(DateTime(2026, 9, 3, 15, 30)), // A Thursday.
-        DateTime(2026, 8, 31), // The preceding Monday.
+        StreetLayout.weekStart(DateTime.utc(2026, 9, 3, 15, 30)), // Thursday.
+        DateTime.utc(2026, 8, 31), // The preceding Monday.
       );
       expect(
-        StreetLayout.weekStart(DateTime(2026, 8, 31, 0, 1)), // A Monday.
-        DateTime(2026, 8, 31),
+        StreetLayout.weekStart(DateTime.utc(2026, 8, 31, 0, 1)), // Monday.
+        DateTime.utc(2026, 8, 31),
+      );
+      // A local time converts to the same UTC week as its instant.
+      expect(
+        StreetLayout.weekStart(DateTime.utc(2026, 9, 3, 12).toLocal()),
+        DateTime.utc(2026, 8, 31),
       );
     });
   });

--- a/test/features/plaza/domain/street_layout_test.dart
+++ b/test/features/plaza/domain/street_layout_test.dart
@@ -1,0 +1,227 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/plaza/domain/plaza_task.dart';
+import 'package:lotti/features/plaza/domain/street_layout.dart';
+
+PlazaTask _task(String id, DateTime createdAt) {
+  return PlazaTask(
+    id: id,
+    createdAt: createdAt,
+    title: 'Task $id',
+    state: PlazaTaskState.open,
+    progress: 0,
+    checklistItems: 0,
+    linkedTaskIds: const [],
+    categoryColor: 0xFF5C9DFF,
+  );
+}
+
+/// A reproducible mixed-density dataset: some busy weeks, some quiet ones,
+/// some empty ones.
+List<PlazaTask> _dataset({int count = 60, int seed = 7}) {
+  final rng = Random(seed);
+  var cursor = DateTime(2026, 3, 2, 9);
+  return [
+    for (var i = 0; i < count; i++)
+      _task(
+        'task-$seed-$i',
+        cursor = cursor.add(
+          rng.nextDouble() < 0.6
+              ? Duration(minutes: 30 + rng.nextInt(600))
+              : Duration(days: 1 + rng.nextInt(12)),
+        ),
+      ),
+  ];
+}
+
+Matcher _samePlacementAs(PlotPlacement expected) => predicate<PlotPlacement>(
+  (actual) =>
+      actual.taskId == expected.taskId &&
+      actual.bucketIndex == expected.bucketIndex &&
+      actual.side == expected.side &&
+      (actual.x - expected.x).abs() < 1e-9 &&
+      (actual.z - expected.z).abs() < 1e-9 &&
+      (actual.facingRadians - expected.facingRadians).abs() < 1e-9 &&
+      (actual.width - expected.width).abs() < 1e-9 &&
+      (actual.height - expected.height).abs() < 1e-9,
+  'placement identical',
+);
+
+void main() {
+  final layout = StreetLayout(projectSeed: 1337);
+
+  group('determinism', () {
+    test('same input produces an identical street across runs', () {
+      final tasks = _dataset();
+      final a = layout.plan(tasks);
+      final b = layout.plan(tasks);
+
+      expect(b.placements.length, a.placements.length);
+      for (final id in a.placements.keys) {
+        expect(b.placements[id], _samePlacementAs(a.placements[id]!));
+      }
+      expect(b.segments.length, a.segments.length);
+    });
+
+    test('shuffled arrival order produces an identical street', () {
+      // Sync delivers tasks in arbitrary order; the street must not care.
+      final tasks = _dataset();
+      final reference = layout.plan(tasks);
+      for (final shuffleSeed in [1, 2, 3]) {
+        final shuffled = [...tasks]..shuffle(Random(shuffleSeed));
+        final plan = layout.plan(shuffled, epoch: reference.epoch);
+        for (final id in reference.placements.keys) {
+          expect(
+            plan.placements[id],
+            _samePlacementAs(reference.placements[id]!),
+            reason: 'shuffle seed $shuffleSeed moved $id',
+          );
+        }
+      }
+    });
+
+    test('stableHash is stable (pinned values)', () {
+      // These values must never change: plot rhythm depends on them.
+      expect(stableHash(''), 0x811c9dc5);
+      expect(stableHash('a'), 0xe40c292c);
+      expect(stableHash('plaza'), 0xd0e788b5);
+    });
+  });
+
+  group('the invariant: nothing ever moves', () {
+    test('appending tasks in later weeks never changes existing placements',
+        () {
+      final tasks = _dataset();
+      final before = layout.plan(tasks);
+
+      final lastCreated = tasks
+          .map((t) => t.createdAt)
+          .reduce((a, b) => a.isAfter(b) ? a : b);
+      final grown = [
+        ...tasks,
+        for (var i = 0; i < 25; i++)
+          _task('new-$i', lastCreated.add(Duration(days: 7 + i * 2))),
+      ];
+      final after = layout.plan(grown, epoch: before.epoch);
+
+      for (final id in before.placements.keys) {
+        expect(
+          after.placements[id],
+          _samePlacementAs(before.placements[id]!),
+          reason: 'appending later tasks moved $id',
+        );
+      }
+      // And the street did grow.
+      expect(after.segments.length, greaterThan(before.segments.length));
+    });
+
+    test(
+        'a late-syncing task jostles only its own bucket — '
+        'every other placement is bit-identical', () {
+      final tasks = _dataset();
+      final before = layout.plan(tasks);
+
+      // Drop a new task into the middle of an existing busy week.
+      final targetBucketTask = tasks[tasks.length ~/ 2];
+      final lateTask = _task(
+        'late-syncer',
+        targetBucketTask.createdAt.add(const Duration(hours: 1)),
+      );
+      final after = layout.plan([...tasks, lateTask], epoch: before.epoch);
+
+      final touchedBucket = after.placements['late-syncer']!.bucketIndex;
+      expect(
+        touchedBucket,
+        before.placements[targetBucketTask.id]!.bucketIndex,
+      );
+
+      for (final id in before.placements.keys) {
+        final b = before.placements[id]!;
+        if (b.bucketIndex == touchedBucket) {
+          // Same plot group is the only permitted blast radius; the task
+          // must stay in its bucket even if it slides within it.
+          expect(after.placements[id]!.bucketIndex, touchedBucket);
+        } else {
+          expect(
+            after.placements[id],
+            _samePlacementAs(b),
+            reason: 'late syncer in bucket $touchedBucket moved $id '
+                'in bucket ${b.bucketIndex}',
+          );
+        }
+      }
+
+      // The road itself is untouched: same segments, same bends.
+      expect(after.segments.length, before.segments.length);
+      for (var i = 0; i < before.segments.length; i++) {
+        expect(after.segments[i].startX, before.segments[i].startX);
+        expect(after.segments[i].startZ, before.segments[i].startZ);
+        expect(
+          after.segments[i].headingRadians,
+          before.segments[i].headingRadians,
+        );
+      }
+    });
+  });
+
+  group('street structure', () {
+    test('empty weeks collapse to gap segments, busy weeks to plot groups',
+        () {
+      final tasks = [
+        _task('w0-a', DateTime(2026, 3, 2, 10)),
+        _task('w0-b', DateTime(2026, 3, 3, 10)),
+        // Weeks 1 and 2 empty.
+        _task('w3-a', DateTime(2026, 3, 24, 10)),
+      ];
+      final plan = layout.plan(tasks);
+
+      expect(plan.segments.map((s) => s.isGap), [false, true, true, false]);
+      expect(plan.segments[1].length, layout.gapLength);
+      expect(plan.segments[0].length, layout.groupLength);
+      expect(plan.placements['w0-a']!.bucketIndex, 0);
+      expect(plan.placements['w3-a']!.bucketIndex, 3);
+    });
+
+    test('within a week, tasks alternate sides in (createdAt, id) order', () {
+      final base = DateTime(2026, 3, 2, 9);
+      final tasks = [
+        for (var i = 0; i < 5; i++)
+          _task('t$i', base.add(Duration(hours: i))),
+      ];
+      final plan = layout.plan(tasks);
+
+      expect(plan.placements['t0']!.side, PlotSide.left);
+      expect(plan.placements['t1']!.side, PlotSide.right);
+      expect(plan.placements['t2']!.side, PlotSide.left);
+      expect(plan.placements['t3']!.side, PlotSide.right);
+      expect(plan.placements['t4']!.side, PlotSide.left);
+    });
+
+    test('building widths stay within bounds however busy the week', () {
+      final base = DateTime(2026, 3, 2, 9);
+      final crowded = [
+        for (var i = 0; i < 40; i++)
+          _task('busy-$i', base.add(Duration(minutes: i))),
+      ];
+      final plan = layout.plan(crowded);
+      for (final placement in plan.placements.values) {
+        expect(
+          placement.width,
+          inInclusiveRange(layout.minBuildingWidth, layout.maxBuildingWidth),
+        );
+      }
+    });
+
+    test('weekStart anchors to Monday 00:00', () {
+      expect(
+        StreetLayout.weekStart(DateTime(2026, 9, 3, 15, 30)), // A Thursday.
+        DateTime(2026, 8, 31), // The preceding Monday.
+      );
+      expect(
+        StreetLayout.weekStart(DateTime(2026, 8, 31, 0, 1)), // A Monday.
+        DateTime(2026, 8, 31),
+      );
+    });
+  });
+}

--- a/test/features/plaza/ui/debug_overlay_test.dart
+++ b/test/features/plaza/ui/debug_overlay_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/plaza/scene/facade_lod_manager.dart';
+import 'package:lotti/features/plaza/ui/debug_overlay.dart';
+
+import '../../../widget_test_utils.dart';
+
+void main() {
+  late PlazaHarnessStats stats;
+  late FacadeLodConfig config;
+  late PlazaLayoutKnobs knobs;
+  late int configChanges;
+  late int knobsApplied;
+  late int presetCycles;
+  late int overheadToggles;
+
+  setUp(() {
+    stats = PlazaHarnessStats()
+      ..fps = 60
+      ..avgFrameMs = 16.6
+      ..worstFrameMs = 20
+      ..buildings = 28
+      ..near = 9
+      ..mid = 13
+      ..far = 6
+      ..captures = 42
+      ..lastCaptureMs = 1.5
+      ..promotions = 3;
+    config = FacadeLodConfig();
+    knobs = PlazaLayoutKnobs();
+    configChanges = 0;
+    knobsApplied = 0;
+    presetCycles = 0;
+    overheadToggles = 0;
+  });
+
+  Widget host() {
+    return makeTestableWidget2(
+      Scaffold(
+        body: SingleChildScrollView(
+          child: PlazaDebugOverlay(
+            stats: stats,
+            config: config,
+            knobs: knobs,
+            presetLabel: 'waddle',
+            onCyclePreset: () => presetCycles++,
+            onConfigChanged: () => configChanges++,
+            onKnobsApplied: () => knobsApplied++,
+            onToggleOverhead: () => overheadToggles++,
+          ),
+        ),
+      ),
+      mediaQueryData: const MediaQueryData(size: Size(600, 1200)),
+    );
+  }
+
+  testWidgets('renders the frame and tier instrumentation', (tester) async {
+    await tester.pumpWidget(host());
+    expect(find.text('60 fps'), findsOneWidget);
+    expect(find.text('buildings 28   preset waddle'), findsOneWidget);
+    expect(find.text('live 9   static 13   far 6'), findsOneWidget);
+    expect(
+      find.text('captures 42   last 1.5 ms   promos 3'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('stats.publish() live-updates the readout', (tester) async {
+    await tester.pumpWidget(host());
+    stats
+      ..fps = 12
+      ..publish();
+    await tester.pump();
+    expect(find.text('12 fps'), findsOneWidget);
+    expect(find.text('60 fps'), findsNothing);
+  });
+
+  testWidgets('cap sliders mutate the LOD config', (tester) async {
+    await tester.pumpWidget(host());
+    final sliders = find.byType(Slider);
+    await tester.drag(sliders.at(0), const Offset(80, 0));
+    await tester.pump();
+    expect(config.nearCap, isNot(12));
+    expect(configChanges, greaterThan(0));
+
+    await tester.drag(sliders.at(1), const Offset(80, 0));
+    await tester.pump();
+    expect(config.midCap, isNot(60));
+  });
+
+  testWidgets('layout knob sliders apply on release', (tester) async {
+    await tester.pumpWidget(host());
+    final sliders = find.byType(Slider);
+    await tester.drag(sliders.at(2), const Offset(60, 0)); // px/m
+    await tester.pump();
+    expect(knobs.pxPerMeter, isNot(90));
+    expect(knobsApplied, greaterThan(0));
+
+    final appliedSoFar = knobsApplied;
+    await tester.drag(sliders.at(3), const Offset(60, 0)); // road width
+    await tester.pump();
+    expect(knobs.roadWidth, isNot(25));
+    expect(knobsApplied, greaterThan(appliedSoFar));
+
+    await tester.drag(sliders.at(4), const Offset(60, 0)); // max height
+    await tester.pump();
+    expect(knobs.maxHeight, isNot(12));
+  });
+
+  testWidgets('stress switch and buttons fire their callbacks', (tester) async {
+    await tester.pumpWidget(host());
+    await tester.tap(find.byType(Switch));
+    await tester.pump();
+    expect(config.forceAllLive, isTrue);
+
+    await tester.tap(find.text('preset'));
+    expect(presetCycles, 1);
+    await tester.tap(find.text('overhead'));
+    expect(overheadToggles, 1);
+  });
+}

--- a/test/features/plaza/ui/facade_widget_test.dart
+++ b/test/features/plaza/ui/facade_widget_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/plaza/domain/plaza_task.dart';
+import 'package:lotti/features/plaza/ui/facade_widget.dart';
+
+import '../../../widget_test_utils.dart';
+
+PlazaTask _task({
+  PlazaTaskState state = PlazaTaskState.open,
+  double progress = 0,
+  int checklistItems = 0,
+  List<String> openItems = const [],
+  List<String> links = const [],
+  DateTime? due,
+  String? coverUrl,
+}) {
+  return PlazaTask(
+    id: 'facade-test',
+    createdAt: DateTime.utc(2026, 3, 2, 9),
+    title: 'Negotiate sardine futures',
+    state: state,
+    progress: progress,
+    checklistItems: checklistItems,
+    openChecklistItems: openItems,
+    linkedTaskIds: links,
+    categoryColor: 0xFF5C9DFF,
+    due: due,
+    coverImageUrl: coverUrl,
+  );
+}
+
+Widget _host(PlazaTask task, {bool interactive = false}) {
+  return makeTestableWidget2(
+    Center(
+      child: SizedBox(
+        width: 500,
+        height: 700,
+        child: FacadeWidget(task: task, interactive: interactive),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('shows title, state label, due date and link count', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _host(
+        _task(
+          state: PlazaTaskState.inProgress,
+          due: DateTime.utc(2026, 7, 17),
+          links: ['a', 'b'],
+        ),
+      ),
+    );
+    expect(find.text('Negotiate sardine futures'), findsOneWidget);
+    expect(find.text('IN PROGRESS'), findsOneWidget);
+    expect(find.text('due Jul 17'), findsOneWidget);
+    expect(find.text('links 2'), findsOneWidget);
+  });
+
+  testWidgets('checklist progress renders as facade fill and counter', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _host(
+        _task(
+          state: PlazaTaskState.inProgress,
+          checklistItems: 4,
+          progress: 0.5,
+          openItems: ['Check bay two', 'Ask the dock crew'],
+        ),
+      ),
+    );
+    final fill = tester.widget<FractionallySizedBox>(
+      find.byType(FractionallySizedBox),
+    );
+    expect(fill.heightFactor, 0.5);
+    expect(find.text('2/4'), findsOneWidget);
+    expect(find.text('Check bay two'), findsOneWidget);
+    expect(find.text('Ask the dock crew'), findsOneWidget);
+  });
+
+  testWidgets('near tier ticks a checklist item live; ticking strikes it', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _host(
+        _task(
+          state: PlazaTaskState.inProgress,
+          checklistItems: 2,
+          openItems: ['Check bay two'],
+        ),
+        interactive: true,
+      ),
+    );
+    expect(
+      tester.widget<Checkbox>(find.byType(Checkbox)).onChanged,
+      isNotNull,
+    );
+    await tester.tap(find.byType(Checkbox));
+    await tester.pump();
+    final struck = tester.widget<Text>(find.text('Check bay two'));
+    expect(struck.style?.decoration, TextDecoration.lineThrough);
+
+    await tester.tap(find.byType(Checkbox));
+    await tester.pump();
+    final unstruck = tester.widget<Text>(find.text('Check bay two'));
+    expect(unstruck.style?.decoration, isNull);
+  });
+
+  testWidgets('static tier renders checkboxes disabled', (tester) async {
+    await tester.pumpWidget(
+      _host(
+        _task(
+          // ignore: avoid_redundant_argument_values
+          state: PlazaTaskState.open,
+          checklistItems: 1,
+          openItems: ['Check bay two'],
+        ),
+      ),
+    );
+    expect(
+      tester.widget<Checkbox>(find.byType(Checkbox)).onChanged,
+      isNull,
+    );
+  });
+
+  testWidgets('done tasks go green and quiet: dim title, muted chip', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(_task(state: PlazaTaskState.done)));
+    expect(find.text('DONE'), findsOneWidget);
+    final title = tester.widget<Text>(find.text('Negotiate sardine futures'));
+    expect(title.style?.color, FacadeStyle.textDim);
+    final material = tester.widget<Material>(find.byType(Material).first);
+    expect(material.color, FacadeStyle.backgroundDone);
+  });
+
+  testWidgets('a cover URL renders the image slot; broken loads collapse', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _host(_task(coverUrl: 'https://demo.invalid/cover.webp')),
+    );
+    // The 16:9 frame exists; the test HTTP client fails the fetch and the
+    // errorBuilder collapses it without throwing into the test harness.
+    expect(find.byType(AspectRatio), findsOneWidget);
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+  });
+
+  test('state colors and labels cover every state', () {
+    for (final state in PlazaTaskState.values) {
+      expect(FacadeStyle.stateLabel(state), isNotEmpty);
+      expect(FacadeStyle.stateColor(state).a, greaterThan(0));
+    }
+  });
+}

--- a/test/features/plaza/ui/facade_widget_test.dart
+++ b/test/features/plaza/ui/facade_widget_test.dart
@@ -149,6 +149,16 @@ void main() {
     expect(find.byType(AspectRatio), findsOneWidget);
     await tester.pump();
     expect(tester.takeException(), isNull);
+    // The failed load renders no image pixels — the slot collapsed to the
+    // errorBuilder's empty box instead of showing a broken image.
+    expect(find.byType(RawImage), findsNothing);
+    expect(
+      find.descendant(
+        of: find.byType(AspectRatio),
+        matching: find.byType(SizedBox),
+      ),
+      findsOneWidget,
+    );
   });
 
   test('state colors and labels cover every state', () {

--- a/test/features/plaza/ui/fly_camera_controller_test.dart
+++ b/test/features/plaza/ui/fly_camera_controller_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_scene/scene.dart' show PerspectiveCamera;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/plaza/ui/fly_camera_controller.dart';
+import 'package:vector_math/vector_math.dart' show Vector3;
+
+KeyDownEvent _down(LogicalKeyboardKey logical, PhysicalKeyboardKey physical) =>
+    KeyDownEvent(
+      logicalKey: logical,
+      physicalKey: physical,
+      timeStamp: Duration.zero,
+    );
+
+KeyUpEvent _up(LogicalKeyboardKey logical, PhysicalKeyboardKey physical) =>
+    KeyUpEvent(
+      logicalKey: logical,
+      physicalKey: physical,
+      timeStamp: Duration.zero,
+    );
+
+FlyCameraController _controller() =>
+    FlyCameraController(position: Vector3(0, 5, 0), yaw: 0);
+
+void main() {
+  group('keys and auto-walk', () {
+    testWidgets('W walks forward along the view direction', (tester) async {
+      final camera = _controller();
+      await simulateKeyDownEvent(LogicalKeyboardKey.keyW);
+      camera
+        ..handleKeyEvent(
+          _down(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
+        )
+        ..update(1);
+      expect(camera.position.z, greaterThan(5)); // 12 m/s walk speed.
+      await simulateKeyUpEvent(LogicalKeyboardKey.keyW);
+      final zAfterWalk = camera.position.z;
+      camera
+        ..handleKeyEvent(_up(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW))
+        ..update(1);
+      expect(camera.position.z, zAfterWalk);
+    });
+
+    testWidgets('shift sprints', (tester) async {
+      final walker = _controller();
+      final sprinter = _controller();
+      await simulateKeyDownEvent(LogicalKeyboardKey.keyW);
+      walker
+        ..handleKeyEvent(
+          _down(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
+        )
+        ..update(1);
+      await simulateKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      sprinter
+        ..handleKeyEvent(
+          _down(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
+        )
+        ..handleKeyEvent(
+          _down(LogicalKeyboardKey.shiftLeft, PhysicalKeyboardKey.shiftLeft),
+        )
+        ..update(1);
+      expect(sprinter.position.z, greaterThan(walker.position.z));
+      await simulateKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await simulateKeyUpEvent(LogicalKeyboardKey.keyW);
+    });
+
+    test('a latched key without real hardware state stops the walk', () {
+      // The regression: a key-up lost to a focus change left W latched and
+      // the camera walking forever. The controller must reconcile with
+      // HardwareKeyboard (which has no keys pressed here) and stand still.
+      final camera = _controller()
+        ..handleKeyEvent(
+          _down(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
+        )
+        ..update(1);
+      expect(camera.position.z, 0);
+    });
+
+    test('space toggles auto-walk and clears held keys', () {
+      final camera = _controller();
+      final handled = camera.handleKeyEvent(
+        _down(LogicalKeyboardKey.space, PhysicalKeyboardKey.space),
+      );
+      expect(handled, isTrue);
+      expect(camera.autoForward, 1);
+      camera.update(1);
+      expect(camera.position.z, greaterThan(0));
+
+      camera.handleKeyEvent(
+        _down(LogicalKeyboardKey.space, PhysicalKeyboardKey.space),
+      );
+      expect(camera.autoForward, 0);
+      final z = camera.position.z;
+      camera.update(1);
+      expect(camera.position.z, z);
+    });
+
+    test('untracked keys are not handled', () {
+      final camera = _controller();
+      expect(
+        camera.handleKeyEvent(
+          _down(LogicalKeyboardKey.keyQ, PhysicalKeyboardKey.keyQ),
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('look and pose', () {
+    test('drag look yaws the camera and clamps pitch', () {
+      final camera = _controller()..addLookDelta(0, -10000);
+      // Pitch clamps well below straight up.
+      final up = camera.camera() as PerspectiveCamera;
+      expect(up.target.y - up.position.y, lessThan(10));
+
+      camera.addLookDelta(0, 20000);
+      final down = camera.camera() as PerspectiveCamera;
+      expect(down.target.y - down.position.y, greaterThan(-10));
+    });
+
+    test('reset jumps to a new pose at eye height', () {
+      final camera = _controller()
+        ..reset(position: Vector3(10, 99, -4), yaw: 3.14)
+        ..update(0.016);
+      expect(camera.position.x, 10);
+      expect(camera.position.z, -4);
+      expect(camera.position.y, 5); // Eye height overrides the given y.
+    });
+  });
+
+  group('overhead mode', () {
+    test('blends the eye upward over time, never cutting', () {
+      final camera = _controller();
+      final groundY = (camera.camera() as PerspectiveCamera).position.y;
+
+      camera
+        ..toggleOverhead()
+        ..update(0.1);
+      final midY = (camera.camera() as PerspectiveCamera).position.y;
+      expect(camera.overhead, isTrue);
+      expect(midY, greaterThan(groundY));
+
+      for (var i = 0; i < 60; i++) {
+        camera.update(0.1);
+      }
+      final topY = (camera.camera() as PerspectiveCamera).position.y;
+      expect(topY, greaterThan(midY));
+      expect(topY, closeTo(90, 1)); // Overhead height.
+
+      // Overhead looks down at the walker's spot.
+      final overheadCam = camera.camera() as PerspectiveCamera;
+      expect(overheadCam.target.y, lessThan(overheadCam.position.y));
+
+      camera.toggleOverhead();
+      expect(camera.overhead, isFalse);
+      for (var i = 0; i < 60; i++) {
+        camera.update(0.1);
+      }
+      expect(
+        (camera.camera() as PerspectiveCamera).position.y,
+        closeTo(groundY, 0.5),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Standalone dev harness (`lib/features/plaza/dev_main.dart`, same pattern as the knowledge-graph explorer's `dev_main.dart`) exploring the knowledge-graph replacement: one project rendered as a street of task buildings whose facades are live Flutter widgets, built on `flutter_scene` (Flutter GPU / Impeller). Not wired into app routes, DI, or the database — synthetic data plus a projection of the penguin demo world.

Run it:

```
fvm flutter run --enable-flutter-gpu -t lib/features/plaza/dev_main.dart -d macos
```

## Pieces

- **Merge-stable street layout** (pure Dart, `domain/street_layout.dart`): placement is a pure function of `(createdAt, id)` bucketed by week, so it survives local-first sync — no global creation order needed. Seeded per-bucket road bends, empty weeks collapse to short gaps, deleted tasks leave fenced lots. Property tests pin the invariant: shuffled arrival yields an identical street, appending tasks never moves existing ones, and a late-syncing task jostles only its own week bucket.
- **Facade surface LOD** (`scene/facade_lod_manager.dart`): near = live interactive widget (hard cap, distance eviction, hysteresis), mid = hosted widget captured once via manual policy, far = state-colored block. Caps and distances are debug-overlay knobs.
- **Harness**: seeded generator presets (20/80/300 tasks), penguin demo-world projection ('waddle' preset), first-person walk camera with animated overhead blend, frontier spawn, fps/tier/capture instrumentation, and a `PLAZA_BENCH=1` auto-walk benchmark mode.

## M0 benchmark (300-task preset, Linux VM — relative numbers are what matter)

| Config | fps avg | ms avg |
|---|---|---|
| far-only (no widgets) | 37.4 | 26.7 |
| default (12 live / 60 static) | 30.4 | 32.8 |
| 30 live saturated | 21.3 | 47.0 |
| 60 live saturated | 14.2 | 70.6 |
| **all-static (292 hosted, no capture)** | **35.0** | **28.6** |
| all-live (292 every-frame) | 2.5 | 395.5 |

Verdict: hosting hundreds of live widget subtrees is free; per-frame *capture* is the entire cost (~0.6 ms/widget/frame here). The capped LOD runs at geometry baseline; the naive all-live version collapses as expected.

## Dependency notes

- `flutter_scene 0.23.0` pins `code_assets ^1.2.1`, which would downgrade the native-assets toolchain repo-wide. Its build hook compiles fine against 2.x, so `code_assets` and `native_toolchain_c` are pinned current via `dependency_overrides` (verified by a full Linux build including the onnxruntime/vodozemac hooks). Comment in `pubspec.yaml`; re-check on every flutter_scene bump.
- No changelog fragment: dev-only harness, nothing user-visible changes at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a 3D project plaza displaying tasks as street-side buildings and deleted tasks as empty lots.
  * Added facades with titles, status, category colors, cover images, due dates, links, checklist progress, and interactive open-item checkboxes.
  * Added deterministic small, medium, and large task presets.
  * Added first-person and overhead camera controls.
  * Added adaptive visual detail, layout controls, performance metrics, and stress-testing options.

* **Tests**
  * Added coverage for deterministic layouts, task projection, facade rendering, camera controls, and plaza stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->