### PR TITLE
fix(tasks): estimate read-out in the header lane, and no 'Up to date' beside a countdown

### DIFF
--- a/changelog.d/2026-09-01-estimate-pill-and-agent-freshness.md
+++ b/changelog.d/2026-09-01-estimate-pill-and-agent-freshness.md
@@ -1,8 +1,10 @@
 ### Fixed
 - **The task estimate is visible at a glance again.** The task header's
-  summary lane shows the estimate as its own read-out, next to the due date,
-  instead of only inside the Details fly-out. Tapping it opens the fly-out
-  as the other read-outs do; a task without an estimate shows nothing extra.
+  summary lane shows the estimate as its own read-out next to the due date —
+  time tracked against the estimate, with the small progress bar, turning red
+  once the estimate is exceeded — instead of only inside the Details fly-out.
+  Tapping it opens the fly-out as the other read-outs do; a task without an
+  estimate shows nothing extra.
 - **The AI summary no longer says "Up to date" while counting down to its
   next update.** A scheduled update means something changed since the last
   summary, so the footer now reads "Out of date" beside the countdown and

--- a/changelog.d/2026-09-01-estimate-pill-and-agent-freshness.md
+++ b/changelog.d/2026-09-01-estimate-pill-and-agent-freshness.md
@@ -1,0 +1,9 @@
+### Fixed
+- **The task estimate is visible at a glance again.** The task header's
+  summary lane shows the estimate as its own read-out, next to the due date,
+  instead of only inside the Details fly-out. Tapping it opens the fly-out
+  as the other read-outs do; a task without an estimate shows nothing extra.
+- **The AI summary no longer says "Up to date" while counting down to its
+  next update.** A scheduled update means something changed since the last
+  summary, so the footer now reads "Out of date" beside the countdown and
+  only claims "Up to date" when nothing is pending.

--- a/knowledge/features/agents/ui-surfaces.md
+++ b/knowledge/features/agents/ui-surfaces.md
@@ -225,7 +225,11 @@ is measured in the *painted* style: tabular figures change digit advance, and
 measuring without them clips the payload.
 
 Freshness is a glyph **and** a word, never colour alone; the full sentence lives
-in the tooltip. With automation on and nothing pending the line reads "Updates
+in the tooltip. **A visible countdown is itself proof the summary is behind**:
+`AgentAutomationRow` derives one outdated flag — the caller's `isStale` OR a
+ticking countdown — and the glyph, word and tooltip all read that flag, so the
+band never says "Up to date" beside "Next update in …", even when the caller's
+staleness watermark has not caught up with the scheduled wake. With automation on and nothing pending the line reads "Updates
 on changes", so flipping the switch never leaves a hole that resizes
 the card. The whole switch row is the interaction target — tapping the label
 toggles the setting — on the band's shared `spacing.step8` minimum; the switch's

