### PR TITLE
fix(tasks): close the details fly-out when a status is picked

### DIFF
--- a/changelog.d/2026-09-03-task-status-closes-details-flyout.md
+++ b/changelog.d/2026-09-03-task-status-closes-details-flyout.md
@@ -1,0 +1,6 @@
+### Fixed
+- **Setting a task's status now closes the Details panel.** Marking a task Done
+  from **Details** left the panel sitting over the task while the completion
+  animation played behind it, dimmed by the panel's own backdrop. The panel now
+  steps aside as soon as you pick a status, so the celebration plays on a clear
+  screen. Setting a task to Blocked still asks what is blocking it.

--- a/knowledge/features/tasks/detail-composition.md
+++ b/knowledge/features/tasks/detail-composition.md
@@ -11,7 +11,7 @@ sources:
   - id: header
     resource: ../../../lib/features/tasks/ui/header
     title: Desktop task header, metadata section, fly-out and details column
-    last_modified: 2026-08-20
+    last_modified: 2026-09-03
   - id: linked-task-row
     resource: ../../../lib/features/tasks/ui/linked_tasks/linked_task_row.dart
     title: Linked task row
@@ -343,6 +343,25 @@ The narrow density stacks rather than narrowing the label column: at
 `kTaskMetaColumnWidth` (320) a fixed 96 pt label column either starves the
 values or clips a long localized label — German "Fälligkeitsdatum" does not
 fit beside its own date.
