### PR TITLE
fix: android 16kb drop openssl

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -40,7 +40,7 @@ if (flutterVersionName == null) {
 android {
     namespace "com.matthiasn.lotti"
     compileSdkVersion rootProject.ext.compileSdkVersion
-    ndkVersion "28.2.13676358"
+    ndkVersion rootProject.ext.ndkVersion
 
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,6 +2,12 @@ buildscript {
     ext {
         kotlin_version = '2.2.20'
         compileSdkVersion = 36
+        // NDK r28 is the first release that aligns shared libraries to 16 KB by
+        // default, which Google Play requires of apps targeting Android 15+.
+        // Plugins that do not pin an NDK fall back to the Android Gradle Plugin
+        // default (r27 or older) and would ship 4 KB-aligned .so files, so the
+        // subprojects block below pins every module to this version.
+        ndkVersion = '28.2.13676358'
     }
     repositories {
         google()
@@ -20,6 +26,12 @@ subprojects {
     
     beforeEvaluate { project ->
         project.ext.compileSdkVersion = rootProject.ext.compileSdkVersion
+    }
+
+    afterEvaluate { project ->
+        if (project.hasProperty('android')) {
+            project.android.ndkVersion = rootProject.ext.ndkVersion
+        }
     }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1110,14 +1110,6 @@ packages:
       relative: true
     source: path
     version: "1.8.0"
-  flutter_openssl_crypto:
-    dependency: "direct main"
-    description:
-      name: flutter_openssl_crypto
-      sha256: "293b4fcda13ab0710645a16e82f3d5b7de19bfc0ab2d06bcdb87637222eda5e1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,7 +68,6 @@ dependencies:
     sdk: flutter
   flutter_map: ^8.0.0
   flutter_onnxruntime: ^1.8.0
-  flutter_openssl_crypto: ^0.5.0
   flutter_quill: ^11.5.1
   flutter_quill_extensions: ^11.0.0
   flutter_rating: ^2.0.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Android build settings to consistently use NDK r28, improving compatibility with Android 15+ 16 KB memory page requirements.

* **Chores**
  * Removed the unused OpenSSL cryptography package dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->