### PR TITLE
ci(windows): make the Codemagic Windows release manual-only

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -13,13 +13,13 @@ workflows:
       flutter: fvm
       groups:
         - windows_signing
-    triggering:
-      events:
-        - tag
-      tag_patterns:
-        - pattern: '*.*.*+*'
-          include: true
-      cancel_previous_builds: true
+    # No `triggering` block on purpose: the Windows build used to fan out from
+    # every release tag (`*.*.*+*`) like the GitHub lanes do, but the
+    # windows_x2 minutes made it the most expensive lane per release. It is
+    # manual-only for now — start it from the Codemagic UI (Start new build →
+    # Windows Release, pick the release tag) or the builds API. Reinstate a
+    # `triggering: events: [tag]` block with that pattern to put it back on
+    # automatic.
     scripts:
       - name: Show toolchain versions
         script: |

--- a/knowledge/architecture/platform-and-release.md
+++ b/knowledge/architecture/platform-and-release.md
@@ -31,7 +31,7 @@ sources:
   - id: codemagic
     resource: ../../codemagic.yaml
     title: Windows release pipeline
-    last_modified: 2026-07-30
+    last_modified: 2026-09-02
 ---
 
 # One codebase, five targets
@@ -157,8 +157,8 @@ written is in [testing conventions](../conventions/testing.md).
 # Release
 
 Release is triggered by **pushing a git tag whose name is the `pubspec.yaml`
-version**. Seven GitHub workflows listen on `push: tags: ['**']`, and Windows
-fans out from the same tag on a different provider:
+version**. Seven GitHub workflows listen on `push: tags: ['**']`; Windows lives
+on a different provider and, since September 2026, is started by hand:
 
 ```mermaid
 flowchart TD
@@ -171,15 +171,20 @@ flowchart TD
   Tag --> E["flutter-linux-release.yml"]
   Tag --> F["flathub-release-pr.yml"]
   Tag --> G["python-services-release.yml"]
-  Tag --> H["codemagic.yaml — Windows MSIX"]
+  Tag -. "manual start, Codemagic UI/API" .-> H["codemagic.yaml — Windows MSIX"]
 ```
 
 **Windows is the one target not built on GitHub Actions.** It runs on
-[Codemagic](../../codemagic.yaml), on a `windows_x2` instance, triggered by the
-same `*.*.*+*` tag pattern, and it reports back as a `Windows Release` check on
-the tagged commit. Because it lives outside `.github/workflows/`, it is easy to
-overlook when auditing CI — its failures show up only on tag commits and in the
-build-notification email, never on a pull request.
+[Codemagic](../../codemagic.yaml), on a `windows_x2` instance, and reports back
+as a `Windows Release` check on the commit it builds. It **no longer triggers
+on the tag**: the `windows_x2` minutes made it the most expensive lane per
+release, so the `triggering` block was removed and a Windows build is started
+manually from the Codemagic UI (Start new build → *Windows Release*, choosing
+the release tag) or the builds API, only for releases that ship a Windows
+package. Reinstating the `*.*.*+*` tag trigger is one block in
+`codemagic.yaml`. Because it lives outside `.github/workflows/`, it is easy to
+overlook when auditing CI — its failures show up only on the built commit and
+in the build-notification email, never on a pull request.
 
 `flathub-release-pr.yml` also accepts `workflow_dispatch` with an explicit
 commit SHA and version override, for re-cutting a Flathub PR without moving the


### PR DESCRIPTION
## What

Removes the `triggering` block from `codemagic.yaml`, so the **Windows Release** workflow no longer starts on every `*.*.*+*` release tag. It stays defined and can be started by hand from the Codemagic UI (Start new build → Windows Release, pick the release tag) or the builds API.

## Why

The `windows_x2` minutes made it the most expensive lane per release; pausing it is a cost decision, not a build problem. Reinstating the trigger is one block in the same file.

## Docs

`knowledge/architecture/platform-and-release.md`: the release diagram now shows the Windows lane as a manual start, and the prose explains how to start it and how to put the trigger back. No changelog fragment: nothing changes at runtime for users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Windows releases are now started manually through the Codemagic interface or builds API.
  * Automatic Windows builds from release tags have been disabled.
* **Documentation**
  * Updated the release architecture documentation to reflect the new manual Windows release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->