### PR TITLE
fix(settings): the settings header switches theme with the page

### DIFF
--- a/changelog.d/2026-09-01-settings-header-theme-switch.md
+++ b/changelog.d/2026-09-01-settings-header-theme-switch.md
@@ -1,0 +1,7 @@
+### Fixed
+- **The settings header now switches theme together with the page.** Picking
+  Light or Dark on the Theming page re-themed the page body at once, but the
+  title bar above it kept the previous theme — a white bar over a dark page,
+  with its title turned invisible — until the page was left and opened again.
+  The header follows the switch immediately, on the Theming page and on every
+  other settings page that uses the same header.

--- a/knowledge/features/design_system/tokens-and-theming.md
+++ b/knowledge/features/design_system/tokens-and-theming.md
@@ -28,6 +28,10 @@ sources:
     resource: ../../../lib/themes/theme_overrides.dart
     title: App theme integration
     last_modified: 2026-07-15
+  - id: settings-header
+    resource: ../../../lib/widgets/app_bar/settings_page_header.dart
+    title: The sliver settings header — tokens read below the delegate
+    last_modified: 2026-09-01
 ---
 
 # The pipeline
@@ -131,6 +135,37 @@ final tokens = context.designTokens;
 `designTokens` throws a `StateError` when the extension is missing. **The explicit
 null check is deliberate** — missing token injection is a wiring bug, not
 something a widget should quietly improvise around.
+
+### Read tokens in a widget, never in a sliver delegate's `build`
+
+`context.designTokens` is `Theme.of(context)` underneath, so it registers a
+theme dependency on whichever element the `context` is. Inside a widget's
+`build` that is the widget's own element and the read follows every theme
+change. Inside `SliverPersistentHeaderDelegate.build` it is the sliver's
+render-object element, and there the dependency can be silently lost:
+
+```mermaid
+sequenceDiagram
+  participant Theme as _InheritedTheme
+  participant Page as Host page (reads tokens for its scaffold)
+  participant Sliver as _SliverPersistentHeaderElement
+  Theme->>Page: didChangeDependencies → dirty
+  Theme->>Sliver: didChangeDependencies → dirty
+  Note over Page,Sliver: build phase, shallowest first
+  Page->>Sliver: update(new delegate)
+  Note over Sliver: RenderObjectElement.update clears the dirty flag
+  Sliver->>Sliver: shouldRebuild(old)? geometry and content only → false
+  Note over Sliver: rebuild() later: not dirty → no-op, delegate never rebuilt
+```
+
+The settings header hit exactly this: its surface colour was read in the
+delegate, the page above it reads tokens for its scaffold colour, and after a
+light/dark switch the bar kept the old theme until the route was rebuilt from
+scratch. The fix is structural, not a `shouldRebuild` tweak —
+`SettingsPageHeader` keeps every theme read in widgets *below* the sliver, so
+each owns an element whose dirty flag nothing else clears. Any new delegate
+follows the same rule: the delegate carries geometry and content, the widgets
+it builds resolve the tokens.
 
 # The alert ramp: `default` fills, `ink` writes
 

--- a/lib/widgets/app_bar/settings_page_header.dart
+++ b/lib/widgets/app_bar/settings_page_header.dart
@@ -14,6 +14,12 @@ import 'package:lotti/widgets/app_bar/settings_header_bar.dart';
 ///
 /// An optional [bottom] accessory (e.g. a sync filter-chip row) renders
 /// beneath the title; the bottom hairline sits below it.
