### PR TITLE
fix(plaza): flights turn smoothly — direction blends, arrival holds the road, diagonal joins

### DIFF
--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -463,7 +463,9 @@ A `Flight` is planned once, as a chain of straight **legs** with one
   diagonal: `pathBetween(a, b, join:)` slides both projections
   `joinDistance` (8 m) along the way, never past the next vertex and never
   past each other, so the first and last legs are slants, not right-angled
-  hops.
+  hops. A vertex within `mergeDistance` of a projection counts as reached:
+  a stop at a corner, or at home, joins the way there and never slides
+  round the corner onto the next stretch.
 
 The street network (`domain/street_network.dart`) is the polyline of
 every segment, gaps and fold connectors included, continued through the

--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -446,10 +446,24 @@ A `Flight` is planned once, as a chain of straight **legs** with one
   ground and at least 55 % horizontal, yaw turns into the travel heading
   over the first ramp's distance, holds it, and settles onto the target
   yaw over the last ramp's distance; shorter or mostly vertical trips
-  blend yaw directly, the short way round. On a routed flight the yaw
-  looks at the point `lookAhead` (12 m) further along the way, which turns
-  a corner before reaching it, and settles onto the stop's yaw over the
-  last ramp; the pitch is level between the two stops' own pitches.
+  blend yaw directly. On a routed flight the yaw looks at the point
+  `lookAhead` (12 m) further along the way, which turns a corner before
+  reaching it. When the stop stands beside the road the last leg is the
+  **arrival** hop off the way: the look-ahead stops where the way leaves
+  the road and the camera holds the road's heading through the hop, then
+  turns onto the stop's own heading over the last ramp, instead of
+  swinging toward the stop and back. Each ramp blends between two *fixed*
+  headings (the way's heading where the ramp ends, or where it starts),
+  so the side the camera turns to is settled for the whole ramp, and a
+  blend is a slerp of the two direction vectors (`_blendHeading`), so a
+  heading that crosses the ±π seam of `atan2` between two frames is no
+  turn at all; only exactly opposite headings fall back to the angle
+  blend. The pitch is level between the two stops' own pitches.
+- **Joins.** A stop beside the road merges onto it and pulls off it on a
+  diagonal: `pathBetween(a, b, join:)` slides both projections
+  `joinDistance` (8 m) along the way, never past the next vertex and never
+  past each other, so the first and last legs are slants, not right-angled
+  hops.
 
 The street network (`domain/street_network.dart`) is the polyline of
 every segment, gaps and fold connectors included, continued through the

--- a/lib/features/plaza/domain/flight.dart
+++ b/lib/features/plaza/domain/flight.dart
@@ -20,6 +20,7 @@ class Flight {
     required List<_Leg> legs,
     required _Profile profile,
     required this.routed,
+    this.arrival = false,
     // A private field cannot be a named initializing formal.
     // ignore: prefer_initializing_formals
   }) : _legs = legs,
@@ -70,10 +71,13 @@ class Flight {
       if (_apart(points.last, x, z) < viaMergeDistance) continue;
       points.add(CameraPose(x: x, y: streetFlightHeight, z: z, yaw: 0));
     }
-    // The stop itself, not a via point a step short of it.
+    // The stop itself, not a via point a step short of it; otherwise the
+    // last leg is the hop off the way to the stop.
+    var arrival = points.length > 1;
     if (points.length > 1 &&
         _apart(points.last, to.x, to.z) < viaMergeDistance) {
       points.removeLast();
+      arrival = false;
     }
     points.add(to);
     final legs = <_Leg>[
@@ -94,6 +98,7 @@ class Flight {
         ramp: rampSeconds / timeScale,
       ),
       routed: true,
+      arrival: arrival && legs.length > 1,
     );
   }
 