+
+**A status pick closes a dismissible host.** The status write is the one edit
+in the section that plays a *celebration* — `TaskStatusSummaryTag` wraps the
+header's status read-out in `CompletionCelebration`, so moving a task to Done
+blooms a glow and throws a spark burst on the pill directly behind the panel.
+`TaskMetaSection.onStatusPicked` is how the host gets out of its way:
+`TaskMetaFlyout` passes its own `Navigator.pop`, the persistent column passes
+nothing. `TaskMetaPickers.showStatusPicker` fires it the instant the picker
+returns a status and **before** `updateTaskStatus`, so the panel's exit runs
+during the write rather than over the burst it triggers. No other row reports
+back — editing a second attribute in the same visit stays possible.
+
+Dismissing the host takes the picker's `context` and `ref` with it, so the
+[Blocked follow-up prompt](relationships.md#where-it-surfaces)
+is set up *before* the pick: the blockers are read through the
+`ProviderContainer`, and the prompt is presented on the hosting navigator's
+**overlay** context — a descendant of the navigator, so `Navigator.of`
+resolves back to it, and it outlives every route on it. Without that, a write
+slower than the panel's exit animation would silently swallow the prompt.
 
 ### The details column
 

--- a/knowledge/features/tasks/relationships.md
+++ b/knowledge/features/tasks/relationships.md
@@ -144,12 +144,15 @@ Spoken relationships ("this task is blocked by X", "this supersedes Y") become
   unresolved (nothing to name or navigate to); otherwise a tappable pill naming
   the single blocker or the count, opening the blocker's detail page directly or
   a list sheet.
-- **The status-enrichment prompt.** When the header sets a task's status to
-  `BLOCKED` — a change, not a no-op — and the task is not already named-blocked,
-  it opens `BlockingTaskPickerModal`: a search picker **fixed** to the `blocks`
-  relationship with no type selector, creating a `blocks` link from the chosen
-  task to this one. Fully skippable — **the status write already committed before
-  the modal opens**, so dismissing persists nothing further.
+- **The status-enrichment prompt.** When the status picker sets a task's status
+  to `BLOCKED` — a change, not a no-op — and the task is not already
+  named-blocked, it opens `BlockingTaskPickerModal`: a search picker **fixed** to
+  the `blocks` relationship with no type selector, creating a `blocks` link from
+  the chosen task to this one. Fully skippable — **the status write already
+  committed before the modal opens**, so dismissing persists nothing further.
+  The panel the picker was opened from has closed by then
+  ([detail composition](detail-composition.md#one-section-two-hosts)), so the
+  prompt is presented on the navigator rather than over that panel.
 
 **Manual `TaskStatus.blocked` and link-derived blockedness never write to each
 other automatically.** The link layer only *offers* the picker after a manual

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -56,7 +56,9 @@ project, and relationships to other tasks.
   task list does not just widen the task: the task's metadata — status,
   priority, category, project, due date, estimate, labels, AI spend — moves
   into a persistent column on the right, editable in place. Narrower than that,
-  the same rows stay one tap away in their fly-out.
+  the same rows stay one tap away in their fly-out — which steps aside the
+  moment you set a status, so the completion animation on a task you just
+  finished is not playing behind a panel.
 
 ## What it owns
 

--- a/lib/features/tasks/ui/header/task_meta_flyout.dart
+++ b/lib/features/tasks/ui/header/task_meta_flyout.dart
@@ -12,11 +12,30 @@ import 'package:lotti/widgets/modal/modal_utils.dart';
 /// twice.
 abstract final class TaskMetaFlyout {
   /// Opens the fly-out for [taskId] near the header ("Details" affordance).
+  ///
+  /// Closes itself when the status picker returns a choice — any choice, a
+  /// re-pick of the current status included, because the reader has finished
+  /// with the panel either way and a selection that visibly does nothing
+  /// reads as a dead tap. The status write plays the completion celebration
+  /// on the header's status pill, directly behind this panel, and a reader
+  /// who has just marked a task Done should see that rather than a scrim over
+  /// it.
+  ///
+  /// Both shapes this modal takes close: the dialog on a wide window, where
+  /// the scrim covers the whole celebration, and the bottom sheet on a phone,
+  /// where it covers less but the rule is worth more than the exception.
   static Future<void> show(BuildContext context, {required String taskId}) {
     return ModalUtils.showSinglePageModal<void>(
       context: context,
       title: context.messages.taskMetaSheetTitle,
-      builder: (_) => TaskMetaSection(taskId: taskId),
+      builder: (modalContext) => TaskMetaSection(
+        taskId: taskId,
+        // The status picker has already popped by the time this runs, so the
+        // fly-out is the top route and `pop` closes it and nothing else.
+        onStatusPicked: () {
+          if (modalContext.mounted) Navigator.of(modalContext).pop();
+        },
+      ),
     );
   }
 }

--- a/lib/features/tasks/ui/header/task_meta_pickers.dart
+++ b/lib/features/tasks/ui/header/task_meta_pickers.dart
@@ -30,14 +30,28 @@ abstract final class TaskMetaPickers {
   /// Opens the status picker; when the task just became `BLOCKED` and carries
   /// no blocker link yet, follows up with the blocking-task picker so the
   /// user can name what it waits on.
+  ///
+  /// [onStatusPicked] dismisses the surface the picker was opened *from* —
+  /// the metadata fly-out passes its own pop, the persistent details column
+  /// has nothing to dismiss and passes nothing. See the call below for why it
+  /// fires before the write rather than after it.
   static Future<void> showStatusPicker(
     BuildContext context,
     WidgetRef ref,
-    Task task,
-  ) async {
+    Task task, {
+    VoidCallback? onStatusPicked,
+  }) async {
     final taskId = task.meta.id;
     final controller = ref.read(entryControllerProvider(taskId).notifier);
     final previousStatus = task.data.status.toDbString;
+    // [onStatusPicked] tears down the host, and with it [context] and [ref].
+    // The Blocked follow-up runs after that, so take a container and a
+    // presentation context that outlive the host now: a navigator's overlay
+    // sits *inside* the navigator (so `Navigator.of` resolves back to it) and
+    // outlives every route pushed onto it.
+    final container = ProviderScope.containerOf(context, listen: false);
+    final hostContext = Navigator.of(context).overlay?.context ?? context;
+
     final selected = await ModalUtils.showSinglePageModal<String>(
       context: context,
       // Strip the trailing colon so the picker title matches the other
@@ -48,20 +62,30 @@ abstract final class TaskMetaPickers {
     );
     if (selected == null) return;
 
+    // Close the host the moment a status is chosen — *before* the write lands.
+    // A task turning Done fires the completion celebration on the header's
+    // status pill, and that should play on an unobstructed screen rather than
+    // dimmed behind the fly-out the reader has finished with. Waiting until
+    // after the write would put the panel's exit on top of the burst.
+    onStatusPicked?.call();
+
     await controller.updateTaskStatus(selected);
 
     final becameBlocked = selected == 'BLOCKED' && selected != previousStatus;
-    if (!becameBlocked || !context.mounted) return;
+    if (!becameBlocked) return;
 
-    final blockers = await ref.read(
+    final blockers = await container.read(
       taskBlockersControllerProvider(taskId).future,
     );
     // isBlocked (not just openBlockers) so an unresolved-only blocker link
     // also counts as "already named" — don't re-prompt over it.
     if (blockers.isBlocked) return;
-    if (!context.mounted) return;
+    if (!hostContext.mounted) return;
 
-    await BlockingTaskPickerModal.show(context: context, blockedTaskId: taskId);
+    await BlockingTaskPickerModal.show(
+      context: hostContext,
+      blockedTaskId: taskId,
+    );
   }
 
   static Future<void> showPriorityPicker(

--- a/lib/features/tasks/ui/header/task_meta_section.dart
+++ b/lib/features/tasks/ui/header/task_meta_section.dart
@@ -59,6 +59,7 @@ class TaskMetaSection extends ConsumerWidget {
   const TaskMetaSection({
     required this.taskId,
     this.density = TaskMetaDensity.wide,
+    this.onStatusPicked,
     super.key,
   });
 
@@ -66,6 +67,16 @@ class TaskMetaSection extends ConsumerWidget {
 
   /// How the rows lay out. See [TaskMetaDensity].
   final TaskMetaDensity density;
+
+  /// Dismisses the surface hosting this section, called the instant the status
+  /// picker returns a choice.
+  ///
+  /// Only the status row reports back: it is the one attribute whose write
+  /// plays a celebration on the header behind this section, and a panel left
+  /// standing over it dims the moment it exists to mark. A dismissible host
+  /// (the fly-out) passes its own pop; the persistent details column has
+  /// nothing to dismiss and passes nothing.
+  final VoidCallback? onStatusPicked;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -86,7 +97,12 @@ class TaskMetaSection extends ConsumerWidget {
           density: density,
           label: stripTrailingColon(messages.taskStatusLabel),
           value: _StatusValue(status: task.data.status),
-          onTap: () => TaskMetaPickers.showStatusPicker(context, ref, task),
+          onTap: () => TaskMetaPickers.showStatusPicker(
+            context,
+            ref,
+            task,
+            onStatusPicked: onStatusPicked,
+          ),
         ),
         TaskMetaFieldRow(
           density: density,

--- a/test/features/tasks/ui/header/task_meta_flyout_test.dart
+++ b/test/features/tasks/ui/header/task_meta_flyout_test.dart
@@ -1,9 +1,13 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
+import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/features/ai_consumption/state/consumption_providers.dart';
 import 'package:lotti/features/labels/state/labels_list_controller.dart';
 import 'package:lotti/features/projects/state/project_providers.dart';
@@ -11,6 +15,7 @@ import 'package:lotti/features/tasks/model/task_progress_state.dart';
 import 'package:lotti/features/tasks/state/task_progress_controller.dart';
 import 'package:lotti/features/tasks/ui/header/task_meta_flyout.dart';
 import 'package:lotti/features/tasks/ui/header/task_meta_section.dart';
+import 'package:lotti/features/tasks/ui/header/task_status_modal_content.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/editor_state_service.dart';
@@ -52,13 +57,15 @@ void main() {
     ),
   );
 
+  late MockJournalDb mockJournalDb;
+
   setUp(() async {
     final mockCache = MockEntitiesCacheService();
     when(() => mockCache.showPrivateEntries).thenReturn(true);
     when(() => mockCache.getCategoryById(any())).thenReturn(null);
     when(() => mockCache.getLabelById(any())).thenReturn(null);
 
-    await setUpTestGetIt(
+    final mocks = await setUpTestGetIt(
       additionalSetup: () {
         getIt
           ..registerSingleton<EntitiesCacheService>(mockCache)
@@ -68,17 +75,32 @@ void main() {
           ..registerSingleton<NavService>(MockNavService());
       },
     );
+    mockJournalDb = mocks.journalDb;
+    when(
+      () => mockJournalDb.typedLinksForTaskIds(
+        any(),
+        types: any(named: 'types'),
+      ),
+    ).thenAnswer((_) async => <EntryLink>[]);
   });
 
   tearDown(tearDownTestGetIt);
 
-  testWidgets('opens the metadata section in a titled modal', (tester) async {
+  Future<void> pumpOpener(
+    WidgetTester tester, {
+    ToggleCallTracker? tracker,
+    Completer<void>? writeGate,
+  }) async {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
-          entryControllerProvider(
-            taskId,
-          ).overrideWith(() => FakeEntryController(task)),
+          entryControllerProvider(taskId).overrideWith(
+            () => ScriptedEntryController(
+              task,
+              tracker: tracker,
+              gate: writeGate,
+            ),
+          ),
           labelsStreamProvider.overrideWith(
             (ref) => Stream<List<LabelDefinition>>.value(const []),
           ),
@@ -106,6 +128,19 @@ void main() {
 
     await tester.tap(find.text('open'));
     await tester.pumpAndSettle();
+  }
+
+  /// Opens the status picker from the fly-out's Status row, and asserts it is
+  /// actually up — every test below turns on which of the two stacked modals
+  /// a later tap lands in.
+  Future<void> openStatusPicker(WidgetTester tester) async {
+    await tester.tap(find.text('Status'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TaskStatusModalContent), findsOneWidget);
+  }
+
+  testWidgets('opens the metadata section in a titled modal', (tester) async {
+    await pumpOpener(tester);
 
     expect(find.text('Task details'), findsOneWidget);
     final section = tester.widget<TaskMetaSection>(
@@ -115,5 +150,84 @@ void main() {
     // The modal host keeps the two-column measure; only the persistent
     // column stacks its rows.
     expect(section.density, TaskMetaDensity.wide);
+  });
+
+  testWidgets('closes itself when a status is picked', (tester) async {
+    // The header's completion celebration plays directly behind this panel,
+    // so the panel gets out of the way rather than dimming the moment it
+    // exists to mark.
+    final tracker = ToggleCallTracker();
+    await pumpOpener(tester, tracker: tracker);
+    await openStatusPicker(tester);
+
+    await tester.tap(find.byKey(const ValueKey('task-status-DONE')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Task details'), findsNothing);
+    expect(find.byType(TaskMetaSection), findsNothing);
+    // Closing the panel is not instead of the write — it precedes it.
+    expect(tracker.updateTaskStatusCalls, equals(['DONE']));
+  });
+
+  testWidgets('stays open when the status picker closes with no choice', (
+    tester,
+  ) async {
+    final tracker = ToggleCallTracker();
+    await pumpOpener(tester, tracker: tracker);
+    await openStatusPicker(tester);
+
+    // The picker is the later of the two modal routes, so its close button is
+    // the later of the two in the tree.
+    await tester.tap(find.byTooltip('Close').last);
+    await tester.pumpAndSettle();
+
+    // The picker really closed — without this the whole test would also pass
+    // on a tap that landed nowhere.
+    expect(find.byType(TaskStatusModalContent), findsNothing);
+    expect(find.text('Task details'), findsOneWidget);
+    expect(tracker.updateTaskStatusCalls, isEmpty);
+  });
+
+  testWidgets('closes on Blocked and still prompts for the blocker', (
+    tester,
+  ) async {
+    // The composition the two halves of this change meet in: the fly-out pops
+    // itself, taking the picker's `context` and `ref` with it, and the
+    // follow-up prompt still has to arrive. The gate holds the write past the
+    // panel's exit animation, so the section really is disposed by the time
+    // the prompt is decided — un-gated, the route's subtree outlives the write
+    // and the test would pass without the durable container/overlay context.
+    final mockFts5Db = MockFts5Db();
+    when(
+      () => mockJournalDb.getTasks(
+        starredStatuses: any(named: 'starredStatuses'),
+        taskStatuses: any(named: 'taskStatuses'),
+        categoryIds: any(named: 'categoryIds'),
+        limit: any(named: 'limit'),
+      ),
+    ).thenAnswer((_) async => <JournalEntity>[]);
+    when(
+      () => mockFts5Db.watchFullTextMatches(any()),
+    ).thenAnswer((_) => Stream.value(<String>[]));
+    getIt.registerSingleton<Fts5Db>(mockFts5Db);
+
+    final tracker = ToggleCallTracker();
+    final writeGate = Completer<void>();
+    await pumpOpener(tester, tracker: tracker, writeGate: writeGate);
+    await openStatusPicker(tester);
+
+    await tester.tap(find.byKey(const ValueKey('task-status-BLOCKED')));
+    await tester.pumpAndSettle();
+
+    // The panel is gone before the write has even landed.
+    expect(find.text('Task details'), findsNothing);
+    expect(find.byType(TaskMetaSection), findsNothing);
+    expect(tracker.updateTaskStatusCalls, isEmpty);
+
+    writeGate.complete();
+    await tester.pumpAndSettle();
+
+    expect(tracker.updateTaskStatusCalls, equals(['BLOCKED']));
+    expect(find.text("What's blocking this?"), findsOneWidget);
   });
 }

--- a/test/features/tasks/ui/header/task_meta_pickers_test.dart
+++ b/test/features/tasks/ui/header/task_meta_pickers_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -33,16 +35,24 @@ import '../../../../widget_test_utils.dart';
 /// Hosts one button per picker so each [TaskMetaPickers] entry point can be
 /// exercised directly, independent of the fly-out or the header.
 class _PickerHost extends ConsumerWidget {
-  const _PickerHost({required this.task});
+  const _PickerHost({required this.task, this.onStatusPicked});
 
   final Task task;
+
+  /// Stands in for the fly-out's own dismissal.
+  final VoidCallback? onStatusPicked;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Column(
       children: [
         TextButton(
-          onPressed: () => TaskMetaPickers.showStatusPicker(context, ref, task),
+          onPressed: () => TaskMetaPickers.showStatusPicker(
+            context,
+            ref,
+            task,
+            onStatusPicked: onStatusPicked,
+          ),
           child: const Text('open-status'),
         ),
         TextButton(
@@ -70,6 +80,31 @@ class _PickerHost extends ConsumerWidget {
           child: const Text('open-labels'),
         ),
       ],
+    );
+  }
+}
+
+/// A host that tears itself down — and with it the `context` and `ref` the
+/// picker was called with — the instant a status is picked, the way the
+/// metadata fly-out does when it pops itself.
+class _SelfDismissingHost extends StatefulWidget {
+  const _SelfDismissingHost({required this.task});
+
+  final Task task;
+
+  @override
+  State<_SelfDismissingHost> createState() => _SelfDismissingHostState();
+}
+
+class _SelfDismissingHostState extends State<_SelfDismissingHost> {
+  bool _open = true;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_open) return const SizedBox.shrink();
+    return _PickerHost(
+      task: widget.task,
+      onStatusPicked: () => setState(() => _open = false),
     );
   }
 }
@@ -155,11 +190,17 @@ void main() {
     );
   }
 
-  Widget pumpHost({required Task task, ToggleCallTracker? tracker}) {
+  Widget pumpHost({
+    required Task task,
+    ToggleCallTracker? tracker,
+    VoidCallback? onStatusPicked,
+    FakeEntryController Function()? controller,
+    Widget? host,
+  }) {
     return ProviderScope(
       overrides: [
         entryControllerProvider(task.id).overrideWith(
-          () => FakeEntryController(task, tracker: tracker),
+          controller ?? () => FakeEntryController(task, tracker: tracker),
         ),
       ],
       child: MaterialApp(
@@ -172,7 +213,9 @@ void main() {
           GlobalCupertinoLocalizations.delegate,
         ],
         supportedLocales: AppLocalizations.supportedLocales,
-        home: Scaffold(body: _PickerHost(task: task)),
+        home: Scaffold(
+          body: host ?? _PickerHost(task: task, onStatusPicked: onStatusPicked),
+        ),
       ),
     );
   }
@@ -321,6 +364,79 @@ void main() {
     });
   });
 
+  group('TaskMetaPickers — the host closes on a status pick', () {
+    testWidgets('onStatusPicked runs before the status is written', (
+      tester,
+    ) async {
+      // Order is the point: the host has to be out of the way *before* the
+      // write lands, or the completion celebration the write fires plays
+      // behind it.
+      final events = <String>[];
+      final task = buildTask();
+      await tester.pumpWidget(
+        pumpHost(
+          task: task,
+          controller: () => ScriptedEntryController(task, events: events),
+          onStatusPicked: () => events.add('dismiss'),
+        ),
+      );
+      await settle(tester);
+
+      await tester.tap(find.text('open-status'));
+      await settle(tester);
+      await tester.tap(find.byKey(const ValueKey('task-status-DONE')));
+      await settle(tester);
+
+      expect(events, equals(['dismiss', 'write:DONE']));
+    });
+
+    testWidgets(
+      'onStatusPicked is not called when the picker closes with no choice',
+      (tester) async {
+        var dismissed = 0;
+        final tracker = ToggleCallTracker();
+        await tester.pumpWidget(
+          pumpHost(
+            task: buildTask(),
+            tracker: tracker,
+            onStatusPicked: () => dismissed++,
+          ),
+        );
+        await settle(tester);
+
+        await tester.tap(find.text('open-status'));
+        await settle(tester);
+        await tester.tap(find.byTooltip('Close'));
+        await settle(tester);
+
+        expect(dismissed, isZero);
+        expect(tracker.updateTaskStatusCalls, isEmpty);
+      },
+    );
+
+    testWidgets('onStatusPicked runs for a re-pick of the current status', (
+      tester,
+    ) async {
+      // Re-picking what is already set is still the reader finishing with the
+      // panel; leaving it standing would read as an unresponsive tap.
+      var dismissed = 0;
+      await tester.pumpWidget(
+        pumpHost(
+          task: buildTask(),
+          onStatusPicked: () => dismissed++,
+        ),
+      );
+      await settle(tester);
+
+      await tester.tap(find.text('open-status'));
+      await settle(tester);
+      await tester.tap(find.byKey(const ValueKey('task-status-OPEN')));
+      await settle(tester);
+
+      expect(dismissed, 1);
+    });
+  });
+
   group('TaskMetaPickers — blocked-status follow-up prompt', () {
     late MockFts5Db mockFts5Db;
 
@@ -432,6 +548,42 @@ void main() {
         await selectBlockedStatus(tester, task);
 
         expect(find.text("What's blocking this?"), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'still prompts after the host that opened the picker has torn itself '
+      'down',
+      (tester) async {
+        // The fly-out closes on the pick, taking the picker's `context` and
+        // `ref` with it, and a write slower than that teardown leaves nothing
+        // of the caller behind. The prompt has to survive it: presented on the
+        // navigator, with the blockers read through the container.
+        final task = buildTask();
+        stubBlockers(task.id, []);
+        final gate = Completer<void>();
+
+        await tester.pumpWidget(
+          pumpHost(
+            task: task,
+            host: _SelfDismissingHost(task: task),
+            controller: () => ScriptedEntryController(task, gate: gate),
+          ),
+        );
+        await settle(tester);
+
+        await tester.tap(find.text('open-status'));
+        await settle(tester);
+        await tester.tap(find.byKey(const ValueKey('task-status-BLOCKED')));
+        await settle(tester);
+        // Nothing of the caller is left by the time the write lands.
+        expect(find.byType(_PickerHost), findsNothing);
+
+        gate.complete();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.text("What's blocking this?"), findsOneWidget);
       },
     );
 

--- a/test/features/tasks/ui/header/task_meta_section_test.dart
+++ b/test/features/tasks/ui/header/task_meta_section_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -9,7 +10,9 @@ import 'package:lotti/classes/task.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/ai_consumption/state/consumption_providers.dart';
 import 'package:lotti/features/ai_consumption/ui/widgets/ai_cost_indicator.dart';
+import 'package:lotti/features/design_system/components/ds_quiet_ink.dart';
 import 'package:lotti/features/design_system/components/time_pickers/design_system_picker_wheels.dart';
+import 'package:lotti/features/design_system/theme/icon_tokens.dart';
 import 'package:lotti/features/labels/state/labels_list_controller.dart';
 import 'package:lotti/features/projects/repository/project_repository.dart';
 import 'package:lotti/features/projects/state/project_providers.dart';
@@ -153,10 +156,15 @@ void main() {
     TaskProgressState? progress,
     int aiCallCount = 0,
     List<Override> extraOverrides = const [],
+    VoidCallback? onStatusPicked,
   }) {
     return makeTestableWidget(
       Material(
-        child: TaskMetaSection(taskId: task.id, density: density),
+        child: TaskMetaSection(
+          taskId: task.id,
+          density: density,
+          onStatusPicked: onStatusPicked,
+        ),
       ),
       overrides: [
         entryControllerProvider(task.id).overrideWith(
@@ -215,6 +223,39 @@ void main() {
       expect(find.text('Apr 25, 2026'), findsOneWidget);
       expect(find.text('0m of 2h'), findsOneWidget);
       expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('a hovered row brightens its chevron', (tester) async {
+      // The row deliberately has no hover fill, so the chevron brightening is
+      // the whole of its tappable affordance.
+      await tester.pumpWidget(pumpSection(task: buildTask()));
+      await settle(tester);
+
+      Color? chevronColor() => tester
+          .widget<Icon>(
+            find.descendant(
+              of: find.ancestor(
+                of: find.text('Status'),
+                matching: find.byType(DsQuietInk),
+              ),
+              matching: find.byIcon(LottiIcons.chevronRight),
+            ),
+          )
+          .color;
+
+      final context = tester.element(find.text('Status'));
+      expect(chevronColor(), TaskShowcasePalette.lowText(context));
+
+      // Hover needs pointer kind `mouse`; a tap won't fire `onEnter`.
+      final gesture = await tester.createGesture(
+        kind: PointerDeviceKind.mouse,
+      );
+      addTearDown(gesture.removePointer);
+      await gesture.addPointer();
+      await gesture.moveTo(tester.getCenter(find.text('Status')));
+      await settle(tester);
+
+      expect(chevronColor(), TaskShowcasePalette.highText(context));
     });
 
     testWidgets('unset fields read "Not set" at low emphasis', (tester) async {
@@ -635,6 +676,65 @@ void main() {
       await settle(tester);
 
       expect(find.byType(EntityPickerSheet), findsOneWidget);
+    });
+  });
+
+  group('TaskMetaSection — reporting a status pick to its host', () {
+    testWidgets('the status row calls onStatusPicked', (tester) async {
+      var dismissed = 0;
+      await tester.pumpWidget(
+        pumpSection(
+          task: buildTask(),
+          onStatusPicked: () => dismissed++,
+        ),
+      );
+      await settle(tester);
+
+      await tester.tap(find.text('Status'));
+      await settle(tester);
+      await tester.tap(find.text('In Progress'));
+      await settle(tester);
+
+      expect(dismissed, 1);
+    });
+
+    testWidgets('another attribute leaves the host standing', (tester) async {
+      // Only the status write celebrates on the header behind the host, so
+      // only the status row reports back — editing a second attribute in the
+      // same panel visit stays possible.
+      var dismissed = 0;
+      await tester.pumpWidget(
+        pumpSection(
+          task: buildTask(),
+          onStatusPicked: () => dismissed++,
+        ),
+      );
+      await settle(tester);
+
+      await tester.tap(find.text('Priority'));
+      await settle(tester);
+      await tester.tap(find.byKey(const ValueKey('task-priority-P0')));
+      await settle(tester);
+
+      expect(dismissed, isZero);
+    });
+
+    testWidgets('a host that passes no callback still persists the pick', (
+      tester,
+    ) async {
+      // The persistent details column has nothing to dismiss.
+      final tracker = ToggleCallTracker();
+      await tester.pumpWidget(
+        pumpSection(task: buildTask(), tracker: tracker),
+      );
+      await settle(tester);
+
+      await tester.tap(find.text('Status'));
+      await settle(tester);
+      await tester.tap(find.byKey(const ValueKey('task-status-DONE')));
+      await settle(tester);
+
+      expect(tracker.updateTaskStatusCalls, equals(['DONE']));
     });
   });
 

--- a/test/helpers/fake_entry_controller.dart
+++ b/test/helpers/fake_entry_controller.dart
@@ -4,6 +4,8 @@
 // file are exported and consumed by sibling `_test.dart` files, so the
 // analyzer's `unreachable_from_main` check doesn't apply here.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
@@ -215,6 +217,50 @@ class StatefulTogglesFakeEntryController extends FakeEntryController {
   Future<void> togglePrivate() async {
     await super.togglePrivate();
     _apply((meta) => meta.copyWith(private: !(meta.private ?? false)));
+  }
+}
+
+/// Fake EntryController that scripts the *status* write's timing and ordering.
+///
+/// Two knobs, for the two things a status-picker test needs to be able to say
+/// about the write that the plain [FakeEntryController] cannot:
+///
+/// * [gate] — the write does not land until the test completes it, standing in
+///   for a database write slower than the host surface's exit animation. That
+///   is the window in which a picker holding its caller's `BuildContext` or
+///   `WidgetRef` finds both already disposed.
+/// * [events] — the write appends `write:<status>` here. Given the same list a
+///   surface writes its own dismissal into, a test can assert the *order* of
+///   the two rather than merely that both happened.
+class ScriptedEntryController extends FakeEntryController {
+  // ignore: use_super_parameters, parent uses private `_entity` field
+  ScriptedEntryController(
+    JournalEntity entity, {
+    ToggleCallTracker? tracker,
+    this.events,
+    this.gate,
+  }) : super(entity, tracker: tracker);
+
+  /// Ordered log the write appends to; shared with whatever else is being
+  /// sequenced against it.
+  final List<String>? events;
+
+  /// Held until the test completes it. Null writes land immediately.
+  final Completer<void>? gate;
+
+  @override
+  Future<void> updateTaskStatus(
+    String? status, {
+    String? blockerTaskId,
+    String? blockerTaskTitle,
+  }) async {
+    await gate?.future;
+    events?.add('write:$status');
+    await super.updateTaskStatus(
+      status,
+      blockerTaskId: blockerTaskId,
+      blockerTaskTitle: blockerTaskTitle,
+    );
   }
 }
 


### PR DESCRIPTION
Marking a task **Done** from the **Details** fly-out left the panel standing over the task while the completion celebration played behind it — the glow bloom and the spark burst on the header's status pill, dimmed by the panel's own scrim. The one moment worth watching was the one thing covered up.

## The cause

The status picker is opened *from* the fly-out (`TaskMetaSection`'s Status row), so it is the fly-out that has to move, and nothing ever told it to. On desktop the fly-out is a centred dialog with a scrim over the whole page; on a phone it is a bottom sheet. Either way, `Navigator.pop` closed the *picker* and left the panel that opened it exactly where it was, over the header pill the celebration anchors to.

That celebration is not incidental: `TaskStatusSummaryTag` wraps the header's status read-out in `CompletionCelebration`, and `spawnCompletionBurst` renders the sparks into the app overlay — so the burst flies *over* the dialog while the glow, the pill pop and the pill itself sit dimmed *under* it. Half the animation on each side of a scrim.

## The fix

- **`TaskMetaSection` reports a status pick to its host.** New `onStatusPicked`: `TaskMetaFlyout` passes its own `Navigator.pop`, the persistent `TaskMetaColumn` has nothing to dismiss and passes nothing.
- **It fires before the write, not after.** `TaskMetaPickers.showStatusPicker` calls it the instant the picker returns a status and *before* `updateTaskStatus`, so the panel's exit animation runs *during* the database write rather than on top of the burst the write triggers. Firing it afterwards just moves the overlap.
- **Only the status row reports back.** It is the one attribute whose write celebrates on the header behind the panel; editing a second attribute in one panel visit still works as before.
- **A re-pick of the current status closes the panel too.** The reader has finished with it either way, and a selection that visibly does nothing reads as a dead tap.
- **The Blocked follow-up survives its own caller.** Dismissing the host takes the picker's `context` and `ref` with it, and a write slower than the panel's exit animation would then have silently swallowed the "What's blocking this?" prompt. The blockers are now read through the `ProviderContainer`, and the prompt is presented on the hosting navigator's **overlay** context — a descendant of the navigator, so `Navigator.of` resolves back to it, and it outlives every route pushed onto it. (Test `still prompts after the host that opened the picker has torn itself down` fails against the old `context`/`ref` form.)

## Tests

Modular, one file per source file, each rule its own case. Two of them are gated: the write is held open past the panel's exit animation, because that window — a database write slower than the teardown — is the only place the durable-context half of the fix is observable.

**`task_meta_pickers_test.dart`** (15 in file, +4)
- `onStatusPicked` runs **before** the write — asserted as an ordered event log, not two independent facts.
- It is *not* called when the picker closes with no choice.
- It *is* called for a re-pick of the current status.
- The blocker prompt still opens after the host has torn itself down (gated write, host unmounted before it lands).

**`task_meta_flyout_test.dart`** (4 in file, +3)
- Picking a status closes the fly-out *and* still persists the write.
- Dismissing the picker with no choice leaves the fly-out open — bracketed by assertions that the picker was up and is then gone, so the test cannot pass on a tap that landed nowhere.
- **Blocked closes the fly-out and still prompts for the blocker** (gated write). This is the composition the two halves of the change meet in, and neither half's own test covered the other. Worth noting how it got here: the first, un-gated version of this test passed against the reverted code — a real modal route's subtree outlives its exit animation, so with an instant fake write the section was still mounted when the prompt was decided. It proved the composition and not the durability. Gating it fixed that.

**`task_meta_section_test.dart`** (26 in file, +4)
- The status row calls `onStatusPicked`; another attribute (priority) leaves the host standing; a host that passes no callback still persists the pick.
- Plus the row's hover chevron, which closed the file's last uncovered line.

**`test/helpers/fake_entry_controller.dart`** — the gate and the ordered log live in one shared `ScriptedEntryController` alongside the file's other purpose-built `EntryController` doubles, rather than two near-identical locals. It is what lets the fly-out test reuse the gate instead of copying it.

## Also

- `knowledge/features/tasks/detail-composition.md` — why a status pick closes a dismissible host, and why the follow-up prompt is set up before the pick; `relationships.md` — the prompt is presented on the navigator, not over the panel. `lib/features/tasks/README.md` and a changelog fragment.

## Screenshots

Hosted in `matthiasn/lotti-docs` on branch `agent/task-status-closes-details-flyout-screenshots` (commit `84bb061c97e4526a7be93e664a0a6f4859ac451e`), the way earlier PRs from this account did; the identical pair is staged at `/tmp/lotti-pr-screenshots/task-status-closes-details-flyout/` for `make pr_screenshots_publish` if the R2 copy is wanted.

Before is the base commit (`c49c1ea91`); after is this branch. Captured with the in-app screenshot harness driving the real path — tap the status pill, tap **Status**, tap **Done** — and held **350 ms into the 1400 ms celebration timeline**, which is where the burst reads widest. Fixture is a synthetic penguin-world task ("Pack the sled for the ice shelf crossing").

### Marking a task Done from Details — desktop dark

Before, the sparks fly over the panel while the glow and the pill sit dimmed under it. After, the panel is gone and the whole celebration plays on the task.

| Before | After |
|---|---|
| ![Done from Details, desktop, before](https://raw.githubusercontent.com/matthiasn/lotti-docs/84bb061c97e4526a7be93e664a0a6f4859ac451e/pr-screenshots/task-status-closes-details-flyout/before/task_status_done_desktop_dark.png) | ![Done from Details, desktop, after](https://raw.githubusercontent.com/matthiasn/lotti-docs/84bb061c97e4526a7be93e664a0a6f4859ac451e/pr-screenshots/task-status-closes-details-flyout/after/task_status_done_desktop_dark.png) |

### Marking a task Done from Details — mobile dark

| Before | After |
|---|---|
| ![Done from Details, mobile, before](https://raw.githubusercontent.com/matthiasn/lotti-docs/84bb061c97e4526a7be93e664a0a6f4859ac451e/pr-screenshots/task-status-closes-details-flyout/before/task_status_done_mobile_dark.png) | ![Done from Details, mobile, after](https://raw.githubusercontent.com/matthiasn/lotti-docs/84bb061c97e4526a7be93e664a0a6f4859ac451e/pr-screenshots/task-status-closes-details-flyout/after/task_status_done_mobile_dark.png) |

## Verification

- `fvm dart analyze` on every touched Dart file: no issues; `fvm dart format`: clean
- Touched tests: `task_meta_pickers_test` 15, `task_meta_section_test` 26, `task_meta_flyout_test` 4, plus the neighbours that render these surfaces — `task_meta_column_test` and `desktop_task_header_connector_test` — **88 in one run, all passing**
- Line coverage of the touched sources from that run: `task_meta_pickers.dart` 64/64, `task_meta_section.dart` 217/217, `task_meta_flyout.dart` 6/6 — **100%** on all three
- Regression tests re-run with each fix reverted, and two of the four now bite in two places:

  | reverted | fails |
  |---|---|
  | dismissal moved after the write | the ordering test **and** the torn-down-host test |
  | the section stops forwarding | the section test |
  | the fly-out stops closing itself | **both** fly-out tests |
  | the durable container / overlay context removed | the torn-down-host test **and** the fly-out's Blocked test |

  Restored, all pass.
- `make changelog_check`, `make knowledge_check` (validator + 514 Mermaid blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3U34aJHXTXqniXw3PUUC7
