### PR TITLE
feat(tasks): quick-pick chips for the task estimate

### DIFF
--- a/changelog.d/2026-09-03-estimate-quick-pick-chips.md
+++ b/changelog.d/2026-09-03-estimate-quick-pick-chips.md
@@ -1,0 +1,16 @@
+### Added
+- **Setting a task estimate no longer means spinning a wheel for a value you
+  use every week.** The estimate picker now opens on a row of one-tap chips —
+  the durations you actually estimate in, ranked from your own tasks over the
+  last three months, with a 30m / 1h / 2h / 4h starter set until you have a
+  history of your own. Tapping one sets the estimate and closes the picker,
+  and the chip holding the task's current estimate is marked so you can see
+  what you are about to replace. The wheel is still there underneath for
+  anything the chips do not cover.
+
+### Fixed
+- **A selected outline chip was almost impossible to spot.** The chip marking
+  the value you had just recorded on a habit changed only its text weight, so
+  the one thing it was there to tell you was carried by a barely visible
+  difference. Selected chips now also take the accent fill and border the rest
+  of the app uses for a selected pill.

--- a/knowledge/features/tasks/detail-composition.md
+++ b/knowledge/features/tasks/detail-composition.md
@@ -48,6 +48,14 @@ sources:
     resource: ../../../lib/features/tasks/ui/widgets/viewport_stable_animated_size.dart
     title: TaskScrollStabilityScope and ViewportStableScrollController
     last_modified: 2026-08-28
+  - id: estimate-quick-pick
+    resource: ../../../lib/features/tasks/ui/header/estimate_quick_pick_chips.dart
+    title: Estimate quick-pick chips
+    last_modified: 2026-09-03
+  - id: estimate-suggestions
+    resource: ../../../lib/features/tasks/state/task_estimate_suggestions_controller.dart
+    title: taskEstimateSuggestionsControllerProvider
+    last_modified: 2026-09-03
 ---
 
 # Band order
@@ -330,6 +338,69 @@ so a persisted edit updates the open host immediately. The Estimate row keeps
 the `{tracked} of {estimate}` read (`1h 30m of 2h`, never a clock-like
 `01:30 / 02:00`) plus the small progress bar, escalating to error ink when
 tracked exceeds the estimate.
