### PR TITLE
fix(daily-os): show events on the Day timeline, and open on the Day view

### DIFF
--- a/changelog.d/2026-09-03-daily-os-events-on-timeline.md
+++ b/changelog.d/2026-09-03-daily-os-events-on-timeline.md
@@ -1,0 +1,14 @@
+### Fixed
+- **An event did not show up on the Daily OS timeline.** An event created on
+  the events page and given a start and end there — dinner from 6 PM to
+  midnight, say — was missing from the Day view: the timeline only asked the
+  journal for time recordings and workouts. Events now appear on the recorded
+  lane at the time they carry, titled and coloured as the event itself, and a
+  tap opens the event page. A cancelled, missed or postponed event stays off
+  the timeline, and events stay hidden while the Events feature is off.
+
+### Changed
+- **The Daily OS opens on the Day timeline.** The calendar-shaped view is now
+  the default, with or without a plan for the day; Agenda and Activity remain
+  a tap away. On a phone, a day with nothing planned opens on the recorded
+  lane, where tracked time and events are.

--- a/docs-site/docs/plan-and-capture/daily-os.mdx
+++ b/docs-site/docs/plan-and-capture/daily-os.mdx
@@ -78,9 +78,10 @@ backlog.
 ## 3. Judge the draft
 
 Choose **Build my day** after the reconciliation decisions look right. The
-result opens on **Agenda**. The capacity card answers “does this fit?” before
-the numbered list answers “what matters?” Task-backed rows keep their real
-category, status, estimate, and cover thumbnail.
+result opens on the **Day** timeline; switch to **Agenda** for the list. The
+capacity card answers “does this fit?” before the numbered list answers “what
+matters?” Task-backed rows keep their real category, status, estimate, and
+cover thumbnail.
 
 <ManualScreenshot
   alt="A Project Waddle Daily OS agenda with capacity, task thumbnails, priorities, and category totals"
@@ -132,11 +133,12 @@ use **Refine** afterward, but proposed changes remain reviewable.
 
 ## 6. Compare the plan with reality
 
-Switch from **Agenda** to **Day** for the calendar projection. On desktop,
-Plan and Actual share one time axis. On a phone, swipe horizontally between
-the planned and recorded lanes. Planned blocks use a lighter treatment and
+**Day**, where Daily OS opens, is the calendar projection. On desktop, Plan
+and Actual share one time axis. On a phone, swipe horizontally between the
+planned and recorded lanes. Planned blocks use a lighter treatment and
 recorded sessions are filled, so drift stays visible without rewriting
-history.
+history. An event with a start and end sits on the recorded lane as well;
+tap it to open the event.
 
 <ManualScreenshot
   alt="Daily OS timeline comparing Project Waddle planned blocks with recorded time"

--- a/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
+++ b/docs-site/i18n/cs/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
@@ -78,7 +78,7 @@ nevyřízených úkolů.
 ## 3. Posuď návrh
 
 Jakmile rozhodnutí při srovnání vypadají správně, zvol **Sestavit můj den**.
-Výsledek se otevře na kartě **Agenda**. Karta kapacity nejdřív odpoví na otázku
+Výsledek se otevře na kartě **Den**; pro seznam přepni na **Agendu**. Karta kapacity nejdřív odpoví na otázku
 „vejde se to?“, číslovaný seznam potom na „na čem záleží?“. Řádky propojené s
 úkolem zachovávají jeho skutečnou kategorii, stav, odhad i náhled titulního
 obrázku.
@@ -133,10 +133,10 @@ můžeš použít **Upřesnit**, ale navržené změny zůstávají ke kontrole.
 
 ## 6. Porovnej plán se skutečností
 
-Přepni z **Agendy** na **Den** a zobraz kalendářní projekci. Na počítači sdílejí
+**Den** je kalendářní projekce, na které se Daily OS otevírá. Na počítači sdílejí
 Plán a Skutečnost jednu časovou osu. Na telefonu přejížděj vodorovně mezi
 plánovanou a zaznamenanou stopou. Plánované bloky jsou světlejší, zaznamenaná
-sezení vyplněná, takže odchylka zůstává viditelná bez přepisování historie.
+sezení vyplněná, takže odchylka zůstává viditelná bez přepisování historie. Událost se začátkem a koncem leží také na zaznamenané stopě; klepnutím ji otevřeš.
 
 <ManualScreenshot
   alt="Časová osa Daily OS porovnávající plánované bloky Project Waddle se zaznamenaným časem"

--- a/docs-site/i18n/da/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
+++ b/docs-site/i18n/da/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
@@ -80,7 +80,7 @@ importere hele efterslæbet.
 ## 3. Bedøm udkastet
 
 Vælg **Byg min dag**, når afstemningsbeslutningerne ser rigtige ud.
-Resultatet åbner på **Dagsorden**. Kapacitetskortet besvarer "kan det her
+Resultatet åbner på **Dag**; skift til **Dagsorden** for listen. Kapacitetskortet besvarer "kan det her
 være der?", før den nummererede liste besvarer "hvad betyder noget?"
 Opgavebaserede rækker beholder deres rigtige kategori, status, estimat og
 coverminiature.
@@ -137,11 +137,11 @@ gennemgås.
 
 ## 6. Sammenlign planen med virkeligheden
 
-Skift fra **Dagsorden** til **Dag** for kalenderprojektionen. På desktop
+**Dag**, hvor Daily OS åbner, er kalenderprojektionen. På desktop
 deler plan og virkelighed én tidsakse. På en telefon swiper du vandret mellem
 de planlagte og registrerede baner. Planlagte blokke bruger en lettere
 gengivelse, og registrerede sessioner er udfyldte, så afvigelser forbliver
-synlige uden at omskrive historien.
+synlige uden at omskrive historien. En begivenhed med start og slut ligger også på den registrerede bane; tryk på den for at åbne den.
 
 <ManualScreenshot
   alt="Daily OS-tidslinje, der sammenligner planlagte Project Waddle-blokke med registreret tid"

--- a/docs-site/i18n/de/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
+++ b/docs-site/i18n/de/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
@@ -76,9 +76,10 @@ gesamten Rückstand zu importieren.
 ## 3. Den Entwurf beurteilen
 
 Wähle **Meinen Tag bauen** nach dem Abgleich. Das Ergebnis öffnet sich als
-**Agenda**. Die Kapazitätskarte beantwortet zuerst „Passt das?“, die nummerierte
-Liste danach „Was ist wichtig?“. Aufgabenzeilen behalten Kategorie, Status,
-Schätzung und eigenes Titelbild.
+**Tag**; für die Liste wechselst du zu **Agenda**. Die Kapazitätskarte
+beantwortet zuerst „Passt das?“, die nummerierte Liste danach „Was ist
+wichtig?“. Aufgabenzeilen behalten Kategorie, Status, Schätzung und eigenes
+Titelbild.
 
 <ManualScreenshot
   alt="Project-Waddle-Agenda in Daily OS mit Kapazität, Aufgabenvorschaubildern, Prioritäten und Kategoriensummen"
@@ -131,10 +132,12 @@ bleibt danach verfügbar; Änderungen bleiben prüfbare Vorschläge.
 
 ## 6. Plan und Wirklichkeit vergleichen
 
-Wechsle von **Agenda** zu **Tag**. Auf dem Desktop teilen sich Plan und
-Wirklichkeit eine Zeitachse. Auf Telefonen wischst du zwischen beiden Spuren.
-Geplante Blöcke sind heller, aufgezeichnete Sitzungen gefüllt. Abweichungen
-bleiben sichtbar, ohne die Geschichte umzuschreiben.
+**Tag** ist die Kalenderansicht, mit der Daily OS öffnet. Auf dem Desktop
+teilen sich Plan und Wirklichkeit eine Zeitachse. Auf Telefonen wischst du
+zwischen beiden Spuren. Geplante Blöcke sind heller, aufgezeichnete Sitzungen
+gefüllt. Abweichungen bleiben sichtbar, ohne die Geschichte umzuschreiben. Ein
+Ereignis mit Anfang und Ende liegt ebenfalls auf der aufgezeichneten Spur;
+tippe es an, um es zu öffnen.
 
 <ManualScreenshot
   alt="Daily-OS-Zeitachse mit Project-Waddle-Planblöcken und aufgezeichneter Zeit"

--- a/docs-site/i18n/es/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
+++ b/docs-site/i18n/es/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
@@ -60,7 +60,7 @@ Daily OS también muestra trabajo que está en curso, atrasado, vence hoy o se h
 
 ## 3. Evalúa el borrador
 
-Elige **Construir mi día** cuando las decisiones de conciliación te parezcan correctas. El resultado se abre en **Agenda**. La tarjeta de capacidad responde a «¿cabe todo?» antes de que la lista numerada responda a «¿qué importa?». Las filas basadas en tareas conservan su categoría, estado, estimación y miniatura de portada reales.
+Elige **Construir mi día** cuando las decisiones de conciliación te parezcan correctas. El resultado se abre en **Día**; cambia a **Agenda** para ver la lista. La tarjeta de capacidad responde a «¿cabe todo?» antes de que la lista numerada responda a «¿qué importa?». Las filas basadas en tareas conservan su categoría, estado, estimación y miniatura de portada reales.
 
 <ManualScreenshot
   alt="Agenda de Daily OS de Project Waddle con capacidad, miniaturas de tareas, prioridades y totales por categoría"
@@ -103,7 +103,7 @@ Confirmar fija el esqueleto del plan, no tu capacidad de adaptarte. Aún puedes 
 
 ## 6. Compara el plan con la realidad
 
-Cambia de **Agenda** a **Día** para ver la proyección de calendario. En escritorio, Plan y Real comparten un eje temporal. En un teléfono, desliza horizontalmente entre los carriles planificado y registrado. Los bloques planificados usan un tratamiento más ligero y las sesiones registradas están rellenas, para que las desviaciones sigan siendo visibles sin reescribir el historial.
+**Día**, donde se abre Daily OS, es la proyección de calendario. En escritorio, Plan y Real comparten un eje temporal. En un teléfono, desliza horizontalmente entre los carriles planificado y registrado. Los bloques planificados usan un tratamiento más ligero y las sesiones registradas están rellenas, para que las desviaciones sigan siendo visibles sin reescribir el historial. Un evento con inicio y fin también aparece en el carril registrado; tócalo para abrirlo.
 
 <ManualScreenshot
   alt="Línea de tiempo de Daily OS que compara bloques planificados de Project Waddle con el tiempo registrado"

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
@@ -54,7 +54,7 @@ Daily OS fait aussi apparaître le travail en cours, en retard, à échéance au
 
 ## 3. Évaluer le brouillon
 
-Choisis **Construire ma journée** lorsque les décisions de rapprochement sont justes. Le résultat s'ouvre sur **Agenda**. La carte de capacité répond à « est-ce que ça tient ? » avant que la liste ne réponde à « qu'est-ce qui compte ? ». Les lignes liées à une tâche conservent catégorie, statut, estimation et miniature de couverture.
+Choisis **Construire ma journée** lorsque les décisions de rapprochement sont justes. Le résultat s'ouvre sur **Journée** ; passe à **Agenda** pour la liste. La carte de capacité répond à « est-ce que ça tient ? » avant que la liste ne réponde à « qu'est-ce qui compte ? ». Les lignes liées à une tâche conservent catégorie, statut, estimation et miniature de couverture.
 
 <ManualScreenshot
   alt="Agenda Daily OS Project Waddle avec capacité, miniatures de tâches, priorités et totaux par catégorie"
@@ -97,7 +97,7 @@ Verrouiller fixe les fondations du plan, pas ta capacité à t'adapter. Tu peux 
 
 ## 6. Comparer le plan à la réalité
 
-Passe d'**Agenda** à **Journée** pour la projection calendrier. Sur ordinateur, Plan et Réel partagent un axe temporel. Sur téléphone, balaie horizontalement entre les pistes planifiée et enregistrée. Les blocs planifiés sont plus légers et les sessions enregistrées sont pleines : l'écart reste visible sans réécrire l'historique.
+**Journée**, où s'ouvre Daily OS, est la projection calendrier. Sur ordinateur, Plan et Réel partagent un axe temporel. Sur téléphone, balaie horizontalement entre les pistes planifiée et enregistrée. Les blocs planifiés sont plus légers et les sessions enregistrées sont pleines : l'écart reste visible sans réécrire l'historique. Un événement avec un début et une fin figure aussi sur la piste enregistrée ; touche-le pour l'ouvrir.
 
 <ManualScreenshot
   alt="Chronologie Daily OS comparant les blocs planifiés Project Waddle au temps enregistré"

--- a/docs-site/i18n/it/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
+++ b/docs-site/i18n/it/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
@@ -85,7 +85,7 @@ l'intero backlog.
 ## 3. Giudica la bozza
 
 Scegli **Costruisci la mia giornata** quando le decisioni di riconciliazione ti
-sembrano giuste. Il risultato si apre su **Ordine del giorno**. La scheda della
+sembrano giuste. Il risultato si apre su **Giorno**; passa a **Ordine del giorno** per l'elenco. La scheda della
 capacità risponde a “ci sta?” prima che l'elenco numerato risponda a “cosa
 conta?”. Le righe collegate ad attività mantengono categoria, stato, stima e
 miniatura di copertina reali.
@@ -143,11 +143,11 @@ rivedere.
 
 ## 6. Confronta il piano con la realtà
 
-Passa da **Ordine del giorno** a **Giorno** per la proiezione a calendario. Sul
+**Giorno**, dove si apre Daily OS, è la proiezione a calendario. Sul
 desktop, piano e reale condividono un unico asse temporale. Su un telefono,
 scorri orizzontalmente tra la corsia pianificata e quella registrata. I blocchi
 pianificati usano un trattamento più leggero e le sessioni registrate sono
-piene, così la deriva resta visibile senza riscrivere la storia.
+piene, così la deriva resta visibile senza riscrivere la storia. Anche un evento con inizio e fine compare sulla corsia registrata; toccalo per aprirlo.
 
 <ManualScreenshot
   alt="Timeline del Daily OS che confronta i blocchi pianificati di Project Waddle con il tempo registrato"

--- a/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
+++ b/docs-site/i18n/nl/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
@@ -78,7 +78,7 @@ de hele backlog te importeren.
 ## 3. Beoordeel het concept
 
 Kies **Bouw mijn dag** nadat de reconciliatiebeslissingen er goed uitzien. Het
-resultaat opent op **Agenda**. De capaciteitskaart beantwoordt “past dit?” voordat
+resultaat opent op **Dag**; schakel naar **Agenda** voor de lijst. De capaciteitskaart beantwoordt “past dit?” voordat
 de genummerde lijst “wat doet ertoe?” beantwoordt. Taakgestuurde rijen behouden hun
 echte categorie, status, schatting en omslagminiatuur.
 
@@ -134,11 +134,11 @@ wijzigingen blijven beoordeelbaar.
 
 ## 6. Vergelijk het plan met de werkelijkheid
 
-Schakel van **Agenda** naar **Dag** voor de kalenderprojectie. Op desktop delen plan
+**Dag**, waar Daily OS opent, is de kalenderprojectie. Op desktop delen plan
 en werkelijkheid één tijdas. Veeg op een telefoon horizontaal tussen de geplande en
 geregistreerde banen. Geplande blokken gebruiken een lichtere weergave en opgenomen
 sessies zijn gevuld, zodat afwijking zichtbaar blijft zonder de geschiedenis te
-herschrijven.
+herschrijven. Een gebeurtenis met begin en einde staat ook op de geregistreerde baan; tik erop om haar te openen.
 
 <ManualScreenshot
   alt="Daily OS-tijdlijn vergelijkt geplande Project Waddle-blokken met geregistreerde tijd"

--- a/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
+++ b/docs-site/i18n/pt/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
@@ -81,7 +81,7 @@ importar toda a lista de pendências.
 ## 3. Julgue o rascunho
 
 Escolha **Construir meu dia** depois que as decisões de reconciliação
-parecerem corretas. O resultado abre em **Agenda**. O cartão de capacidade
+parecerem corretas. O resultado abre em **Dia**; mude para **Agenda** para ver a lista. O cartão de capacidade
 responde “isso cabe?” antes de a lista numerada responder “o que importa?” As
 linhas vinculadas a tarefas mantêm sua categoria, status, estimativa e
 miniatura de capa reais.
@@ -138,11 +138,11 @@ passíveis de revisão.
 
 ## 6. Compare o plano com a realidade
 
-Mude de **Agenda** para **Dia** para ver a projeção no calendário. No desktop,
+**Dia**, onde o Daily OS abre, é a projeção no calendário. No desktop,
 Plano e Real compartilham um mesmo eixo de tempo. No celular, deslize
 horizontalmente entre as faixas planejada e registrada. Os blocos planejados
 usam um tratamento mais leve e as sessões gravadas aparecem preenchidas, então
-o desvio permanece visível sem reescrever a história.
+o desvio permanece visível sem reescrever a história. Um evento com início e fim também aparece na faixa registrada; toque nele para abri-lo.
 
 <ManualScreenshot
   alt="Linha do tempo do Daily OS comparando os blocos planejados do Project Waddle com o tempo registrado"

--- a/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
+++ b/docs-site/i18n/ro/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
@@ -60,7 +60,7 @@ Daily OS afișează și munca în curs, întârziată, scadentă astăzi sau rat
 
 ## 3. Evaluați schița
 
-Alegeți **Construiți-mi ziua** după ce deciziile de corelare arată așa cum trebuie. Rezultatul se deschide în **Agendă**. Cardul de capacitate răspunde la „încape?” înainte ca lista numerotată să răspundă la „ce contează?”. Rândurile asociate sarcinilor își păstrează categoria, starea, estimarea și miniatura copertei reale.
+Alegeți **Construiți-mi ziua** după ce deciziile de corelare arată așa cum trebuie. Rezultatul se deschide în **Zi**; treceți la **Agendă** pentru listă. Cardul de capacitate răspunde la „încape?” înainte ca lista numerotată să răspundă la „ce contează?”. Rândurile asociate sarcinilor își păstrează categoria, starea, estimarea și miniatura copertei reale.
 
 <ManualScreenshot
   alt="O agendă Daily OS Project Waddle cu capacitate, miniaturi de sarcini, priorități și totaluri pe categorii"
