### PR TITLE
fix(notifications): a task opened from the bell has a way back on mobile

### DIFF
--- a/changelog.d/2026-09-02-notification-task-back.md
+++ b/changelog.d/2026-09-02-notification-task-back.md
@@ -1,0 +1,8 @@
+### Fixed
+- **A task opened from the notification bell had no way back on a phone.**
+  Tapping a task suggestion or an overdue alert in the bell's inbox opened the
+  task, but the back chevron did nothing and tapping the Tasks tab again did
+  not return to the list either — the only way out was to restart the app.
+  The bell now opens the task through the same route as the task list, so
+  the back chevron takes you back out of it again, from whichever tab the
+  bell was tapped on.

--- a/knowledge/architecture/navigation.md
+++ b/knowledge/architecture/navigation.md
@@ -56,6 +56,10 @@ sources:
     resource: ../../lib/features/projects/ui/pages/projects_tab_page.dart
     title: Projects desktop split host
     last_modified: 2026-08-15
+  - id: notification-bell
+    resource: ../../lib/features/notifications/ui/widgets/notification_bell.dart
+    title: NotificationBell — a global entry point that beams to a task
+    last_modified: 2026-09-02
 ---
 
 # One stack per tab
@@ -263,6 +267,36 @@ doing nothing, so no route reached by any means is a dead end. That fallback
 root above it — a push would leave the detail underneath, and the next back
 would drop the user straight back into the page they just escaped. The tab root
 is therefore terminal: `canBeamBack` stays false and further backs are no-ops.
+
+## A pageless push is invisible to the router
+
+`Navigator.of(context).push(MaterialPageRoute(...))` from inside a tab lands
+on that tab's Beamer navigator as a *pageless* route: it sits above the pages
+`buildPages` produced, and neither the delegate's configuration nor its
+beaming history records it. Every exit the shell offers reads that state and
+nothing else. `NavService.beamBack` pops the delegate's history, and its
+fallback compares `routeForTab` with the tab root — both see a tab standing at
+its root and do nothing. `tapIndex` on the already-active tab re-beams that
+root, a no-op for a delegate already there. The mobile bottom bar shows or
+hides on `TasksLocation`'s path parameters, which never changed. So a pageless
+page has a dead back chevron, survives a tap on its own tab, and keeps the
+bottom bar docked underneath it.
+
+The notification bell was the case that proved it. Its task rows went through
+`openLinkedTaskDetail`, whose mobile branch is exactly that push, and a task
+opened from the bell on a phone could not be left. **A global entry point
+opens a task by beaming to `/tasks/<id>`** — the list, the logbook cards, the
+Daily OS lanes and the bell all do — so the route is the router's on every
+form factor: on a phone `TasksLocation` stacks `TaskDetailsPage` above the tab
+root with a history entry behind it, on desktop it returns the root page alone
+and selects the task in the split through `resetDesktopTaskDetail`. The beam
+stacks on whatever the Tasks tab already held, like every other beam into a
+tab: a Tasks tab parked on `/tasks/A` while the bell is tapped elsewhere walks
+back through A before reaching the list. That is deliberate — a notification
+tap must not discard the tab's history — and `beamBack` always has a step to
+take. `openLinkedTaskDetail` remains what its name says: a linked task layered
+on top of an *open* task detail, where the base task's own history still gives
+`beamBack` something to pop.
 
 ## Background tabs must not steal the foreground
 

--- a/knowledge/features/notifications.md
+++ b/knowledge/features/notifications.md
@@ -11,7 +11,11 @@ sources:
   - id: src
     resource: ../../lib/features/notifications
     title: Synced notifications source
-    last_modified: 2026-08-27
+    last_modified: 2026-09-02
+  - id: bell
+    resource: ../../lib/features/notifications/ui/widgets/notification_bell.dart
+    title: NotificationBell — the inbox popover and where its rows lead
+    last_modified: 2026-09-02
   - id: os-boundary
     resource: ../../lib/services/notification_service.dart
     title: NotificationService — the OS delivery boundary
@@ -318,6 +322,18 @@ task — which is what happened the moment a second entity kind got a
 notification. The same trap exists in the bell, where `_InboxRow` routes
 through `onSelectEntry` with the whole entity for the same reason. An
 auto-completion row leads to `/habits`, on both channels.