+
+### The estimate picker answers in one tap
+
+Opening Estimate lands on a row of **quick-pick chips** above the duration
+wheel, not on the wheel alone. The chips are the same affordance the habit
+completion sheet gives a measurable — `DsPillVariant.outline` at the canonical
+28pt shell, `spacing.step2` apart in a `Wrap`, `spacing.sectionGap` down to the
+wheel — because the problem is the same one: a user reaches for the same
+handful of values over and over, and a wheel charges a scroll for each of them.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Open: tap the Estimate read-out
+    Open --> Committed: tap a chip (writes, pops)
+    Open --> Open: tap the chip already holding the estimate (pops, no write)
+    Open --> Spun: scroll the wheel
+    Spun --> Committed: Done
+    Open --> Cleared: Clear
+    Open --> [*]: dismiss
+    Committed --> [*]
+    Cleared --> [*]
+```
+
+A chip **commits and closes** — pop first, then await the write, the order
+`Clear` already used — so the common case costs one tap rather than a scroll
+plus a confirm. Re-tapping the chip that already carries the task's estimate
+closes without writing, so a confirming tap does not push an update or a sync
+message. The wheel stays for everything else and is deliberately **unframed**:
+it is the fallback now, and the bordered card it used to wear made the escape
+hatch the largest object in the modal.
+
+The four values come from `taskEstimateSuggestionsControllerProvider`, which
+ranks the estimates actually set on tasks over the last 90 days
+(`JournalDb.getRankedTaskEstimates`) — popularity picks the set, duration sorts
+it shortest-first, and a history too thin to fill the row is topped up from a
+30m / 1h / 2h / 4h starter ladder so a fresh install still opens on chips. The
+query honours the `private` flag like every other task read, and only ranks
+whole-minute durations, which is what lets the row key on `inMinutes` without
+two values colliding. Because the row is kept alive for `dashboardCacheDuration`,
+the controller also *subscribes* to that flag and invalidates itself when it
+changes: a cached row would otherwise outlive the visibility decision that
+produced it.
+Labels use `formatRangeDuration`, the same compact form the header's estimate
+read-out speaks, so tapping `2h` produces a header that says `2h`.
+
+The chip matching **the value on show** reads `selected` — the task's own
+estimate as the modal opens, then whatever the wheel is spun to, so the row and
+the wheel can never state two different answers to "what is the estimate". This
+chip *overwrites* rather than appends, so the selection doubles as the read-out
+of what is about to be replaced. Making that visible needed a design-system fix:
+`DsPillVariant.outline` had ignored `selected` in everything but label weight,
+and now takes the `surface.selected` fill and the full-alpha interactive border
+the other variants do — which the habit sheet's quick-record chips inherit.
+Selection carries no leading glyph, deliberately: fill, border and weight say it
+in three channels without changing a chip's width, so spinning the wheel moves
+the selection between chips without reflowing the `Wrap`.
+
+A caption above the row — **"Tap to save and close"** — states the commit
+contract in terms of the outcome rather than the gesture, because a `Done`
+button sits at the bottom of the same sheet and otherwise teaches that nothing
+is saved until it is pressed. Until the ranking lands, the row renders
+the starter ladder in `DsPillVariant.muted`, the design system's placeholder
+variant: the real row's shape and height at any text scale, and not tappable.
 
 The section has two hosts, and `TaskMetaDensity` is the only difference
 between them:

--- a/lib/database/database_task_queries.dart
+++ b/lib/database/database_task_queries.dart
@@ -27,6 +27,91 @@ mixin _JournalDbTaskQueries
     }
   }
 
+  /// The estimates most often set on tasks dated on or after [since], most
+  /// used first, capped at [limit].
+  ///
+  /// [limit] is required: how many values a caller can show is the caller's
+  /// business, and a default here would be a second place to change the
+  /// estimate picker's row size.
+  ///
+  /// Powers the estimate picker's quick-pick chips the way
+  /// `rankedByPopularity` powers the measurement quick-add: the values offered
+  /// are the ones this user actually reaches for, not a guessed ladder.
+  ///
+  /// Honours the `private` config flag like every other task read here, so a
+  /// hidden task cannot put a value on the chip row that the task list would
+  /// not explain.
+  ///
+  /// Only **whole minutes above zero** are ranked. Zero is not a value anyone
+  /// would pick from a chip ("no estimate" is already the `Clear` action), and
+  /// a sub-minute or fractional-minute duration has no distinct rendering in
+  /// the compact `1h 30m` form the callers label with — two of them would read
+  /// identically. Enforcing it here keeps that a property of the data rather
+  /// than an assumption in the widget.
+  ///
+  /// Ties break on the shorter duration so the ordering is stable across runs
+  /// rather than left to the planner.
+  Future<List<Duration>> getRankedTaskEstimates({
+    required DateTime since,
+    required int limit,
+  }) async {
+    if (limit <= 0) {
+      return const <Duration>[];
+    }
+
+    final visiblePrivate = await _visiblePrivateStatuses();
+    // Omitted entirely when every private state is visible, the way
+    // `_JournalDbTaskQueriesBuilders` does it — an always-true `IN` clause
+    // only gets in the planner's way.
+    final privateFilter = _matchesAllPrivateStates(visiblePrivate)
+        ? const <bool>[]
+        : visiblePrivate;
+    final privateClause = privateFilter.isEmpty
+        ? ''
+        : 'AND private IN '
+              '(${List.filled(privateFilter.length, '?').join(', ')})';
+    const microsPerMinute = Duration.microsecondsPerMinute;
+
+    // EXPLAIN QUERY PLAN on the shipped schema reports
+    // `SEARCH journal USING INDEX idx_journal_browse
+    //  (deleted=? AND type=? AND date_from>?)` — the (deleted, type,
+    // date_from) index seeks straight to tasks inside the window, so the
+    // `json_extract` runs over those rows rather than over 90 days of every
+    // entry type. Group and order then use temp b-trees over that small set.
+    // The result is cached by the calling controller, so this runs about once
+    // per picker open.
+    final rows = await customSelect(
+      '''
+      SELECT estimate_us, COUNT(*) AS uses
+      FROM (
+        SELECT json_extract(serialized, '\$.data.estimate') AS estimate_us
+        FROM journal
+        WHERE deleted = FALSE
+        AND type = 'Task'
+        AND task = 1
+        AND date_from >= ?
+        $privateClause
+      )
+      WHERE estimate_us >= $microsPerMinute
+      AND estimate_us % $microsPerMinute = 0
+      GROUP BY estimate_us
+      ORDER BY uses DESC, estimate_us ASC
+      LIMIT ?
+      ''',
+      variables: [
+        Variable<DateTime>(since),
+        for (final private in privateFilter) Variable<bool>(private),
+        Variable<int>(limit),
+      ],
+      readsFrom: {journal},
+    ).get();
+
+    return [
+      for (final row in rows)
+        Duration(microseconds: row.read<int>('estimate_us')),
+    ];
+  }
+
   Future<Map<String, Duration?>> getTaskEstimatesByIds(Set<String> ids) async {
     if (ids.isEmpty) {
       return const <String, Duration?>{};

--- a/lib/features/design_system/components/chips/ds_pill.dart
+++ b/lib/features/design_system/components/chips/ds_pill.dart
@@ -103,15 +103,28 @@ class DsPill extends StatelessWidget {
 
   /// Orthogonal selection state. Composes with [variant] (it is **not** a new
   /// variant): when true, the pill draws a 1px teal `interactive.enabled`
-  /// border, a teal-tinted fill (`surface.selected` on the `filled` variant;
-  /// the variant's own tint is kept on `tinted`), and a bold label — the
-  /// multi-channel "active saved filter" treatment used by the mobile saved
-  /// filter rail.
+  /// border, a teal-tinted fill (`surface.selected` on the `filled` and
+  /// `outline` variants; the variant's own tint is kept on `tinted`), and a
+  /// bold label — the multi-channel "active saved filter" treatment used by
+  /// the mobile saved filter rail.
   ///
-  /// Only `filled` and `tinted` react to selection; `outline` / `muted` ignore
-  /// it. **Regression guarantee:** `selected: false` leaves every existing
+  /// `outline` reacts too: it trades its 50%-alpha `color` border for the
+  /// full-alpha interactive one and gains the tinted fill. It used to react
+  /// with the bold label alone, which was a single 12pt weight bump and not
+  /// enough to say "this is the current value" — the estimate picker's
+  /// quick-pick chips need selection to survive a glance, and the habit
+  /// sheet's quick-record chips gain the same clarity.
+  ///
+  /// `muted` still ignores it: a dashed placeholder that is also "selected"
+  /// is not a state the design system has.
+  ///
+  /// **Regression guarantee:** `selected: false` leaves every existing
   /// consumer byte-identical (no border, no fill change, no weight change), so
   /// the orthogonal flag is safe to add without touching current callers.
+  ///
+  /// Note that the bold label does widen the pill slightly — w700 carries a
+  /// larger glyph advance — so a row that toggles selection between shells
+  /// nudges, it does not hold its metrics exactly.
   final bool selected;
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
@@ -227,8 +240,11 @@ class DsPill extends StatelessWidget {
       ),
       DsPillVariant.outline => DecoratedBox(
         decoration: BoxDecoration(
+          color: selected ? tokens.colors.surface.selected : null,
           borderRadius: radius,
-          border: Border.all(color: color!.withValues(alpha: 0.5)),
+          border: selected
+              ? selectedBorder
+              : Border.all(color: color!.withValues(alpha: 0.5)),
         ),
         child: content,
       ),

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -9,6 +9,10 @@ project, and relationships to other tasks.
 
 - **Tracks a piece of work end to end.** Title, status, priority, due date and
   time estimate, with tracked time compared against the estimate as work happens.
+- **Estimates in one tap.** The estimate picker opens on chips for the durations
+  you actually use — ranked from your own tasks, the way the habit sheet offers
+  the amounts you actually log — so the usual half hour or two hours is a tap
+  rather than a scroll. The wheel underneath still takes anything else.
 - **Starts a new task with somewhere to go.** A task you have just created opens
   with the cursor in its title field, and offers the four things a task usually
   needs next — write a note, add a checklist, record a voice note, assign an

--- a/lib/features/tasks/state/task_estimate_suggestions_controller.dart
+++ b/lib/features/tasks/state/task_estimate_suggestions_controller.dart
@@ -1,0 +1,115 @@
+// ignore_for_file: specify_nonobvious_property_types
+
+import 'dart:async';
+
+import 'package:clock/clock.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/utils/cache_extension.dart';
+import 'package:lotti/utils/consts.dart';
+import 'package:lotti/utils/date_utils_extension.dart';
+
+/// How far back the ranking looks. Long enough that an occasional estimator
+/// still has a history to rank, short enough that a changed way of working
+/// pushes the old values out.
+///
+/// The window is measured against a task's own `date_from`, not against when
+/// its estimate was set — so an estimate added today to a task dated last year
+/// is outside it, and a task planned for next quarter is inside it. `date_from`
+/// is the indexed column (`idx_journal_browse` covers deleted / type /
+/// date_from); `updated_at` would express the intent more directly but has no
+/// index, and this is a ranking rather than a ledger, so the approximation is
+/// the deliberate trade.
+const kEstimateSuggestionWindow = Duration(days: 90);
+
+/// How many chips the estimate picker offers.
+///
+/// Four, not the measurement row's three: the estimate modal has a full-width
+/// row to itself rather than sharing a compact signal card, and four covers
+/// the usual "half an hour / an hour / an afternoon / a day's work" spread
+/// without wrapping to a second line on a phone.
+const kEstimateSuggestionCount = 4;
+
+/// The ladder offered before a user has an estimating history of their own —
+/// and used to top up a history too thin to fill the row.
+///
+/// A fresh install must not open a picker with no chips at all; these are the
+/// values that make the feature explain itself on first use.
+const kDefaultEstimateSuggestions = <Duration>[
+  Duration(minutes: 30),
+  Duration(hours: 1),
+  Duration(hours: 2),
+  Duration(hours: 4),
+];
+
+/// The estimate picker's quick-pick values. See
+/// [TaskEstimateSuggestionsController].
+final taskEstimateSuggestionsControllerProvider =
+    AsyncNotifierProvider.autoDispose<
+      TaskEstimateSuggestionsController,
+      List<Duration>
+    >(TaskEstimateSuggestionsController.new);
+
+/// Ranks the estimates this user actually sets and offers the top
+/// [kEstimateSuggestionCount] as quick-pick chips.
+///
+/// The same idea as the measurement quick-add chips: the values on offer are
+/// the ones already in the user's own history, so the row gets more useful the
+/// more it is used. Two departures from that precedent, both deliberate:
+///
+/// * **A thin history is topped up** from [kDefaultEstimateSuggestions]. A
+///   measurable with no history has nothing meaningful to guess; durations do
+///   — everyone's first estimate is one of an hour or two.
+/// * **Chips are displayed in ascending order**, not popularity order. The
+///   selection is by popularity, but a duration row that reshuffles itself as
+///   usage shifts is harder to aim at than a stable ladder.
+///
+/// The ranking is kept alive for `dashboardCacheDuration` so reopening the
+/// picker is instant, which makes private visibility a live dependency rather
+/// than a read-once one — see [build].
+class TaskEstimateSuggestionsController extends AsyncNotifier<List<Duration>> {
+  // Resolved on use, not in a field initializer: a test that overrides this
+  // provider with a fixed row must be able to construct the notifier without
+  // standing up a database.
+  JournalDb get _journalDb => getIt<JournalDb>();
+
+  @override
+  Future<List<Duration>> build() async {
+    ref.cacheFor(dashboardCacheDuration);
+
+    // The keep-alive above makes private visibility a *live* dependency:
+    // `getRankedTaskEstimates` resolves the flag itself, but a row already
+    // cached would survive the flag being turned off and keep offering a
+    // duration ranked from tasks that are now hidden. `watchConfigFlag`
+    // replays the current value on subscribe, so the seed is skipped and only
+    // an actual change re-derives the row.
+    final flagSubscription = _journalDb
+        .watchConfigFlag(privateFlag)
+        .skip(1)
+        .listen((_) => ref.invalidateSelf());
+    ref.onDispose(flagSubscription.cancel);
+
+    final ranked = await _journalDb.getRankedTaskEstimates(
+      since: clock.now().dayAtMidnight.subtract(kEstimateSuggestionWindow),
+      limit: kEstimateSuggestionCount,
+    );
+
+    return toppedUpAndSorted(ranked);
+  }
+
+  /// Fills [ranked] up to [kEstimateSuggestionCount] from
+  /// [kDefaultEstimateSuggestions] without repeating a value already ranked,
+  /// then sorts the result shortest-first.
+  ///
+  /// Exposed for tests: it is the whole of the controller's logic that does
+  /// not need a database.
+  static List<Duration> toppedUpAndSorted(List<Duration> ranked) {
+    final chosen = <Duration>{...ranked.take(kEstimateSuggestionCount)};
+    for (final fallback in kDefaultEstimateSuggestions) {
+      if (chosen.length >= kEstimateSuggestionCount) break;
+      chosen.add(fallback);
+    }
+    return chosen.toList()..sort();
+  }
+}

--- a/lib/features/tasks/ui/header/estimate_quick_pick_chips.dart
+++ b/lib/features/tasks/ui/header/estimate_quick_pick_chips.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/journal/util/entry_tools.dart';
+import 'package:lotti/features/tasks/state/task_estimate_suggestions_controller.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+
+/// The estimate picker's one-tap row: the durations this user reaches for
+/// most, as chips above the duration wheel.
+///
+/// The same affordance the habit completion sheet gives a measurable — an
+/// outline [DsPill] per value, in a [Wrap] so a long locale or large
+/// accessibility text runs to a second line rather than clipping. Two
+/// differences, both because an estimate is a single value rather than a
+/// stream of recordings:
+///
+/// * **No "+ Other" chip.** The measurement row needs one because its full
+///   capture lives in another modal; here the wheel is directly beneath, and
+///   a second route to it would be noise.
+/// * **The chip matching the value on show reads selected**, so the row
+///   doubles as the read-out of what is about to be replaced. A measurement
+///   chip appends; this one overwrites, and the user should see what they are
+///   overwriting.
+///
+/// A tap commits — [onPick] writes the estimate and closes the modal — which
+/// is the whole point: the common case costs one tap, not a scroll plus a
+/// confirm. Labels use [formatRangeDuration], the same compact form the task
+/// header reads the estimate back in, so tapping `2h` produces a header that
+/// says `2h`.
+///
+/// The gap between chips is `spacing.step3`, one step wider than the habit
+/// row's: duration labels are short enough that at `step2` four of them read
+/// as one segmented control rather than four choices.
+class EstimateQuickPickChips extends ConsumerWidget {
+  const EstimateQuickPickChips({
+    required this.currentEstimate,
+    required this.onPick,
+    super.key,
+  });
+
+  /// The estimate currently on show — the task's own as the modal opens, then
+  /// whatever the wheel is spun to. The chip carrying it reads selected, so
+  /// the row and the wheel never state two different answers to "what is the
+  /// estimate". `Duration.zero` (no estimate) matches no chip, since zero is
+  /// never suggested.
+  final Duration currentEstimate;
+
+  final ValueChanged<Duration> onPick;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tokens = context.designTokens;
+    final suggestions = ref
+        .watch(taskEstimateSuggestionsControllerProvider)
+        .value;
+    final accent = tokens.colors.interactive.enabled;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // What a tap does, said out loud, naming the outcome rather than
+        // the gesture. A chip saves and closes while a Done button sits at
+        // the bottom of the same sheet — without this line the row reads as
+        // a staging control, and the users most wary of an irreversible tap
+        // were the ones who would not risk it.
+        Text(
+          context.messages.taskEstimateQuickPickHint,
+          // Centred over a centred row: at large accessibility text, or in a
+          // locale whose wording is longer, this line wraps and its second
+          // line would otherwise sit left of the chips it describes.
+          textAlign: TextAlign.center,
+          style: tokens.typography.styles.others.caption.copyWith(
+            color: tokens.colors.text.mediumEmphasis,
+          ),
+        ),
+        SizedBox(height: tokens.spacing.step3),
+        _chipRow(tokens, accent, suggestions),
+      ],
+    );
+  }
+
+  /// The chips themselves: the ranking once it lands, the design system's
+  /// placeholder variant until then.
+  Widget _chipRow(
+    DsTokens tokens,
+    Color accent,
+    List<Duration>? suggestions,
+  ) {
+    return Wrap(
+      alignment: WrapAlignment.center,
+      // step4, not step3: at step3 the gap between chips equalled DsPill's
+      // own interior padding, and four short duration labels read as one
+      // segmented control rather than four choices.
+      spacing: tokens.spacing.step4,
+      runSpacing: tokens.spacing.step4,
+      children: suggestions == null
+          // The row's shape while the ranking loads. A blank strip would
+          // open the modal's lead control as a hole, and would be the wrong
+          // height once accessibility text wraps the real row to two lines.
+          //
+          // Quiet outline rather than `DsPillVariant.muted`: the dashed
+          // muted shell is this app's "unset — tap me to fill" vocabulary
+          // (the task header's own category and due-date offers wear it),
+          // and these placeholders are inert.
+          ? [
+              for (final duration in kDefaultEstimateSuggestions)
+                DsPill(
+                  key: ValueKey(
+                    'estimate-quick-pick-placeholder-'
+                    '${duration.inMinutes}',
+                  ),
+                  variant: DsPillVariant.outline,
+                  color: tokens.colors.decorative.level03,
+                  labelColor: tokens.colors.text.lowEmphasis,
+                  label: formatRangeDuration(duration),
+                ),
+            ]
+          : [
+              for (final duration in suggestions)
+                // Keyed on whole minutes, which `getRankedTaskEstimates`
+                // guarantees: it ranks only whole-minute durations, so two
+                // suggestions can never collapse to the same key (or to the
+                // same label) here.
+                _EstimateChip(
+                  key: ValueKey('estimate-quick-pick-${duration.inMinutes}'),
+                  duration: duration,
+                  accent: accent,
+                  selected: duration == currentEstimate,
+                  onPick: onPick,
+                ),
+            ],
+    );
+  }
+}
+
+class _EstimateChip extends StatelessWidget {
+  const _EstimateChip({
+    required this.duration,
+    required this.accent,
+    required this.selected,
+    required this.onPick,
+    super.key,
+  });
+
+  final Duration duration;
+  final Color accent;
+  final bool selected;
+  final ValueChanged<Duration> onPick;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = formatRangeDuration(duration);
+    void pick() => onPick(duration);
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: context.messages.taskEstimateQuickPickSemanticsLabel(label),
+      // The node carries the tap itself: `excludeSemantics` drops the
+      // InkWell's own action, and without this the row's whole point — one
+      // tap to the estimate — would not be activatable from a screen reader.
+      onTap: pick,
+      excludeSemantics: true,
+      child: DsPill(
+        variant: DsPillVariant.outline,
+        color: accent,
+        // Fill, full-alpha border and a bold label — three channels, two of
+        // them luminance rather than hue. No leading glyph: a tick would say
+        // the same thing a fourth time, and an icon appearing and vanishing
+        // shifts a chip by its whole width plus a gap every time the wheel
+        // moves the selection. (The bold weight does widen the label a
+        // little; that is a glyph-advance nudge, not a re-layout.)
+        selected: selected,
+        label: label,
+        onTap: pick,
+      ),
+    );
+  }
+}

