### PR TITLE
fix(l10n): distinct measurable choices heading in es, fr, pt, ro

### DIFF
--- a/changelog.d/2026-09-01-measurable-choices-heading.md
+++ b/changelog.d/2026-09-01-measurable-choices-heading.md
@@ -1,0 +1,4 @@
+### Fixed
+- **The measurable "Choices" heading no longer repeats the "Options" heading**
+  in Spanish, Portuguese and Romanian, and no longer reads the same as the
+  "Choice" value kind in French.

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4701,7 +4701,7 @@
   "settingsMeasurableChoicesArchivedTitle": "Opciones archivadas",
   "settingsMeasurableChoicesDescription": "Al registrar eliges una de ellas. Puedes renombrarlas o reordenarlas cuando quieras: las entradas ya registradas conservan su opción.",
   "settingsMeasurableChoicesRequired": "Añade al menos una opción",
-  "settingsMeasurableChoicesTitle": "Opciones",
+  "settingsMeasurableChoicesTitle": "Opciones de respuesta",
   "settingsMeasurableDeleteTooltip": "Eliminar tipo de medición",
   "settingsMeasurableDescriptionLabel": "Descripción (opcional)",
   "settingsMeasurableDetailsLabel": "Editar valor medible",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4701,7 +4701,7 @@
   "settingsMeasurableChoicesArchivedTitle": "Choix archivés",
   "settingsMeasurableChoicesDescription": "Tu en choisis un à chaque enregistrement. Renomme-les ou réordonne-les quand tu veux : les entrées déjà enregistrées gardent leur choix.",
   "settingsMeasurableChoicesRequired": "Ajoute au moins un choix",
-  "settingsMeasurableChoicesTitle": "Choix",
+  "settingsMeasurableChoicesTitle": "Choix possibles",
   "settingsMeasurableDeleteTooltip": "Supprimer type mesurable",
   "settingsMeasurableDescriptionLabel": "Description",
   "settingsMeasurableDetailsLabel": "Modifier l'élément mesurable",

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -12226,7 +12226,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsMeasurableChoicesRequired => 'Añade al menos una opción';
 
   @override
-  String get settingsMeasurableChoicesTitle => 'Opciones';
+  String get settingsMeasurableChoicesTitle => 'Opciones de respuesta';
 
   @override
   String get settingsMeasurableDeleteTooltip => 'Eliminar tipo de medición';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -12269,7 +12269,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsMeasurableChoicesRequired => 'Ajoute au moins un choix';
 
   @override
-  String get settingsMeasurableChoicesTitle => 'Choix';
+  String get settingsMeasurableChoicesTitle => 'Choix possibles';
 
   @override
   String get settingsMeasurableDeleteTooltip => 'Supprimer type mesurable';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -12170,7 +12170,7 @@ class AppLocalizationsPt extends AppLocalizations {
       'Adicione pelo menos uma opção';
 
   @override
-  String get settingsMeasurableChoicesTitle => 'Opções';
+  String get settingsMeasurableChoicesTitle => 'Opções de resposta';
 
   @override
   String get settingsMeasurableDeleteTooltip => 'Excluir tipo mensurável';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -12290,7 +12290,7 @@ class AppLocalizationsRo extends AppLocalizations {
       'Adăugați cel puțin o opțiune';
 
   @override
-  String get settingsMeasurableChoicesTitle => 'Opțiuni';
+  String get settingsMeasurableChoicesTitle => 'Variante de răspuns';
 
   @override
   String get settingsMeasurableDeleteTooltip => 'Ștergeți tipul măsurătorii';

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -5236,7 +5236,7 @@
   "settingsMeasurableChoicesArchivedTitle": "Opções arquivadas",
   "settingsMeasurableChoicesDescription": "Ao registrar, você escolhe uma delas. Renomeie ou reordene quando quiser – as entradas já registradas mantêm a opção.",
   "settingsMeasurableChoicesRequired": "Adicione pelo menos uma opção",
-  "settingsMeasurableChoicesTitle": "Opções",
+  "settingsMeasurableChoicesTitle": "Opções de resposta",
   "settingsMeasurableDeleteTooltip": "Excluir tipo mensurável",
   "settingsMeasurableDescriptionLabel": "Descrição (opcional)",
   "settingsMeasurableDetailsLabel": "Editar mensurável",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4701,7 +4701,7 @@
   "settingsMeasurableChoicesArchivedTitle": "Opțiuni arhivate",
   "settingsMeasurableChoicesDescription": "La înregistrare alegeți una dintre ele. Le puteți redenumi sau reordona oricând – intrările deja înregistrate își păstrează opțiunea.",
   "settingsMeasurableChoicesRequired": "Adăugați cel puțin o opțiune",
-  "settingsMeasurableChoicesTitle": "Opțiuni",
+  "settingsMeasurableChoicesTitle": "Variante de răspuns",
   "settingsMeasurableDeleteTooltip": "Ștergeți tipul măsurătorii",
   "settingsMeasurableDescriptionLabel": "Descriere",
   "settingsMeasurableDetailsLabel": "Editare măsurătoare",


### PR DESCRIPTION
Fixes the nightly manual screenshot capture, which has failed for es, fr, pt and ro since 2026-08-30 (4 tests each). Push runs skip the capture jobs, which is why they looked green.

The measurable choices heading added in #4069 translated to the same word as the page's *Options* section in Spanish, Portuguese and Romanian (`Opciones` / `Opções` / `Opțiuni`), and to the same word as the *Choice* value kind in French (`Choix`). The capture test asserts that heading is unique, so it found two or three matches. The heading is now distinct in those four catalogs, as it already was in every other language: "Opciones de respuesta", "Choix possibles", "Opções de resposta", "Variante de răspuns".

Verified by running the choice-detail screenshot tests locally in all four locales. Includes a changelog fragment, since the heading text is user-visible.

Follow-up to #4108, which fixed the other Manual-workflow break (the browserslist audit gate). Unblocks a fully green #4107.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the measurable Choices heading translations in Spanish, Portuguese, Romanian, and French.
  - Updated wording to more clearly describe available response options in each language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->