### PR TITLE
chore: bump build number

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.26+4369
+version: 1.0.26+4370
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
Bumps the build number so the Android 16 KB page-size fixes in #4125 can ship.

Play refuses a version code it has already seen, and `1.0.26+4369` is already
on the internal track, so shipping #4125 needs a fresh build number.

No code changes — one line in `pubspec.yaml`.

## Why this build matters

#4125 fixed the Google Play production rejection:

```
403 — "Artifact does not support 16KB page size: 4369."
```

Verified locally on a profile build: all 36 arm64-v8a and x86_64 native
libraries are now 16 KB-aligned, and `libmp3lame.so` moved from clang 18.0.1
(NDK r27) to clang 19.0.1 (NDK r28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NZ7h1xZY5Hy4Q6ngGS2HT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to build 4370.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->