--- a/lib/features/tasks/ui/header/estimated_time_widget.dart
+++ b/lib/features/tasks/ui/header/estimated_time_widget.dart
@@ -3,6 +3,7 @@ import 'package:lotti/features/design_system/components/buttons/design_system_bu
 import 'package:lotti/features/design_system/components/buttons/design_system_modal_action_bar.dart';
 import 'package:lotti/features/design_system/components/time_pickers/design_system_picker_wheels.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/tasks/ui/header/estimate_quick_pick_chips.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
 
@@ -21,6 +22,14 @@ Future<void> showEstimatePicker({
         initialDuration: initialDuration,
         onDurationChanged: (duration) {
           selectedDuration = duration;
+        },
+        onQuickPick: (duration) async {
+          // Pop first, then write — the same order `Clear` uses below, so the
+          // modal never sits open over an awaited save.
+          Navigator.of(modalContext).pop();
+          if (duration != initialDuration) {
+            await onEstimateChanged(duration);
+          }
         },
       );
     },
@@ -48,15 +57,24 @@ Future<void> showEstimatePicker({
   );
 }
 
-/// The time picker widget for selecting estimated duration
+/// The estimate picker's body: a row of one-tap quick-pick chips over the
+/// duration wheel.
+///
+/// The chips answer the common case — the handful of durations this user
+/// actually estimates in — and commit on tap. The wheel below stays for
+/// everything else, and is deliberately unframed: it is the fallback now, and
+/// a bordered card around it made the escape hatch the largest object in the
+/// modal.
 class _EstimatedTimePicker extends StatefulWidget {
   const _EstimatedTimePicker({
     required this.initialDuration,
     required this.onDurationChanged,
+    required this.onQuickPick,
   });
 
   final Duration initialDuration;
   final void Function(Duration) onDurationChanged;
+  final ValueChanged<Duration> onQuickPick;
 
   @override
   State<_EstimatedTimePicker> createState() => _EstimatedTimePickerState();
@@ -83,14 +101,20 @@ class _EstimatedTimePickerState extends State<_EstimatedTimePicker> {
           _selectedDuration.inHours,
           _selectedDuration.inMinutes.remainder(60),
         );
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(tokens.radii.sectionCards),
-        border: Border.all(color: tokens.colors.decorative.level01),
-      ),
-      child: Padding(
-        padding: EdgeInsets.all(tokens.spacing.cardPadding),
-        child: DesignSystemDurationWheel(
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // The wheel's draft, not the value the modal opened on: spinning the
+        // wheel moves the selected chip with it, so the row and the wheel
+        // never claim two different estimates at once.
+        EstimateQuickPickChips(
+          currentEstimate: _selectedDuration,
+          onPick: widget.onQuickPick,
+        ),
+        // A gap larger than anything inside either element is the whole
+        // separation the two groups need — no divider, no second card.
+        SizedBox(height: tokens.spacing.sectionGap),
+        DesignSystemDurationWheel(
           initialDuration: widget.initialDuration,
           semanticsLabel:
               '${context.messages.taskEstimateModalTitle}: $durationLabel',
@@ -100,7 +124,7 @@ class _EstimatedTimePickerState extends State<_EstimatedTimePicker> {
             widget.onDurationChanged(duration);
           },
         ),
-      ),
+      ],
     );
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -5250,6 +5250,8 @@
       }
     }
   },
+  "taskEstimateQuickPickHint": "Klepni pro uložení a zavření",
+  "taskEstimateQuickPickSemanticsLabel": "Nastavit odhad na {duration}",
   "taskEstimateTooltip": "Zaznamenaný čas: {tracked} z odhadovaných {estimate}",
   "@taskEstimateTooltip": {
     "placeholders": {

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -5800,6 +5800,8 @@
       }
     }
   },
+  "taskEstimateQuickPickHint": "Tryk for at gemme og lukke",
+  "taskEstimateQuickPickSemanticsLabel": "Sæt estimat til {duration}",
   "taskEstimateTooltip": "Tid registreret: {tracked} af {estimate} estimeret",
   "@taskEstimateTooltip": {
     "placeholders": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -5243,6 +5243,8 @@
       }
     }
   },
+  "taskEstimateQuickPickHint": "Tippen zum Speichern und Schließen",
+  "taskEstimateQuickPickSemanticsLabel": "Schätzung auf {duration} setzen",
   "taskEstimateTooltip": "Erfasste Zeit: {tracked} von {estimate} geschätzt",
   "@taskEstimateTooltip": {
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7521,6 +7521,15 @@
       }
     }
   },
+  "taskEstimateQuickPickHint": "Tap to save and close",
+  "taskEstimateQuickPickSemanticsLabel": "Set estimate to {duration}",
+  "@taskEstimateQuickPickSemanticsLabel": {
+    "placeholders": {
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "taskEstimateTooltip": "Time tracked: {tracked} of {estimate} estimated",
   "@taskEstimateTooltip": {
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -5243,6 +5243,8 @@
       }
     }
   },
+  "taskEstimateQuickPickHint": "Toca para guardar y cerrar",
+  "taskEstimateQuickPickSemanticsLabel": "Establecer la estimación en {duration}",
   "taskEstimateTooltip": "Tiempo registrado: {tracked} de {estimate} estimado",
   "@taskEstimateTooltip": {
     "placeholders": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -5243,6 +5243,8 @@
       }
     }
   },
+  "taskEstimateQuickPickHint": "Tape pour enregistrer et fermer",
+  "taskEstimateQuickPickSemanticsLabel": "Définir l'estimation à {duration}",
   "taskEstimateTooltip": "Temps suivi : {tracked} sur {estimate} estimé",
   "@taskEstimateTooltip": {
     "placeholders": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -5800,6 +5800,8 @@
       }
     }
   },
