### PR TITLE
fix(health): store workouts under the spelling the charts use, and show them on the Daily OS lane

### DIFF
--- a/changelog.d/2026-08-31-workouts-land-again.md
+++ b/changelog.d/2026-08-31-workouts-land-again.md
@@ -1,0 +1,15 @@
+### Fixed
+- **Workouts from Apple Health and Health Connect stopped showing up.** Since
+  the move to the upstream health library, a walk started on the watch was
+  imported under that library's own spelling of the activity (`WALKING`),
+  while every workout chart, every dashboard and the workout history said
+  `walking`. Dashboards therefore showed "No data" over months of workouts,
+  and a workout's own detail card lost its trend charts. Imported workouts are
+  stored under the spelling the charts use again, the charts also count the
+  workouts imported in between, and a workout imported on Android now keeps
+  the app it came from as its source.
+- **Workouts appear on the Daily OS timeline by name.** The Actual lane used
+  to print a workout's internal id as its title; it now reads "Walking" or
+  "Functional Strength Training", and opening a day pulls new workouts from
+  the health store itself instead of waiting for a dashboard with a workout
+  chart to be opened.

--- a/changelog.d/2026-08-31-workouts-land-again.md
+++ b/changelog.d/2026-08-31-workouts-land-again.md
@@ -6,8 +6,9 @@
   `walking`. Dashboards therefore showed "No data" over months of workouts,
   and a workout's own detail card lost its trend charts. Imported workouts are
   stored under the spelling the charts use again, the charts also count the
-  workouts imported in between, and a workout imported on Android now keeps
-  the app it came from as its source.
+  workouts imported in between, habit signals that watch a workout match it
+  in either spelling, and a workout imported on Android now keeps the app it
+  came from as its source.
 - **Workouts appear on the Daily OS timeline by name.** The Actual lane used
   to print a workout's internal id as its title; it now reads "Walking" or
   "Functional Strength Training", and opening a day pulls new workouts from

--- a/knowledge/features/daily_os_next/ui-surfaces.md
+++ b/knowledge/features/daily_os_next/ui-surfaces.md
@@ -5,7 +5,7 @@ description: The Day page, the anchored voice template, timeline editing, the ca
 resource: ../../../lib/features/daily_os_next/ui
 tags: [daily-os, ui, voice, timeline, onboarding]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-08-02T12:00:00+02:00 }
+generated: { by: claude-code/fable-5, at: 2026-08-31T12:00:00Z }
 stale_after: 2026-10-26
 sources:
   - id: ui
@@ -28,6 +28,10 @@ sources:
     resource: ../../../lib/features/onboarding/model/onboarding_event.dart
     title: Shared onboarding event vocabulary
     last_modified: 2026-08-01
+  - id: actual-lane
+    resource: ../../../lib/features/daily_os_next/state/actual_time_blocks_provider.dart
+    title: The Actual lane's blocks, and the workout nudge behind them
+    last_modified: 2026-08-31
 ---
 
 # The planning modal
@@ -183,6 +187,21 @@ expander that keeps the most recent sessions visible.
 Capture pins it at the top of its column with a date-neutral title for non-today
 dates; the Agenda tab reuses it as the empty-state body under a dashed "No plan
 yet" hint card.
+
+The Day timeline's **Actual** lane is the same recorded time, one block per
+entry, projected by `dailyOsActualTimeBlocksProvider`. Imported workouts count as
+recorded time too. A workout block is titled by its activity — `Walking`,
+`Functional Strength Training`, through `humanWorkoutType` — unless the user
+annotated the entry, in which case the first line of the annotation wins as it
+does for any recording; it stays in the uncategorised grey because a workout
+carries no category. (Before this, a workout fell through every title fallback
+and the lane printed its entry id.) Nothing on this surface used to *import*
+workouts — a walk reached the lane only after some dashboard with a workout
+chart had been opened — so each recompute of the lane now nudges
+`HealthSignalRefreshService.refreshWorkouts()`, fire and forget: the importer
+throttles it to one delta per ten minutes, a failure is logged and swallowed,
+and the journal write a delta produces comes back through the same notification
+stream that triggers the recompute. See [health import](../health_import.md).
 
 ## Task-linked versus standalone
 

--- a/knowledge/features/dashboards.md
+++ b/knowledge/features/dashboards.md
@@ -5,13 +5,13 @@ description: A view layer over journal-backed data — definitions routed to cha
 resource: ../../lib/features/dashboards
 tags: [dashboards, charts, visualization]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T03:45:00Z }
+generated: { by: claude-code/fable-5, at: 2026-08-31T12:00:00Z }
 stale_after: 2027-02-22
 sources:
   - id: src
     resource: ../../lib/features/dashboards
     title: Dashboards feature source
-    last_modified: 2026-08-28
+    last_modified: 2026-08-31
   - id: aggregation
     resource: ../../lib/features/dashboards/state/health_data.dart
     title: Health aggregations — and which day a sample belongs to
@@ -99,6 +99,16 @@ for such an item, and the measurable picker adds it with `AggregationType.none`.
 only the aggregation on the same measurable is therefore a different chart
 identity — drop that component and the new aggregation would render against the
 old one's retained data.
+
+The `workoutType` half of the workout key is Lotti's canonical camelCase
+spelling — `walking`, `functionalStrengthTraining` — which is what the catalogue
+in `dashboard_workout_config.dart`, every persisted `DashboardWorkoutItem` and the
+health import all use. Rows imported by the upstream health plugin before the
+import normalised its spelling say `WALKING` instead; `aggregateWorkoutDailySum`
+and `WorkoutObservationsController` compare through `isSameWorkoutType`, so those
+rows chart too, and the workout detail card's `WorkoutSummary` picks its trend
+charts the same way rather than by a substring of the catalogue key. The
+background is in [health import](health_import.md#workout-types-keep-the-forks-spelling).
 
 **Two of the five can write.** A measurement chart is constructed with
 `enableCreate: true` and opens the capture flow for its data type, and a survey

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -5,13 +5,13 @@ description: Two record streams reconciled into "what should the user see now" �
 resource: ../../lib/features/habits
 tags: [habits, derivation, streaks, heatmap]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-08-01T15:30:00Z }
+generated: { by: claude-code/fable-5, at: 2026-09-01T12:00:00Z }
 stale_after: 2027-02-22
 sources:
   - id: src
     resource: ../../lib/features/habits
     title: Habits feature source
-    last_modified: 2026-08-31
+    last_modified: 2026-09-01
   - id: definitions
     resource: ../../lib/classes/entity_definitions.dart
     title: HabitDefinition
@@ -282,8 +282,14 @@ Triggers, in order of what actually happens:
 2. **Journal updates.** The engine listens to `UpdateNotifications.updateStream`
    (local *and* sync batches) and matches the tokens `JournalEntity.affectedIds`
    emits — a measurable id, a health data type, a workout type, another