--- a/knowledge/features/tasks/detail-composition.md
+++ b/knowledge/features/tasks/detail-composition.md
@@ -287,11 +287,15 @@ always-visible button-styled chrome.** The summary lane is read-outs only:
 [AI cost?] → [Set category?] → Details`.
 
 **The estimate is a read-out in the lane, not only a fly-out row.** "How big
-is this?" is answered at the same glance as "when is it due?": the planned
-time renders as compact units (`1h 30m`) behind the timer glyph, and a null or
-zero estimate leaves no trace, the way a missing due date does. Tracked time
-against the estimate — the progress bar — stays in `TaskMetaSection`, which
-has the room for it.
+is this, and how far along?" is answered at the same glance as "when is it
+due?": the tag reads tracked-of-estimated as compact units (`45m of 1h 30m`)
+behind the timer glyph, with the 36×6 `TaskEstimateProgressBar` the
+pre-redesign header chip carried — the same bar `TaskMetaSection`'s Estimate
+row draws, so the two densities never disagree. Overtime escalates the tag to
+the tinted alert shell, the way an overdue due date does. A null or zero
+estimate leaves no trace, the way a missing due date does. The tracked figure
+comes from `taskProgressControllerProvider` through the connector, read with
+`.value` so a time-entry write recomputes without blanking the tag.
 
 **The AI cost sits in that lane, not behind a panel.** What the machine has
 cost on this task is readable at the same glance as its status, through the

--- a/knowledge/features/tasks/detail-composition.md
+++ b/knowledge/features/tasks/detail-composition.md
@@ -292,8 +292,9 @@ due?": the tag reads tracked-of-estimated as compact units (`45m of 1h 30m`)
 behind the timer glyph, with the 36×6 `TaskEstimateProgressBar` the
 pre-redesign header chip carried — the same bar `TaskMetaSection`'s Estimate
 row draws, so the two densities never disagree. Overtime escalates the tag to
-the tinted alert shell, the way an overdue due date does. A null or zero
-estimate leaves no trace, the way a missing due date does. The tracked figure
+the tinted alert shell, the way an overdue due date does. A null estimate, or
+one under a whole minute (which the units could only render as `0m`), leaves
+no trace, the way a missing due date does. The tracked figure
 comes from `taskProgressControllerProvider` through the connector, read with
 `.value` so a time-entry write recomputes without blanking the tag.
 

--- a/knowledge/features/tasks/detail-composition.md
+++ b/knowledge/features/tasks/detail-composition.md
@@ -283,8 +283,15 @@ category is set.
 
 **Metadata is set once and rarely changed, so it no longer wears
 always-visible button-styled chrome.** The summary lane is read-outs only:
-`[status] → [blocked-by?] → [priority] → [due?] → [labels?] → [AI cost?] →
-[Set category?] → Details`.
+`[status] → [blocked-by?] → [priority] → [due?] → [estimate?] → [labels?] →
+[AI cost?] → [Set category?] → Details`.
+
+**The estimate is a read-out in the lane, not only a fly-out row.** "How big
+is this?" is answered at the same glance as "when is it due?": the planned
+time renders as compact units (`1h 30m`) behind the timer glyph, and a null or
+zero estimate leaves no trace, the way a missing due date does. Tracked time
+against the estimate — the progress bar — stays in `TaskMetaSection`, which
+has the room for it.
 
 **The AI cost sits in that lane, not behind a panel.** What the machine has
 cost on this task is readable at the same glance as its status, through the
@@ -302,7 +309,7 @@ Every read-out wears `DsPillShape.tag` — the tight `radii.xs` (4) corner —
 so a fact can never be mistaken for the fully-rounded filter/action pills
 elsewhere on the page. The one lever in the lane, the **Details** trigger,
 keeps the fully-rounded interactive pill shape. Tapping any **editable**
-read-out — status, priority, due, labels — opens the same fly-out, so a tap on
+read-out — status, priority, due, estimate, labels — opens the same fly-out, so a tap on
 the fact lands on its editor. The AI cost is the exception in both directions:
 it has no editor, and its tap opens the details for the fuller reading, which
 is why it stands down to a plain read-out once the column is showing them.

--- a/lib/features/agents/ui/agent_automation_row.dart
+++ b/lib/features/agents/ui/agent_automation_row.dart
@@ -101,7 +101,9 @@ class AgentAutomationRow extends StatefulWidget {
   final bool hasReportContent;
 
   /// Whether the current report is stale. Only meaningful when
-  /// [hasReportContent] is true.
+  /// [hasReportContent] is true. A pending countdown also counts as stale —
+  /// see [_AgentAutomationRowState._isOutdated] — so a caller that passes
+  /// `false` here while a wake is scheduled still gets an honest label.
   final bool isStale;
   final ValueChanged<bool> onAutomaticUpdatesChanged;
   final VoidCallback? onRunNow;
@@ -168,6 +170,13 @@ class _AgentAutomationRowState extends State<AgentAutomationRow> {
       widget.nextWakeAt != null &&
       _widthAnchorSeconds > 0;
 
+  /// The one answer to "is this summary current?" that the label, glyph and
+  /// tooltip all read. A scheduled update exists because something changed
+  /// since the last report, so a ticking countdown is itself proof the
+  /// summary is behind — the row must never say "Up to date" beside it, even
+  /// when the caller's own staleness flag has not caught up.
+  bool get _isOutdated => widget.isStale || _countdownVisible;
+
   /// The schedule wording at each width tier, longest first, rendered against
   /// [seconds]. Empty when there is nothing to say about the next update.
   List<String> _scheduleLabels(BuildContext context, int seconds) {
@@ -198,20 +207,22 @@ class _AgentAutomationRowState extends State<AgentAutomationRow> {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
+    final outdated = _isOutdated;
     final freshnessLabel = widget.hasReportContent
-        ? (widget.isStale
+        ? (outdated
               ? messages.taskAgentStatusOutOfDate
               : messages.taskAgentStatusUpToDate)
+        : null;
+    final freshnessTooltip = widget.hasReportContent
+        ? (outdated
+              ? messages.taskAgentReportOutdatedTitle
+              : messages.taskAgentReportUpToDate)
         : null;
     if (widget.compact) {
       final freshness = _FreshnessCluster(
         label: freshnessLabel,
-        tooltip: widget.hasReportContent
-            ? (widget.isStale
-                  ? messages.taskAgentReportOutdatedTitle
-                  : messages.taskAgentReportUpToDate)
-            : null,
-        isStale: widget.isStale,
+        tooltip: freshnessTooltip,
+        isStale: outdated,
       );
       final trigger = _UpdateNowButton(
         isRunning: widget.isRunning,
@@ -258,12 +269,8 @@ class _AgentAutomationRowState extends State<AgentAutomationRow> {
 
         final freshness = _FreshnessCluster(
           label: freshnessLabel,
-          tooltip: widget.hasReportContent
-              ? (widget.isStale
-                    ? messages.taskAgentReportOutdatedTitle
-                    : messages.taskAgentReportUpToDate)
-              : null,
-          isStale: widget.isStale,
+          tooltip: freshnessTooltip,
+          isStale: outdated,
         );
         final trigger = _UpdateNowButton(
           isRunning: widget.isRunning,

--- a/lib/features/tasks/ui/header/desktop_task_header.dart
+++ b/lib/features/tasks/ui/header/desktop_task_header.dart
@@ -61,6 +61,7 @@ class DesktopTaskHeaderData {
     this.project,
     this.category,
     this.dueDate,
+    this.estimate,
     this.oneLiner,
     this.labels = const [],
   });
@@ -71,6 +72,10 @@ class DesktopTaskHeaderData {
   final DesktopTaskHeaderProject? project;
   final DesktopTaskHeaderCategory? category;
   final DesktopTaskHeaderDueDate? dueDate;
+
+  /// The task's time estimate. Null or zero means "not set", and the summary
+  /// lane shows no estimate read-out at all.
+  final Duration? estimate;
   final String? oneLiner;
   final List<LabelDefinition> labels;
 }
@@ -280,6 +285,7 @@ class _DesktopTaskHeaderState extends State<DesktopTaskHeader> {
             status: widget.data.status,
             priority: widget.data.priority,
             dueDate: widget.data.dueDate,
+            estimate: widget.data.estimate,
             labels: widget.data.labels,
             blockedBySlot: widget.blockedBySlot,
             aiCostSlot: widget.aiCostSlot,

--- a/lib/features/tasks/ui/header/desktop_task_header.dart
+++ b/lib/features/tasks/ui/header/desktop_task_header.dart
@@ -62,6 +62,7 @@ class DesktopTaskHeaderData {
     this.category,
     this.dueDate,
     this.estimate,
+    this.trackedTime = Duration.zero,
     this.oneLiner,
     this.labels = const [],
   });
@@ -76,6 +77,10 @@ class DesktopTaskHeaderData {
   /// The task's time estimate. Null or zero means "not set", and the summary
   /// lane shows no estimate read-out at all.
   final Duration? estimate;
+
+  /// Time recorded against the task so far, read out against [estimate]
+  /// ("45m of 1h 30m"). Ignored without an estimate.
+  final Duration trackedTime;
   final String? oneLiner;
   final List<LabelDefinition> labels;
 }
@@ -286,6 +291,7 @@ class _DesktopTaskHeaderState extends State<DesktopTaskHeader> {
             priority: widget.data.priority,
             dueDate: widget.data.dueDate,
             estimate: widget.data.estimate,
+            trackedTime: widget.data.trackedTime,
             labels: widget.data.labels,
             blockedBySlot: widget.blockedBySlot,
             aiCostSlot: widget.aiCostSlot,

--- a/lib/features/tasks/ui/header/desktop_task_header.dart
+++ b/lib/features/tasks/ui/header/desktop_task_header.dart
@@ -74,8 +74,8 @@ class DesktopTaskHeaderData {
   final DesktopTaskHeaderCategory? category;
   final DesktopTaskHeaderDueDate? dueDate;
 
-  /// The task's time estimate. Null or zero means "not set", and the summary
-  /// lane shows no estimate read-out at all.
+  /// The task's time estimate. Null, or anything under a whole minute, means
+  /// "not set" to the summary lane, which then shows no estimate read-out.
   final Duration? estimate;
 
   /// Time recorded against the task so far, read out against [estimate]

--- a/lib/features/tasks/ui/header/desktop_task_header_connector.dart
+++ b/lib/features/tasks/ui/header/desktop_task_header_connector.dart
@@ -12,6 +12,7 @@ import 'package:lotti/features/labels/state/labels_list_controller.dart';
 import 'package:lotti/features/projects/state/project_providers.dart';
 import 'package:lotti/features/tasks/state/task_blockers_controller.dart';
 import 'package:lotti/features/tasks/state/task_one_liner_provider.dart';
+import 'package:lotti/features/tasks/state/task_progress_controller.dart';
 import 'package:lotti/features/tasks/ui/header/desktop_task_header.dart';
 import 'package:lotti/features/tasks/ui/header/task_meta_column.dart';
 import 'package:lotti/features/tasks/ui/header/task_meta_flyout.dart';
@@ -60,13 +61,18 @@ class DesktopTaskHeaderConnector extends ConsumerWidget {
     // `.value` preserves the established tagline while a background refresh
     // reloads the provider, avoiding a one-line header reflow.
     final oneLiner = ref.watch(taskOneLinerProvider(taskId)).value;
+    // `.value` again: the estimate read-out keeps its last tracked figure
+    // while the progress controller recomputes after a time-entry write.
+    final trackedTime =
+        ref.watch(taskProgressControllerProvider(taskId)).value?.progress ??
+        Duration.zero;
 
     // With the details column mounted beside the task, its metadata is
     // already on screen: the header keeps its read-outs but stops offering a
     // fly-out over a panel showing the same eight rows.
     final hasMetaColumn = TaskMetaColumnScope.isVisible(context);
 
-    final data = _buildData(context, task, project, oneLiner);
+    final data = _buildData(context, task, project, oneLiner, trackedTime);
     final controller = ref.read(entryControllerProvider(taskId).notifier);
     final categoryId = task.meta.categoryId;
 
@@ -120,6 +126,7 @@ class DesktopTaskHeaderConnector extends ConsumerWidget {
     Task task,
     ProjectEntry? project,
     String? oneLiner,
+    Duration trackedTime,
   ) {
     final cache = getIt<EntitiesCacheService>();
     final categoryId = task.meta.categoryId;
@@ -170,6 +177,7 @@ class DesktopTaskHeaderConnector extends ConsumerWidget {
       category: category,
       dueDate: dueDate,
       estimate: task.data.estimate,
+      trackedTime: trackedTime,
       oneLiner: oneLiner,
       labels: labels,
     );

--- a/lib/features/tasks/ui/header/desktop_task_header_connector.dart
+++ b/lib/features/tasks/ui/header/desktop_task_header_connector.dart
@@ -169,6 +169,7 @@ class DesktopTaskHeaderConnector extends ConsumerWidget {
             ),
       category: category,
       dueDate: dueDate,
+      estimate: task.data.estimate,
       oneLiner: oneLiner,
       labels: labels,
     );

--- a/lib/features/tasks/ui/header/desktop_task_header_meta.dart
+++ b/lib/features/tasks/ui/header/desktop_task_header_meta.dart
@@ -11,6 +11,7 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/features/settings/state/celebration_preferences_controller.dart';
 import 'package:lotti/features/tasks/ui/header/desktop_task_header.dart';
+import 'package:lotti/features/tasks/ui/widgets/task_estimate_progress_bar.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_showcase_palette.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_showcase_shared_widgets.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -46,6 +47,7 @@ class TaskMetaSummaryLine extends StatelessWidget {
     required this.labels,
     required this.onOpenDetails,
     this.estimate,
+    this.trackedTime = Duration.zero,
     this.aiCostSlot,
     this.blockedBySlot,
     this.showSetCategory = false,
@@ -62,6 +64,11 @@ class TaskMetaSummaryLine extends StatelessWidget {
   /// zero drops the tag — the lane makes no "Not set" claim, matching how a
   /// missing due date or an empty label list leave no trace either.
   final Duration? estimate;
+
+  /// Time recorded against the task, read out against [estimate] in the same
+  /// tag ("45m of 1h 30m" plus the small progress bar). Only meaningful with
+  /// an estimate.
+  final Duration trackedTime;
   final List<LabelDefinition> labels;
 
   /// Opens the metadata fly-out. Wired to the Details trigger and to every
@@ -118,7 +125,11 @@ class TaskMetaSummaryLine extends StatelessWidget {
         if (dueDate case final dueDate?)
           _DueSummaryTag(dueDate: dueDate, onTap: onOpenDetails),
         if (estimate case final estimate? when estimate > Duration.zero)
-          _EstimateSummaryTag(estimate: estimate, onTap: onOpenDetails),
+          _EstimateSummaryTag(
+            estimate: estimate,
+            tracked: trackedTime,
+            onTap: onOpenDetails,
+          ),
         if (labels.isNotEmpty)
           _LabelsSummaryTag(labels: labels, onTap: onOpenDetails),
         // What the AI has cost on this task, at the same glance as its status
@@ -156,6 +167,7 @@ class _SummaryTag extends StatelessWidget {
   const _SummaryTag({
     required this.label,
     this.leading,
+    this.trailing,
     this.labelColor,
     this.tintColor,
     this.onTap,
@@ -163,6 +175,7 @@ class _SummaryTag extends StatelessWidget {
 
   final String label;
   final Widget? leading;
+  final Widget? trailing;
   final Color? labelColor;
 
   /// When set, renders the tinted variant (urgent due dates) instead of the
@@ -181,6 +194,7 @@ class _SummaryTag extends StatelessWidget {
         label: label,
         labelColor: labelColor,
         leading: leading,
+        trailing: trailing,
         onTap: onTap,
       );
     }
@@ -191,6 +205,7 @@ class _SummaryTag extends StatelessWidget {
       label: label,
       labelColor: labelColor ?? TaskShowcasePalette.mediumText(context),
       leading: leading,
+      trailing: trailing,
       onTap: onTap,
     );
   }
@@ -331,36 +346,49 @@ class _DueSummaryTag extends StatelessWidget {
   }
 }
 
-/// The estimate read-out: the planned time as compact units ("45m", "1h 30m")
-/// behind the timer glyph, on the same neutral shell as priority. Tracked
-/// time against the estimate stays in the fly-out and details column, which
-/// have room for the progress bar; the lane only answers "how big is this?".
+/// The estimate read-out: tracked-of-estimated as compact units ("45m of
+/// 1h 30m") behind the timer glyph, with the same 36×6 progress bar the
+/// pre-redesign header chip carried. Overtime escalates to the tinted alert
+/// shell, the way an overdue due date does, so a task that has blown its
+/// estimate reads as a warning at the same glance.
 class _EstimateSummaryTag extends StatelessWidget {
-  const _EstimateSummaryTag({required this.estimate, this.onTap});
+  const _EstimateSummaryTag({
+    required this.estimate,
+    required this.tracked,
+    this.onTap,
+  });
 
   final Duration estimate;
+  final Duration tracked;
   final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
-    final value = formatRangeDuration(estimate);
-    // Sighted readers get the timer glyph to say what the number is; a screen
-    // reader gets the word instead, so the tag is announced as
-    // "Estimate: 1h 30m" rather than a bare duration.
+    final messages = context.messages;
+    final trackedText = formatRangeDuration(tracked);
+    final estimateText = formatRangeDuration(estimate);
+    final overtime = TaskEstimateProgressBar.isOvertime(
+      tracked: tracked,
+      estimate: estimate,
+    );
+    final ink = overtime
+        ? TaskShowcasePalette.errorInk(context)
+        : TaskShowcasePalette.mediumText(context);
+    // Sighted readers get the timer glyph to say what the numbers are; a
+    // screen reader gets the full sentence instead, so the tag is announced
+    // as "Time tracked: 45m of 1h 30m estimated" rather than bare durations.
     return Semantics(
       key: const ValueKey('task-estimate-summary-tag'),
       container: true,
       excludeSemantics: true,
       button: onTap != null,
-      label: '${context.messages.taskMetaEstimateLabel}: $value',
+      label: messages.taskEstimateTooltip(trackedText, estimateText),
       onTap: onTap,
       child: _SummaryTag(
-        label: value,
-        leading: Icon(
-          LottiIcons.timer,
-          size: kTaskChipGlyphSize,
-          color: TaskShowcasePalette.mediumText(context),
-        ),
+        label: messages.taskEstimateProgressLabel(trackedText, estimateText),
+        tintColor: overtime ? ink : null,
+        leading: Icon(LottiIcons.timer, size: kTaskChipGlyphSize, color: ink),
+        trailing: TaskEstimateProgressBar(tracked: tracked, estimate: estimate),
         onTap: onTap,
       ),
     );

--- a/lib/features/tasks/ui/header/desktop_task_header_meta.dart
+++ b/lib/features/tasks/ui/header/desktop_task_header_meta.dart
@@ -60,9 +60,10 @@ class TaskMetaSummaryLine extends StatelessWidget {
   final DesktopTaskHeaderDueDate? dueDate;
 
   /// The task's time estimate, shown as its own read-out so it is legible at
-  /// the same glance as the due date rather than one fly-out away. Null or
-  /// zero drops the tag — the lane makes no "Not set" claim, matching how a
-  /// missing due date or an empty label list leave no trace either.
+  /// the same glance as the due date rather than one fly-out away. Null, or
+  /// anything under [minStatedEstimate], drops the tag — the lane makes no
+  /// "Not set" claim, matching how a missing due date or an empty label list
+  /// leave no trace either.
   final Duration? estimate;
 
   /// Time recorded against the task, read out against [estimate] in the same
@@ -101,6 +102,10 @@ class TaskMetaSummaryLine extends StatelessWidget {
   /// compress into a "+N" suffix.
   static const int maxNamedLabels = 2;
 
+  /// The shortest estimate the tag states. Its units are whole minutes, so a
+  /// shorter estimate has no non-zero rendering and leaves the lane alone.
+  static const Duration minStatedEstimate = Duration(minutes: 1);
+
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
@@ -124,7 +129,10 @@ class TaskMetaSummaryLine extends StatelessWidget {
         ),
         if (dueDate case final dueDate?)
           _DueSummaryTag(dueDate: dueDate, onTap: onOpenDetails),
-        if (estimate case final estimate? when estimate > Duration.zero)
+        // The compact units read in whole minutes, so anything shorter would
+        // say "0m of 0m"; the tag waits for an estimate it can actually state.
+        if (estimate case final estimate?
+            when estimate >= TaskMetaSummaryLine.minStatedEstimate)
           _EstimateSummaryTag(
             estimate: estimate,
             tracked: trackedTime,

--- a/lib/features/tasks/ui/header/desktop_task_header_meta.dart
+++ b/lib/features/tasks/ui/header/desktop_task_header_meta.dart
@@ -159,7 +159,6 @@ class _SummaryTag extends StatelessWidget {
     this.labelColor,
     this.tintColor,
     this.onTap,
-    super.key,
   });
 
   final String label;
@@ -344,15 +343,26 @@ class _EstimateSummaryTag extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _SummaryTag(
+    final value = formatRangeDuration(estimate);
+    // Sighted readers get the timer glyph to say what the number is; a screen
+    // reader gets the word instead, so the tag is announced as
+    // "Estimate: 1h 30m" rather than a bare duration.
+    return Semantics(
       key: const ValueKey('task-estimate-summary-tag'),
-      label: formatRangeDuration(estimate),
-      leading: Icon(
-        LottiIcons.timer,
-        size: kTaskChipGlyphSize,
-        color: TaskShowcasePalette.mediumText(context),
-      ),
+      container: true,
+      excludeSemantics: true,
+      button: onTap != null,
+      label: '${context.messages.taskMetaEstimateLabel}: $value',
       onTap: onTap,
+      child: _SummaryTag(
+        label: value,
+        leading: Icon(
+          LottiIcons.timer,
+          size: kTaskChipGlyphSize,
+          color: TaskShowcasePalette.mediumText(context),
+        ),
+        onTap: onTap,
+      ),
     );
   }
 }

--- a/lib/features/tasks/ui/header/desktop_task_header_meta.dart
+++ b/lib/features/tasks/ui/header/desktop_task_header_meta.dart
@@ -8,6 +8,7 @@ import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/design_system/components/celebration/completion_celebration.dart';
 import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/features/settings/state/celebration_preferences_controller.dart';
 import 'package:lotti/features/tasks/ui/header/desktop_task_header.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_showcase_palette.dart';
@@ -24,7 +25,8 @@ import 'package:lotti/utils/color.dart';
 const double kTaskChipGlyphSize = 14;
 
 /// The compact metadata summary under the title: a single lane of quiet,
-/// **informational** read-outs (status, priority, due date, labels) followed
+/// **informational** read-outs (status, priority, due date, estimate, labels)
+/// followed
 /// by the one interactive element — the "Details" trigger that opens the
 /// metadata fly-out where every value is edited. A null [onOpenDetails] drops
 /// both the trigger and the tags' hit targets: that is the state where the
@@ -43,6 +45,7 @@ class TaskMetaSummaryLine extends StatelessWidget {
     required this.dueDate,
     required this.labels,
     required this.onOpenDetails,
+    this.estimate,
     this.aiCostSlot,
     this.blockedBySlot,
     this.showSetCategory = false,
@@ -53,6 +56,12 @@ class TaskMetaSummaryLine extends StatelessWidget {
   final TaskStatus status;
   final TaskPriority priority;
   final DesktopTaskHeaderDueDate? dueDate;
+
+  /// The task's time estimate, shown as its own read-out so it is legible at
+  /// the same glance as the due date rather than one fly-out away. Null or
+  /// zero drops the tag — the lane makes no "Not set" claim, matching how a
+  /// missing due date or an empty label list leave no trace either.
+  final Duration? estimate;
   final List<LabelDefinition> labels;
 
   /// Opens the metadata fly-out. Wired to the Details trigger and to every
@@ -108,6 +117,8 @@ class TaskMetaSummaryLine extends StatelessWidget {
         ),
         if (dueDate case final dueDate?)
           _DueSummaryTag(dueDate: dueDate, onTap: onOpenDetails),
+        if (estimate case final estimate? when estimate > Duration.zero)
+          _EstimateSummaryTag(estimate: estimate, onTap: onOpenDetails),
         if (labels.isNotEmpty)
           _LabelsSummaryTag(labels: labels, onTap: onOpenDetails),
         // What the AI has cost on this task, at the same glance as its status
@@ -148,6 +159,7 @@ class _SummaryTag extends StatelessWidget {
     this.labelColor,
     this.tintColor,
     this.onTap,
+    super.key,
   });
 
   final String label;
@@ -314,6 +326,31 @@ class _DueSummaryTag extends StatelessWidget {
         LottiIcons.today,
         size: kTaskChipGlyphSize,
         color: accent,
+      ),
+      onTap: onTap,
+    );
+  }
+}
+
+/// The estimate read-out: the planned time as compact units ("45m", "1h 30m")
+/// behind the timer glyph, on the same neutral shell as priority. Tracked
+/// time against the estimate stays in the fly-out and details column, which
+/// have room for the progress bar; the lane only answers "how big is this?".
+class _EstimateSummaryTag extends StatelessWidget {
+  const _EstimateSummaryTag({required this.estimate, this.onTap});
+
+  final Duration estimate;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return _SummaryTag(
+      key: const ValueKey('task-estimate-summary-tag'),
+      label: formatRangeDuration(estimate),
+      leading: Icon(
+        LottiIcons.timer,
+        size: kTaskChipGlyphSize,
+        color: TaskShowcasePalette.mediumText(context),
       ),
       onTap: onTap,
     );

--- a/lib/features/tasks/ui/header/task_meta_section.dart
+++ b/lib/features/tasks/ui/header/task_meta_section.dart
@@ -1,5 +1,3 @@
-import 'dart:math' as math;
-
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -13,11 +11,13 @@ import 'package:lotti/features/design_system/components/ds_quiet_ink.dart';
 import 'package:lotti/features/design_system/components/task_filters/design_system_filter_shared.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
+import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/features/labels/state/labels_list_controller.dart';
 import 'package:lotti/features/projects/state/project_providers.dart';
 import 'package:lotti/features/tasks/state/task_progress_controller.dart';
 import 'package:lotti/features/tasks/ui/header/task_meta_pickers.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_ai_cost_indicator.dart';
+import 'package:lotti/features/tasks/ui/widgets/task_estimate_progress_bar.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_showcase_palette.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_showcase_shared_widgets.dart';
 import 'package:lotti/features/tasks/util/due_date_utils.dart';
@@ -421,21 +421,11 @@ class _DueDateValue extends StatelessWidget {
 }
 
 /// Tracked-of-estimated read-out with the same small progress bar the header
-/// chip used to carry, or "Not set" when the task has no estimate.
+/// estimate tag carries, or "Not set" when the task has no estimate.
 class _TimeValue extends ConsumerWidget {
   const _TimeValue({required this.task});
 
   final Task task;
-
-  /// Formats a duration as plain units ("1h 30m", "45m", "2h") rather than a
-  /// zero-padded clock — see the estimate chip this replaces.
-  static String format(Duration duration) {
-    final hours = duration.inHours;
-    final minutes = duration.inMinutes.remainder(60);
-    if (hours > 0 && minutes > 0) return '${hours}h ${minutes}m';
-    if (hours > 0) return '${hours}h';
-    return '${minutes}m';
-  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -453,16 +443,10 @@ class _TimeValue extends ConsumerWidget {
         .watch(taskProgressControllerProvider(task.meta.id))
         .value;
     final progress = progressState?.progress ?? Duration.zero;
-    final isOvertime = progress > estimate;
-    final progressValue = estimate.inSeconds > 0
-        ? math.min(progress.inSeconds / estimate.inSeconds, 1).toDouble()
-        : 0.0;
-    final barTrack = isOvertime
-        ? TaskShowcasePalette.error(context).withValues(alpha: 0.2)
-        : TaskShowcasePalette.lowText(context).withValues(alpha: 0.2);
-    final barFill = isOvertime
-        ? TaskShowcasePalette.error(context)
-        : TaskShowcasePalette.success(context);
+    final isOvertime = TaskEstimateProgressBar.isOvertime(
+      tracked: progress,
+      estimate: estimate,
+    );
 
     return Row(
       mainAxisSize: MainAxisSize.min,
@@ -470,8 +454,8 @@ class _TimeValue extends ConsumerWidget {
         Flexible(
           child: Text(
             context.messages.taskEstimateProgressLabel(
-              format(progress),
-              format(estimate),
+              formatRangeDuration(progress),
+              formatRangeDuration(estimate),
             ),
             overflow: TextOverflow.ellipsis,
             style: _valueStyle(context).copyWith(
@@ -482,21 +466,7 @@ class _TimeValue extends ConsumerWidget {
           ),
         ),
         SizedBox(width: tokens.spacing.step3),
-        ClipRRect(
-          borderRadius: BorderRadius.circular(tokens.radii.xs),
-          // The same 36×6 bar the old header estimate chip carried — kept
-          // verbatim so the read-out is visually continuous with what it
-          // replaced (no sizing token matches a 6px bar height).
-          child: SizedBox(
-            width: 36,
-            height: 6,
-            child: LinearProgressIndicator(
-              value: progressValue,
-              backgroundColor: barTrack,
-              color: barFill,
-            ),
-          ),
-        ),
+        TaskEstimateProgressBar(tracked: progress, estimate: estimate),
       ],
     );
   }

--- a/lib/features/tasks/ui/widgets/task_estimate_progress_bar.dart
+++ b/lib/features/tasks/ui/widgets/task_estimate_progress_bar.dart
@@ -1,0 +1,64 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/tasks/ui/widgets/task_showcase_palette.dart';
+
+/// The small tracked-of-estimated bar shared by the task header's estimate
+/// read-out and the details section's Estimate row: green while the tracked
+/// time fits inside the estimate, red once it runs over.
+///
+/// Sized 36×6 verbatim from the header chip it descends from, so the read-out
+/// stays visually continuous with what it replaced (no sizing token matches a
+/// 6px bar height).
+class TaskEstimateProgressBar extends StatelessWidget {
+  const TaskEstimateProgressBar({
+    required this.tracked,
+    required this.estimate,
+    super.key,
+  });
+
+  final Duration tracked;
+  final Duration estimate;
+
+  /// Whether [tracked] has run past [estimate].
+  static bool isOvertime({
+    required Duration tracked,
+    required Duration estimate,
+  }) => tracked > estimate;
+
+  /// The filled fraction of the bar, clamped to `1` once the estimate is
+  /// exceeded and `0` for a non-positive estimate.
+  static double fraction({
+    required Duration tracked,
+    required Duration estimate,
+  }) {
+    if (estimate <= Duration.zero) return 0;
+    if (tracked <= Duration.zero) return 0;
+    return math.min(tracked.inSeconds / estimate.inSeconds, 1).toDouble();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final overtime = isOvertime(tracked: tracked, estimate: estimate);
+    final barTrack = overtime
+        ? TaskShowcasePalette.error(context).withValues(alpha: 0.2)
+        : TaskShowcasePalette.lowText(context).withValues(alpha: 0.2);
+    final barFill = overtime
+        ? TaskShowcasePalette.error(context)
+        : TaskShowcasePalette.success(context);
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(tokens.radii.xs),
+      child: SizedBox(
+        width: 36,
+        height: 6,
+        child: LinearProgressIndicator(
+          value: fraction(tracked: tracked, estimate: estimate),
+          backgroundColor: barTrack,
+          color: barFill,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/tasks/widgetbook/desktop_task_header_widgetbook.dart
+++ b/lib/features/tasks/widgetbook/desktop_task_header_widgetbook.dart
@@ -124,6 +124,7 @@ DesktopTaskHeaderData _fixtureData({
   bool showDueDate = true,
   DesktopTaskHeaderDueUrgency dueUrgency = DesktopTaskHeaderDueUrgency.normal,
   bool showLabels = true,
+  bool showEstimate = true,
 }) {
   return DesktopTaskHeaderData(
     title: title,
@@ -146,6 +147,7 @@ DesktopTaskHeaderData _fixtureData({
             urgency: dueUrgency,
           )
         : null,
+    estimate: showEstimate ? const Duration(hours: 1, minutes: 30) : null,
     labels: showLabels
         ? [
             _label(id: 'bug-fix', name: 'Bug fix', color: '#1CA3E3'),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1441,7 +1441,7 @@ packages:
     source: hosted
     version: "4.1.2"
   image:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: image
       sha256: "1976370a4df3091bb0f72409c187ad1f9132a818bc6b95ca59c0bae1c75c688e"

--- a/test/features/agents/ui/agent_automation_row_test.dart
+++ b/test/features/agents/ui/agent_automation_row_test.dart
@@ -352,6 +352,81 @@ void main() {
       }
     });
 
+    testWidgets(
+      'a pending countdown reads Out of date even when the stale flag is off',
+      (tester) async {
+        // A wake is scheduled because something changed since the last
+        // report, so the row must never say "Up to date" next to it.
+        for (final compact in [false, true]) {
+          await withClock(Clock.fixed(now), () async {
+            await pumpRow(
+              tester,
+              subject(
+                hasReportContent: true,
+                automaticUpdatesEnabled: true,
+                showCountdown: true,
+                nextWakeAt: now.add(const Duration(minutes: 1, seconds: 30)),
+                compact: compact,
+                onRunNow: () {},
+              ),
+            );
+          });
+
+          expect(
+            find.text('Out of date'),
+            findsOneWidget,
+            reason: 'compact=$compact',
+          );
+          expect(
+            find.text('Up to date'),
+            findsNothing,
+            reason: 'compact=$compact',
+          );
+          expect(
+            find.byKey(const ValueKey('taskAgentStaleGlyph')),
+            findsOneWidget,
+            reason: 'compact=$compact',
+          );
+          expect(
+            tester
+                .widget<Tooltip>(
+                  find.ancestor(
+                    of: find.byKey(const ValueKey('taskAgentStaleGlyph')),
+                    matching: find.byType(Tooltip),
+                  ),
+                )
+                .message,
+            'This summary is out of date',
+            reason: 'compact=$compact',
+          );
+          // The countdown itself stays: it is the honest part of the pair.
+          if (!compact) {
+            expect(find.text('Next update in 1:30'), findsOneWidget);
+          }
+        }
+      },
+    );
+
+    testWidgets('Up to date shows with no countdown beside it', (
+      tester,
+    ) async {
+      await withClock(Clock.fixed(now), () async {
+        await pumpRow(
+          tester,
+          subject(
+            hasReportContent: true,
+            automaticUpdatesEnabled: true,
+            onRunNow: () {},
+          ),
+        );
+      });
+
+      expect(find.text('Up to date'), findsOneWidget);
+      expect(find.text('Out of date'), findsNothing);
+      expect(find.byKey(const ValueKey('taskAgentFreshGlyph')), findsOneWidget);
+      expect(find.textContaining('Next update'), findsNothing);
+    });
+
     testWidgets('spends the alert tint on the glyph, never on the word', (
       tester,
     ) async {

--- a/test/features/tasks/ui/header/desktop_task_header_connector_test.dart
+++ b/test/features/tasks/ui/header/desktop_task_header_connector_test.dart
@@ -490,6 +490,37 @@ void main() {
     );
   });
 
+  group('DesktopTaskHeaderConnector — estimate in the summary lane', () {
+    final estimateTag = find.byKey(const ValueKey('task-estimate-summary-tag'));
+
+    testWidgets('shows the task estimate without opening the fly-out', (
+      tester,
+    ) async {
+      final task = buildTask(estimate: const Duration(hours: 2));
+
+      await tester.pumpWidget(pumpConnector(task: task));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(estimateTag, findsOneWidget);
+      expect(find.text('2h'), findsOneWidget);
+      expect(find.byType(TaskMetaSection), findsNothing);
+    });
+
+    testWidgets('shows no estimate tag for a task without an estimate', (
+      tester,
+    ) async {
+      final task = buildTask();
+
+      await tester.pumpWidget(pumpConnector(task: task));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(estimateTag, findsNothing);
+      expect(find.byType(DesktopTaskHeader), findsOneWidget);
+    });
+  });
+
   group('DesktopTaskHeaderConnector — AI cost in the summary lane', () {
     testWidgets('shows the cost beside the status once AI has run', (
       tester,

--- a/test/features/tasks/ui/header/desktop_task_header_connector_test.dart
+++ b/test/features/tasks/ui/header/desktop_task_header_connector_test.dart
@@ -503,8 +503,31 @@ void main() {
       await tester.pump(const Duration(milliseconds: 300));
 
       expect(estimateTag, findsOneWidget);
-      expect(find.text('2h'), findsOneWidget);
+      expect(find.text('0m of 2h'), findsOneWidget);
       expect(find.byType(TaskMetaSection), findsNothing);
+    });
+
+    testWidgets('reads the tracked time from the progress controller', (
+      tester,
+    ) async {
+      final task = buildTask(estimate: const Duration(hours: 2));
+
+      await tester.pumpWidget(
+        pumpConnector(
+          task: task,
+          progress: const TaskProgressState(
+            progress: Duration(minutes: 45),
+            estimate: Duration(hours: 2),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(
+        find.descendant(of: estimateTag, matching: find.text('45m of 2h')),
+        findsOneWidget,
+      );
     });
 
     testWidgets('shows no estimate tag for a task without an estimate', (
@@ -646,7 +669,8 @@ void main() {
         expect(find.text('Status'), findsOneWidget);
         expect(find.text('Priority'), findsOneWidget);
         expect(find.text('Estimate'), findsOneWidget);
-        expect(find.text('0m of 2h'), findsOneWidget);
+        // Once in the fly-out's Estimate row, once in the header lane.
+        expect(find.text('0m of 2h'), findsNWidgets(2));
       },
     );
 

--- a/test/features/tasks/ui/header/desktop_task_header_test.dart
+++ b/test/features/tasks/ui/header/desktop_task_header_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -1039,6 +1040,28 @@ void main() {
       await tester.pump();
 
       expect(opened, 1);
+    });
+
+    testWidgets('announces the tag as the estimate, not a bare duration', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await _pumpDesktop(
+        tester,
+        DesktopTaskHeader(
+          data: _fixture(estimate: const Duration(hours: 1, minutes: 30)),
+          onTitleSaved: (_) {},
+          onOpenDetails: () {},
+        ),
+      );
+
+      final node = tester.getSemantics(estimateTag);
+      // One node, one sentence: the glyph carries "estimate" for sighted
+      // readers, the label carries it for everyone else.
+      expect(node.label, 'Estimate: 1h 30m');
+      expect(node.flagsCollection.isButton, isTrue);
+      expect(node.getSemanticsData().hasAction(SemanticsAction.tap), isTrue);
+      handle.dispose();
     });
 
     testWidgets('omits the tag when the estimate is unset or zero', (

--- a/test/features/tasks/ui/header/desktop_task_header_test.dart
+++ b/test/features/tasks/ui/header/desktop_task_header_test.dart
@@ -1132,10 +1132,16 @@ void main() {
       expect(bar.color, TaskShowcasePalette.error(context));
     });
 
-    testWidgets('omits the tag when the estimate is unset or zero', (
+    testWidgets('omits the tag when the estimate is unset or under a minute', (
       tester,
     ) async {
-      for (final estimate in <Duration?>[null, Duration.zero]) {
+      // The units are whole minutes, so a 30-second estimate would read
+      // "0m of 0m" — the tag waits until it has something to state.
+      for (final estimate in <Duration?>[
+        null,
+        Duration.zero,
+        const Duration(seconds: 30),
+      ]) {
         await _pumpDesktop(
           tester,
           DesktopTaskHeader(
@@ -1148,7 +1154,7 @@ void main() {
         // No placeholder either: like a missing due date, an unset estimate
         // leaves no trace in the lane.
         expect(estimateTag, findsNothing, reason: 'estimate=$estimate');
-        expect(find.text('0m'), findsNothing, reason: 'estimate=$estimate');
+        expect(find.textContaining('0m'), findsNothing, reason: '$estimate');
         expect(find.text('Open'), findsOneWidget);
       }
     });

--- a/test/features/tasks/ui/header/desktop_task_header_test.dart
+++ b/test/features/tasks/ui/header/desktop_task_header_test.dart
@@ -106,6 +106,7 @@ DesktopTaskHeaderData _fixture({
   DesktopTaskHeaderCategory? category,
   DesktopTaskHeaderDueDate? dueDate,
   Duration? estimate,
+  Duration trackedTime = Duration.zero,
   List<LabelDefinition> labels = const [],
 }) {
   final createdAt = DateTime.utc(2026);
@@ -120,6 +121,7 @@ DesktopTaskHeaderData _fixture({
     category: category,
     dueDate: dueDate,
     estimate: estimate,
+    trackedTime: trackedTime,
     labels: labels,
   );
 }
@@ -1001,12 +1003,12 @@ void main() {
         );
 
         // Visible at a glance, without opening the fly-out.
-        expect(find.text('1h 30m'), findsOneWidget);
+        expect(find.text('0m of 1h 30m'), findsOneWidget);
         expect(
           tester
               .widget<DsPill>(
                 find.ancestor(
-                  of: find.text('1h 30m'),
+                  of: find.text('0m of 1h 30m'),
                   matching: find.byType(DsPill),
                 ),
               )
@@ -1016,7 +1018,7 @@ void main() {
         );
 
         final due = tester.getTopLeft(find.text('Due: Apr 1, 2026'));
-        final estimate = tester.getTopLeft(find.text('1h 30m'));
+        final estimate = tester.getTopLeft(find.text('0m of 1h 30m'));
         final labels = tester.getTopLeft(find.text('Bug fix, Release blocker'));
         expect(estimate.dx, greaterThan(due.dx));
         expect(labels.dx, greaterThan(estimate.dx));
@@ -1036,7 +1038,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.text('45m'));
+      await tester.tap(find.text('0m of 45m'));
       await tester.pump();
 
       expect(opened, 1);
@@ -1049,7 +1051,10 @@ void main() {
       await _pumpDesktop(
         tester,
         DesktopTaskHeader(
-          data: _fixture(estimate: const Duration(hours: 1, minutes: 30)),
+          data: _fixture(
+            estimate: const Duration(hours: 1, minutes: 30),
+            trackedTime: const Duration(minutes: 45),
+          ),
           onTitleSaved: (_) {},
           onOpenDetails: () {},
         ),
@@ -1058,10 +1063,73 @@ void main() {
       final node = tester.getSemantics(estimateTag);
       // One node, one sentence: the glyph carries "estimate" for sighted
       // readers, the label carries it for everyone else.
-      expect(node.label, 'Estimate: 1h 30m');
+      expect(node.label, 'Time tracked: 45m of 1h 30m estimated');
       expect(node.flagsCollection.isButton, isTrue);
       expect(node.getSemanticsData().hasAction(SemanticsAction.tap), isTrue);
       handle.dispose();
+    });
+
+    testWidgets('reads tracked time against the estimate, with the bar', (
+      tester,
+    ) async {
+      await _pumpDesktop(
+        tester,
+        DesktopTaskHeader(
+          data: _fixture(
+            estimate: const Duration(hours: 2),
+            trackedTime: const Duration(minutes: 30),
+          ),
+          onTitleSaved: (_) {},
+        ),
+      );
+
+      expect(find.text('30m of 2h'), findsOneWidget);
+      final bar = tester.widget<LinearProgressIndicator>(
+        find.descendant(
+          of: estimateTag,
+          matching: find.byType(LinearProgressIndicator),
+        ),
+      );
+      expect(bar.value, 0.25);
+      // Within the estimate: the neutral filled shell, green fill.
+      final pill = tester.widget<DsPill>(
+        find.descendant(of: estimateTag, matching: find.byType(DsPill)),
+      );
+      expect(pill.variant, DsPillVariant.filled);
+      final context = tester.element(find.text('30m of 2h'));
+      expect(bar.color, TaskShowcasePalette.success(context));
+    });
+
+    testWidgets('overtime escalates to the alert shell, like an overdue date', (
+      tester,
+    ) async {
+      await _pumpDesktop(
+        tester,
+        DesktopTaskHeader(
+          data: _fixture(
+            estimate: const Duration(hours: 1),
+            trackedTime: const Duration(hours: 1, minutes: 20),
+          ),
+          onTitleSaved: (_) {},
+        ),
+      );
+
+      expect(find.text('1h 20m of 1h'), findsOneWidget);
+      final context = tester.element(find.text('1h 20m of 1h'));
+      final pill = tester.widget<DsPill>(
+        find.descendant(of: estimateTag, matching: find.byType(DsPill)),
+      );
+      expect(pill.variant, DsPillVariant.tinted);
+      expect(pill.color, TaskShowcasePalette.errorInk(context));
+      final bar = tester.widget<LinearProgressIndicator>(
+        find.descendant(
+          of: estimateTag,
+          matching: find.byType(LinearProgressIndicator),
+        ),
+      );
+      // The bar saturates rather than overflowing its 36px.
+      expect(bar.value, 1);
+      expect(bar.color, TaskShowcasePalette.error(context));
     });
 
     testWidgets('omits the tag when the estimate is unset or zero', (

--- a/test/features/tasks/ui/header/desktop_task_header_test.dart
+++ b/test/features/tasks/ui/header/desktop_task_header_test.dart
@@ -104,6 +104,7 @@ DesktopTaskHeaderData _fixture({
   DesktopTaskHeaderProject? project,
   DesktopTaskHeaderCategory? category,
   DesktopTaskHeaderDueDate? dueDate,
+  Duration? estimate,
   List<LabelDefinition> labels = const [],
 }) {
   final createdAt = DateTime.utc(2026);
@@ -117,6 +118,7 @@ DesktopTaskHeaderData _fixture({
     project: project,
     category: category,
     dueDate: dueDate,
+    estimate: estimate,
     labels: labels,
   );
 }
@@ -976,6 +978,89 @@ void main() {
         expect(lane.runSpacing, greaterThan(lane.spacing));
       },
     );
+  });
+
+  group('DesktopTaskHeader — estimate read-out', () {
+    final estimateTag = find.byKey(const ValueKey('task-estimate-summary-tag'));
+
+    testWidgets(
+      'shows the estimate as an informational tag between due date and labels',
+      (tester) async {
+        await _pumpDesktop(
+          tester,
+          DesktopTaskHeader(
+            data: _fixture(
+              dueDate: _dueFixture,
+              estimate: const Duration(hours: 1, minutes: 30),
+              labels: _labelFixtures,
+            ),
+            onTitleSaved: (_) {},
+            onOpenDetails: () {},
+          ),
+        );
+
+        // Visible at a glance, without opening the fly-out.
+        expect(find.text('1h 30m'), findsOneWidget);
+        expect(
+          tester
+              .widget<DsPill>(
+                find.ancestor(
+                  of: find.text('1h 30m'),
+                  matching: find.byType(DsPill),
+                ),
+              )
+              .shape,
+          DsPillShape.tag,
+          reason: 'a fact wears the tag shape, like the due date beside it',
+        );
+
+        final due = tester.getTopLeft(find.text('Due: Apr 1, 2026'));
+        final estimate = tester.getTopLeft(find.text('1h 30m'));
+        final labels = tester.getTopLeft(find.text('Bug fix, Release blocker'));
+        expect(estimate.dx, greaterThan(due.dx));
+        expect(labels.dx, greaterThan(estimate.dx));
+      },
+    );
+
+    testWidgets('tapping the estimate tag opens the details fly-out', (
+      tester,
+    ) async {
+      var opened = 0;
+      await _pumpDesktop(
+        tester,
+        DesktopTaskHeader(
+          data: _fixture(estimate: const Duration(minutes: 45)),
+          onTitleSaved: (_) {},
+          onOpenDetails: () => opened++,
+        ),
+      );
+
+      await tester.tap(find.text('45m'));
+      await tester.pump();
+
+      expect(opened, 1);
+    });
+
+    testWidgets('omits the tag when the estimate is unset or zero', (
+      tester,
+    ) async {
+      for (final estimate in <Duration?>[null, Duration.zero]) {
+        await _pumpDesktop(
+          tester,
+          DesktopTaskHeader(
+            data: _fixture(estimate: estimate),
+            onTitleSaved: (_) {},
+            onOpenDetails: () {},
+          ),
+        );
+
+        // No placeholder either: like a missing due date, an unset estimate
+        // leaves no trace in the lane.
+        expect(estimateTag, findsNothing, reason: 'estimate=$estimate');
+        expect(find.text('0m'), findsNothing, reason: 'estimate=$estimate');
+        expect(find.text('Open'), findsOneWidget);
+      }
+    });
   });
 
   group('DesktopTaskHeader — label compression', () {

--- a/test/features/tasks/ui/pages/task_details_page_test.dart
+++ b/test/features/tasks/ui/pages/task_details_page_test.dart
@@ -25,6 +25,7 @@ import 'package:lotti/features/journal/ui/widgets/entry_detail_linked_from.dart'
 import 'package:lotti/features/journal/ui/widgets/linked_entries_with_timer.dart';
 import 'package:lotti/features/tasks/state/task_focus_controller.dart';
 import 'package:lotti/features/tasks/state/task_link_groups_controller.dart';
+import 'package:lotti/features/tasks/state/task_progress_controller.dart';
 import 'package:lotti/features/tasks/ui/checklists/correction_undo_snackbar.dart';
 import 'package:lotti/features/tasks/ui/header/desktop_task_header_connector.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/linked_tasks_widget.dart';
@@ -46,6 +47,7 @@ import 'package:path_provider/path_provider.dart';
 import '../../../../helpers/fake_linked_entries_controller.dart';
 import '../../../../helpers/fallbacks.dart';
 import '../../../../helpers/path_provider.dart';
+import '../../../../helpers/task_progress_test_controller.dart';
 import '../../../../mocks/mocks.dart';
 import '../../../../test_data/test_data.dart';
 import '../../../../widget_test_utils.dart';
@@ -457,7 +459,16 @@ void main() {
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
           TaskDetailsPage(taskId: testTask.id),
-          overrides: hTaskDetailsPageOverrides(),
+          overrides: [
+            ...hTaskDetailsPageOverrides(),
+            // One hour logged against the fixture's four-hour estimate.
+            taskProgressControllerProvider(testTask.id).overrideWith(
+              () => TestTaskProgressController(
+                progress: const Duration(hours: 1),
+                estimate: const Duration(hours: 4),
+              ),
+            ),
+          ],
         ),
       );
 
@@ -465,14 +476,22 @@ void main() {
 
       await tester.pump(const Duration(milliseconds: 300));
 
-      // test task displays progress bar (now in Labels row)
-      final progressBarFinder = find.byType(LinearProgressIndicator);
-      if (progressBarFinder.evaluate().isNotEmpty) {
-        final progressBar =
-            tester.firstWidget(progressBarFinder) as LinearProgressIndicator;
-        expect(progressBar, isNotNull);
-        expect(progressBar.value, 0.25);
-      }
+      // The header's estimate tag reads the tracked time against the
+      // estimate, bar included.
+      final estimateTag = find.byKey(
+        const ValueKey('task-estimate-summary-tag'),
+      );
+      expect(
+        find.descendant(of: estimateTag, matching: find.text('1h of 4h')),
+        findsOneWidget,
+      );
+      final progressBar = tester.widget<LinearProgressIndicator>(
+        find.descendant(
+          of: estimateTag,
+          matching: find.byType(LinearProgressIndicator),
+        ),
+      );
+      expect(progressBar.value, 0.25);
 
       // test task title is displayed once (inside the new desktop header).
       expect(find.text(testTask.data.title), findsOneWidget);

--- a/test/features/tasks/ui/widgets/task_estimate_progress_bar_test.dart
+++ b/test/features/tasks/ui/widgets/task_estimate_progress_bar_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
+import 'package:lotti/features/tasks/ui/widgets/task_estimate_progress_bar.dart';
+import 'package:lotti/features/tasks/ui/widgets/task_showcase_palette.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  group('TaskEstimateProgressBar.fraction', () {
+    test('is the tracked share of the estimate, clamped to one', () {
+      expect(
+        TaskEstimateProgressBar.fraction(
+          tracked: const Duration(minutes: 30),
+          estimate: const Duration(hours: 2),
+        ),
+        0.25,
+      );
+      expect(
+        TaskEstimateProgressBar.fraction(
+          tracked: const Duration(hours: 3),
+          estimate: const Duration(hours: 2),
+        ),
+        1,
+      );
+    });
+
+    test('is zero for a non-positive estimate or no tracked time', () {
+      expect(
+        TaskEstimateProgressBar.fraction(
+          tracked: const Duration(hours: 1),
+          estimate: Duration.zero,
+        ),
+        0,
+      );
+      expect(
+        TaskEstimateProgressBar.fraction(
+          tracked: Duration.zero,
+          estimate: const Duration(hours: 1),
+        ),
+        0,
+      );
+      expect(
+        TaskEstimateProgressBar.fraction(
+          tracked: const Duration(minutes: -5),
+          estimate: const Duration(hours: 1),
+        ),
+        0,
+      );
+    });
+
+    glados.Glados2(
+      glados.any.intInRange(0, 100000),
+      glados.any.intInRange(1, 100000),
+    ).test(
+      'stays within [0, 1] and saturates exactly when overtime',
+      (trackedSeconds, estimateSeconds) {
+        final tracked = Duration(seconds: trackedSeconds);
+        final estimate = Duration(seconds: estimateSeconds);
+        final fraction = TaskEstimateProgressBar.fraction(
+          tracked: tracked,
+          estimate: estimate,
+        );
+        expect(fraction, inInclusiveRange(0, 1));
+        final overtime = TaskEstimateProgressBar.isOvertime(
+          tracked: tracked,
+          estimate: estimate,
+        );
+        if (overtime) {
+          expect(fraction, 1);
+        } else {
+          expect(fraction, trackedSeconds / estimateSeconds);
+        }
+      },
+      tags: ['glados'],
+    );
+  });
+
+  group('TaskEstimateProgressBar', () {
+    testWidgets('paints green within the estimate and red once over', (
+      tester,
+    ) async {
+      for (final (tracked, overtime) in [
+        (const Duration(minutes: 30), false),
+        (const Duration(minutes: 90), true),
+      ]) {
+        await tester.pumpWidget(
+          makeTestableWidget(
+            Center(
+              child: TaskEstimateProgressBar(
+                tracked: tracked,
+                estimate: const Duration(hours: 1),
+              ),
+            ),
+          ),
+        );
+        final context = tester.element(find.byType(LinearProgressIndicator));
+        final bar = tester.widget<LinearProgressIndicator>(
+          find.byType(LinearProgressIndicator),
+        );
+        expect(
+          bar.color,
+          overtime
+              ? TaskShowcasePalette.error(context)
+              : TaskShowcasePalette.success(context),
+          reason: 'tracked=$tracked',
+        );
+        expect(bar.value, overtime ? 1 : 0.5, reason: 'tracked=$tracked');
+        expect(
+          tester.getSize(find.byType(LinearProgressIndicator)),
+          const Size(36, 6),
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
Two small display fixes on the task detail surfaces.

## 1. The estimate is visible at a glance again, with progress

The task header redesign (#3999) moved the estimate into the Details fly-out, so it was only visible after opening that panel. The summary lane now renders it as its own informational tag (timer glyph + `45m of 1h 30m` + the same 36×6 progress bar the pre-redesign header chip carried), between the due date and the labels, on the same `DsPillShape.tag` shell as the other read-outs. Once tracked time runs over the estimate the tag escalates to the tinted alert shell, the way an overdue due date does. Tapping it opens the fly-out like the other facts do. A null or zero estimate renders nothing, the way a missing due date does.

The bar is extracted into `TaskEstimateProgressBar`, shared with the details section's Estimate row, so the two densities draw the same thing. Tracked time reaches the header through the connector from `taskProgressControllerProvider` (read with `.value`, so a time-entry write recomputes without blanking the tag). The tag is announced to assistive tech as "Time tracked: 45m of 1h 30m estimated".

| | before | after |
|---|---|---|
| desktop | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/estimate-pill-agent-freshness/2acdb02520cecce64c37c8d26f7d209bb99b4890/before/task_header_desktop_light.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/estimate-pill-agent-freshness/2acdb02520cecce64c37c8d26f7d209bb99b4890/after/task_header_desktop_light.png) |
| mobile | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/estimate-pill-agent-freshness/2acdb02520cecce64c37c8d26f7d209bb99b4890/before/task_header_mobile_light.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/estimate-pill-agent-freshness/2acdb02520cecce64c37c8d26f7d209bb99b4890/after/task_header_mobile_light.png) |
| desktop, overtime | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/estimate-pill-agent-freshness/2acdb02520cecce64c37c8d26f7d209bb99b4890/before/task_header_overtime_desktop_light.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/estimate-pill-agent-freshness/2acdb02520cecce64c37c8d26f7d209bb99b4890/after/task_header_overtime_desktop_light.png) |
| mobile, overtime | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/estimate-pill-agent-freshness/2acdb02520cecce64c37c8d26f7d209bb99b4890/before/task_header_overtime_mobile_light.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/estimate-pill-agent-freshness/2acdb02520cecce64c37c8d26f7d209bb99b4890/after/task_header_overtime_mobile_light.png) |

(The overtime "before" is the same lane: before this change the lane showed no estimate tag regardless of tracked time.)

## 2. No "Up to date" beside a countdown

`AgentAutomationRow` read the caller's `isStale` flag for the freshness word, glyph and tooltip, while the countdown was driven independently by `showCountdown` + `nextWakeAt`. When the report watermark said fresh but a wake was scheduled, the footer said "Up to date" next to "Next update in 1:30". The row now derives a single `_isOutdated` flag — `isStale || countdown visible` — and every freshness indicator reads that. A scheduled update exists because something changed since the last report, so the countdown is itself proof the summary is behind. Freshness computation in the services is untouched; this is display logic only, and it covers both callers (task agent card and goal agent page).

| | before | after |
|---|---|---|
| desktop | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/estimate-pill-agent-freshness/2acdb02520cecce64c37c8d26f7d209bb99b4890/before/agent_freshness_desktop_light.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/estimate-pill-agent-freshness/2acdb02520cecce64c37c8d26f7d209bb99b4890/after/agent_freshness_desktop_light.png) |
| mobile | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/estimate-pill-agent-freshness/2acdb02520cecce64c37c8d26f7d209bb99b4890/before/agent_freshness_mobile_light.png) | ![](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/estimate-pill-agent-freshness/2acdb02520cecce64c37c8d26f7d209bb99b4890/after/agent_freshness_mobile_light.png) |

## Tests

- `desktop_task_header_test.dart`: tag placement + shape, tracked-of-estimate text and bar fraction, overtime shell + saturated bar, tap opens details, semantics label, omitted for null/zero.
- `desktop_task_header_connector_test.dart`: tag visible without opening the fly-out; tracked time read from the progress controller; absent without an estimate.
- `task_estimate_progress_bar_test.dart`: fraction/overtime logic (incl. a Glados property test), colours and 36×6 size.
- `agent_automation_row_test.dart`: a pending countdown reads "Out of date" (normal + compact), "Up to date" shows with no countdown.
- New regression tests were re-run with their fix reverted and failed.

Concept docs updated (`knowledge/features/tasks/detail-composition.md`, `knowledge/features/agents/ui-surfaces.md`), widgetbook fixture shows the estimate, changelog fragment added.