+
+**A task row in the bell beams to `/tasks/<id>`** through `beamToNamed`, the
+route the task list, the logbook cards and the Daily OS lanes use, so the
+router owns the task on every form factor and the back chevron walks the
+Tasks tab's own history — the list, unless that tab already held a task. A
+suggestion row publishes the suggestions focus intent on the task's
+`taskFocusControllerProvider` *before* the beam, so a detail page that this
+very beam mounts finds the intent after load, and one already on screen
+scrolls at once. Why the rows must not go through `openLinkedTaskDetail`, and
+what its pageless push does to every exit the shell offers, lives with the
+shell under
+[a pageless push is invisible to the router](../architecture/navigation.md#a-pageless-push-is-invisible-to-the-router).
 
 **The payload is still not consumed anywhere.** `initialize` is called without
 `onDidReceiveNotificationResponse`, and nothing calls

--- a/lib/features/notifications/ui/widgets/notification_bell.dart
+++ b/lib/features/notifications/ui/widgets/notification_bell.dart
@@ -6,7 +6,7 @@ import 'package:lotti/classes/notification_entity.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/notifications/repository/notification_repository.dart';
 import 'package:lotti/features/notifications/state/notification_inbox_controller.dart';
-import 'package:lotti/features/tasks/util/task_navigation.dart';
+import 'package:lotti/features/tasks/state/task_focus_controller.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/nav_service.dart';
@@ -50,6 +50,46 @@ class NotificationBell extends ConsumerStatefulWidget {
 class _NotificationBellState extends ConsumerState<NotificationBell> {
   final MenuController _menu = MenuController();
 
+  /// Closes the popover and takes the user to whatever [entity] is about.
+  ///
+  /// Every destination is a Beamer route through [beamToNamed] — the same
+  /// path the task list, the logbook cards and the Daily OS lanes take to
+  /// open a task. The task rows used to go through `openLinkedTaskDetail`,
+  /// which exists for layering a linked task *inside* an open task detail:
+  /// on desktop it pushes the right pane's own stack, on a phone it pushes a
+  /// pageless `MaterialPageRoute` onto the tab's Beamer navigator. A pageless
+  /// route is invisible to the router — `NavService.beamBack` found no history
+  /// to pop, and resetting the tab to its root left the page where it was —
+  /// so a task opened from the bell had no way out on mobile. Beaming to
+  /// `/tasks/<id>` hands the task to `TasksLocation` — a real page on a
+  /// phone, the selected task of the split on desktop — so the back chevron
+  /// works, from whichever tab the bell was tapped on.
+  ///
+  /// Exhaustive over the union rather than routing `linkedEntityId` into the
+  /// task detail: every variant answers that getter, so the task route
+  /// silently swallowed ids that were never tasks.
+  void _openEntry(NotificationEntity entity) {
+    _menu.close();
+    switch (entity) {
+      case TaskSuggestionNotification(:final linkedTaskId):
+        // Opening from a suggestion row is the one case that should land on
+        // the suggestions themselves. Published before the beam, so a detail
+        // page that is already mounted scrolls now and one this beam mounts
+        // consumes the intent after load.
+        ref
+            .read(taskFocusControllerProvider(linkedTaskId).notifier)
+            .publishSuggestionFocus();
+        beamToNamed('/tasks/$linkedTaskId');
+      case TaskOverdueNotification(:final linkedTaskId):
+        // No focus intent: an overdue alert is about the task itself.
+        beamToNamed('/tasks/$linkedTaskId');
+      case RelationshipCheckInNotification(:final linkedRelationshipId):
+        beamToNamed('/people/$linkedRelationshipId');
+      case HabitAutoCompletedNotification():
+        beamToNamed('/habits');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
@@ -62,11 +102,6 @@ class _NotificationBellState extends ConsumerState<NotificationBell> {
         ? LottiIcons.notificationActive
         : LottiIcons.notification;
 
-    // Capture the bell's own context so a row tap can navigate even after
-    // the popover overlay (and therefore the row's own context) is torn down
-    // by `_menu.close`. Without this, the row's `_handleTap` would close the
-    // menu and its own context would no longer be safe for navigation.
-    final bellContext = context;
     return MenuAnchor(
       controller: _menu,
       style: MenuStyle(
@@ -95,39 +130,7 @@ class _NotificationBellState extends ConsumerState<NotificationBell> {
               MediaQuery.sizeOf(context).width,
             ),
           ),
-          child: _InboxPanel(
-            onSelectEntry: (entity) {
-              _menu.close();
-              if (!bellContext.mounted) return;
-              // Exhaustive over the union rather than routing
-              // `linkedEntityId` into the task detail: every variant answers
-              // that getter, so the task route silently swallowed ids that
-              // were never tasks.
-              switch (entity) {
-                case TaskSuggestionNotification(:final linkedTaskId):
-                  openLinkedTaskDetail(
-                    context: bellContext,
-                    taskId: linkedTaskId,
-                    // Opening from a suggestion row is the one case that
-                    // should land on the suggestions themselves.
-                    focusSuggestions: true,
-                  );
-                case TaskOverdueNotification(:final linkedTaskId):
-                  // No focusSuggestions: an overdue alert is about the task
-                  // itself, and the parameter already defaults to false.
-                  openLinkedTaskDetail(
-                    context: bellContext,
-                    taskId: linkedTaskId,
-                  );
-                case RelationshipCheckInNotification(
-                  :final linkedRelationshipId,
-                ):
-                  beamToNamed('/people/$linkedRelationshipId');
-                case HabitAutoCompletedNotification():
-                  beamToNamed('/habits');
-              }
-            },
-          ),
+          child: _InboxPanel(onSelectEntry: _openEntry),
         ),
       ],
       builder: (context, controller, _) {
@@ -226,9 +229,9 @@ class _InboxPanel extends ConsumerWidget {
   });
 
   /// Called when the user taps a row. The callback owns both popover
-  /// dismissal and the navigation so it can run from the bell's stable
-  /// context — see comment in [NotificationBell] — and receives the whole
-  /// entity because where a row leads depends on its variant.
+  /// dismissal and the navigation — closing the menu tears the row down, so
+  /// the row itself cannot safely do anything after it — and receives the
+  /// whole entity because where a row leads depends on its variant.
   final void Function(NotificationEntity entity) onSelectEntry;
 
   @override
@@ -412,10 +415,8 @@ class _InboxRow extends StatelessWidget {
   }
 
   void _handleTap() {
-    // Navigation runs against the bell's stable context (captured by
-    // `onSelectEntry` in [NotificationBell.build]) — using the row's own
-    // context here would fail mid-flight because closing the menu
-    // unmounts the popover overlay first.
+    // The bell owns dismissal and navigation: closing the menu unmounts this
+    // row, so nothing here may touch the row's own context afterwards.
     onSelectEntry(entity);
     // Fire markSeen after navigation so the badge clears as the target opens.
     // Opening the target is not the same as acting on an agent suggestion;

--- a/test/README.md
+++ b/test/README.md
@@ -71,6 +71,13 @@ Three consequences:
   `test/widgets/media/thumb_hash_backed_image_test.dart`).
 - `tester.runAsync` is the escape hatch when real decoding is the point.
 
+The same fake clock stalls `dart:io`: a harness that creates a temp directory,
+opens in-memory databases and seeds them — the full-shell recipe in
+`integration_test/manual_screenshots_test.dart` — never gets past
+`Directory.systemTemp.createTemp` inside a `testWidgets` body. Build it in
+`setUp` and dispose it in `tearDown`, both of which run on the real event
+loop, and keep only the pumping inside the test.
+
 ## Simulating a platform without a directory watch
 
 `FileWatcherMixin` polls where `FileSystemEntity.isWatchSupported` is false

--- a/test/features/notifications/ui/widgets/notification_bell_test.dart
+++ b/test/features/notifications/ui/widgets/notification_bell_test.dart
@@ -18,14 +18,36 @@ import 'package:mocktail/mocktail.dart';
 import '../../../../mocks/mocks.dart';
 import '../../../../widget_test_utils.dart';
 
-/// Registers a stubbed [MockNavService] for tests that route desktop task
-/// detail through `getIt<NavService>()`; the file-level `tearDownTestGetIt`
-/// removes it again.
+const _phoneSize = Size(390, 844);
+const _desktopSize = Size(1400, 900);
+
+/// Registers a [MockNavService] so a test can prove the bell never reaches
+/// for the desktop detail stack directly — every destination goes through
+/// the `beamToNamed` seam. The file-level `tearDownTestGetIt` removes it.
 MockNavService _registerNavService() {
   final navService = MockNavService();
   getIt.registerSingleton<NavService>(navService);
-  when(() => navService.pushDesktopTaskDetail(any())).thenAnswer((_) {});
   return navService;
+}
+
+/// Routes the bell's `beamToNamed` calls into the returned list, restoring
+/// the real function on teardown.
+List<String> _captureBeams() {
+  final beamedTo = <String>[];
+  beamToNamedOverride = beamedTo.add;
+  addTearDown(() => beamToNamedOverride = null);
+  return beamedTo;
+}
+
+/// Records every route pushed onto the harness navigator, so a phone-sized
+/// test can prove the bell no longer pushes a pageless task page.
+class _PushRecordingObserver extends NavigatorObserver {
+  final List<Route<dynamic>> pushed = [];
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pushed.add(route);
+  }
 }
 
 void main() {
@@ -324,101 +346,141 @@ void main() {
     },
   );
 
-  testWidgets(
-    'tapping a suggestion row marks it seen and opens suggestions',
-    (tester) async {
-      // Force desktop layout so `openLinkedTaskDetail` goes through
-      // NavService (a registered mock) instead of pushing a MaterialPageRoute
-      // for the still-missing TaskDetailsPage.
-      final navService = _registerNavService();
+  group('opening a task row', () {
+    testWidgets(
+      'a suggestion row on a phone beams to the task route and pushes nothing',
+      (tester) async {
+        // The regression this guards: the row used to push a pageless
+        // MaterialPageRoute onto the tab's Beamer navigator on mobile, which
+        // NavService.beamBack and the tab-root reset cannot see — so the task
+        // had no way out. Beaming lets TasksLocation build it as a real page.
+        final navService = _registerNavService();
+        final beamedTo = _captureBeams();
+        final observer = _PushRecordingObserver();
+        await _openInboxWith(
+          tester,
+          entity: _makeNotification(id: 'act-on-me', title: 'Review', body: ''),
+          size: _phoneSize,
+          navigatorObservers: [observer],
+        );
+        observer.pushed.clear();
 
-      final entity = _makeNotification(
-        id: 'act-on-me',
-        title: 'Review',
-        body: 'Take action',
-      );
-      final container = ProviderContainer(
-        overrides: [
-          unseenNotificationCountProvider.overrideWith(() => _CountUnseen(1)),
-          inboxNotificationsProvider.overrideWith(
-            () => _StaticInbox([entity]),
+        await tester.tap(find.text('Review'));
+        await tester.pump();
+
+        expect(beamedTo, ['/tasks/task-act-on-me']);
+        expect(observer.pushed, isEmpty);
+        verifyNever(() => navService.pushDesktopTaskDetail(any()));
+      },
+    );
+
+    testWidgets(
+      'a suggestion row on desktop beams to the same route rather than '
+      'layering the desktop detail stack',
+      (tester) async {
+        // Selecting the task, like the list pane does, keeps the URL and the
+        // persisted route on the task the user is looking at — and works
+        // from a tab that is not Tasks, where the detail stack is offstage.
+        final navService = _registerNavService();
+        final beamedTo = _captureBeams();
+        await _openInboxWith(
+          tester,
+          entity: _makeNotification(id: 'act-on-me', title: 'Review', body: ''),
+          size: _desktopSize,
+        );
+
+        await tester.tap(find.text('Review'));
+        await tester.pump();
+
+        expect(beamedTo, ['/tasks/task-act-on-me']);
+        verifyNever(() => navService.pushDesktopTaskDetail(any()));
+      },
+    );
+
+    testWidgets(
+      'a suggestion row publishes the suggestions focus intent before the beam',
+      (tester) async {
+        // Order matters: a detail page mounted by this very beam reads the
+        // intent after load, so it has to be there before the route changes.
+        _registerNavService();
+        late final ProviderContainer container;
+        TaskFocusIntent? intentAtBeam;
+        beamToNamedOverride = (_) {
+          intentAtBeam = container.read(
+            taskFocusControllerProvider('task-act-on-me'),
+          );
+        };
+        addTearDown(() => beamToNamedOverride = null);
+        container = await _openInboxWith(
+          tester,
+          entity: _makeNotification(id: 'act-on-me', title: 'Review', body: ''),
+          size: _phoneSize,
+        );
+
+        await tester.tap(find.text('Review'));
+        await tester.pump();
+
+        expect(intentAtBeam, isNotNull);
+        expect(intentAtBeam!.taskId, 'task-act-on-me');
+        expect(intentAtBeam!.target, TaskFocusTarget.suggestions);
+      },
+    );
+
+    testWidgets(
+      'an overdue row beams to the task without a focus intent',
+      (tester) async {
+        final navService = _registerNavService();
+        final beamedTo = _captureBeams();
+        final observer = _PushRecordingObserver();
+        final container = await _openInboxWith(
+          tester,
+          entity: _makeOverdueNotification(
+            id: 'overdue-act-on-me',
+            title: 'Overdue task',
+            body: 'Open task',
           ),
-        ],
-      );
-      addTearDown(container.dispose);
+          size: _phoneSize,
+          navigatorObservers: [observer],
+        );
+        observer.pushed.clear();
 
-      await tester.pumpWidget(
-        _makeBellHarness(
-          container: container,
-          mediaQueryData: const MediaQueryData(size: Size(1400, 900)),
-        ),
-      );
-      await tester.pump();
+        await tester.tap(find.text('Overdue task'));
+        await tester.pump();
 
-      await tester.tap(find.byIcon(LottiIcons.notificationActive));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('Review'));
-      await tester.pump();
+        expect(beamedTo, ['/tasks/task-overdue-act-on-me']);
+        expect(observer.pushed, isEmpty);
+        verifyNever(() => navService.pushDesktopTaskDetail(any()));
+        // An overdue alert is about the task itself, not its suggestions.
+        expect(
+          container.read(taskFocusControllerProvider('task-overdue-act-on-me')),
+          isNull,
+        );
+      },
+    );
 
-      verify(() => repository.markSeen('act-on-me')).called(1);
-      verifyNever(() => repository.markTaskSuggestionsActedOn(any()));
-      verify(
-        () => navService.pushDesktopTaskDetail('task-act-on-me'),
-      ).called(1);
-      final intent = container.read(
-        taskFocusControllerProvider('task-act-on-me'),
-      );
-      expect(intent, isNotNull);
-      expect(intent!.target, TaskFocusTarget.suggestions);
-    },
-  );
+    testWidgets(
+      'tapping a task row marks it seen and closes the popover',
+      (tester) async {
+        _registerNavService();
+        _captureBeams();
+        await _openInboxWith(
+          tester,
+          entity: _makeNotification(id: 'act-on-me', title: 'Review', body: ''),
+          size: _phoneSize,
+        );
 
-  testWidgets(
-    'tapping a non-suggestion row marks only that row seen',
-    (tester) async {
-      final navService = _registerNavService();
+        await tester.tap(find.text('Review'));
+        await tester.pumpAndSettle();
 
-      final entity = _makeOverdueNotification(
-        id: 'overdue-act-on-me',
-        title: 'Overdue task',
-        body: 'Open task',
-      );
-      final container = ProviderContainer(
-        overrides: [
-          unseenNotificationCountProvider.overrideWith(() => _CountUnseen(1)),
-          inboxNotificationsProvider.overrideWith(
-            () => _StaticInbox([entity]),
-          ),
-        ],
-      );
-      addTearDown(container.dispose);
-
-      await tester.pumpWidget(
-        _makeBellHarness(
-          container: container,
-          mediaQueryData: const MediaQueryData(size: Size(1400, 900)),
-        ),
-      );
-      await tester.pump();
-
-      await tester.tap(find.byIcon(LottiIcons.notificationActive));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('Overdue task'));
-      await tester.pump();
-
-      verify(() => repository.markSeen('overdue-act-on-me')).called(1);
-      verifyNever(() => repository.markTaskSuggestionsActedOn(any()));
-      verify(
-        () => navService.pushDesktopTaskDetail('task-overdue-act-on-me'),
-      ).called(1);
-      expect(
-        container.read(
-          taskFocusControllerProvider('task-overdue-act-on-me'),
-        ),
-        isNull,
-      );
-    },
-  );
+        verify(() => repository.markSeen('act-on-me')).called(1);
+        // Opening the target is not acting on the suggestion; the
+        // confirmation flow owns that.
+        verifyNever(() => repository.markTaskSuggestionsActedOn(any()));
+        expect(find.text('Review'), findsNothing);
+        expect(find.byType(NotificationBell), findsOneWidget);
+      },
+    );
+  });
 
   testWidgets(
     'tapping a check-in reminder opens the person, never a task detail',
@@ -427,9 +489,7 @@ void main() {
       // relationship id to `openLinkedTaskDetail` and land on a dead task
       // route. Routing switches on the union instead.
       final navService = _registerNavService();
-      final beamedTo = <String>[];
-      beamToNamedOverride = beamedTo.add;
-      addTearDown(() => beamToNamedOverride = null);
+      final beamedTo = _captureBeams();
 
       final entity = _makeCheckInNotification(
         id: 'anna',
@@ -470,9 +530,7 @@ void main() {
     'tapping an auto-completion row opens the habits page',
     (tester) async {
       final navService = _registerNavService();
-      final beamedTo = <String>[];
-      beamToNamedOverride = beamedTo.add;
-      addTearDown(() => beamToNamedOverride = null);
+      final beamedTo = _captureBeams();
 
       final entity = _makeHabitAutoCompletedNotification(
         id: 'auto-sat',
@@ -546,6 +604,7 @@ void main() {
     'markSeen failure is reported and navigation still proceeds',
     (tester) async {
       final navService = _registerNavService();
+      final beamedTo = _captureBeams();
 
       when(
         () => repository.markSeen(any()),
@@ -580,9 +639,8 @@ void main() {
       ).called(1);
       verifyNever(() => repository.markTaskSuggestionsActedOn(any()));
       // Navigation runs even when markSeen throws.
-      verify(
-        () => navService.pushDesktopTaskDetail('task-mark-failure'),
-      ).called(1);
+      expect(beamedTo, ['/tasks/task-mark-failure']);
+      verifyNever(() => navService.pushDesktopTaskDetail(any()));
       // FlutterError.reportError should have been called with the exception.
       expect(tester.takeException().toString(), contains('mark-seen-boom'));
     },
@@ -628,15 +686,47 @@ void main() {
   );
 }
 
+/// Pumps the bell hosting a single unseen [entity] at [size] and opens the
+/// popover, so a test starts with the row on screen. Returns the container
+/// so the test can read what the tap published.
+Future<ProviderContainer> _openInboxWith(
+  WidgetTester tester, {
+  required NotificationEntity entity,
+  required Size size,
+  List<NavigatorObserver> navigatorObservers = const [],
+}) async {
+  final container = ProviderContainer(
+    overrides: [
+      unseenNotificationCountProvider.overrideWith(() => _CountUnseen(1)),
+      inboxNotificationsProvider.overrideWith(() => _StaticInbox([entity])),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    _makeBellHarness(
+      container: container,
+      mediaQueryData: MediaQueryData(size: size),
+      navigatorObservers: navigatorObservers,
+    ),
+  );
+  await tester.pump();
+  await tester.tap(find.byIcon(LottiIcons.notificationActive));
+  await tester.pumpAndSettle();
+  return container;
+}
+
 Widget _makeBellHarness({
   required ProviderContainer container,
   required MediaQueryData mediaQueryData,
+  List<NavigatorObserver> navigatorObservers = const [],
 }) {
   return UncontrolledProviderScope(
     container: container,
     child: MediaQuery(
       data: mediaQueryData,
       child: MaterialApp(
+        navigatorObservers: navigatorObservers,
         theme: resolveTestTheme(),
         localizationsDelegates: const [
           AppLocalizations.delegate,


### PR DESCRIPTION
Tapping a task suggestion (or an overdue alert) in the notification bell on a phone opened the task, but the back chevron did nothing and tapping the Tasks tab again did not return to the list either — the only way out was to restart the app.

## The cause

Every other surface opens a task by beaming to `/tasks/<id>` — the task list, the logbook cards, the Daily OS lanes. The bell alone went through `openLinkedTaskDetail`, the helper for layering a *linked* task inside an open task detail. On desktop that pushes the right pane's own stack; on a phone it is `Navigator.of(context).push(MaterialPageRoute(TaskDetailsPage))` — a pageless route on the tab's Beamer navigator that neither the delegate's configuration nor its beaming history records.

Every exit reads that state and nothing else. `NavService.beamBack` pops the delegate's history and, failing that, compares `routeForTab` with the tab root — both see a tab standing at `/tasks` and do nothing. `tapIndex` on the already-active tab re-beams `/tasks`, a no-op for a delegate already there. The bottom bar hides on `TasksLocation`'s path parameters, which never changed — which is why it stayed docked underneath the task page, over the task's own action bar. Tapped from the Logbook or Projects tab, the page landed on *that* tab's navigator instead.

## The fix

- The bell's task rows beam to `/tasks/<id>` like every other entry point (`_openEntry` in `notification_bell.dart`), on both form factors. A suggestion row publishes the suggestions focus intent *before* the beam, so a detail page mounted by that beam consumes it after load and one already on screen scrolls at once. `TasksLocation` builds the detail as a real page: the back chevron returns to the task list, the bottom bar hides under the detail as for any task opened from the list, and the URL and persisted route point at the task. On desktop this selects the task the way the list pane does instead of layering the detail stack — which also makes the bell work from a tab other than Tasks, where that stack was offstage.
- `openLinkedTaskDetail` is untouched and keeps its in-task callers (linked task rows, the blocked-by chip).
- Tests in `notification_bell_test.dart`: a phone-sized regression that asserts the beam and that nothing is pushed on the navigator; the same on desktop with the detail stack never touched; the focus intent present *at* the beam; an overdue row with no intent; mark-seen and popover close. The check-in and habit rows keep their tests, on a shared beam-capture helper.
- A `knowledge/` gotcha under the navigation concept (a pageless push is invisible to the router) and the bell's routing in the notifications concept; a note in `test/README.md` on building a full-shell harness in `setUp`.
- Changelog fragment.

## Screenshots

Hosted in `matthiasn/lotti-docs` on branch `agent/notification-bell-task-back-screenshots` (commit `1729e44e05a24c1326991defa23c8a36f8080555`), the way earlier PRs from this account did; the identical pair is staged at `/tmp/lotti-pr-screenshots/notification-bell-task-back/` for `make pr_screenshots_publish` if the R2 copy is wanted.

Before is the base commit (`dc103e126`); after is this branch. Captured with the widget-test harness on the real app shell (in-memory databases, the penguin demo tasks, no user data) at phone size, dark theme. The flow starts from the bell on the Tasks tab:

![Bell inbox open](https://raw.githubusercontent.com/matthiasn/lotti-docs/1729e44e05a24c1326991defa23c8a36f8080555/pr-screenshots/notification-bell-task-back/after/bell_inbox_open_mobile_dark.png)

### Task opened from the bell — mobile

Before, the bottom bar is still docked under the task and covers its action bar; after, the task is a real page of the Tasks tab.

| Before | After |
|---|---|
| ![Task from bell, before](https://raw.githubusercontent.com/matthiasn/lotti-docs/1729e44e05a24c1326991defa23c8a36f8080555/pr-screenshots/notification-bell-task-back/before/task_opened_from_bell_mobile_dark.png) | ![Task from bell, after](https://raw.githubusercontent.com/matthiasn/lotti-docs/1729e44e05a24c1326991defa23c8a36f8080555/pr-screenshots/notification-bell-task-back/after/task_opened_from_bell_mobile_dark.png) |

### After tapping the back chevron — mobile

| Before | After |
|---|---|
| ![After back, before](https://raw.githubusercontent.com/matthiasn/lotti-docs/1729e44e05a24c1326991defa23c8a36f8080555/pr-screenshots/notification-bell-task-back/before/after_back_chevron_mobile_dark.png) | ![After back, after](https://raw.githubusercontent.com/matthiasn/lotti-docs/1729e44e05a24c1326991defa23c8a36f8080555/pr-screenshots/notification-bell-task-back/after/after_back_chevron_mobile_dark.png) |

## Verification

- `fvm dart analyze` on the two touched Dart files — clean; `fvm dart format` — clean
- `fvm flutter test test/features/notifications/ui/widgets/notification_bell_test.dart` — 23 passed
- Line coverage from that run: `notification_bell.dart` 165/165 (100%)
- The five new routing tests re-run with the fix reverted: all five fail
- `make changelog_check`, `make knowledge_check` (validator + 513 Mermaid blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShRjmDjwiW6cf2sqEwACYs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed phone navigation when opening tasks from the notification bell.
  - The back chevron now reliably returns to the task list.
  - Tapping the Tasks tab no longer leaves users stuck on an opened task.
  - Notification entries now open tasks, people, and habits through the correct navigation paths.
  - Suggestion notifications preserve the intended suggestions focus when opening a task.

- **Documentation**
  - Updated navigation and notification guidance.
  - Added testing guidance for temporary files and database setup and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->