@@ -103,7 +103,7 @@ Confirmarea fixează structura planului, nu capacitatea dvs. de adaptare. Puteț
 
 ## 6. Comparați planul cu realitatea
 
-Treceți de la **Agendă** la **Zi** pentru proiecția de calendar. Pe desktop, Planul și Realitatea împart aceeași axă a timpului. Pe telefon, glisați orizontal între benzile planificate și cele înregistrate. Blocurile planificate au un aspect mai discret, iar sesiunile înregistrate apar în culoare plină, astfel încât abaterea rămâne vizibilă fără rescrierea istoricului.
+**Zi**, unde se deschide Daily OS, este proiecția de calendar. Pe desktop, Planul și Realitatea împart aceeași axă a timpului. Pe telefon, glisați orizontal între benzile planificate și cele înregistrate. Blocurile planificate au un aspect mai discret, iar sesiunile înregistrate apar în culoare plină, astfel încât abaterea rămâne vizibilă fără rescrierea istoricului. Un eveniment cu început și sfârșit apare și pe banda înregistrată; atingeți-l pentru a-l deschide.
 
 <ManualScreenshot
   alt="Cronologia Daily OS care compară blocurile planificate Project Waddle cu timpul înregistrat"

--- a/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
+++ b/docs-site/i18n/sv/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
@@ -81,7 +81,7 @@ importera hela backloggen.
 ## 3. Bedöm utkastet
 
 Välj **Bygg min dag** när avstämningsbesluten ser rätt ut. Resultatet öppnas
-på **Agenda**. Kapacitetskortet svarar på ”får det här plats?” innan den
+på **Dag**; byt till **Agenda** för listan. Kapacitetskortet svarar på ”får det här plats?” innan den
 numrerade listan svarar på ”vad spelar roll?”. Uppgiftsbaserade rader
 behåller sin verkliga kategori, status, uppskattning och omslagsminiatyr.
 
@@ -137,11 +137,11 @@ granskningsbara.
 
 ## 6. Jämför planen med verkligheten
 
-Byt från **Agenda** till **Dag** för kalenderprojektionen. På skrivbordet
+**Dag**, där Daily OS öppnas, är kalenderprojektionen. På skrivbordet
 delar Plan och Nutid en tidsaxel. På en telefon sveper du horisontellt mellan
 de planerade och inspelade banorna. Planerade block använder en lättare
 stil och inspelade sessioner är fyllda, så att avvikelsen förblir synlig
-utan att historien skrivs om.
+utan att historien skrivs om. Ett evenemang med start och slut ligger också på den inspelade banan; tryck på det för att öppna det.
 
 <ManualScreenshot
   alt="Daily OS-tidslinjen som jämför planerade Project Waddle-block med inspelad tid"