+  "taskEstimateQuickPickHint": "Toccare per salvare e chiudere",
+  "taskEstimateQuickPickSemanticsLabel": "Imposta la stima a {duration}",
   "taskEstimateTooltip": "Tempo tracciato: {tracked} di {estimate} stimato",
   "@taskEstimateTooltip": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -22657,6 +22657,18 @@ abstract class AppLocalizations {
   /// **'{tracked} of {estimate}'**
   String taskEstimateProgressLabel(String tracked, String estimate);
 
+  /// No description provided for @taskEstimateQuickPickHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Tap to save and close'**
+  String get taskEstimateQuickPickHint;
+
+  /// No description provided for @taskEstimateQuickPickSemanticsLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Set estimate to {duration}'**
+  String taskEstimateQuickPickSemanticsLabel(String duration);
+
   /// No description provided for @taskEstimateTooltip.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -13605,6 +13605,14 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get taskEstimateQuickPickHint => 'Klepni pro uložení a zavření';
+
+  @override
+  String taskEstimateQuickPickSemanticsLabel(String duration) {
+    return 'Nastavit odhad na $duration';
+  }
+
+  @override
   String taskEstimateTooltip(String tracked, String estimate) {
     return 'Zaznamenaný čas: $tracked z odhadovaných $estimate';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -13447,6 +13447,14 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get taskEstimateQuickPickHint => 'Tryk for at gemme og lukke';
+
+  @override
+  String taskEstimateQuickPickSemanticsLabel(String duration) {
+    return 'Sæt estimat til $duration';
+  }
+
+  @override
   String taskEstimateTooltip(String tracked, String estimate) {
     return 'Tid registreret: $tracked af $estimate estimeret';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -13546,6 +13546,14 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get taskEstimateQuickPickHint => 'Tippen zum Speichern und Schließen';
+
+  @override
+  String taskEstimateQuickPickSemanticsLabel(String duration) {
+    return 'Schätzung auf $duration setzen';
+  }
+
+  @override
   String taskEstimateTooltip(String tracked, String estimate) {
     return 'Erfasste Zeit: $tracked von $estimate geschätzt';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -13367,6 +13367,14 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get taskEstimateQuickPickHint => 'Tap to save and close';
+
+  @override
+  String taskEstimateQuickPickSemanticsLabel(String duration) {
+    return 'Set estimate to $duration';
+  }
+
+  @override
   String taskEstimateTooltip(String tracked, String estimate) {
     return 'Time tracked: $tracked of $estimate estimated';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -13644,6 +13644,14 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get taskEstimateQuickPickHint => 'Toca para guardar y cerrar';
+
+  @override
+  String taskEstimateQuickPickSemanticsLabel(String duration) {
+    return 'Establecer la estimación en $duration';
+  }
+
+  @override
   String taskEstimateTooltip(String tracked, String estimate) {
     return 'Tiempo registrado: $tracked de $estimate estimado';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -13684,6 +13684,14 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get taskEstimateQuickPickHint => 'Tape pour enregistrer et fermer';
+
+  @override
+  String taskEstimateQuickPickSemanticsLabel(String duration) {
+    return 'Définir l\'estimation à $duration';
+  }
+
+  @override
   String taskEstimateTooltip(String tracked, String estimate) {
     return 'Temps suivi : $tracked sur $estimate estimé';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -13631,6 +13631,14 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get taskEstimateQuickPickHint => 'Toccare per salvare e chiudere';
+
+  @override
+  String taskEstimateQuickPickSemanticsLabel(String duration) {
+    return 'Imposta la stima a $duration';
+  }
+
+  @override
   String taskEstimateTooltip(String tracked, String estimate) {
     return 'Tempo tracciato: $tracked di $estimate stimato';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -13486,6 +13486,14 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get taskEstimateQuickPickHint => 'Tik om op te slaan en te sluiten';
+
+  @override
+  String taskEstimateQuickPickSemanticsLabel(String duration) {
+    return 'Schatting instellen op $duration';
+  }
+
+  @override
   String taskEstimateTooltip(String tracked, String estimate) {
     return 'Gespoorde tijd: $tracked van $estimate geraamd';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -13579,6 +13579,14 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get taskEstimateQuickPickHint => 'Toque para salvar e fechar';
+
+  @override
+  String taskEstimateQuickPickSemanticsLabel(String duration) {
+    return 'Definir a estimativa para $duration';
+  }
+
+  @override
   String taskEstimateTooltip(String tracked, String estimate) {
     return 'Tempo monitorado: $tracked de $estimate estimado';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -13715,6 +13715,14 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get taskEstimateQuickPickHint => 'Apăsați pentru a salva și a închide';
+
+  @override
+  String taskEstimateQuickPickSemanticsLabel(String duration) {
+    return 'Setați estimarea la $duration';
+  }
+
+  @override
   String taskEstimateTooltip(String tracked, String estimate) {
     return 'Timp înregistrat: $tracked din $estimate estimat';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -13462,6 +13462,14 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get taskEstimateQuickPickHint => 'Tryck för att spara och stänga';
+
+  @override
+  String taskEstimateQuickPickSemanticsLabel(String duration) {
+    return 'Ange uppskattning till $duration';
+  }
+
+  @override
   String taskEstimateTooltip(String tracked, String estimate) {
     return 'Tid spårad: $tracked av $estimate uppskattad';
   }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -5799,6 +5799,8 @@
       }
     }
   },
+  "taskEstimateQuickPickHint": "Tik om op te slaan en te sluiten",
+  "taskEstimateQuickPickSemanticsLabel": "Schatting instellen op {duration}",
   "taskEstimateTooltip": "Gespoorde tijd: {tracked} van {estimate} geraamd",
   "@taskEstimateTooltip": {
     "placeholders": {

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -5799,6 +5799,8 @@
       }
     }
   },
+  "taskEstimateQuickPickHint": "Toque para salvar e fechar",
+  "taskEstimateQuickPickSemanticsLabel": "Definir a estimativa para {duration}",
   "taskEstimateTooltip": "Tempo monitorado: {tracked} de {estimate} estimado",
   "@taskEstimateTooltip": {
     "placeholders": {

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -5243,6 +5243,8 @@
       }
     }
   },
+  "taskEstimateQuickPickHint": "Apăsați pentru a salva și a închide",
+  "taskEstimateQuickPickSemanticsLabel": "Setați estimarea la {duration}",
   "taskEstimateTooltip": "Timp înregistrat: {tracked} din {estimate} estimat",
   "@taskEstimateTooltip": {
     "placeholders": {

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -5800,6 +5800,8 @@
       }
     }
   },
+  "taskEstimateQuickPickHint": "Tryck för att spara och stänga",
+  "taskEstimateQuickPickSemanticsLabel": "Ange uppskattning till {duration}",
   "taskEstimateTooltip": "Tid spårad: {tracked} av {estimate} uppskattad",
   "@taskEstimateTooltip": {
     "placeholders": {

--- a/test/database/database_task_queries_test.dart
+++ b/test/database/database_task_queries_test.dart
@@ -1938,6 +1938,285 @@ void main() {
       });
     });
 
+    group('getRankedTaskEstimates -', () {
+      // Every task in this group is dated relative to [base] so the `since`
+      // window is exercised against known distances, never the wall clock.
+      final base = DateTime(2024, 8, 2);
+      final windowStart = base.subtract(const Duration(days: 90));
+
+      var statusCounter = 0;
+      Future<void> seedTask({
+        required String id,
+        required Duration? estimate,
+        DateTime? timestamp,
+        DateTime? deletedAt,
+        bool private = false,
+      }) async {
+        final at = timestamp ?? base;
+        statusCounter++;
+        final task = JournalEntity.task(
+          meta: Metadata(
+            id: id,
+            createdAt: at,
+            updatedAt: at,
+            dateFrom: at,
+            dateTo: at,
+            deletedAt: deletedAt,
+            private: private,
+          ),
+          data: testTask.data.copyWith(
+            status: TaskStatus.open(
+              id: 'ranked-status-$statusCounter',
+              createdAt: at,
+              utcOffset: 0,
+            ),
+            statusHistory: [],
+            title: 'Ranked $id',
+            dateFrom: at,
+            dateTo: at,
+            estimate: estimate,
+          ),
+          entryText: const EntryText(plainText: 'Ranked task'),
+        );
+        await db!.upsertJournalDbEntity(toDbEntity(task));
+      }
+
+      test('returns nothing when no task carries an estimate', () async {
+        await seedTask(id: 'ranked-none', estimate: null);
+
+        expect(
+          await db!.getRankedTaskEstimates(since: windowStart, limit: 4),
+          isEmpty,
+        );
+      });
+
+      test('orders by how often each estimate was used', () async {
+        for (var i = 0; i < 3; i++) {
+          await seedTask(id: 'one-hour-$i', estimate: const Duration(hours: 1));
+        }
+        for (var i = 0; i < 2; i++) {
+          await seedTask(
+            id: 'two-hours-$i',
+            estimate: const Duration(hours: 2),
+          );
+        }
+        await seedTask(id: 'half-hour', estimate: const Duration(minutes: 30));
+
+        expect(
+          await db!.getRankedTaskEstimates(since: windowStart, limit: 4),
+          const [
+            Duration(hours: 1),
+            Duration(hours: 2),
+            Duration(minutes: 30),
+          ],
+        );
+      });
+
+      test('breaks a tie on the shorter duration', () async {
+        await seedTask(id: 'tie-long', estimate: const Duration(hours: 3));
+        await seedTask(id: 'tie-short', estimate: const Duration(minutes: 15));
+
+        expect(
+          await db!.getRankedTaskEstimates(since: windowStart, limit: 4),
+          const [
+            Duration(minutes: 15),
+            Duration(hours: 3),
+          ],
+        );
+      });
+
+      test(
+        'ignores a zero estimate — "none" is the Clear action, not a chip',
+        () async {
+          await seedTask(id: 'zero-1', estimate: Duration.zero);
+          await seedTask(id: 'zero-2', estimate: Duration.zero);
+          await seedTask(id: 'real', estimate: const Duration(hours: 1));
+
+          expect(
+            await db!.getRankedTaskEstimates(since: windowStart, limit: 4),
+            const [
+              Duration(hours: 1),
+            ],
+          );
+        },
+      );
+
+      test('ignores tasks dated before the window', () async {
+        await seedTask(
+          id: 'stale-1',
+          estimate: const Duration(hours: 8),
+          timestamp: windowStart.subtract(const Duration(days: 1)),
+        );
+        await seedTask(
+          id: 'stale-2',
+          estimate: const Duration(hours: 8),
+          timestamp: windowStart.subtract(const Duration(days: 2)),
+        );
+        await seedTask(id: 'recent', estimate: const Duration(hours: 1));
+
+        expect(
+          await db!.getRankedTaskEstimates(since: windowStart, limit: 4),
+          const [
+            Duration(hours: 1),
+          ],
+        );
+      });
+
+      test('ignores deleted tasks', () async {
+        await seedTask(
+          id: 'deleted-1',
+          estimate: const Duration(hours: 6),
+          deletedAt: base,
+        );
+        await seedTask(
+          id: 'deleted-2',
+          estimate: const Duration(hours: 6),
+          deletedAt: base,
+        );
+        await seedTask(id: 'alive', estimate: const Duration(hours: 1));
+
+        expect(
+          await db!.getRankedTaskEstimates(since: windowStart, limit: 4),
+          const [
+            Duration(hours: 1),
+          ],
+        );
+      });
+
+      test('ignores non-task entities', () async {
+        await db!.upsertJournalDbEntity(
+          toDbEntity(
+            buildJournalEntry(
+              id: 'ranked-not-a-task',
+              timestamp: base,
+              text: 'Not a task',
+            ),
+          ),
+        );
+        await seedTask(id: 'ranked-task', estimate: const Duration(hours: 1));
+
+        expect(
+          await db!.getRankedTaskEstimates(since: windowStart, limit: 4),
+          const [
+            Duration(hours: 1),
+          ],
+        );
+      });
+
+      test('returns at most `limit` values, keeping the most used', () async {
+        for (var i = 0; i < 4; i++) {
+          await seedTask(id: 'lim-a-$i', estimate: const Duration(hours: 1));
+        }
+        for (var i = 0; i < 3; i++) {
+          await seedTask(id: 'lim-b-$i', estimate: const Duration(hours: 2));
+        }
+        for (var i = 0; i < 2; i++) {
+          await seedTask(id: 'lim-c-$i', estimate: const Duration(hours: 3));
+        }
+        await seedTask(id: 'lim-d', estimate: const Duration(hours: 4));
+
+        expect(
+          await db!.getRankedTaskEstimates(since: windowStart, limit: 2),
+          const [Duration(hours: 1), Duration(hours: 2)],
+        );
+      });
+
+      test(
+        'ignores a private task while private entries are hidden, and counts '
+        'it once they are shown',
+        () async {
+          Future<void> setPrivateFlag({required bool status}) =>
+              db!.upsertConfigFlag(
+                ConfigFlag(
+                  name: privateFlag,
+                  description: 'Show private entries?',
+                  status: status,
+                ),
+              );
+
+          await seedTask(
+            id: 'private-1',
+            estimate: const Duration(hours: 6),
+            private: true,
+          );
+          await seedTask(
+            id: 'private-2',
+            estimate: const Duration(hours: 6),
+            private: true,
+          );
+          await seedTask(id: 'public', estimate: const Duration(hours: 1));
+
+          // The flag ships enabled, so start from the shown case.
+          expect(
+            await db!.getRankedTaskEstimates(since: windowStart, limit: 4),
+            const [Duration(hours: 6), Duration(hours: 1)],
+            reason: 'shown private tasks rank like any other',
+          );
+
+          await setPrivateFlag(status: false);
+          addTearDown(() => setPrivateFlag(status: true));
+
+          expect(
+            await db!.getRankedTaskEstimates(since: windowStart, limit: 4),
+            const [Duration(hours: 1)],
+            reason: 'a hidden task must not put a value on the chip row',
+          );
+        },
+      );
+
+      test(
+        'ignores an estimate that is not a whole number of minutes',
+        () async {
+          // `formatRangeDuration` renders 90m and 90m30s identically, and the
+          // chip row keys on whole minutes — two of these would collide.
+          await seedTask(
+            id: 'fractional-1',
+            estimate: const Duration(minutes: 90, seconds: 30),
+          );
+          await seedTask(
+            id: 'fractional-2',
+            estimate: const Duration(minutes: 90, milliseconds: 1),
+          );
+          await seedTask(id: 'whole', estimate: const Duration(minutes: 90));
+
+          expect(
+            await db!.getRankedTaskEstimates(since: windowStart, limit: 4),
+            const [
+              Duration(minutes: 90),
+            ],
+          );
+        },
+      );
+
+      test(
+        'ignores a sub-minute estimate, which would render as "0m"',
+        () async {
+          await seedTask(id: 'seconds', estimate: const Duration(seconds: 45));
+          await seedTask(id: 'minute', estimate: const Duration(minutes: 1));
+
+          expect(
+            await db!.getRankedTaskEstimates(since: windowStart, limit: 4),
+            const [
+              Duration(minutes: 1),
+            ],
+          );
+        },
+      );
+
+      test('a non-positive limit short-circuits without querying', () async {
+        await seedTask(id: 'limit-zero', estimate: const Duration(hours: 1));
+
+        expect(
+          await db!.getRankedTaskEstimates(since: windowStart, limit: 0),
+          isEmpty,
+        );
+        expect(
+          await db!.getRankedTaskEstimates(since: windowStart, limit: -1),
+          isEmpty,
+        );
+      });
+    });
+
     group('getTasks not-all-starred sortByDate branches -', () {
       // starredStatuses single-valued ([true]) forces the slower
       // `_selectTasks` branches (1779+ / 1871+) instead of the

--- a/test/features/design_system/components/chips/ds_pill_test.dart
+++ b/test/features/design_system/components/chips/ds_pill_test.dart
@@ -20,6 +20,68 @@ void main() {
       );
     }
 
+    Future<void> pumpLight(WidgetTester tester, Widget child) {
+      return tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Theme(
+            data: DesignSystemTheme.light(),
+            child: Scaffold(body: Center(child: child)),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('labelWidget replaces the label and keeps the caller’s style', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        const DsPill(
+          variant: DsPillVariant.filled,
+          label: 'ignored',
+          labelWidget: Text(
+            'custom',
+            style: TextStyle(fontSize: 21, color: Color(0xFF00FF00)),
+          ),
+        ),
+      );
+
+      expect(find.text('ignored'), findsNothing);
+      final style = tester.widget<Text>(find.text('custom')).style!;
+      expect(style.fontSize, 21);
+      expect(style.color, const Color(0xFF00FF00));
+      expect(
+        find.ancestor(of: find.text('custom'), matching: find.byType(Flexible)),
+        findsOneWidget,
+        reason: 'a bounded pill must ellipsize the custom label, not overflow',
+      );
+    });
+
+    testWidgets(
+      'muted label reads high-emphasis in light theme, medium in dark',
+      (tester) async {
+        // In light theme mediumEmphasis grey on white flirted with the
+        // disabled affordance, so the unset chip's label steps up instead.
+        await pumpLight(
+          tester,
+          const DsPill(variant: DsPillVariant.muted, label: 'Unset'),
+        );
+        expect(
+          tester.widget<Text>(find.text('Unset')).style?.color,
+          dsTokensLight.colors.text.highEmphasis,
+        );
+
+        await pump(
+          tester,
+          const DsPill(variant: DsPillVariant.muted, label: 'Unset'),
+        );
+        expect(
+          tester.widget<Text>(find.text('Unset')).style?.color,
+          dsTokensDark.colors.text.mediumEmphasis,
+        );
+      },
+    );
+
     testWidgets('renders the label text', (tester) async {
       await pump(
         tester,
@@ -467,6 +529,84 @@ void main() {
         expect(
           tester.widget<Text>(find.text('P0')).style?.fontWeight,
           FontWeight.w700,
+        );
+      },
+    );
+
+    testWidgets(
+      'outline + selected: full-alpha interactive border, teal fill, bold',
+      (tester) async {
+        const accent = Color(0xFF4AB6E8);
+        await pump(
+          tester,
+          const DsPill(
+            variant: DsPillVariant.outline,
+            label: '2h',
+            color: accent,
+            selected: true,
+          ),
+        );
+
+        final decoration = decorationOf(tester);
+        expect(decoration.color, dsTokensDark.colors.surface.selected);
+        expect(
+          (decoration.border! as Border).top.color,
+          dsTokensDark.colors.interactive.enabled,
+          reason: 'selection replaces the quiet 50% accent stroke',
+        );
+        expect(
+          tester.widget<Text>(find.text('2h')).style?.fontWeight,
+          FontWeight.w700,
+        );
+      },
+    );
+
+    testWidgets(
+      'regression: selected:false leaves the outline pill byte-identical',
+      (tester) async {
+        const accent = Color(0xFF4AB6E8);
+        await pump(
+          tester,
+          const DsPill(
+            variant: DsPillVariant.outline,
+            label: '2h',
+            color: accent,
+          ),
+        );
+
+        final decoration = decorationOf(tester);
+        expect(decoration.color, isNull);
+        expect(
+          (decoration.border! as Border).top.color,
+          accent.withValues(alpha: 0.5),
+        );
+        expect(
+          tester.widget<Text>(find.text('2h')).style?.fontWeight,
+          isNot(FontWeight.w700),
+        );
+      },
+    );
+
+    testWidgets(
+      'muted still ignores selection — a dashed "selected" is not a state',
+      (tester) async {
+        await pump(
+          tester,
+          const DsPill(
+            variant: DsPillVariant.muted,
+            label: 'Unset',
+            selected: true,
+          ),
+        );
+
+        // No DecoratedBox shell at all: the muted variant renders a
+        // DsDashedBorder, selected or not.
+        expect(
+          find.descendant(
+            of: find.byType(DsPill),
+            matching: find.byType(DsDashedBorder),
+          ),
+          findsOneWidget,
         );
       },
     );

--- a/test/features/tasks/state/task_estimate_suggestions_controller_test.dart
+++ b/test/features/tasks/state/task_estimate_suggestions_controller_test.dart
@@ -1,0 +1,239 @@
+import 'dart:async';
+
+import 'package:clock/clock.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/tasks/state/task_estimate_suggestions_controller.dart';
+import 'package:lotti/utils/consts.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../mocks/mocks.dart';
+import '../../../widget_test_utils.dart';
+
+void main() {
+  late MockJournalDb journalDb;
+
+  // Fixed so the 90-day window has a knowable start; the wall clock never
+  // decides what `since` this test asserts on.
+  final now = DateTime(2026, 3, 15, 11, 20);
+
+  // Drives the `private` config flag the controller watches, so a test can
+  // flip visibility and observe the ranking re-derive.
+  late StreamController<bool> privateFlips;
+  late bool privateVisible;
+
+  setUp(() async {
+    // The shared harness, not a hand-rolled GetIt: it already registers the
+    // MockJournalDb this controller resolves, and it leaves no
+    // `allowReassignment` flag behind for the next file in the shard.
+    journalDb = (await setUpTestGetIt()).journalDb;
+    privateFlips = StreamController<bool>.broadcast();
+    privateVisible = true;
+    // Mirrors the real `watchConfigFlag`: every subscriber gets the current
+    // value first, then subsequent changes. A bare broadcast stream would
+    // drop the seed before the provider had subscribed.
+    when(() => journalDb.watchConfigFlag(privateFlag)).thenAnswer((_) async* {
+      yield privateVisible;
+      yield* privateFlips.stream;
+    });
+  });
+
+  tearDown(() async {
+    await privateFlips.close();
+    await tearDownTestGetIt();
+  });
+
+  void stubRanked(List<Duration> ranked) {
+    when(
+      () => journalDb.getRankedTaskEstimates(
+        since: any(named: 'since'),
+        limit: any(named: 'limit'),
+      ),
+    ).thenAnswer((_) async => ranked);
+  }
+
+  ProviderContainer buildContainer() {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  Future<List<Duration>> read({ProviderContainer? container}) => withClock(
+    Clock.fixed(now),
+    () => (container ?? buildContainer()).read(
+      taskEstimateSuggestionsControllerProvider.future,
+    ),
+  );
+
+  group('toppedUpAndSorted', () {
+    test('a full ranking is used as-is, shortest first', () {
+      expect(
+        TaskEstimateSuggestionsController.toppedUpAndSorted(const [
+          Duration(hours: 2),
+          Duration(minutes: 30),
+          Duration(hours: 4),
+          Duration(minutes: 45),
+        ]),
+        const [
+          Duration(minutes: 30),
+          Duration(minutes: 45),
+          Duration(hours: 2),
+          Duration(hours: 4),
+        ],
+      );
+    });
+
+    test('an empty ranking falls back to the starter ladder', () {
+      expect(
+        TaskEstimateSuggestionsController.toppedUpAndSorted(const []),
+        kDefaultEstimateSuggestions,
+      );
+    });
+
+    test('a thin ranking is topped up to a full row', () {
+      final result = TaskEstimateSuggestionsController.toppedUpAndSorted(const [
+        Duration(minutes: 20),
+      ]);
+
+      expect(result, hasLength(kEstimateSuggestionCount));
+      expect(result.first, const Duration(minutes: 20));
+      expect(result, containsAll(kDefaultEstimateSuggestions.take(3)));
+    });
+
+    test('a top-up never repeats a value already ranked', () {
+      final result = TaskEstimateSuggestionsController.toppedUpAndSorted(const [
+        Duration(hours: 1),
+        Duration(hours: 4),
+      ]);
+
+      expect(result, hasLength(kEstimateSuggestionCount));
+      expect(
+        result.where((d) => d == const Duration(hours: 1)),
+        hasLength(1),
+        reason: 'the ladder must not duplicate a ranked value',
+      );
+      expect(result, const [
+        Duration(minutes: 30),
+        Duration(hours: 1),
+        Duration(hours: 2),
+        Duration(hours: 4),
+      ]);
+    });
+
+    test('an over-long ranking is cut to the row size before sorting', () {
+      final result = TaskEstimateSuggestionsController.toppedUpAndSorted(const [
+        Duration(hours: 5),
+        Duration(hours: 4),
+        Duration(hours: 3),
+        Duration(hours: 2),
+        // Ranked fifth: past the row, so it must not appear even though it
+        // would sort first.
+        Duration(minutes: 10),
+      ]);
+
+      expect(result, const [
+        Duration(hours: 2),
+        Duration(hours: 3),
+        Duration(hours: 4),
+        Duration(hours: 5),
+      ]);
+    });
+
+    test('a repeated ranked value collapses and the ladder fills the gap', () {
+      final result = TaskEstimateSuggestionsController.toppedUpAndSorted(const [
+        Duration(hours: 1),
+        Duration(hours: 1),
+      ]);
+
+      expect(result, hasLength(kEstimateSuggestionCount));
+      expect(result.where((d) => d == const Duration(hours: 1)), hasLength(1));
+    });
+  });
+
+  group('build', () {
+    test('queries the 90-day window for a full row of values', () async {
+      stubRanked(const [Duration(hours: 1)]);
+
+      await read();
+
+      final captured = verify(
+        () => journalDb.getRankedTaskEstimates(
+          since: captureAny(named: 'since'),
+          limit: captureAny(named: 'limit'),
+        ),
+      ).captured;
+
+      expect(
+        captured.first,
+        DateTime(2026, 3, 15).subtract(kEstimateSuggestionWindow),
+        reason: 'the window starts at midnight, not at the current time',
+      );
+      expect(captured.last, kEstimateSuggestionCount);
+    });
+
+    test('serves the ranked estimates, shortest first', () async {
+      stubRanked(const [
+        Duration(hours: 3),
+        Duration(minutes: 30),
+        Duration(hours: 1),
+        Duration(hours: 2),
+      ]);
+
+      expect(await read(), const [
+        Duration(minutes: 30),
+        Duration(hours: 1),
+        Duration(hours: 2),
+        Duration(hours: 3),
+      ]);
+    });
+
+    test(
+      're-derives the ranking when private visibility is turned off',
+      () async {
+        // The row is kept alive for five minutes, so a flag change inside that
+        // window has to invalidate it — otherwise a reopened picker still
+        // offers a duration ranked from tasks that are now hidden.
+        stubRanked(const [Duration(hours: 6)]);
+        final container = buildContainer();
+
+        expect(
+          await read(container: container),
+          contains(const Duration(hours: 6)),
+        );
+
+        stubRanked(const [Duration(hours: 1)]);
+        privateVisible = false;
+        privateFlips.add(false);
+        await container.read(
+          taskEstimateSuggestionsControllerProvider.future,
+        );
+
+        expect(
+          await container.read(
+            taskEstimateSuggestionsControllerProvider.future,
+          ),
+          contains(const Duration(hours: 1)),
+        );
+        expect(
+          await container.read(
+            taskEstimateSuggestionsControllerProvider.future,
+          ),
+          isNot(contains(const Duration(hours: 6))),
+          reason: 'the value ranked from now-hidden tasks is gone',
+        );
+        verify(
+          () => journalDb.getRankedTaskEstimates(
+            since: any(named: 'since'),
+            limit: any(named: 'limit'),
+          ),
+        ).called(2);
+      },
+    );
+
+    test('falls back to the starter ladder with no history at all', () async {
+      stubRanked(const []);
+
+      expect(await read(), kDefaultEstimateSuggestions);
+    });
+  });
+}

--- a/test/features/tasks/ui/header/estimate_quick_pick_chips_test.dart
+++ b/test/features/tasks/ui/header/estimate_quick_pick_chips_test.dart
@@ -1,0 +1,426 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/tasks/state/task_estimate_suggestions_controller.dart';
+import 'package:lotti/features/tasks/ui/header/estimate_quick_pick_chips.dart';
+
+import '../../../../test_helper.dart';
+
+/// Serves a fixed row of suggestions, so a test states the values it is
+/// asserting about instead of standing up a database.
+class _FixedSuggestions extends TaskEstimateSuggestionsController {
+  _FixedSuggestions(this.values);
+  final List<Duration> values;
+
+  @override
+  Future<List<Duration>> build() async => values;
+}
+
+/// Never completes: the row's loading state, held open for as long as the
+/// test needs it.
+class _PendingSuggestions extends TaskEstimateSuggestionsController {
+  @override
+  Future<List<Duration>> build() => Completer<List<Duration>>().future;
+}
+
+void main() {
+  const thirtyMinutes = Duration(minutes: 30);
+  const oneHour = Duration(hours: 1);
+  const twoHours = Duration(hours: 2);
+  const ninetyMinutes = Duration(minutes: 90);
+
+  Future<List<Duration>> pumpChips(
+    WidgetTester tester, {
+    required Override override,
+    Duration currentEstimate = Duration.zero,
+  }) async {
+    final picked = <Duration>[];
+    await tester.pumpWidget(
+      WidgetTestBench(
+        overrides: [override],
+        child: Scaffold(
+          body: EstimateQuickPickChips(
+            currentEstimate: currentEstimate,
+            onPick: picked.add,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return picked;
+  }
+
+  Override fixed(List<Duration> values) =>
+      taskEstimateSuggestionsControllerProvider.overrideWith(
+        () => _FixedSuggestions(values),
+      );
+
+  DsPill pillOf(WidgetTester tester, String label) => tester.widget<DsPill>(
+    find.ancestor(of: find.text(label), matching: find.byType(DsPill)),
+  );
+
+  group('rendering', () {
+    testWidgets('the row names the outcome of a tap, above the chips', (
+      tester,
+    ) async {
+      // A chip commits and closes while a Done button sits on the same
+      // sheet; without this line the row reads as staging, and the users
+      // most wary of an irreversible tap were the ones who avoided it.
+      await pumpChips(
+        tester,
+        override: fixed(const [thirtyMinutes, oneHour]),
+      );
+
+      expect(find.text('Tap to save and close'), findsOneWidget);
+      expect(
+        tester.getRect(find.text('Tap to save and close')).bottom,
+        lessThanOrEqualTo(tester.getRect(find.text('30m')).top),
+        reason: 'the contract is read before the control it describes',
+      );
+    });
+
+    testWidgets('the wrapped hint stays centred over the chips at 2x text', (
+      tester,
+    ) async {
+      // At 1x the line fits and centring is invisible; at accessibility
+      // sizes it wraps, and an uncentred second line sits left of the row it
+      // describes. Only a scaled pump can catch that.
+      await tester.pumpWidget(
+        WidgetTestBench(
+          overrides: [
+            fixed(const [thirtyMinutes, oneHour]),
+          ],
+          mediaQueryData: const MediaQueryData(
+            size: Size(390, 844),
+            textScaler: TextScaler.linear(2),
+          ),
+          child: const Scaffold(
+            body: EstimateQuickPickChips(
+              currentEstimate: Duration.zero,
+              onPick: _noop,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final hint = find.text('Tap to save and close');
+      expect(
+        tester.widget<Text>(hint).textAlign,
+        TextAlign.center,
+      );
+      expect(
+        tester.getSize(hint).height,
+        greaterThan(tester.getSize(find.text('30m')).height),
+        reason: 'the hint has actually wrapped at this scale',
+      );
+    });
+
+    testWidgets('the hint stays while the ranking is still loading', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        WidgetTestBench(
+          overrides: [
+            taskEstimateSuggestionsControllerProvider.overrideWith(
+              _PendingSuggestions.new,
+            ),
+          ],
+          child: const Scaffold(
+            body: EstimateQuickPickChips(
+              currentEstimate: Duration.zero,
+              onPick: _noop,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Tap to save and close'), findsOneWidget);
+    });
+
+    testWidgets('one chip per suggestion, in the order supplied', (
+      tester,
+    ) async {
+      await pumpChips(
+        tester,
+        override: fixed(const [thirtyMinutes, oneHour, twoHours]),
+      );
+
+      expect(find.byType(DsPill), findsNWidgets(3));
+      final labels = tester
+          .widgetList<DsPill>(find.byType(DsPill))
+          .map((pill) => pill.label)
+          .toList();
+      expect(labels, ['30m', '1h', '2h']);
+    });
+
+    testWidgets('labels use the compact form the header reads back', (
+      tester,
+    ) async {
+      await pumpChips(tester, override: fixed(const [ninetyMinutes]));
+
+      // Not "1h 30m 0s", not "01:30" — the same string
+      // `formatRangeDuration` gives the task header's estimate read-out.
+      expect(find.text('1h 30m'), findsOneWidget);
+    });
+
+    testWidgets('no "+ Other" escape chip — the wheel is directly below', (
+      tester,
+    ) async {
+      await pumpChips(
+        tester,
+        override: fixed(const [thirtyMinutes, oneHour]),
+      );
+
+      expect(find.byType(DsPill), findsNWidgets(2));
+      expect(find.byIcon(LottiIcons.add), findsNothing);
+    });
+
+    testWidgets(
+      'an empty ranking renders no chips rather than an empty shell',
+      (tester) async {
+        await pumpChips(tester, override: fixed(const []));
+
+        expect(find.byType(DsPill), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'while the ranking loads the row shows quiet, inert placeholders',
+      (tester) async {
+        await tester.pumpWidget(
+          WidgetTestBench(
+            overrides: [
+              taskEstimateSuggestionsControllerProvider.overrideWith(
+                _PendingSuggestions.new,
+              ),
+            ],
+            child: const Scaffold(
+              body: EstimateQuickPickChips(
+                currentEstimate: Duration.zero,
+                onPick: _noop,
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // Tokens from the tree under test, so the assertion holds in
+        // whichever theme the bench resolves.
+        final tokens = tester
+            .element(find.byType(EstimateQuickPickChips))
+            .designTokens;
+        final pills = tester.widgetList<DsPill>(find.byType(DsPill)).toList();
+        expect(pills, hasLength(kDefaultEstimateSuggestions.length));
+        expect(
+          pills.every(
+            (pill) =>
+                pill.variant == DsPillVariant.outline &&
+                pill.color == tokens.colors.decorative.level03,
+          ),
+          isTrue,
+          reason: 'a quiet outline, not the dashed "unset — tap me" shell',
+        );
+        expect(
+          pills.every((pill) => pill.onTap == null),
+          isTrue,
+          reason: 'a placeholder tap would commit a value nobody chose',
+        );
+        // The row holds the real row's shape, so nothing below it jumps when
+        // the ranking lands.
+        expect(find.text('30m'), findsOneWidget);
+        expect(find.text('4h'), findsOneWidget);
+      },
+    );
+  });
+
+  group('selection', () {
+    testWidgets('the chip holding the current estimate reads selected', (
+      tester,
+    ) async {
+      await pumpChips(
+        tester,
+        override: fixed(const [thirtyMinutes, oneHour, twoHours]),
+        currentEstimate: oneHour,
+      );
+
+      expect(pillOf(tester, '1h').selected, isTrue);
+      expect(pillOf(tester, '30m').selected, isFalse);
+      expect(pillOf(tester, '2h').selected, isFalse);
+    });
+
+    testWidgets('selection carries no leading glyph', (tester) async {
+      // An icon appearing and vanishing would shift a chip by its whole
+      // width plus a gap every time the wheel moved the selection to
+      // another chip. Fill, border and weight say it instead.
+      await pumpChips(
+        tester,
+        override: fixed(const [thirtyMinutes, oneHour]),
+        currentEstimate: oneHour,
+      );
+
+      expect(find.byIcon(LottiIcons.confirm), findsNothing);
+      expect(pillOf(tester, '1h').leading, isNull);
+      expect(pillOf(tester, '30m').leading, isNull);
+    });
+
+    testWidgets('selection follows the value on show, not a fixed one', (
+      tester,
+    ) async {
+      // Same chips, a different `currentEstimate`: the row re-points rather
+      // than staying pinned to whatever it first rendered.
+      await pumpChips(
+        tester,
+        override: fixed(const [thirtyMinutes, oneHour, twoHours]),
+        currentEstimate: twoHours,
+      );
+
+      expect(pillOf(tester, '2h').selected, isTrue);
+      expect(pillOf(tester, '1h').selected, isFalse);
+    });
+
+    testWidgets('no estimate selects nothing — zero is never suggested', (
+      tester,
+    ) async {
+      await pumpChips(
+        tester,
+        override: fixed(const [thirtyMinutes, oneHour]),
+      );
+
+      expect(
+        tester
+            .widgetList<DsPill>(find.byType(DsPill))
+            .every((pill) => !pill.selected),
+        isTrue,
+      );
+    });
+
+    testWidgets('an off-ladder estimate selects nothing — the wheel holds it', (
+      tester,
+    ) async {
+      await pumpChips(
+        tester,
+        override: fixed(const [thirtyMinutes, oneHour, twoHours]),
+        currentEstimate: const Duration(minutes: 47),
+      );
+
+      expect(
+        tester
+            .widgetList<DsPill>(find.byType(DsPill))
+            .every((pill) => !pill.selected),
+        isTrue,
+      );
+    });
+  });
+
+  group('picking', () {
+    testWidgets('a tap reports that chip’s duration', (tester) async {
+      final picked = await pumpChips(
+        tester,
+        override: fixed(const [thirtyMinutes, oneHour, twoHours]),
+      );
+
+      await tester.tap(find.text('2h'));
+      await tester.pumpAndSettle();
+
+      expect(picked, [twoHours]);
+    });
+
+    testWidgets('tapping the already-selected chip still reports it', (
+      tester,
+    ) async {
+      // The picker decides whether that is a no-op write; the row's job is
+      // only to report the tap.
+      final picked = await pumpChips(
+        tester,
+        override: fixed(const [thirtyMinutes, oneHour]),
+        currentEstimate: oneHour,
+      );
+
+      await tester.tap(find.text('1h'));
+      await tester.pumpAndSettle();
+
+      expect(picked, [oneHour]);
+    });
+  });
+
+  group('semantics', () {
+    testWidgets('each chip announces the estimate its tap would set', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await pumpChips(
+        tester,
+        override: fixed(const [thirtyMinutes, oneHour]),
+        currentEstimate: oneHour,
+      );
+
+      expect(find.bySemanticsLabel('Set estimate to 30m'), findsOneWidget);
+      expect(find.bySemanticsLabel('Set estimate to 1h'), findsOneWidget);
+      handle.dispose();
+    });
+
+    testWidgets('the chip is activatable from a screen reader', (
+      tester,
+    ) async {
+      // `excludeSemantics` drops the InkWell's own tap action, so the node
+      // has to carry it — otherwise the whole point of the row is
+      // unreachable without sighted pointing. `semantics.tap` throws when
+      // the node does not advertise the action, so this asserts both that
+      // the action exists and that performing it picks.
+      final handle = tester.ensureSemantics();
+      final picked = await pumpChips(
+        tester,
+        override: fixed(const [thirtyMinutes, oneHour]),
+      );
+
+      tester.semantics.tap(find.semantics.byLabel('Set estimate to 30m'));
+      await tester.pumpAndSettle();
+
+      expect(picked, [thirtyMinutes]);
+      handle.dispose();
+    });
+
+    testWidgets('the current estimate is announced as selected', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await pumpChips(
+        tester,
+        override: fixed(const [thirtyMinutes, oneHour]),
+        currentEstimate: oneHour,
+      );
+
+      expect(
+        tester.getSemantics(find.bySemanticsLabel('Set estimate to 1h')),
+        matchesSemantics(
+          label: 'Set estimate to 1h',
+          isButton: true,
+          hasSelectedState: true,
+          isSelected: true,
+          hasTapAction: true,
+        ),
+      );
+      expect(
+        tester.getSemantics(find.bySemanticsLabel('Set estimate to 30m')),
+        matchesSemantics(
+          label: 'Set estimate to 30m',
+          isButton: true,
+          // Selectable, but not selected — the distinction a screen reader
+          // needs to say which value the task currently holds.
+          hasSelectedState: true,
+          hasTapAction: true,
+        ),
+        reason: 'only the current estimate announces as selected',
+      );
+      handle.dispose();
+    });
+  });
+}
+
+void _noop(Duration _) {}

--- a/test/features/tasks/ui/header/estimated_time_widget_test.dart
+++ b/test/features/tasks/ui/header/estimated_time_widget_test.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/tasks/state/task_estimate_suggestions_controller.dart';
+import 'package:lotti/features/tasks/ui/header/estimate_quick_pick_chips.dart';
 import 'package:lotti/features/tasks/ui/header/estimated_time_widget.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/time_service.dart';
@@ -11,8 +15,26 @@ import '../../../../mocks/mocks.dart';
 import '../../../../test_helper.dart';
 import '../../../../widget_test_utils.dart';
 
+/// A fixed quick-pick row, so the picker's tests state the chips they act on
+/// rather than depending on what a database would rank.
+class _FixedSuggestions extends TaskEstimateSuggestionsController {
+  @override
+  Future<List<Duration>> build() async => const [
+    Duration(minutes: 30),
+    Duration(hours: 1),
+    Duration(hours: 2),
+    Duration(hours: 4),
+  ];
+}
+
 void main() {
   late MockTimeService mockTimeService;
+
+  List<Override> quickPickOverrides() => [
+    taskEstimateSuggestionsControllerProvider.overrideWith(
+      _FixedSuggestions.new,
+    ),
+  ];
 
   setUp(() async {
     mockTimeService = MockTimeService();
@@ -171,6 +193,191 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(selected, equals(const Duration(hours: 3)));
+  });
+
+  group('quick-pick chips', () {
+    Future<Duration?> openAndTap(
+      WidgetTester tester, {
+      required Duration initialDuration,
+      required String chipLabel,
+    }) async {
+      Duration? saved;
+      await tester.pumpWidget(
+        WidgetTestBench(
+          overrides: quickPickOverrides(),
+          child: Builder(
+            builder: (context) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () => showEstimatePicker(
+                    context: context,
+                    initialDuration: initialDuration,
+                    onEstimateChanged: (duration) async => saved = duration,
+                  ),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(chipLabel));
+      await tester.pumpAndSettle();
+      return saved;
+    }
+
+    testWidgets('a chip tap writes the estimate and closes the modal', (
+      tester,
+    ) async {
+      final saved = await openAndTap(
+        tester,
+        initialDuration: const Duration(hours: 1),
+        chipLabel: '2h',
+      );
+
+      expect(saved, const Duration(hours: 2));
+      expect(find.byType(CupertinoTimerPicker), findsNothing);
+      expect(find.text('Done'), findsNothing);
+    });
+
+    testWidgets(
+      'the chip already holding the estimate closes without a write',
+      (tester) async {
+        // Re-writing the value the task already has would push an unnecessary
+        // update — and a sync message — for a tap that changed nothing.
+        final saved = await openAndTap(
+          tester,
+          initialDuration: const Duration(hours: 1),
+          chipLabel: '1h',
+        );
+
+        expect(saved, isNull);
+        expect(find.byType(CupertinoTimerPicker), findsNothing);
+      },
+    );
+
+    testWidgets('a chip sets an estimate on a task that had none', (
+      tester,
+    ) async {
+      final saved = await openAndTap(
+        tester,
+        initialDuration: Duration.zero,
+        chipLabel: '30m',
+      );
+
+      expect(saved, const Duration(minutes: 30));
+    });
+
+    testWidgets('the chip row sits above the wheel, not beside the actions', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        WidgetTestBench(
+          overrides: quickPickOverrides(),
+          child: Builder(
+            builder: (context) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () => showEstimatePicker(
+                    context: context,
+                    initialDuration: const Duration(hours: 1),
+                    onEstimateChanged: (_) async {},
+                  ),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(EstimateQuickPickChips), findsOneWidget);
+      expect(find.byType(DsPill), findsNWidgets(4));
+      expect(
+        tester.getRect(find.byType(EstimateQuickPickChips)).bottom,
+        lessThan(tester.getRect(find.byType(CupertinoTimerPicker)).top),
+        reason: 'the cheap path is met before the fallback',
+      );
+    });
+
+    testWidgets('spinning the wheel moves the selected chip with it', (
+      tester,
+    ) async {
+      // The row and the wheel must never state two different estimates: the
+      // chips track the wheel's draft, not the value the modal opened on.
+      await tester.pumpWidget(
+        WidgetTestBench(
+          overrides: quickPickOverrides(),
+          child: Builder(
+            builder: (context) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () => showEstimatePicker(
+                    context: context,
+                    initialDuration: const Duration(hours: 1),
+                    onEstimateChanged: (_) async {},
+                  ),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      DsPill pillOf(String label) => tester.widget<DsPill>(
+        find.ancestor(of: find.text(label), matching: find.byType(DsPill)),
+      );
+      expect(pillOf('1h').selected, isTrue);
+
+      tester
+          .widget<CupertinoTimerPicker>(find.byType(CupertinoTimerPicker))
+          .onTimerDurationChanged(const Duration(hours: 4));
+      await tester.pumpAndSettle();
+
+      expect(pillOf('4h').selected, isTrue);
+      expect(pillOf('1h').selected, isFalse);
+    });
+
+    testWidgets('the wheel path still commits through Done', (tester) async {
+      // The chips do not replace the wheel; an off-ladder value still works.
+      Duration? saved;
+      await tester.pumpWidget(
+        WidgetTestBench(
+          overrides: quickPickOverrides(),
+          child: Builder(
+            builder: (context) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () => showEstimatePicker(
+                    context: context,
+                    initialDuration: const Duration(hours: 1),
+                    onEstimateChanged: (duration) async => saved = duration,
+                  ),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      tester
+          .widget<CupertinoTimerPicker>(find.byType(CupertinoTimerPicker))
+          .onTimerDurationChanged(const Duration(minutes: 47));
+      await tester.tap(find.text('Done'));
+      await tester.pumpAndSettle();
+
+      expect(saved, const Duration(minutes: 47));
+    });
   });
 
   testWidgets('Clear resets a non-zero estimate without wheel manipulation', (


### PR DESCRIPTION
## Quick-pick chips for the task estimate

Setting an estimate meant spinning a wheel every time, even though almost every
estimate is one of the same handful of durations. The picker now opens on a row
of one-tap chips — the durations you actually use, ranked from your own tasks —
with the wheel underneath for everything else.

It is the affordance the habit completion sheet already gives a measurable, in
the same design language: same `DsPill` outline variant, same 28pt shell, same
`Wrap`. That was the ask — "the little chips we use for measurables, but for
the estimate".

## Before / after

### Estimate picker — mobile (390×844)

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/2b0675ee28b587e4491e97642a6e116ba3ce054a/pr-screenshots/estimate-quick-pick/before/estimate_picker_mobile_dark.png" width="360"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/2b0675ee28b587e4491e97642a6e116ba3ce054a/pr-screenshots/estimate-quick-pick/after/estimate_picker_mobile_dark.png" width="360"> |

### Estimate picker — desktop (1280×800)

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/2b0675ee28b587e4491e97642a6e116ba3ce054a/pr-screenshots/estimate-quick-pick/before/estimate_picker_desktop_dark.png" width="440"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/2b0675ee28b587e4491e97642a6e116ba3ce054a/pr-screenshots/estimate-quick-pick/after/estimate_picker_desktop_dark.png" width="440"> |

### The design-language reference

The habit completion sheet for a habit with a measurement — the chip row this
one was matched to:

<img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/2b0675ee28b587e4491e97642a6e116ba3ce054a/pr-screenshots/estimate-quick-pick/after/reference_habit_completion_mobile_dark.png" width="360">

Captures are deterministic renders from `test/test_utils/screenshot_harness.dart`
(real fonts, production theme, dark). The same pair is staged at
`/tmp/lotti-pr-screenshots/estimate-quick-pick/` for `make pr_screenshots_publish`
if an R2 copy is wanted.

## What it does

- **The values are yours.** `JournalDb.getRankedTaskEstimates` ranks the
  estimates actually set on tasks over the last 90 days — the same idea as
  `rankedByPopularity` behind the measurement quick-add. Popularity picks the
  set, duration sorts it shortest-first (a row that reshuffles as usage shifts
  is harder to aim at than a stable ladder). A history too thin to fill the row
  is topped up from a 30m / 1h / 2h / 4h starter set, so a fresh install still
  opens on chips. The query honours the `private` config flag like every other
  task read in that mixin, so a hidden task cannot put a value on the chip row
  that the task list would not explain, and it ranks only whole-minute
  durations above zero — the invariant the compact `1h 30m` label and the row's
  keys both depend on, enforced where the data enters rather than assumed in
  the widget. `EXPLAIN QUERY PLAN` puts it on `idx_journal_browse`
  (`deleted`, `type`, `date_from`), so the `json_extract` runs over tasks in
  the window rather than over 90 days of every entry type.
- **A tap saves and closes** — pop first, then await the write, the order
  `Clear` already used. Re-tapping the chip that already holds the task's
  estimate closes without a write, so a confirming tap pushes no update and no
  sync message. A caption above the row says so in words: a `Done` button sits
  on the same sheet and would otherwise teach that nothing is saved until it is
  pressed.
- **The selected chip tracks the wheel**, not the value the modal opened on, so
  the row and the wheel can never state two different answers to "what is the
  estimate". Selection is fill + full-alpha border + bold weight — three
  channels, two of them luminance rather than hue, and no leading glyph — an
  icon appearing and vanishing would shift a chip by its whole width every
  time the wheel moved the selection.
- **The wheel stays, unframed.** It is the only route to an off-ladder value, so
  it is not hidden behind a disclosure; but its bordered card is gone, because
  the fallback should not be the largest object in the modal.
- **Labels use `formatRangeDuration`**, the same compact form the task header
  reads the estimate back in, so tapping `2h` produces a header that says `2h`.

### Design-system fix that comes with it

`DsPillVariant.outline` ignored `selected` in everything but label weight — a
12pt weight bump was carrying the whole "this is the current value" signal. It
now takes the `surface.selected` fill and the full-alpha interactive border the
other variants do. The habit sheet's own quick-record chips inherit the fix.

Also fixed: the chip's `Semantics` node carries its own `onTap`. The
`excludeSemantics` wrapper had been dropping the `InkWell`'s action, which would
have left the one-tap path unreachable from a screen reader.

## Design review

Run through the `design-review-panel` skill — six craft experts and five user
personas, all scoring real captures, three rounds:

| Round | Experts | Personas |
| --- | --- | --- |
| Baseline (wheel-only) | 4.92 | 4.0 — all five *would-struggle* |
| After round 1 | 7.25 | 7.0 |
| After round 2 | 7.75 | 7.9 — all five *would-use* |
| After round 3 | **8.25** | **8.5** — target cleared |

Taken from the panel: commit-and-close over staging; the row above the wheel;
four chips ascending; deleting the wheel's card; no card or divider for the row;
the `DsPill` selection fix; the wheel-tracking selection; the semantics action;
quiet-outline placeholders instead of a blank strip while the ranking loads
(not the `muted` shell — that dashed vocabulary means "unset, tap me to fill"
elsewhere in the task header); a `step4` chip gutter, so the gap between chips
is no longer identical to `DsPill`'s own interior padding; and the caption,
worded as the outcome rather than the gesture and centred so it stays over the
chips when it wraps.

Deliberately not taken, each for a stated reason: 48pt chips with body-size
labels (the ask was parity with the measurable chips; a bigger chip is a
different control, and short labels rendered as circles), localizing
`formatRangeDuration` (a pre-existing app-wide gap; fixing it here would touch
four unrelated surfaces), `minuteInterval: 5` on the wheel
(`CupertinoTimerPicker` asserts the initial duration is a multiple of it, so it
would crash on any task already carrying an off-interval estimate), and several
items on shared design-system geometry — the wheel's height and selection band,
the action bar's conditional `Clear` slot, a `DsPill` min-width floor, hit-slop
inside `DsPill` — which change other surfaces and want their own screenshots.

## Tests

122 tests across the five touched files, **100% line coverage on every file the
branch changes** (192/192 lines, plus 17/17 on the new query region):

- `getRankedTaskEstimates` — ordering by use, tie-breaking, zero estimates,
  sub-minute and fractional-minute estimates, the date window, deleted rows,
  private rows with the flag both ways, non-task rows, the limit, the
  non-positive short-circuit.
- `TaskEstimateSuggestionsController` — the query window and row size, top-up
  without duplicates, over-long rankings, ascending display order, the
  no-history fallback.
- `EstimateQuickPickChips` — rendering, labels, the hint and its wrap at 2x
  text scale, the loading placeholders, selection (current / none / off-ladder /
  moving), picking, and screen-reader announcement *and activation* (via
  `tester.semantics.tap`, which fails if the node does not advertise the
  action).
- `showEstimatePicker` — chip commits and closes, the no-op re-tap, setting on
  a task with no estimate, row position relative to the wheel, the wheel
  moving the selection, and the wheel path still committing through `Done`.
- `DsPill` — outline + selected, the `selected: false` regression guarantee for
  outline, and muted still ignoring selection.

Each new regression test was re-run with its fix reverted and fails.

The branch was then put through `/skeptical-review`; its five findings — the
missing private filter, a hand-rolled GetIt setup that leaked
`allowReassignment` into the shard's isolate, an unverified query-plan comment,
the fractional-minute key collision, and an under-documented window column —
are all fixed here rather than deferred.

## Docs

`knowledge/features/tasks/detail-composition.md` gains an "estimate picker
answers in one tap" section with a `stateDiagram-v2` of the commit paths;
`lib/features/tasks/README.md` gains the user-facing line;
`changelog.d/2026-09-03-estimate-quick-pick-chips.md` carries the release note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWUgMrszxNxoTN8kSQzNXd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-tap estimate duration chips ranked from task estimates used during the past 90 days.
  * Added fallback suggestions of 30 minutes, 1 hour, 2 hours, and 4 hours when history is limited.
  * Tapping a chip saves the estimate and closes the picker; the duration wheel remains available for custom values.
  * Added selected-state styling and accessibility support for estimate chips.

* **Localization**
  * Added translated quick-pick guidance and accessibility labels across supported languages.

* **Documentation**
  * Documented estimate suggestions and quick-pick behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->