+///
+/// The sliver delegate carries geometry and content only. Everything the
+/// theme decides — the surface colour, the hairline, the title typography —
+/// is resolved by widgets *below* the sliver ([_SettingsHeaderSurface],
+/// [SettingsHeaderBar]), never inside the delegate's `build`; see
+/// [_SettingsHeaderSurface] for why that distinction matters.
 class SettingsPageHeader extends StatelessWidget {
   const SettingsPageHeader({
     required this.title,
@@ -96,15 +102,8 @@ class _SettingsHeaderDelegate extends SliverPersistentHeaderDelegate {
 
   @override
   Widget build(BuildContext context, double shrinkOffset, bool overlaps) {
-    final tokens = context.designTokens;
     final accessory = bottom;
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: tokens.colors.background.level01,
-        border: Border(
-          bottom: BorderSide(color: tokens.colors.decorative.level01),
-        ),
-      ),
+    return _SettingsHeaderSurface(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
@@ -136,4 +135,37 @@ class _SettingsHeaderDelegate extends SliverPersistentHeaderDelegate {
       old.onBack != onBack ||
       old.bottom != bottom ||
       old.actions != actions;
+}
+
+/// The header's painted surface — the level-01 background under a decorative
+/// bottom hairline — resolved from the theme by a widget of its own.
+///
+/// Every theme read belongs in a widget below the sliver, never in the
+/// delegate's `build`: that `build` runs with the sliver's render-object
+/// element as its context, and when the host page rebuilds in the same frame
+/// as a theme switch, the sliver's `update` clears its dirty flag before the
+/// `performRebuild` that would rebuild the delegate ever runs — so a surface
+/// painted there kept the previous theme until the route was rebuilt. A
+/// widget owns an element nothing else clears and re-resolves the tokens on
+/// every theme change. The full sequence is in
+/// `knowledge/features/design_system/tokens-and-theming.md`, under "Read
+/// tokens in a widget, never in a sliver delegate's `build`".
+class _SettingsHeaderSurface extends StatelessWidget {
+  const _SettingsHeaderSurface({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: tokens.colors.background.level01,
+        border: Border(
+          bottom: BorderSide(color: tokens.colors.decorative.level01),
+        ),
+      ),
+      child: child,
+    );
+  }
 }

--- a/test/README.md
+++ b/test/README.md
@@ -142,6 +142,23 @@ rows' rects must not change across hover).
 `onHoverChanged` only when it has an `onTap`, so a list of non-tappable rows
 (the Logging settings switches) has no hover state to test.
 
+## Settings header surface: `test_utils/settings_header_harness.dart`
+
+`settingsHeaderSurface(tester)` reads back the `BoxDecoration` the sliver
+`SettingsPageHeader` paints — its background and bottom hairline, the one
+theme-dependent value the header paints itself, so the first place a stale
+theme shows. Use it in the header's own tests and in any page that hosts the
+header and asserts the chrome followed a theme change, rather than hunting for
+the `DecoratedBox` by hand: only the helper knows the surface is one.
+
+When such a page drives `MaterialApp.themeMode` from `ThemingController`, pin
+`tester.platformDispatcher.platformBrightnessTestValue` to the stored mode
+first (and clear it in a teardown). The controller's first frame is always
+`ThemeMode.system`, so without the pin the page silently switches theme once
+on load — the header goes stale *there*, and a "dark → light" regression test
+then passes against the broken code because both sides are light again by the
+time it looks.
+
 ## Database test layout
 
 `lib/database/database.dart` and `lib/database/sync_db.dart` are shells (constructor + migration ladder) whose query surfaces live in `part` files holding private mixins (`database_task_queries.dart`, `sync_db_outbox.dart`, …). The tests mirror that layout one test file per part file:

--- a/test/features/goals/ui/checkins/goal_checkin_composer_test.dart
+++ b/test/features/goals/ui/checkins/goal_checkin_composer_test.dart
@@ -77,10 +77,14 @@ void main() {
 
   testWidgets('names the goal and the moment', (tester) async {
     await pump(tester);
-    await tester.pump();
+    // The frame that lands the resolved capture target rebuilds the header,
+    // and the header formats `clock.now()` on every build — so this pump has
+    // to run under the fixed clock too, or the month tracks the wall calendar
+    // (the test rolled over on 1 September).
+    await withClock(Clock.fixed(now), tester.pump);
 
     expect(find.text('Check in · Fitness'), findsOneWidget);
-    expect(find.textContaining('August'), findsOneWidget);
+    expect(find.textContaining('August 18, 2026'), findsOneWidget);
   });
 
   testWidgets('opens on the recorder, not on a keyboard', (tester) async {

--- a/test/features/settings/ui/pages/manual/theming_page_test.dart
+++ b/test/features/settings/ui/pages/manual/theming_page_test.dart
@@ -7,6 +7,7 @@ import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/design_system/components/buttons/ds_segmented_toggle.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/settings/ui/pages/theming_page.dart';
+import 'package:lotti/features/theming/state/theming_controller.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/l10n/app_localizations.dart';
 import 'package:lotti/services/db_notification.dart';
@@ -15,6 +16,7 @@ import 'package:lotti/utils/consts.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../../mocks/mocks.dart';
+import '../../../../../test_utils/settings_header_harness.dart';
 import '../../../../../widget_test_utils.dart';
 
 void main() {
@@ -70,21 +72,29 @@ void main() {
     GetIt.I.reset();
   });
 
+  /// The page under a `MaterialApp` whose theme mode follows the controller,
+  /// as `beamer_app` wires it — so a mode picked on the page re-themes the
+  /// very tree the page is rendered in.
   Widget createTestWidget({Locale? locale}) {
     return ProviderScope(
-      child: MaterialApp(
-        theme: resolveTestTheme(ThemeData.light()),
-        darkTheme: resolveTestTheme(ThemeData.dark()),
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        locale: locale,
-        home: const MediaQuery(
-          data: MediaQueryData(
-            size: Size(390, 844),
-            padding: EdgeInsets.only(top: 47),
+      child: Consumer(
+        builder: (context, ref, _) => MaterialApp(
+          theme: resolveTestTheme(ThemeData.light()),
+          darkTheme: resolveTestTheme(ThemeData.dark()),
+          themeMode: ref.watch(
+            themingControllerProvider.select((state) => state.themeMode),
           ),
-          child: Scaffold(
-            body: ThemingPage(),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: locale,
+          home: const MediaQuery(
+            data: MediaQueryData(
+              size: Size(390, 844),
+              padding: EdgeInsets.only(top: 47),
+            ),
+            child: Scaffold(
+              body: ThemingPage(),
+            ),
           ),
         ),
       ),
@@ -152,5 +162,49 @@ void main() {
         findsNWidgets(3), // dark, system, light
       );
     });
+
+    // The controller's first frame is ThemeMode.system, so the platform
+    // brightness is pinned to the stored mode: the tap is then the only
+    // theme switch the page goes through, and the header cannot go stale
+    // on a hidden first switch instead.
+    for (final (stored, platform, segment, brightness) in [
+      ('light', Brightness.light, LottiIcons.night, Brightness.dark),
+      ('dark', Brightness.dark, LottiIcons.day, Brightness.light),
+    ]) {
+      testWidgets(
+        'picking ${brightness.name} re-themes the page header with the body',
+        (tester) async {
+          when(
+            () => mockSettingsDb.itemByKey('THEME_MODE'),
+          ).thenAnswer((_) async => stored);
+          tester.platformDispatcher.platformBrightnessTestValue = platform;
+          addTearDown(
+            tester.platformDispatcher.clearPlatformBrightnessTestValue,
+          );
+          await tester.pumpWidget(
+            createTestWidget(locale: const Locale('en')),
+          );
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.byIcon(segment));
+          await tester.pumpAndSettle();
+
+          final body = tester.element(
+            find.byType(DsSegmentedToggle<ThemeMode>),
+          );
+          expect(
+            Theme.of(body).brightness,
+            brightness,
+            reason: 'the body must already wear the picked mode',
+          );
+          final surface = settingsHeaderSurface(tester);
+          expect(surface.color, body.designTokens.colors.background.level01);
+          expect(
+            surface.border?.bottom.color,
+            body.designTokens.colors.decorative.level01,
+          );
+        },
+      );
+    }
   });
 }

--- a/test/test_utils/settings_header_harness.dart
+++ b/test/test_utils/settings_header_harness.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/widgets/app_bar/settings_page_header.dart';
+
+/// The painted surface of the [SettingsPageHeader] on screen — the outermost
+/// [DecoratedBox] the sliver wraps around its content — as the decoration it
+/// currently carries.
+///
+/// The header's own tests and the pages that host it both read this back:
+/// the surface colour is the one theme-dependent value the header paints
+/// itself, so it is where a stale theme shows first. Only this helper knows
+/// that the surface is a `DecoratedBox`; if the header's structure changes,
+/// this is the one place to follow it.
+BoxDecoration settingsHeaderSurface(WidgetTester tester) {
+  final box = tester.widget<DecoratedBox>(
+    find
+        .descendant(
+          of: find.byType(SettingsPageHeader),
+          matching: find.byType(DecoratedBox),
+        )
+        .first,
+  );
+  return box.decoration as BoxDecoration;
+}

--- a/test/widgets/app_bar/settings_page_header_test.dart
+++ b/test/widgets/app_bar/settings_page_header_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/widgets/app_bar/settings_page_header.dart';
 
+import '../../test_utils/settings_header_harness.dart';
 import '../../widget_test_utils.dart';
 
 /// Pumps a [SettingsPageHeader] inside the standard scroll-view scaffolding,
@@ -23,8 +24,8 @@ Future<void> _pumpHeader(
 }) async {
   await tester.pumpWidget(
     MaterialApp(
-      // The header reads context.designTokens (for the bottom corner
-      // radius); the central helper attaches the brightness-matched
+      // The header reads context.designTokens (for its surface and title
+      // colours); the central helper attaches the brightness-matched
       // DsTokens extension to whatever theme the test supplies.
       theme: resolveTestTheme(theme ?? ThemeData.light()),
       home: MediaQuery(
@@ -55,6 +56,44 @@ Future<void> _pumpHeader(
   // scroll-gesture tests settle explicitly after dragging.
   await tester.pump();
   await tester.pump(const Duration(seconds: 1));
+}
+
+/// Pumps the header under a `MaterialApp` whose theme mode follows [mode],
+/// beneath an ancestor that reads the tokens for its own colour — the shape
+/// of `SliverBoxAdapterPage`, whose scaffold colour makes it rebuild in the
+/// very frame the theme changes and hand the sliver a fresh delegate.
+///
+/// [title] is a parameter so the header cannot be const-canonicalised: a
+/// const `SettingsPageHeader` would be reused across the ancestor's rebuilds
+/// and the sliver would never receive a new delegate, which is the half of
+/// the trap this host exists to reproduce.
+Future<void> _pumpThemeSwitchingHeader(
+  WidgetTester tester, {
+  required ValueNotifier<ThemeMode> mode,
+  required String title,
+}) async {
+  await tester.pumpWidget(
+    ValueListenableBuilder<ThemeMode>(
+      valueListenable: mode,
+      builder: (context, themeMode, _) => MaterialApp(
+        theme: resolveTestTheme(ThemeData.light()),
+        darkTheme: resolveTestTheme(ThemeData.dark()),
+        themeMode: themeMode,
+        home: Builder(
+          builder: (context) => Scaffold(
+            backgroundColor: context.designTokens.colors.background.level01,
+            body: CustomScrollView(
+              slivers: [
+                SettingsPageHeader(title: title),
+                const SliverToBoxAdapter(child: SizedBox(height: 400)),
+              ],
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
 }
 
 void main() {
@@ -238,6 +277,66 @@ void main() {
         );
       }
     });
+
+    for (final theme in [ThemeData.light(), ThemeData.dark()]) {
+      testWidgets(
+        'paints the level-01 background under a decorative hairline '
+        '(${theme.brightness.name})',
+        (tester) async {
+          await _pumpHeader(tester, theme: theme, contentHeight: 200);
+
+          final tokens = tester
+              .element(find.byType(SettingsPageHeader))
+              .designTokens;
+          final surface = settingsHeaderSurface(tester);
+          expect(surface.color, tokens.colors.background.level01);
+          expect(
+            surface.border?.bottom.color,
+            tokens.colors.decorative.level01,
+          );
+        },
+      );
+    }
+
+    for (final (from, to) in [
+      (ThemeMode.light, ThemeMode.dark),
+      (ThemeMode.dark, ThemeMode.light),
+    ]) {
+      testWidgets(
+        'surface follows a theme switch while a token-reading ancestor '
+        'rebuilds in the same frame (${from.name} to ${to.name})',
+        (tester) async {
+          final mode = ValueNotifier<ThemeMode>(from);
+          addTearDown(mode.dispose);
+          await _pumpThemeSwitchingHeader(
+            tester,
+            mode: mode,
+            title: 'Theming',
+          );
+
+          mode.value = to;
+          await tester.pumpAndSettle();
+
+          final dark = to == ThemeMode.dark;
+          final expected = dark ? dsTokensDark : dsTokensLight;
+          expect(
+            Theme.of(
+              tester.element(find.byType(SettingsPageHeader)),
+            ).brightness,
+            dark ? Brightness.dark : Brightness.light,
+            reason:
+                'the switch itself must have landed before the surface '
+                'is judged',
+          );
+          final surface = settingsHeaderSurface(tester);
+          expect(surface.color, expected.colors.background.level01);
+          expect(
+            surface.border?.bottom.color,
+            expected.colors.decorative.level01,
+          );
+        },
+      );
+    }
   });
 }
 


### PR DESCRIPTION
Switching the mode on the Theming page re-themed the page body at once, but the settings header above it kept the previous theme — a white bar over a dark page with its title turned white-on-white, or a dark bar with a black title over a light page — until the page was left and opened again.

## The cause

`SettingsPageHeader` painted its surface (the level-01 background and the decorative hairline) inside `SliverPersistentHeaderDelegate.build`. That `build` receives the sliver's own `RenderObjectElement` as its `BuildContext`, so `context.designTokens` registered the theme dependency on the sliver element itself. On a theme switch the framework does mark that element dirty — but the host page (`SliverBoxAdapterPage`, which reads the tokens for its scaffold colour) is a dependent too, sits shallower, and rebuilds first in the same frame. It hands the sliver a fresh delegate; `RenderObjectElement.update` clears the sliver's dirty flag on the way, and `shouldRebuild` — comparing geometry, title and actions only — returns `false`. When the build owner reaches the sliver element it is no longer dirty, so `_SliverPersistentHeaderElement.performRebuild` (the only path that calls `triggerRebuild`) never runs and the old `DecoratedBox` stays. The title inside `SettingsHeaderBar` *did* recolour, because it is a proper widget with its own element — which is exactly why the stale bar rendered its title invisible.

Verified against the Flutter 3.47.2 source (`_SliverPersistentHeaderElement.update` / `performRebuild`, `RenderObjectElement._performRebuild`) and reproduced in two tests that fail on `main` at the surface colour (expected `#181818`, got `#FFFFFF`).

## The fix

- The surface moves into a widget below the sliver (`_SettingsHeaderSurface`). It owns an element whose dirty flag nothing else clears, so it re-resolves the tokens on every theme change like any other widget. The delegate now carries geometry and content only; every theme read happens in widgets beneath it. This covers every settings surface on the header — leaf pages, definition lists and editors, sync, AI.
- Regression tests at the header: the surface follows a theme switch while a token-reading ancestor rebuilds in the same frame (both directions), and a token contract for the background + hairline in both brightnesses.
- Regression test on the Theming page: picking a mode re-themes the header together with the body, both directions, with the platform brightness pinned to the stored mode so the tap is the only switch the page goes through (the controller's first frame is `ThemeMode.system`, which otherwise hides a first switch and lets the dark→light case pass vacuously). The page test host now wires `MaterialApp.themeMode` from the controller the way `beamer_app` does.
- A `knowledge/` gotcha under the design-system access API, with the sequence diagram of the trap, so the next delegate does not repeat it.
- Changelog fragment.

## Screenshots

Hosted in `matthiasn/lotti-docs` on branch `agent/settings-header-theme-switch-screenshots` (commit `c57fe9b0864f33247ac4000ac0a780f20d808de3`), the way earlier PRs from this account did; the identical pair is staged at `/tmp/lotti-pr-screenshots/settings-header-theme-switch/` for `make pr_screenshots_publish` if the R2 copy is wanted.

Before is the base commit (`e13eb78db`); after is this branch. Captured with the widget-test harness at phone size, right after tapping the new mode. The Theming page holds nothing but the mode toggle — no user data.

### Theming page — right after switching Light → Dark — mobile

| Before | After |
|---|---|
| ![Switched to dark, before](https://raw.githubusercontent.com/matthiasn/lotti-docs/c57fe9b0864f33247ac4000ac0a780f20d808de3/pr-screenshots/settings-header-theme-switch/before/theming_page_after_switch_mobile_dark.png) | ![Switched to dark, after](https://raw.githubusercontent.com/matthiasn/lotti-docs/c57fe9b0864f33247ac4000ac0a780f20d808de3/pr-screenshots/settings-header-theme-switch/after/theming_page_after_switch_mobile_dark.png) |

### Theming page — right after switching Dark → Light — mobile

| Before | After |
|---|---|
| ![Switched to light, before](https://raw.githubusercontent.com/matthiasn/lotti-docs/c57fe9b0864f33247ac4000ac0a780f20d808de3/pr-screenshots/settings-header-theme-switch/before/theming_page_after_switch_mobile_light.png) | ![Switched to light, after](https://raw.githubusercontent.com/matthiasn/lotti-docs/c57fe9b0864f33247ac4000ac0a780f20d808de3/pr-screenshots/settings-header-theme-switch/after/theming_page_after_switch_mobile_light.png) |

## Verification

- `fvm dart analyze` on the touched files — clean; `fvm dart format --set-exit-if-changed` — clean
- `fvm flutter test test/widgets/app_bar/settings_page_header_test.dart test/features/settings/ui/pages/manual/theming_page_test.dart test/features/settings/ui/pages/sliver_box_adapter_page_test.dart test/widgets/app_bar/settings_header_bar_test.dart test/widgets/settings/settings_detail_scaffold_test.dart test/features/sync/ui/widgets/sync_list_scaffold_test.dart` — 48 passed
- Line coverage from that run: `settings_page_header.dart` 54/54 (100%), `theming_page.dart` 25/25, `sliver_box_adapter_page.dart` 33/33
- Both new regression tests re-run with the fix reverted: fail at the surface colour (expected `#181818`, got `#FFFFFF`)
- `make changelog_check`, `make knowledge_check` (validator + 511 Mermaid blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LFNff9mfhUMteQCJxPgdm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Settings page headers now switch themes immediately with the rest of the page.
  * Fixed stale header backgrounds and decorative borders when changing between light and dark themes.
  * Applied the fix consistently across Theming and other settings pages.
  * Header titles and decorative elements now remain visible and correctly styled after theme changes.

* **Documentation**
  * Added guidance for maintaining theme-aware settings headers and testing theme changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->