@@ -119,6 +124,10 @@ class Flight {
 
   /// A street flight looks at the point this far ahead along the way.
   static const lookAhead = 12.0;
+
+  /// A stop beside the road joins it, and leaves it, on a diagonal this
+  /// long along the way (see `StreetNetwork.pathBetween`).
+  static const joinDistance = 8.0;
 
   /// A via point this close to the previous point is dropped.
   static const viaMergeDistance = 0.5;
@@ -156,6 +165,12 @@ class Flight {
 
   /// Whether the flight follows the street (see [Flight.route]).
   final bool routed;
+
+  /// Whether the last leg is the hop off the way to a stop beside it: the
+  /// camera holds the road's heading through it and turns onto the stop's
+  /// own heading over the last ramp, instead of swinging toward the stop
+  /// and back.
+  final bool arrival;
 
   final List<_Leg> _legs;
   final _Profile _profile;
@@ -272,14 +287,22 @@ class Flight {
         ? 1.0
         : ((d - (total - ramp)) / ramp).clamp(0.0, 1.0);
 
+    // The ramps blend between two fixed headings (the way's heading where
+    // the ramp ends, and where it starts), so the side the camera turns to
+    // is settled for the whole ramp; between them the camera looks down
+    // the way.
     final double yaw;
     final along = routed ? _lookAheadYaw(d, x, z, leg) : travelYaw;
     if (along == null) {
-      yaw = _turn(from.yaw, to.yaw, _smooth(t));
+      yaw = _blendHeading(from.yaw, to.yaw, _smooth(t));
     } else if (d < ramp) {
-      yaw = _turn(from.yaw, along, _smooth(inRamp));
+      yaw = _blendHeading(from.yaw, _wayHeadingAt(ramp), _smooth(inRamp));
     } else if (d > total - ramp) {
-      yaw = _turn(along, to.yaw, _smooth(outRamp));
+      yaw = _blendHeading(
+        _wayHeadingAt(total - ramp),
+        to.yaw,
+        _smooth(outRamp),
+      );
     } else {
       yaw = along;
     }
@@ -299,22 +322,57 @@ class Flight {
     return CameraPose(x: x, y: y, z: z, yaw: yaw, pitch: pitch + pitchDip);
   }
 
+  /// The heading the camera looks in [d] metres along the way: the
+  /// look-ahead heading of a routed flight, the travel heading of a direct
+  /// one.
+  double _wayHeadingAt(double d) {
+    if (!routed) return travelYaw ?? to.yaw;
+    final (leg, f) = _locate(d);
+    final x = leg.from.x + (leg.to.x - leg.from.x) * f;
+    final z = leg.from.z + (leg.to.z - leg.from.z) * f;
+    return _lookAheadYaw(d, x, z, leg);
+  }
+
   /// The heading from ([x], [z]) to the point [lookAhead] metres further
-  /// along the way; the leg's own heading once the way runs out.
+  /// along the way, which ends where the way leaves the road when the
+  /// flight has an [arrival] hop; past that, the road's last heading.
   double _lookAheadYaw(double d, double x, double z, _Leg leg) {
-    final ahead = math.min(length, d + lookAhead);
+    final road = arrival ? _legs[_legs.length - 2] : _legs.last;
+    final wayEnd = arrival ? length - _legs.last.length : length;
+    final ahead = math.min(wayEnd, d + lookAhead);
+    if (ahead <= d + 1e-6) return _heading(road);
     final (ax, az) = _groundAt(ahead);
     final dx = ax - x;
     final dz = az - z;
-    if (dx * dx + dz * dz < 1e-6) {
-      return math.atan2(leg.to.x - leg.from.x, leg.to.z - leg.from.z);
-    }
+    if (dx * dx + dz * dz < 1e-6) return _heading(leg);
     return math.atan2(dx, dz);
   }
 
+  static double _heading(_Leg leg) =>
+      math.atan2(leg.to.x - leg.from.x, leg.to.z - leg.from.z);
+
   static double _smooth(double t) => t * t * (3 - 2 * t);
 
-  /// Interpolates a heading the short way round.
+  /// Interpolates a heading the short way round, as a turn of the
+  /// direction itself (a slerp of the two unit vectors), so a heading
+  /// that crosses the ±π seam of `atan2` between two frames turns the
+  /// camera by nothing, not by a full circle. Opposite headings, where the
+  /// short way is either way, turn through the angle.
+  static double _blendHeading(double a, double b, double s) {
+    final ax = math.sin(a);
+    final az = math.cos(a);
+    final bx = math.sin(b);
+    final bz = math.cos(b);
+    final dot = (ax * bx + az * bz).clamp(-1.0, 1.0);
+    final omega = math.acos(dot);
+    if (omega < 1e-4) return a;
+    if (omega > math.pi - 1e-3) return _turn(a, b, s);
+    final wa = math.sin((1 - s) * omega) / math.sin(omega);
+    final wb = math.sin(s * omega) / math.sin(omega);
+    return math.atan2(wa * ax + wb * bx, wa * az + wb * bz);
+  }
+
+  /// Interpolates a heading the short way round, by angle.
   static double _turn(double a, double b, double s) {
     var d = b - a;
     while (d > math.pi) {

--- a/lib/features/plaza/domain/street_network.dart
+++ b/lib/features/plaza/domain/street_network.dart
@@ -117,15 +117,27 @@ class StreetNetwork {
     return (along: best.along, x: best.x, z: best.z, offset: bestOffset);
   }
 
-  /// The way along the network from [a] to [b]: the projection of [a],
-  /// every vertex between, and the projection of [b], in travel order.
-  /// A stop standing on the network contributes no projection of its own.
-  List<(double, double)> pathBetween((double, double) a, (double, double) b) {
+  /// The way along the network from [a] to [b]: where [a] joins it, every
+  /// vertex between, and where [b] leaves it, in travel order. With [join]
+  /// the joins slide [join] metres along the way (never past the next
+  /// vertex, never past each other), so a stop beside the road merges onto
+  /// it and pulls off it on a diagonal instead of a right-angled hop.
+  /// Coincident points are merged, so a stop on the way adds nothing.
+  List<(double, double)> pathBetween(
+    (double, double) a,
+    (double, double) b, {
+    double join = 0,
+  }) {
     final pa = project(a.$1, a.$2);
     final pb = project(b.$1, b.$2);
     final forward = pa.along <= pb.along;
-    final lo = math.min(pa.along, pb.along);
-    final hi = math.max(pa.along, pb.along);
+    final dir = forward ? 1.0 : -1.0;
+    final span = (pb.along - pa.along).abs();
+    final slide = math.min(join, span / 2);
+    final start = _slide(pa.along, dir * slide);
+    final end = _slide(pb.along, -dir * slide);
+    final lo = math.min(start, end);
+    final hi = math.max(start, end);
     final between = <(double, double)>[
       for (var i = 0; i < vertices.length; i++)
         if (_cumulative[i] > lo + mergeDistance &&
@@ -133,10 +145,25 @@ class StreetNetwork {
           vertices[i],
     ];
     final way = <(double, double)>[
-      if (pa.offset > mergeDistance) (pa.x, pa.z),
+      pointAt(start),
       ...forward ? between : between.reversed,
-      if (pb.offset > mergeDistance) (pb.x, pb.z),
+      pointAt(end),
     ];
     return _distinct(way);
+  }
+
+  /// [along] moved by [by] metres, stopped at the first vertex on the way:
+  /// a join slides along its own stretch, never round a corner.
+  double _slide(double along, double by) {
+    if (by == 0) return along;
+    var limit = by > 0 ? length : 0.0;
+    for (final c in _cumulative) {
+      if (by > 0 && c > along + mergeDistance) {
+        limit = math.min(limit, c);
+      } else if (by < 0 && c < along - mergeDistance) {
+        limit = math.max(limit, c);
+      }
+    }
+    return by > 0 ? math.min(along + by, limit) : math.max(along + by, limit);
   }
 }

--- a/lib/features/plaza/domain/street_network.dart
+++ b/lib/features/plaza/domain/street_network.dart
@@ -128,6 +128,7 @@ class StreetNetwork {
     (double, double) b, {
     double join = 0,
   }) {
+    assert(join >= 0, 'a join is a distance along the way');
     final pa = project(a.$1, a.$2);
     final pb = project(b.$1, b.$2);
     final forward = pa.along <= pb.along;
@@ -152,18 +153,22 @@ class StreetNetwork {
     return _distinct(way);
   }
 
-  /// [along] moved by [by] metres, stopped at the first vertex on the way:
-  /// a join slides along its own stretch, never round a corner.
+  /// [along] moved by [by] metres, stopped at the first vertex on the way,
+  /// one within [mergeDistance] of [along] included: a join slides along
+  /// its own stretch, never round a corner, and a stop at a corner joins
+  /// the way there.
   double _slide(double along, double by) {
     if (by == 0) return along;
     var limit = by > 0 ? length : 0.0;
     for (final c in _cumulative) {
-      if (by > 0 && c > along + mergeDistance) {
+      if (by > 0 && c > along - mergeDistance) {
         limit = math.min(limit, c);
-      } else if (by < 0 && c < along - mergeDistance) {
+      } else if (by < 0 && c < along + mergeDistance) {
         limit = math.max(limit, c);
       }
     }
-    return by > 0 ? math.min(along + by, limit) : math.max(along + by, limit);
+    return by > 0
+        ? math.max(along, math.min(along + by, limit))
+        : math.min(along, math.max(along + by, limit));
   }
 }

--- a/lib/features/plaza/ui/fly_camera_controller.dart
+++ b/lib/features/plaza/ui/fly_camera_controller.dart
@@ -111,6 +111,7 @@ class FlyCameraController {
             via: network.pathBetween(
               (_pose.x, _pose.z),
               (target.x, target.z),
+              join: Flight.joinDistance,
             ),
             timeScale: timeScale,
             solids: _solids,

--- a/test/features/plaza/domain/flight_test.dart
+++ b/test/features/plaza/domain/flight_test.dart
@@ -152,7 +152,9 @@ void main() {
       const CameraPose(x: 0, y: 0, z: 0, yaw: 0.2),
     );
     // Half-way between -0.2 and 0.2: a full turn, not back through π.
-    expect(f.poseAt(0.5).yaw % (2 * math.pi), closeTo(0, 1e-9));
+    // Compared as a direction: the seam of atan2 is not a turn.
+    expect(math.sin(f.poseAt(0.5).yaw), closeTo(0, 1e-9));
+    expect(math.cos(f.poseAt(0.5).yaw), closeTo(1, 1e-9));
   });
 
   test('advance accumulates time and clamps at the end', () {
@@ -431,6 +433,64 @@ void main() {
         expect(f.poseAt(1).pitch, closeTo(0.1, 1e-9));
       },
     );
+
+    test(
+      'the arrival hop holds the road heading; no swing toward the stop',
+      () {
+        expect(f.arrival, isTrue);
+        // Eight metres before the way leaves the road (d = 103), the
+        // look-ahead would already point at the stop; the camera keeps
+        // looking north instead.
+        expect(f.poseAt(timeAt(f, 95)).yaw, closeTo(0, 1e-6));
+        // Through the last ramp the heading turns from north to the stop's
+        // own, one way, never past either.
+        var last = 0.0;
+        for (var d = 98.0; d <= f.length; d += 0.25) {
+          final yaw = f.poseAt(timeAt(f, d)).yaw;
+          expect(yaw, greaterThanOrEqualTo(last - 1e-9), reason: 'd $d');
+          expect(yaw, lessThanOrEqualTo(1 + 1e-9), reason: 'd $d');
+          last = yaw;
+        }
+        // Without the hop the way runs to the stop itself.
+        final onWay = Flight.route(
+          from,
+          const CameraPose(x: 50, y: 2.2, z: 50, yaw: 1),
+          via: via,
+        );
+        expect(onWay.arrival, isFalse);
+      },
+    );
+
+    test('a way down the -Z axis never spins across the atan2 seam', () {
+      // Facing +Z, the way goes straight back down -Z: a half turn at the
+      // start, then a quarter turn onto the stop at the end.
+      const from = CameraPose(x: 2, y: 2.2, z: 3, yaw: 0);
+      const to = CameraPose(x: 3, y: 2.2, z: -63, yaw: math.pi / 2);
+      final g = Flight.route(
+        from,
+        to,
+        via: const [(0.0, 0.0), (0.0, -60.0)],
+      );
+      var turned = 0.0;
+      var maxStep = 0.0;
+      var previous = g.poseAt(0).yaw;
+      for (var t = 0.001; t <= 1.0001; t += 0.001) {
+        final yaw = g.poseAt(t).yaw;
+        // The turn between two frames, as directions: the seam is no turn.
+        final step = math.acos(
+          (math.sin(previous) * math.sin(yaw) +
+                  math.cos(previous) * math.cos(yaw))
+              .clamp(-1.0, 1.0),
+        );
+        turned += step;
+        maxStep = math.max(maxStep, step);
+        previous = yaw;
+      }
+      expect(maxStep, lessThan(0.06));
+      // A half turn, a small swing onto the way, a quarter turn: not more.
+      expect(turned, lessThan(math.pi + math.pi / 2 + 0.3));
+      expect(turned, greaterThan(math.pi + math.pi / 2 - 0.3));
+    });
 
     test(
       'a via point on a stop is dropped, and a stop on the way needs none',

--- a/test/features/plaza/domain/street_network_test.dart
+++ b/test/features/plaza/domain/street_network_test.dart
@@ -73,8 +73,40 @@ void main() {
         // Two stops six metres apart share the middle.
         final close = corner.pathBetween((10, -3), (16, -3), join: 8);
         expect(close, [(13, 0)]);
+        // A stop at the corner, or within the merge tolerance of it, joins
+        // the way at the corner: the join never slides round it onto the
+        // next stretch.
+        expect(corner.pathBetween((49.98, -3), (53, 40), join: 8), [
+          (50, 0),
+          (50, 32),
+        ]);
+        expect(corner.pathBetween((50, 0), (53, 40), join: 8), [
+          (50, 0),
+          (50, 32),
+        ]);
+        expect(corner.pathBetween((53, 40), (50.02, -3), join: 8), [
+          (50, 32),
+          (50, 0),
+        ]);
+        // A stop at the end of the network joins it there.
+        expect(corner.pathBetween((10, -3), (50, 50), join: 8), [
+          (18, 0),
+          (50, 0),
+          (50, 50),
+        ]);
       },
     );
+
+    test('a join is a distance: never negative', () {
+      expect(
+        () => corner.pathBetween((10, -3), (53, 40), join: -1),
+        throwsAssertionError,
+      );
+      expect(
+        () => corner.pathBetween((10, -3), (53, 40), join: double.nan),
+        throwsAssertionError,
+      );
+    });
   });
 
   group('of a street plan', () {

--- a/test/features/plaza/domain/street_network_test.dart
+++ b/test/features/plaza/domain/street_network_test.dart
@@ -48,11 +48,33 @@ void main() {
       expect(out, [(10, 0), (50, 0), (50, 40)]);
       final back = corner.pathBetween((53, 40), (10, -3));
       expect(back, out.reversed.toList());
-      // A stop on the way contributes no projection: two on one stretch
-      // have nothing between them, and a flight joins them directly.
-      expect(corner.pathBetween((10, 0), (30, 0)), isEmpty);
+      // Two stops on one stretch: their own points, nothing between.
+      expect(corner.pathBetween((10, 0), (30, 0)), [(10, 0), (30, 0)]);
       expect(corner.pathBetween((10, -3), (30, -3)), [(10, 0), (30, 0)]);
     });
+
+    test(
+      'a join slides along the way, never round a corner or past the other',
+      () {
+        // Eight metres in from each stop's projection.
+        expect(
+          corner.pathBetween((10, -3), (53, 40), join: 8),
+          [(18, 0), (50, 0), (50, 32)],
+        );
+        expect(
+          corner.pathBetween((53, 40), (10, -3), join: 8),
+          [(50, 32), (50, 0), (18, 0)],
+        );
+        // A join five metres from the corner stops at the corner.
+        expect(corner.pathBetween((45, -3), (53, 40), join: 8), [
+          (50, 0),
+          (50, 32),
+        ]);
+        // Two stops six metres apart share the middle.
+        final close = corner.pathBetween((10, -3), (16, -3), join: 8);
+        expect(close, [(13, 0)]);
+      },
+    );
   });
 
   group('of a street plan', () {
@@ -93,11 +115,11 @@ void main() {
         (pose.x, pose.z),
         (plaza.home.x, plaza.home.z),
       );
-      // Starts at the pose's projection, ends at the mouth: home itself is
-      // on the network and needs no point.
+      // Starts at the pose's projection and ends at home, which is on the
+      // network: its own point.
       final start = network.project(pose.x, pose.z);
       expect(way.first, (start.x, start.z));
-      expect(way.last, network.vertices[network.vertices.length - 2]);
+      expect(way.last, (plaza.home.x, plaza.home.z));
       // Every point between is a vertex, in order of the way.
       for (var i = 1; i < way.length; i++) {
         expect(network.vertices, contains(way[i]));

--- a/test/features/plaza/scene/plaza_world_test.dart
+++ b/test/features/plaza/scene/plaza_world_test.dart
@@ -204,7 +204,11 @@ void main() {
         final f = Flight.route(
           from,
           to,
-          via: network.pathBetween((from.x, from.z), (to.x, to.z)),
+          via: network.pathBetween(
+            (from.x, from.z),
+            (to.x, to.z),
+            join: Flight.joinDistance,
+          ),
           solids: world.solids,
         );
         routed++;


### PR DESCRIPTION
## What

Follow-up to #4122 on the flights, from the first walk on the merged build: some turns spun more than necessary, and the flights were not smooth overall.

- **The spin.** A routed flight's heading comes from `atan2`, which wraps at ±π, and roads that run toward −Z sit exactly on that seam: the look-ahead heading flipped sign between frames on lateral noise, and the angle blend during the first and last ramps flipped the camera with it. Headings now blend as direction vectors (a slerp of the two unit vectors), so crossing the seam is no turn at all; each ramp blends between two *fixed* headings (the way's heading where the ramp ends, or where it starts), so the side the camera turns to is settled for the whole ramp; only exactly opposite headings fall back to the angle blend.
- **The swing at arrival.** The last leg to a stop beside the road is a hop off the way, and the look-ahead used to point at the stop through it, swinging the camera toward the stop and then back onto the building. The look-ahead now ends where the way leaves the road and the camera holds the road's heading through the hop, then turns onto the stop's own heading over the last ramp.
- **Diagonal joins.** A stop beside the road used to join it with a right-angled hop. `StreetNetwork.pathBetween` now slides both joins 8 m along the way (never past the next vertex, never past each other), so the first and last legs are slants.

Motion only; no stills. `knowledge/features/plaza.md` describes the yaw model and the joins.

## Verification

- `dart analyze` and `dart format` clean; the plaza flight, network, controller and world tests pass (65).
- New tests: a way down the −Z axis turns at most a few hundredths of a radian per frame and about a half turn plus a quarter turn in total (fails on the old angle blend); the arrival hop holds north eight metres before the way leaves the road and turns one way onto the stop (fails on the old look-ahead); joins slide along the way but never round a corner; the fixture's morning walk is routed with the joins and still needs no lift.
- `make knowledge_check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Camera movement on routed flights now transitions more smoothly when leaving roads for nearby stops.
  * Arrival hops maintain the road’s heading before gradually turning toward the stop, reducing unwanted camera swings.
  * Road joins and departures now use diagonal transitions for more natural movement.
  * Heading changes across angle boundaries no longer cause unexpected full rotations.
* **Documentation**
  * Updated flight documentation to describe the revised heading and road-joining behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->