-   habit's id — against each rule's `SignalNeeds`. A hit queues the habit; a
-   2 s debounce collapses an import of many samples into one evaluation.
+   habit's id — against each rule's `SignalNeeds.notificationTokens`. That
+   set is the rule's series verbatim, except that a workout type expands to
+   every spelling its rows may be stored under (`running` and `RUNNING`; see
+   [health import](health_import.md#workout-types-keep-the-forks-spelling)):
+   a workout notifies under its *stored* type, so a rule persisted in one
+   era would otherwise never hear a run stored in the other. The status
+   controller subscribes on the same set. A hit queues the habit; a 2 s
+   debounce collapses an import of many samples into one evaluation.
 3. **Midnight.** A timer to the next local midnight runs a full pass and
    re-arms, so a day whose data was already there is checked off as soon as it
    begins.

--- a/knowledge/features/health_import.md
+++ b/knowledge/features/health_import.md
@@ -5,13 +5,25 @@ description: How samples get out of Apple Health / Health Connect and into the j
 resource: ../../lib/logic/health_import.dart
 tags: [health, healthkit, health-connect, import, dashboards, settings]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-08-04T11:30:00Z }
+generated: { by: claude-code/fable-5, at: 2026-08-31T12:00:00Z }
 stale_after: 2027-03-01
 sources:
   - id: import
     resource: ../../lib/logic/health_import.dart
     title: HealthImport — the queue, the gate and the per-type fetchers
-    last_modified: 2026-08-27
+    last_modified: 2026-08-31
+  - id: workout-types
+    resource: ../../lib/logic/health_workout_types.dart
+    title: canonicalWorkoutType — one spelling across both import eras
+    last_modified: 2026-08-31
+  - id: signal-refresh
+    resource: ../../lib/logic/signals/health_signal_refresh_service.dart
+    title: HealthSignalRefreshService — the surfaces' contained, fire-and-forget refresh
+    last_modified: 2026-08-31
+  - id: actual-lane
+    resource: ../../lib/features/daily_os_next/state/actual_time_blocks_provider.dart
+    title: The Daily OS actual lane — the workout delta's other caller
+    last_modified: 2026-08-31
   - id: daily-steps
     resource: ../../lib/logic/health_daily_steps.dart
     title: resolveDailySteps — the merged total versus the best single source
@@ -59,12 +71,13 @@ where they came from.
 **Everything funnels through one `HealthImport` singleton**, and that is
 load-bearing rather than incidental. See [One request at a time](#one-request-at-a-time).
 
-# Two callers, different urgencies
+# Who asks, and how urgently
 
 | Caller | Entry point | Range | Awaited? |
 |--------|-------------|-------|----------|
 | A dashboard chart | `fetchHealthDataDelta(type)` / `getWorkoutsHealthDataDelta()` | newest stored sample → now (cumulative types: the day **before** the newest stored day → now) | No — returns as soon as the type is queued |
 | Settings → Health Import | `getActivityHealthData` / `fetchHealthData` / `getWorkoutsHealthData` | user-chosen | Yes — the page renders the outcome |
+| The Daily OS timeline's actual lane; the Habits and Goals pages | `HealthSignalRefreshService.refreshWorkouts()` / `refreshRequests()` — the same background deltas, with a failing importer contained so the surface keeps painting what is stored | as the dashboard row | No |
 
 `HealthObservationsController`'s constructor schedules a delta fetch for its
 health type after a short jittered delay, so **a dashboard with six health cards
@@ -77,6 +90,10 @@ differ.
 ```mermaid
 flowchart TD
   Chart["HealthObservationsController<br/>(one per chart)"] -->|fetchHealthDataDelta| Queue[["queue: Queue&lt;String&gt;"]]
+  Signals["Habits / Goals pages"] -->|HealthSignalRefreshService<br/>refreshRequests| Queue
+  WChart["WorkoutChartDataController"] -->|getWorkoutsHealthDataDelta| WDelta["workout delta<br/>(one at a time, 10-minute throttle)"]
+  Lane["Daily OS actual lane"] -->|HealthSignalRefreshService<br/>refreshWorkouts| WDelta
+  WDelta --> Gate
   Page["Health Import page"] -->|getActivityHealthData<br/>fetchHealthData<br/>getWorkoutsHealthData| Gate
   Queue -->|_start drains, one at a time| Delta["_fetchHealthDataDelta"]
   Delta --> Gate{{"_serialized<br/>(one at a time)"}}
@@ -204,6 +221,16 @@ nothing while charts kept rendering stale data. `workoutImportRunning` guards
 
 Cumulative (activity) types are re-fetched at most every ten minutes, because
 their per-day totals move continuously; discrete samples are not throttled.
+
+**The workout delta is not queued, and it is throttled.** `getWorkoutsHealthDataDelta`
+runs one at a time behind `workoutImportRunning`, and since the Daily OS actual
+lane asks for one on every journal notification it also keeps quiet for
+`workoutDeltaInterval` (ten minutes) after a run: a call inside that window
+returns an empty import without touching the database or the store. The stamp
+(`lastWorkoutDelta`) is taken when a run *starts* and is kept when it fails, so a
+store that is down is not hammered once per note saved. A refused overlap does
+not count as a run. The user-initiated import on the Health Import page is never
+throttled, and is the way to retry sooner.
 
 # What a request returns
 
@@ -383,6 +410,44 @@ flowchart TD
 The fix is the `SLEEP_ASLEEP` entry in `compositeStorageTypes` rather than a
 change at the call site, and it costs no extra authorization sheet:
 `expandToPermissionFamilies` already widens any sleep type to the whole family.
+
+# Workout types keep the fork's spelling
+
+A `WorkoutEntry` stores its activity as a string, and two eras spelled it
+differently. Until the move from the `flutter_health_fit` fork to the upstream
+`health` plugin (#2041), a workout's type was the fork's enum name —
+`walking`, `running`, `cycling`, `functionalStrengthTraining` — and that is what
+the dashboard catalogue (`dashboard_workout_config.dart`), every persisted
+`DashboardWorkoutItem` and every habit signal keyed on a workout still say. The
+upstream plugin names the same activities `HealthWorkoutActivityType.WALKING`,
+`FUNCTIONAL_STRENGTH_TRAINING`, and the import wrote that name verbatim — so
+every workout recorded since matched nothing: dashboards read "No data" over
+months of walks, and a workout's own detail card found no trend charts. Nothing
+failed; the rows were there, spelled so that nobody looked for them.
+
+`canonicalWorkoutType` (`health_workout_types.dart`) is the single answer. It
+folds `UPPER_SNAKE` into `lowerCamelCase` mechanically, aliases the plugin's
+`BIKING` to the `cycling` HealthKit and the fork both record, and passes a
+canonical value through unchanged, so it is idempotent. Two rules follow:
+
+- **The import writes the canonical form.** `_getWorkoutsHealthData` stores
+  `workoutTypeForActivity(value.workoutActivityType)`, never the enum name.
+- **Readers compare through `isSameWorkoutType`.** `aggregateWorkoutDailySum`,
+  `WorkoutObservationsController`'s empty-chart check and `WorkoutSummary`'s
+  chart selection all do, so the rows imported between #2041 and this
+  normalisation — still stored as `WALKING` — chart alongside the rest without
+  a data migration.
+
+**Known limit:** the habit-signal path reads workouts by SQL equality on the
+row's `subtype` (`workoutsByType`), and the signal picker lists the distinct
+stored strings. Plugin-era rows therefore show up there under their own spelling
+and are matched only by a signal that names it. A one-off rewrite of those rows,
+in the shape of `SleepAsleepBackfillService`, would close that; it has not been
+written.
+
+The same import also records a workout's `source` as `sourceId`, falling back
+to `sourceName` — Health Connect leaves the id empty and names the provider's
+package in the name, so Android workouts used to be stored sourceless.
 
 # Platform gates
 

--- a/knowledge/features/health_import.md
+++ b/knowledge/features/health_import.md
@@ -438,12 +438,15 @@ canonical value through unchanged, so it is idempotent. Two rules follow:
   normalisation — still stored as `WALKING` — chart alongside the rest without
   a data migration.
 
-**Known limit:** the habit-signal path reads workouts by SQL equality on the
-row's `subtype` (`workoutsByType`), and the signal picker lists the distinct
-stored strings. Plugin-era rows therefore show up there under their own spelling
-and are matched only by a signal that names it. A one-off rewrite of those rows,
-in the shape of `SleepAsleepBackfillService`, would close that; it has not been
-written.
+The habit-signal path reads workouts by SQL equality on the row's `subtype`
+(`workoutsByType`), which neither rule above reaches — so `SignalReader
+.workoutEntities` fans out one query per known spelling of the chosen activity
+(`workoutTypeSpellings`: canonical, `UPPER_SNAKE`, the alias family, and the
+raw input) and merges by entry id, and the habit picker canonicalises and
+de-duplicates the stored strings. A rule persisted in either era therefore
+matches rows from both. The stored strings themselves are left as imported —
+unifying them would be a row rewrite in the shape of
+`SleepAsleepBackfillService`, and nothing needs it for matching.
 
 The same import also records a workout's `source` as `sourceId`, falling back
 to `sourceName` — Health Connect leaves the id empty and names the provider's

--- a/knowledge/features/health_import.md
+++ b/knowledge/features/health_import.md
@@ -5,7 +5,7 @@ description: How samples get out of Apple Health / Health Connect and into the j
 resource: ../../lib/logic/health_import.dart
 tags: [health, healthkit, health-connect, import, dashboards, settings]
 status: stable
-generated: { by: claude-code/fable-5, at: 2026-08-31T12:00:00Z }
+generated: { by: claude-code/fable-5, at: 2026-09-01T12:00:00Z }
 stale_after: 2027-03-01
 sources:
   - id: import
@@ -442,9 +442,14 @@ The habit-signal path reads workouts by SQL equality on the row's `subtype`
 (`workoutsByType`), which neither rule above reaches — so `SignalReader
 .workoutEntities` fans out one query per known spelling of the chosen activity
 (`workoutTypeSpellings`: canonical, `UPPER_SNAKE`, the alias family, and the
-raw input) and merges by entry id, and the habit picker canonicalises and
-de-duplicates the stored strings. A rule persisted in either era therefore
-matches rows from both. The stored strings themselves are left as imported —
+raw input) and merges by entry id, `SignalNeeds.notificationTokens` expands a
+rule's workout types the same way so a write stored in the other spelling still
+triggers evaluation (a workout notifies under its stored type only), the habit
+picker canonicalises and de-duplicates the stored strings, and
+`HabitFormMapping.fromRule` reads a persisted leaf back canonical — collapsing
+`RUNNING` beside `running` into one signal — so the editor's selection matches
+the picker. A rule persisted in either era therefore matches, and hears, rows
+from both. The stored strings themselves are left as imported —
 unifying them would be a row rewrite in the shape of
 `SleepAsleepBackfillService`, and nothing needs it for matching.
 

--- a/lib/database/database_data_queries.dart
+++ b/lib/database/database_data_queries.dart
@@ -222,8 +222,9 @@ mixin _JournalDbDataQueries on _$JournalDb, _JournalDbConfigFlags {
   }
 
   /// The distinct workout types present in the journal, sorted. Workout type
-  /// strings arrive from Apple Health / Health Connect un-normalised, so a
-  /// picker must offer what was actually imported rather than a fixed list.
+  /// strings changed spelling with the import eras, so consumers normalise:
+  /// the habit picker canonicalises and de-duplicates (`workoutTypesProvider`)
+  /// and the signal reader matches a chosen activity across every spelling.
   Future<List<String>> getWorkoutTypes() async {
     final types = await workoutTypes().get();
     return types.nonNulls.toList();

--- a/lib/features/daily_os_next/state/actual_time_blocks_provider.dart
+++ b/lib/features/daily_os_next/state/actual_time_blocks_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entity_definitions.dart';
@@ -7,7 +9,9 @@ import 'package:lotti/database/database.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/logic/recorded_time.dart';
+import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/signals/health_signal_refresh_service.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/utils/date_utils_extension.dart';
@@ -40,10 +44,20 @@ Stream<Set<String>> actualTimelineUpdateBatches(Stream<Set<String>> updates) {
 /// [dailyOsActualTimeUpdateProvider] signals a change; the heavy lifting
 /// (tombstone/zero-length filtering, linked-from resolution) lives in
 /// [actualTimeBlocksForEntries] via the shared `resolveTimeEntries` core.
+///
+/// Workouts are recorded time too, but they reach the journal only through the
+/// health import, and nothing on this surface used to ask for one — a walk
+/// appeared on the timeline only after some dashboard with a workout chart had
+/// been opened. Each recompute therefore nudges the workout delta, fire and
+/// forget: the importer throttles it, and the journal write it produces comes
+/// back through [dailyOsActualTimeUpdateProvider] to repaint the lane.
 // ignore: specify_nonobvious_property_types
 final dailyOsActualTimeBlocksProvider = FutureProvider.autoDispose
     .family<List<TimeBlock>, DateTime>((ref, date) async {
       ref.watch(dailyOsActualTimeUpdateProvider);
+      unawaited(
+        ref.read(healthSignalRefreshServiceProvider)?.refreshWorkouts(),
+      );
       final db = ref.watch(journalDbProvider);
       final dayStart = date.dayAtMidnight;
       final dayEnd = dayStart.add(const Duration(days: 1));
@@ -152,6 +166,13 @@ String _actualBlockTitle({
   final entryText = entry.entryText?.plainText.trim();
   if (entryText != null && entryText.isNotEmpty) {
     return entryText.split('\n').first.trim();
+  }
+
+  // An imported workout carries no text and no category; its activity is the
+  // title ("Walking"), not the entry id the last fallback would print.
+  if (entry is WorkoutEntry) {
+    final activity = humanWorkoutType(entry.data.workoutType);
+    if (activity.isNotEmpty) return activity;
   }
 
   if (category.name.isNotEmpty) return category.name;

--- a/lib/features/dashboards/state/workout_chart_controller.dart
+++ b/lib/features/dashboards/state/workout_chart_controller.dart
@@ -145,9 +145,12 @@ class WorkoutObservationsController extends AsyncNotifier<List<Observation>> {
     final config = chartConfig as DashboardWorkoutItem;
 
     // No workout of this type in range -> return empty so the chart shows its
-    // "No data" state rather than a flat row of prefilled zero buckets.
+    // "No data" state rather than a flat row of prefilled zero buckets. Types
+    // are compared across spellings (`WALKING` versus `walking`), the same way
+    // the aggregation below counts them.
     final hasMatchingWorkout = items.whereType<WorkoutEntry>().any(
-      (workout) => workout.data.workoutType == config.workoutType,
+      (workout) =>
+          isSameWorkoutType(workout.data.workoutType, config.workoutType),
     );
     if (!hasMatchingWorkout) return const <Observation>[];
 

--- a/lib/features/dashboards/state/workout_data.dart
+++ b/lib/features/dashboards/state/workout_data.dart
@@ -2,6 +2,7 @@ import 'dart:core';
 
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/logic/health_workout_types.dart';
 import 'package:lotti/utils/date_utils_extension.dart';
 import 'package:lotti/widgets/charts/utils.dart';
 
@@ -9,8 +10,10 @@ import 'package:lotti/widgets/charts/utils.dart';
 /// prefilling every day in `[rangeStart, rangeEnd]` with a zero bucket so the
 /// chart has a continuous daily series.
 ///
-/// Only workouts whose `workoutType` matches `chartConfig` contribute. The
-/// dimension summed is chosen by `chartConfig.valueType`: distance and energy
+/// Only workouts of `chartConfig`'s activity contribute — compared through
+/// `isSameWorkoutType`, so a row stored under the plugin's `WALKING` counts
+/// towards a chart configured for `walking`. The dimension summed is chosen by
+/// `chartConfig.valueType`: distance and energy
 /// add the entry's stored values (when present); duration adds the entry's
 /// elapsed minutes (dateTo − dateFrom). Each output observation is dated at the
 /// day's local midnight.
@@ -33,7 +36,7 @@ List<Observation> aggregateWorkoutDailySum(
     entity.maybeMap(
       workout: (WorkoutEntry workoutEntry) {
         final data = workoutEntry.data;
-        if (data.workoutType == chartConfig.workoutType) {
+        if (isSameWorkoutType(data.workoutType, chartConfig.workoutType)) {
           final dayString = entity.meta.dateFrom.ymd;
           final n = sumsByDay[dayString] ?? 0;
 

--- a/lib/features/habits/model/habit_form_mapping.dart
+++ b/lib/features/habits/model/habit_form_mapping.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/logic/health_workout_types.dart';
 
 /// What kind of journal series a signal row watches.
 enum HabitSignalKind { measurable, health, workout }
@@ -35,7 +36,8 @@ class HabitSignalForm {
 
   final HabitSignalKind kind;
 
-  /// Measurable id, health data type or raw workout type.
+  /// Measurable id, health data type or canonical workout type
+  /// (`canonicalWorkoutType` — a persisted `RUNNING` reads back as `running`).
   final String id;
   final HabitSignalMode mode;
   final num? threshold;
@@ -249,9 +251,12 @@ class HabitFormMapping {
           :final valueBasis,
           :final title,
         ):
+          // The picker offers canonical activities, so a leaf persisted in
+          // the plugin-era spelling has to read back canonical too, or the
+          // editor shows it unchecked beside the activity it names.
           final base = _leaf(
             HabitSignalKind.workout,
-            dataType,
+            canonicalWorkoutType(dataType),
             minimum,
             maximum,
             valueBasis,
@@ -280,6 +285,15 @@ class HabitFormMapping {
     }
 
     collect(rule);
+    // Canonicalising workout leaves can make two persisted leaves name one
+    // activity (`RUNNING` beside `running`, the duplicate the un-normalised
+    // picker used to let through); the card shows one signal per series, so
+    // the first stays.
+    final seen = <(HabitSignalKind, String)>{};
+    final distinct = [
+      for (final leaf in leaves)
+        if (seen.add((leaf.kind, leaf.id))) leaf,
+    ];
     final (composite, required) = switch (rule) {
       AutoCompleteRuleAnd() => (HabitCompositeRule.all, 1),
       AutoCompleteRuleMultiple(:final successes) => (
@@ -289,7 +303,7 @@ class HabitFormMapping {
       _ => (HabitCompositeRule.any, 1),
     };
     return HabitSignalsForm(
-      signals: leaves,
+      signals: distinct,
       composite: composite,
       requiredCount: required,
     ).normalized();

--- a/lib/features/habits/service/habit_auto_completion_service.dart
+++ b/lib/features/habits/service/habit_auto_completion_service.dart
@@ -129,13 +129,7 @@ class HabitAutoCompletionService {
     if (candidates.isEmpty) return;
     var touched = false;
     for (final habit in candidates) {
-      final needs = SignalNeeds.of(habit.autoCompleteRule!);
-      final tokens = {
-        ...needs.measurableIds,
-        ...needs.quantitativeTypes,
-        ...needs.workoutTypes,
-        ...needs.habitIds,
-      };
+      final tokens = SignalNeeds.of(habit.autoCompleteRule!).notificationTokens;
       if (tokens.intersection(affectedIds).isNotEmpty) {
         _pendingHabitIds.add(habit.id);
         touched = true;

--- a/lib/features/habits/state/habit_editor_providers.dart
+++ b/lib/features/habits/state/habit_editor_providers.dart
@@ -1,10 +1,20 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/health_workout_types.dart';
 
-/// The workout types actually present in the journal — imported strings are
-/// not normalised, so the picker offers what exists rather than a fixed list.
+/// The workout activities present in the journal, canonicalised, de-duplicated
+/// and sorted: rows imported in the plugin era say `RUNNING` while older and
+/// newer rows say `running`, and one activity must appear in the picker once.
+/// Canonicalising here loses nothing — the signal reader matches a chosen
+/// activity across every stored spelling (`workoutTypeSpellings`).
 final FutureProvider<List<String>> workoutTypesProvider =
-    FutureProvider.autoDispose<List<String>>(
-      (ref) => getIt<JournalDb>().getWorkoutTypes(),
-    );
+    FutureProvider.autoDispose<List<String>>((ref) async {
+      final stored = await getIt<JournalDb>().getWorkoutTypes();
+      return stored
+          .map(canonicalWorkoutType)
+          .where((type) => type.isNotEmpty)
+          .toSet()
+          .toList()
+        ..sort();
+    });

--- a/lib/features/habits/state/habit_signal_status_controller.dart
+++ b/lib/features/habits/state/habit_signal_status_controller.dart
@@ -70,13 +70,7 @@ class HabitSignalStatusController extends AsyncNotifier<HabitSignalStatus?> {
     final rule = habit?.autoCompleteRule;
     if (rule == null) return null;
 
-    final needs = SignalNeeds.of(rule);
-    final tokens = {
-      ...needs.measurableIds,
-      ...needs.quantitativeTypes,
-      ...needs.workoutTypes,
-      ...needs.habitIds,
-    };
+    final tokens = SignalNeeds.of(rule).notificationTokens;
     _subscription = getIt<UpdateNotifications>().updateStream.listen((
       affectedIds,
     ) {

--- a/lib/features/journal/ui/widgets/entry_details/workout_summary.dart
+++ b/lib/features/journal/ui/widgets/entry_details/workout_summary.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/dashboards/config/dashboard_workout_config.dart';
 import 'package:lotti/features/dashboards/ui/widgets/charts/dashboard_workout_chart.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/ui/widgets/helpers.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
+import 'package:lotti/logic/health_workout_types.dart';
 import 'package:lotti/widgets/charts/utils.dart';
 
 /// Detail-view summary for a workout entry: optional per-metric charts for the
@@ -24,14 +24,12 @@ class WorkoutSummary extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final data = workoutEntry.data;
-    final items = <DashboardWorkoutItem>[];
-    final workoutType = workoutEntry.data.workoutType;
-
-    workoutTypes.forEach((key, value) {
-      if (key.contains(workoutType)) {
-        items.add(value);
-      }
-    });
+    // The catalogue series for this entry's activity, whichever spelling the
+    // row was imported under. An exact activity match, not a substring of the
+    // catalogue key: `walk` must not pick up every `walking.*` chart.
+    final items = workoutTypes.values
+        .where((item) => isSameWorkoutType(item.workoutType, data.workoutType))
+        .toList();
 
     final tokens = context.designTokens;
     // Lead with the Energy/Duration value lines (the facts users scan for);

--- a/lib/features/journal/util/entry_tools.dart
+++ b/lib/features/journal/util/entry_tools.dart
@@ -166,12 +166,9 @@ String entryTextForWorkout(
   bool includeTitle = true,
 }) {
   final duration = data.dateTo.difference(data.dateFrom);
-  final type = data.workoutType;
-  // Capitalize the workout type so the group heading reads as a title
-  // ("Running"), not a bare lowercase word.
-  final heading = type.isEmpty
-      ? type
-      : '${type[0].toUpperCase()}${type.substring(1)}';
+  // The activity as a title ("Running", "Functional Strength Training"), the
+  // same reading the journal card gives it — not a bare identifier.
+  final heading = humanWorkoutType(data.workoutType);
   final title = includeTitle ? '$heading\n' : '';
   final energy = data.energy ?? 0;
 

--- a/lib/logic/health_import.dart
+++ b/lib/logic/health_import.dart
@@ -17,6 +17,7 @@ import 'package:lotti/logic/health_daily_steps.dart'
 import 'package:lotti/logic/health_data_types.dart';
 import 'package:lotti/logic/health_import_result.dart';
 import 'package:lotti/logic/health_permission_gate.dart';
+import 'package:lotti/logic/health_workout_types.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/health_service.dart';
@@ -27,16 +28,18 @@ import 'package:permission_handler/permission_handler.dart';
 export 'package:lotti/logic/health_data_types.dart';
 export 'package:lotti/logic/health_import_result.dart';
 export 'package:lotti/logic/health_permission_gate.dart';
+export 'package:lotti/logic/health_workout_types.dart';
 
 /// Reads samples out of Apple Health / Health Connect and persists them as
 /// quantitative and workout journal entries.
 ///
-/// Two entry points drive it:
+/// Two kinds of entry point drive it:
 ///
-/// - **Dashboards**, via [fetchHealthDataDelta] / [getWorkoutsHealthDataDelta]:
-///   background, incremental (from the newest stored sample forward), and
-///   queued so a dashboard full of charts does not fan out into one health
-///   request per chart.
+/// - **Dashboards, habit and goal surfaces, and the Daily OS timeline**, via
+///   [fetchHealthDataDelta] / [getWorkoutsHealthDataDelta]: background,
+///   incremental (from the newest stored sample forward), and queued so a
+///   dashboard full of charts does not fan out into one health request per
+///   chart.
 /// - **Settings → Health Import**, via [getActivityHealthData],
 ///   [fetchHealthData] and [getWorkoutsHealthData]: an explicit user-chosen
 ///   date range, awaited so the page can report what happened.
@@ -96,6 +99,18 @@ class HealthImport {
   final queue = Queue<String>();
   bool running = false;
   bool workoutImportRunning = false;
+
+  /// How long [getWorkoutsHealthDataDelta] stays quiet after a run.
+  ///
+  /// The Daily OS timeline asks for a delta every time its recorded lane is
+  /// recomputed — which is every journal notification — and a dashboard asks
+  /// on every chart construction. A workout is a discrete session that lands
+  /// once, so re-reading the store more often than the cumulative types
+  /// (see [fetchHealthDataDelta]) buys nothing.
+  static const workoutDeltaInterval = Duration(minutes: 10);
+
+  /// When the last workout delta started, or null before the first one.
+  DateTime? lastWorkoutDelta;
 
   late final String platform;
   String? deviceType;
@@ -798,8 +813,11 @@ class HealthImport {
             dateTo: dataPoint.dateTo,
             distance: value.totalDistance,
             energy: value.totalEnergyBurned,
-            source: dataPoint.sourceId,
-            workoutType: value.workoutActivityType.name,
+            source: _workoutSource(dataPoint),
+            // The plugin's `WALKING`; the journal, the dashboard catalogue and
+            // every persisted chart say `walking` — see
+            // [canonicalWorkoutType] for why the import is where they meet.
+            workoutType: workoutTypeForActivity(value.workoutActivityType),
             id: dataPoint.uuid,
           );
 
@@ -827,8 +845,19 @@ class HealthImport {
     }
   }
 
+  /// The app or device a workout came from.
+  ///
+  /// HealthKit fills `sourceId` with the writing app's bundle identifier.
+  /// Health Connect leaves it empty and puts the provider's package name in
+  /// `sourceName` instead, so a workout imported on Android would otherwise be
+  /// stored with no source at all.
+  static String _workoutSource(HealthDataPoint dataPoint) =>
+      dataPoint.sourceId.isNotEmpty ? dataPoint.sourceId : dataPoint.sourceName;
+
   /// Imports workouts recorded since the newest stored one.
   ///
+  /// Returns an empty import without touching the store when a delta ran less
+  /// than [workoutDeltaInterval] ago, or when one is still in flight.
   /// [workoutImportRunning] guards against overlapping runs and is cleared in a
   /// `finally`: leaving it set on failure used to deadlock every later workout
   /// import for the rest of the session.
@@ -840,11 +869,16 @@ class HealthImport {
       return const HealthImportResult.imported(0);
     }
 
+    final now = clock.now();
+    final previous = lastWorkoutDelta;
+    if (previous != null && now.difference(previous) < workoutDeltaInterval) {
+      return const HealthImportResult.imported(0);
+    }
+    lastWorkoutDelta = now;
     workoutImportRunning = true;
 
     try {
       final latest = await _db.latestWorkout();
-      final now = clock.now();
 
       return await getWorkoutsHealthData(
         dateFrom: latest?.data.dateFrom ?? now.subtract(defaultFetchDuration),

--- a/lib/logic/health_workout_types.dart
+++ b/lib/logic/health_workout_types.dart
@@ -5,9 +5,9 @@ import 'package:health/health.dart';
 ///
 /// That spelling is the one every stored `WorkoutEntry` carried until the app
 /// moved from its `flutter_health_fit` fork to the upstream `health` plugin
-/// (#2041), and it is what the dashboard workout catalogue, every persisted
-/// `DashboardWorkoutItem` and every habit signal keyed on a workout type still
-/// use. The upstream plugin names the same activities `UPPER_SNAKE_CASE`
+/// (#2041), and it is what the dashboard workout catalogue and every persisted
+/// `DashboardWorkoutItem` still use. The upstream plugin names the same
+/// activities `UPPER_SNAKE_CASE`
 /// (`HealthWorkoutActivityType.WALKING`), and importing that name verbatim is
 /// what made every workout recorded since invisible to the charts that looked
 /// for `walking`.
@@ -20,8 +20,10 @@ import 'package:health/health.dart';
 /// values alike.
 ///
 /// Rows imported between #2041 and this normalisation are still stored under
-/// the plugin's spelling; readers that compare types go through
-/// [isSameWorkoutType] so those rows chart too.
+/// the plugin's spelling; readers that compare types in Dart go through
+/// [isSameWorkoutType], and readers that match by SQL equality query every
+/// spelling via [workoutTypeSpellings], so those rows — and rules keyed on
+/// them — keep working.
 String canonicalWorkoutType(String raw) {
   final trimmed = raw.trim();
   if (trimmed.isEmpty) {
@@ -60,6 +62,35 @@ String workoutTypeForActivity(HealthWorkoutActivityType activity) =>
 /// activity, whichever era's spelling each of them carries.
 bool isSameWorkoutType(String a, String b) =>
     canonicalWorkoutType(a) == canonicalWorkoutType(b);
+
+/// Every spelling under which rows of [type]'s activity may be stored, for
+/// readers that match by SQL equality on the row's `subtype`
+/// (`workoutsByType`): the canonical camelCase, the plugin's
+/// `UPPER_SNAKE_CASE`, any alias family ([type] `cycling` also queries
+/// `biking`/`BIKING`), and — future-proofing against spellings this module
+/// never produced — [type] itself, verbatim.
+///
+/// The canonical form leads and the order is deterministic, so callers that
+/// fan one query out per spelling do so in a stable sequence. Empty strings
+/// are dropped: no stored row carries an empty activity worth matching.
+List<String> workoutTypeSpellings(String type) {
+  final canonical = canonicalWorkoutType(type);
+  final spellings = <String>{
+    if (canonical.isNotEmpty) ...[canonical, _upperSnakeOf(canonical)],
+    for (final MapEntry(key: alias, value: target) in _aliases.entries)
+      if (target == canonical) ...[alias, _upperSnakeOf(alias)],
+    type.trim(),
+  }..remove('');
+  return List.unmodifiable(spellings);
+}
+
+/// The plugin's `UPPER_SNAKE_CASE` rendering of a canonical camelCase name.
+String _upperSnakeOf(String camel) => camel
+    .replaceAllMapped(
+      RegExp('([a-z0-9])([A-Z])'),
+      (match) => '${match[1]}_${match[2]}',
+    )
+    .toUpperCase();
 
 /// Plugin spellings that differ from the canonical one by more than case.
 const _aliases = <String, String>{

--- a/lib/logic/health_workout_types.dart
+++ b/lib/logic/health_workout_types.dart
@@ -1,0 +1,70 @@
+import 'package:health/health.dart';
+
+/// Lotti's canonical spelling of a workout type: `lowerCamelCase`, as in
+/// `walking`, `running`, `cycling`, `functionalStrengthTraining`.
+///
+/// That spelling is the one every stored `WorkoutEntry` carried until the app
+/// moved from its `flutter_health_fit` fork to the upstream `health` plugin
+/// (#2041), and it is what the dashboard workout catalogue, every persisted
+/// `DashboardWorkoutItem` and every habit signal keyed on a workout type still
+/// use. The upstream plugin names the same activities `UPPER_SNAKE_CASE`
+/// (`HealthWorkoutActivityType.WALKING`), and importing that name verbatim is
+/// what made every workout recorded since invisible to the charts that looked
+/// for `walking`.
+///
+/// The conversion is mechanical — split on `_`, lower-case, camel-join — with
+/// one alias on top: the plugin folds HealthKit's `cycling` into `BIKING`, and
+/// the fork (like HealthKit, and the rows imported through it) called it
+/// `cycling`. Anything already in the canonical shape passes through unchanged,
+/// so the function is idempotent and safe to apply to stored and incoming
+/// values alike.
+///
+/// Rows imported between #2041 and this normalisation are still stored under
+/// the plugin's spelling; readers that compare types go through
+/// [isSameWorkoutType] so those rows chart too.
+String canonicalWorkoutType(String raw) {
+  final trimmed = raw.trim();
+  if (trimmed.isEmpty) {
+    return trimmed;
+  }
+
+  final String camel;
+  if (trimmed.contains('_') || trimmed.toUpperCase() == trimmed) {
+    // The plugin's `UPPER_SNAKE_CASE` enum name.
+    final segments = trimmed
+        .split('_')
+        .where((segment) => segment.isNotEmpty)
+        .map((segment) => segment.toLowerCase())
+        .toList();
+    if (segments.isEmpty) {
+      return '';
+    }
+    camel = segments.first + segments.skip(1).map(_capitalize).join();
+  } else {
+    // Already camelCase — only a stray leading capital is folded.
+    camel = trimmed[0].toLowerCase() + trimmed.substring(1);
+  }
+
+  // A value without a single lower-case letter — digits, or a lone capital —
+  // would otherwise read as UPPER_SNAKE on the next pass and change again.
+  final settled = camel.contains(RegExp('[a-z]')) ? camel : camel.toLowerCase();
+  return _aliases[settled] ?? settled;
+}
+
+/// The canonical type string for a plugin activity — what a workout imported
+/// from Apple Health or Health Connect is stored under.
+String workoutTypeForActivity(HealthWorkoutActivityType activity) =>
+    canonicalWorkoutType(activity.name);
+
+/// Whether two stored or configured workout type strings name the same
+/// activity, whichever era's spelling each of them carries.
+bool isSameWorkoutType(String a, String b) =>
+    canonicalWorkoutType(a) == canonicalWorkoutType(b);
+
+/// Plugin spellings that differ from the canonical one by more than case.
+const _aliases = <String, String>{
+  'biking': 'cycling',
+};
+
+String _capitalize(String segment) =>
+    segment[0].toUpperCase() + segment.substring(1);

--- a/lib/logic/signals/health_signal_refresh_service.dart
+++ b/lib/logic/signals/health_signal_refresh_service.dart
@@ -6,8 +6,9 @@ import 'package:lotti/services/domain_logging.dart';
 
 /// Pulls journal-backed health signals forward from the platform health store.
 ///
-/// Goal and habit surfaces both read imported journal rows. This service owns
-/// the platform-type mapping and failure containment they share, without
+/// Goal and habit surfaces read imported journal rows, and the Daily OS
+/// timeline projects imported workouts onto its recorded lane. This service
+/// owns the platform-type mapping and failure containment they share, without
 /// making the always-available Habits feature depend on the Goals feature.
 class HealthSignalRefreshService {
   HealthSignalRefreshService(
@@ -60,6 +61,27 @@ class HealthSignalRefreshService {
           subDomain: _logSubDomain,
         );
       }
+    }
+  }
+
+  /// Pulls workouts recorded since the newest stored one forward.
+  ///
+  /// Workouts are not a `HealthDataType` request — they have their own delta,
+  /// throttled inside [HealthImport] — so a surface that shows recorded
+  /// sessions (the Daily OS timeline) calls this rather than
+  /// [refreshRequests]. Failures are contained the same way: the surface keeps
+  /// painting what is stored.
+  Future<void> refreshWorkouts() async {
+    try {
+      await _healthImport.getWorkoutsHealthDataDelta();
+    } catch (error, stackTrace) {
+      _domainLogger?.error(
+        LogDomain.health,
+        error,
+        message: 'refreshing workouts failed',
+        stackTrace: stackTrace,
+        subDomain: _logSubDomain,
+      );
     }
   }
 }

--- a/lib/logic/signals/signal_needs.dart
+++ b/lib/logic/signals/signal_needs.dart
@@ -1,4 +1,5 @@
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/logic/health_workout_types.dart';
 
 /// The distinct journal series an [AutoCompleteRule] tree reads.
 ///
@@ -20,6 +21,24 @@ class SignalNeeds {
       measurableIds.isEmpty &&
       workoutTypes.isEmpty &&
       habitIds.isEmpty;
+
+  /// The `JournalEntity.affectedIds` tokens a write to one of these series
+  /// carries — what a consumer intersects with a notification batch to decide
+  /// whether the tree needs re-evaluating.
+  ///
+  /// Measurables, health types and habits notify under their own id. A
+  /// workout notifies under its *stored* type, and rows of one activity are
+  /// stored under either era's spelling (`running` before #2041 and since the
+  /// canonicalisation, `RUNNING` in between) — so each workout type expands
+  /// to every spelling, the same set the reader queries. Without this a rule
+  /// persisted as `RUNNING` read new `running` rows correctly but was never
+  /// told they had arrived.
+  Set<String> get notificationTokens => {
+    ...measurableIds,
+    ...quantitativeTypes,
+    for (final type in workoutTypes) ...workoutTypeSpellings(type),
+    ...habitIds,
+  };
 
   void collect(AutoCompleteRule rule) {
     switch (rule) {

--- a/lib/logic/signals/signal_reader.dart
+++ b/lib/logic/signals/signal_reader.dart
@@ -1,6 +1,7 @@
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/logic/health_workout_types.dart';
 import 'package:lotti/logic/signals/signal_day_buckets.dart';
 import 'package:lotti/logic/signals/signal_needs.dart';
 import 'package:lotti/logic/signals/signal_window.dart';
@@ -47,16 +48,36 @@ class SignalReader {
     rangeEnd: rangeEnd,
   );
 
-  /// Workout entities of [workoutType] in the range.
+  /// Workout entities of [workoutType]'s activity in the range, whichever
+  /// spelling era each stored row carries.
+  ///
+  /// The habit picker offered — and rules therefore persisted — whatever
+  /// distinct `subtype` strings existed at the time, and the rows themselves
+  /// changed spelling with the import eras (`running` before #2041 and since
+  /// the canonicalisation, `RUNNING` in between). `workoutsByType` matches by
+  /// SQL equality, so this fans out one query per known spelling
+  /// ([workoutTypeSpellings]) and merges: a rule keyed in either era matches
+  /// rows from both. De-duplicated by entry id, newest first — the same
+  /// contract as the single query.
   Future<List<JournalEntity>> workoutEntities({
     required String workoutType,
     required DateTime rangeStart,
     required DateTime rangeEnd,
-  }) => journalDb.getWorkoutsByType(
-    workoutType: workoutType,
-    rangeStart: rangeStart,
-    rangeEnd: rangeEnd,
-  );
+  }) async {
+    final byId = <String, JournalEntity>{};
+    for (final spelling in workoutTypeSpellings(workoutType)) {
+      final entities = await journalDb.getWorkoutsByType(
+        workoutType: spelling,
+        rangeStart: rangeStart,
+        rangeEnd: rangeEnd,
+      );
+      for (final entity in entities) {
+        byId[entity.meta.id] = entity;
+      }
+    }
+    return byId.values.toList(growable: false)
+      ..sort((a, b) => b.meta.dateFrom.compareTo(a.meta.dateFrom));
+  }
 
   /// Every series an [AutoCompleteRule] tree needs, covering [days] calendar
   /// days ending on [reference]'s day (so `days: 14` is a two-week window

--- a/test/features/daily_os_next/state/actual_time_blocks_provider_test.dart
+++ b/test/features/daily_os_next/state/actual_time_blocks_provider_test.dart
@@ -1,10 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/rating_data.dart';
 import 'package:lotti/features/daily_os_next/state/actual_time_blocks_provider.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/health_import.dart';
+import 'package:lotti/logic/signals/health_signal_refresh_service.dart';
+import 'package:lotti/providers/service_providers.dart';
+import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/entities_cache_service.dart';
+import 'package:mocktail/mocktail.dart';
 
+import '../../../mocks/mocks.dart';
 import 'actual_time_blocks_provider_test_helpers.dart';
 
 void main() {
@@ -276,6 +285,262 @@ void main() {
       );
 
       expect(blocks, isEmpty);
+    });
+
+    // An imported workout has no text, no category and no linked task, so it
+    // used to fall through every fallback and print its own id on the lane.
+    test('titles an imported workout by its activity, in either spelling', () {
+      final day = DateTime(2026, 5, 27);
+
+      final blocks = actualTimeBlocksForEntries(
+        entries: [
+          hWorkout(id: 'walk', day: day, startHour: 7),
+          hWorkout(
+            id: 'strength',
+            day: day,
+            startHour: 18,
+            workoutType: 'functionalStrengthTraining',
+          ),
+        ],
+        links: const [],
+        linkedFromById: const {},
+        categoryById: (_) => null,
+      );
+
+      expect(blocks.map((b) => b.title), [
+        'Walking',
+        'Functional Strength Training',
+      ]);
+      expect(blocks.first.taskId, isNull);
+      expect(blocks.first.duration, const Duration(minutes: 45));
+      expect(blocks.first.category.name, isEmpty);
+    });
+
+    test('a workout the user annotated keeps the annotation as its title', () {
+      final day = DateTime(2026, 5, 27);
+
+      final blocks = actualTimeBlocksForEntries(
+        entries: [
+          hWorkout(
+            id: 'walk',
+            day: day,
+            startHour: 7,
+            text: 'Morning walk\nround the lake',
+          ),
+        ],
+        links: const [],
+        linkedFromById: const {},
+        categoryById: (_) => null,
+      );
+
+      expect(blocks.single.title, 'Morning walk');
+    });
+
+    test('a workout without an activity falls through to the id', () {
+      final day = DateTime(2026, 5, 27);
+
+      final blocks = actualTimeBlocksForEntries(
+        entries: [
+          hWorkout(id: 'blank', day: day, startHour: 7, workoutType: ''),
+        ],
+        links: const [],
+        linkedFromById: const {},
+        categoryById: (_) => null,
+      );
+
+      expect(blocks.single.title, 'blank');
+    });
+  });
+
+  group('dailyOsActualTimeUpdateProvider', () {
+    test('actualTimelineUpdateBatches drops empty batches', () async {
+      final batches = await actualTimelineUpdateBatches(
+        Stream.fromIterable([
+          <String>{},
+          {'entry-1'},
+          <String>{},
+          {'entry-2', 'entry-3'},
+        ]),
+      ).toList();
+
+      expect(batches, [
+        {'entry-1'},
+        {'entry-2', 'entry-3'},
+      ]);
+    });
+
+    test(
+      'bridges the registered notification stream, empties dropped',
+      () async {
+        final notifications = MockUpdateNotifications();
+        when(() => notifications.updateStream).thenAnswer(
+          (_) => Stream.fromIterable([
+            <String>{},
+            {'entry-1'},
+          ]),
+        );
+        getIt.registerSingleton<UpdateNotifications>(notifications);
+        addTearDown(getIt.reset);
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        // autoDispose: without a live listener the provider is torn down
+        // between the read and the first emission.
+        final subscription = container.listen(
+          dailyOsActualTimeUpdateProvider,
+          (_, _) {},
+        );
+        addTearDown(subscription.close);
+
+        final first = await container.read(
+          dailyOsActualTimeUpdateProvider.future,
+        );
+
+        expect(first, {'entry-1'});
+      },
+    );
+  });
+
+  group('dailyOsActualTimeBlocksProvider', () {
+    final day = DateTime(2026, 5, 27);
+    late MockJournalDb db;
+
+    setUp(() {
+      db = MockJournalDb();
+      final walk = hWorkout(id: 'walk', day: day, startHour: 7);
+      when(
+        () => db.sortedCalendarEntries(
+          rangeStart: day,
+          rangeEnd: day.add(const Duration(days: 1)),
+        ),
+      ).thenAnswer((_) async => [walk]);
+      when(
+        () => db.basicLinksForEntryIds({walk.meta.id}),
+      ).thenAnswer((_) async => const []);
+    });
+
+    // Workouts reach the journal only through the health import, and this
+    // lane used to wait for a dashboard to ask for one.
+    test('nudges the workout importer and projects the day', () async {
+      final healthImport = MockHealthImport();
+      when(
+        healthImport.getWorkoutsHealthDataDelta,
+      ).thenAnswer((_) async => const HealthImportResult.imported(0));
+      final container = ProviderContainer(
+        overrides: [
+          journalDbProvider.overrideWithValue(db),
+          healthSignalRefreshServiceProvider.overrideWithValue(
+            HealthSignalRefreshService(healthImport),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final blocks = await container.read(
+        dailyOsActualTimeBlocksProvider(day).future,
+      );
+
+      expect(blocks.single.title, 'Walking');
+      expect(blocks.single.id, 'actual:walk');
+      verify(healthImport.getWorkoutsHealthDataDelta).called(1);
+    });
+
+    test(
+      'projects the day without an importer (desktop, demo worlds)',
+      () async {
+        final container = ProviderContainer(
+          overrides: [
+            journalDbProvider.overrideWithValue(db),
+            healthSignalRefreshServiceProvider.overrideWithValue(null),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final blocks = await container.read(
+          dailyOsActualTimeBlocksProvider(day).future,
+        );
+
+        expect(blocks.single.title, 'Walking');
+      },
+    );
+
+    test(
+      'resolves linked-from entities through the database and categories '
+      'through the cache',
+      () async {
+        final task = hTask(
+          id: 'task-1',
+          title: 'Write release notes',
+          categoryId: 'cat-work',
+          day: day,
+        );
+        final entry = hEntry(
+          id: 'entry-1',
+          day: day,
+          startHour: 9,
+          endHour: 10,
+        );
+        final link = hLink(
+          'l1',
+          from: task.meta.id,
+          to: entry.meta.id,
+          day: day,
+        );
+        when(
+          () => db.sortedCalendarEntries(
+            rangeStart: day,
+            rangeEnd: day.add(const Duration(days: 1)),
+          ),
+        ).thenAnswer((_) async => [entry]);
+        when(
+          () => db.basicLinksForEntryIds({entry.meta.id}),
+        ).thenAnswer((_) async => [link]);
+        when(
+          () => db.getJournalEntitiesForIdsUnordered({task.meta.id}),
+        ).thenAnswer((_) async => [task]);
+        final cache = MockEntitiesCacheService();
+        when(() => cache.getCategoryById('cat-work')).thenReturn(
+          hCategory(id: 'cat-work', name: 'Work', color: '#5ED4B7'),
+        );
+        getIt.registerSingleton<EntitiesCacheService>(cache);
+        addTearDown(getIt.reset);
+        final container = ProviderContainer(
+          overrides: [
+            journalDbProvider.overrideWithValue(db),
+            healthSignalRefreshServiceProvider.overrideWithValue(null),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final blocks = await container.read(
+          dailyOsActualTimeBlocksProvider(day).future,
+        );
+
+        expect(blocks.single.title, 'Write release notes');
+        expect(blocks.single.taskId, 'task-1');
+        expect(blocks.single.category.name, 'Work');
+      },
+    );
+
+    test('a failing importer does not take the lane down', () async {
+      final healthImport = MockHealthImport();
+      when(
+        healthImport.getWorkoutsHealthDataDelta,
+      ).thenThrow(StateError('health store unavailable'));
+      final container = ProviderContainer(
+        overrides: [
+          journalDbProvider.overrideWithValue(db),
+          healthSignalRefreshServiceProvider.overrideWithValue(
+            HealthSignalRefreshService(healthImport),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final blocks = await container.read(
+        dailyOsActualTimeBlocksProvider(day).future,
+      );
+
+      expect(blocks.single.title, 'Walking');
     });
   });
 }

--- a/test/features/daily_os_next/state/actual_time_blocks_provider_test_helpers.dart
+++ b/test/features/daily_os_next/state/actual_time_blocks_provider_test_helpers.dart
@@ -93,3 +93,38 @@ CategoryDefinition hCategory({
     color: color,
   );
 }
+
+/// A workout as the health import stores it: no entry text unless the user
+/// annotated it, no category, and — for rows imported by the upstream plugin
+/// before its spelling was normalised — an UPPER_SNAKE activity.
+WorkoutEntry hWorkout({
+  required String id,
+  required DateTime day,
+  required int startHour,
+  int minutes = 45,
+  String workoutType = 'WALKING',
+  String? text,
+}) {
+  final start = day.add(Duration(hours: startHour));
+  final end = start.add(Duration(minutes: minutes));
+  return JournalEntity.workout(
+        meta: Metadata(
+          id: id,
+          createdAt: end,
+          updatedAt: end,
+          dateFrom: start,
+          dateTo: end,
+        ),
+        data: WorkoutData(
+          dateFrom: start,
+          dateTo: end,
+          id: id,
+          workoutType: workoutType,
+          energy: 180,
+          distance: 3400,
+          source: 'com.apple.health',
+        ),
+        entryText: text == null ? null : EntryText(plainText: text),
+      )
+      as WorkoutEntry;
+}

--- a/test/features/dashboards/state/workout_chart_controller_test.dart
+++ b/test/features/dashboards/state/workout_chart_controller_test.dart
@@ -263,6 +263,52 @@ void main() {
       },
     );
 
+    // The chart is configured with the catalogue's `walking`; the row was
+    // imported by the upstream plugin as `WALKING`. Before the spellings were
+    // reconciled this rendered "No data" over a week of walks.
+    test('charts a row stored under the plugin spelling', () async {
+      const walkingDurationConfig =
+          DashboardItem.workoutChart(
+                workoutType: 'walking',
+                displayName: 'Walking (time)',
+                color: '#82E6CE',
+                valueType: WorkoutValueType.duration,
+              )
+              as DashboardWorkoutItem;
+
+      when(
+        () => mocks.journalDb.getWorkouts(
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          makeWorkoutEntry(
+            dateFrom: DateTime(2024, 3, 12, 7),
+            dateTo: DateTime(2024, 3, 12, 7, 45),
+            workoutType: 'WALKING',
+          ),
+        ],
+      );
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        workoutObservationsControllerProvider((
+          chartConfig: walkingDurationConfig,
+          rangeStart: rangeStart,
+          rangeEnd: rangeEnd,
+        )).future,
+      );
+
+      expect(result, hasLength(5));
+      expect(
+        result.singleWhere((o) => o.dateTime == DateTime(2024, 3, 12)).value,
+        45,
+      );
+    });
+
     test(
       'guest/demo world (no HealthImport registered): still charts DB data '
       'and skips the device delta fetch',

--- a/test/features/dashboards/state/workout_data_test.dart
+++ b/test/features/dashboards/state/workout_data_test.dart
@@ -203,6 +203,79 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
+  group('aggregateWorkoutDailySum — spelling eras', () {
+    // Rows imported through the upstream plugin before the import normalised
+    // its spelling say `RUNNING`; the chart they belong to says `running`.
+    test('counts a row stored under the plugin spelling', () {
+      final result = aggregateWorkoutDailySum(
+        [
+          makeWorkoutEntry(
+            dateFrom: DateTime(2024, 3, 11, 8),
+            dateTo: DateTime(2024, 3, 11, 9),
+            workoutType: 'RUNNING',
+            energy: 300,
+            id: 'plugin-era',
+          ),
+          makeWorkoutEntry(
+            dateFrom: DateTime(2024, 3, 11, 17),
+            dateTo: DateTime(2024, 3, 11, 18),
+            workoutType: 'running',
+            energy: 200,
+            id: 'fork-era',
+          ),
+        ],
+        chartConfig: runningEnergyConfig,
+        rangeStart: rangeStart,
+        rangeEnd: rangeEnd,
+      );
+
+      expect(result[1].value, 500);
+    });
+
+    test('matches a multi-word activity across spellings', () {
+      const strengthConfig = DashboardWorkoutItem(
+        workoutType: 'functionalStrengthTraining',
+        displayName: 'Strength training (time)',
+        color: '#82E6CE',
+        valueType: WorkoutValueType.duration,
+      );
+      final result = aggregateWorkoutDailySum(
+        [
+          makeWorkoutEntry(
+            dateFrom: DateTime(2024, 3, 12, 7),
+            dateTo: DateTime(2024, 3, 12, 7, 40),
+            workoutType: 'FUNCTIONAL_STRENGTH_TRAINING',
+            id: 'strength',
+          ),
+        ],
+        chartConfig: strengthConfig,
+        rangeStart: rangeStart,
+        rangeEnd: rangeEnd,
+      );
+
+      expect(result[2].value, 40);
+    });
+
+    test('still ignores a different activity in the plugin spelling', () {
+      final result = aggregateWorkoutDailySum(
+        [
+          makeWorkoutEntry(
+            dateFrom: DateTime(2024, 3, 11, 8),
+            dateTo: DateTime(2024, 3, 11, 9),
+            workoutType: 'WALKING',
+            energy: 300,
+            id: 'walk',
+          ),
+        ],
+        chartConfig: runningEnergyConfig,
+        rangeStart: rangeStart,
+        rangeEnd: rangeEnd,
+      );
+
+      expect(result.map((o) => o.value), everyElement(0));
+    });
+  });
+
   // Glados property tests.
   // -------------------------------------------------------------------------
 

--- a/test/features/goals/ui/checkins/goal_checkin_composer_test.dart
+++ b/test/features/goals/ui/checkins/goal_checkin_composer_test.dart
@@ -77,10 +77,14 @@ void main() {
 
   testWidgets('names the goal and the moment', (tester) async {
     await pump(tester);
-    await tester.pump();
+    // The frame that lands the resolved capture target rebuilds the header,
+    // and the header formats `clock.now()` on every build — so this pump has
+    // to run under the fixed clock too, or the month tracks the wall calendar
+    // (the test rolled over on 1 September).
+    await withClock(Clock.fixed(now), tester.pump);
 
     expect(find.text('Check in · Fitness'), findsOneWidget);
-    expect(find.textContaining('August'), findsOneWidget);
+    expect(find.textContaining('August 18, 2026'), findsOneWidget);
   });
 
   testWidgets('opens on the recorder, not on a keyboard', (tester) async {

--- a/test/features/habits/model/habit_form_mapping_test.dart
+++ b/test/features/habits/model/habit_form_mapping_test.dart
@@ -176,6 +176,29 @@ void main() {
       );
       expect(form.signals.single, anyRun);
     });
+
+    // The picker offers canonical activities; a leaf persisted while rows
+    // were spelled `RUNNING` has to read back as the same signal, or the
+    // editor shows it unchecked and lets a duplicate be added beside it.
+    test('a plugin-era workout leaf reads back canonical', () {
+      final form = HabitFormMapping.fromRule(
+        const AutoCompleteRule.workout(dataType: 'RUNNING'),
+      );
+      expect(form.signals.single, anyRun);
+    });
+
+    test('leaves that name one activity in two spellings collapse', () {
+      final form = HabitFormMapping.fromRule(
+        const AutoCompleteRule.or(
+          rules: [
+            AutoCompleteRule.workout(dataType: 'RUNNING'),
+            AutoCompleteRule.workout(dataType: 'running'),
+            AutoCompleteRule.measurable(dataTypeId: 'water', minimum: 1000),
+          ],
+        ),
+      );
+      expect(form.signals, [anyRun, water]);
+    });
   });
 
   group('round trips', () {

--- a/test/features/habits/service/habit_auto_completion_service_test.dart
+++ b/test/features/habits/service/habit_auto_completion_service_test.dart
@@ -325,6 +325,50 @@ void main() {
   });
 
   group('journal updates', () {
+    // A workout notifies under its stored type. A rule persisted while rows
+    // were spelled `RUNNING` must still hear a run stored as `running`, and
+    // the read behind it must find that row.
+    test('a plugin-era workout rule hears and reads a canonical run', () {
+      final runHabit = habitFlossing.copyWith(
+        id: 'habit-run',
+        name: 'Go running',
+        autoCompleteRule: const AutoCompleteRule.workout(dataType: 'RUNNING'),
+      );
+      stubHabits([runHabit]);
+      when(
+        () => journalDb.getWorkoutsByType(
+          workoutType: any(named: 'workoutType'),
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).thenAnswer((_) async => const []);
+      run((async) {
+        service.start();
+        async.flushMicrotasks();
+        expect(written, isEmpty);
+
+        // The new run is stored canonically; only that spelling answers.
+        when(
+          () => journalDb.getWorkoutsByType(
+            workoutType: 'running',
+            rangeStart: any(named: 'rangeStart'),
+            rangeEnd: any(named: 'rangeEnd'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            workoutEntity(
+              DateTime(2026, 8, 8, 7),
+              length: const Duration(minutes: 30),
+            ),
+          ],
+        );
+        updateNotifications.notify({workoutNotification, 'running'});
+        async.elapse(const Duration(seconds: 3));
+      });
+      expect(written, hasLength(1));
+      expect(written.single.habitId, 'habit-run');
+    });
+
     test(
       'a write to a series the rule reads re-evaluates after the debounce',
       () {

--- a/test/features/habits/state/habit_editor_providers_test.dart
+++ b/test/features/habits/state/habit_editor_providers_test.dart
@@ -9,6 +9,49 @@ import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
 
 void main() {
+  Future<ProviderContainer> containerWithStoredTypes(
+    List<String> stored,
+  ) async {
+    final journalDb = MockJournalDb();
+    when(journalDb.getWorkoutTypes).thenAnswer((_) async => stored);
+    await setUpTestGetIt(
+      additionalSetup: () => getIt
+        ..unregister<JournalDb>()
+        ..registerSingleton<JournalDb>(journalDb),
+    );
+    addTearDown(tearDownTestGetIt);
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  // Rows imported in the plugin era say `RUNNING`; older and newer rows say
+  // `running`. One activity must appear in the picker once, canonically.
+  test(
+    'workoutTypesProvider canonicalises, de-duplicates and sorts',
+    () async {
+      final container = await containerWithStoredTypes([
+        'RUNNING',
+        'running',
+        'BIKING',
+        'WALKING_TREADMILL',
+      ]);
+      expect(await container.read(workoutTypesProvider.future), [
+        'cycling',
+        'running',
+        'walkingTreadmill',
+      ]);
+    },
+  );
+
+  test(
+    'workoutTypesProvider drops activities that canonicalise to nothing',
+    () async {
+      final container = await containerWithStoredTypes(['', '   ']);
+      expect(await container.read(workoutTypesProvider.future), isEmpty);
+    },
+  );
+
   test(
     'workoutTypesProvider reads the distinct types from the journal',
     () async {

--- a/test/features/habits/state/habit_signal_status_controller_test.dart
+++ b/test/features/habits/state/habit_signal_status_controller_test.dart
@@ -137,6 +137,74 @@ void main() {
     });
   });
 
+  group('a workout rule persisted in the plugin-era spelling', () {
+    final runHabit = habitFlossing.copyWith(
+      id: 'run-habit',
+      autoCompleteRule: const AutoCompleteRule.workout(dataType: 'RUNNING'),
+    );
+
+    setUp(() {
+      when(() => cache.getHabitById(runHabit.id)).thenReturn(runHabit);
+      when(
+        () => journalDb.getWorkoutsByType(
+          workoutType: any(named: 'workoutType'),
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).thenAnswer((_) async => const []);
+    });
+
+    // The row notifies under its stored `running`; the rule says `RUNNING`.
+    test('re-reads when a canonically spelled run lands', () {
+      withClock(Clock.fixed(now), () {
+        fakeAsync((async) {
+          final sub = container.listen(
+            habitSignalStatusProvider(runHabit.id),
+            (_, _) {},
+          );
+          async.flushMicrotasks();
+          clearInteractions(journalDb);
+          updates.notify({workoutNotification, 'running'});
+          async.elapse(const Duration(milliseconds: 150));
+          // One query per known spelling of the activity.
+          for (final spelling in ['running', 'RUNNING']) {
+            verify(
+              () => journalDb.getWorkoutsByType(
+                workoutType: spelling,
+                rangeStart: any(named: 'rangeStart'),
+                rangeEnd: any(named: 'rangeEnd'),
+              ),
+            ).called(1);
+          }
+          sub.close();
+        }, initialTime: now);
+      });
+    });
+
+    test('ignores a different activity', () {
+      withClock(Clock.fixed(now), () {
+        fakeAsync((async) {
+          final sub = container.listen(
+            habitSignalStatusProvider(runHabit.id),
+            (_, _) {},
+          );
+          async.flushMicrotasks();
+          clearInteractions(journalDb);
+          updates.notify({workoutNotification, 'WALKING'});
+          async.elapse(const Duration(milliseconds: 150));
+          verifyNever(
+            () => journalDb.getWorkoutsByType(
+              workoutType: any(named: 'workoutType'),
+              rangeStart: any(named: 'rangeStart'),
+              rangeEnd: any(named: 'rangeEnd'),
+            ),
+          );
+          sub.close();
+        }, initialTime: now);
+      });
+    });
+  });
+
   test('an unrelated write does not re-read', () {
     withClock(Clock.fixed(now), () {
       fakeAsync((async) {

--- a/test/features/journal/ui/widgets/entry_details/workout_summary_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/workout_summary_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/dashboards/ui/widgets/charts/dashboard_workout_chart.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details/workout_summary.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/health_import.dart';
@@ -51,6 +52,59 @@ void main() {
       expect(find.text('Running (time)'), findsOneWidget);
       expect(find.text('Running (calories)'), findsOneWidget);
       expect(find.text('Running distance (m)'), findsOneWidget);
+    });
+
+    Future<void> pumpSummaryFor(WidgetTester tester, String workoutType) async {
+      when(
+        () => mockJournalDb.getWorkouts(
+          rangeEnd: any(named: 'rangeEnd'),
+          rangeStart: any(named: 'rangeStart'),
+        ),
+      ).thenAnswer((_) async => [testWorkoutRunning]);
+      when(
+        mockHealthImport.getWorkoutsHealthDataDelta,
+      ).thenAnswer((_) async => const HealthImportResult.imported(0));
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          WorkoutSummary(
+            testWorkoutRunning.copyWith(
+              data: testWorkoutRunning.data.copyWith(workoutType: workoutType),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    // A row imported by the upstream plugin says `RUNNING`; the catalogue that
+    // provides the trend charts says `running`. The detail card used to show
+    // no charts at all for such a row.
+    testWidgets('finds the charts for a workout in the plugin spelling', (
+      tester,
+    ) async {
+      await pumpSummaryFor(tester, 'RUNNING');
+
+      expect(find.byType(DashboardWorkoutChart), findsNWidgets(3));
+      expect(find.text('Running (time)'), findsOneWidget);
+    });
+
+    testWidgets('does not pick a catalogue series by key substring', (
+      tester,
+    ) async {
+      // `walk` is a prefix of every `walking.*` key; it is not a walking row.
+      await pumpSummaryFor(tester, 'walk');
+
+      expect(find.byType(DashboardWorkoutChart), findsNothing);
+      expect(find.textContaining('Duration: 60 min'), findsOneWidget);
+    });
+
+    testWidgets('renders no charts for an activity outside the catalogue', (
+      tester,
+    ) async {
+      await pumpSummaryFor(tester, 'yoga');
+
+      expect(find.byType(DashboardWorkoutChart), findsNothing);
     });
   });
 }

--- a/test/features/journal/util/entry_tools_test.dart
+++ b/test/features/journal/util/entry_tools_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/classes/entity_definitions.dart';
@@ -6,6 +7,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
 
 import '../../../test_data/test_data.dart';
+import '../../../widget_test_utils.dart';
 
 /// Glados generators for entry-tools property tests.
 extension _AnyDuration on glados.Any {
@@ -313,6 +315,50 @@ void main() {
     });
   });
 
+  group('isTimeRecordingSpan', () {
+    test('a minute or more reads as a tracked interval', () {
+      expect(isTimeRecordingSpan(const Duration(minutes: 1)), isTrue);
+      expect(isTimeRecordingSpan(const Duration(hours: 2)), isTrue);
+    });
+
+    test('anything shorter is a point in time', () {
+      expect(isTimeRecordingSpan(const Duration(seconds: 59)), isFalse);
+      expect(isTimeRecordingSpan(Duration.zero), isFalse);
+    });
+  });
+
+  group('formatEntryTimestamp', () {
+    // ICU separates the meridiem with a narrow no-break space in newer data;
+    // the assertion is about the words and their order, not the space.
+    String plainSpaces(String? s) =>
+        s!.replaceAll('\u202F', ' ').replaceAll('\u00A0', ' ');
+
+    test('renders a locale-aware date and time', () {
+      expect(
+        plainSpaces(
+          formatEntryTimestamp(DateTime(2024, 3, 15, 10, 30), locale: 'en_US'),
+        ),
+        'Mar 15, 2024 10:30 AM',
+      );
+    });
+
+    testWidgets('entryDateLabel resolves the widget locale', (tester) async {
+      String? label;
+      await tester.pumpWidget(
+        makeTestableWidget(
+          Builder(
+            builder: (context) {
+              label = entryDateLabel(context, DateTime(2024, 3, 15, 10, 30));
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(plainSpaces(label), 'Mar 15, 2024 10:30 AM');
+    });
+  });
+
   group('humanWorkoutType', () {
     test('title-cases a simple type', () {
       expect(humanWorkoutType('running'), 'Running');
@@ -408,6 +454,39 @@ void main() {
           includeTitle: false,
         ),
         'Energy: 0 kcal\nDuration: 12 min',
+      );
+    });
+
+    test('titles a multi-word activity the way the journal card does', () {
+      expect(
+        entryTextForWorkout(
+          workout(
+            workoutType: 'functionalStrengthTraining',
+            energy: 100,
+            minutes: 20,
+          ),
+        ),
+        'Functional Strength Training\nEnergy: 100 kcal\nDuration: 20 min',
+      );
+    });
+
+    test('reads a row imported under the plugin spelling the same way', () {
+      expect(
+        entryTextForWorkout(
+          workout(
+            workoutType: 'FUNCTIONAL_STRENGTH_TRAINING',
+            energy: 100,
+            minutes: 20,
+          ),
+        ),
+        'Functional Strength Training\nEnergy: 100 kcal\nDuration: 20 min',
+      );
+    });
+
+    test('an empty activity leaves an empty title line', () {
+      expect(
+        entryTextForWorkout(workout(workoutType: '', energy: 5, minutes: 1)),
+        '\nEnergy: 5 kcal\nDuration: 1 min',
       );
     });
   });

--- a/test/logic/health_import_test.dart
+++ b/test/logic/health_import_test.dart
@@ -2550,7 +2550,10 @@ void main() {
         });
       }
 
-      int storeReads() => verify(
+      /// Store reads since the previous call: mocktail's `verify` consumes
+      /// the invocations it matches, so each call counts only what happened
+      /// after the last one.
+      int newStoreReads() => verify(
         () => mockHealthService.getHealthDataFromTypes(
           types: workoutTypes,
           startTime: any(named: 'startTime'),
@@ -2571,7 +2574,7 @@ void main() {
 
           expect(second?.status, HealthImportStatus.imported);
           expect(second?.sampleCount, 0);
-          expect(storeReads(), 1);
+          expect(newStoreReads(), 1);
           verify(() => mockJournalDb.latestWorkout()).called(1);
         });
       });
@@ -2586,12 +2589,16 @@ void main() {
             );
           mobileImport.getWorkoutsHealthDataDelta();
           async.flushMicrotasks();
-          expect(storeReads(), 1);
+          expect(newStoreReads(), 1);
 
           async.elapse(const Duration(seconds: 1));
           mobileImport.getWorkoutsHealthDataDelta();
           async.flushMicrotasks();
-          expect(storeReads(), 1, reason: 'one more read after the interval');
+          expect(
+            newStoreReads(),
+            1,
+            reason: 'one new read once the interval is up',
+          );
         });
       });
 
@@ -2644,7 +2651,7 @@ void main() {
           );
           async.flushMicrotasks();
 
-          expect(storeReads(), 2);
+          expect(newStoreReads(), 2);
         });
       });
     });

--- a/test/logic/health_import_test.dart
+++ b/test/logic/health_import_test.dart
@@ -2238,13 +2238,97 @@ void main() {
 
       expect(captured.length, 1);
       final workoutData = captured.first as WorkoutData;
-      expect(workoutData.workoutType, 'RUNNING');
+      expect(workoutData.workoutType, 'running');
       expect(workoutData.distance, 5000);
       expect(workoutData.energy, 350);
       expect(workoutData.source, 'apple-watch');
       expect(workoutData.id, 'workout-uuid-1');
       expect(workoutData.dateFrom, dateFrom);
       expect(workoutData.dateTo, dateTo);
+    });
+
+    HealthDataPoint workoutPoint({
+      required HealthWorkoutActivityType activity,
+      String uuid = 'workout-uuid',
+      String sourceId = 'apple-watch',
+      String sourceName = 'Apple Watch',
+    }) => HealthDataPoint(
+      uuid: uuid,
+      value: WorkoutHealthValue(workoutActivityType: activity),
+      type: HealthDataType.WORKOUT,
+      unit: HealthDataUnit.NO_UNIT,
+      dateFrom: DateTime(2024, 3, 1, 8),
+      dateTo: DateTime(2024, 3, 1, 9),
+      sourcePlatform: HealthPlatformType.appleHealth,
+      sourceDeviceId: 'test-device',
+      sourceId: sourceId,
+      sourceName: sourceName,
+    );
+
+    Future<WorkoutData> importSingle(HealthDataPoint point) async {
+      final mobileImport = createMobileHealthImport();
+      stubHealthStore(dataPoints: [point]);
+      await mobileImport.getWorkoutsHealthData(
+        dateFrom: point.dateFrom,
+        dateTo: point.dateTo,
+      );
+      return verify(
+            () => mockPersistenceLogic.createWorkoutEntry(captureAny()),
+          ).captured.single
+          as WorkoutData;
+    }
+
+    // The regression behind "workouts stopped landing in dashboards": the
+    // upstream plugin names activities `FUNCTIONAL_STRENGTH_TRAINING`, while
+    // every stored row, the catalogue and every persisted chart say
+    // `functionalStrengthTraining`. The import is where the two must meet.
+    test('stores the activity under the spelling the dashboards use', () async {
+      final stored = await importSingle(
+        workoutPoint(
+          activity: HealthWorkoutActivityType.FUNCTIONAL_STRENGTH_TRAINING,
+        ),
+      );
+
+      expect(stored.workoutType, 'functionalStrengthTraining');
+    });
+
+    test(
+      "stores the plugin's BIKING as the cycling HealthKit records",
+      () async {
+        final stored = await importSingle(
+          workoutPoint(activity: HealthWorkoutActivityType.BIKING),
+        );
+
+        expect(stored.workoutType, 'cycling');
+      },
+    );
+
+    // Health Connect leaves `sourceId` empty and names the provider package in
+    // `sourceName`; keeping the id verbatim stored Android workouts sourceless.
+    test(
+      'falls back to the source name when the store leaves the id empty',
+      () async {
+        final stored = await importSingle(
+          workoutPoint(
+            activity: HealthWorkoutActivityType.WALKING,
+            sourceId: '',
+            sourceName: 'com.google.android.apps.fitness',
+          ),
+        );
+
+        expect(stored.source, 'com.google.android.apps.fitness');
+      },
+    );
+
+    test('prefers the source id when the store provides one', () async {
+      final stored = await importSingle(
+        workoutPoint(
+          activity: HealthWorkoutActivityType.WALKING,
+          sourceId: 'com.apple.health',
+        ),
+      );
+
+      expect(stored.source, 'com.apple.health');
     });
 
     test('should skip non-workout health values', () async {
@@ -2312,8 +2396,8 @@ void main() {
       ).captured;
 
       expect(captured.length, 2);
-      expect((captured[0] as WorkoutData).workoutType, 'YOGA');
-      expect((captured[1] as WorkoutData).workoutType, 'RUNNING');
+      expect((captured[0] as WorkoutData).workoutType, 'yoga');
+      expect((captured[1] as WorkoutData).workoutType, 'running');
     });
 
     test('reports failed and logs when the health store throws', () async {
@@ -2445,6 +2529,126 @@ void main() {
       expect(mobileImport.workoutImportRunning, false);
     });
 
+    group('throttling', () {
+      /// Runs [body] under fake time with a mobile import whose store answers
+      /// empty, so each delta that reaches the store is one
+      /// `getHealthDataFromTypes` call.
+      void withQuietStore(void Function(FakeAsync async, HealthImport) body) {
+        fakeAsync((async) {
+          final mobileImport = createMobileHealthImport();
+          when(
+            () => mockJournalDb.latestWorkout(),
+          ).thenAnswer((_) async => null);
+          stubHealthStore();
+          // Health Connect's definitive yes: an empty read is then not
+          // followed by the access probe's second `latestWorkout()`, so each
+          // delta that runs is exactly one DB read and one store read.
+          when(
+            () => mockHealthService.hasPermissions(any()),
+          ).thenAnswer((_) async => true);
+          body(async, mobileImport);
+        });
+      }
+
+      int storeReads() => verify(
+        () => mockHealthService.getHealthDataFromTypes(
+          types: workoutTypes,
+          startTime: any(named: 'startTime'),
+          endTime: any(named: 'endTime'),
+        ),
+      ).callCount;
+
+      // The Daily OS timeline asks for a delta on every journal notification;
+      // without this each note saved would have re-read HealthKit.
+      test('a second delta inside the interval reads nothing', () {
+        withQuietStore((async, mobileImport) {
+          mobileImport.getWorkoutsHealthDataDelta();
+          async.flushMicrotasks();
+
+          HealthImportResult? second;
+          mobileImport.getWorkoutsHealthDataDelta().then((r) => second = r);
+          async.flushMicrotasks();
+
+          expect(second?.status, HealthImportStatus.imported);
+          expect(second?.sampleCount, 0);
+          expect(storeReads(), 1);
+          verify(() => mockJournalDb.latestWorkout()).called(1);
+        });
+      });
+
+      test('the interval is HealthImport.workoutDeltaInterval', () {
+        withQuietStore((async, mobileImport) {
+          mobileImport.getWorkoutsHealthDataDelta();
+          async
+            ..flushMicrotasks()
+            ..elapse(
+              HealthImport.workoutDeltaInterval - const Duration(seconds: 1),
+            );
+          mobileImport.getWorkoutsHealthDataDelta();
+          async.flushMicrotasks();
+          expect(storeReads(), 1);
+
+          async.elapse(const Duration(seconds: 1));
+          mobileImport.getWorkoutsHealthDataDelta();
+          async.flushMicrotasks();
+          expect(storeReads(), 1, reason: 'one more read after the interval');
+        });
+      });
+
+      test('records when the run started, not when it finished', () {
+        withQuietStore((async, mobileImport) {
+          final started = clock.now();
+          mobileImport.getWorkoutsHealthDataDelta();
+          async
+            ..flushMicrotasks()
+            ..elapse(const Duration(minutes: 3));
+
+          expect(mobileImport.lastWorkoutDelta, started);
+        });
+      });
+
+      test('a refused overlap does not count as a run', () async {
+        final mobileImport = createMobileHealthImport()
+          ..workoutImportRunning = true;
+
+        await mobileImport.getWorkoutsHealthDataDelta();
+
+        expect(mobileImport.lastWorkoutDelta, isNull);
+      });
+
+      // Deliberate: a failing store must not be hammered once per notification
+      // either. The settings page import below is the way to retry sooner.
+      test('a failed delta still counts as a run', () {
+        fakeAsync((async) {
+          final mobileImport = createMobileHealthImport();
+          when(
+            () => mockJournalDb.latestWorkout(),
+          ).thenThrow(Exception('db down'));
+
+          mobileImport.getWorkoutsHealthDataDelta();
+          async.flushMicrotasks();
+          mobileImport.getWorkoutsHealthDataDelta();
+          async.flushMicrotasks();
+
+          verify(() => mockJournalDb.latestWorkout()).called(1);
+        });
+      });
+
+      test('the user-initiated import is never throttled', () {
+        withQuietStore((async, mobileImport) {
+          mobileImport.getWorkoutsHealthDataDelta();
+          async.flushMicrotasks();
+          mobileImport.getWorkoutsHealthData(
+            dateFrom: DateTime(2024),
+            dateTo: DateTime(2024, 1, 2),
+          );
+          async.flushMicrotasks();
+
+          expect(storeReads(), 2);
+        });
+      });
+    });
+
     // The workout-deadlock regression: the guard flag used to be set before an
     // unguarded fetch and cleared only on the line after it, so a throw left it
     // set forever and every later workout import returned early — silently, for
@@ -2470,27 +2674,40 @@ void main() {
       expect(mobileImport.workoutImportRunning, isFalse);
     });
 
-    test('a later delta still runs after an earlier one failed', () async {
-      final mobileImport = createMobileHealthImport();
+    test('a later delta still runs after an earlier one failed', () {
+      fakeAsync((async) {
+        final mobileImport = createMobileHealthImport();
 
-      when(() => mockJournalDb.latestWorkout()).thenThrow(Exception('db down'));
+        when(
+          () => mockJournalDb.latestWorkout(),
+        ).thenThrow(Exception('db down'));
 
-      final first = await mobileImport.getWorkoutsHealthDataDelta();
-      expect(first.status, HealthImportStatus.failed);
-      expect(mobileImport.workoutImportRunning, isFalse);
+        HealthImportResult? first;
+        mobileImport.getWorkoutsHealthDataDelta().then((r) => first = r);
+        async.flushMicrotasks();
+        expect(first?.status, HealthImportStatus.failed);
+        expect(mobileImport.workoutImportRunning, isFalse);
 
-      when(() => mockJournalDb.latestWorkout()).thenAnswer((_) async => null);
-      stubHealthStore();
+        when(() => mockJournalDb.latestWorkout()).thenAnswer((_) async => null);
+        stubHealthStore();
 
-      final second = await mobileImport.getWorkoutsHealthDataDelta();
-      expect(second.status, isNot(HealthImportStatus.failed));
-      verify(
-        () => mockHealthService.getHealthDataFromTypes(
-          types: workoutTypes,
-          startTime: any(named: 'startTime'),
-          endTime: any(named: 'endTime'),
-        ),
-      ).called(1);
+        // A failed run still counts towards the throttle (see the throttling
+        // group); what must not happen is the guard flag wedging the delta
+        // for the rest of the session.
+        async.elapse(HealthImport.workoutDeltaInterval);
+        HealthImportResult? second;
+        mobileImport.getWorkoutsHealthDataDelta().then((r) => second = r);
+        async.flushMicrotasks();
+
+        expect(second?.status, isNot(HealthImportStatus.failed));
+        verify(
+          () => mockHealthService.getHealthDataFromTypes(
+            types: workoutTypes,
+            startTime: any(named: 'startTime'),
+            endTime: any(named: 'endTime'),
+          ),
+        ).called(1);
+      });
     });
 
     test('a failing DB read is logged against the delta sub-domain', () async {

--- a/test/logic/health_workout_types_test.dart
+++ b/test/logic/health_workout_types_test.dart
@@ -1,0 +1,240 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
+import 'package:health/health.dart';
+import 'package:lotti/features/dashboards/config/dashboard_workout_config.dart'
+    as catalogue;
+import 'package:lotti/logic/health_workout_types.dart';
+
+/// Spellings in the shapes the two import eras — and a few stray inputs —
+/// produce: the fork's camelCase, the plugin's UPPER_SNAKE, and fragments
+/// with no letters or a lone capital.
+extension _AnyWorkoutSpelling on glados.Any {
+  glados.Generator<String> get workoutSegment => choose(const [
+    'walking',
+    'RUNNING',
+    'Strength',
+    'training',
+    'BIKING',
+    'x',
+    'A',
+    '1',
+    '',
+  ]);
+
+  glados.Generator<String> get workoutSpelling => combine2(
+    list(workoutSegment),
+    choose(const ['_', '']),
+    (List<String> segments, String separator) => segments.join(separator),
+  );
+
+  glados.Generator<HealthWorkoutActivityType> get activity =>
+      choose(HealthWorkoutActivityType.values);
+}
+
+void main() {
+  group('canonicalWorkoutType', () {
+    test('folds the plugin enum name into lowerCamelCase', () {
+      expect(canonicalWorkoutType('WALKING'), 'walking');
+      expect(
+        canonicalWorkoutType('FUNCTIONAL_STRENGTH_TRAINING'),
+        'functionalStrengthTraining',
+      );
+      expect(
+        canonicalWorkoutType('HIGH_INTENSITY_INTERVAL_TRAINING'),
+        'highIntensityIntervalTraining',
+      );
+    });
+
+    test("maps the plugin's BIKING onto the cycling HealthKit records", () {
+      expect(canonicalWorkoutType('BIKING'), 'cycling');
+      expect(canonicalWorkoutType('biking'), 'cycling');
+      // Only the bare activity is aliased; a stationary bike is its own type.
+      expect(canonicalWorkoutType('BIKING_STATIONARY'), 'bikingStationary');
+    });
+
+    test('passes an already canonical value through unchanged', () {
+      for (final canonical in const [
+        'walking',
+        'running',
+        'cycling',
+        'functionalStrengthTraining',
+      ]) {
+        expect(canonicalWorkoutType(canonical), canonical);
+      }
+    });
+
+    test('folds a stray leading capital', () {
+      expect(canonicalWorkoutType('Running'), 'running');
+    });
+
+    test('trims whitespace', () {
+      expect(canonicalWorkoutType('  WALKING '), 'walking');
+      expect(canonicalWorkoutType(' running'), 'running');
+    });
+
+    test('settles empty and underscore-only input on the empty string', () {
+      expect(canonicalWorkoutType(''), '');
+      expect(canonicalWorkoutType('   '), '');
+      expect(canonicalWorkoutType('___'), '');
+    });
+
+    test('lower-cases a value without a single lower-case letter', () {
+      expect(canonicalWorkoutType('A'), 'a');
+      expect(canonicalWorkoutType('1_A'), '1a');
+      expect(canonicalWorkoutType('123'), '123');
+    });
+  });
+
+  group('workoutTypeForActivity', () {
+    test('maps every plugin activity to a canonical, distinct name', () {
+      final seen = <String>{};
+      for (final activity in HealthWorkoutActivityType.values) {
+        final type = workoutTypeForActivity(activity);
+        expect(type, isNotEmpty, reason: activity.name);
+        expect(type, isNot(contains('_')), reason: activity.name);
+        expect(type[0], type[0].toLowerCase(), reason: activity.name);
+        expect(canonicalWorkoutType(type), type, reason: activity.name);
+        expect(seen.add(type), isTrue, reason: '$type is produced twice');
+      }
+    });
+
+    test('names the four activities the dashboards chart', () {
+      expect(
+        workoutTypeForActivity(HealthWorkoutActivityType.WALKING),
+        'walking',
+      );
+      expect(
+        workoutTypeForActivity(HealthWorkoutActivityType.RUNNING),
+        'running',
+      );
+      expect(
+        workoutTypeForActivity(HealthWorkoutActivityType.SWIMMING),
+        'swimming',
+      );
+      expect(
+        workoutTypeForActivity(
+          HealthWorkoutActivityType.FUNCTIONAL_STRENGTH_TRAINING,
+        ),
+        'functionalStrengthTraining',
+      );
+    });
+  });
+
+  group('the dashboard catalogue', () {
+    test('is spelled canonically, so imported rows match it', () {
+      for (final item in catalogue.workoutTypes.values) {
+        expect(
+          canonicalWorkoutType(item.workoutType),
+          item.workoutType,
+          reason: item.displayName,
+        );
+      }
+    });
+
+    test('charts only activities the plugin can deliver', () {
+      final deliverable = HealthWorkoutActivityType.values
+          .map(workoutTypeForActivity)
+          .toSet();
+      for (final item in catalogue.workoutTypes.values) {
+        expect(
+          deliverable,
+          contains(item.workoutType),
+          reason: item.displayName,
+        );
+      }
+    });
+  });
+
+  group('isSameWorkoutType', () {
+    test('matches an activity across both eras', () {
+      expect(isSameWorkoutType('WALKING', 'walking'), isTrue);
+      expect(isSameWorkoutType('walking', 'WALKING'), isTrue);
+      expect(
+        isSameWorkoutType(
+          'FUNCTIONAL_STRENGTH_TRAINING',
+          'functionalStrengthTraining',
+        ),
+        isTrue,
+      );
+      expect(isSameWorkoutType('BIKING', 'cycling'), isTrue);
+    });
+
+    test('keeps different activities apart, prefixes included', () {
+      expect(isSameWorkoutType('walking', 'running'), isFalse);
+      expect(isSameWorkoutType('walk', 'walking'), isFalse);
+      expect(isSameWorkoutType('WALKING_TREADMILL', 'walking'), isFalse);
+    });
+  });
+
+  group('properties', () {
+    glados.Glados(
+      glados.any.workoutSpelling,
+      glados.ExploreConfig(numRuns: 160),
+    ).test(
+      'canonicalWorkoutType is idempotent',
+      (raw) {
+        final once = canonicalWorkoutType(raw);
+        expect(canonicalWorkoutType(once), once, reason: 'raw: "$raw"');
+      },
+      tags: 'glados',
+    );
+
+    glados.Glados(
+      glados.any.workoutSpelling,
+      glados.ExploreConfig(numRuns: 160),
+    ).test(
+      'the canonical form has no underscores and no leading capital',
+      (raw) {
+        final canonical = canonicalWorkoutType(raw);
+        expect(canonical, isNot(contains('_')), reason: 'raw: "$raw"');
+        if (canonical.isNotEmpty) {
+          expect(
+            canonical[0],
+            canonical[0].toLowerCase(),
+            reason: 'raw: "$raw"',
+          );
+        }
+      },
+      tags: 'glados',
+    );
+
+    glados.Glados2(
+      glados.any.workoutSpelling,
+      glados.any.workoutSpelling,
+      glados.ExploreConfig(numRuns: 120),
+    ).test(
+      'isSameWorkoutType is reflexive and symmetric',
+      (a, b) {
+        expect(isSameWorkoutType(a, a), isTrue, reason: 'a: "$a"');
+        expect(
+          isSameWorkoutType(a, b),
+          isSameWorkoutType(b, a),
+          reason: 'a: "$a", b: "$b"',
+        );
+      },
+      tags: 'glados',
+    );
+
+    glados.Glados(
+      glados.any.activity,
+      glados.ExploreConfig(numRuns: 120),
+    ).test(
+      'every spelling of a plugin activity names the same canonical type',
+      (activity) {
+        final canonical = workoutTypeForActivity(activity);
+        for (final spelling in [
+          activity.name,
+          activity.name.toLowerCase(),
+          canonical,
+        ]) {
+          expect(
+            isSameWorkoutType(spelling, canonical),
+            isTrue,
+            reason: '${activity.name} as "$spelling"',
+          );
+        }
+      },
+      tags: 'glados',
+    );
+  });
+}

--- a/test/logic/health_workout_types_test.dart
+++ b/test/logic/health_workout_types_test.dart
@@ -166,6 +166,38 @@ void main() {
     });
   });
 
+  group('workoutTypeSpellings', () {
+    test('covers both eras for a simple activity, canonical first', () {
+      expect(workoutTypeSpellings('running'), ['running', 'RUNNING']);
+      expect(workoutTypeSpellings('RUNNING'), ['running', 'RUNNING']);
+    });
+
+    test('covers the alias family for cycling, from either name', () {
+      const family = ['cycling', 'CYCLING', 'biking', 'BIKING'];
+      expect(workoutTypeSpellings('cycling'), family);
+      expect(workoutTypeSpellings('BIKING'), family);
+    });
+
+    test('keeps an off-era raw spelling as a last resort', () {
+      expect(
+        workoutTypeSpellings('Running'),
+        ['running', 'RUNNING', 'Running'],
+      );
+    });
+
+    test('splits a multi-word activity back into the plugin spelling', () {
+      expect(workoutTypeSpellings('functionalStrengthTraining'), [
+        'functionalStrengthTraining',
+        'FUNCTIONAL_STRENGTH_TRAINING',
+      ]);
+    });
+
+    test('drops empty input instead of querying for nothing', () {
+      expect(workoutTypeSpellings(''), isEmpty);
+      expect(workoutTypeSpellings('   '), isEmpty);
+    });
+  });
+
   group('properties', () {
     glados.Glados(
       glados.any.workoutSpelling,
@@ -211,6 +243,35 @@ void main() {
           isSameWorkoutType(b, a),
           reason: 'a: "$a", b: "$b"',
         );
+      },
+      tags: 'glados',
+    );
+
+    glados.Glados(
+      glados.any.activity,
+      glados.ExploreConfig(numRuns: 120),
+    ).test(
+      'workoutTypeSpellings bridges the plugin name and the canonical form',
+      (activity) {
+        final canonical = workoutTypeForActivity(activity);
+        final fromCanonical = workoutTypeSpellings(canonical);
+        expect(
+          fromCanonical,
+          containsAll([canonical, activity.name]),
+          reason: activity.name,
+        );
+        expect(
+          workoutTypeSpellings(activity.name),
+          fromCanonical,
+          reason: '${activity.name}: both directions yield one family',
+        );
+        for (final spelling in fromCanonical) {
+          expect(
+            canonicalWorkoutType(spelling),
+            canonical,
+            reason: '${activity.name} spelling "$spelling"',
+          );
+        }
       },
       tags: 'glados',
     );

--- a/test/logic/signals/health_signal_refresh_service_test.dart
+++ b/test/logic/signals/health_signal_refresh_service_test.dart
@@ -69,6 +69,52 @@ void main() {
     ).called(1);
   });
 
+  test('refreshWorkouts runs the workout delta', () async {
+    when(
+      healthImport.getWorkoutsHealthDataDelta,
+    ).thenAnswer((_) async => const HealthImportResult.imported(0));
+
+    await HealthSignalRefreshService(healthImport).refreshWorkouts();
+
+    verify(healthImport.getWorkoutsHealthDataDelta).called(1);
+  });
+
+  test('refreshWorkouts contains and logs a failing delta', () async {
+    final loggingService = MockLoggingService();
+    stubLoggingService(loggingService);
+    when(
+      healthImport.getWorkoutsHealthDataDelta,
+    ).thenThrow(StateError('health store unavailable'));
+    final service = HealthSignalRefreshService(
+      healthImport,
+      DomainLogger(loggingService: loggingService),
+    );
+
+    await expectLater(service.refreshWorkouts(), completes);
+
+    verify(
+      () => loggingService.captureException(
+        any<dynamic>(),
+        domain: any(named: 'domain'),
+        subDomain: 'healthSignalRefresh',
+        stackTrace: any<dynamic>(named: 'stackTrace'),
+        level: any(named: 'level'),
+        type: any(named: 'type'),
+      ),
+    ).called(1);
+  });
+
+  test('refreshWorkouts without a logger swallows the failure', () async {
+    when(
+      healthImport.getWorkoutsHealthDataDelta,
+    ).thenThrow(StateError('health store unavailable'));
+
+    await expectLater(
+      HealthSignalRefreshService(healthImport).refreshWorkouts(),
+      completes,
+    );
+  });
+
   test('provider resolves only when the profile registers an importer', () {
     final absent = ProviderContainer();
     addTearDown(absent.dispose);

--- a/test/logic/signals/signal_needs_test.dart
+++ b/test/logic/signals/signal_needs_test.dart
@@ -30,6 +30,59 @@ void main() {
     expect(needs.isEmpty, isFalse);
   });
 
+  group('notificationTokens', () {
+    test('expands a workout type to every spelling, the rest verbatim', () {
+      const rule = AutoCompleteRule.and(
+        rules: [
+          AutoCompleteRule.measurable(dataTypeId: 'water'),
+          AutoCompleteRule.health(dataType: 'cumulative_step_count'),
+          AutoCompleteRule.workout(dataType: 'RUNNING'),
+          AutoCompleteRule.habit(habitId: 'habit-a'),
+        ],
+      );
+      expect(SignalNeeds.of(rule).notificationTokens, {
+        'water',
+        'cumulative_step_count',
+        'running',
+        'RUNNING',
+        'habit-a',
+      });
+    });
+
+    // A rule persisted in either era must be told about a workout stored in
+    // the other: the row notifies under its stored type only.
+    test('a plugin-era rule hears a canonical write and vice versa', () {
+      const pluginEra = AutoCompleteRule.workout(dataType: 'RUNNING');
+      const canonical = AutoCompleteRule.workout(dataType: 'running');
+      expect(
+        SignalNeeds.of(pluginEra).notificationTokens,
+        contains('running'),
+      );
+      expect(
+        SignalNeeds.of(canonical).notificationTokens,
+        contains('RUNNING'),
+      );
+    });
+
+    test('covers the alias family', () {
+      expect(
+        SignalNeeds.of(
+          const AutoCompleteRule.workout(dataType: 'cycling'),
+        ).notificationTokens,
+        {'cycling', 'CYCLING', 'biking', 'BIKING'},
+      );
+    });
+
+    test('is empty for an empty tree', () {
+      expect(
+        SignalNeeds.of(
+          const AutoCompleteRule.and(rules: []),
+        ).notificationTokens,
+        isEmpty,
+      );
+    });
+  });
+
   test('an empty composite needs nothing', () {
     expect(
       SignalNeeds.of(const AutoCompleteRule.and(rules: [])).isEmpty,

--- a/test/logic/signals/signal_reader_test.dart
+++ b/test/logic/signals/signal_reader_test.dart
@@ -204,6 +204,90 @@ void main() {
     },
   );
 
+  group('workoutEntities across spelling eras', () {
+    final rangeStart = DateTime(2026, 8);
+    final rangeEnd = DateTime(2026, 8, 9);
+
+    void stubSpelling(String spelling, List<JournalEntity> entities) => when(
+      () => journalDb.getWorkoutsByType(
+        workoutType: spelling,
+        rangeStart: any(named: 'rangeStart'),
+        rangeEnd: any(named: 'rangeEnd'),
+      ),
+    ).thenAnswer((_) async => entities);
+
+    // The picker persisted whatever spelling the rows carried at the time, so
+    // a rule keyed `RUNNING` (created against plugin-era rows) must keep
+    // matching once new rows are stored as `running` — and vice versa.
+    test('merges rows stored in either spelling, newest first', () async {
+      final older = workoutEntity(
+        DateTime(2026, 8, 5, 7),
+        length: const Duration(minutes: 30),
+      );
+      final newer = workoutEntity(
+        DateTime(2026, 8, 7, 7),
+        length: const Duration(minutes: 45),
+      );
+      stubWorkouts(const []);
+      stubSpelling('running', [older]);
+      stubSpelling('RUNNING', [newer]);
+
+      final entities = await reader.workoutEntities(
+        workoutType: 'RUNNING',
+        rangeStart: rangeStart,
+        rangeEnd: rangeEnd,
+      );
+
+      expect(entities, [newer, older]);
+      for (final spelling in ['running', 'RUNNING']) {
+        verify(
+          () => journalDb.getWorkoutsByType(
+            workoutType: spelling,
+            rangeStart: rangeStart,
+            rangeEnd: rangeEnd,
+          ),
+        ).called(1);
+      }
+    });
+
+    test('a row answering under both spellings counts once', () async {
+      final run = workoutEntity(
+        DateTime(2026, 8, 5, 7),
+        length: const Duration(minutes: 30),
+      );
+      stubWorkouts(const []);
+      stubSpelling('running', [run]);
+      stubSpelling('RUNNING', [run]);
+
+      final entities = await reader.workoutEntities(
+        workoutType: 'running',
+        rangeStart: rangeStart,
+        rangeEnd: rangeEnd,
+      );
+
+      expect(entities, [run]);
+    });
+
+    test('a plugin-era rule reads canonical rows through read()', () async {
+      stubWorkouts(const []);
+      final run = workoutEntity(
+        DateTime(2026, 8, 8, 7),
+        length: const Duration(minutes: 30),
+      );
+      stubSpelling('running', [run]);
+
+      final window = await reader.read(
+        rule: const AutoCompleteRule.workout(dataType: 'RUNNING'),
+        reference: reference,
+      );
+
+      // Bucketed under the rule's own key, so the evaluator finds it.
+      expect(window.workoutsByDay['RUNNING'], {
+        todayKey: [(run as WorkoutEntry).data],
+      });
+    });
+  });
+
   test('a rule that needs nothing touches the database not at all', () async {
     final window = await reader.read(
       rule: const AutoCompleteRule.and(rules: []),


### PR DESCRIPTION
## Summary

- store imported workouts under Lotti's canonical camelCase activity name
  (`walking`, `functionalStrengthTraining`, `cycling`) instead of the upstream
  plugin's `WALKING` / `FUNCTIONAL_STRENGTH_TRAINING` / `BIKING`, via a new
  idempotent `canonicalWorkoutType`
- compare workout types across both spellings in `aggregateWorkoutDailySum`,
  `WorkoutObservationsController` and `WorkoutSummary`, so the workouts imported
  since the plugin switch chart again without a data migration; the detail card
  now matches the activity exactly rather than a substring of the catalogue key
- match habit workout signals across both spellings too: the signal reader
  queries every known spelling of the chosen activity
  (`workoutTypeSpellings`), `SignalNeeds.notificationTokens` expands a rule's
  workout types the same way so a write in the other spelling still triggers
  evaluation, the picker canonicalises and de-duplicates, and
  `HabitFormMapping.fromRule` reads a persisted leaf back canonical (collapsing
  `RUNNING` beside `running`), so a rule persisted in either era matches, hears
  and edits as one signal
- title workouts on the Daily OS Actual lane by their activity ("Walking") and
  nudge the workout delta from that lane through
  `HealthSignalRefreshService.refreshWorkouts()`
- throttle `getWorkoutsHealthDataDelta` to one run per ten minutes, and keep the
  source app of workouts imported on Android (Health Connect leaves `sourceId`
  empty)

## Root causes

1. **Type spelling drift since #2041.** The `flutter_health_fit` fork named
   activities `walking` / `functionalStrengthTraining`; the dashboard catalogue
   (`dashboard_workout_config.dart`, unchanged since 2022), every persisted
   `DashboardWorkoutItem` and every stored row used that. The upstream `health`
   plugin names them `WALKING` / `FUNCTIONAL_STRENGTH_TRAINING`, and
   `_getWorkoutsHealthData` stored `value.workoutActivityType.name` verbatim.
   `aggregateWorkoutDailySum` and the controller's empty check compared exactly,
   so every workout imported since May 2025 rendered as "No data", and
   `WorkoutSummary`'s `key.contains(workoutType)` found no charts.
2. **No title for a workout on the Actual lane.** `_actualBlockTitle` fell back
   task → entry text → category → entry id; an imported workout has none of the
   first three, so the lane printed a UUID.
3. **No importer on the Daily OS surface.** The only callers of
   `getWorkoutsHealthDataDelta` have ever been the dashboard workout chart's
   controller and the Health Import page, so with Daily OS as the primary
   surface nothing pulled new workouts in.

## Not in this PR (flagged)

- **Android Health Connect permissions are not declared.**
  `android/app/src/main/AndroidManifest.xml` has never carried any
  `android.permission.health.READ_*` permission (nor `ACTIVITY_RECOGNITION`,
  which the app requests at runtime), so Health Connect cannot grant workout,
  step or sleep reads on Android at all. Declaring them is a Play Console
  (Health Connect declaration form) decision, so it is left for a separate
  change.
- Rows imported between #2041 and this fix keep their stored `WALKING`
  spelling. Every reader handles both spellings, so nothing needs a rewrite
  for matching; unifying the stored strings themselves would be a one-off in
  the shape of `SleepAsleepBackfillService` if ever wanted.

## Verification

- `fvm dart analyze` on every touched file: zero issues
- 339 targeted tests across `health_workout_types_test` (new, with Glados
  properties: idempotence, no-underscore/leading-lowercase shape,
  reflexive/symmetric `isSameWorkoutType`, every plugin activity across
  spellings), `health_import_test`, `health_signal_refresh_service_test`,
  `actual_time_blocks_provider_test` (incl. new provider-level tests),
  `workout_data_test`, `workout_chart_controller_test`, `workout_summary_test`,
  `entry_tools_test`, `signal_reader_test`, `habit_editor_providers_test`,
  `signal_needs_test`, `habit_form_mapping_test`,
  `habit_auto_completion_service_test`, `habit_signal_status_controller_test`
- every changed source line is covered (lcov over the touched files)
- with each behavioural fix reverted (API kept so the suites compile), 26 of
  the new/updated tests fail — spelling at import, cross-era matching in the
  aggregation/controller/summary, the lane title and nudge, the throttle, the
  Android source fallback, `refreshWorkouts`; restored, all 251 pass
- `make knowledge_check`, `make changelog_check`

## Screenshots

Hosted in `matthiasn/lotti-docs` on branch `agent/workout-import-type-drift-screenshots` (commit `4713570ab77f5beca5d27344f3cbc4d28dca1fcc`), the way earlier PRs from this account did; the identical pair is staged at `/tmp/lotti-pr-screenshots/workout-import-type-drift/` for `make pr_screenshots_publish` if the R2 copy is wanted. App commit `85d97c42ea621a518478b1612288a52523967a6e`.

Before is the base commit; after is this branch. Fixtures are synthetic
(a 45-minute walk stored as the plugin's `WALKING`).

### Daily OS timeline — Actual lane, desktop dark

| Before | After |
|---|---|
| ![Timeline desktop before](https://raw.githubusercontent.com/matthiasn/lotti-docs/4713570ab77f5beca5d27344f3cbc4d28dca1fcc/pr-screenshots/workout-import-type-drift/before/daily_os_timeline_desktop_dark.png) | ![Timeline desktop after](https://raw.githubusercontent.com/matthiasn/lotti-docs/4713570ab77f5beca5d27344f3cbc4d28dca1fcc/pr-screenshots/workout-import-type-drift/after/daily_os_timeline_desktop_dark.png) |

### Daily OS timeline — Actual lane, mobile dark

| Before | After |
|---|---|
| ![Timeline mobile before](https://raw.githubusercontent.com/matthiasn/lotti-docs/4713570ab77f5beca5d27344f3cbc4d28dca1fcc/pr-screenshots/workout-import-type-drift/before/daily_os_timeline_mobile_dark.png) | ![Timeline mobile after](https://raw.githubusercontent.com/matthiasn/lotti-docs/4713570ab77f5beca5d27344f3cbc4d28dca1fcc/pr-screenshots/workout-import-type-drift/after/daily_os_timeline_mobile_dark.png) |

### Dashboard workout chart — mobile dark

| Before | After |
|---|---|
| ![Chart mobile before](https://raw.githubusercontent.com/matthiasn/lotti-docs/4713570ab77f5beca5d27344f3cbc4d28dca1fcc/pr-screenshots/workout-import-type-drift/before/workout_dashboard_chart_mobile_dark.png) | ![Chart mobile after](https://raw.githubusercontent.com/matthiasn/lotti-docs/4713570ab77f5beca5d27344f3cbc4d28dca1fcc/pr-screenshots/workout-import-type-drift/after/workout_dashboard_chart_mobile_dark.png) |

### Dashboard workout chart — desktop dark

| Before | After |
|---|---|
| ![Chart desktop before](https://raw.githubusercontent.com/matthiasn/lotti-docs/4713570ab77f5beca5d27344f3cbc4d28dca1fcc/pr-screenshots/workout-import-type-drift/before/workout_dashboard_chart_desktop_dark.png) | ![Chart desktop after](https://raw.githubusercontent.com/matthiasn/lotti-docs/4713570ab77f5beca5d27344f3cbc4d28dca1fcc/pr-screenshots/workout-import-type-drift/after/workout_dashboard_chart_desktop_dark.png) |

### Workout entry detail — mobile dark

| Before | After |
|---|---|
| ![Detail mobile before](https://raw.githubusercontent.com/matthiasn/lotti-docs/4713570ab77f5beca5d27344f3cbc4d28dca1fcc/pr-screenshots/workout-import-type-drift/before/workout_entry_detail_mobile_dark.png) | ![Detail mobile after](https://raw.githubusercontent.com/matthiasn/lotti-docs/4713570ab77f5beca5d27344f3cbc4d28dca1fcc/pr-screenshots/workout-import-type-drift/after/workout_entry_detail_mobile_dark.png) |

### Workout entry detail — desktop light

| Before | After |
|---|---|
| ![Detail desktop before](https://raw.githubusercontent.com/matthiasn/lotti-docs/4713570ab77f5beca5d27344f3cbc4d28dca1fcc/pr-screenshots/workout-import-type-drift/before/workout_entry_detail_desktop_light.png) | ![Detail desktop after](https://raw.githubusercontent.com/matthiasn/lotti-docs/4713570ab77f5beca5d27344f3cbc4d28dca1fcc/pr-screenshots/workout-import-type-drift/after/workout_entry_detail_desktop_light.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJJwntNc5i6m7rCvFgpb3x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored imported workouts in dashboards, workout details, habits, and the Daily OS timeline.
  * Workout types with different spelling or capitalization now match consistently across charts, habits, goals, and health imports.
  * Daily OS entries show readable activity names instead of internal identifiers.
  * Opening a day refreshes newly imported workouts automatically, with refreshes limited to avoid unnecessary updates.
  * Imported workout sources are preserved more reliably, with duplicate and legacy records handled correctly.

* **Documentation**
  * Updated health import, dashboard, habits, and Daily OS documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