--- a/integration_test/daily_os_manual_screenshots_test.dart
+++ b/integration_test/daily_os_manual_screenshots_test.dart
@@ -479,14 +479,18 @@ void main() {
     await withClock(Clock.fixed(_now), () async {
       await tester.pumpWidget(_desktopDayApp());
       await _settle(tester);
+      // The surface opens on the Day timeline; the agenda capture asks for
+      // the Agenda projection explicitly.
+      final context = tester.element(find.byType(DayPage));
+      final messages = AppLocalizations.of(context)!;
+      await tester.tap(find.text(messages.dailyOsNextPlanViewAgenda).last);
+      await _settle(tester);
       await captureManualScreenshot(
         binding: binding,
         tester: tester,
         name: 'day_desktop_01_agenda_dark',
       );
 
-      final context = tester.element(find.byType(DayPage));
-      final messages = AppLocalizations.of(context)!;
       await tester.tap(find.text(messages.dailyOsNextPlanViewDay).last);
       await _settle(tester);
       await captureManualScreenshot(

--- a/knowledge/features/daily_os_next/overview.md
+++ b/knowledge/features/daily_os_next/overview.md
@@ -89,8 +89,9 @@ empty Day surface. The selected local plan date lives in
 the same provider.
 
 **The root surface is identical on every no-plan day.** `DayPage` mounts in
-*empty mode* with a synthetic `DraftPlan.emptyForDay`, so recorded sessions stay
-visible in Activity without creating a plan first. Empty mode renders an honest
+*empty mode* with a synthetic `DraftPlan.emptyForDay`, so recorded sessions and
+events stay visible on the Day timeline — the default projection, plan or not —
+without creating a plan first. Empty mode renders an honest
 "No plan yet" stat strip, swaps the Refine/Commit footer for a single "Speak a
 check-in" CTA, and hides the delete-plan menu entry.
 

--- a/knowledge/features/daily_os_next/ui-surfaces.md
+++ b/knowledge/features/daily_os_next/ui-surfaces.md
@@ -30,8 +30,12 @@ sources:
     last_modified: 2026-08-01
   - id: actual-lane
     resource: ../../../lib/features/daily_os_next/state/actual_time_blocks_provider.dart
-    title: The Actual lane's blocks, and the workout nudge behind them
-    last_modified: 2026-08-31
+    title: The Actual lane's blocks, the workout nudge and the Events flag behind them
+    last_modified: 2026-09-03
+  - id: recorded-time
+    resource: ../../../lib/features/daily_os_next/logic/recorded_time.dart
+    title: What counts as recorded time, shared by the lane and the planner lookback
+    last_modified: 2026-09-03
 ---
 
 # The planning modal
@@ -159,10 +163,8 @@ Three invariants make repeated navigation cheap:
 ```mermaid
 stateDiagram-v2
   [*] --> NoExplicitPick: app start
-  NoExplicitPick --> DefaultAgenda: render, day has a plan
-  NoExplicitPick --> DefaultActivity: render, day has no plan
-  DefaultAgenda --> ExplicitPick: user taps the toggle
-  DefaultActivity --> ExplicitPick: user taps the toggle
+  NoExplicitPick --> DefaultDay: render, with or without a plan
+  DefaultDay --> ExplicitPick: user taps the toggle
   ExplicitPick --> ExplicitPick: date changes (chevrons / Today / picker / sidebar)
   ExplicitPick --> [*]: app restart clears the in-memory provider
 ```
@@ -170,11 +172,14 @@ stateDiagram-v2
 - **The projection survives the day change.** The root re-keys `DayPage` on
   every date change, so the selected `PlanView` lives in
   `dailyOsNextPlanViewProvider` rather than in the page's `State`. `null` there
-  means "not chosen yet" and the page falls back to its per-day default —
-  Agenda with a plan, Activity without one. The provider is in-memory, so a
-  fresh app start lands on that default again, while every date-change path
-  (chevrons, `Today`, the picker, the sidebar month calendar) keeps whichever
-  view the user picked.
+  means "not chosen yet" and the page falls back to its default — the **Day**
+  timeline, with or without a plan: the calendar-shaped projection is where
+  the surface opens, and Agenda and Activity are a tap away. (Empty mode used
+  to land on Activity so a failed recording was in view at once; that recovery
+  path is now one tap away, while tracked time and events are visible at
+  once.) The provider is in-memory, so a fresh app start lands on that default
+  again, while every date-change path (chevrons, `Today`, the picker, the
+  sidebar month calendar) keeps whichever view the user picked.
 
 ## Tracked time
 
@@ -202,6 +207,40 @@ chart had been opened — so each recompute of the lane now nudges
 throttles it to one delta per ten minutes, a failure is logged and swallowed,
 and the journal write a delta produces comes back through the same notification
 stream that triggers the recompute. See [health import](../health_import.md).
+
+**Events are recorded time too.** An event the user gave a span on the events
+page — `meta.dateFrom`..`dateTo`; the date line there is the single source of
+its when — reaches the lane through the same `sortedCalendarEntries` query,
+whose SQL admits `JournalEvent` rows beside recordings and workouts. (Before
+this, the query named only `JournalEntry` and `WorkoutEntry`, so an event
+edited to run 18:00–24:00 was simply absent from the Day view.)
+`resolveTimeEntries` in
+[recorded_time.dart](../../../lib/features/daily_os_next/logic/recorded_time.dart)
+owns the rules once, for this lane *and* the planner's week-context lookback:
+
+- an event counts only while the **Events feature flag** is on — with it off,
+  events are hidden everywhere, so the lane awaits
+  `configFlagProvider(enableEventsFlag)` and re-runs when it flips, and the
+  week-context service reads `getConfigFlag` before it resolves;
+- and only when it **took place** (`eventTookPlace`): a cancelled or missed
+  event never happened and a postponed one has left its slot without naming
+  a new one; every other status — tentative, planned, ongoing, completed,
+  rescheduled — stands at its stored slot and is not second-guessed against
+  the date;
+- an event resolves with **no linked-from entity**: its own title and category
+  are the block's, never those of a task it was created under, and it carries
+  no `taskId`.
+
+It projects as a `TimeBlockType.cal` block whose id carries the `actual:`
+prefix, so it is read-only and never arrangeable like every tracked block, and
+a tap on it beams to `/events/<id>` — the event's one way in — where a tracked
+manual block would open its task. Its state follows the status
+(`eventBlockState`): `completed` earns the lane's check mark and a place in
+the time-spent card's "N done", `ongoing` the in-progress treatment, and an
+event still ahead — tentative, planned, rescheduled — is `committed`, filled
+but unchecked; a recording, finished by definition, is always `completed`. A
+multi-day event stays outside the containment query, as a recording crossing
+midnight does.
 
 ## The docked day-view column (desktop shell)
 
@@ -257,6 +296,19 @@ touching it:
   the planned and actual lanes side by side while a narrow one falls back to
   the swipeable `PageView` — the same gesture as the Day surface, and it
   feeds the same one-shot `timelineGesturesLearned` preference.
+- **A paged timeline with nothing planned opens on the recorded lane.** The
+  planned lane is empty by construction then, and since the Day view is the
+  default projection a phone would otherwise land on a blank page with the
+  tracked time and events one swipe away. The coaching line reads "Swipe for
+  plan" in that state, and the swipe counts as learned only by travelling
+  away from the lane the pager opened on — opening on the recorded lane is
+  not a demonstration of the gesture. The choice is re-made when "nothing
+  planned" flips under a live widget: the docked column hands the timeline
+  `DraftPlan.emptyForDay` while `currentDraftPlanProvider` is still loading,
+  so the pager opens on the recorded lane, and when the real plan resolves
+  into the same `State` the pager jumps to the planned lane (and back, should
+  a plan be emptied) — programmatically, so it is not counted as the swipe
+  either.
 
 ## Task-linked versus standalone
 

--- a/knowledge/features/events.md
+++ b/knowledge/features/events.md
@@ -20,8 +20,9 @@ memory-forward overview and a photographic detail page.
 
 **Gated behind `enableEventsFlag`.** With it off, events are hidden *everywhere*:
 the logbook query drops the `JournalEvent` type, `EntryDetailsWidget` renders a
-linked event as nothing, and the tab, create-event and type-filter affordances are
-absent.
+linked event as nothing, the tab, create-event and type-filter affordances are
+absent, and the Daily OS timeline's recorded lane — and the planner's
+recorded-time lookback behind it — leave events out.
 
 # An entity, not a task subtype
 
@@ -68,10 +69,20 @@ language updates both surfaces immediately without migrating an event.
 # One way in
 
 There is **one** way to open an event: `/events/<id>`. Every entry point routes
-there — the overview, a logbook card tap, a freshly created event, and a linked
-event inside a task's timeline. A linked event renders as a compact summary card
-resolved the same way the detail page resolves its cover, **not** the generic
-entry editor.
+there — the overview, a logbook card tap, a freshly created event, a linked
+event inside a task's timeline, and the event's block on the Daily OS Day
+timeline. A linked event renders as a compact summary card resolved the same
+way the detail page resolves its cover, **not** the generic entry editor.
+
+# On the day
+
+An event with a span is recorded time on the Daily OS Day timeline: it sits on
+the recorded lane at the start and end the date line gave it, titled and
+coloured as the event itself — never as a task it hangs off — and its block
+opens the event page. A cancelled, missed or postponed event stays off the
+lane. The
+query, the flag gate and the status rule live with the lane, in
+[Daily OS UI surfaces](daily_os_next/ui-surfaces.md#tracked-time).
 
 # The hero is the interaction surface
 

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -488,7 +488,7 @@ SELECT id FROM journal
 
 sortedCalenderEntriesInRange:
 SELECT * FROM journal
-  WHERE type in ('JournalEntry', 'WorkoutEntry') AND
+  WHERE type in ('JournalEntry', 'WorkoutEntry', 'JournalEvent') AND
   deleted = false
   AND date_from >= :rangeStart
   AND date_to <= :rangeEnd

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -6175,7 +6175,7 @@ abstract class _$JournalDb extends GeneratedDatabase {
     DateTime rangeEnd,
   ) {
     return customSelect(
-      'SELECT * FROM journal WHERE type IN (\'JournalEntry\', \'WorkoutEntry\') AND deleted = FALSE AND date_from >= ?1 AND date_to <= ?2 ORDER BY date_from DESC',
+      'SELECT * FROM journal WHERE type IN (\'JournalEntry\', \'WorkoutEntry\', \'JournalEvent\') AND deleted = FALSE AND date_from >= ?1 AND date_to <= ?2 ORDER BY date_from DESC',
       variables: [Variable<DateTime>(rangeStart), Variable<DateTime>(rangeEnd)],
       readsFrom: {journal},
     ).asyncMap(journal.mapFromRow);

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -25,6 +25,10 @@ via the rail's calendar button and resized by its edge; both survive restarts.
   rejected per change.
 - **Respects what's real.** The plan knows about tasks already tracked today, due
   dates, estimates, and which tasks are blocked by others.
+- **Opens on the calendar.** The Day timeline is the default view, plan or no
+  plan: recorded time, imported workouts and events with a start and end sit on
+  its recorded lane, and an event opens from its block. Agenda and Activity are
+  a tap away.
 - **Keeps everything even when things fail.** A recording is saved before anything
   is transcribed, and a failed transcription is retried in the background rather
   than losing the recording. Closing the app mid-plan does not lose the request.

--- a/lib/features/daily_os_next/agents/service/day_agent_week_context_service.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_week_context_service.dart
@@ -18,6 +18,7 @@ import 'package:lotti/features/daily_os_next/logic/recorded_time.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/utils/consts.dart';
 
 /// Raised by the week-context service for an invalid tool/argument.
 class DayAgentWeekContextException implements Exception {
@@ -196,11 +197,16 @@ class DayAgentWeekContextService {
 
   /// Shared recorded-time resolution for an arbitrary local-midnight range
   /// (containment query semantics — see [_recordedSpans] for the caveats).
+  ///
+  /// Events count as recorded time only while the Events feature is on —
+  /// they are hidden everywhere else with it off, and a planner quoting
+  /// hours the user cannot see anywhere would be a puzzle, not context.
   Future<List<RecordedSpan>> _recordedSpansInRange({
     required DateTime rangeStart,
     required DateTime rangeEnd,
     bool canonicalDurations = false,
   }) async {
+    final eventsEnabled = await journalDb.getConfigFlag(enableEventsFlag);
     final entries = await journalDb.sortedCalendarEntries(
       rangeStart: rangeStart,
       rangeEnd: rangeEnd,
@@ -218,6 +224,7 @@ class DayAgentWeekContextService {
       linkedFromById: {
         for (final entity in linkedFrom) entity.meta.id: entity,
       },
+      eventsEnabled: eventsEnabled,
     );
     return [
       for (final pair in resolved)

--- a/lib/features/daily_os_next/logic/day_agent_timeline_models.dart
+++ b/lib/features/daily_os_next/logic/day_agent_timeline_models.dart
@@ -6,7 +6,10 @@ enum TimeBlockType {
   /// Agent-drafted block.
   ai,
 
-  /// Real calendar event imported from the device calendar.
+  /// A calendar event: on the Actual lane, a Lotti event projected from the
+  /// journal (its id carries the [actualTimeBlockIdPrefix], and a tap opens
+  /// the event page); on the planned lane, a calendar-owned block the plan
+  /// must schedule around. Never editable or arrangeable.
   cal,
 
   /// Buffer between focus blocks (transition / commute / decompression).

--- a/lib/features/daily_os_next/logic/recorded_time.dart
+++ b/lib/features/daily_os_next/logic/recorded_time.dart
@@ -1,4 +1,5 @@
 import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/classes/event_status.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
 
@@ -9,6 +10,10 @@ import 'package:lotti/features/journal/util/entry_tools.dart';
 /// time, and what work do they belong to?": skip tombstones, skip zero-length
 /// entries, and resolve each survivor's linked-from entity (a linked Task wins,
 /// ratings never count, otherwise the first surviving non-rating link).
+/// An event with a span counts too — it is the user's own statement of where
+/// the time went — as long as the Events feature is on and the event
+/// actually took place ([eventTookPlace]); an event is always its own thing
+/// and is never attributed to the task it may hang off.
 /// This module owns that resolution once; each consumer projects the resolved
 /// pairs into its own shape (UI `TimeBlock`s, prompt span buckets).
 
@@ -22,12 +27,15 @@ class ResolvedTimeEntry {
     required this.duration,
   });
 
-  /// The time-recording journal entry itself (carries id, dateFrom/dateTo,
-  /// entry text — everything a UI projection needs that a bare span loses).
+  /// The time-recording journal entry — or the [JournalEvent] — itself
+  /// (carries id, dateFrom/dateTo, entry text — everything a UI projection
+  /// needs that a bare span loses).
   final JournalEntity entry;
 
   /// The entity the time was recorded against: a linked [Task] when one
   /// exists, else the first surviving non-rating linked entity, else null.
+  /// Always null for a [JournalEvent]: the event is the thing the time went
+  /// to, so its own title and category stand.
   final JournalEntity? linkedFrom;
 
   /// The entry's recorded duration (strictly positive by construction).
@@ -48,12 +56,34 @@ class ResolvedTimeEntry {
   DateTime get start => entry.meta.dateFrom;
 }
 
+/// Whether an [event] took place at the time it carries.
+///
+/// A cancelled or missed event never happened, and a postponed one has left
+/// its slot without yet naming a new one — none of them fills the Actual lane
+/// or the planner's recorded-time lookback. Every other status — tentative,
+/// planned, ongoing, completed, rescheduled — describes an event that stands
+/// at its stored slot: the date line on the event page is the single source
+/// of the event's when, so the status is not second-guessed against it.
+bool eventTookPlace(JournalEvent event) => switch (event.data.status) {
+  EventStatus.cancelled || EventStatus.missed || EventStatus.postponed => false,
+  EventStatus.tentative ||
+  EventStatus.planned ||
+  EventStatus.ongoing ||
+  EventStatus.completed ||
+  EventStatus.rescheduled => true,
+};
+
 /// Resolves the entries that count as recorded time into
 /// entry/linked-from pairs.
 ///
 /// Skips deleted entries and entries without a positive [entryDuration];
 /// resolves each survivor's linked-from entity via [resolveLinkedFrom] using
 /// the non-deleted [links]. Output preserves the order of [entries].
+///
+/// A [JournalEvent] survives only while [eventsEnabled] (the Events feature
+/// flag — with it off, events are hidden everywhere, this resolution
+/// included) and while it [eventTookPlace]; it resolves with no linked-from
+/// entity, so its own category and title are what the consumers see.
 ///
 /// The [links] are ordered by `(createdAt, fromId)` before the candidate
 /// sets are built: the backing query carries no ORDER BY, so its row order
@@ -66,6 +96,7 @@ List<ResolvedTimeEntry> resolveTimeEntries({
   required List<JournalEntity> entries,
   required List<EntryLink> links,
   required Map<String, JournalEntity> linkedFromById,
+  required bool eventsEnabled,
 }) {
   final orderedLinks = links.toList()
     ..sort((a, b) {
@@ -84,16 +115,20 @@ List<ResolvedTimeEntry> resolveTimeEntries({
   final out = <ResolvedTimeEntry>[];
   for (final entry in entries) {
     if (entry.meta.deletedAt != null) continue;
+    final isEvent = entry is JournalEvent;
+    if (isEvent && (!eventsEnabled || !eventTookPlace(entry))) continue;
     final duration = entryDuration(entry);
     if (duration <= Duration.zero) continue;
 
     out.add(
       ResolvedTimeEntry(
         entry: entry,
-        linkedFrom: resolveLinkedFrom(
-          linkedFromIds: entryIdToLinkedFromIds[entry.meta.id],
-          linkedFromById: linkedFromById,
-        ),
+        linkedFrom: isEvent
+            ? null
+            : resolveLinkedFrom(
+                linkedFromIds: entryIdToLinkedFromIds[entry.meta.id],
+                linkedFromById: linkedFromById,
+              ),
         duration: duration,
       ),
     );

--- a/lib/features/daily_os_next/state/actual_time_blocks_provider.dart
+++ b/lib/features/daily_os_next/state/actual_time_blocks_provider.dart
@@ -4,8 +4,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/classes/event_status.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/logic/recorded_time.dart';
@@ -14,6 +16,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/signals/health_signal_refresh_service.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/date_utils_extension.dart';
 
 const _fallbackActualCategory = DayAgentCategory(
@@ -45,6 +48,13 @@ Stream<Set<String>> actualTimelineUpdateBatches(Stream<Set<String>> updates) {
 /// (tombstone/zero-length filtering, linked-from resolution) lives in
 /// [actualTimeBlocksForEntries] via the shared `resolveTimeEntries` core.
 ///
+/// An event whose span sits inside the day is recorded time too — the user
+/// set its start and end on the event page — and lands on the lane as a
+/// calendar block whose state follows the event's status
+/// ([eventBlockState]). Because events are hidden everywhere while the
+/// Events feature is off, the projection watches that flag and re-runs when
+/// it flips.
+///
 /// Workouts are recorded time too, but they reach the journal only through the
 /// health import, and nothing on this surface used to ask for one — a walk
 /// appeared on the timeline only after some dashboard with a workout chart had
@@ -55,6 +65,9 @@ Stream<Set<String>> actualTimelineUpdateBatches(Stream<Set<String>> updates) {
 final dailyOsActualTimeBlocksProvider = FutureProvider.autoDispose
     .family<List<TimeBlock>, DateTime>((ref, date) async {
       ref.watch(dailyOsActualTimeUpdateProvider);
+      final eventsEnabled = ref.watch(
+        configFlagProvider(enableEventsFlag).future,
+      );
       unawaited(
         ref.read(healthSignalRefreshServiceProvider)?.refreshWorkouts(),
       );
@@ -73,6 +86,7 @@ final dailyOsActualTimeBlocksProvider = FutureProvider.autoDispose
         links: links,
         linkedFromById: await _linkedFromById(db, links),
         categoryById: _categoryById,
+        eventsEnabled: await eventsEnabled,
       );
     });
 
@@ -91,20 +105,28 @@ CategoryDefinition? _categoryById(String id) {
   return getIt<EntitiesCacheService>().getCategoryById(id);
 }
 
+/// Projects the day's entries onto the Actual lane.
+///
+/// A [JournalEvent] becomes a [TimeBlockType.cal] block so the timeline can
+/// route a tap to the event page, in the state its status implies; everything
+/// else is a [TimeBlockType.manual] recording, finished by definition.
+/// [eventsEnabled] is the Events feature flag, forwarded to the shared core.
 @visibleForTesting
 List<TimeBlock> actualTimeBlocksForEntries({
   required List<JournalEntity> entries,
   required List<EntryLink> links,
   required Map<String, JournalEntity> linkedFromById,
   required CategoryDefinition? Function(String id) categoryById,
+  required bool eventsEnabled,
 }) {
   // The shared core decides what counts as recorded time (tombstones,
-  // zero-length entries, linked-from resolution); this provider only projects
-  // the resolved pairs into UI TimeBlocks.
+  // zero-length entries, linked-from resolution, events); this provider only
+  // projects the resolved pairs into UI TimeBlocks.
   final resolved = resolveTimeEntries(
     entries: entries,
     links: links,
     linkedFromById: linkedFromById,
+    eventsEnabled: eventsEnabled,
   );
 
   final out = <TimeBlock>[];
@@ -123,8 +145,10 @@ List<TimeBlock> actualTimeBlocksForEntries({
         title: title,
         start: entry.meta.dateFrom,
         end: entry.meta.dateTo,
-        type: TimeBlockType.manual,
-        state: TimeBlockState.completed,
+        type: entry is JournalEvent ? TimeBlockType.cal : TimeBlockType.manual,
+        state: entry is JournalEvent
+            ? eventBlockState(entry)
+            : TimeBlockState.completed,
         category: category,
         taskId: pair.taskId,
       ),
@@ -134,6 +158,28 @@ List<TimeBlock> actualTimeBlocksForEntries({
   out.sort((a, b) => a.start.compareTo(b.start));
   return out;
 }
+
+/// The lane state an [event] projects to: a recording is finished by
+/// definition, an event is only as far along as its status says.
+///
+/// `completed` earns the tracked lane's check mark (and a place in "N done"
+/// on the time-spent card), `ongoing` the in-progress treatment, and an event
+/// still ahead of the user — tentative, planned, rescheduled — is `committed`:
+/// on the lane, filled, unchecked. Cancelled, missed and postponed never reach
+/// the projection ([resolveTimeEntries] drops them), so they map to
+/// [TimeBlockState.dropped] only to keep the mapping total.
+@visibleForTesting
+TimeBlockState eventBlockState(JournalEvent event) =>
+    switch (event.data.status) {
+      EventStatus.completed => TimeBlockState.completed,
+      EventStatus.ongoing => TimeBlockState.inProgress,
+      EventStatus.tentative ||
+      EventStatus.planned ||
+      EventStatus.rescheduled => TimeBlockState.committed,
+      EventStatus.cancelled ||
+      EventStatus.missed ||
+      EventStatus.postponed => TimeBlockState.dropped,
+    };
 
 DayAgentCategory _projectCategory(
   String? categoryId,
@@ -158,6 +204,13 @@ String _actualBlockTitle({
   required JournalEntity? linkedFrom,
   required DayAgentCategory category,
 }) {
+  // An event is titled on its own page; that title is the block's. An
+  // untitled event falls through the same chain as any other recording.
+  if (entry is JournalEvent) {
+    final eventTitle = entry.data.title.trim();
+    if (eventTitle.isNotEmpty) return eventTitle;
+  }
+
   if (linkedFrom is Task) {
     final taskTitle = linkedFrom.data.title.trim();
     if (taskTitle.isNotEmpty) return taskTitle;

--- a/lib/features/daily_os_next/state/plan_view_provider.dart
+++ b/lib/features/daily_os_next/state/plan_view_provider.dart
@@ -11,8 +11,8 @@ import 'package:lotti/features/daily_os_next/ui/widgets/plan_view_toggle.dart';
 /// jump-to-today button, the date picker, the sidebar calendar).
 ///
 /// `null` means "the user has not chosen yet", in which case the page falls
-/// back to its per-day default (Agenda with a plan, Activity without one).
-/// The provider is deliberately in-memory only, so a fresh app start lands on
+/// back to its default, the Day timeline — with or without a plan. The
+/// provider is deliberately in-memory only, so a fresh app start lands on
 /// that default again.
 class DailyOsNextPlanView extends Notifier<PlanView?> {
   @override

--- a/lib/features/daily_os_next/ui/pages/day_page.dart
+++ b/lib/features/daily_os_next/ui/pages/day_page.dart
@@ -39,19 +39,22 @@ import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
 
 enum _QuickRefinement { tooMuch, moveLighter, addBuffer }
 
-/// Hosts the two projections of the [DraftPlan] — Agenda (intent) and
-/// Day (mechanics) — with a pill toggle at the top.
+/// Hosts the three projections of the [DraftPlan] — Agenda (intent), Day
+/// (mechanics) and Activity (what was said and recorded) — with a pill
+/// toggle at the top.
 ///
-/// Agenda is the default surface per the prototype: it's the
-/// "what today is about" view; Day is the "when does it happen"
-/// projection a tap away. A footer pill opens the Refine screen for
+/// Day is the default surface: the calendar-shaped "when does it happen"
+/// projection, where planned blocks and the day's recorded time and events
+/// sit on one time axis. Agenda ("what today is about") and Activity are a
+/// tap away, and a pick survives day changes through
+/// [dailyOsNextPlanViewProvider]. A footer pill opens the Refine screen for
 /// voice-driven plan changes.
 ///
 /// With no plan ([hasPlan] false — the route-level root passes a
-/// synthetic empty [draft]) the page lands on **Activity** so every saved or
-/// recoverable recording remains immediately visible, and the
-/// footer carries a single "Speak a check-in" CTA instead of
-/// Refine/Commit (handoff v2 item 2).
+/// synthetic empty [draft]) the page still lands on Day, so recorded
+/// sessions and events stay visible on the timeline, and the footer carries
+/// a single "Speak a check-in" CTA instead of Refine/Commit (handoff v2
+/// item 2). Saved or recoverable recordings remain one tap away on Activity.
 class DayPage extends ConsumerStatefulWidget {
   const DayPage({
     required this.draft,
@@ -82,12 +85,10 @@ class DayPage extends ConsumerStatefulWidget {
 
 class _DayPageState extends ConsumerState<DayPage> {
   /// The projection to render: the user's explicit pick when there is one,
-  /// otherwise this day's default. The pick lives in
+  /// otherwise the Day timeline. The pick lives in
   /// [dailyOsNextPlanViewProvider] so stepping to another day — which re-keys
   /// this page — does not throw it away.
-  PlanView get _view =>
-      ref.watch(dailyOsNextPlanViewProvider) ??
-      (widget.hasPlan ? PlanView.agenda : PlanView.activity);
+  PlanView get _view => ref.watch(dailyOsNextPlanViewProvider) ?? PlanView.day;
 
   /// Measurement anchor for the onboarding spotlight over the empty-Day CTA.
   final GlobalKey _checkInCtaKey = GlobalKey();

--- a/lib/features/daily_os_next/ui/widgets/day_timeline.dart
+++ b/lib/features/daily_os_next/ui/widgets/day_timeline.dart
@@ -157,7 +157,9 @@ class _DayTimelineState extends State<DayTimeline> {
   void initState() {
     super.initState();
     _pxPerMinute = widget.pxPerMinute;
+    _initialLanePage = _recordedLaneFirst ? 1 : 0;
     _pageController = PageController(
+      initialPage: _initialLanePage,
       viewportFraction: _horizontalPeekFraction,
     )..addListener(_onLanePageScroll);
     _timelineScrollController = ScrollController()
@@ -180,12 +182,40 @@ class _DayTimelineState extends State<DayTimeline> {
     if (oldWidget.pxPerMinute != widget.pxPerMinute) {
       _pxPerMinute = widget.pxPerMinute;
     }
+    _reselectLaneIfPlanPresenceChanged();
+  }
+
+  /// With nothing planned the planned lane is empty by construction, so a
+  /// phone opens on the recorded lane — where tracked time and events are —
+  /// rather than on a blank page with the real content one swipe away.
+  bool get _recordedLaneFirst => widget.draft.blocks.isEmpty;
+
+  /// The lane the pager opened on — or was last re-pointed at, see
+  /// [_reselectLaneIfPlanPresenceChanged]; the swipe is learned by travelling
+  /// away from it, not by where it started.
+  late int _initialLanePage;
+
+  /// Follows the natural first lane when "nothing planned" flips under a
+  /// live widget. The docked day-view column hands this timeline
+  /// `DraftPlan.emptyForDay` while the plan provider is still loading, so
+  /// the pager opened on the recorded lane; once the real plan resolves the
+  /// state is kept, and without this the planned day would stay on the
+  /// Actual lane under a coaching line pointing the wrong way. The jump is
+  /// programmatic and lands on the new baseline, so it never reads as the
+  /// user's swipe.
+  void _reselectLaneIfPlanPresenceChanged() {
+    final lane = _recordedLaneFirst ? 1 : 0;
+    if (lane == _initialLanePage) return;
+    _initialLanePage = lane;
+    if (_pageController.hasClients) _pageController.jumpToPage(lane);
   }
 
   void _onLanePageScroll() {
     final page = _pageController.hasClients ? _pageController.page : null;
     // Half a page of travel = the swipe gesture has been demonstrated.
-    if (page != null && page > 0.5) _markGesturesLearned();
+    if (page != null && (page - _initialLanePage).abs() > 0.5) {
+      _markGesturesLearned();
+    }
   }
 
   void _scheduleNextMinute() {
@@ -286,7 +316,16 @@ class _DayTimelineState extends State<DayTimeline> {
     final paneLabelHeight =
         tokens.typography.lineHeight.overline + tokens.spacing.step2;
     final timelineTopInset = paneLabelHeight + tokens.spacing.step3;
-    final timelineContentHeight = totalHeight + tokens.spacing.step9;
+    // The scroll content is exactly what a pane lays out — its label, the
+    // folded hour grid and the pane's own vertical inset — plus a step of
+    // room below the last block. Spelled in the pane's terms rather than as
+    // one larger token so it keeps fitting when a spacing token changes;
+    // a flat `step9` only fit the default tokens by coincidence.
+    final timelineContentHeight =
+        paneLabelHeight +
+        totalHeight +
+        tokens.spacing.step5 +
+        tokens.spacing.step4;
     // Hour labels and the now-chip live on the rail; widen it with the
     // user's text scale so "09:00" never clips at accessibility sizes.
     final timeRailWidth = math.max(
@@ -308,6 +347,7 @@ class _DayTimelineState extends State<DayTimeline> {
                 mode: comparisonMode,
                 arrangeMode: _arrangeMode,
                 showHint: widget.showGestureHint,
+                recordedLaneFirst: _recordedLaneFirst,
                 onToggleMode: _toggleComparisonMode,
                 onToggleArrange: widget.onRescheduleBlock == null
                     ? null

--- a/lib/features/daily_os_next/ui/widgets/day_timeline_block.dart
+++ b/lib/features/daily_os_next/ui/widgets/day_timeline_block.dart
@@ -403,7 +403,14 @@ class DayBlock extends ConsumerWidget {
     final openEditor = canEdit ? () => onEdit!(effectiveBlock) : null;
     final isDrafted =
         !tracked && effectiveBlock.state == TimeBlockState.drafted;
-    final onTap = taskId == null || taskId.isEmpty
+    // A tracked calendar block projects a Lotti event, and an event has one
+    // destination: its own page. Nothing else on the lane routes there.
+    final eventId = tracked && effectiveBlock.type == TimeBlockType.cal
+        ? effectiveBlock.trackedEntryId
+        : null;
+    final onTap = eventId != null
+        ? () => beamToNamed('/events/$eventId')
+        : taskId == null || taskId.isEmpty
         ? null
         : () {
             // Tracked blocks project a real time recording. Publish the

--- a/lib/features/daily_os_next/ui/widgets/day_timeline_fold_surface.dart
+++ b/lib/features/daily_os_next/ui/widgets/day_timeline_fold_surface.dart
@@ -123,39 +123,9 @@ class _FoldRegionToggle extends StatelessWidget {
                   ),
                 ),
               Center(
-                child: Container(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: tokens.spacing.step2,
-                    vertical: tokens.spacing.step1,
-                  ),
-                  decoration: BoxDecoration(
-                    color: tokens.colors.background.level03.withValues(
-                      alpha: 0.88,
-                    ),
-                    borderRadius: BorderRadius.circular(tokens.radii.xs),
-                    border: Border.all(
-                      color: tokens.colors.decorative.level01.withValues(
-                        alpha: 0.32,
-                      ),
-                    ),
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(
-                        LottiIcons.collapseBoth,
-                        size: tokens.spacing.step3,
-                        color: tokens.colors.text.lowEmphasis,
-                      ),
-                      SizedBox(width: tokens.spacing.step1),
-                      Text(
-                        _formatFoldRange(region),
-                        style: tokens.typography.styles.others.caption.copyWith(
-                          color: tokens.colors.text.lowEmphasis,
-                        ),
-                      ),
-                    ],
-                  ),
+                child: _FoldRangePill(
+                  icon: LottiIcons.collapseBoth,
+                  label: _formatFoldRange(region),
                 ),
               ),
             ],
@@ -199,35 +169,64 @@ class _CompressedFoldSurface extends StatelessWidget {
         spineColor: tokens.colors.text.lowEmphasis.withValues(alpha: 0.54),
       ),
       child: Center(
-        child: Container(
-          padding: EdgeInsets.symmetric(
-            horizontal: tokens.spacing.step2,
-            vertical: tokens.spacing.step1,
+        child: _FoldRangePill(icon: LottiIcons.expandBoth, label: label),
+      ),
+    );
+  }
+}
+
+/// The range pill both fold states centre in their region: a glyph and the
+/// `HH:00-HH:00` range the fold spans.
+///
+/// The label yields before the row does. At large accessibility text sizes
+/// the caption outgrows a narrow lane — the phone timeline at 2× text is the
+/// case — and a row that shrink-wraps two rigid children overflows the lane.
+/// Ellipsizing the label keeps the pill inside the region, and the full range
+/// stays one long-press (or hover) away as the pill's tooltip, so what the
+/// ellipsis takes is never lost.
+class _FoldRangePill extends StatelessWidget {
+  const _FoldRangePill({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return Tooltip(
+      message: label,
+      child: Container(
+        padding: EdgeInsets.symmetric(
+          horizontal: tokens.spacing.step2,
+          vertical: tokens.spacing.step1,
+        ),
+        decoration: BoxDecoration(
+          color: tokens.colors.background.level03.withValues(alpha: 0.88),
+          borderRadius: BorderRadius.circular(tokens.radii.xs),
+          border: Border.all(
+            color: tokens.colors.decorative.level01.withValues(alpha: 0.32),
           ),
-          decoration: BoxDecoration(
-            color: tokens.colors.background.level03.withValues(alpha: 0.88),
-            borderRadius: BorderRadius.circular(tokens.radii.xs),
-            border: Border.all(
-              color: tokens.colors.decorative.level01.withValues(alpha: 0.32),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              icon,
+              size: tokens.spacing.step3,
+              color: tokens.colors.text.lowEmphasis,
             ),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                LottiIcons.expandBoth,
-                size: tokens.spacing.step3,
-                color: tokens.colors.text.lowEmphasis,
-              ),
-              SizedBox(width: tokens.spacing.step1),
-              Text(
+            SizedBox(width: tokens.spacing.step1),
+            Flexible(
+              child: Text(
                 label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
                 style: tokens.typography.styles.others.caption.copyWith(
                   color: tokens.colors.text.lowEmphasis,
                 ),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/features/daily_os_next/ui/widgets/day_timeline_widgets.dart
+++ b/lib/features/daily_os_next/ui/widgets/day_timeline_widgets.dart
@@ -7,6 +7,7 @@ class _TimelineToolbar extends StatelessWidget {
     required this.mode,
     required this.arrangeMode,
     required this.showHint,
+    required this.recordedLaneFirst,
     required this.onToggleMode,
     required this.onToggleArrange,
     this.leading,
@@ -26,6 +27,10 @@ class _TimelineToolbar extends StatelessWidget {
   /// demonstrated the gestures. The mode-toggle icon stays — it is an
   /// affordance, not narration.
   final bool showHint;
+
+  /// Whether the pager opened on the recorded lane (nothing planned), in
+  /// which case the swipe leads to the plan, and the coaching line says so.
+  final bool recordedLaneFirst;
 
   final VoidCallback onToggleMode;
   final VoidCallback? onToggleArrange;
@@ -51,6 +56,8 @@ class _TimelineToolbar extends StatelessWidget {
               null when showHint => Text(
                 showingBoth
                     ? messages.dailyOsNextTimelineBoth
+                    : recordedLaneFirst
+                    ? messages.dailyOsNextTimelineSwipeHintToPlan
                     : messages.dailyOsNextTimelineSwipeHint,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,

--- a/lib/features/events/README.md
+++ b/lib/features/events/README.md
@@ -14,6 +14,9 @@ Behind the **Enable Events** flag. With it off, events are hidden everywhere.
   swipeable full-screen gallery that follows phone rotation on iOS and Android.
 - **Turns into work when needed.** A task can be created from an event and stays
   linked to it.
+- **Shows up on the day.** An event with a start and end sits on the Daily OS
+  Day timeline at that time, beside recorded work, and opens from there. A
+  cancelled, missed or postponed one stays off it.
 - **Rates a memory, but only once it is a memory.** Stars appear once the event
   has happened, so a plan is not asked to rate itself.
 - **Picks its own cover.** The first linked photo becomes the cover; after that

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2136,6 +2136,7 @@
   "dailyOsNextTimelineShowBoth": "Zobrazit plán a skutečnost společně",
   "dailyOsNextTimelineShowPaged": "Zobrazit plán a skutečnost posouváním",
   "dailyOsNextTimelineSwipeHint": "Přejeď na Skutečnost · svislým sevřením prstů přiblížíš",
+  "dailyOsNextTimelineSwipeHintToPlan": "Přejeď na Plán · svislým sevřením prstů přiblížíš",
   "dailyOsNextTimelineTracked": "zaznamenáno",
   "dailyOsNextTimeSpentEarlierSessions": "{count, plural, one{1 starší záznam} few{{count} starší záznamy} other{{count} starších záznamů}}",
   "dailyOsNextTimeSpentShowLess": "Zobrazit méně",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -2344,6 +2344,7 @@
   "dailyOsNextTimelineShowBoth": "Showplan og faktisk sammen",
   "dailyOsNextTimelineShowPaged": "Vis swipebar plan og faktisk",
   "dailyOsNextTimelineSwipeHint": "Swipe for actual · klem lodret for at zoome ind",
+  "dailyOsNextTimelineSwipeHintToPlan": "Swipe for plan · klem lodret for at zoome ind",
   "dailyOsNextTimelineTracked": "sporet",
   "dailyOsNextTimeSpentEarlierSessions": "{count, plural, one{1 tidligere session} other{{count} tidligere sessioner}}",
   "@dailyOsNextTimeSpentEarlierSessions": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2129,6 +2129,7 @@
   "dailyOsNextTimelineShowBoth": "Plan und Ist gemeinsam anzeigen",
   "dailyOsNextTimelineShowPaged": "Plan und Ist zum Wischen anzeigen",
   "dailyOsNextTimelineSwipeHint": "Wische zu Ist · vertikal kneifen zum Zoomen",
+  "dailyOsNextTimelineSwipeHintToPlan": "Wische zum Plan · vertikal kneifen zum Zoomen",
   "dailyOsNextTimelineTracked": "erfasst",
   "dailyOsNextTimeSpentEarlierSessions": "{count, plural, one{1 frühere Sitzung} other{{count} frühere Sitzungen}}",
   "dailyOsNextTimeSpentShowLess": "Weniger anzeigen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2793,6 +2793,7 @@
   "dailyOsNextTimelineShowBoth": "Show plan and actual together",
   "dailyOsNextTimelineShowPaged": "Show swipeable plan and actual",
   "dailyOsNextTimelineSwipeHint": "Swipe for actual · pinch vertically to zoom",
+  "dailyOsNextTimelineSwipeHintToPlan": "Swipe for plan · pinch vertically to zoom",
   "dailyOsNextTimelineTracked": "tracked",
   "dailyOsNextTimeSpentEarlierSessions": "{count, plural, one{1 earlier session} other{{count} earlier sessions}}",
   "@dailyOsNextTimeSpentEarlierSessions": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2129,6 +2129,7 @@
   "dailyOsNextTimelineShowBoth": "Mostrar plan y real juntos",
   "dailyOsNextTimelineShowPaged": "Mostrar plan y real deslizable",
   "dailyOsNextTimelineSwipeHint": "Desliza para ver lo real · pellizca verticalmente para zoom",
+  "dailyOsNextTimelineSwipeHintToPlan": "Desliza para ver el plan · pellizca verticalmente para zoom",
   "dailyOsNextTimelineTracked": "registrado",
   "dailyOsNextTimeSpentEarlierSessions": "{count, plural, one{1 sesión anterior} other{{count} sesiones anteriores}}",
   "dailyOsNextTimeSpentShowLess": "Mostrar menos",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2129,6 +2129,7 @@
   "dailyOsNextTimelineShowBoth": "Afficher plan et réel ensemble",
   "dailyOsNextTimelineShowPaged": "Afficher plan et réel en balayage",
   "dailyOsNextTimelineSwipeHint": "Balaye vers le réel · pince verticalement pour zoomer",
+  "dailyOsNextTimelineSwipeHintToPlan": "Balaye vers le plan · pince verticalement pour zoomer",
   "dailyOsNextTimelineTracked": "suivi",
   "dailyOsNextTimeSpentEarlierSessions": "{count, plural, =1{1 session précédente} other{{count} sessions précédentes}}",
   "dailyOsNextTimeSpentShowLess": "Afficher moins",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -2343,7 +2343,8 @@
   },
   "dailyOsNextTimelineShowBoth": "Mostra piano e reale insieme",
   "dailyOsNextTimelineShowPaged": "Mostra piano e vero e proprio",
-  "dailyOsNextTimelineSwipeHint": "Swipe per reale · pizzicare verticalmente per ingrandire",
+  "dailyOsNextTimelineSwipeHint": "Scorri per il reale · pizzica verticalmente per ingrandire",
+  "dailyOsNextTimelineSwipeHintToPlan": "Scorri per il piano · pizzica verticalmente per ingrandire",
   "dailyOsNextTimelineTracked": "tracciato",
   "dailyOsNextTimeSpentEarlierSessions": "{count, plural, one{1 sessione precedente} other{{count} sessioni precedenti}}",
   "@dailyOsNextTimeSpentEarlierSessions": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -8153,6 +8153,12 @@ abstract class AppLocalizations {
   /// **'Swipe for actual · pinch vertically to zoom'**
   String get dailyOsNextTimelineSwipeHint;
 
+  /// No description provided for @dailyOsNextTimelineSwipeHintToPlan.
+  ///
+  /// In en, this message translates to:
+  /// **'Swipe for plan · pinch vertically to zoom'**
+  String get dailyOsNextTimelineSwipeHintToPlan;
+
   /// No description provided for @dailyOsNextTimelineTracked.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4864,6 +4864,10 @@ class AppLocalizationsCs extends AppLocalizations {
       'Přejeď na Skutečnost · svislým sevřením prstů přiblížíš';
 
   @override
+  String get dailyOsNextTimelineSwipeHintToPlan =>
+      'Přejeď na Plán · svislým sevřením prstů přiblížíš';
+
+  @override
   String get dailyOsNextTimelineTracked => 'zaznamenáno';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4810,6 +4810,10 @@ class AppLocalizationsDa extends AppLocalizations {
       'Swipe for actual · klem lodret for at zoome ind';
 
   @override
+  String get dailyOsNextTimelineSwipeHintToPlan =>
+      'Swipe for plan · klem lodret for at zoome ind';
+
+  @override
   String get dailyOsNextTimelineTracked => 'sporet';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4844,6 +4844,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wische zu Ist · vertikal kneifen zum Zoomen';
 
   @override
+  String get dailyOsNextTimelineSwipeHintToPlan =>
+      'Wische zum Plan · vertikal kneifen zum Zoomen';
+
+  @override
   String get dailyOsNextTimelineTracked => 'erfasst';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4785,6 +4785,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Swipe for actual · pinch vertically to zoom';
 
   @override
+  String get dailyOsNextTimelineSwipeHintToPlan =>
+      'Swipe for plan · pinch vertically to zoom';
+
+  @override
   String get dailyOsNextTimelineTracked => 'tracked';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4869,6 +4869,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Desliza para ver lo real · pellizca verticalmente para zoom';
 
   @override
+  String get dailyOsNextTimelineSwipeHintToPlan =>
+      'Desliza para ver el plan · pellizca verticalmente para zoom';
+
+  @override
   String get dailyOsNextTimelineTracked => 'registrado';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4884,6 +4884,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Balaye vers le réel · pince verticalement pour zoomer';
 
   @override
+  String get dailyOsNextTimelineSwipeHintToPlan =>
+      'Balaye vers le plan · pince verticalement pour zoomer';
+
+  @override
   String get dailyOsNextTimelineTracked => 'suivi';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4862,7 +4862,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get dailyOsNextTimelineSwipeHint =>
-      'Swipe per reale · pizzicare verticalmente per ingrandire';
+      'Scorri per il reale · pizzica verticalmente per ingrandire';
+
+  @override
+  String get dailyOsNextTimelineSwipeHintToPlan =>
+      'Scorri per il piano · pizzica verticalmente per ingrandire';
 
   @override
   String get dailyOsNextTimelineTracked => 'tracciato';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4823,6 +4823,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Veeg voor werkelijke · knijp verticaal naar zoom';
 
   @override
+  String get dailyOsNextTimelineSwipeHintToPlan =>
+      'Veeg voor plan · knijp verticaal naar zoom';
+
+  @override
   String get dailyOsNextTimelineTracked => 'traced';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4849,6 +4849,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Deslize para real · aperte verticalmente para ampliar';
 
   @override
+  String get dailyOsNextTimelineSwipeHintToPlan =>
+      'Deslize para o plano · aperte verticalmente para ampliar';
+
+  @override
   String get dailyOsNextTimelineTracked => 'rastreado';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4885,6 +4885,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Glisați spre real · ciupiți vertical pentru zoom';
 
   @override
+  String get dailyOsNextTimelineSwipeHintToPlan =>
+      'Glisați spre plan · ciupiți vertical pentru zoom';
+
+  @override
   String get dailyOsNextTimelineTracked => 'înregistrat';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4816,6 +4816,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Svep för faktiska · nyp vertikalt för att zooma in';
 
   @override
+  String get dailyOsNextTimelineSwipeHintToPlan =>
+      'Svep för plan · nyp vertikalt för att zooma in';
+
+  @override
   String get dailyOsNextTimelineTracked => 'spårade';
 
   @override

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -2343,6 +2343,7 @@
   "dailyOsNextTimelineShowBoth": "Plan en werkelijke samen tonen",
   "dailyOsNextTimelineShowPaged": "Bewegingsbaar plan en werkelijke tonen",
   "dailyOsNextTimelineSwipeHint": "Veeg voor werkelijke · knijp verticaal naar zoom",
+  "dailyOsNextTimelineSwipeHintToPlan": "Veeg voor plan · knijp verticaal naar zoom",
   "dailyOsNextTimelineTracked": "traced",
   "dailyOsNextTimeSpentEarlierSessions": "{count, plural, one{1 vorige zitting} other{{count} eerdere sessies}}",
   "@dailyOsNextTimeSpentEarlierSessions": {

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -2343,6 +2343,7 @@
   "dailyOsNextTimelineShowBoth": "Mostrar o plano e o real juntos",
   "dailyOsNextTimelineShowPaged": "Mostrar plano deslizante e real",
   "dailyOsNextTimelineSwipeHint": "Deslize para real · aperte verticalmente para ampliar",
+  "dailyOsNextTimelineSwipeHintToPlan": "Deslize para o plano · aperte verticalmente para ampliar",
   "dailyOsNextTimelineTracked": "rastreado",
   "dailyOsNextTimeSpentEarlierSessions": "{count, plural, one{1 sessão anterior} other{{count} sessões anteriores}}",
   "@dailyOsNextTimeSpentEarlierSessions": {

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2129,6 +2129,7 @@
   "dailyOsNextTimelineShowBoth": "Afișați planul și realul împreună",
   "dailyOsNextTimelineShowPaged": "Afișați planul și realul prin glisare",
   "dailyOsNextTimelineSwipeHint": "Glisați spre real · ciupiți vertical pentru zoom",
+  "dailyOsNextTimelineSwipeHintToPlan": "Glisați spre plan · ciupiți vertical pentru zoom",
   "dailyOsNextTimelineTracked": "înregistrat",
   "dailyOsNextTimeSpentEarlierSessions": "{count, plural, one{1 sesiune anterioară} few{{count} sesiuni anterioare} other{{count} de sesiuni anterioare}}",
   "dailyOsNextTimeSpentShowLess": "Afișați mai puțin",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -2344,6 +2344,7 @@
   "dailyOsNextTimelineShowBoth": "Showplan och verklighet tillsammans",
   "dailyOsNextTimelineShowPaged": "Visa swipebar plan och faktisk",
   "dailyOsNextTimelineSwipeHint": "Svep för faktiska · nyp vertikalt för att zooma in",
+  "dailyOsNextTimelineSwipeHintToPlan": "Svep för plan · nyp vertikalt för att zooma in",
   "dailyOsNextTimelineTracked": "spårade",
   "dailyOsNextTimeSpentEarlierSessions": "{count, plural, one{1 tidigare session} other{{count} tidigare sessioner}}",
   "@dailyOsNextTimeSpentEarlierSessions": {

--- a/test/README.md
+++ b/test/README.md
@@ -120,6 +120,23 @@ It happens when the widget's `await for` is still attached to the controller's s
 - A test that asserts a transient mid-stream UI state ("…while an event is in flight") is inherently racy; assert the settled state after a finite stream completes instead.
 - The inverse also hangs: `close()` on a single-subscription controller that was **never listened to** returns a future that never completes, so `addTearDown(controller.close)` stalls the teardown until the test times out. If a shared pump helper creates a controller the widget under test may not consume (e.g. an `items:`-mode variant of a stream widget), discard the future — `addTearDown(() => unawaited(controller.close()))`.
 
+## An autoDispose provider that awaits a stream provider
+
+`dailyOsActualTimeBlocksProvider` awaits `configFlagProvider(...).future`
+before it projects. In a test, a bare
+`container.read(provider.future)` closes its own subscription the moment
+`read` returns; the autoDispose family member is then scheduled for disposal,
+and the stream provider it depends on is torn down before its first value
+arrives — the failure reads "was disposed during loading state, yet no value
+could be emitted". Production never hits this (every surface `ref.watch`es
+the lane), so the fix is in the test: hold a live subscription across the
+read, the way `readActualBlocks` in
+`test/features/daily_os_next/state/actual_time_blocks_provider_test_helpers.dart`
+does (`container.listen(...)` + `addTearDown(subscription.close)`, then
+`read(.future)`). A `MockJournalDb` with no `watchConfigFlag` stub answers
+`false` through its `watchConfigFlags` fallback, so a test that needs the
+flag on stubs `watchConfigFlag(enableEventsFlag)` with `Stream.value(true)`.
+
 ## Native drag-and-drop wrappers
 
 Production pages may include `MediaDropTarget`, which registers

--- a/test/database/calendar_entries_coalescing_test.dart
+++ b/test/database/calendar_entries_coalescing_test.dart
@@ -44,7 +44,9 @@ class _CountingJournalDb extends JournalDb {
     List<drift.Variable<Object>> variables = const [],
     Set<drift.ResultSetImplementation<dynamic, dynamic>> readsFrom = const {},
   }) {
-    if (query.contains("type IN ('JournalEntry', 'WorkoutEntry')") &&
+    if (query.contains(
+          "type IN ('JournalEntry', 'WorkoutEntry', 'JournalEvent')",
+        ) &&
         query.contains('date_from >= ?1 AND date_to <= ?2')) {
       calendarQueryCount += 1;
     }

--- a/test/database/database_journal_queries_test.dart
+++ b/test/database/database_journal_queries_test.dart
@@ -655,6 +655,56 @@ void main() {
           equals(['jan-20-workout', 'jan-05']),
         );
       });
+
+      // The Daily OS timeline reads this query; an event the user gave a
+      // span on the events page has to come back from it, while a task —
+      // whose meta span is a creation instant — must not.
+      test(
+        'sortedCalendarEntries admits events by their span, not tasks',
+        () async {
+          final dinner = buildEventEntry(
+            id: 'jan-10-dinner',
+            start: DateTime(2024, 1, 10, 18),
+            end: DateTime(2024, 1, 11),
+          );
+          final deletedEvent = buildEventEntry(
+            id: 'jan-11-deleted',
+            start: DateTime(2024, 1, 11, 18),
+            end: DateTime(2024, 1, 11, 20),
+            deletedAt: DateTime(2024, 1, 12),
+          );
+          final task = buildTaskEntry(
+            id: 'jan-12-task',
+            timestamp: DateTime(2024, 1, 12, 9),
+            status: TaskStatus.open(
+              id: 'jan-12-status',
+              createdAt: DateTime(2024, 1, 12, 9),
+              utcOffset: 0,
+            ),
+          );
+          final note = buildTextEntry(
+            id: 'jan-05',
+            timestamp: DateTime(2024, 1, 5, 8),
+            text: 'Entry Jan 05',
+          );
+
+          await db!.updateJournalEntity(dinner);
+          await db!.updateJournalEntity(deletedEvent);
+          await db!.updateJournalEntity(task);
+          await db!.updateJournalEntity(note);
+
+          final results = await db!.sortedCalendarEntries(
+            rangeStart: DateTime(2024),
+            rangeEnd: DateTime(2024, 1, 31, 23, 59),
+          );
+
+          expect(
+            results.map((e) => e.meta.id),
+            equals(['jan-10-dinner', 'jan-05']),
+          );
+          expect(results.first, isA<JournalEvent>());
+        },
+      );
     });
 
     group('Vector clock streaming for sequence log population -', () {

--- a/test/database/test_utils.dart
+++ b/test/database/test_utils.dart
@@ -15,6 +15,8 @@ import 'package:lotti/classes/day_audio_context.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/event_data.dart';
+import 'package:lotti/classes/event_status.dart';
 import 'package:lotti/classes/health.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
@@ -299,6 +301,32 @@ JournalEntity buildWorkoutEntry({
       id: 'workout-$id',
       source: 'test',
     ),
+  );
+}
+
+/// An event whose span (`meta.dateFrom`..`meta.dateTo`) is what the events
+/// page's date line edits — the calendar queries read that, not `data`.
+JournalEntity buildEventEntry({
+  required String id,
+  required DateTime start,
+  required DateTime end,
+  String title = 'Event',
+  EventStatus status = EventStatus.planned,
+  DateTime? deletedAt,
+}) {
+  return JournalEntity.event(
+    meta: Metadata(
+      id: id,
+      createdAt: start,
+      updatedAt: start,
+      dateFrom: start,
+      dateTo: end,
+      deletedAt: deletedAt,
+      starred: false,
+      private: false,
+    ),
+    data: EventData(title: title, stars: 0, status: status),
+    entryText: const EntryText(plainText: ''),
   );
 }
 

--- a/test/features/daily_os_next/agents/service/day_agent_week_context_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_week_context_service_test.dart
@@ -4,6 +4,8 @@ import 'package:lotti/classes/day_agent_identity.dart';
 import 'package:lotti/classes/day_plan.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/classes/event_data.dart';
+import 'package:lotti/classes/event_status.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
@@ -13,6 +15,7 @@ import 'package:lotti/features/daily_os_next/agents/tools/day_agent_tool_names.d
 import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../helpers/fallbacks.dart';
@@ -75,6 +78,7 @@ void main() {
     when(() => journalDb.basicLinksForEntryIds(any())).thenAnswer(
       (_) async => const [],
     );
+    when(() => journalDb.getConfigFlag(any())).thenAnswer((_) async => false);
     when(() => syncService.upsertEntity(any())).thenAnswer((invocation) async {
       upserted.add(invocation.positionalArguments.single as AgentDomainEntity);
     });
@@ -375,6 +379,63 @@ void main() {
 
       // The span inherits the linked task's category.
       expect(ctx!.recentDays, contains('cat-work: 2h recorded.'));
+    });
+
+    // An event with a span is the user's own account of where an evening
+    // went, so it feeds the lookback — but only while the Events feature is
+    // on, because with it off events are hidden everywhere.
+    JournalEvent dinnerOn(DateTime day) =>
+        JournalEntity.event(
+              meta: Metadata(
+                id: 'evt-1',
+                createdAt: day,
+                updatedAt: day,
+                dateFrom: day.add(const Duration(hours: 18)),
+                dateTo: day.add(const Duration(hours: 21)),
+                categoryId: 'cat-social',
+              ),
+              data: const EventData(
+                title: 'Dinner with a friend',
+                stars: 0,
+                status: EventStatus.planned,
+              ),
+            )
+            as JournalEvent;
+
+    test('an event counts toward the recorded lookback while the Events '
+        'feature is on', () async {
+      when(
+        () => journalDb.getConfigFlag(enableEventsFlag),
+      ).thenAnswer((_) async => true);
+      when(
+        () => journalDb.sortedCalendarEntries(
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).thenAnswer((_) async => [dinnerOn(DateTime(2026, 6, 9))]);
+
+      final ctx = await withNow(
+        () => service.buildForDay(planDate: DateTime(2026, 6, 10)),
+      );
+
+      expect(ctx!.recentDays, contains('cat-social: 3h recorded.'));
+    });
+
+    test('events stay out of the recorded lookback while the Events feature '
+        'is off', () async {
+      when(
+        () => journalDb.sortedCalendarEntries(
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).thenAnswer((_) async => [dinnerOn(DateTime(2026, 6, 9))]);
+
+      final ctx = await withNow(
+        () => service.buildForDay(planDate: DateTime(2026, 6, 10)),
+      );
+
+      expect(ctx?.recentDays ?? '', isNot(contains('cat-social')));
+      verify(() => journalDb.getConfigFlag(enableEventsFlag)).called(1);
     });
 
     test('an explicitly passed now drives day classification end-to-end '

--- a/test/features/daily_os_next/logic/recorded_time_test.dart
+++ b/test/features/daily_os_next/logic/recorded_time_test.dart
@@ -1,6 +1,8 @@
 import 'package:glados/glados.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/event_data.dart';
+import 'package:lotti/classes/event_status.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/rating_data.dart';
 import 'package:lotti/classes/task.dart';
@@ -73,6 +75,30 @@ JournalEntity _note({required String id, String? categoryId}) {
     ),
     entryText: const EntryText(plainText: 'a linked note'),
   );
+}
+
+/// An event the way the events page stores it: the span lives on `meta`,
+/// the title and status on `data`.
+JournalEvent _event({
+  required String id,
+  required int startHour,
+  int durationMinutes = 180,
+  String? categoryId,
+  EventStatus status = EventStatus.planned,
+}) {
+  final start = _day.add(Duration(hours: startHour));
+  return JournalEntity.event(
+        meta: Metadata(
+          id: id,
+          createdAt: _day,
+          updatedAt: _day,
+          dateFrom: start,
+          dateTo: start.add(Duration(minutes: durationMinutes)),
+          categoryId: categoryId,
+        ),
+        data: EventData(title: 'Dinner', stars: 0, status: status),
+      )
+      as JournalEvent;
 }
 
 JournalEntity _rating({required String id}) {
@@ -161,6 +187,7 @@ void main() {
         entries: [entry],
         links: [_link(fromId: 'task-1', toId: 'e1')],
         linkedFromById: {'task-1': task},
+        eventsEnabled: true,
       );
 
       final pair = resolved.single;
@@ -180,6 +207,7 @@ void main() {
         entries: [entry],
         links: [_link(fromId: 'task-1', toId: 'e1')],
         linkedFromById: {'task-1': task},
+        eventsEnabled: true,
       ).single;
 
       expect(pair.categoryId, 'cat-own');
@@ -196,6 +224,7 @@ void main() {
         entries: [deleted, zero, linkedViaDeletedLink],
         links: [_link(fromId: 'task-1', toId: 'e-live', deleted: true)],
         linkedFromById: {'task-1': task},
+        eventsEnabled: true,
       );
 
       // Only the live entry survives, and its tombstoned link contributes no
@@ -215,11 +244,78 @@ void main() {
         entries: [entry],
         links: [_link(fromId: 'note-1', toId: 'e1')],
         linkedFromById: {'note-1': note},
+        eventsEnabled: true,
       ).single;
 
       expect(pair.linkedFrom?.meta.id, 'note-1');
       expect(pair.categoryId, 'cat-note');
       expect(pair.taskId, isNull);
+    });
+
+    test('an event counts on its own: own category, never attributed to the '
+        'task it hangs off', () {
+      final task = _task(id: 'task-1', categoryId: 'cat-work');
+      final event = _event(
+        id: 'evt-1',
+        startHour: 18,
+        categoryId: 'cat-social',
+      );
+
+      final pair = resolveTimeEntries(
+        entries: [event],
+        links: [_link(fromId: 'task-1', toId: 'evt-1')],
+        linkedFromById: {'task-1': task},
+        eventsEnabled: true,
+      ).single;
+
+      expect(pair.entry.meta.id, 'evt-1');
+      expect(pair.linkedFrom, isNull);
+      expect(pair.taskId, isNull);
+      expect(pair.categoryId, 'cat-social');
+      expect(pair.duration, const Duration(hours: 3));
+      expect(pair.start, _day.add(const Duration(hours: 18)));
+    });
+
+    test('a zero-length event is a point in time, not recorded time', () {
+      final resolved = resolveTimeEntries(
+        entries: [_event(id: 'evt-0', startHour: 18, durationMinutes: 0)],
+        links: const [],
+        linkedFromById: const {},
+        eventsEnabled: true,
+      );
+
+      expect(resolved, isEmpty);
+    });
+
+    test('an event survives only in the statuses where it took place', () {
+      for (final status in EventStatus.values) {
+        final resolved = resolveTimeEntries(
+          entries: [_event(id: 'evt-1', startHour: 18, status: status)],
+          links: const [],
+          linkedFromById: const {},
+          eventsEnabled: true,
+        );
+        final tookPlace =
+            status != EventStatus.cancelled &&
+            status != EventStatus.missed &&
+            status != EventStatus.postponed;
+        expect(resolved, hasLength(tookPlace ? 1 : 0), reason: '$status');
+      }
+    });
+
+    test('events are dropped while the Events feature is off; recordings '
+        'are kept', () {
+      final entry = _entry(id: 'e1', startHour: 9);
+      final event = _event(id: 'evt-1', startHour: 18);
+
+      final resolved = resolveTimeEntries(
+        entries: [event, entry],
+        links: const [],
+        linkedFromById: const {},
+        eventsEnabled: false,
+      );
+
+      expect(resolved.map((pair) => pair.entry.meta.id), ['e1']);
     });
 
     test('the fallback pick is invariant to the link list order '
@@ -254,6 +350,7 @@ void main() {
           entries: [entry],
           links: permutation,
           linkedFromById: {'note-a': noteA, 'note-b': noteB},
+          eventsEnabled: true,
         ).single;
         expect(
           pair.linkedFrom?.meta.id,
@@ -304,6 +401,7 @@ void main() {
           entries: entries,
           links: links,
           linkedFromById: linkedFromById,
+          eventsEnabled: true,
         );
 
         // Oracle: live entries with positive duration survive, in input order.
@@ -358,6 +456,23 @@ void main() {
       },
       tags: 'glados',
     );
+  });
+
+  group('eventTookPlace', () {
+    test('is false for cancelled, missed and postponed, true for every other '
+        'status', () {
+      final didNotHappen = {
+        for (final status in EventStatus.values)
+          if (!eventTookPlace(_event(id: 'evt', startHour: 18, status: status)))
+            status,
+      };
+
+      expect(didNotHappen, {
+        EventStatus.cancelled,
+        EventStatus.missed,
+        EventStatus.postponed,
+      });
+    });
   });
 
   group('resolveLinkedFrom', () {

--- a/test/features/daily_os_next/state/actual_time_blocks_provider_streams_test.dart
+++ b/test/features/daily_os_next/state/actual_time_blocks_provider_streams_test.dart
@@ -108,9 +108,7 @@ void main() {
         );
         addTearDown(container.dispose);
 
-        final blocks = await container.read(
-          dailyOsActualTimeBlocksProvider(day).future,
-        );
+        final blocks = await readActualBlocks(container, day);
 
         expect(blocks.single.id, 'actual:entry-1');
         expect(blocks.single.title, 'Day entry');
@@ -156,9 +154,7 @@ void main() {
         );
         addTearDown(container.dispose);
 
-        final blocks = await container.read(
-          dailyOsActualTimeBlocksProvider(day).future,
-        );
+        final blocks = await readActualBlocks(container, day);
 
         expect(blocks.single.taskId, 'task-1');
         expect(blocks.single.title, 'From link');
@@ -201,9 +197,7 @@ void main() {
         );
         addTearDown(container.dispose);
 
-        final blocks = await container.read(
-          dailyOsActualTimeBlocksProvider(day).future,
-        );
+        final blocks = await readActualBlocks(container, day);
 
         expect(blocks.single.category.name, 'Work');
         expect(blocks.single.category.colorHex, '5ED4B7');

--- a/test/features/daily_os_next/state/actual_time_blocks_provider_test.dart
+++ b/test/features/daily_os_next/state/actual_time_blocks_provider_test.dart
@@ -1,9 +1,13 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/event_status.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/rating_data.dart';
+import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/state/actual_time_blocks_provider.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/health_import.dart';
@@ -11,6 +15,7 @@ import 'package:lotti/logic/signals/health_signal_refresh_service.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
@@ -59,6 +64,7 @@ void main() {
           name: id == 'cat-work' ? 'Work' : 'Study',
           color: id == 'cat-work' ? '#5ED4B7' : '#FFAA00',
         ),
+        eventsEnabled: true,
       );
 
       expect(blocks.map((block) => block.id), [
@@ -140,6 +146,7 @@ void main() {
           },
           categoryById: (id) =>
               hCategory(id: id, name: 'Work', color: '5ED4B7'),
+          eventsEnabled: true,
         );
 
         expect(blocks.single.taskId, task.meta.id);
@@ -176,6 +183,7 @@ void main() {
         ],
         linkedFromById: {note.meta.id: note},
         categoryById: (_) => null,
+        eventsEnabled: true,
       );
 
       // No task is linked, so taskId stays null and the category comes from
@@ -214,6 +222,7 @@ void main() {
         categoryById: (id) => id == 'cat-named'
             ? hCategory(id: id, name: 'Named cat', color: '#112233')
             : null,
+        eventsEnabled: true,
       );
 
       final byId = {for (final b in blocks) b.id: b};
@@ -238,6 +247,7 @@ void main() {
         linkedFromById: const {},
         categoryById: (id) =>
             hCategory(id: id, name: 'Color cat', color: '#AABBCCDD'),
+        eventsEnabled: true,
       );
 
       // RRGGBBAA → keep first 6 chars (RRGGBB) per project convention.
@@ -260,6 +270,7 @@ void main() {
         links: const [],
         linkedFromById: const {},
         categoryById: (id) => hCategory(id: id, name: 'Short', color: '#ABC'),
+        eventsEnabled: true,
       );
 
       expect(blocks.single.category.colorHex, '8E8E8E');
@@ -282,6 +293,7 @@ void main() {
         links: const [],
         linkedFromById: const {},
         categoryById: (_) => null,
+        eventsEnabled: true,
       );
 
       expect(blocks, isEmpty);
@@ -305,6 +317,7 @@ void main() {
         links: const [],
         linkedFromById: const {},
         categoryById: (_) => null,
+        eventsEnabled: true,
       );
 
       expect(blocks.map((b) => b.title), [
@@ -331,9 +344,202 @@ void main() {
         links: const [],
         linkedFromById: const {},
         categoryById: (_) => null,
+        eventsEnabled: true,
       );
 
       expect(blocks.single.title, 'Morning walk');
+    });
+
+    // The event the user edited on the events page to run from 18:00 to
+    // midnight: it is recorded time like any session, but it is its own
+    // thing — its own title, its own category, no task behind it — and a
+    // calendar block so the timeline can open the event page from it.
+    test('projects an event as a calendar block titled by the event, in its '
+        'own category, sorted among the recordings', () {
+      final day = DateTime(2026, 5, 27);
+      final task = hTask(
+        id: 'task-1',
+        title: 'Plan the reunion',
+        categoryId: 'cat-work',
+        day: day,
+      );
+      final event = hEvent(
+        id: 'evt-1',
+        day: day,
+        startHour: 18,
+        endHour: 24,
+        title: ' Dinner with a friend ',
+        categoryId: 'cat-social',
+      );
+
+      final blocks = actualTimeBlocksForEntries(
+        entries: [
+          event,
+          hEntry(id: 'entry-1', day: day, startHour: 9, endHour: 10),
+        ],
+        links: [
+          hLink('l1', from: task.meta.id, to: event.meta.id, day: day),
+        ],
+        linkedFromById: {task.meta.id: task},
+        categoryById: (id) => id == 'cat-social'
+            ? hCategory(id: id, name: 'Social', color: '#E8A33D')
+            : hCategory(id: id, name: 'Work', color: '#5ED4B7'),
+        eventsEnabled: true,
+      );
+
+      expect(blocks.map((block) => block.id), [
+        'actual:entry-1',
+        'actual:evt-1',
+      ]);
+      final eventBlock = blocks.last;
+      expect(eventBlock.title, 'Dinner with a friend');
+      expect(eventBlock.type, TimeBlockType.cal);
+      // Planned, not done: the lane shows it filled but unchecked.
+      expect(eventBlock.state, TimeBlockState.committed);
+      expect(eventBlock.taskId, isNull);
+      expect(eventBlock.trackedEntryId, 'evt-1');
+      expect(eventBlock.category.name, 'Social');
+      expect(eventBlock.category.colorHex, 'E8A33D');
+      expect(eventBlock.start, day.add(const Duration(hours: 18)));
+      expect(eventBlock.end, day.add(const Duration(days: 1)));
+      expect(blocks.first.type, TimeBlockType.manual);
+    });
+
+    // A recording is finished by definition; an event is only as far along as
+    // its status says — a dinner still ahead must not wear the lane's check
+    // mark or count as done.
+    test('the block state follows the event status', () {
+      final day = DateTime(2026, 5, 27);
+      final byStatus = {
+        for (final status in EventStatus.values)
+          status: eventBlockState(
+            hEvent(
+              id: 'evt-${status.name}',
+              day: day,
+              startHour: 18,
+              endHour: 20,
+              status: status,
+            ),
+          ),
+      };
+
+      expect(byStatus, {
+        EventStatus.completed: TimeBlockState.completed,
+        EventStatus.ongoing: TimeBlockState.inProgress,
+        EventStatus.tentative: TimeBlockState.committed,
+        EventStatus.planned: TimeBlockState.committed,
+        EventStatus.rescheduled: TimeBlockState.committed,
+        EventStatus.cancelled: TimeBlockState.dropped,
+        EventStatus.missed: TimeBlockState.dropped,
+        EventStatus.postponed: TimeBlockState.dropped,
+      });
+    });
+
+    test('a completed event is checked on the lane, an ongoing one is in '
+        'progress, and a recording is always completed', () {
+      final day = DateTime(2026, 5, 27);
+
+      final blocks = actualTimeBlocksForEntries(
+        entries: [
+          hEvent(
+            id: 'done',
+            day: day,
+            startHour: 12,
+            endHour: 13,
+            status: EventStatus.completed,
+          ),
+          hEvent(
+            id: 'now',
+            day: day,
+            startHour: 18,
+            endHour: 20,
+            status: EventStatus.ongoing,
+          ),
+          hEntry(id: 'entry-1', day: day, startHour: 9, endHour: 10),
+        ],
+        links: const [],
+        linkedFromById: const {},
+        categoryById: (_) => null,
+        eventsEnabled: true,
+      );
+
+      expect(blocks.map((block) => block.state), [
+        TimeBlockState.completed,
+        TimeBlockState.completed,
+        TimeBlockState.inProgress,
+      ]);
+    });
+
+    test('an untitled event falls through to its text, then its category', () {
+      final day = DateTime(2026, 5, 27);
+
+      final blocks = actualTimeBlocksForEntries(
+        entries: [
+          hEvent(
+            id: 'noted',
+            day: day,
+            startHour: 18,
+            endHour: 20,
+            title: '',
+            text: 'Table for two\nby the window',
+          ),
+          hEvent(
+            id: 'bare',
+            day: day,
+            startHour: 20,
+            endHour: 22,
+            title: '  ',
+            categoryId: 'cat-social',
+          ),
+        ],
+        links: const [],
+        linkedFromById: const {},
+        categoryById: (id) =>
+            hCategory(id: id, name: 'Social', color: '#E8A33D'),
+        eventsEnabled: true,
+      );
+
+      expect(blocks.map((block) => block.title), ['Table for two', 'Social']);
+    });
+
+    test('a cancelled event stays off the lane', () {
+      final day = DateTime(2026, 5, 27);
+
+      final blocks = actualTimeBlocksForEntries(
+        entries: [
+          hEvent(
+            id: 'evt-1',
+            day: day,
+            startHour: 18,
+            endHour: 20,
+            status: EventStatus.cancelled,
+          ),
+          hEntry(id: 'entry-1', day: day, startHour: 9, endHour: 10),
+        ],
+        links: const [],
+        linkedFromById: const {},
+        categoryById: (_) => null,
+        eventsEnabled: true,
+      );
+
+      expect(blocks.map((block) => block.id), ['actual:entry-1']);
+    });
+
+    test('events stay off the lane while the Events feature is off', () {
+      final day = DateTime(2026, 5, 27);
+
+      final blocks = actualTimeBlocksForEntries(
+        entries: [
+          hEvent(id: 'evt-1', day: day, startHour: 18, endHour: 20),
+          hEntry(id: 'entry-1', day: day, startHour: 9, endHour: 10),
+        ],
+        links: const [],
+        linkedFromById: const {},
+        categoryById: (_) => null,
+        eventsEnabled: false,
+      );
+
+      expect(blocks.map((block) => block.id), ['actual:entry-1']);
     });
 
     test('a workout without an activity falls through to the id', () {
@@ -346,6 +552,7 @@ void main() {
         links: const [],
         linkedFromById: const {},
         categoryById: (_) => null,
+        eventsEnabled: true,
       );
 
       expect(blocks.single.title, 'blank');
@@ -435,9 +642,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final blocks = await container.read(
-        dailyOsActualTimeBlocksProvider(day).future,
-      );
+      final blocks = await readActualBlocks(container, day);
 
       expect(blocks.single.title, 'Walking');
       expect(blocks.single.id, 'actual:walk');
@@ -455,9 +660,7 @@ void main() {
         );
         addTearDown(container.dispose);
 
-        final blocks = await container.read(
-          dailyOsActualTimeBlocksProvider(day).future,
-        );
+        final blocks = await readActualBlocks(container, day);
 
         expect(blocks.single.title, 'Walking');
       },
@@ -511,15 +714,96 @@ void main() {
         );
         addTearDown(container.dispose);
 
-        final blocks = await container.read(
-          dailyOsActualTimeBlocksProvider(day).future,
-        );
+        final blocks = await readActualBlocks(container, day);
 
         expect(blocks.single.title, 'Write release notes');
         expect(blocks.single.taskId, 'task-1');
         expect(blocks.single.category.name, 'Work');
       },
     );
+
+    group('the Events flag', () {
+      late JournalEvent dinner;
+
+      setUp(() {
+        final walk = hWorkout(id: 'walk', day: day, startHour: 7);
+        dinner = hEvent(id: 'dinner', day: day, startHour: 18, endHour: 24);
+        when(
+          () => db.sortedCalendarEntries(
+            rangeStart: day,
+            rangeEnd: day.add(const Duration(days: 1)),
+          ),
+        ).thenAnswer((_) async => [walk, dinner]);
+        when(
+          () => db.basicLinksForEntryIds({walk.meta.id, dinner.meta.id}),
+        ).thenAnswer((_) async => const []);
+      });
+
+      ProviderContainer container() {
+        final container = ProviderContainer(
+          overrides: [
+            journalDbProvider.overrideWithValue(db),
+            healthSignalRefreshServiceProvider.overrideWithValue(null),
+          ],
+        );
+        addTearDown(container.dispose);
+        return container;
+      }
+
+      test('on: the event is on the lane', () async {
+        when(
+          () => db.watchConfigFlag(enableEventsFlag),
+        ).thenAnswer((_) => Stream.value(true));
+
+        final blocks = await readActualBlocks(container(), day);
+
+        expect(blocks.map((block) => block.title), [
+          'Walking',
+          'Dinner with a friend',
+        ]);
+      });
+
+      test('off: the event is hidden, like everywhere else', () async {
+        when(
+          () => db.watchConfigFlag(enableEventsFlag),
+        ).thenAnswer((_) => Stream.value(false));
+
+        final blocks = await readActualBlocks(container(), day);
+
+        expect(blocks.map((block) => block.title), ['Walking']);
+      });
+
+      test('flipping it repaints the lane without a restart', () async {
+        final flag = StreamController<bool>();
+        addTearDown(flag.close);
+        when(
+          () => db.watchConfigFlag(enableEventsFlag),
+        ).thenAnswer((_) => flag.stream);
+        final scope = container();
+        final painted = <List<String>>[];
+        final subscription = scope.listen(
+          dailyOsActualTimeBlocksProvider(day),
+          (_, next) {
+            // Only settled paints: a reload first re-emits the previous
+            // value as a loading state, which is not a repaint of the lane.
+            if (next is AsyncData<List<TimeBlock>>) {
+              painted.add(next.value.map((block) => block.title).toList());
+            }
+          },
+        );
+        addTearDown(subscription.close);
+
+        flag.add(true);
+        await scope.read(dailyOsActualTimeBlocksProvider(day).future);
+        flag.add(false);
+        await pumpEventQueue();
+
+        expect(painted, [
+          ['Walking', 'Dinner with a friend'],
+          ['Walking'],
+        ]);
+      });
+    });
 
     test('a failing importer does not take the lane down', () async {
       final healthImport = MockHealthImport();
@@ -536,9 +820,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final blocks = await container.read(
-        dailyOsActualTimeBlocksProvider(day).future,
-      );
+      final blocks = await readActualBlocks(container, day);
 
       expect(blocks.single.title, 'Walking');
     });

--- a/test/features/daily_os_next/state/actual_time_blocks_provider_test_helpers.dart
+++ b/test/features/daily_os_next/state/actual_time_blocks_provider_test_helpers.dart
@@ -1,8 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/event_data.dart';
+import 'package:lotti/classes/event_status.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
+import 'package:lotti/features/daily_os_next/state/actual_time_blocks_provider.dart';
 
 EntryLink hLink(
   String id, {
@@ -127,4 +133,49 @@ WorkoutEntry hWorkout({
         entryText: text == null ? null : EntryText(plainText: text),
       )
       as WorkoutEntry;
+}
+
+/// An event the way the events page stores it: the span on `meta` (the date
+/// line is the single source of its when), the title and status on `data`.
+/// [endHour] may be 24 for an event that runs to midnight.
+JournalEvent hEvent({
+  required String id,
+  required DateTime day,
+  required int startHour,
+  required int endHour,
+  String title = 'Dinner with a friend',
+  String? categoryId,
+  EventStatus status = EventStatus.planned,
+  String? text,
+}) {
+  return JournalEntity.event(
+        meta: Metadata(
+          id: id,
+          createdAt: day,
+          updatedAt: day,
+          dateFrom: day.add(Duration(hours: startHour)),
+          dateTo: day.add(Duration(hours: endHour)),
+          categoryId: categoryId,
+        ),
+        data: EventData(title: title, stars: 0, status: status),
+        entryText: text == null ? null : EntryText(plainText: text),
+      )
+      as JournalEvent;
+}
+
+/// Reads the day's Actual lane the way the surfaces do — under a live
+/// subscription. The lane is autoDispose and awaits the Events flag stream
+/// before it projects; a bare `read(.future)` closes its subscription as soon
+/// as it returns, and the flag provider is then torn down between the read
+/// and its first emission ("disposed during loading state").
+Future<List<TimeBlock>> readActualBlocks(
+  ProviderContainer container,
+  DateTime day,
+) {
+  final subscription = container.listen(
+    dailyOsActualTimeBlocksProvider(day),
+    (_, _) {},
+  );
+  addTearDown(subscription.close);
+  return container.read(dailyOsActualTimeBlocksProvider(day).future);
 }

--- a/test/features/daily_os_next/ui/pages/daily_os_next_root_test.dart
+++ b/test/features/daily_os_next/ui/pages/daily_os_next_root_test.dart
@@ -363,6 +363,12 @@ void main() {
           await tester.pump();
 
           expect(find.byType(DayPage), findsOneWidget);
+          // The agenda row is the rendered content to keep; the page opens
+          // on the Day timeline, so pick Agenda first.
+          tester
+              .widget<PlanViewToggle>(find.byType(PlanViewToggle))
+              .onChanged(PlanView.agenda);
+          await tester.pump();
           expect(find.text('Deep work'), findsOneWidget);
 
           reloadTicks.add(1);
@@ -408,6 +414,10 @@ void main() {
           await tester.pump();
 
           expect(find.byType(DayPage), findsOneWidget);
+          tester
+              .widget<PlanViewToggle>(find.byType(PlanViewToggle))
+              .onChanged(PlanView.agenda);
+          await tester.pump();
           expect(find.text('Deep work'), findsOneWidget);
 
           ProviderScope.containerOf(
@@ -1041,23 +1051,26 @@ void main() {
           await tester.pump();
           await tester.pump();
 
-          // Default projection for a day with a plan.
-          expect(find.byType(AgendaView), findsOneWidget);
-
-          tester
-              .widget<PlanViewToggle>(find.byType(PlanViewToggle))
-              .onChanged(PlanView.day);
-          await tester.pump();
+          // The default projection is the Day timeline, plan or not.
           expect(find.byType(DayTimeline), findsOneWidget);
           expect(find.byType(AgendaView), findsNothing);
 
-          // Chevron navigation must not bounce the user back to Activity.
+          tester
+              .widget<PlanViewToggle>(find.byType(PlanViewToggle))
+              .onChanged(PlanView.agenda);
+          await tester.pump();
+          expect(find.byType(AgendaView), findsOneWidget);
+          expect(find.byType(DayTimeline), findsNothing);
+
+          // Chevron navigation re-keys the page; it must not bounce the user
+          // back to the Day default.
           await tester.tap(find.byIcon(LottiIcons.chevronRight));
           await tester.pump();
           await tester.pump();
           await tester.pump();
           expect(find.text('Wed, May 27, 2026'), findsOneWidget);
-          expect(find.byType(DayTimeline), findsOneWidget);
+          expect(find.byType(AgendaView), findsOneWidget);
+          expect(find.byType(DayTimeline), findsNothing);
           expect(find.byType(DayActivityView), findsNothing);
 
           // Neither does the jump-to-today control.
@@ -1066,7 +1079,8 @@ void main() {
           await tester.pump();
           await tester.pump();
           expect(find.text('Today'), findsOneWidget);
-          expect(find.byType(DayTimeline), findsOneWidget);
+          expect(find.byType(AgendaView), findsOneWidget);
+          expect(find.byType(DayTimeline), findsNothing);
           expect(find.byType(DayActivityView), findsNothing);
         });
       },

--- a/test/features/daily_os_next/ui/pages/day_page_screenshots_test.dart
+++ b/test/features/daily_os_next/ui/pages/day_page_screenshots_test.dart
@@ -1035,6 +1035,14 @@ Future<void> _tapPlanViewSegment(
   });
 }
 
+/// The surface opens on the Day timeline; the agenda captures have to ask
+/// for the Agenda projection explicitly.
+Future<void> _switchToAgendaView(WidgetTester tester) => _tapPlanViewSegment(
+  tester,
+  label: _messages(tester).dailyOsNextPlanViewAgenda,
+  icon: LottiIcons.list,
+);
+
 Future<void> _switchToDayView(WidgetTester tester) => _tapPlanViewSegment(
   tester,
   label: _messages(tester).dailyOsNextPlanViewDay,
@@ -1188,6 +1196,7 @@ void main() {
         device: device,
         showPlannerReview: false,
       );
+      await _switchToAgendaView(tester);
       expect(find.byType(AgendaView), findsOneWidget);
       _expectAgendaThumbnails(tester);
       await captureScreenshot(tester, 'day_${device.name}_01_agenda_dark');
@@ -1290,6 +1299,7 @@ void main() {
       brightness: Brightness.light,
       showPlannerReview: false,
     );
+    await _switchToAgendaView(tester);
     expect(find.byType(AgendaView), findsOneWidget);
     _expectAgendaThumbnails(tester);
     await captureScreenshot(tester, 'day_mini_04_agenda_light');
@@ -1302,6 +1312,7 @@ void main() {
       brightness: Brightness.light,
       showPlannerReview: false,
     );
+    await _switchToAgendaView(tester);
     expect(find.byType(AgendaView), findsOneWidget);
     _expectAgendaThumbnails(tester);
     await captureScreenshot(tester, 'day_desktop_03_agenda_light');
@@ -1454,12 +1465,16 @@ void main() {
 
   testWidgets('mini agenda — dark, 1.3x text', (tester) async {
     await _pumpDayPage(tester, device: miniDevice, textScale: 1.3);
+    await _switchToAgendaView(tester);
+    expect(find.byType(AgendaView), findsOneWidget);
     await captureScreenshot(tester, 'day_mini_06_agenda_dark_ts13');
   });
 
   // 2.0x — the upper end of common accessibility text sizes.
   testWidgets('mini agenda — dark, 2.0x text', (tester) async {
     await _pumpDayPage(tester, device: miniDevice, textScale: 2);
+    await _switchToAgendaView(tester);
+    expect(find.byType(AgendaView), findsOneWidget);
     await captureScreenshot(tester, 'day_mini_07_agenda_dark_ts20');
   });
 

--- a/test/features/daily_os_next/ui/pages/day_page_test.dart
+++ b/test/features/daily_os_next/ui/pages/day_page_test.dart
@@ -120,21 +120,33 @@ void main() {
   });
 
   group('DayPage', () {
-    testWidgets('default title and AgendaView render, DayTimeline absent', (
-      tester,
-    ) async {
+    testWidgets('lands on the Day timeline by default, under the default '
+        'title, with Agenda a tap away', (tester) async {
       _setSurface(tester);
       await tester.pumpWidget(_wrap(DayPage(draft: _drafted())));
       await tester.pump();
 
       final messages = tester.element(find.byType(DayPage)).messages;
       expect(find.text(messages.dailyOsNextDayTitle), findsOneWidget);
+      expect(find.byType(DayTimeline), findsOneWidget);
+      expect(find.byType(AgendaView), findsNothing);
+      expect(find.byType(DayActivityView), findsNothing);
+      expect(
+        tester.widget<PlanViewToggle>(find.byType(PlanViewToggle)).selected,
+        PlanView.day,
+      );
+
+      tester
+          .widget<PlanViewToggle>(find.byType(PlanViewToggle))
+          .onChanged(PlanView.agenda);
+      await tester.pump();
+
       expect(find.byType(AgendaView), findsOneWidget);
       expect(find.byType(DayTimeline), findsNothing);
     });
 
     testWidgets(
-      'empty mode (no plan) lands on Activity with the check-in CTA '
+      'empty mode (no plan) lands on the Day timeline with the check-in CTA '
       'instead of Refine/Commit, and hides the delete-plan menu entry',
       (tester) async {
         _setSurface(tester);
@@ -161,11 +173,20 @@ void main() {
         await tester.pump();
         await tester.pump();
 
-        // Failed or pending recordings are the primary no-plan recovery path,
-        // while already-tracked time remains visible on the same surface.
+        // Already-tracked time is visible on the timeline without a plan;
+        // failed or pending recordings — the no-plan recovery path — stay one
+        // tap away on Activity.
+        expect(find.byType(DayTimeline), findsOneWidget);
+        expect(find.byType(DayActivityView), findsNothing);
+        expect(find.byType(AgendaView), findsNothing);
+        expect(find.text('Recorded session'), findsOneWidget);
+        tester
+            .widget<PlanViewToggle>(find.byType(PlanViewToggle))
+            .onChanged(PlanView.activity);
+        await tester.pump();
+        await tester.pump();
         expect(find.byType(DayActivityView), findsOneWidget);
         expect(find.byType(DayTimeline), findsNothing);
-        expect(find.byType(AgendaView), findsNothing);
         expect(find.text('Recorded session'), findsOneWidget);
 
         // Footer carries the single check-in CTA, not Refine/Commit.
@@ -291,6 +312,13 @@ void main() {
           ),
         );
         await tester.pump();
+        // The surface opens on the Day timeline; the recovery row lives on
+        // Activity.
+        tester
+            .widget<PlanViewToggle>(find.byType(PlanViewToggle))
+            .onChanged(PlanView.activity);
+        await tester.pump();
+        await tester.pump();
 
         final messages = tester.element(find.byType(DayPage)).messages;
         await tester.tap(find.text(messages.dailyOsNextActivityUseToPlan));
@@ -342,6 +370,13 @@ void main() {
       await tester.pump();
       final messages = tester.element(find.byType(DayPage)).messages;
 
+      // The surface opens on the Day timeline; the recovery row lives on
+      // Activity.
+      tester
+          .widget<PlanViewToggle>(find.byType(PlanViewToggle))
+          .onChanged(PlanView.activity);
+      await tester.pump();
+      await tester.pump();
       await tester.tap(find.text(messages.dailyOsNextActivityUseToPlan));
       await tester.pump();
 
@@ -469,6 +504,11 @@ void main() {
           ],
         );
         await _pumpDayPage(tester, draft: draft, agent: agent);
+        // Agenda rows are the inline-rename surface; the page opens on Day.
+        tester
+            .widget<PlanViewToggle>(find.byType(PlanViewToggle))
+            .onChanged(PlanView.agenda);
+        await tester.pump();
 
         await tester.tap(find.text('Standalone block'));
         await tester.pump();
@@ -1018,20 +1058,27 @@ void main() {
       expect(find.text('2026-05-26'), findsOneWidget);
     });
 
-    testWidgets('toggling the plan view switches Agenda → DayTimeline', (
-      tester,
-    ) async {
+    testWidgets('toggling the plan view switches DayTimeline → Agenda → '
+        'DayTimeline', (tester) async {
       _setSurface(tester);
       await tester.pumpWidget(_wrap(DayPage(draft: _drafted())));
+      await tester.pump();
+
+      expect(find.byType(DayTimeline), findsOneWidget);
+      expect(find.byType(AgendaView), findsNothing);
+
+      // Drive the toggle directly; chip tap behavior is covered by
+      // PlanViewToggle's focused widget tests.
+      final toggle = tester.widget<PlanViewToggle>(find.byType(PlanViewToggle));
+      toggle.onChanged(PlanView.agenda);
       await tester.pump();
 
       expect(find.byType(AgendaView), findsOneWidget);
       expect(find.byType(DayTimeline), findsNothing);
 
-      // Drive the toggle directly; chip tap behavior is covered by
-      // PlanViewToggle's focused widget tests.
-      final toggle = tester.widget<PlanViewToggle>(find.byType(PlanViewToggle));
-      toggle.onChanged(PlanView.day);
+      tester
+          .widget<PlanViewToggle>(find.byType(PlanViewToggle))
+          .onChanged(PlanView.day);
       await tester.pump();
 
       expect(find.byType(AgendaView), findsNothing);
@@ -1173,6 +1220,10 @@ void main() {
     ) async {
       _setSurface(tester);
       await tester.pumpWidget(_wrap(DayPage(draft: _drafted())));
+      await tester.pump();
+      tester
+          .widget<PlanViewToggle>(find.byType(PlanViewToggle))
+          .onChanged(PlanView.agenda);
       await tester.pump();
 
       expect(find.text('Deep work'), findsOneWidget);

--- a/test/features/daily_os_next/ui/widgets/day_timeline_fold_surface_test.dart
+++ b/test/features/daily_os_next/ui/widgets/day_timeline_fold_surface_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/daily_os_next/ui/widgets/day_timeline_fold_surface.dart';
+import 'package:lotti/features/daily_os_next/ui/widgets/day_timeline_folding.dart';
+
+import '../../../../widget_test_utils.dart';
+
+/// A phone lane's width once the hour rail and the gutters are taken: the
+/// width the fold pill actually gets on an iPhone SE.
+const double _narrowLane = 174;
+
+TimelineFoldingState _stateWithFold({
+  required bool expanded,
+  int startHour = 8,
+  int endHour = 18,
+}) => TimelineFoldingState(
+  startHour: 0,
+  endHour: 24,
+  segments: [
+    TimelineVisibleRegion(startHour: 0, endHour: startHour),
+    TimelineFoldRegion(
+      startHour: startHour,
+      endHour: endHour,
+      isExpanded: expanded,
+      collapsedHourHeight: 6,
+    ),
+    if (endHour < 24) TimelineVisibleRegion(startHour: endHour, endHour: 24),
+  ],
+);
+
+Widget _layer({
+  required TimelineFoldingState state,
+  required ValueChanged<int> onToggle,
+  double width = _narrowLane,
+  double textScale = 1,
+}) => makeTestableWidget2(
+  Align(
+    alignment: Alignment.topLeft,
+    child: SizedBox(
+      width: width,
+      height: state.totalHeight(1),
+      child: FoldRegionLayer(
+        foldingState: state,
+        pxPerMinute: 1,
+        onToggleFoldRegion: onToggle,
+      ),
+    ),
+  ),
+  mediaQueryData: phoneMediaQueryData.copyWith(
+    textScaler: TextScaler.linear(textScale),
+  ),
+);
+
+void main() {
+  group('FoldRegionLayer', () {
+    // The pill used to shrink-wrap an icon and a rigid caption; at 2× text in
+    // a narrow lane the caption alone outgrew the region and the row
+    // overflowed — a striped error box on the default Day view of a small
+    // phone with large text.
+    for (final expanded in [false, true]) {
+      testWidgets(
+        '${expanded ? 'an expanded' : 'a compressed'} fold pill stays inside '
+        'a narrow lane at large text',
+        (tester) async {
+          final state = _stateWithFold(expanded: expanded);
+          await tester.pumpWidget(
+            _layer(state: state, onToggle: (_) {}, textScale: 2),
+          );
+          await tester.pump();
+
+          expect(tester.takeException(), isNull);
+          final label = find.text('08:00-18:00');
+          expect(label, findsOneWidget);
+          // What the ellipsis takes at this size is still one long-press
+          // away.
+          expect(find.byTooltip('08:00-18:00'), findsOneWidget);
+          final region = find.byKey(const Key('daily_os_timeline_fold_8_18'));
+          final regionRect = tester.getRect(region);
+          final labelRect = tester.getRect(label);
+          expect(labelRect.right, lessThanOrEqualTo(regionRect.right));
+          expect(labelRect.left, greaterThanOrEqualTo(regionRect.left));
+          expect(regionRect.width, _narrowLane);
+        },
+      );
+    }
+
+    testWidgets('at regular text the label is not clipped', (tester) async {
+      await tester.pumpWidget(
+        _layer(state: _stateWithFold(expanded: false), onToggle: (_) {}),
+      );
+      await tester.pump();
+
+      final text = tester.widget<Text>(find.text('08:00-18:00'));
+      final paragraph = tester.renderObject<RenderParagraph>(
+        find.text('08:00-18:00'),
+      );
+      expect(text.overflow, TextOverflow.ellipsis);
+      expect(paragraph.didExceedMaxLines, isFalse);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('tapping a fold region reports its start hour, in either '
+        'state', (tester) async {
+      for (final expanded in [false, true]) {
+        final toggled = <int>[];
+        // A short fold: expanded it is 4 h × 60 px, so its centre stays
+        // inside the test view either way.
+        await tester.pumpWidget(
+          _layer(
+            state: _stateWithFold(expanded: expanded, startHour: 1, endHour: 5),
+            onToggle: toggled.add,
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.byKey(const Key('daily_os_timeline_fold_1_5')));
+        await tester.pump();
+
+        expect(toggled, [1], reason: 'expanded: $expanded');
+      }
+    });
+
+    testWidgets('a fold that runs to midnight is labelled 24:00', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _layer(
+          state: _stateWithFold(expanded: false, startHour: 18, endHour: 24),
+          onToggle: (_) {},
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('18:00-24:00'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/daily_os_next/ui/widgets/day_timeline_test.dart
+++ b/test/features/daily_os_next/ui/widgets/day_timeline_test.dart
@@ -24,6 +24,7 @@ import 'package:mocktail/mocktail.dart';
 import '../../../../helpers/entity_factories.dart';
 import '../../../../widget_test_utils.dart';
 import '../../../categories/test_utils.dart';
+import '../pages/day_page_test_helpers.dart';
 
 const _work = DayAgentCategory(
   id: 'cat_work',
@@ -318,6 +319,92 @@ void main() {
       );
 
       await tester.tapAt(blockRect.center);
+      await tester.pump();
+
+      expect(openedPath, isNull);
+    });
+
+    // A tracked calendar block projects a Lotti event; the event page is its
+    // one way in, so the block opens it — not a task, not the entry editor.
+    testWidgets('a tracked calendar block opens its event page', (
+      tester,
+    ) async {
+      _setView(tester, const Size(1280, 1200));
+
+      String? openedPath;
+      beamToNamedOverride = (path) => openedPath = path;
+
+      await tester.pumpWidget(
+        _wrap(
+          DayTimeline(
+            draft: _draftWithBlocks(
+              blocks: const [],
+              actualBlocks: [
+                _timeBlock(
+                  id: '${actualTimeBlockIdPrefix}evt-1',
+                  title: 'Dinner with a friend',
+                  startHour: 8,
+                  endHour: 9,
+                  type: TimeBlockType.cal,
+                  state: TimeBlockState.completed,
+                ),
+              ],
+            ),
+            clock: () => DateTime(2026, 5, 25, 9, 15),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final block = find.byKey(
+        const Key('daily_os_day_block_${actualTimeBlockIdPrefix}evt-1'),
+      );
+      expect(
+        find.descendant(of: block, matching: find.byType(Ink)),
+        findsOneWidget,
+      );
+
+      await tester.tap(block);
+      await tester.pump();
+
+      expect(openedPath, '/events/evt-1');
+    });
+
+    testWidgets('a tracked recording with neither task nor event stays inert', (
+      tester,
+    ) async {
+      _setView(tester, const Size(1280, 1200));
+
+      String? openedPath;
+      beamToNamedOverride = (path) => openedPath = path;
+
+      await tester.pumpWidget(
+        _wrap(
+          DayTimeline(
+            draft: _draftWithBlocks(
+              blocks: const [],
+              actualBlocks: [
+                _timeBlock(
+                  id: '${actualTimeBlockIdPrefix}entry-3',
+                  title: 'Loose recording',
+                  startHour: 8,
+                  endHour: 9,
+                  type: TimeBlockType.manual,
+                  state: TimeBlockState.completed,
+                ),
+              ],
+            ),
+            clock: () => DateTime(2026, 5, 25, 9, 15),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final block = find.byKey(
+        const Key('daily_os_day_block_${actualTimeBlockIdPrefix}entry-3'),
+      );
+
+      await tester.tap(block);
       await tester.pump();
 
       expect(openedPath, isNull);
@@ -1028,6 +1115,217 @@ void main() {
         );
       },
     );
+
+    // The Day view is the default projection now, so with nothing planned a
+    // phone would otherwise land on a blank planned lane with the tracked
+    // time and events one swipe away — and the pager used to count its own
+    // starting position as the swipe being learned.
+    testWidgets(
+      'with nothing planned the pager opens on the recorded lane, coaches the '
+      'swipe to the plan, and learns the swipe only when it happens',
+      (tester) async {
+        _setView(tester, const Size(430, 900));
+        var learned = 0;
+
+        await tester.pumpWidget(
+          _wrap(
+            DayTimeline(
+              draft: _draftWithBlocks(
+                blocks: const [],
+                actualBlocks: [
+                  _timeBlock(
+                    id: '${actualTimeBlockIdPrefix}evt-1',
+                    title: 'Dinner with a friend',
+                    startHour: 18,
+                    endHour: 20,
+                    type: TimeBlockType.cal,
+                    state: TimeBlockState.committed,
+                  ),
+                ],
+              ),
+              clock: () => DateTime(2026, 5, 25, 9, 15),
+              onGesturesLearned: () => learned++,
+            ),
+            size: const Size(430, 900),
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        final messages = tester.element(find.byType(DayTimeline)).messages;
+        final pageView = tester.widget<PageView>(find.byType(PageView));
+        expect(pageView.controller!.initialPage, 1);
+        // The peeking page fraction settles the last page short of 1.0; what
+        // matters is that the recorded lane is the one in view.
+        expect(pageView.controller!.page, greaterThan(0.5));
+        final actualPane = tester.getRect(
+          find.byKey(const Key('daily_os_timeline_actual_pane')),
+        );
+        expect(actualPane.left, greaterThanOrEqualTo(0));
+        expect(actualPane.right, lessThanOrEqualTo(430));
+        expect(
+          find.text(messages.dailyOsNextTimelineSwipeHintToPlan),
+          findsOneWidget,
+        );
+        expect(find.text(messages.dailyOsNextTimelineSwipeHint), findsNothing);
+        expect(learned, 0, reason: 'opening on a lane is not a swipe');
+
+        // Swiping back to the planned lane is the demonstration.
+        await tester.drag(find.byType(PageView), const Offset(300, 0));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(pageView.controller!.page, lessThan(0.5));
+        expect(learned, 1);
+      },
+    );
+
+    // The docked day-view column hands the timeline an empty plan while the
+    // provider is still loading; the real plan arrives into the same State.
+    testWidgets(
+      'a plan arriving after an empty first frame moves the pager to the '
+      'planned lane, the coaching line follows, and it is not a swipe',
+      (tester) async {
+        _setView(tester, const Size(430, 900));
+        var learned = 0;
+        Widget timeline(DraftPlan draft) => _wrap(
+          DayTimeline(
+            draft: draft,
+            clock: () => DateTime(2026, 5, 25, 9, 15),
+            onGesturesLearned: () => learned++,
+          ),
+          size: const Size(430, 900),
+        );
+
+        await tester.pumpWidget(
+          timeline(_draftWithBlocks(blocks: const [])),
+        );
+        await tester.pump();
+        final messages = tester.element(find.byType(DayTimeline)).messages;
+        final pageView = tester.widget<PageView>(find.byType(PageView));
+        expect(pageView.controller!.page, greaterThan(0.5));
+        expect(
+          find.text(messages.dailyOsNextTimelineSwipeHintToPlan),
+          findsOneWidget,
+        );
+
+        await tester.pumpWidget(timeline(_draft()));
+        await tester.pump();
+
+        expect(pageView.controller!.page, 0);
+        expect(
+          find.text(messages.dailyOsNextTimelineSwipeHint),
+          findsOneWidget,
+        );
+        expect(
+          find.text(messages.dailyOsNextTimelineSwipeHintToPlan),
+          findsNothing,
+        );
+        expect(learned, 0, reason: 'a programmatic jump is not a swipe');
+      },
+    );
+
+    testWidgets(
+      'a plan emptied under a live timeline moves the pager to the recorded '
+      'lane',
+      (tester) async {
+        _setView(tester, const Size(430, 900));
+        Widget timeline(DraftPlan draft) => _wrap(
+          DayTimeline(
+            draft: draft,
+            clock: () => DateTime(2026, 5, 25, 9, 15),
+          ),
+          size: const Size(430, 900),
+        );
+
+        await tester.pumpWidget(timeline(_draft()));
+        await tester.pump();
+        final pageView = tester.widget<PageView>(find.byType(PageView));
+        expect(pageView.controller!.page, 0);
+
+        await tester.pumpWidget(
+          timeline(_draftWithBlocks(blocks: const [])),
+        );
+        await tester.pump();
+
+        final messages = tester.element(find.byType(DayTimeline)).messages;
+        expect(pageView.controller!.page, greaterThan(0.5));
+        expect(
+          find.text(messages.dailyOsNextTimelineSwipeHintToPlan),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets('with a plan the pager opens on the planned lane as before', (
+      tester,
+    ) async {
+      _setView(tester, const Size(430, 900));
+      var learned = 0;
+
+      await tester.pumpWidget(
+        _wrap(
+          DayTimeline(
+            draft: _draft(),
+            clock: () => DateTime(2026, 5, 25, 9, 15),
+            onGesturesLearned: () => learned++,
+          ),
+          size: const Size(430, 900),
+        ),
+      );
+      await tester.pump();
+
+      final messages = tester.element(find.byType(DayTimeline)).messages;
+      expect(
+        tester.widget<PageView>(find.byType(PageView)).controller!.initialPage,
+        0,
+      );
+      expect(find.text(messages.dailyOsNextTimelineSwipeHint), findsOneWidget);
+      expect(
+        find.text(messages.dailyOsNextTimelineSwipeHintToPlan),
+        findsNothing,
+      );
+      expect(learned, 0);
+    });
+
+    // The scroll content used to be `totalHeight + step9`, which held the
+    // pane — label (overline + step2), grid, step5 inset — only because
+    // 16 + 4 + 16 happens to leave 12 px under 48 at the default tokens. A
+    // larger step2 overflowed the pane by the difference, which the Day page
+    // header test caught on CI once Day became the default view.
+    testWidgets('the scroll content fits the pane when a spacing token grows', (
+      tester,
+    ) async {
+      _setView(tester, const Size(430, 900));
+
+      await tester.pumpWidget(
+        _wrap(
+          Theme(
+            data: themeWithHeaderSpacing(32),
+            child: DayTimeline(
+              draft: _draft(),
+              clock: () => DateTime(2026, 5, 25, 9, 15),
+            ),
+          ),
+          size: const Size(430, 900),
+        ),
+      );
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      final pane = tester.getRect(
+        find.byKey(const Key('daily_os_timeline_plan_pane')),
+      );
+      final content = tester.getRect(
+        find
+            .descendant(
+              of: find.byKey(const Key('daily_os_timeline_scroll')),
+              matching: find.byType(SizedBox),
+            )
+            .first,
+      );
+      expect(pane.bottom, lessThanOrEqualTo(content.bottom));
+    });
 
     testWidgets('toolbar toggle button switches comparison mode paged→both', (
       tester,

--- a/test/features/daily_os_next/ui/widgets/day_view_side_panel_test.dart
+++ b/test/features/daily_os_next/ui/widgets/day_view_side_panel_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -425,6 +427,55 @@ void main() {
       // actual lanes — the same interaction as the Daily OS day surface.
       expect(find.byType(PageView), findsOneWidget);
     });
+
+    // The panel hands the timeline `DraftPlan.emptyForDay` while the plan
+    // provider is still loading, so the pager opens on the recorded lane;
+    // the real plan then lands in the same widget state.
+    testWidgets(
+      'a plan that resolves after the loading frame lands the narrow panel '
+      'on the planned lane',
+      (tester) async {
+        const size = Size(340, 900);
+        setView(tester, size);
+        final plan = Completer<DraftPlan?>();
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              currentDraftPlanProvider.overrideWith(
+                (ref, date) => plan.future,
+              ),
+              dailyOsActualTimeBlocksProvider.overrideWith(
+                (ref, date) async => _actualForToday(),
+              ),
+              dailyOsPreferencesControllerProvider.overrideWith(
+                _SeededPreferencesController.new,
+              ),
+            ],
+            child: makeTestableWidget2(
+              SizedBox(
+                width: size.width,
+                height: size.height,
+                child: DayViewSidePanel(onToggleHidden: () {}),
+              ),
+              mediaQueryData: const MediaQueryData(size: size),
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        final pageView = tester.widget<PageView>(find.byType(PageView));
+        expect(pageView.controller!.page, greaterThan(0.5));
+
+        plan.complete(_planForToday());
+        await tester.pump();
+        await tester.pump();
+
+        expect(pageView.controller!.page, 0);
+        expect(find.byType(PageView), findsOneWidget);
+      },
+    );
 
     testWidgets(
       'the calendar button at the end of the toolbar row fires the hide callback',

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -253,6 +253,25 @@ class MockJournalDb extends Mock implements JournalDb {
     return Stream<Set<String>>.value(<String>{}).asBroadcastStream();
   }
 
+  /// Unstubbed, a flag reads as off — the same answer [watchConfigFlag]
+  /// falls back to, so a service that gates on a feature flag (the Daily OS
+  /// week context reads `enable_events`) sees a consistent default instead
+  /// of a null `Future<bool>`.
+  @override
+  Future<bool> getConfigFlag(String flagName) {
+    try {
+      final result = super.noSuchMethod(
+        Invocation.method(#getConfigFlag, [flagName]),
+      );
+      if (result is Future<bool>) {
+        return result;
+      }
+    } catch (_) {
+      // ignore and fall back
+    }
+    return Future<bool>.value(false);
+  }
+
   @override
   Stream<bool> watchConfigFlag(String flagName) {
     try {


### PR DESCRIPTION
An event created on the events page and given a start and end there — dinner from 18:00 to midnight — did not show up on the Daily OS Day view. And the Daily OS opened on Agenda (or Activity without a plan) rather than on the calendar.

## The cause

`sortedCalenderEntriesInRange`, the drift query behind the Day view's recorded lane (and the planner's recorded-time lookback), named only `JournalEntry` and `WorkoutEntry`. A `JournalEvent` row never reached the lane no matter what span the date line gave it — the 18:00–24:00 slot simply folded away as an idle gap.

The default projection was a per-day rule in `DayPage`: Agenda with a plan, Activity without one. The user's explicit pick already lived in `dailyOsNextPlanViewProvider`; only the fallback changes.

## The fix

- **Events reach the lane.** The query admits `JournalEvent` rows (one regenerated line in `database.g.dart`). `resolveTimeEntries` — the shared "what counts as recorded time" core for the lane *and* the week-context lookback — owns the rules once: an event counts while the Events feature flag is on (with it off, events are hidden everywhere, so the lane awaits `configFlagProvider(enableEventsFlag)` and re-runs when it flips; the week-context service reads `getConfigFlag`), and only when it took place (`eventTookPlace`: cancelled, missed and postponed never count — a postponed event has left its slot without naming a new one; the date line stays the single source of the event's when for every other status). An event resolves with no linked-from entity, so its own title and category are the block's, never a task it was created under.
- **The block is the event.** It projects as a `TimeBlockType.cal` block (read-only, never arrangeable, like every tracked block) whose state follows the status (`eventBlockState`: completed → checked, ongoing → in progress, anything still ahead → committed and unchecked; a recording stays completed by definition), and a tap beams to `/events/<id>` — the event's one way in — where a tracked manual block opens its task.
- **Day is the default.** `DayPage` falls back to `PlanView.day` with or without a plan; Agenda and Activity are a tap away, and a pick still survives day changes. Empty mode used to land on Activity so a failed recording was in view at once; that recovery path is now one tap away while tracked time and events are visible at once. On a phone, a day with nothing planned opens the pager on the *recorded* lane (the planned lane is empty by construction), with a matching "Swipe for plan" coaching line in all eleven catalogs; the swipe counts as learned only by travelling away from the lane the pager opened on. The lane is re-selected when "nothing planned" flips under a live widget (the docked column hands the timeline an empty plan while the provider loads; when the real plan resolves the pager jumps to the planned lane, and back should a plan be emptied), which is not counted as a swipe either.
- **A large-text overflow on the timeline, now that it is the landing view.** The fold pill (the `18:00-24:00` marker on a collapsed idle gap) shrink-wrapped an icon and a rigid caption; at 2× text in a narrow lane the row overflowed — the existing iPhone SE large-text page test caught it the moment Day became the default. Both fold states now share one `_FoldRangePill` whose label yields (ellipsis) before the row does and carries the full range as its tooltip, and `day_timeline_fold_surface.dart` gets the test file it never had.
- **Two CI follow-ups.** The week-context service's new flag read hit the shared `MockJournalDb` unstubbed in the wake benchmark gate (a null `Future<bool>` tripped the service's fail-soft path and the prompt lost its plan lines); the mock now answers `false` for an unstubbed `getConfigFlag`, the way it already did for `watchConfigFlag`. And the Day page header's spacing-token test overflowed once Day became the default: the timeline's scroll content was `totalHeight + step9`, which held the pane (overline + step2 + grid + step5) only because 16 + 4 + 16 leaves 12 px under 48 at the default tokens; it is now spelled in the pane's own terms plus a `step4` of room — identical at default tokens, safe under any, with its own regression test.

## Tests

One test file per source file, each rule its own test:

- `recorded_time_test.dart`: an event counts on its own (own category, no linked-from, no taskId); a zero-length event is a point in time; per-status survival across all eight statuses; events dropped while the flag is off; `eventTookPlace` over the enum (cancelled, missed, postponed).
- `actual_time_blocks_provider_test.dart` (+ helpers `hEvent`, `readActualBlocks`): the event block — title, `cal` type, `committed` for a planned event, no task, `trackedEntryId`, own category, 18:00→midnight span, sorted among recordings; `eventBlockState` over every status and the completed/ongoing/recording states on the lane; untitled event falls through text → category; cancelled event off the lane; flag-off off the lane; provider-level: flag on / off from the database stream, and a flipped flag repaints the lane without a restart.
- `day_timeline_test.dart`: a tracked calendar block opens `/events/<id>`; a tracked recording with neither task nor event stays inert; with nothing planned the pager opens on the recorded lane with the "Swipe for plan" line and does not count that as the swipe being learned; a plan arriving into a live timeline moves it to the planned lane with the line following (and a plan emptied moves it back); with a plan it opens on the planned lane as before. `day_view_side_panel_test.dart`: a plan resolving after the loading frame lands the narrow docked column on the planned lane.
- `day_agent_week_context_service_test.dart`: an event counts toward the lookback with the flag on; stays out with it off (and the flag is read).
- `database_journal_queries_test.dart` (+ `buildEventEntry`): the query admits a live event by its span, not a deleted one, not a task.
- `day_timeline_fold_surface_test.dart` (new): compressed and expanded pills stay inside a 174 px lane at 2× text and keep the full range as a tooltip; the label is ellipsis-bound but not clipped at regular text; tap reports the fold's start hour in either state; a fold to midnight reads `24:00`.
- `day_page_test.dart`, `daily_os_next_root_test.dart`: the surface lands on Day with and without a plan, Agenda/Activity by explicit pick, and the pick survives chevrons and jump-to-today (asserted against the Day default now).
- `day_page_screenshots_test.dart` and the Linux integration capture pick Agenda explicitly for the agenda cases, so the manual's `daily-os/agenda` case still shows the agenda.

## Also

- `knowledge/`: the Day-surface state diagram and view-memory prose, an "events are recorded time too" section on the Actual lane, the events concept's flag gate / one-way-in / on-the-day, both READMEs.
- Manual (`docs-site`), all eleven locales: "opens on Agenda" → "opens on the Day timeline; switch to Agenda for the list", and section 6 now names Day as where Daily OS opens and mentions events on the recorded lane.
- Changelog fragment.
- `test/README.md`: the autoDispose-provider-awaiting-a-stream pitfall and the `readActualBlocks` pattern.

Out of scope, flagged: a multi-day event (a trip) stays outside the containment query, as a recording crossing midnight does; and an event scheduled later *today* counts toward today's recorded total in the planner lookback, which is the accepted "range ends at end of day" behaviour that already applied to recordings.

## Screenshots

Hosted in `matthiasn/lotti-docs` on branch `agent/daily-os-events-timeline-screenshots` (commit `824a03b0e14d3071bf555972bbe4fc5a1af8e5db`), the way earlier PRs from this account did; the identical pair is staged at `/tmp/lotti-pr-screenshots/daily-os-events-timeline/` for `make pr_screenshots_publish` if the R2 copy is wanted.

Before is the base commit (`047db09e9`); after is this branch. Captured with the Day page screenshot harness over a real in-memory database — the penguin demo world's recorded sessions as journal rows plus one synthetic event, "Dinner with the emperor penguin delegation", edited to run 18:00–24:00 — with the Day view selected explicitly for the timeline pair, so it isolates the event fix; the landing pair is the surface exactly as it opens.

### Daily OS timeline, recorded lane — desktop dark

Before, the evening is a folded idle gap; after, the event sits on the lane at 18:00 with its own title and category.

| Before | After |
|---|---|
| ![Timeline desktop before](https://raw.githubusercontent.com/matthiasn/lotti-docs/824a03b0e14d3071bf555972bbe4fc5a1af8e5db/pr-screenshots/daily-os-events-timeline/before/daily_os_timeline_event_desktop_dark.png) | ![Timeline desktop after](https://raw.githubusercontent.com/matthiasn/lotti-docs/824a03b0e14d3071bf555972bbe4fc5a1af8e5db/pr-screenshots/daily-os-events-timeline/after/daily_os_timeline_event_desktop_dark.png) |

### Daily OS timeline, recorded lane — mobile dark

| Before | After |
|---|---|
| ![Timeline mobile before](https://raw.githubusercontent.com/matthiasn/lotti-docs/824a03b0e14d3071bf555972bbe4fc5a1af8e5db/pr-screenshots/daily-os-events-timeline/before/daily_os_timeline_event_mobile_dark.png) | ![Timeline mobile after](https://raw.githubusercontent.com/matthiasn/lotti-docs/824a03b0e14d3071bf555972bbe4fc5a1af8e5db/pr-screenshots/daily-os-events-timeline/after/daily_os_timeline_event_mobile_dark.png) |

### Daily OS landing view with a plan — desktop light

| Before | After |
|---|---|
| ![Landing desktop before](https://raw.githubusercontent.com/matthiasn/lotti-docs/824a03b0e14d3071bf555972bbe4fc5a1af8e5db/pr-screenshots/daily-os-events-timeline/before/daily_os_landing_view_desktop_light.png) | ![Landing desktop after](https://raw.githubusercontent.com/matthiasn/lotti-docs/824a03b0e14d3071bf555972bbe4fc5a1af8e5db/pr-screenshots/daily-os-events-timeline/after/daily_os_landing_view_desktop_light.png) |

### Daily OS landing view without a plan — mobile dark

| Before | After |
|---|---|
| ![Landing no-plan mobile before](https://raw.githubusercontent.com/matthiasn/lotti-docs/824a03b0e14d3071bf555972bbe4fc5a1af8e5db/pr-screenshots/daily-os-events-timeline/before/daily_os_landing_view_no_plan_mobile_dark.png) | ![Landing no-plan mobile after](https://raw.githubusercontent.com/matthiasn/lotti-docs/824a03b0e14d3071bf555972bbe4fc5a1af8e5db/pr-screenshots/daily-os-events-timeline/after/daily_os_landing_view_no_plan_mobile_dark.png) |

## Verification

- `fvm dart analyze` on every touched Dart file: no issues; `fvm dart format`: clean
- Touched test files, each run on its own: `recorded_time_test` 13, `actual_time_blocks_provider_test` 25, `actual_time_blocks_provider_streams_test` 6, `day_timeline_test` 62, `day_timeline_fold_surface_test` 5, `day_timeline_folding_test` 10, `day_agent_week_context_service_test` 51, `database_journal_queries_test` 41, `calendar_entries_coalescing_test` 5, `day_page_test` 40, `daily_os_next_root_test` 21, `plan_view_provider_test` 3, `day_view_side_panel_test` 12, `day_page_header_test` 4, `day_agent_wake_benchmark_test` 4 — all passing
- Line coverage of the touched sources from those runs: `recorded_time.dart` 42/42, `actual_time_blocks_provider.dart` 82/82, `day_timeline_widgets.dart` 194/194, `day_timeline_fold_surface.dart` 164/164, `day_agent_week_context_service.dart` 204/204, `plan_view_provider.dart` 4/4, `day_agent_timeline_models.dart` 24/24 (100%); `day_timeline.dart` 307/308, `day_timeline_block.dart` 375/376 and `day_page.dart` 496/497, where the missed lines (687; 680; 994) are outside this diff — every line this branch adds or changes is covered
- Regression tests re-run with each fix reverted: with each fix reverted in turn (SQL, the recorded-time event rules, the projection, the block tap, the Day default, the fold pill, the week-context flag, and after review: the status-driven block state, the postponed rule, the recorded-lane-first pager, the fold tooltip, the scroll-content height, the lane re-selection on plan arrival) the corresponding new tests fail — 32 failures across the thirteen reverts; restored, all pass
- `make changelog_check`, `make knowledge_check` (validator + 514 Mermaid blocks), `npm --prefix docs-site run validate` (11 locales)
- `day_page_screenshots_test.dart` run with `LOTTI_SCREENSHOT_DIR` (the manual-capture-check path): 39 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126LMFUB7k9RqLZZuU4QNU4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily OS now opens on the **Day** timeline by default; **Agenda** and **Activity** remain available.
  * Timed events appear on the recorded lane with their title and color and can be tapped to open event details.
  * Cancelled, missed, and postponed events remain hidden from the timeline.
  * When nothing is planned, the recorded lane opens first with guidance for switching to the plan.

* **Documentation**
  * Updated Daily OS and Events guidance across supported languages to reflect the new timeline behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
