### PR TITLE
fix(projects): harden membership and agent lifecycle integrity

### DIFF
--- a/changelog.d/2026-09-04-project-data-integrity.md
+++ b/changelog.d/2026-09-04-project-data-integrity.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Project membership stays consistent when tasks or projects change.** Task
+  links now respect category and privacy changes, failed task assignments clean
+  up newly created tasks, and project edits preserve unrelated synced changes.
+  A project's category cannot change while it has linked tasks or a live agent.
+- **Project agents follow synced project changes.** Agents are retired when a
+  synced project disappears, and their category permissions follow synced moves
+  without scheduling an unnecessary report.

--- a/knowledge/features/agents/project-and-event-agents.md
+++ b/knowledge/features/agents/project-and-event-agents.md
@@ -5,7 +5,7 @@ description: The digest-shaped project agent that resists waking on every linked
 resource: ../../../lib/features/agents/workflow/project_agent_workflow.dart
 tags: [agents, project-agent, event-agent, digest, notifications]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T00:00:00Z }
+generated: { by: codex/gpt-5, at: 2026-09-04T12:00:00Z }
 stale_after: 2026-10-12
 sources:
   - id: project-workflow
@@ -19,7 +19,11 @@ sources:
   - id: project-service
     resource: ../../../lib/features/agents/service/project_agent_service.dart
     title: ProjectAgentService (creation and announcement)
-    last_modified: 2026-08-14
+    last_modified: 2026-08-16
+  - id: project-mutations
+    resource: ../../../lib/features/agents/service/project_agent_mutation_coordinator.dart
+    title: Shared project category, provisioning, and retirement exclusion
+    last_modified: 2026-09-04
   - id: event-service
     resource: ../../../lib/features/agents/service/event_agent_service.dart
     title: EventAgentService (creation, content gate and announcement)
@@ -46,15 +50,39 @@ expensive and useless.
 
 `ProjectAgentService.createProjectAgent()`:
 
-1. Enforces one project agent per project.
-2. Validates the template is a project-agent template.
-3. Creates identity and state.
-4. Sets `slots.activeProjectId` and marks the explicit creation work pending.
-5. Persists a one-shot next-06:00 fallback for the in-memory creation wake.
-6. Creates `agent_project` and `template_assignment` links.
-7. Announces itself (see below).
-8. Registers the project subscription.
-9. Enqueues the explicit creation wake.
+1. Serializes with scope reconciliation of the same project,
+   then verifies the journal project still exists with the requested category.
+2. Enforces one project agent per project.
+3. Re-reads the template and validates that it is an active project-agent
+   template whose category scope still applies to the requested project scope.
+4. Creates identity and state.
+5. Sets `slots.activeProjectId` and marks the explicit creation work pending.
+6. Persists a one-shot next-06:00 fallback for the in-memory creation wake.
+7. Creates `agent_project` and `template_assignment` links.
+8. Rechecks the journal project and category; a sync tombstone or scope change
+   compensates by deleting the just-created agent before it can be announced,
+   subscribed, or woken.
+9. Announces itself (see below).
+10. Registers the project subscription.
+11. Enqueues the explicit creation wake.
+
+Synced scope reconciliation holds the same per-project coordinator as
+provisioning. It verifies the current journal scope after waiting and reads
+identities and assigned templates inside the agent transaction, preserving
+unrelated preferences. Missing, deleted, wrong-kind, or category-incompatible
+templates retire their agents without granting access to the new category.
+Local category changes are rejected while any live agent or linked task exists.
+Agent and journal data use separate databases, so the coordinator provides
+local exclusion; pre/post-create scope checks cover stale category input and
+independent tombstones or category changes arriving through sync.
+Because a peer can still apply its tombstone or category move after that final check,
+`ProjectActivityMonitor` also listens to `syncUpdateStream` for project rows.
+Reconciliation shares the per-project mutation coordinator. When the announced
+project is absent, it rechecks absence immediately before each retirement,
+cancels queued/running work, and attempts every linked agent even if one fails.
+A project restored during link lookup instead receives scope reconciliation.
+Surviving projects retain only agents whose templates permit the synced category. This is reconciliation only: synced edits never enter the
+local activity path and therefore never arm a new wake.
 
 ## Announcing a newly created agent
 

--- a/knowledge/features/projects.md
+++ b/knowledge/features/projects.md
@@ -5,7 +5,7 @@ description: The middle layer between categories and tasks — a denormalized me
 resource: ../../lib/features/projects
 tags: [projects, grouping, health, agents]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T03:00:00Z }
+generated: { by: codex/gpt-5, at: 2026-09-04T21:30:00Z }
 stale_after: 2027-03-01
 sources:
   - id: src
@@ -69,11 +69,24 @@ the latest non-hidden `ProjectLink` on every link and entity write**, so the
 result is identical to the old join without its
 `USE TEMP B-TREE FOR ORDER BY` sort.
 
-## Membership is scoped to a category — from the task's side
+## Membership is scoped to category and privacy
 
-`linkTaskToProject` refuses a link whose two sides disagree on category, which
-covers the moment the link is created. But a category can move afterwards, and
-that write is nowhere near the link, so the rule has to be re-checked there too.
+`linkTaskToProject` re-reads both entities and refuses a link whose two sides
+disagree on category or privacy. The fresh privacy check closes the async gap
+between resolving a project for task creation and persisting its link: if sync
+changes project privacy in between, the link is rejected and the creation path
+soft-deletes the new task. Nullable privacy is normalized with `?? false`, so
+legacy `null` and explicit `false` are both public and remain link-compatible.
+`createTask` also rejects conflicting explicit-project and linked-entity privacy
+before writing anything; it does not silently downgrade either context. If an
+assignment race requires cleanup and that cleanup cannot be confirmed, creation
+throws instead of claiming success. The Tasks tab catches that failure, shows a
+localized error, and does not navigate to the failed task.
+Project-agent
+`create_task` calls pass the project's privacy into task creation before
+linking. A category can still move after linking, and that
+write is nowhere near the link, so the category rule has to be re-checked there
+too.
 
 **`EntryController.updateCategoryId` does that for the task side**: it drops the
 project link of every task it moves when the new category is not the project's
@@ -82,12 +95,12 @@ own.
 ```mermaid
 stateDiagram-v2
   [*] --> Unlinked
-  Unlinked --> Linked: linkTaskToProject (same category only)
+  Unlinked --> Linked: linkTaskToProject (same category and privacy)
   Linked --> Linked: task category re-picked unchanged
   Linked --> Unlinked: task category changed or cleared
-  Linked --> Mismatched: project moved to another category
-  note right of Mismatched
-    Not reconciled — see below
+  Linked --> Linked: project category change rejected
+  note right of Linked
+    Membership always resolves to one category
   end note
 ```
 
@@ -111,6 +124,13 @@ A task whose category write did not land is not swept. A failed write means the
 entity was not found — deleted since it was read, or never there — so it keeps
 the category it had, and its project is still correct for it.
 
+Privacy toggles follow the same invariant. After a task privacy write commits,
+`EntryController.togglePrivate` requests a conditional repository unlink. Its
+transaction rechecks the membership and both entries without the private gate;
+a concurrent replacement link or newly matching privacy is preserved.
+The cleanup does not run after a failed privacy write, so a task that stayed
+public cannot lose a still-valid public-project membership.
+
 The sweep covers the entries the same call re-categorized, not just the edited
 one. `getLinkedEntities` is **not filtered by link type**, so the propagation
 loop rewrites the category of linked *tasks* along with the timers and images it
@@ -121,12 +141,24 @@ Only the task detail header changes a task's category
 (`CategorySelectionIconButton` excludes tasks and events explicitly), so the
 controller is the single funnel this rule has to sit in.
 
-**The project side is not reconciled.** `ProjectDetailController.updateCategoryId`
-persists a project's new category through `ProjectRepository.updateProject`
-without touching its member tasks, so moving a *project* between categories
-leaves every linked task behind in the old one and reproduces exactly the
-mismatch the task side now prevents. Nothing repairs pre-existing mismatches
-either — only a subsequent task-side category change clears one.
+**Project category changes are guarded, not bulk migrations.**
+Both editors save through `ProjectRepository.updateProject`, which rejects a
+category change while any task remains linked or any live project agent exists.
+Updates share the per-project mutation coordinator with agent provisioning, so
+the cross-store guard cannot race a locally created agent.
+The task guard uses unfiltered denormalized membership, including hidden private
+tasks. Neither editor rewrites task categories, attachments, membership or
+agent permissions as a side effect of changing the project category.
+
+Synced category moves are reconciled through `ProjectActivityMonitor`.
+`ProjectAgentService.updateProjectAgentScopes` shares the provisioning/deletion
+coordinator, rechecks the current journal scope after waiting, and reads agent
+identities and assigned templates inside its transaction. Only global or
+matching-category templates retain their agents; missing, deleted, wrong-kind,
+or incompatible templates cause retirement without granting the new scope.
+Unchanged valid scopes produce no writes or notifications, and unrelated
+identity preferences are preserved. Reconciliation
+does not classify the remote edit as local activity or schedule a wake.
 
 # Two hot reads are shaped for bursts
 
@@ -176,6 +208,16 @@ the shared 960 pt detail
 measure with its one standard horizontal gutter, keeping report lines and cards
 readable when the list releases a wide canvas without double-insetting mobile
 content.
+
+# Editor persistence
+
+`ProjectDetailController` retains the persisted baseline and local draft.
+Reloads apply only locally changed fields to the latest project, preserving
+unrelated synced fields and rich-text payloads when plain text changes.
+A generation guard discards stale reload completions. A tombstone clears both
+baseline and draft before loading tasks, so saving cannot resurrect a deleted
+project. Repository writes verify ambiguous negative persistence results against
+the committed row before reporting failure.
 
 # Health is agent-authored
 

--- a/lib/features/agents/model/agent_constants.dart
+++ b/lib/features/agents/model/agent_constants.dart
@@ -12,6 +12,12 @@ abstract final class AgentKinds {
   static const relationshipAgent = 'relationship_agent';
 }
 
+/// Notification scopes that carry meaning beyond a single agent entity ID.
+abstract final class AgentNotificationScopes {
+  /// Forces the Projects overview to refresh agent-authored one-liners.
+  static const projectOverview = 'PROJECT_AGENT_OVERVIEW_CHANGED';
+}
+
 /// Tool-call names that carry user-visible conversation output.
 ///
 /// A reply remains an action in the durable log rather than introducing a

--- a/lib/features/agents/service/agent_service.dart
+++ b/lib/features/agents/service/agent_service.dart
@@ -255,6 +255,30 @@ class AgentService {
     return true;
   }
 
+  /// Restores an agent to an exact lifecycle captured before a reversible
+  /// operation.
+  ///
+  /// This is deliberately separate from [resumeAgent]: rollback must not turn
+  /// a previously dormant or not-yet-activated agent into an active one. The
+  /// caller remains responsible for re-registering subscriptions when
+  /// [lifecycle] is [AgentLifecycle.active]. Non-active states remove any
+  /// subscriptions left by the interrupted operation.
+  Future<bool> restoreAgentLifecycle(
+    String agentId,
+    AgentLifecycle lifecycle,
+  ) async {
+    final updated = await _updateLifecycle(agentId, lifecycle);
+    if (!updated) return false;
+    if (lifecycle != AgentLifecycle.active) {
+      orchestrator.removeSubscriptions(agentId);
+    }
+    developer.log(
+      'Restored agent ${DomainLogger.sanitizeId(agentId)} to ${lifecycle.name}',
+      name: 'AgentService',
+    );
+    return true;
+  }
+
   /// Transition agent to [AgentLifecycle.destroyed] and unregister
   /// wake subscriptions.
   ///
@@ -281,9 +305,17 @@ class AgentService {
   /// transition, which syncs the `destroyed` lifecycle to all devices.
   ///
   /// Destroys the agent first if it is not already destroyed, then hard-deletes
-  /// all entities, links, wake runs, and saga ops from the database.
+  /// all entities, links, wake runs, and saga ops from the database. Linked
+  /// project IDs are captured first so project detail/list providers can drop
+  /// agent-authored summaries after the link rows disappear.
   Future<void> deleteAgent(String agentId) async {
     final identity = await getAgent(agentId);
+    final projectIds = identity?.kind == AgentKinds.projectAgent
+        ? (await repository.getLinksFrom(
+            agentId,
+            type: AgentLinkTypes.agentProject,
+          )).map((link) => link.toId).toSet()
+        : const <String>{};
     if (identity != null && identity.lifecycle != AgentLifecycle.destroyed) {
       await destroyAgent(agentId);
     } else {
@@ -298,6 +330,11 @@ class AgentService {
       entityIds: removed.entityIds,
       linkIds: removed.linkIds,
     );
+    final notifyPersistedStateChanged = onPersistedStateChanged;
+    if (projectIds.isNotEmpty && notifyPersistedStateChanged != null) {
+      notifyPersistedStateChanged(AgentNotificationScopes.projectOverview);
+      projectIds.forEach(notifyPersistedStateChanged);
+    }
     developer.log(
       'Deleted all data for agent ${DomainLogger.sanitizeId(agentId)}',
       name: 'AgentService',

--- a/lib/features/agents/service/project_activity_monitor.dart
+++ b/lib/features/agents/service/project_activity_monitor.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
 import 'package:lotti/features/agents/model/agent_time_utils.dart';
+import 'package:lotti/features/agents/service/project_agent_mutation_coordinator.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/agents/util/agent_error_logging.dart';
 import 'package:lotti/features/projects/repository/project_repository.dart';
@@ -127,8 +128,13 @@ class ProjectActivityMonitor with AgentErrorLogging {
     required this._syncService,
     this.domainLogger,
     this._clock = const Clock(),
+    this.retireProjectAgent,
+    this.updateProjectAgentScopes,
+    ProjectAgentMutationCoordinator? mutationCoordinator,
     ProjectActivityCancellationCoordinator? cancellationCoordinator,
-  }) : _cancellationCoordinator =
+  }) : _mutationCoordinator =
+           mutationCoordinator ?? ProjectAgentMutationCoordinator(),
+       _cancellationCoordinator =
            cancellationCoordinator ?? ProjectActivityCancellationCoordinator();
 
   final UpdateNotifications _notifications;
@@ -136,6 +142,13 @@ class ProjectActivityMonitor with AgentErrorLogging {
   final ProjectRepository _projectRepository;
   final AgentSyncService _syncService;
   final ProjectActivityCancellationCoordinator _cancellationCoordinator;
+  final ProjectAgentMutationCoordinator _mutationCoordinator;
+  final Future<void> Function(String agentId)? retireProjectAgent;
+  final Future<void> Function(
+    String projectId,
+    Set<String> allowedCategoryIds,
+  )?
+  updateProjectAgentScopes;
   @override
   final DomainLogger? domainLogger;
 
@@ -144,6 +157,7 @@ class ProjectActivityMonitor with AgentErrorLogging {
   final Clock _clock;
 
   StreamSubscription<Set<String>>? _subscription;
+  StreamSubscription<Set<String>>? _syncSubscription;
 
   void _log(String message, {String? subDomain}) {
     domainLogger?.log(
@@ -156,17 +170,104 @@ class ProjectActivityMonitor with AgentErrorLogging {
   /// Start tracking local project activity.
   void start() {
     _subscription?.cancel();
+    _syncSubscription?.cancel();
     _subscription = _notifications.localUpdateStream.listen((affectedIds) {
       final observedAt = _clock.now();
       final observedSequence = _cancellationCoordinator.captureActivity();
       unawaited(_handleBatch(affectedIds, observedAt, observedSequence));
     });
+    if (retireProjectAgent != null || updateProjectAgentScopes != null) {
+      _syncSubscription = _notifications.syncUpdateStream.listen((affectedIds) {
+        unawaited(_reconcileSyncedProjects(affectedIds));
+      });
+    }
   }
 
   /// Stop tracking project activity.
   Future<void> stop() async {
-    await _subscription?.cancel();
+    await Future.wait([
+      if (_subscription != null) _subscription!.cancel(),
+      if (_syncSubscription != null) _syncSubscription!.cancel(),
+    ]);
     _subscription = null;
+    _syncSubscription = null;
+  }
+
+  /// Reconciles project-agent lifecycle and scope after project sync updates.
+  ///
+  /// Provisioning necessarily spans the journal and agent databases. Even
+  /// after its final existence check, a peer can commit a project tombstone
+  /// before the new identity is announced and woken. The sync notification is
+  /// the durable reconciliation point for that last race: a missing project
+  /// must not retain active agents or queued work, while a surviving project
+  /// must keep every linked agent scoped to its current category.
+  Future<void> _reconcileSyncedProjects(
+    Set<String> affectedIds,
+  ) async {
+    final retireAgent = retireProjectAgent;
+    final updateScopes = updateProjectAgentScopes;
+    if ((retireAgent == null && updateScopes == null) ||
+        !affectedIds.contains(projectNotification)) {
+      return;
+    }
+
+    final candidateProjectIds = affectedIds.difference({
+      projectNotification,
+      labelUsageNotification,
+    });
+    for (final projectId in candidateProjectIds) {
+      try {
+        await _mutationCoordinator.run(projectId, () async {
+          final project = await _projectRepository.getProjectById(projectId);
+          if (project != null) {
+            await updateScopes?.call(projectId, {
+              if (project.meta.categoryId case final String categoryId)
+                categoryId,
+            });
+            return;
+          }
+          if (retireAgent == null) return;
+          final links = await _agentRepository.getLinksTo(
+            projectId,
+            type: AgentLinkTypes.agentProject,
+          );
+          final retiredAgentIds = <String>{};
+          for (final link in links) {
+            if (retiredAgentIds.add(link.fromId)) {
+              try {
+                final currentProject = await _projectRepository.getProjectById(
+                  projectId,
+                );
+                if (currentProject != null) {
+                  await updateScopes?.call(projectId, {
+                    if (currentProject.meta.categoryId
+                        case final String categoryId)
+                      categoryId,
+                  });
+                  return;
+                }
+                await retireAgent(link.fromId);
+              } catch (error, stackTrace) {
+                logError(
+                  'failed to retire project agent '
+                  '${DomainLogger.sanitizeId(link.fromId)} for project '
+                  '${DomainLogger.sanitizeId(projectId)}',
+                  error: error,
+                  stackTrace: stackTrace,
+                );
+              }
+            }
+          }
+        });
+      } catch (error, stackTrace) {
+        logError(
+          'failed to reconcile synced project '
+          '${DomainLogger.sanitizeId(projectId)}',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+    }
   }
 
   Future<void> _handleBatch(

--- a/lib/features/agents/service/project_agent_mutation_coordinator.dart
+++ b/lib/features/agents/service/project_agent_mutation_coordinator.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Serializes project-agent provisioning with destructive project mutations.
+///
+/// Agent state and projects live in separate databases, so they cannot share a
+/// database transaction. Holding this per-project coordinator across both the
+/// final project existence checks and the destructive project flow closes the
+/// local create/delete race; a post-create check still compensates project
+/// tombstones arriving independently through sync.
+class ProjectAgentMutationCoordinator {
+  static final Object _activeProjectZoneKey = Object();
+  final Map<String, Future<void>> _tails = {};
+
+  Future<T> run<T>(String projectId, Future<T> Function() action) async {
+    if (Zone.current[_activeProjectZoneKey] == projectId) {
+      return action();
+    }
+    final previous = _tails[projectId] ?? Future<void>.value();
+    final completed = Completer<void>();
+    final tail = completed.future;
+    _tails[projectId] = tail;
+    await previous;
+    try {
+      return await runZoned(
+        action,
+        zoneValues: {_activeProjectZoneKey: projectId},
+      );
+    } finally {
+      completed.complete();
+      if (identical(_tails[projectId], tail)) {
+        final _ = _tails.remove(projectId);
+      }
+    }
+  }
+}
+
+/// Shared by journal category edits, agent provisioning, and retirement.
+final projectAgentMutationCoordinatorProvider =
+    Provider<ProjectAgentMutationCoordinator>(
+      (_) => ProjectAgentMutationCoordinator(),
+      name: 'projectAgentMutationCoordinatorProvider',
+    );

--- a/lib/features/agents/service/project_agent_service.dart
+++ b/lib/features/agents/service/project_agent_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:clock/clock.dart';
@@ -12,11 +13,15 @@ import 'package:lotti/features/agents/model/agent_link.dart';
 import 'package:lotti/features/agents/model/agent_time_utils.dart';
 import 'package:lotti/features/agents/service/agent_service.dart';
 import 'package:lotti/features/agents/service/project_activity_monitor.dart';
+import 'package:lotti/features/agents/service/project_agent_mutation_coordinator.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:uuid/uuid.dart';
+
+export 'package:lotti/features/agents/service/project_agent_mutation_coordinator.dart'
+    show ProjectAgentMutationCoordinator;
 
 /// Project-agent-specific lifecycle management.
 ///
@@ -28,6 +33,8 @@ class ProjectAgentService {
     required this.repository,
     required this.orchestrator,
     required this.syncService,
+    required this.projectScopeIsCurrent,
+    required this.mutationCoordinator,
     this.domainLogger,
     this.onPersistedStateChanged,
     ProjectActivityCancellationCoordinator? cancellationCoordinator,
@@ -37,6 +44,12 @@ class ProjectAgentService {
   final AgentService agentService;
   final AgentRepository repository;
   final WakeOrchestrator orchestrator;
+  final Future<bool> Function(
+    String projectId,
+    Set<String> allowedCategoryIds,
+  )
+  projectScopeIsCurrent;
+  final ProjectAgentMutationCoordinator mutationCoordinator;
   final ProjectActivityCancellationCoordinator _cancellationCoordinator;
 
   /// Sync-aware write service. All entity/link writes go through this so
@@ -53,23 +66,31 @@ class ProjectAgentService {
   /// Create a new Project Agent for [projectId].
   ///
   /// Steps:
-  /// 1. Create the agent via [AgentService.createAgent] with kind
+  /// 1. Serialize with project deletion and verify the project still exists.
+  /// 2. Create the agent via [AgentService.createAgent] with kind
   ///    `'project_agent'`.
-  /// 2. Update the agent's state with `activeProjectId = projectId`.
-  /// 3. Create an [AgentProjectLink] from agentId → projectId.
-  /// 4. If [templateId] is provided, create a `templateAssignment` link.
-  /// 5. Enqueue a creation wake with a one-shot persisted fallback.
+  /// 3. Update the agent's state with `activeProjectId = projectId`.
+  /// 4. Create an [AgentProjectLink] from agentId → projectId.
+  /// 5. If [templateId] is provided, create a `templateAssignment` link.
+  /// 6. Compensate a concurrent sync tombstone before announcing the agent.
+  /// 7. Enqueue a creation wake with a one-shot persisted fallback.
   ///
   /// Returns the created [AgentIdentityEntity].
   ///
-  /// Throws [StateError] if a Project Agent already exists for [projectId].
+  /// Throws [StateError] if the project no longer exists, its current category
+  /// differs from [allowedCategoryIds], or a Project Agent already exists for
+  /// [projectId].
   Future<AgentIdentityEntity> createProjectAgent({
     required String projectId,
     required String templateId,
     required String displayName,
     required Set<String> allowedCategoryIds,
     String? profileId,
-  }) async {
+  }) => mutationCoordinator.run(projectId, () async {
+    if (!await projectScopeIsCurrent(projectId, allowedCategoryIds)) {
+      throw StateError('Project $projectId no longer has the requested scope.');
+    }
+
     final identity = await syncService.runInTransaction(() async {
       // Definitive duplicate check inside the transaction to prevent
       // concurrent createProjectAgent calls from both committing.
@@ -89,9 +110,11 @@ class ProjectAgentService {
       final templateEntity = await repository.getEntity(templateId);
       if (templateEntity is! AgentTemplateEntity ||
           templateEntity.deletedAt != null ||
-          templateEntity.kind != AgentTemplateKind.projectAgent) {
+          templateEntity.kind != AgentTemplateKind.projectAgent ||
+          !_templateAppliesToScope(templateEntity, allowedCategoryIds)) {
         throw StateError(
-          'Template $templateId is not an active project-agent template.',
+          'Template $templateId is not an active project-agent template for '
+          'the requested project scope.',
         );
       }
 
@@ -156,6 +179,14 @@ class ProjectAgentService {
       return identity;
     });
 
+    // Sync can tombstone the journal project while the independent agent-store
+    // transaction is committing. Compensate before announcing, subscribing, or
+    // waking the new identity so no orphan project agent escapes this method.
+    if (!await projectScopeIsCurrent(projectId, allowedCategoryIds)) {
+      await agentService.deleteAgent(identity.agentId);
+      throw StateError('Project $projectId no longer has the requested scope.');
+    }
+
     onPersistedStateChanged
       ?..call(identity.agentId)
       // `projectAgentProvider` refreshes on the *project* id, and nothing in
@@ -182,6 +213,15 @@ class ProjectAgentService {
     );
 
     return identity;
+  });
+
+  static bool _templateAppliesToScope(
+    AgentTemplateEntity template,
+    Set<String> allowedCategoryIds,
+  ) {
+    if (template.categoryIds.isEmpty) return true;
+    return allowedCategoryIds.length == 1 &&
+        template.categoryIds.contains(allowedCategoryIds.single);
   }
 
   /// Find the Project Agent for [projectId], or `null` if none exists.
@@ -200,6 +240,96 @@ class ProjectAgentService {
     final agentId = links.selectPrimary().fromId;
     return agentService.getAgent(agentId);
   }
+
+  /// Finds every live project agent linked to [projectId].
+  ///
+  /// Concurrent provisioning can temporarily leave multiple active links for
+  /// one project. Destructive project operations must retire all of them, not
+  /// only the primary identity used for ordinary report presentation.
+  Future<List<AgentIdentityEntity>> getProjectAgentsForProject(
+    String projectId,
+  ) async {
+    final links = (await repository.getLinksTo(
+      projectId,
+      type: AgentLinkTypes.agentProject,
+    )).orderedPrimaryFirst();
+    final agentIds = <String>[];
+    final seenAgentIds = <String>{};
+    for (final link in links) {
+      if (seenAgentIds.add(link.fromId)) agentIds.add(link.fromId);
+    }
+    if (agentIds.isEmpty) return const [];
+
+    final entitiesById = await repository.getEntitiesByIds(agentIds);
+    return [
+      for (final agentId in agentIds)
+        if (entitiesById[agentId] case final AgentIdentityEntity identity)
+          if (identity.kind == _agentKind &&
+              identity.lifecycle != AgentLifecycle.destroyed)
+            identity,
+    ];
+  }
+
+  /// Re-scopes every live project agent to [allowedCategoryIds].
+  ///
+  /// Synced project edits share the coordinator used by provisioning and
+  /// deletion. Stale scope requests are ignored; identities are re-read inside
+  /// the agent transaction so unrelated preference changes are preserved.
+  /// Agents with missing, deleted, or category-incompatible templates are
+  /// retired without ever granting access to the new category.
+  Future<void> updateProjectAgentScopes({
+    required String projectId,
+    required Set<String> allowedCategoryIds,
+  }) => mutationCoordinator.run(projectId, () async {
+    if (!await projectScopeIsCurrent(projectId, allowedCategoryIds)) return;
+    final updatedIds = <String>[];
+    final incompatibleIds = <String>[];
+    await syncService.runInTransaction(() async {
+      final identities = await getProjectAgentsForProject(projectId);
+      for (final identity in identities) {
+        final assignments = await repository.getLinksTo(
+          identity.agentId,
+          type: AgentLinkTypes.templateAssignment,
+        );
+        final template = assignments.isEmpty
+            ? null
+            : await repository.getEntity(assignments.selectPrimary().fromId);
+        if (template is! AgentTemplateEntity ||
+            template.deletedAt != null ||
+            template.kind != AgentTemplateKind.projectAgent ||
+            !_templateAppliesToScope(template, allowedCategoryIds)) {
+          incompatibleIds.add(identity.agentId);
+          continue;
+        }
+        if (identity.allowedCategoryIds.length == allowedCategoryIds.length &&
+            identity.allowedCategoryIds.containsAll(allowedCategoryIds)) {
+          continue;
+        }
+        await syncService.upsertEntity(
+          identity.copyWith(
+            allowedCategoryIds: Set<String>.unmodifiable(allowedCategoryIds),
+            updatedAt: clock.now(),
+          ),
+        );
+        updatedIds.add(identity.agentId);
+      }
+    });
+    // Keep incompatible agents on their old scope until retirement commits.
+    // Lifecycle writes own their transaction and runtime cleanup; never detach
+    // subscriptions from inside an enclosing transaction that could roll back.
+    for (final agentId in incompatibleIds) {
+      agentService
+        ..abortRunningWake(agentId)
+        ..cancelPendingWake(agentId);
+      await agentService.destroyAgent(agentId);
+      updatedIds.add(agentId);
+    }
+    if (updatedIds.isNotEmpty) {
+      onPersistedStateChanged?.call(projectId);
+      final notify = onPersistedStateChanged;
+      if (notify != null) updatedIds.forEach(notify);
+    }
+  });
 
   /// Trigger a manual re-analysis wake for [agentId].
   void triggerReanalysis(String agentId) {

--- a/lib/features/agents/state/agent_providers.dart
+++ b/lib/features/agents/state/agent_providers.dart
@@ -399,11 +399,25 @@ final projectActivityMonitorProvider = Provider<ProjectActivityMonitor>(
   name: 'projectActivityMonitorProvider',
 );
 ProjectActivityMonitor projectActivityMonitor(Ref ref) {
+  final agentService = ref.watch(agentServiceProvider);
+  final projectAgentService = ref.watch(projectAgentServiceProvider);
   final monitor = ProjectActivityMonitor(
     notifications: ref.watch(updateNotificationsProvider),
     agentRepository: ref.watch(agentRepositoryProvider),
     projectRepository: ref.watch(projectRepositoryProvider),
     syncService: ref.watch(agentSyncServiceProvider),
+    mutationCoordinator: ref.watch(projectAgentMutationCoordinatorProvider),
+    retireProjectAgent: (agentId) async {
+      agentService
+        ..abortRunningWake(agentId)
+        ..cancelPendingWake(agentId);
+      await agentService.destroyAgent(agentId);
+    },
+    updateProjectAgentScopes: (projectId, allowedCategoryIds) =>
+        projectAgentService.updateProjectAgentScopes(
+          projectId: projectId,
+          allowedCategoryIds: allowedCategoryIds,
+        ),
     domainLogger: ref.watch(domainLoggerProvider),
     cancellationCoordinator: ref.watch(
       projectActivityCancellationCoordinatorProvider,

--- a/lib/features/agents/state/project_agent_providers.dart
+++ b/lib/features/agents/state/project_agent_providers.dart
@@ -1,8 +1,13 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/service/project_agent_mutation_coordinator.dart';
 import 'package:lotti/features/agents/service/project_agent_service.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/projects/repository/project_repository.dart';
+
+export 'package:lotti/features/agents/service/project_agent_mutation_coordinator.dart'
+    show projectAgentMutationCoordinatorProvider;
 
 /// The project-agent-specific service.
 final projectAgentServiceProvider = Provider<ProjectAgentService>(
@@ -11,11 +16,22 @@ final projectAgentServiceProvider = Provider<ProjectAgentService>(
 );
 ProjectAgentService projectAgentService(Ref ref) {
   final notifications = ref.watch(updateNotificationsProvider);
+  final projectRepository = ref.watch(projectRepositoryProvider);
   return ProjectAgentService(
     agentService: ref.watch(agentServiceProvider),
     repository: ref.watch(agentRepositoryProvider),
     orchestrator: ref.watch(wakeOrchestratorProvider),
     syncService: ref.watch(agentSyncServiceProvider),
+    projectScopeIsCurrent: (projectId, allowedCategoryIds) async {
+      final project = await projectRepository.getProjectById(projectId);
+      if (project == null) return false;
+      final currentCategoryIds = {
+        if (project.meta.categoryId case final String categoryId) categoryId,
+      };
+      return currentCategoryIds.length == allowedCategoryIds.length &&
+          currentCategoryIds.containsAll(allowedCategoryIds);
+    },
+    mutationCoordinator: ref.watch(projectAgentMutationCoordinatorProvider),
     domainLogger: ref.watch(domainLoggerProvider),
     cancellationCoordinator: ref.watch(
       projectActivityCancellationCoordinatorProvider,

--- a/lib/features/agents/workflow/project_tool_dispatcher.dart
+++ b/lib/features/agents/workflow/project_tool_dispatcher.dart
@@ -210,6 +210,7 @@ class ProjectToolDispatcher {
       ),
       entryText: entryText,
       categoryId: categoryId,
+      private: project.meta.private,
     );
 
     if (task == null) {

--- a/lib/features/journal/state/entry_controller.dart
+++ b/lib/features/journal/state/entry_controller.dart
@@ -606,9 +606,33 @@ class EntryController extends AsyncNotifier<EntryState?> {
     final item = await _journalDb.journalEntityById(id);
     if (item != null) {
       final prev = item.meta.private ?? false;
-      await _persistenceLogic.updateJournalEntity(
+      final nextPrivate = !prev;
+      final updated = await _persistenceLogic.updateJournalEntity(
         item,
-        item.meta.copyWith(private: !prev),
+        item.meta.copyWith(private: nextPrivate),
+      );
+      if (updated && item is Task) {
+        await _dropPrivacyMismatchedProjectLink(item.id);
+      }
+    }
+  }
+
+  /// Removes an incompatible membership after a successful privacy toggle.
+  /// The repository rechecks the current task, project, and link atomically.
+  Future<void> _dropPrivacyMismatchedProjectLink(String taskId) async {
+    try {
+      await ref
+          .read(projectRepositoryProvider)
+          .unlinkTaskFromProject(
+            taskId,
+            onlyIfPrivacyMismatched: true,
+          );
+    } catch (e, stackTrace) {
+      developer.log(
+        'Failed to drop privacy-incompatible project link for entry $id: $e',
+        name: 'EntryController',
+        error: e,
+        stackTrace: stackTrace,
       );
     }
   }

--- a/lib/features/projects/repository/project_repository.dart
+++ b/lib/features/projects/repository/project_repository.dart
@@ -3,7 +3,14 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/conversions.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/agents/database/agent_database.dart';
+import 'package:lotti/features/agents/database/agent_repository.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/service/project_agent_mutation_coordinator.dart';
 import 'package:lotti/features/projects/model/projects_overview_models.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
@@ -28,14 +35,19 @@ class ProjectRepository {
     required this._persistenceLogic,
     required this._updateNotifications,
     required this._vectorClockService,
+    this.projectHasActiveAgent,
+    ProjectAgentMutationCoordinator? mutationCoordinator,
     this.projectsOverviewRefetchDebounce = const Duration(milliseconds: 300),
-  });
+  }) : _mutationCoordinator =
+           mutationCoordinator ?? ProjectAgentMutationCoordinator();
 
+  final ProjectAgentMutationCoordinator _mutationCoordinator;
   final JournalDb _journalDb;
   final EntitiesCacheService _entitiesCacheService;
   final PersistenceLogic _persistenceLogic;
   final UpdateNotifications _updateNotifications;
   final VectorClockService _vectorClockService;
+  final Future<bool> Function(String projectId)? projectHasActiveAgent;
 
   /// Debounce window applied to notification-driven `watchProjectsOverview`
   /// refetches. Each refetch reruns the project rollup aggregate, so a burst
@@ -301,17 +313,74 @@ class ProjectRepository {
 
   /// Saves an updated project entity.
   ///
-  /// Bumps vector clock and enqueues sync via [PersistenceLogic].
-  Future<bool> updateProject(ProjectEntry project) async {
-    final updatedMeta = await _persistenceLogic.updateMetadata(project.meta);
-    final updated = project.copyWith(meta: updatedMeta);
-    final result = await _persistenceLogic.updateDbEntity(updated);
-    if (result ?? false) {
+  /// Bumps vector clock and enqueues sync via [PersistenceLogic]. A project
+  /// with linked tasks or an active project agent cannot change category
+  /// because both membership and agent permissions are category-scoped;
+  /// callers must unlink the tasks and retire the agent first.
+  ///
+  /// [PersistenceLogic.updateDbEntity] can report failure after the journal
+  /// row committed (for example when a later search-index update fails), so a
+  /// negative result is verified against the stored project before this method
+  /// reports failure.
+  Future<bool> updateProject(
+    ProjectEntry project,
+  ) => _mutationCoordinator.run(project.id, () async {
+    ProjectEntry? updated;
+    final committed = await _journalDb.transaction<bool>(() async {
+      final persistedRow = await _journalDb.entityById(project.id);
+      final persisted = persistedRow == null
+          ? null
+          : fromDbEntity(persistedRow);
+      if (persisted is! ProjectEntry) return false;
+      if (persisted.meta.categoryId != project.meta.categoryId) {
+        if ((await _journalDb.getTaskIdsForProjects({project.id})).isNotEmpty) {
+          return false;
+        }
+        final hasActiveAgent = projectHasActiveAgent;
+        if (hasActiveAgent != null && await hasActiveAgent(project.id)) {
+          return false;
+        }
+      }
+
+      final updatedMeta = await _persistenceLogic.updateMetadata(project.meta);
+      updated = project.copyWith(meta: updatedMeta);
+      final result = await _persistenceLogic.updateDbEntity(updated!);
+      if (result ?? false) return true;
+
+      final committedRow = await _journalDb.entityById(project.id);
+      final committedProject = committedRow == null
+          ? null
+          : fromDbEntity(committedRow);
+      return committedProject == updated;
+    });
+    if (committed) {
       _updateNotifications.notify({
-        projectEntityUpdateNotification(updated.id),
+        projectEntityUpdateNotification(updated!.id),
       });
     }
-    return result ?? false;
+    return committed;
+  });
+
+  /// Soft-deletes [project] and emits the same scoped notification as an
+  /// ordinary project update so list/detail providers reconcile immediately.
+  Future<bool> deleteProject(
+    ProjectEntry project, {
+    required DateTime deletedAt,
+  }) async {
+    final updatedMeta = await _persistenceLogic.updateMetadata(
+      project.meta,
+      deletedAt: deletedAt,
+    );
+    final deleted = project.copyWith(meta: updatedMeta);
+    final result = await _persistenceLogic.updateDbEntity(deleted);
+    final committed =
+        (result ?? false) || await getProjectById(project.id) == null;
+    if (committed) {
+      _updateNotifications.notify({
+        projectEntityUpdateNotification(deleted.id),
+      });
+    }
+    return committed;
   }
 
   // ── Linking ────────────────────────────────────────────────────────────────
@@ -327,23 +396,20 @@ class ProjectRepository {
     required String projectId,
     required String taskId,
   }) async {
-    // Validate same-category constraint (parallel fetch)
-    final results = await Future.wait([
-      getProjectById(projectId),
-      _journalDb.journalEntityById(taskId),
-    ]);
-    final project = results[0] as ProjectEntry?;
-    final task = results[1];
-    if (project == null || task is! Task) return false;
-    if (project.meta.categoryId != task.meta.categoryId) return false;
-
-    // Remove existing project link if the task is already in another project
+    // This read chooses the mutation shape and reserves the right number of
+    // vector clocks. Every branch re-reads both entities and this link inside
+    // the write transaction before it commits, so a sync update between this
+    // snapshot and the mutation can only reject the operation, never create a
+    // category/privacy-invalid link.
     final existingLink = await _journalDb.getProjectLinkForTask(taskId);
     if (existingLink != null) {
       if (existingLink.fromId == projectId) {
-        return true; // already linked to this project
+        return _existingProjectLinkIsStillValid(
+          existingLink: existingLink,
+          projectId: projectId,
+          taskId: taskId,
+        );
       }
-      // Atomically soft-delete old link + create new link
       return _relinkTask(
         oldLink: existingLink,
         projectId: projectId,
@@ -370,8 +436,19 @@ class ProjectRepository {
           vectorClock: await _vectorClockService.getNextVectorClock(),
         );
 
-        final res = await _journalDb.upsertEntryLink(link);
-        if (res == 0) return false;
+        final committed = await _journalDb.transaction(() async {
+          if (!await _projectLinkInputsAreValid(
+            projectId: projectId,
+            taskId: taskId,
+          )) {
+            return false;
+          }
+          if (await _journalDb.getProjectLinkForTask(taskId) != null) {
+            return false;
+          }
+          return await _journalDb.upsertEntryLink(link) != 0;
+        });
+        if (!committed) return false;
         await _recordLinkSequence(
           link,
           subDomain: 'linkTaskToProject.recordSent',
@@ -414,11 +491,18 @@ class ProjectRepository {
   /// Removes a task from its project.
   ///
   /// Soft-deletes the ProjectLink if one exists. Returns `true` if a link
-  /// was removed.
-  Future<bool> unlinkTaskFromProject(String taskId) async {
+  /// was removed. Privacy cleanup rechecks both entries and the membership
+  /// inside the deletion transaction so concurrent sync edits are preserved.
+  Future<bool> unlinkTaskFromProject(
+    String taskId, {
+    bool onlyIfPrivacyMismatched = false,
+  }) async {
     final existingLink = await _journalDb.getProjectLinkForTask(taskId);
     if (existingLink == null) return false;
-    return _softDeleteLink(existingLink);
+    return _softDeleteLink(
+      existingLink,
+      onlyIfPrivacyMismatched: onlyIfPrivacyMismatched,
+    );
   }
 
   /// Copies the project assignment from [sourceTaskId] to [newTaskId].
@@ -474,6 +558,41 @@ class ProjectRepository {
   // Private helpers behind the public link/unlink methods. (Previously the
   // `_ProjectLinkHelpers` part-file extension.)
 
+  /// Reads link invariants directly from the transaction's journal snapshot.
+  ///
+  /// The public `journalEntityById` read is intentionally microtask-coalesced;
+  /// using `entityById` here prevents this integrity check from joining a read
+  /// wave created outside the active write transaction.
+  Future<bool> _projectLinkInputsAreValid({
+    required String projectId,
+    required String taskId,
+  }) async {
+    final projectRow = await _journalDb.entityById(projectId);
+    final taskRow = await _journalDb.entityById(taskId);
+    final project = projectRow == null ? null : fromDbEntity(projectRow);
+    final task = taskRow == null ? null : fromDbEntity(taskRow);
+    if (project is! ProjectEntry || task is! Task) return false;
+    if (project.meta.categoryId != task.meta.categoryId) return false;
+    return (project.meta.private ?? false) == (task.meta.private ?? false);
+  }
+
+  Future<bool> _existingProjectLinkIsStillValid({
+    required EntryLink existingLink,
+    required String projectId,
+    required String taskId,
+  }) {
+    return _journalDb.transaction(() async {
+      if (!await _projectLinkInputsAreValid(
+        projectId: projectId,
+        taskId: taskId,
+      )) {
+        return false;
+      }
+      final currentLink = await _journalDb.getProjectLinkForTask(taskId);
+      return currentLink == existingLink;
+    });
+  }
+
   /// Atomically soft-deletes an old project link and creates a new one
   /// within a single DB transaction. Notifications and sync enqueuing are
   /// deferred until after the transaction commits.
@@ -499,13 +618,32 @@ class ProjectRepository {
           vectorClock: await _vectorClockService.getNextVectorClock(),
         );
 
-        // Both writes in one transaction — if either fails, both roll back.
-        final success = await _journalDb.transaction(() async {
-          final deleteRes = await _journalDb.upsertEntryLink(deletedLink);
-          if (deleteRes == 0) return false;
-          final insertRes = await _journalDb.upsertEntryLink(newLink);
-          return insertRes != 0;
-        });
+        // The final invariant reads and both writes share one transaction. If
+        // sync changed either entity or the old link after the shape-selection
+        // snapshot, reject instead of committing stale validation.
+        var success = false;
+        try {
+          success = await _journalDb.transaction(() async {
+            if (!await _projectLinkInputsAreValid(
+              projectId: projectId,
+              taskId: taskId,
+            )) {
+              return false;
+            }
+            final currentLink = await _journalDb.getProjectLinkForTask(taskId);
+            if (currentLink != oldLink) return false;
+            final deleteRes = await _journalDb.upsertEntryLink(deletedLink);
+            if (deleteRes == 0) return false;
+            final insertRes = await _journalDb.upsertEntryLink(newLink);
+            if (insertRes == 0) throw const _RelinkInsertFailed();
+            return true;
+          });
+        } on _RelinkInsertFailed {
+          // Throwing from the Drift transaction is what rolls the already-
+          // written tombstone back. Translate the private sentinel only after
+          // the transaction has restored the old link.
+          success = false;
+        }
 
         if (!success) return false;
         await _recordLinkSequence(
@@ -551,12 +689,33 @@ class ProjectRepository {
     );
   }
 
-  Future<bool> _softDeleteLink(EntryLink link) async {
+  Future<bool> _softDeleteLink(
+    EntryLink link, {
+    bool onlyIfPrivacyMismatched = false,
+  }) async {
     return _vectorClockService.withVcScope<bool>(
       () async {
         final now = DateTime.now();
         final deleted = await _prepareDeletedLink(link, now);
-        final res = await _journalDb.upsertEntryLink(deleted);
+        final res = await _journalDb.transaction(() async {
+          final currentLink = await _journalDb.getProjectLinkForTask(link.toId);
+          if (currentLink != link) return 0;
+          if (onlyIfPrivacyMismatched) {
+            final taskRow = await _journalDb.entityById(link.toId);
+            final projectRow = await _journalDb.entityById(link.fromId);
+            final task = taskRow == null ? null : fromDbEntity(taskRow);
+            final project = projectRow == null
+                ? null
+                : fromDbEntity(projectRow);
+            if (task is! Task ||
+                project is! ProjectEntry ||
+                (task.meta.private ?? false) ==
+                    (project.meta.private ?? false)) {
+              return 0;
+            }
+          }
+          return _journalDb.upsertEntryLink(deleted);
+        });
         if (res == 0) return false;
         await _recordLinkSequence(
           deleted,
@@ -614,6 +773,10 @@ class ProjectRepository {
   }
 }
 
+class _RelinkInsertFailed implements Exception {
+  const _RelinkInsertFailed();
+}
+
 const Set<String> _overviewNotificationTokens = {
   projectNotification,
   taskNotification,
@@ -635,5 +798,31 @@ ProjectRepository projectRepository(Ref ref) {
     persistenceLogic: getIt<PersistenceLogic>(),
     updateNotifications: getIt<UpdateNotifications>(),
     vectorClockService: getIt<VectorClockService>(),
+    projectHasActiveAgent: projectHasActiveAgent,
+    mutationCoordinator: ref.watch(projectAgentMutationCoordinatorProvider),
+  );
+}
+
+/// Returns whether [projectId] still owns a non-destroyed project agent.
+///
+/// Project and agent state live in separate databases, so the repository takes
+/// this as an injected integrity guard. The production provider resolves it
+/// directly from the agent store; tests can supply a deterministic callback.
+Future<bool> projectHasActiveAgent(String projectId) async {
+  if (!getIt.isRegistered<AgentDatabase>()) return false;
+  final repository = AgentRepository(getIt<AgentDatabase>());
+  final links = await repository.getLinksTo(
+    projectId,
+    type: AgentLinkTypes.agentProject,
+  );
+  if (links.isEmpty) return false;
+  final entities = await repository.getEntitiesByIds(
+    links.map((link) => link.fromId).toSet(),
+  );
+  return entities.values.any(
+    (entity) =>
+        entity is AgentIdentityEntity &&
+        entity.kind == AgentKinds.projectAgent &&
+        entity.lifecycle != AgentLifecycle.destroyed,
   );
 }

--- a/lib/features/projects/state/project_detail_controller.dart
+++ b/lib/features/projects/state/project_detail_controller.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/project_data.dart';
 import 'package:lotti/features/projects/repository/project_repository.dart';
@@ -55,18 +56,32 @@ final projectDetailControllerProvider = NotifierProvider.autoDispose
 /// changed), then promotes it to the new baseline.
 ///
 /// It subscribes to the repository update stream and reloads on changes to this
-/// project, but a reload preserves unsaved edits: the baseline refreshes only
-/// when there are no pending changes, so a concurrent sync never clobbers what
-/// the user is typing.
+/// project. A reload rebases only locally changed fields onto the newest
+/// persisted entity, so concurrent sync updates to other fields are retained.
+/// If the project was deleted remotely, the pending editor is invalidated so a
+/// later save cannot recreate it. Reload completions are generation-guarded,
+/// preventing an older in-flight read from overwriting a newer sync result.
 class ProjectDetailController extends Notifier<ProjectDetailState> {
   ProjectDetailController(this._projectId);
 
   final String _projectId;
   late final ProjectRepository _repository;
   StreamSubscription<Set<String>>? _subscription;
+  int _reloadGeneration = 0;
 
   ProjectEntry? _originalProject;
   ProjectEntry? _pendingProject;
+
+  /// Whether the title differs from the latest persisted baseline.
+  bool get isTitleDirty =>
+      _pendingProject?.data.title != _originalProject?.data.title;
+
+  /// Whether the description differs from the latest persisted baseline.
+  bool get isDescriptionDirty =>
+      _pendingProject != null &&
+      _originalProject != null &&
+      _projectDescription(_pendingProject!) !=
+          _projectDescription(_originalProject!);
 
   @override
   ProjectDetailState build() {
@@ -90,31 +105,49 @@ class ProjectDetailController extends Notifier<ProjectDetailState> {
   }
 
   Future<void> _reload() async {
+    final reloadGeneration = ++_reloadGeneration;
     try {
-      final (project, tasks) = await (
-        _repository.getProjectById(_projectId),
-        _repository.getTasksForProject(_projectId),
-      ).wait;
+      final project = await _repository.getProjectById(_projectId);
+      if (!ref.mounted || reloadGeneration != _reloadGeneration) return;
 
-      if (project != null) {
-        if (_originalProject == null || !_hasChanges()) {
-          // First load or clean reload: update both baseline and pending
-          _originalProject = project;
-          _pendingProject = project;
-        }
-      }
-
-      if (ref.mounted) {
+      if (project == null) {
+        _originalProject = null;
+        _pendingProject = null;
         state = state.copyWith(
-          project: _hasChanges() ? _pendingProject : project,
-          linkedTasks: tasks,
+          project: null,
+          linkedTasks: const [],
           isLoading: false,
-          hasChanges: _hasChanges(),
+          hasChanges: false,
           error: null,
         );
+        return;
       }
+
+      final tasks = await _repository.getTasksForProject(_projectId);
+      if (!ref.mounted || reloadGeneration != _reloadGeneration) return;
+
+      if (_originalProject == null || !_hasChanges()) {
+        // First load or clean reload: update both baseline and pending.
+        _originalProject = project;
+        _pendingProject = project;
+      } else {
+        _pendingProject = _rebasePendingProject(
+          persisted: project,
+          original: _originalProject!,
+          pending: _pendingProject!,
+        );
+        _originalProject = project;
+      }
+
+      state = state.copyWith(
+        project: _hasChanges() ? _pendingProject : project,
+        linkedTasks: tasks,
+        isLoading: false,
+        hasChanges: _hasChanges(),
+        error: null,
+      );
     } catch (e) {
-      if (ref.mounted) {
+      if (ref.mounted && reloadGeneration == _reloadGeneration) {
         state = state.copyWith(
           isLoading: false,
           error: ProjectDetailError.loadFailed,
@@ -125,10 +158,48 @@ class ProjectDetailController extends Notifier<ProjectDetailState> {
 
   bool _hasChanges() {
     if (_pendingProject == null || _originalProject == null) return false;
-    return _pendingProject!.data.title != _originalProject!.data.title ||
+    return isTitleDirty ||
+        isDescriptionDirty ||
         _pendingProject!.meta.categoryId != _originalProject!.meta.categoryId ||
         _pendingProject!.data.targetDate != _originalProject!.data.targetDate ||
         _pendingProject!.data.status != _originalProject!.data.status;
+  }
+
+  ProjectEntry _rebasePendingProject({
+    required ProjectEntry persisted,
+    required ProjectEntry original,
+    required ProjectEntry pending,
+  }) {
+    var rebased = persisted;
+    if (pending.data.title != original.data.title) {
+      rebased = rebased.copyWith(
+        data: rebased.data.copyWith(title: pending.data.title),
+      );
+    }
+    if (_projectDescription(pending) != _projectDescription(original)) {
+      final plainText = pending.entryText?.plainText ?? '';
+      rebased = rebased.copyWith(
+        entryText:
+            persisted.entryText?.copyWith(plainText: plainText) ??
+            EntryText(plainText: plainText),
+      );
+    }
+    if (pending.meta.categoryId != original.meta.categoryId) {
+      rebased = rebased.copyWith(
+        meta: rebased.meta.copyWith(categoryId: pending.meta.categoryId),
+      );
+    }
+    if (pending.data.targetDate != original.data.targetDate) {
+      rebased = rebased.copyWith(
+        data: rebased.data.copyWith(targetDate: pending.data.targetDate),
+      );
+    }
+    if (pending.data.status != original.data.status) {
+      rebased = rebased.copyWith(
+        data: rebased.data.copyWith(status: pending.data.status),
+      );
+    }
+    return rebased;
   }
 
   /// Updates the pending project title.
@@ -136,6 +207,22 @@ class ProjectDetailController extends Notifier<ProjectDetailState> {
     if (_pendingProject == null) return;
     _pendingProject = _pendingProject!.copyWith(
       data: _pendingProject!.data.copyWith(title: title),
+    );
+    state = state.copyWith(
+      project: _pendingProject,
+      hasChanges: _hasChanges(),
+      error: null,
+    );
+  }
+
+  /// Updates the user-authored project description.
+  void updateDescription(String description) {
+    if (_pendingProject == null) return;
+    final existingText = _pendingProject!.entryText;
+    _pendingProject = _pendingProject!.copyWith(
+      entryText:
+          existingText?.copyWith(plainText: description) ??
+          EntryText(plainText: description),
     );
     state = state.copyWith(
       project: _pendingProject,
@@ -182,6 +269,20 @@ class ProjectDetailController extends Notifier<ProjectDetailState> {
     state = state.copyWith(
       project: _pendingProject,
       hasChanges: _hasChanges(),
+      error: null,
+    );
+  }
+
+  /// Restores the last persisted project after an optimistic inline edit
+  /// could not be saved.
+  void discardChanges() {
+    final original = _originalProject;
+    if (original == null) return;
+    _pendingProject = original;
+    state = state.copyWith(
+      project: original,
+      hasChanges: false,
+      isSaving: false,
       error: null,
     );
   }
@@ -244,3 +345,6 @@ class ProjectDetailController extends Notifier<ProjectDetailState> {
     }
   }
 }
+
+String _projectDescription(ProjectEntry project) =>
+    project.entryText?.plainText ?? '';

--- a/lib/features/projects/ui/widgets/project_agent_report_card.dart
+++ b/lib/features/projects/ui/widgets/project_agent_report_card.dart
@@ -48,7 +48,12 @@ class ProjectAgentReportCard extends ConsumerWidget {
         templates = await templateService.listTemplates();
       }
       templates = templates
-          .where((t) => t.kind == AgentTemplateKind.projectAgent)
+          .where(
+            (t) =>
+                t.kind == AgentTemplateKind.projectAgent &&
+                t.deletedAt == null &&
+                (t.categoryIds.isEmpty || t.categoryIds.contains(categoryId)),
+          )
           .toList();
 
       if (templates.isEmpty) {

--- a/lib/features/tasks/ui/pages/tasks_tab_page.dart
+++ b/lib/features/tasks/ui/pages/tasks_tab_page.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 import 'dart:math' as math;
 
 import 'package:clock/clock.dart';
@@ -19,6 +20,8 @@ import 'package:lotti/features/design_system/components/empty_states/design_syst
 import 'package:lotti/features/design_system/components/headers/tab_section_header.dart';
 import 'package:lotti/features/design_system/components/layout/detail_content_width.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_palette.dart';
+import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
+import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/state/journal_page_controller.dart';
@@ -1033,24 +1036,41 @@ Future<void> _defaultCreateTaskPressed(
 ) async {
   // Capture the service before the await to avoid using ref after disposal.
   final agentService = ref.read(taskAgentServiceProvider);
-  final task = await createTask(
-    categoryId: filterContext.categoryId,
-    projectId: filterContext.projectId,
-    labelIds: filterContext.labelIds.isEmpty
-        ? null
-        : filterContext.labelIds.toList(growable: false),
-    status: filterContext.status,
-  );
-  if (task != null) {
-    // Awaited, not fire-and-forget: the assignment decides what the task page
-    // paints. Navigating first meant a category with a default agent opened
-    // its new task as first-run (block, narrow measure), then flipped to the
-    // established layout the moment the agent landed — a full reflow one beat
-    // after the page appeared. It is a local write, and it is a no-op for a
-    // category with no default template.
-    await autoAssignCategoryAgentWith(agentService, task);
-    getIt<NavService>().beamToNamed('/tasks/${task.meta.id}');
+  final context = ref.context;
+  Task? task;
+  try {
+    task = await createTask(
+      categoryId: filterContext.categoryId,
+      projectId: filterContext.projectId,
+      labelIds: filterContext.labelIds.isEmpty
+          ? null
+          : filterContext.labelIds.toList(growable: false),
+      status: filterContext.status,
+    );
+  } catch (error, stackTrace) {
+    developer.log(
+      'Failed to create task',
+      name: 'TasksTabPage',
+      error: error,
+      stackTrace: stackTrace,
+    );
   }
+  if (task == null) {
+    if (!context.mounted) return;
+    context.showToast(
+      tone: DesignSystemToastTone.error,
+      title: context.messages.commonError,
+    );
+    return;
+  }
+  // Awaited, not fire-and-forget: the assignment decides what the task page
+  // paints. Navigating first meant a category with a default agent opened
+  // its new task as first-run (block, narrow measure), then flipped to the
+  // established layout the moment the agent landed — a full reflow one beat
+  // after the page appeared. It is a local write, and it is a no-op for a
+  // category with no default template.
+  await autoAssignCategoryAgentWith(agentService, task);
+  getIt<NavService>().beamToNamed('/tasks/${task.meta.id}');
 }
 
 /// End-aligned floating location that sits [bottomMargin] above the content

--- a/lib/logic/create/create_entry.dart
+++ b/lib/logic/create/create_entry.dart
@@ -63,9 +63,11 @@ Future<JournalEntity?> createChecklist({
 /// Category, labels, status, and [title] are part of the initial entity write.
 /// An explicit [projectId] is validated before that write, its category is
 /// authoritative, and the project is linked before this future completes.
-/// Invalid projects or failed explicit links return `null`. Without these
-/// optional values, the existing open, uncategorized, unlabeled, project-free
-/// defaults are kept.
+/// Invalid projects return `null` before task persistence. A failed explicit
+/// link soft-deletes the just-created task before returning `null`, so a
+/// project race cannot leave an orphaned blank task. Without these optional
+/// values, the existing open, uncategorized, unlabeled, project-free defaults
+/// are kept.
 ///
 /// [title] defaults to empty, which is what every caller that opens the new
 /// task for editing wants. Callers that already know the title — the link
@@ -73,11 +75,14 @@ Future<JournalEntity?> createChecklist({
 /// the task is never briefly nameless; a non-empty title is also indexed for
 /// full-text search here, which nothing on the create path otherwise does.
 ///
-/// [inheritContextFrom] names a parent task whose project *and* privacy the
-/// new task adopts, without writing a link to it. [linkedId] does both
-/// together; callers that own their own linking (the link picker writes one
-/// typed edge) would otherwise have to unpick a plain link to get the context
-/// across.
+/// An explicit [projectId] makes that project's category and privacy
+/// authoritative for the new task. A [linkedId] with conflicting privacy is
+/// rejected before persistence rather than silently changing either context.
+/// Otherwise, [inheritContextFrom] names a
+/// parent task whose project *and* privacy the new task adopts, without
+/// writing a link to it. [linkedId] does both together; callers that own their
+/// own linking (the link picker writes one typed edge) would otherwise have to
+/// unpick a plain link to get the context across.
 Future<Task?> createTask({
   String? linkedId,
   String? categoryId,
@@ -93,13 +98,15 @@ Future<Task?> createTask({
       ? _createProjectRepository()
       : null;
   var effectiveCategoryId = categoryId;
+  bool? inheritedPrivate;
   final nonEmptyLabelIds = labelIds
       ?.where((id) => id.isNotEmpty)
       .toList(growable: false);
 
-  // Project links require tasks and projects to share a category. Resolve the
-  // project before creating the task and treat its category as authoritative,
-  // including when the filter context also supplies a conflicting category.
+  // Project links require tasks and projects to share category and privacy.
+  // Resolve the project before creating the task and treat both fields as
+  // authoritative, including when the filter context supplies a conflicting
+  // category.
   if (projectId != null) {
     ProjectEntry? project;
     try {
@@ -119,6 +126,14 @@ Future<Task?> createTask({
       return null;
     }
     effectiveCategoryId = project.meta.categoryId;
+    inheritedPrivate = project.meta.private;
+    if (linkedId != null) {
+      final linked = await getIt<JournalDb>().journalEntityById(linkedId);
+      if (linked != null &&
+          (linked.meta.private ?? false) != (inheritedPrivate ?? false)) {
+        return null;
+      }
+    }
   }
 
   // Look up category defaults for profile inheritance.
@@ -126,12 +141,12 @@ Future<Task?> createTask({
       ? getIt<EntitiesCacheService>().getCategoryById(effectiveCategoryId)
       : null;
 
-  // Privacy travels with a link-free context too. With a `linkedId`,
+  // Without an explicit project, privacy travels with a link-free context too.
+  // With a `linkedId`,
   // `createDbEntity` copies it off the linked entity; without one the new task
   // persists as public, so a task created from inside a *private* task's
   // picker would expose it.
-  bool? inheritedPrivate;
-  if (inheritContextFrom != null) {
+  if (projectId == null && inheritContextFrom != null) {
     final parent = await getIt<JournalDb>().journalEntityById(
       inheritContextFrom,
     );
@@ -164,7 +179,16 @@ Future<Task?> createTask({
       projectId: projectId,
       taskId: task.meta.id,
     );
-    if (!assigned) return null;
+    if (!assigned) {
+      final cleanedUp = await _softDeleteFailedProjectTask(task);
+      if (!cleanedUp) {
+        throw StateError(
+          'Project assignment failed and the created task could not be '
+          'soft-deleted: ${task.meta.id}',
+        );
+      }
+      return null;
+    }
   } else if (task != null && (linkedId ?? inheritContextFrom) != null) {
     // Inherit project from the parent task when no explicit project was
     // requested by the creation context.
@@ -200,6 +224,24 @@ Future<Task?> createTask({
   }
 
   return task;
+}
+
+Future<bool> _softDeleteFailedProjectTask(Task task) async {
+  final persistenceLogic = getIt<PersistenceLogic>();
+  final deletedMetadata = await persistenceLogic.updateMetadata(
+    task.meta,
+    deletedAt: DateTime.now(),
+  );
+  final updated = await persistenceLogic.updateDbEntity(
+    task.copyWith(meta: deletedMetadata),
+  );
+  if (updated ?? false) return true;
+  // Ordinary by-id reads exclude tombstones; verify the raw persisted row.
+  final db = getIt<JournalDb>();
+  final committed = await (db.select(
+    db.journal,
+  )..where((row) => row.id.equals(task.id))).getSingleOrNull();
+  return committed?.deleted == true;
 }
 
 /// Copies the project assignment from [linkedId] to [newTaskId] via
@@ -269,6 +311,7 @@ ProjectRepository _createProjectRepository() {
     persistenceLogic: getIt<PersistenceLogic>(),
     updateNotifications: getIt<UpdateNotifications>(),
     vectorClockService: getIt<VectorClockService>(),
+    projectHasActiveAgent: projectHasActiveAgent,
   );
 }
 

--- a/test/features/agents/service/agent_service_test.dart
+++ b/test/features/agents/service/agent_service_test.dart
@@ -970,6 +970,62 @@ void main() {
       });
     });
 
+    group('restoreAgentLifecycle', () {
+      test('restores the exact prior non-active lifecycle', () async {
+        final destroyed = makeTestIdentity(
+          id: 'agent-1',
+          agentId: 'agent-1',
+          lifecycle: AgentLifecycle.destroyed,
+        );
+        when(
+          () => mockRepository.getEntity('agent-1'),
+        ).thenAnswer((_) async => destroyed);
+        when(
+          () => mockOrchestrator.removeSubscriptions('agent-1'),
+        ).thenReturn(null);
+
+        final result = await service.restoreAgentLifecycle(
+          'agent-1',
+          AgentLifecycle.dormant,
+        );
+
+        expect(result, isTrue);
+        final restored =
+            verify(
+                  () => mockSyncService.upsertEntity(captureAny()),
+                ).captured.single
+                as AgentIdentityEntity;
+        expect(restored.lifecycle, AgentLifecycle.dormant);
+        expect(restored.destroyedAt, isNull);
+        verify(() => mockOrchestrator.removeSubscriptions('agent-1')).called(1);
+      });
+
+      test('leaves active subscription restoration to the caller', () async {
+        final destroyed = makeTestIdentity(
+          id: 'agent-1',
+          agentId: 'agent-1',
+          lifecycle: AgentLifecycle.destroyed,
+        );
+        when(
+          () => mockRepository.getEntity('agent-1'),
+        ).thenAnswer((_) async => destroyed);
+
+        final result = await service.restoreAgentLifecycle(
+          'agent-1',
+          AgentLifecycle.active,
+        );
+
+        expect(result, isTrue);
+        final restored =
+            verify(
+                  () => mockSyncService.upsertEntity(captureAny()),
+                ).captured.single
+                as AgentIdentityEntity;
+        expect(restored.lifecycle, AgentLifecycle.active);
+        verifyNever(() => mockOrchestrator.removeSubscriptions(any()));
+      });
+    });
+
     group('destroyAgent', () {
       test('sets lifecycle to destroyed, sets destroyedAt, '
           'and unregisters subscriptions', () async {
@@ -1017,6 +1073,56 @@ void main() {
     }
 
     group('deleteAgent', () {
+      test(
+        'refreshes linked project surfaces after hard-deleting a project agent',
+        () async {
+          final identity = makeTestIdentity(
+            id: 'project-agent-1',
+            agentId: 'project-agent-1',
+            kind: AgentKinds.projectAgent,
+            lifecycle: AgentLifecycle.destroyed,
+          );
+          final projectLink = AgentLink.agentProject(
+            id: 'project-link-1',
+            fromId: identity.agentId,
+            toId: 'project-1',
+            createdAt: kAgentTestDate,
+            updatedAt: kAgentTestDate,
+            vectorClock: null,
+          );
+          when(
+            () => mockRepository.getEntity(identity.agentId),
+          ).thenAnswer((_) async => identity);
+          when(
+            () => mockRepository.getLinksFrom(
+              identity.agentId,
+              type: AgentLinkTypes.agentProject,
+            ),
+          ).thenAnswer((_) async => [projectLink]);
+          when(
+            () => mockOrchestrator.removeSubscriptions(identity.agentId),
+          ).thenReturn(null);
+          when(
+            () => mockRepository.hardDeleteAgent(identity.agentId),
+          ).thenAnswer(
+            (_) async => (entityIds: <String>[], linkIds: <String>[]),
+          );
+
+          await service.deleteAgent(identity.agentId);
+
+          expect(notifiedAgentIds, [
+            AgentNotificationScopes.projectOverview,
+            'project-1',
+          ]);
+          verify(
+            () => mockRepository.getLinksFrom(
+              identity.agentId,
+              type: AgentLinkTypes.agentProject,
+            ),
+          ).called(1);
+        },
+      );
+
       test('reclaims the sidecars of everything it deleted', () async {
         // The database rows are only half of what a synced agent leaves
         // behind: its JSON sidecars stay readable on disk otherwise,

--- a/test/features/agents/service/project_activity_monitor_test.dart
+++ b/test/features/agents/service/project_activity_monitor_test.dart
@@ -14,6 +14,7 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
+import '../../projects/test_utils.dart' as projects;
 import '../test_utils.dart';
 import 'project_activity_monitor_test_helpers.dart';
 
@@ -26,6 +27,7 @@ void main() {
   late MockProjectRepository projectRepository;
   late MockAgentSyncService syncService;
   late StreamController<Set<String>> updateController;
+  late StreamController<Set<String>> syncUpdateController;
   late ProjectActivityMonitor monitor;
 
   setUp(() {
@@ -34,9 +36,13 @@ void main() {
     projectRepository = MockProjectRepository();
     syncService = MockAgentSyncService();
     updateController = StreamController<Set<String>>.broadcast();
+    syncUpdateController = StreamController<Set<String>>.broadcast();
 
     when(() => notifications.localUpdateStream).thenAnswer(
       (_) => updateController.stream,
+    );
+    when(() => notifications.syncUpdateStream).thenAnswer(
+      (_) => syncUpdateController.stream,
     );
     when(
       () => notifications.notify(
@@ -67,9 +73,303 @@ void main() {
   tearDown(() async {
     await monitor.stop();
     await updateController.close();
+    await syncUpdateController.close();
   });
 
   group('ProjectActivityMonitor', () {
+    test(
+      'retires every linked agent when sync tombstones its project',
+      () async {
+        final retiredAgentIds = <String>[];
+        final tombstoneMonitor = ProjectActivityMonitor(
+          notifications: notifications,
+          agentRepository: repository,
+          projectRepository: projectRepository,
+          syncService: syncService,
+          retireProjectAgent: (agentId) async {
+            retiredAgentIds.add(agentId);
+          },
+          clock: Clock.fixed(now),
+        );
+        addTearDown(tombstoneMonitor.stop);
+        when(
+          () => projectRepository.getProjectById('project-tombstoned'),
+        ).thenAnswer((_) async => null);
+        when(
+          () => repository.getLinksTo(
+            'project-tombstoned',
+            type: AgentLinkTypes.agentProject,
+          ),
+        ).thenAnswer(
+          (_) async => [
+            AgentLink.agentProject(
+              id: 'link-1',
+              fromId: 'agent-1',
+              toId: 'project-tombstoned',
+              createdAt: now,
+              updatedAt: now,
+              vectorClock: null,
+            ),
+            AgentLink.agentProject(
+              id: 'link-2',
+              fromId: 'agent-2',
+              toId: 'project-tombstoned',
+              createdAt: now,
+              updatedAt: now,
+              vectorClock: null,
+            ),
+            AgentLink.agentProject(
+              id: 'duplicate-link',
+              fromId: 'agent-1',
+              toId: 'project-tombstoned',
+              createdAt: now,
+              updatedAt: now,
+              vectorClock: null,
+            ),
+          ],
+        );
+
+        tombstoneMonitor.start();
+        syncUpdateController.add({
+          'project-tombstoned',
+          projectNotification,
+          labelUsageNotification,
+        });
+        await pumpEventQueue(times: 3);
+
+        expect(retiredAgentIds, ['agent-1', 'agent-2']);
+        verifyNever(() => syncService.upsertEntity(any()));
+      },
+    );
+
+    test(
+      'keeps agents when a project is restored during link lookup',
+      () async {
+        var restored = false;
+        final retired = <String>[];
+        final scopes = <Set<String>>[];
+        final reconciliationMonitor = ProjectActivityMonitor(
+          notifications: notifications,
+          agentRepository: repository,
+          projectRepository: projectRepository,
+          syncService: syncService,
+          retireProjectAgent: (id) async => retired.add(id),
+          updateProjectAgentScopes: (_, categories) async =>
+              scopes.add(categories),
+        );
+        addTearDown(reconciliationMonitor.stop);
+        when(
+          () => projectRepository.getProjectById('project-restored'),
+        ).thenAnswer(
+          (_) async => restored
+              ? projects.makeTestProject(
+                  id: 'project-restored',
+                  categoryId: 'restored-category',
+                )
+              : null,
+        );
+        when(
+          () => repository.getLinksTo(
+            'project-restored',
+            type: AgentLinkTypes.agentProject,
+          ),
+        ).thenAnswer((_) async {
+          restored = true;
+          return [
+            AgentLink.agentProject(
+              id: 'restored-link',
+              fromId: 'agent-1',
+              toId: 'project-restored',
+              createdAt: now,
+              updatedAt: now,
+              vectorClock: null,
+            ),
+          ];
+        });
+        reconciliationMonitor.start();
+        syncUpdateController.add({'project-restored', projectNotification});
+        await pumpEventQueue(times: 3);
+        expect(retired, isEmpty);
+        expect(scopes, [
+          const {'restored-category'},
+        ]);
+      },
+    );
+
+    test(
+      'reconciliation waits for the shared project mutation coordinator',
+      () async {
+        final coordinator = ProjectAgentMutationCoordinator();
+        final entered = Completer<void>();
+        final release = Completer<void>();
+        final blocker = coordinator.run('project-live', () async {
+          entered.complete();
+          await release.future;
+        });
+        await entered.future;
+        final updates = <Set<String>>[];
+        final reconciliationMonitor = ProjectActivityMonitor(
+          notifications: notifications,
+          agentRepository: repository,
+          projectRepository: projectRepository,
+          syncService: syncService,
+          mutationCoordinator: coordinator,
+          updateProjectAgentScopes: (projectId, categories) =>
+              coordinator.run(projectId, () async => updates.add(categories)),
+        );
+        addTearDown(reconciliationMonitor.stop);
+        when(() => projectRepository.getProjectById('project-live')).thenAnswer(
+          (_) async => projects.makeTestProject(
+            id: 'project-live',
+            categoryId: 'restored',
+          ),
+        );
+        reconciliationMonitor.start();
+        syncUpdateController.add({'project-live', projectNotification});
+        await pumpEventQueue(times: 3);
+        verifyNever(() => projectRepository.getProjectById('project-live'));
+        expect(updates, isEmpty);
+        release.complete();
+        await blocker;
+        await pumpEventQueue(times: 3);
+        expect(updates, [
+          const {'restored'},
+        ]);
+      },
+    );
+
+    test(
+      'a failed synced lookup does not block later project updates',
+      () async {
+        final updates = <String>[];
+        final reconciliationMonitor = ProjectActivityMonitor(
+          notifications: notifications,
+          agentRepository: repository,
+          projectRepository: projectRepository,
+          syncService: syncService,
+          updateProjectAgentScopes: (id, _) async => updates.add(id),
+        );
+        addTearDown(reconciliationMonitor.stop);
+        when(
+          () => projectRepository.getProjectById('project-failed'),
+        ).thenThrow(StateError('read failed'));
+        when(
+          () => projectRepository.getProjectById('project-live'),
+        ).thenAnswer((_) async => projects.makeTestProject(id: 'project-live'));
+        reconciliationMonitor.start();
+        syncUpdateController.add({
+          'project-failed',
+          'project-live',
+          projectNotification,
+        });
+        await pumpEventQueue(times: 3);
+        verify(
+          () => projectRepository.getProjectById('project-failed'),
+        ).called(1);
+        expect(updates, ['project-live']);
+      },
+    );
+
+    test(
+      'continues retiring linked agents after one retirement fails',
+      () async {
+        final attemptedAgentIds = <String>[];
+        final tombstoneMonitor = ProjectActivityMonitor(
+          notifications: notifications,
+          agentRepository: repository,
+          projectRepository: projectRepository,
+          syncService: syncService,
+          retireProjectAgent: (agentId) async {
+            attemptedAgentIds.add(agentId);
+            if (agentId == 'agent-1') {
+              throw StateError('first retirement failed');
+            }
+          },
+          clock: Clock.fixed(now),
+        );
+        addTearDown(tombstoneMonitor.stop);
+        when(
+          () => projectRepository.getProjectById('project-tombstoned'),
+        ).thenAnswer((_) async => null);
+        when(
+          () => repository.getLinksTo(
+            'project-tombstoned',
+            type: AgentLinkTypes.agentProject,
+          ),
+        ).thenAnswer(
+          (_) async => [
+            AgentLink.agentProject(
+              id: 'link-1',
+              fromId: 'agent-1',
+              toId: 'project-tombstoned',
+              createdAt: now,
+              updatedAt: now,
+              vectorClock: null,
+            ),
+            AgentLink.agentProject(
+              id: 'link-2',
+              fromId: 'agent-2',
+              toId: 'project-tombstoned',
+              createdAt: now,
+              updatedAt: now,
+              vectorClock: null,
+            ),
+          ],
+        );
+
+        tombstoneMonitor.start();
+        syncUpdateController.add({'project-tombstoned', projectNotification});
+        await pumpEventQueue(times: 3);
+
+        expect(attemptedAgentIds, ['agent-1', 'agent-2']);
+      },
+    );
+
+    test(
+      're-scopes linked agents when the synced project still exists',
+      () async {
+        final retiredAgentIds = <String>[];
+        final scopeUpdates = <(String, Set<String>)>[];
+        final reconciliationMonitor = ProjectActivityMonitor(
+          notifications: notifications,
+          agentRepository: repository,
+          projectRepository: projectRepository,
+          syncService: syncService,
+          retireProjectAgent: (agentId) async {
+            retiredAgentIds.add(agentId);
+          },
+          updateProjectAgentScopes: (projectId, categoryIds) async {
+            scopeUpdates.add((projectId, categoryIds));
+          },
+          clock: Clock.fixed(now),
+        );
+        addTearDown(reconciliationMonitor.stop);
+        when(
+          () => projectRepository.getProjectById('project-live'),
+        ).thenAnswer(
+          (_) async => projects.makeTestProject(
+            id: 'project-live',
+            categoryId: 'synced-category',
+          ),
+        );
+
+        reconciliationMonitor.start();
+        syncUpdateController.add({'project-live', projectNotification});
+        await pumpEventQueue(times: 3);
+
+        expect(retiredAgentIds, isEmpty);
+        expect(scopeUpdates, hasLength(1));
+        expect(scopeUpdates.single.$1, 'project-live');
+        expect(scopeUpdates.single.$2, {'synced-category'});
+        verifyNever(
+          () => repository.getLinksTo(
+            'project-live',
+            type: AgentLinkTypes.agentProject,
+          ),
+        );
+      },
+    );
+
     test(
       'failed cancellation restores eligibility for the older activity batch',
       () async {
@@ -234,6 +534,8 @@ void main() {
           repository: repository,
           orchestrator: orchestrator,
           syncService: syncService,
+          projectScopeIsCurrent: (_, _) async => true,
+          mutationCoordinator: ProjectAgentMutationCoordinator(),
           cancellationCoordinator: coordinator,
         );
         final raceMonitor = ProjectActivityMonitor(

--- a/test/features/agents/service/project_agent_mutation_coordinator_test.dart
+++ b/test/features/agents/service/project_agent_mutation_coordinator_test.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/service/project_agent_mutation_coordinator.dart';
+
+void main() {
+  test('serializes one project while allowing another to progress', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final coordinator = container.read(projectAgentMutationCoordinatorProvider);
+    final entered = Completer<void>();
+    final release = Completer<void>();
+    final events = <String>[];
+    final first = coordinator.run('project-a', () async {
+      events.add('first');
+      entered.complete();
+      await release.future;
+      events.add('released');
+    });
+    await entered.future;
+    final second = coordinator.run(
+      'project-a',
+      () async => events.add('second'),
+    );
+    await coordinator.run('project-b', () async => events.add('independent'));
+    expect(events, ['first', 'independent']);
+    release.complete();
+    await Future.wait([first, second]);
+    expect(events, ['first', 'independent', 'released', 'second']);
+  });
+
+  test('nested operations reuse the held project scope', () async {
+    final coordinator = ProjectAgentMutationCoordinator();
+    final result = await coordinator.run('project', () async {
+      return coordinator.run('project', () async => 'nested result');
+    });
+    expect(result, 'nested result');
+  });
+
+  test('a failing operation releases the next queued mutation', () async {
+    final coordinator = ProjectAgentMutationCoordinator();
+    final entered = Completer<void>();
+    final release = Completer<void>();
+    final first = coordinator.run<void>('project', () async {
+      entered.complete();
+      await release.future;
+      throw StateError('mutation failed');
+    });
+    final failure = expectLater(first, throwsStateError);
+    await entered.future;
+    final second = coordinator.run('project', () async => 'recovered');
+    release.complete();
+    await failure;
+    expect(await second, 'recovered');
+  });
+}

--- a/test/features/agents/service/project_agent_service_test.dart
+++ b/test/features/agents/service/project_agent_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
@@ -147,6 +149,7 @@ void main() {
   late MockAgentSyncService mockSyncService;
   late ProjectAgentService service;
   late List<String> notifiedAgentIds;
+  late bool scopeIsCurrent;
 
   AgentIdentityEntity makeIdentity({
     String agentId = 'agent-1',
@@ -183,6 +186,7 @@ void main() {
     mockOrchestrator = MockWakeOrchestrator();
     mockSyncService = MockAgentSyncService();
     notifiedAgentIds = [];
+    scopeIsCurrent = true;
 
     when(() => mockSyncService.upsertEntity(any())).thenAnswer((_) async {});
     when(() => mockSyncService.upsertLink(any())).thenAnswer((_) async {});
@@ -211,6 +215,8 @@ void main() {
       repository: mockRepository,
       orchestrator: mockOrchestrator,
       syncService: mockSyncService,
+      projectScopeIsCurrent: (_, _) async => scopeIsCurrent,
+      mutationCoordinator: ProjectAgentMutationCoordinator(),
       domainLogger: DomainLogger(loggingService: LoggingService())
         ..enabledDomains.add(LogDomain.agentRuntime),
       onPersistedStateChanged: notifiedAgentIds.add,
@@ -219,6 +225,78 @@ void main() {
 
   group('ProjectAgentService', () {
     group('createProjectAgent', () {
+      test(
+        'rejects a stale project category before creating an agent',
+        () async {
+          final scopedService = ProjectAgentService(
+            agentService: mockAgentService,
+            repository: mockRepository,
+            orchestrator: mockOrchestrator,
+            syncService: mockSyncService,
+            projectScopeIsCurrent: (_, categoryIds) async =>
+                categoryIds.contains('current-category'),
+            mutationCoordinator: ProjectAgentMutationCoordinator(),
+          );
+
+          await expectLater(
+            () => scopedService.createProjectAgent(
+              projectId: 'project-with-new-category',
+              templateId: kTestTemplateId,
+              displayName: 'Stale scope',
+              allowedCategoryIds: const {'old-category'},
+            ),
+            throwsA(isA<StateError>()),
+          );
+
+          verifyNever(
+            () => mockAgentService.createAgent(
+              kind: any(named: 'kind'),
+              displayName: any(named: 'displayName'),
+              config: any(named: 'config'),
+              allowedCategoryIds: any(named: 'allowedCategoryIds'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'rejects a template whose synced category no longer matches',
+        () async {
+          final staleTemplate = makeTestTemplate(
+            kind: AgentTemplateKind.projectAgent,
+            categoryIds: const {'old-category'},
+          );
+          when(
+            () => mockRepository.getLinksTo(
+              'project-with-new-category',
+              type: AgentLinkTypes.agentProject,
+            ),
+          ).thenAnswer((_) async => const []);
+          when(
+            () => mockRepository.getEntity(kTestTemplateId),
+          ).thenAnswer((_) async => staleTemplate);
+
+          await expectLater(
+            () => service.createProjectAgent(
+              projectId: 'project-with-new-category',
+              templateId: kTestTemplateId,
+              displayName: 'Fresh template check',
+              allowedCategoryIds: const {'new-category'},
+            ),
+            throwsA(isA<StateError>()),
+          );
+
+          verifyNever(
+            () => mockAgentService.createAgent(
+              kind: any(named: 'kind'),
+              displayName: any(named: 'displayName'),
+              config: any(named: 'config'),
+              allowedCategoryIds: any(named: 'allowedCategoryIds'),
+            ),
+          );
+        },
+      );
+
       glados.Glados(
         glados.any.projectAgentCreateScenario,
         glados.ExploreConfig(numRuns: 180),
@@ -233,6 +311,8 @@ void main() {
           repository: generatedRepository,
           orchestrator: generatedOrchestrator,
           syncService: generatedSyncService,
+          projectScopeIsCurrent: (_, _) async => true,
+          mutationCoordinator: ProjectAgentMutationCoordinator(),
           onPersistedStateChanged: generatedNotifiedAgentIds.add,
         );
         const projectId = 'generated-project';
@@ -558,6 +638,79 @@ void main() {
       });
 
       test(
+        'deletes a newly created agent when the project is tombstoned',
+        () async {
+          final identity = makeIdentity();
+          final template = makeTestTemplate(
+            kind: AgentTemplateKind.projectAgent,
+          );
+          var existenceChecks = 0;
+          final compensatingService = ProjectAgentService(
+            agentService: mockAgentService,
+            repository: mockRepository,
+            orchestrator: mockOrchestrator,
+            syncService: mockSyncService,
+            projectScopeIsCurrent: (_, _) async => existenceChecks++ == 0,
+            mutationCoordinator: ProjectAgentMutationCoordinator(),
+            onPersistedStateChanged: notifiedAgentIds.add,
+          );
+          when(
+            () => mockRepository.getLinksTo(
+              'project-deleted-by-sync',
+              type: AgentLinkTypes.agentProject,
+            ),
+          ).thenAnswer((_) async => []);
+          when(
+            () => mockRepository.getEntity(kTestTemplateId),
+          ).thenAnswer((_) async => template);
+          when(
+            () => mockAgentService.createAgent(
+              kind: any(named: 'kind'),
+              displayName: any(named: 'displayName'),
+              config: any(named: 'config'),
+              allowedCategoryIds: any(named: 'allowedCategoryIds'),
+            ),
+          ).thenAnswer((_) async => identity);
+          when(
+            () => mockRepository.getAgentState(identity.agentId),
+          ).thenAnswer((_) async => makeState());
+          when(
+            () => mockAgentService.deleteAgent(identity.agentId),
+          ).thenAnswer((_) async {});
+
+          await expectLater(
+            () => compensatingService.createProjectAgent(
+              projectId: 'project-deleted-by-sync',
+              templateId: kTestTemplateId,
+              displayName: 'Orphan prevention',
+              allowedCategoryIds: const {},
+            ),
+            throwsA(
+              isA<StateError>().having(
+                (error) => error.message,
+                'message',
+                contains('project-deleted-by-sync'),
+              ),
+            ),
+          );
+
+          expect(existenceChecks, 2);
+          verify(
+            () => mockAgentService.deleteAgent(identity.agentId),
+          ).called(1);
+          verifyNever(() => mockOrchestrator.addSubscription(any()));
+          verifyNever(
+            () => mockOrchestrator.enqueueManualWake(
+              agentId: any(named: 'agentId'),
+              reason: any(named: 'reason'),
+              triggerTokens: any(named: 'triggerTokens'),
+            ),
+          );
+          expect(notifiedAgentIds, isEmpty);
+        },
+      );
+
+      test(
         'persists a one-shot fallback for the explicit creation wake',
         () async {
           final identity = makeIdentity();
@@ -858,6 +1011,35 @@ void main() {
       );
     });
 
+    test(
+      'serializes same-project mutations without blocking other projects',
+      () async {
+        final coordinator = ProjectAgentMutationCoordinator();
+        final firstStarted = Completer<void>();
+        final releaseFirst = Completer<void>();
+        final order = <String>[];
+
+        final first = coordinator.run('project-1', () async {
+          order.add('first-start');
+          firstStarted.complete();
+          await releaseFirst.future;
+          order.add('first-end');
+        });
+        await firstStarted.future;
+        final second = coordinator.run('project-1', () async {
+          order.add('second');
+        });
+        await coordinator.run('project-2', () async {
+          order.add('other-project');
+        });
+
+        expect(order, ['first-start', 'other-project']);
+        releaseFirst.complete();
+        await Future.wait([first, second]);
+        expect(order, ['first-start', 'other-project', 'first-end', 'second']);
+      },
+    );
+
     group('getProjectAgentForProject', () {
       test('returns identity via link lookup', () async {
         final link = AgentLink.agentProject(
@@ -924,6 +1106,301 @@ void main() {
 
         expect(result, isNull);
       });
+    });
+
+    group('getProjectAgentsForProject', () {
+      test('returns every unique live linked project agent', () async {
+        final olderDate = kAgentTestDate.subtract(const Duration(days: 1));
+        final links = [
+          AgentLink.agentProject(
+            id: 'link-new',
+            fromId: 'agent-new',
+            toId: 'project-1',
+            createdAt: kAgentTestDate,
+            updatedAt: kAgentTestDate,
+            vectorClock: null,
+          ),
+          AgentLink.agentProject(
+            id: 'link-old',
+            fromId: 'agent-old',
+            toId: 'project-1',
+            createdAt: olderDate,
+            updatedAt: olderDate,
+            vectorClock: null,
+          ),
+          AgentLink.agentProject(
+            id: 'link-old-duplicate',
+            fromId: 'agent-old',
+            toId: 'project-1',
+            createdAt: olderDate,
+            updatedAt: olderDate,
+            vectorClock: null,
+          ),
+          AgentLink.agentProject(
+            id: 'link-destroyed',
+            fromId: 'agent-destroyed',
+            toId: 'project-1',
+            createdAt: olderDate,
+            updatedAt: olderDate,
+            vectorClock: null,
+          ),
+        ];
+        final newer = makeIdentity(agentId: 'agent-new');
+        final older = makeIdentity(
+          agentId: 'agent-old',
+          lifecycle: AgentLifecycle.dormant,
+        );
+        final destroyed = makeIdentity(
+          agentId: 'agent-destroyed',
+          lifecycle: AgentLifecycle.destroyed,
+        );
+        when(
+          () => mockRepository.getLinksTo(
+            'project-1',
+            type: AgentLinkTypes.agentProject,
+          ),
+        ).thenAnswer((_) async => links);
+        when(
+          () => mockRepository.getEntitiesByIds([
+            'agent-new',
+            'agent-old',
+            'agent-destroyed',
+          ]),
+        ).thenAnswer(
+          (_) async => {
+            newer.id: newer,
+            older.id: older,
+            destroyed.id: destroyed,
+          },
+        );
+
+        final result = await service.getProjectAgentsForProject('project-1');
+
+        expect(result.map((identity) => identity.agentId), [
+          'agent-new',
+          'agent-old',
+        ]);
+      });
+    });
+
+    group('project category scopes', () {
+      setUp(() {
+        when(() => mockAgentService.abortRunningWake(any())).thenReturn(true);
+        when(
+          () => mockRepository.getLinksTo(
+            any(),
+            type: AgentLinkTypes.templateAssignment,
+          ),
+        ).thenAnswer(
+          (invocation) async => [
+            AgentLink.templateAssignment(
+              id: 'global-assignment',
+              fromId: 'global-template',
+              toId: invocation.positionalArguments.first as String,
+              createdAt: kAgentTestDate,
+              updatedAt: kAgentTestDate,
+              vectorClock: null,
+            ),
+          ],
+        );
+        when(() => mockRepository.getEntity('global-template')).thenAnswer(
+          (_) async => makeTestTemplate(kind: AgentTemplateKind.projectAgent),
+        );
+      });
+      test(
+        'retires an agent whose template excludes the synced category',
+        () async {
+          final identity = makeIdentity().copyWith(
+            allowedCategoryIds: const {'old-category'},
+          );
+          when(
+            () => mockRepository.getLinksTo(
+              'project-1',
+              type: AgentLinkTypes.agentProject,
+            ),
+          ).thenAnswer(
+            (_) async => [
+              AgentLink.agentProject(
+                id: 'project-link',
+                fromId: identity.id,
+                toId: 'project-1',
+                createdAt: kAgentTestDate,
+                updatedAt: kAgentTestDate,
+                vectorClock: null,
+              ),
+            ],
+          );
+          when(
+            () => mockRepository.getEntitiesByIds(any()),
+          ).thenAnswer((_) async => {identity.id: identity});
+          when(
+            () => mockRepository.getLinksTo(
+              identity.id,
+              type: AgentLinkTypes.templateAssignment,
+            ),
+          ).thenAnswer(
+            (_) async => [
+              AgentLink.templateAssignment(
+                id: 'assignment',
+                fromId: 'scoped-template',
+                toId: identity.id,
+                createdAt: kAgentTestDate,
+                updatedAt: kAgentTestDate,
+                vectorClock: null,
+              ),
+            ],
+          );
+          when(() => mockRepository.getEntity('scoped-template')).thenAnswer(
+            (_) async => makeTestTemplate(
+              kind: AgentTemplateKind.projectAgent,
+              categoryIds: const {'old-category'},
+            ),
+          );
+          when(
+            () => mockAgentService.destroyAgent(identity.id),
+          ).thenAnswer((_) async => true);
+          await service.updateProjectAgentScopes(
+            projectId: 'project-1',
+            allowedCategoryIds: const {'new-category'},
+          );
+          verify(() => mockAgentService.destroyAgent(identity.id)).called(1);
+          verify(
+            () => mockAgentService.abortRunningWake(identity.id),
+          ).called(1);
+          verify(
+            () => mockAgentService.cancelPendingWake(identity.id),
+          ).called(1);
+          verifyNever(() => mockSyncService.upsertEntity(any()));
+          expect(notifiedAgentIds, contains('project-1'));
+        },
+      );
+
+      test('ignores a scope request that became stale while queued', () async {
+        when(
+          () => mockRepository.getLinksTo(
+            'project-1',
+            type: AgentLinkTypes.agentProject,
+          ),
+        ).thenAnswer((_) async => []);
+        final started = Completer<void>();
+        final release = Completer<void>();
+        final blocker = service.mutationCoordinator.run('project-1', () async {
+          started.complete();
+          await release.future;
+        });
+        await started.future;
+        final update = service.updateProjectAgentScopes(
+          projectId: 'project-1',
+          allowedCategoryIds: const {'old-category'},
+        );
+        scopeIsCurrent = false;
+        release.complete();
+        await blocker;
+        await update;
+        verifyNever(
+          () => mockRepository.getLinksTo(
+            any(),
+            type: any(named: 'type'),
+          ),
+        );
+        verifyNever(() => mockSyncService.upsertEntity(any()));
+        expect(notifiedAgentIds, isEmpty);
+      });
+
+      test('does not rewrite or announce unchanged scopes', () async {
+        final identity = makeIdentity().copyWith(
+          allowedCategoryIds: const {'same-category'},
+        );
+        when(
+          () => mockRepository.getLinksTo(
+            'project-1',
+            type: AgentLinkTypes.agentProject,
+          ),
+        ).thenAnswer(
+          (_) async => [
+            AgentLink.agentProject(
+              id: 'link-1',
+              fromId: identity.agentId,
+              toId: 'project-1',
+              createdAt: kAgentTestDate,
+              updatedAt: kAgentTestDate,
+              vectorClock: null,
+            ),
+          ],
+        );
+        when(() => mockRepository.getEntitiesByIds(any())).thenAnswer(
+          (_) async => {identity.agentId: identity},
+        );
+        await service.updateProjectAgentScopes(
+          projectId: 'project-1',
+          allowedCategoryIds: const {'same-category'},
+        );
+        verify(
+          () => mockRepository.getEntitiesByIds([identity.agentId]),
+        ).called(1);
+        verifyNever(() => mockSyncService.upsertEntity(any()));
+        expect(notifiedAgentIds, isEmpty);
+      });
+
+      test(
+        'updates every live project-agent scope',
+        () async {
+          final first = makeIdentity().copyWith(
+            allowedCategoryIds: const {'old-1'},
+          );
+          final second = makeIdentity(agentId: 'agent-2').copyWith(
+            allowedCategoryIds: const {'old-2'},
+          );
+          final links = [
+            AgentLink.agentProject(
+              id: 'link-1',
+              fromId: first.agentId,
+              toId: 'project-1',
+              createdAt: kAgentTestDate,
+              updatedAt: kAgentTestDate,
+              vectorClock: null,
+            ),
+            AgentLink.agentProject(
+              id: 'link-2',
+              fromId: second.agentId,
+              toId: 'project-1',
+              createdAt: kAgentTestDate,
+              updatedAt: kAgentTestDate,
+              vectorClock: null,
+            ),
+          ];
+          when(
+            () => mockRepository.getLinksTo(
+              'project-1',
+              type: AgentLinkTypes.agentProject,
+            ),
+          ).thenAnswer((_) async => links);
+          when(
+            () => mockRepository.getEntitiesByIds(any()),
+          ).thenAnswer(
+            (_) async => {first.agentId: first, second.agentId: second},
+          );
+
+          await service.updateProjectAgentScopes(
+            projectId: 'project-1',
+            allowedCategoryIds: const {'new-category'},
+          );
+
+          final writes = verify(
+            () => mockSyncService.upsertEntity(captureAny()),
+          ).captured.whereType<AgentIdentityEntity>().toList();
+          expect(writes, hasLength(2));
+          expect(
+            writes.map((identity) => identity.allowedCategoryIds),
+            everyElement(const {'new-category'}),
+          );
+          expect(notifiedAgentIds.first, 'project-1');
+          expect(notifiedAgentIds.skip(1).toSet(), {
+            first.agentId,
+            second.agentId,
+          });
+        },
+      );
     });
 
     group('triggerReanalysis', () {
@@ -1027,6 +1504,8 @@ void main() {
             repository: mockRepository,
             orchestrator: mockOrchestrator,
             syncService: failingSyncService,
+            projectScopeIsCurrent: (_, _) async => true,
+            mutationCoordinator: ProjectAgentMutationCoordinator(),
             onPersistedStateChanged: notifiedAgentIds.add,
             cancellationCoordinator: cancellationCoordinator,
           );
@@ -1093,6 +1572,8 @@ void main() {
             repository: mockRepository,
             orchestrator: mockOrchestrator,
             syncService: failingSyncService,
+            projectScopeIsCurrent: (_, _) async => true,
+            mutationCoordinator: ProjectAgentMutationCoordinator(),
             onPersistedStateChanged: notifiedAgentIds.add,
           );
           final state = makeState().copyWith(
@@ -1870,6 +2351,8 @@ void main() {
             repository: mockRepository,
             orchestrator: mockOrchestrator,
             syncService: mockSyncService,
+            projectScopeIsCurrent: (_, _) async => true,
+            mutationCoordinator: ProjectAgentMutationCoordinator(),
           );
 
           final failingAgent = makeIdentity(agentId: 'pa-fail');

--- a/test/features/agents/state/agent_providers_test.dart
+++ b/test/features/agents/state/agent_providers_test.dart
@@ -24,6 +24,7 @@ import 'package:lotti/features/agents/service/improver_agent_service.dart';
 import 'package:lotti/features/agents/service/project_activity_monitor.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/agent_runtime_registry.dart';
+import 'package:lotti/features/agents/state/project_agent_providers.dart';
 import 'package:lotti/features/agents/wake/scheduled_wake_manager.dart';
 import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
 import 'package:lotti/features/agents/wake/wake_queue.dart';
@@ -433,19 +434,39 @@ void main() {
   });
 
   group('projectActivityMonitorProvider', () {
-    test('creates the monitor from injected dependencies', () {
+    test('creates the monitor and wires project-agent retirement', () async {
       final mockNotifications = MockUpdateNotifications();
       final mockSyncService = MockAgentSyncService();
       final mockProjectRepository = MockProjectRepository();
+      final mockProjectAgentService = MockProjectAgentService();
       final logger = DomainLogger(loggingService: LoggingService());
+      when(
+        () => mockService.abortRunningWake('retired-project-agent'),
+      ).thenReturn(true);
+      when(
+        () => mockService.cancelPendingWake('retired-project-agent'),
+      ).thenReturn(null);
+      when(
+        () => mockService.destroyAgent('retired-project-agent'),
+      ).thenAnswer((_) async => true);
+      when(
+        () => mockProjectAgentService.updateProjectAgentScopes(
+          projectId: 'synced-project',
+          allowedCategoryIds: const {'synced-category'},
+        ),
+      ).thenAnswer((_) async => const {});
 
       final container = ProviderContainer(
         overrides: [
+          agentServiceProvider.overrideWithValue(mockService),
           updateNotificationsProvider.overrideWithValue(mockNotifications),
           loggingServiceProvider.overrideWithValue(LoggingService()),
           agentRepositoryProvider.overrideWithValue(mockRepository),
           projectRepositoryProvider.overrideWithValue(mockProjectRepository),
           agentSyncServiceProvider.overrideWithValue(mockSyncService),
+          projectAgentServiceProvider.overrideWithValue(
+            mockProjectAgentService,
+          ),
           domainLoggerProvider.overrideWithValue(logger),
         ],
       );
@@ -454,6 +475,24 @@ void main() {
       final monitor = container.read(projectActivityMonitorProvider);
 
       expect(monitor, isA<ProjectActivityMonitor>());
+      expect(monitor.retireProjectAgent, isNotNull);
+      expect(monitor.updateProjectAgentScopes, isNotNull);
+      await monitor.retireProjectAgent!('retired-project-agent');
+      verifyInOrder([
+        () => mockService.abortRunningWake('retired-project-agent'),
+        () => mockService.cancelPendingWake('retired-project-agent'),
+        () => mockService.destroyAgent('retired-project-agent'),
+      ]);
+      await monitor.updateProjectAgentScopes!(
+        'synced-project',
+        const {'synced-category'},
+      );
+      verify(
+        () => mockProjectAgentService.updateProjectAgentScopes(
+          projectId: 'synced-project',
+          allowedCategoryIds: const {'synced-category'},
+        ),
+      ).called(1);
 
       // Dispose should exercise the provider cleanup hook without errors.
       container.dispose();

--- a/test/features/agents/state/project_agent_providers_test.dart
+++ b/test/features/agents/state/project_agent_providers_test.dart
@@ -3,49 +3,85 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/service/project_agent_service.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/project_agent_providers.dart';
+import 'package:lotti/features/projects/repository/project_repository.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
+import '../../projects/test_utils.dart';
 
 void main() {
   group('projectAgentServiceProvider', () {
-    test('creates service and wires persisted-state notifications', () {
-      final mockAgentService = MockAgentService();
-      final mockRepository = MockAgentRepository();
-      final mockOrchestrator = MockWakeOrchestrator();
-      final mockSyncService = MockAgentSyncService();
-      final mockDomainLogger = MockDomainLogger();
-      final mockNotifications = MockUpdateNotifications();
-      final container = ProviderContainer(
-        overrides: [
-          agentServiceProvider.overrideWithValue(mockAgentService),
-          agentRepositoryProvider.overrideWithValue(mockRepository),
-          wakeOrchestratorProvider.overrideWithValue(mockOrchestrator),
-          agentSyncServiceProvider.overrideWithValue(mockSyncService),
-          domainLoggerProvider.overrideWithValue(mockDomainLogger),
-          updateNotificationsProvider.overrideWithValue(mockNotifications),
-        ],
-      );
-      addTearDown(container.dispose);
+    test(
+      'creates service and wires project validation and notifications',
+      () async {
+        final mockAgentService = MockAgentService();
+        final mockRepository = MockAgentRepository();
+        final mockOrchestrator = MockWakeOrchestrator();
+        final mockSyncService = MockAgentSyncService();
+        final mockDomainLogger = MockDomainLogger();
+        final mockNotifications = MockUpdateNotifications();
+        final mockProjectRepository = MockProjectRepository();
+        when(
+          () => mockProjectRepository.getProjectById('missing-project'),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockProjectRepository.getProjectById('current-project'),
+        ).thenAnswer(
+          (_) async => makeTestProject(
+            id: 'current-project',
+            categoryId: 'current-category',
+          ),
+        );
+        final container = ProviderContainer(
+          overrides: [
+            agentServiceProvider.overrideWithValue(mockAgentService),
+            agentRepositoryProvider.overrideWithValue(mockRepository),
+            wakeOrchestratorProvider.overrideWithValue(mockOrchestrator),
+            agentSyncServiceProvider.overrideWithValue(mockSyncService),
+            domainLoggerProvider.overrideWithValue(mockDomainLogger),
+            updateNotificationsProvider.overrideWithValue(mockNotifications),
+            projectRepositoryProvider.overrideWithValue(mockProjectRepository),
+          ],
+        );
+        addTearDown(container.dispose);
 
-      final service = container.read(projectAgentServiceProvider);
+        final service = container.read(projectAgentServiceProvider);
 
-      expect(service, isA<ProjectAgentService>());
-      expect(service.agentService, same(mockAgentService));
-      expect(service.repository, same(mockRepository));
-      expect(service.orchestrator, same(mockOrchestrator));
-      expect(service.syncService, same(mockSyncService));
-      expect(service.domainLogger, same(mockDomainLogger));
+        expect(service, isA<ProjectAgentService>());
+        expect(service.agentService, same(mockAgentService));
+        expect(service.repository, same(mockRepository));
+        expect(service.orchestrator, same(mockOrchestrator));
+        expect(service.syncService, same(mockSyncService));
+        expect(service.domainLogger, same(mockDomainLogger));
+        expect(
+          await service.projectScopeIsCurrent('missing-project', const {}),
+          isFalse,
+        );
+        expect(
+          await service.projectScopeIsCurrent(
+            'current-project',
+            const {'current-category'},
+          ),
+          isTrue,
+        );
+        expect(
+          await service.projectScopeIsCurrent(
+            'current-project',
+            const {'stale-category'},
+          ),
+          isFalse,
+        );
 
-      service.onPersistedStateChanged?.call('agent-project-1');
+        service.onPersistedStateChanged?.call('agent-project-1');
 
-      verify(
-        () => mockNotifications.notifyUiOnly({
-          'agent-project-1',
-          agentNotification,
-        }),
-      ).called(1);
-    });
+        verify(
+          () => mockNotifications.notifyUiOnly({
+            'agent-project-1',
+            agentNotification,
+          }),
+        ).called(1);
+      },
+    );
   });
 }

--- a/test/features/agents/workflow/project_agent_workflow_test.dart
+++ b/test/features/agents/workflow/project_agent_workflow_test.dart
@@ -1576,6 +1576,8 @@ void main() {
             repository: mockAgentRepository,
             orchestrator: orchestrator,
             syncService: statefulSync,
+            projectScopeIsCurrent: (_, _) async => true,
+            mutationCoordinator: ProjectAgentMutationCoordinator(),
           );
 
           final wake = withClock(Clock.fixed(DateTime(2026, 3, 20, 10)), () {

--- a/test/features/agents/workflow/project_tool_dispatcher_test.dart
+++ b/test/features/agents/workflow/project_tool_dispatcher_test.dart
@@ -202,6 +202,7 @@ void main() {
           data: any(named: 'data'),
           entryText: any(named: 'entryText'),
           categoryId: any(named: 'categoryId'),
+          private: any(named: 'private'),
         ),
       ).thenAnswer((_) async => createdTask);
       when(
@@ -251,6 +252,9 @@ void main() {
           ),
           entryText: any(named: 'entryText'),
           categoryId: 'cat-001',
+          // Explicitly verifies that public projects preserve null privacy.
+          // ignore: avoid_redundant_argument_values
+          private: null,
         ),
       ).called(1);
       verify(
@@ -268,6 +272,50 @@ void main() {
           awaitContent: true,
           // ignore: avoid_redundant_argument_values
           automaticUpdatesEnabled: false,
+        ),
+      ).called(1);
+    });
+
+    test('create_task inherits privacy from a private project', () async {
+      final privateProject = project.copyWith(
+        meta: project.meta.copyWith(private: true),
+      );
+      final createdTask = makeTestTask(id: taskId, title: 'Private work');
+
+      when(
+        () => mockProjectRepository.getProjectById(projectId),
+      ).thenAnswer((_) async => privateProject);
+      when(
+        () => mockEntitiesCacheService.getCategoryById('cat-001'),
+      ).thenReturn(null);
+      when(
+        () => mockPersistenceLogic.createTaskEntry(
+          data: any(named: 'data'),
+          entryText: any(named: 'entryText'),
+          categoryId: 'cat-001',
+          private: true,
+        ),
+      ).thenAnswer((_) async => createdTask);
+      when(
+        () => mockProjectRepository.linkTaskToProject(
+          projectId: projectId,
+          taskId: taskId,
+        ),
+      ).thenAnswer((_) async => true);
+
+      final result = await dispatcher.dispatch(
+        ProjectAgentToolNames.createTask,
+        {'title': 'Private work'},
+        projectId,
+      );
+
+      expect(result.success, isTrue);
+      verify(
+        () => mockPersistenceLogic.createTaskEntry(
+          data: any(named: 'data'),
+          entryText: any(named: 'entryText'),
+          categoryId: 'cat-001',
+          private: true,
         ),
       ).called(1);
     });
@@ -303,6 +351,7 @@ void main() {
           data: any(named: 'data'),
           entryText: any(named: 'entryText'),
           categoryId: any(named: 'categoryId'),
+          private: any(named: 'private'),
         ),
       ).thenAnswer((_) async => createdTask);
       when(
@@ -373,6 +422,7 @@ void main() {
             data: any(named: 'data'),
             entryText: any(named: 'entryText'),
             categoryId: any(named: 'categoryId'),
+            private: any(named: 'private'),
           ),
         ).thenAnswer((_) async => createdTask);
         when(
@@ -468,6 +518,7 @@ void main() {
             data: any(named: 'data'),
             entryText: any(named: 'entryText'),
             categoryId: any(named: 'categoryId'),
+            private: any(named: 'private'),
           ),
         ).thenAnswer((_) async => createdTask);
         when(
@@ -561,6 +612,7 @@ void main() {
           data: any(named: 'data'),
           entryText: any(named: 'entryText'),
           categoryId: any(named: 'categoryId'),
+          private: any(named: 'private'),
         ),
       );
     });
@@ -580,6 +632,7 @@ void main() {
           data: any(named: 'data'),
           entryText: any(named: 'entryText'),
           categoryId: any(named: 'categoryId'),
+          private: any(named: 'private'),
         ),
       ).thenAnswer((invocation) async {
         capturedPriorities.add(
@@ -808,6 +861,7 @@ void main() {
             data: any(named: 'data'),
             entryText: any(named: 'entryText'),
             categoryId: any(named: 'categoryId'),
+            private: any(named: 'private'),
           ),
         ).thenAnswer((_) async => null);
 
@@ -844,6 +898,7 @@ void main() {
           data: any(named: 'data'),
           entryText: any(named: 'entryText'),
           categoryId: any(named: 'categoryId'),
+          private: any(named: 'private'),
         ),
       ).thenAnswer((_) async => createdTask);
       when(
@@ -910,6 +965,7 @@ void main() {
           data: any(named: 'data'),
           entryText: any(named: 'entryText'),
           categoryId: any(named: 'categoryId'),
+          private: any(named: 'private'),
         ),
       ).thenAnswer((_) async => createdTask);
       when(
@@ -963,6 +1019,7 @@ void main() {
             data: any(named: 'data'),
             entryText: any(named: 'entryText'),
             categoryId: any(named: 'categoryId'),
+            private: any(named: 'private'),
           ),
         ).thenAnswer((_) async => createdTask);
         when(
@@ -1008,6 +1065,7 @@ void main() {
             data: any(named: 'data'),
             entryText: any(named: 'entryText'),
             categoryId: any(named: 'categoryId'),
+            private: any(named: 'private'),
           ),
         ).thenAnswer((_) async => createdTask);
         when(
@@ -1054,6 +1112,7 @@ void main() {
             data: any(named: 'data'),
             entryText: any(named: 'entryText'),
             categoryId: any(named: 'categoryId'),
+            private: any(named: 'private'),
           ),
         ).thenAnswer((_) async => createdTask);
         when(

--- a/test/features/journal/state/entry_controller_test.dart
+++ b/test/features/journal/state/entry_controller_test.dart
@@ -746,6 +746,104 @@ void main() {
       verify(testFn).called(1);
     });
 
+    test('toggle private unlinks a task from a public project', () async {
+      reset(mockPersistenceLogic);
+      when(
+        () => mockPersistenceLogic.updateJournalEntity(
+          testTask,
+          testTask.meta.copyWith(private: true),
+        ),
+      ).thenAnswer((_) async => true);
+      when(
+        () => mockProjectRepository.getLinkedProjectForTask(testTask.id),
+      ).thenAnswer(
+        (_) async => makeTestProject(
+          id: 'project-public',
+          categoryId: testTask.meta.categoryId,
+        ),
+      );
+      when(
+        () => mockProjectRepository.unlinkTaskFromProject(
+          testTask.id,
+          onlyIfPrivacyMismatched: true,
+        ),
+      ).thenAnswer((_) async => true);
+      final container = makeProviderContainer();
+      final notifier = container.read(
+        entryControllerProvider(testTask.id).notifier,
+      );
+
+      await notifier.togglePrivate();
+
+      verify(
+        () => mockProjectRepository.unlinkTaskFromProject(
+          testTask.id,
+          onlyIfPrivacyMismatched: true,
+        ),
+      ).called(1);
+    });
+
+    test(
+      'privacy cleanup failure preserves the successful privacy write',
+      () async {
+        when(
+          () => mockPersistenceLogic.updateJournalEntity(
+            testTask,
+            testTask.meta.copyWith(private: true),
+          ),
+        ).thenAnswer((_) async => true);
+        when(
+          () => mockProjectRepository.unlinkTaskFromProject(
+            testTask.id,
+            onlyIfPrivacyMismatched: true,
+          ),
+        ).thenThrow(StateError('membership store unavailable'));
+        final container = makeProviderContainer();
+        final notifier = container.read(
+          entryControllerProvider(testTask.id).notifier,
+        );
+        await expectLater(notifier.togglePrivate(), completes);
+        verify(
+          () => mockPersistenceLogic.updateJournalEntity(
+            testTask,
+            testTask.meta.copyWith(private: true),
+          ),
+        ).called(1);
+        verify(
+          () => mockProjectRepository.unlinkTaskFromProject(
+            testTask.id,
+            onlyIfPrivacyMismatched: true,
+          ),
+        ).called(1);
+      },
+    );
+
+    test('failed privacy toggle keeps the existing project link', () async {
+      reset(mockPersistenceLogic);
+      when(
+        () => mockPersistenceLogic.updateJournalEntity(
+          testTask,
+          testTask.meta.copyWith(private: true),
+        ),
+      ).thenAnswer((_) async => false);
+      final container = makeProviderContainer();
+      final notifier = container.read(
+        entryControllerProvider(testTask.id).notifier,
+      );
+
+      await notifier.togglePrivate();
+
+      verifyNever(
+        () => mockProjectRepository.getLinkedProjectForTask(any()),
+      );
+      verifyNever(
+        () => mockProjectRepository.unlinkTaskFromProject(
+          any(),
+          onlyIfPrivacyMismatched: true,
+        ),
+      );
+    });
+
     test('toggle flagged', () async {
       reset(mockPersistenceLogic);
       final container = makeProviderContainer();

--- a/test/features/projects/repository/project_repository_test.dart
+++ b/test/features/projects/repository/project_repository_test.dart
@@ -8,7 +8,13 @@ import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/project_data.dart';
 import 'package:lotti/classes/task.dart';
+import 'package:lotti/database/conversions.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/agents/database/agent_database.dart';
+import 'package:lotti/features/agents/database/agent_repository.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/service/project_agent_mutation_coordinator.dart';
 import 'package:lotti/features/projects/model/projects_overview_models.dart';
 import 'package:lotti/features/projects/repository/project_repository.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
@@ -25,8 +31,73 @@ import 'package:mocktail/mocktail.dart';
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
+import '../../agents/test_data/entity_factories.dart';
+import '../../agents/test_data/link_factories.dart';
 import '../../categories/test_utils.dart';
 import '../test_utils.dart';
+
+class _TransactionTrackingJournalDb extends MockJournalDb {
+  _TransactionTrackingJournalDb({
+    required this.rows,
+    this.onTransactionStart,
+  });
+
+  final Map<String, JournalDbEntity> rows;
+  final void Function()? onTransactionStart;
+  bool entityReadInsideTransaction = false;
+  bool taskReadInsideTransaction = false;
+  bool _insideTransaction = false;
+  bool get insideTransaction => _insideTransaction;
+
+  @override
+  Future<T> transaction<T>(
+    Future<T> Function() action, {
+    bool requireNew = false,
+  }) async {
+    onTransactionStart?.call();
+    _insideTransaction = true;
+    try {
+      return await action();
+    } finally {
+      _insideTransaction = false;
+    }
+  }
+
+  @override
+  Future<JournalDbEntity?> entityById(String id) async {
+    entityReadInsideTransaction |= _insideTransaction;
+    return rows[id];
+  }
+
+  @override
+  Future<JournalEntity?> journalEntityById(String id) async {
+    final row = rows[id];
+    return row == null ? null : fromDbEntity(row);
+  }
+
+  @override
+  Future<Set<String>> getTaskIdsForProjects(Set<String> projectIds) async {
+    taskReadInsideTransaction |= _insideTransaction;
+    return const {};
+  }
+}
+
+class _RollbackTrackingJournalDb extends MockJournalDb {
+  bool rolledBack = false;
+
+  @override
+  Future<T> transaction<T>(
+    Future<T> Function() action, {
+    bool requireNew = false,
+  }) async {
+    try {
+      return await action();
+    } catch (_) {
+      rolledBack = true;
+      rethrow;
+    }
+  }
+}
 
 void main() {
   final testDate = DateTime(2024, 3, 15, 10, 30);
@@ -39,6 +110,7 @@ void main() {
   late MockOutboxService mockOutboxService;
   late StreamController<Set<String>> updateStreamController;
   late ProjectRepository repository;
+  late bool hasActiveProjectAgent;
 
   final projectMeta = Metadata(
     id: 'project-001',
@@ -115,6 +187,7 @@ void main() {
     mockEntitiesCacheService = MockEntitiesCacheService();
     mockOutboxService = MockOutboxService();
     updateStreamController = StreamController<Set<String>>.broadcast();
+    hasActiveProjectAgent = false;
 
     // Register OutboxService via the central helper (used by
     // _enqueueLinkSync); setUpTestGetIt owns reset + base registrations.
@@ -135,11 +208,23 @@ void main() {
     when(() => mockNotifications.notify(any())).thenReturn(null);
     when(() => mockDb.upsertEntryLink(any())).thenAnswer((_) async => 1);
     when(
+      () => mockDb.getProjectLinkForTask(any()),
+    ).thenAnswer((_) async => null);
+    when(
+      mockVectorClockService.getNextVectorClock,
+    ).thenAnswer((_) async => const VectorClock({'d': 1}));
+    when(
       () => mockDb.journalEntityById('project-001'),
     ).thenAnswer((_) async => projectEntry);
     when(
       () => mockDb.journalEntityById('task-001'),
     ).thenAnswer((_) async => taskEntry);
+    when(
+      () => mockDb.entityById('project-001'),
+    ).thenAnswer((_) async => toDbEntity(projectEntry));
+    when(
+      () => mockDb.entityById('task-001'),
+    ).thenAnswer((_) async => toDbEntity(taskEntry));
     when(
       () => mockNotifications.updateStream,
     ).thenAnswer((_) => updateStreamController.stream);
@@ -159,6 +244,7 @@ void main() {
       persistenceLogic: mockPersistence,
       updateNotifications: mockNotifications,
       vectorClockService: mockVectorClockService,
+      projectHasActiveAgent: (_) async => hasActiveProjectAgent,
       // Collapse the refetch debounce so the stream-matcher tests below see
       // notification-driven refetches without waiting on a real timer. The
       // debounce timing itself is covered by a dedicated fakeAsync test.
@@ -169,6 +255,68 @@ void main() {
   tearDown(() async {
     await updateStreamController.close();
     await tearDownTestGetIt();
+  });
+
+  group('projectHasActiveAgent', () {
+    test('returns false when the agent store is unavailable', () async {
+      if (getIt.isRegistered<AgentDatabase>()) {
+        await getIt.unregister<AgentDatabase>();
+      }
+
+      expect(await projectHasActiveAgent('project-001'), isFalse);
+    });
+
+    test('recognizes only live project-agent identities', () async {
+      if (getIt.isRegistered<AgentDatabase>()) {
+        await getIt.unregister<AgentDatabase>();
+      }
+      final agentDatabase = AgentDatabase(
+        inMemoryDatabase: true,
+        background: false,
+      );
+      getIt.registerSingleton<AgentDatabase>(agentDatabase);
+      addTearDown(() async {
+        if (getIt.isRegistered<AgentDatabase>()) {
+          await getIt.unregister<AgentDatabase>();
+        }
+        await agentDatabase.close();
+      });
+      final agentRepository = AgentRepository(agentDatabase);
+      await agentRepository.upsertLink(
+        makeTestAgentProjectLink(
+          fromId: 'candidate-agent',
+        ),
+      );
+
+      expect(await projectHasActiveAgent('project-001'), isFalse);
+
+      await agentRepository.upsertEntity(
+        makeTestIdentity(
+          id: 'candidate-agent',
+          agentId: 'candidate-agent',
+        ),
+      );
+      expect(await projectHasActiveAgent('project-001'), isFalse);
+
+      await agentRepository.upsertEntity(
+        makeTestIdentity(
+          id: 'candidate-agent',
+          agentId: 'candidate-agent',
+          kind: AgentKinds.projectAgent,
+        ),
+      );
+      expect(await projectHasActiveAgent('project-001'), isTrue);
+
+      await agentRepository.upsertEntity(
+        makeTestIdentity(
+          id: 'candidate-agent',
+          agentId: 'candidate-agent',
+          kind: AgentKinds.projectAgent,
+          lifecycle: AgentLifecycle.destroyed,
+        ),
+      );
+      expect(await projectHasActiveAgent('project-001'), isFalse);
+    });
   });
 
   group('getProjectById', () {
@@ -705,6 +853,62 @@ void main() {
   });
 
   group('updateProject', () {
+    test('rejects a late failure that lost a metadata-only edit', () async {
+      final changed = projectEntry.copyWith(
+        meta: projectMeta.copyWith(starred: true),
+      );
+      when(
+        () => mockPersistence.updateMetadata(changed.meta),
+      ).thenAnswer((_) async => changed.meta);
+      when(
+        () => mockPersistence.updateDbEntity(changed),
+      ).thenAnswer((_) async => false);
+      expect(await repository.updateProject(changed), isFalse);
+      verifyNever(() => mockNotifications.notify(any()));
+    });
+
+    test(
+      'category edits wait for project-agent creation before checking guards',
+      () async {
+        final coordinator = ProjectAgentMutationCoordinator();
+        final entered = Completer<void>();
+        final release = Completer<void>();
+        final creation = coordinator.run(projectEntry.id, () async {
+          entered.complete();
+          await release.future;
+          hasActiveProjectAgent = true;
+        });
+        await entered.future;
+        final guarded = ProjectRepository(
+          journalDb: mockDb,
+          entitiesCacheService: mockEntitiesCacheService,
+          persistenceLogic: mockPersistence,
+          updateNotifications: mockNotifications,
+          vectorClockService: mockVectorClockService,
+          mutationCoordinator: coordinator,
+          projectHasActiveAgent: (_) async => hasActiveProjectAgent,
+        );
+        when(
+          () => mockDb.getTaskIdsForProjects({projectEntry.id}),
+        ).thenAnswer((_) async => {});
+        final changed = projectEntry.copyWith(
+          meta: projectMeta.copyWith(categoryId: 'cat-2'),
+        );
+        when(
+          () => mockPersistence.updateMetadata(changed.meta),
+        ).thenAnswer((_) async => changed.meta);
+        when(
+          () => mockPersistence.updateDbEntity(any()),
+        ).thenAnswer((_) async => true);
+        final update = guarded.updateProject(changed);
+        await pumpEventQueue(times: 3);
+        release.complete();
+        await creation;
+        expect(await update, isFalse);
+        verifyNever(() => mockPersistence.updateDbEntity(any()));
+      },
+    );
+
     test('bumps metadata and persists', () async {
       final updatedMeta = projectMeta.copyWith(
         updatedAt: DateTime(2024, 3, 16),
@@ -732,6 +936,9 @@ void main() {
     });
 
     test('returns false when persistence fails', () async {
+      final changedProject = projectEntry.copyWith(
+        data: projectEntry.data.copyWith(title: 'Changed title'),
+      );
       final updatedMeta = projectMeta.copyWith(
         updatedAt: DateTime(2024, 3, 16),
         vectorClock: const VectorClock({'device-1': 2}),
@@ -742,11 +949,11 @@ void main() {
       ).thenAnswer((_) async => updatedMeta);
       when(
         () => mockPersistence.updateDbEntity(
-          projectEntry.copyWith(meta: updatedMeta),
+          changedProject.copyWith(meta: updatedMeta),
         ),
       ).thenAnswer((_) async => false);
 
-      final result = await repository.updateProject(projectEntry);
+      final result = await repository.updateProject(changedProject);
 
       expect(result, isFalse);
       verifyNever(() => mockNotifications.notify(any()));
@@ -755,6 +962,9 @@ void main() {
     test('returns false when persistence returns null', () async {
       // Exercises the `result ?? false` coalescing branch: a null result
       // must be treated as failure — no notification is emitted.
+      final changedProject = projectEntry.copyWith(
+        data: projectEntry.data.copyWith(title: 'Changed title'),
+      );
       final updatedMeta = projectMeta.copyWith(
         updatedAt: DateTime(2024, 3, 16),
         vectorClock: const VectorClock({'device-1': 2}),
@@ -765,15 +975,272 @@ void main() {
       ).thenAnswer((_) async => updatedMeta);
       when(
         () => mockPersistence.updateDbEntity(
-          projectEntry.copyWith(meta: updatedMeta),
+          changedProject.copyWith(meta: updatedMeta),
         ),
       ).thenAnswer((_) async => null);
 
-      final result = await repository.updateProject(projectEntry);
+      final result = await repository.updateProject(changedProject);
 
       expect(result, isFalse);
       verifyNever(() => mockNotifications.notify(any()));
     });
+
+    test(
+      'accepts a matching row when persistence reports late failure',
+      () async {
+        final changedProject = projectEntry.copyWith(
+          data: projectEntry.data.copyWith(title: 'Committed title'),
+        );
+        final updatedMeta = projectMeta.copyWith(
+          updatedAt: DateTime(2024, 3, 16),
+          vectorClock: const VectorClock({'device-1': 2}),
+        );
+        final committedProject = changedProject.copyWith(meta: updatedMeta);
+        var readCount = 0;
+        when(
+          () => mockDb.entityById(projectEntry.id),
+        ).thenAnswer(
+          (_) async => toDbEntity(
+            readCount++ == 0 ? projectEntry : committedProject,
+          ),
+        );
+        when(
+          () => mockPersistence.updateMetadata(projectMeta),
+        ).thenAnswer((_) async => updatedMeta);
+        when(
+          () => mockPersistence.updateDbEntity(committedProject),
+        ).thenAnswer((_) async => false);
+
+        final result = await repository.updateProject(changedProject);
+
+        expect(result, isTrue);
+        verify(
+          () => mockNotifications.notify({
+            projectEntityUpdateNotification(projectEntry.id),
+          }),
+        ).called(1);
+      },
+    );
+
+    test('rejects category changes while tasks remain linked', () async {
+      final movedProject = projectEntry.copyWith(
+        meta: projectMeta.copyWith(categoryId: 'cat-2'),
+      );
+      when(
+        () => mockDb.getTaskIdsForProjects({projectEntry.id}),
+      ).thenAnswer((_) async => {taskEntry.id});
+
+      final result = await repository.updateProject(movedProject);
+
+      expect(result, isFalse);
+      verifyNever(() => mockPersistence.updateMetadata(any()));
+      verifyNever(() => mockPersistence.updateDbEntity(any()));
+      verifyNever(() => mockNotifications.notify(any()));
+    });
+
+    test(
+      'rejects category changes while a project agent remains active',
+      () async {
+        hasActiveProjectAgent = true;
+        final movedProject = projectEntry.copyWith(
+          meta: projectMeta.copyWith(categoryId: 'cat-2'),
+        );
+        when(
+          () => mockDb.getTaskIdsForProjects({projectEntry.id}),
+        ).thenAnswer((_) async => const {});
+
+        final result = await repository.updateProject(movedProject);
+
+        expect(result, isFalse);
+        verifyNever(() => mockPersistence.updateMetadata(any()));
+        verifyNever(() => mockPersistence.updateDbEntity(any()));
+        verifyNever(() => mockNotifications.notify(any()));
+      },
+    );
+
+    test(
+      'rejects category changes when private linked tasks are hidden',
+      () async {
+        final privateProject = projectEntry.copyWith(
+          meta: projectMeta.copyWith(private: true),
+        );
+        final movedProject = privateProject.copyWith(
+          meta: privateProject.meta.copyWith(categoryId: 'cat-2'),
+        );
+        when(
+          () => mockDb.entityById(projectEntry.id),
+        ).thenAnswer((_) async => toDbEntity(privateProject));
+        when(
+          () => mockDb.getTasksForProject(projectEntry.id),
+        ).thenAnswer((_) async => const []);
+        when(
+          () => mockDb.getTaskIdsForProjects({projectEntry.id}),
+        ).thenAnswer((_) async => {taskEntry.id});
+
+        final result = await repository.updateProject(movedProject);
+
+        expect(result, isFalse);
+        verify(
+          () => mockDb.getTaskIdsForProjects({projectEntry.id}),
+        ).called(1);
+        verifyNever(() => mockDb.getTasksForProject(any()));
+        verifyNever(() => mockPersistence.updateMetadata(any()));
+        verifyNever(() => mockPersistence.updateDbEntity(any()));
+        verifyNever(() => mockNotifications.notify(any()));
+      },
+    );
+
+    test('checks category membership and writes in one transaction', () async {
+      final trackingDb = _TransactionTrackingJournalDb(
+        rows: {projectEntry.id: toDbEntity(projectEntry)},
+      );
+      final movedProject = projectEntry.copyWith(
+        meta: projectMeta.copyWith(categoryId: 'cat-2'),
+      );
+      final updatedMeta = movedProject.meta.copyWith(
+        updatedAt: DateTime(2024, 3, 16),
+        vectorClock: const VectorClock({'device-1': 2}),
+      );
+      var writeInsideTransaction = false;
+      when(
+        () => mockPersistence.updateMetadata(movedProject.meta),
+      ).thenAnswer((_) async => updatedMeta);
+      when(
+        () => mockPersistence.updateDbEntity(
+          movedProject.copyWith(meta: updatedMeta),
+        ),
+      ).thenAnswer((_) async {
+        writeInsideTransaction = trackingDb.insideTransaction;
+        return true;
+      });
+      final trackingRepository = ProjectRepository(
+        journalDb: trackingDb,
+        entitiesCacheService: mockEntitiesCacheService,
+        persistenceLogic: mockPersistence,
+        updateNotifications: mockNotifications,
+        vectorClockService: mockVectorClockService,
+      );
+
+      final result = await trackingRepository.updateProject(movedProject);
+
+      expect(result, isTrue);
+      expect(trackingDb.entityReadInsideTransaction, isTrue);
+      expect(trackingDb.taskReadInsideTransaction, isTrue);
+      expect(writeInsideTransaction, isTrue);
+    });
+  });
+
+  group('deleteProject', () {
+    test('soft-deletes, persists, and notifies the project scope', () async {
+      final deletedMeta = projectMeta.copyWith(
+        updatedAt: testDate.add(const Duration(minutes: 1)),
+        deletedAt: testDate,
+      );
+      when(
+        () => mockPersistence.updateMetadata(
+          projectMeta,
+          deletedAt: testDate,
+        ),
+      ).thenAnswer((_) async => deletedMeta);
+      when(
+        () => mockPersistence.updateDbEntity(
+          projectEntry.copyWith(meta: deletedMeta),
+        ),
+      ).thenAnswer((_) async => true);
+
+      final result = await repository.deleteProject(
+        projectEntry,
+        deletedAt: testDate,
+      );
+
+      expect(result, isTrue);
+      verify(
+        () => mockPersistence.updateMetadata(
+          projectMeta,
+          deletedAt: testDate,
+        ),
+      ).called(1);
+      verify(
+        () => mockPersistence.updateDbEntity(
+          projectEntry.copyWith(meta: deletedMeta),
+        ),
+      ).called(1);
+      verify(
+        () => mockNotifications.notify({
+          projectEntityUpdateNotification(projectEntry.id),
+        }),
+      ).called(1);
+    });
+
+    test('does not notify when persistence rejects the delete', () async {
+      final deletedMeta = projectMeta.copyWith(deletedAt: testDate);
+      when(
+        () => mockPersistence.updateMetadata(
+          projectMeta,
+          deletedAt: testDate,
+        ),
+      ).thenAnswer((_) async => deletedMeta);
+      when(
+        () => mockPersistence.updateDbEntity(
+          projectEntry.copyWith(meta: deletedMeta),
+        ),
+      ).thenAnswer((_) async => false);
+      when(
+        () => mockDb.journalEntityById(projectEntry.id),
+      ).thenAnswer((_) async => projectEntry);
+
+      final result = await repository.deleteProject(
+        projectEntry,
+        deletedAt: testDate,
+      );
+
+      expect(result, isFalse);
+      verify(
+        () => mockPersistence.updateMetadata(
+          projectMeta,
+          deletedAt: testDate,
+        ),
+      ).called(1);
+      verify(
+        () => mockPersistence.updateDbEntity(
+          projectEntry.copyWith(meta: deletedMeta),
+        ),
+      ).called(1);
+      verifyNever(() => mockNotifications.notify(any()));
+    });
+
+    test(
+      'accepts a false result when the project tombstone committed',
+      () async {
+        final deletedMeta = projectMeta.copyWith(deletedAt: testDate);
+        when(
+          () => mockPersistence.updateMetadata(
+            projectMeta,
+            deletedAt: testDate,
+          ),
+        ).thenAnswer((_) async => deletedMeta);
+        when(
+          () => mockPersistence.updateDbEntity(
+            projectEntry.copyWith(meta: deletedMeta),
+          ),
+        ).thenAnswer((_) async => false);
+        when(
+          () => mockDb.journalEntityById(projectEntry.id),
+        ).thenAnswer((_) async => null);
+
+        final result = await repository.deleteProject(
+          projectEntry,
+          deletedAt: testDate,
+        );
+
+        expect(result, isTrue);
+        verify(
+          () => mockNotifications.notify({
+            projectEntityUpdateNotification(projectEntry.id),
+          }),
+        ).called(1);
+      },
+    );
   });
 
   group('linkTaskToProject', () {
@@ -828,8 +1295,8 @@ void main() {
       );
 
       when(
-        () => mockDb.journalEntityById('task-cross'),
-      ).thenAnswer((_) async => crossCategoryTask);
+        () => mockDb.entityById('task-cross'),
+      ).thenAnswer((_) async => toDbEntity(crossCategoryTask));
 
       final result = await repository.linkTaskToProject(
         projectId: 'project-001',
@@ -837,6 +1304,53 @@ void main() {
       );
 
       expect(result, isFalse);
+    });
+
+    test('rejects linking when project and task privacy differ', () async {
+      final privateProject = projectEntry.copyWith(
+        meta: projectEntry.meta.copyWith(private: true),
+      );
+      when(
+        () => mockDb.entityById('project-private'),
+      ).thenAnswer((_) async => toDbEntity(privateProject));
+
+      final result = await repository.linkTaskToProject(
+        projectId: 'project-private',
+        taskId: 'task-001',
+      );
+
+      expect(result, isFalse);
+      verify(
+        () => mockDb.getProjectLinkForTask('task-001'),
+      ).called(1);
+      verifyNever(() => mockDb.upsertEntryLink(any()));
+    });
+
+    test('treats null and false privacy as the same public value', () async {
+      final explicitlyPublicTask = Task(
+        meta: taskMeta.copyWith(private: false),
+        data: taskEntry.data,
+      );
+      when(
+        () => mockDb.entityById('task-explicitly-public'),
+      ).thenAnswer((_) async => toDbEntity(explicitlyPublicTask));
+      when(
+        () => mockDb.getProjectLinkForTask('task-explicitly-public'),
+      ).thenAnswer((_) async => null);
+      when(
+        mockVectorClockService.getNextVectorClock,
+      ).thenAnswer((_) async => const VectorClock({'d': 1}));
+
+      final result = await repository.linkTaskToProject(
+        projectId: 'project-001',
+        taskId: 'task-explicitly-public',
+      );
+
+      expect(result, isTrue);
+      final link =
+          verify(() => mockDb.upsertEntryLink(captureAny())).captured.single
+              as EntryLink;
+      expect(link.toId, 'task-explicitly-public');
     });
 
     test('rejects non-Task entity', () async {
@@ -847,8 +1361,8 @@ void main() {
       );
 
       when(
-        () => mockDb.journalEntityById('task-001'),
-      ).thenAnswer((_) async => noteEntry);
+        () => mockDb.entityById('task-001'),
+      ).thenAnswer((_) async => toDbEntity(noteEntry));
 
       final result = await repository.linkTaskToProject(
         projectId: 'project-001',
@@ -861,7 +1375,7 @@ void main() {
 
     test('returns false when project does not exist', () async {
       when(
-        () => mockDb.journalEntityById('missing'),
+        () => mockDb.entityById('missing'),
       ).thenAnswer((_) async => null);
 
       final result = await repository.linkTaskToProject(
@@ -874,7 +1388,7 @@ void main() {
 
     test('returns false when task does not exist', () async {
       when(
-        () => mockDb.journalEntityById('missing'),
+        () => mockDb.entityById('missing'),
       ).thenAnswer((_) async => null);
 
       final result = await repository.linkTaskToProject(
@@ -903,6 +1417,50 @@ void main() {
       verifyNever(() => mockNotifications.notify(any()));
       verifyNever(() => mockOutboxService.enqueueMessage(any()));
     });
+
+    test(
+      'revalidates privacy in the same transaction as a new link write',
+      () async {
+        final rows = <String, JournalDbEntity>{
+          projectEntry.id: toDbEntity(projectEntry),
+          taskEntry.id: toDbEntity(taskEntry),
+        };
+        final trackingDb = _TransactionTrackingJournalDb(
+          rows: rows,
+          onTransactionStart: () {
+            final privateProject = projectEntry.copyWith(
+              meta: projectEntry.meta.copyWith(private: true),
+            );
+            rows[projectEntry.id] = toDbEntity(privateProject);
+          },
+        );
+        when(
+          () => trackingDb.getProjectLinkForTask(taskEntry.id),
+        ).thenAnswer((_) async => null);
+        when(
+          () => trackingDb.upsertEntryLink(any()),
+        ).thenAnswer((_) async => 1);
+        when(
+          mockVectorClockService.getNextVectorClock,
+        ).thenAnswer((_) async => const VectorClock({'d': 1}));
+        final trackingRepository = ProjectRepository(
+          journalDb: trackingDb,
+          entitiesCacheService: mockEntitiesCacheService,
+          persistenceLogic: mockPersistence,
+          updateNotifications: mockNotifications,
+          vectorClockService: mockVectorClockService,
+        );
+
+        final result = await trackingRepository.linkTaskToProject(
+          projectId: projectEntry.id,
+          taskId: taskEntry.id,
+        );
+
+        expect(result, isFalse);
+        expect(trackingDb.entityReadInsideTransaction, isTrue);
+        verifyNever(() => trackingDb.upsertEntryLink(any()));
+      },
+    );
 
     test('returns true if task is already linked to same project', () async {
       final existingLink = EntryLink.project(
@@ -1016,8 +1574,9 @@ void main() {
     );
 
     test(
-      'returns false when insert fails after soft-delete in transaction',
+      'rolls back the soft-delete when relink insertion fails',
       () async {
+        final rollbackDb = _RollbackTrackingJournalDb();
         final oldLink = EntryLink.project(
           id: 'link-old',
           fromId: 'project-old',
@@ -1027,12 +1586,18 @@ void main() {
           vectorClock: null,
         );
 
+        when(() => rollbackDb.entityById('project-001')).thenAnswer(
+          (_) async => toDbEntity(projectEntry),
+        );
+        when(() => rollbackDb.entityById('task-001')).thenAnswer(
+          (_) async => toDbEntity(taskEntry),
+        );
         when(
-          () => mockDb.getProjectLinkForTask('task-001'),
+          () => rollbackDb.getProjectLinkForTask('task-001'),
         ).thenAnswer((_) async => oldLink);
         // First call (soft-delete) succeeds, second call (insert) fails
         var callCount = 0;
-        when(() => mockDb.upsertEntryLink(any())).thenAnswer((_) async {
+        when(() => rollbackDb.upsertEntryLink(any())).thenAnswer((_) async {
           callCount++;
           return callCount == 1 ? 1 : 0;
         });
@@ -1040,14 +1605,22 @@ void main() {
           mockVectorClockService.getNextVectorClock,
         ).thenAnswer((_) async => const VectorClock({'d': 1}));
 
-        final result = await repository.linkTaskToProject(
+        final rollbackRepository = ProjectRepository(
+          journalDb: rollbackDb,
+          entitiesCacheService: mockEntitiesCacheService,
+          persistenceLogic: mockPersistence,
+          updateNotifications: mockNotifications,
+          vectorClockService: mockVectorClockService,
+        );
+
+        final result = await rollbackRepository.linkTaskToProject(
           projectId: 'project-001',
           taskId: 'task-001',
         );
 
         expect(result, isFalse);
-        // Both writes were attempted inside transaction
-        verify(() => mockDb.upsertEntryLink(any())).called(2);
+        expect(rollbackDb.rolledBack, isTrue);
+        verify(() => rollbackDb.upsertEntryLink(any())).called(2);
         // No side effects — transaction failed
         verifyNever(() => mockNotifications.notify(any()));
         verifyNever(() => mockOutboxService.enqueueMessage(any()));
@@ -1056,6 +1629,106 @@ void main() {
   });
 
   group('unlinkTaskFromProject', () {
+    test(
+      'conditional cleanup removes only a currently mismatched membership',
+      () async {
+        final link = EntryLink.project(
+          id: 'link-001',
+          fromId: projectEntry.id,
+          toId: taskEntry.id,
+          createdAt: testDate,
+          updatedAt: testDate,
+          vectorClock: null,
+        );
+        when(
+          () => mockDb.getProjectLinkForTask(taskEntry.id),
+        ).thenAnswer((_) async => link);
+        when(() => mockDb.entityById(taskEntry.id)).thenAnswer(
+          (_) async => toDbEntity(
+            taskEntry.copyWith(meta: taskMeta.copyWith(private: true)),
+          ),
+        );
+        expect(
+          await repository.unlinkTaskFromProject(
+            taskEntry.id,
+            onlyIfPrivacyMismatched: true,
+          ),
+          isTrue,
+        );
+        final deleted =
+            verify(() => mockDb.upsertEntryLink(captureAny())).captured.single
+                as EntryLink;
+        expect(deleted.id, link.id);
+        expect(deleted.deletedAt, isNotNull);
+        expect(deleted.hidden, isTrue);
+        verify(() => mockOutboxService.enqueueMessage(any())).called(1);
+      },
+    );
+
+    for (final race in ['project privacy', 'task privacy', 'membership']) {
+      test(
+        'preserves a compatible membership after concurrent $race update',
+        () async {
+          final link = EntryLink.project(
+            id: 'link-001',
+            fromId: projectEntry.id,
+            toId: taskEntry.id,
+            createdAt: testDate,
+            updatedAt: testDate,
+            vectorClock: null,
+          );
+          var currentLink = link;
+          final rows = {
+            projectEntry.id: toDbEntity(projectEntry),
+            taskEntry.id: toDbEntity(
+              taskEntry.copyWith(meta: taskMeta.copyWith(private: true)),
+            ),
+          };
+          final db = _TransactionTrackingJournalDb(
+            rows: rows,
+            onTransactionStart: () {
+              switch (race) {
+                case 'project privacy':
+                  rows[projectEntry.id] = toDbEntity(
+                    projectEntry.copyWith(
+                      meta: projectMeta.copyWith(private: true),
+                    ),
+                  );
+                case 'task privacy':
+                  rows[taskEntry.id] = toDbEntity(taskEntry);
+                case 'membership':
+                  currentLink = link.copyWith(
+                    id: 'replacement-link',
+                    fromId: 'another-project',
+                  );
+              }
+            },
+          );
+          when(
+            () => db.getProjectLinkForTask(taskEntry.id),
+          ).thenAnswer((_) async => currentLink);
+          when(() => db.upsertEntryLink(any())).thenAnswer((_) async => 1);
+          final guardedRepository = ProjectRepository(
+            journalDb: db,
+            entitiesCacheService: mockEntitiesCacheService,
+            persistenceLogic: mockPersistence,
+            updateNotifications: mockNotifications,
+            vectorClockService: mockVectorClockService,
+          );
+          expect(
+            await guardedRepository.unlinkTaskFromProject(
+              taskEntry.id,
+              onlyIfPrivacyMismatched: true,
+            ),
+            isFalse,
+          );
+          verifyNever(() => db.upsertEntryLink(any()));
+          verifyNever(() => mockNotifications.notify(any()));
+          verifyNever(() => mockOutboxService.enqueueMessage(any()));
+        },
+      );
+    }
+
     test('returns false when no link exists', () async {
       when(
         () => mockDb.getProjectLinkForTask('task-001'),
@@ -1664,7 +2337,7 @@ void main() {
       );
 
       expect(result, isFalse);
-      verifyNever(() => mockDb.journalEntityById(any()));
+      verifyNever(() => mockDb.entityById(any()));
     });
 
     test('links new task to the source task project when found', () async {
@@ -1678,8 +2351,8 @@ void main() {
         data: taskEntry.data,
       );
       when(
-        () => mockDb.journalEntityById('new-task'),
-      ).thenAnswer((_) async => newTaskEntry);
+        () => mockDb.entityById('new-task'),
+      ).thenAnswer((_) async => toDbEntity(newTaskEntry));
       when(
         () => mockDb.getProjectLinkForTask('new-task'),
       ).thenAnswer((_) async => null);

--- a/test/features/projects/state/project_detail_controller_test.dart
+++ b/test/features/projects/state/project_detail_controller_test.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/geolocation.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/project_data.dart';
 import 'package:lotti/features/projects/repository/project_repository.dart';
@@ -90,8 +92,64 @@ void main() {
       final state = container.read(
         projectDetailControllerProvider(projectId),
       );
+      final notifier = container.read(
+        projectDetailControllerProvider(projectId).notifier,
+      );
       expect(state.hasChanges, isTrue);
       expect(state.project!.data.title, 'New Title');
+      expect(notifier.isTitleDirty, isTrue);
+      expect(notifier.isDescriptionDirty, isFalse);
+    });
+
+    test('updateDescription marks hasChanges true', () async {
+      final container = await createLoadedContainer();
+
+      container
+          .read(projectDetailControllerProvider(projectId).notifier)
+          .updateDescription('A clear project brief.');
+
+      final state = container.read(projectDetailControllerProvider(projectId));
+      final notifier = container.read(
+        projectDetailControllerProvider(projectId).notifier,
+      );
+      expect(state.hasChanges, isTrue);
+      expect(state.project?.entryText?.plainText, 'A clear project brief.');
+      expect(notifier.isTitleDirty, isFalse);
+      expect(notifier.isDescriptionDirty, isTrue);
+    });
+
+    test('updateDescription preserves ancillary entry text', () async {
+      final geolocation = Geolocation(
+        createdAt: DateTime(2026, 8, 16),
+        latitude: 52.52,
+        longitude: 13.405,
+        geohashString: 'u33d',
+      );
+      final project = makeTestProject(id: projectId).copyWith(
+        entryText: EntryText(
+          plainText: 'Old description',
+          markdown: '**Old description**',
+          quill: '[{"insert":"Old description"}]',
+          geolocation: geolocation,
+        ),
+      );
+      when(
+        () => mockRepo.getProjectById(projectId),
+      ).thenAnswer((_) async => project);
+      final container = await createLoadedContainer();
+
+      container
+          .read(projectDetailControllerProvider(projectId).notifier)
+          .updateDescription('Updated description');
+
+      final entryText = container
+          .read(projectDetailControllerProvider(projectId))
+          .project
+          ?.entryText;
+      expect(entryText?.plainText, 'Updated description');
+      expect(entryText?.markdown, '**Old description**');
+      expect(entryText?.quill, '[{"insert":"Old description"}]');
+      expect(entryText?.geolocation, geolocation);
     });
 
     test('updateTargetDate marks hasChanges true', () async {
@@ -274,8 +332,6 @@ void main() {
         expect(state.hasChanges, isFalse);
         expect(state.project!.meta.categoryId, 'new-category-id');
 
-        // The repository receives the entity with the new category, proving the
-        // pending edit was propagated through saveChanges.
         verify(() => mockRepo.updateProject(any())).called(1);
         expect(persisted, isNotNull);
         expect(persisted!.meta.categoryId, 'new-category-id');
@@ -304,6 +360,369 @@ void main() {
         expect(state.isSaving, isFalse);
       },
     );
+
+    test(
+      'discardChanges restores persisted state after a failed save',
+      () async {
+        when(
+          () => mockRepo.updateProject(any()),
+        ).thenAnswer((_) async => false);
+
+        final container = await createLoadedContainer();
+        final notifier = container.read(
+          projectDetailControllerProvider(projectId).notifier,
+        )..updateTitle('Unsaved optimistic title');
+        await notifier.saveChanges();
+
+        expect(
+          container
+              .read(projectDetailControllerProvider(projectId))
+              .project!
+              .data
+              .title,
+          'Unsaved optimistic title',
+        );
+
+        notifier.discardChanges();
+        final restored = container.read(
+          projectDetailControllerProvider(projectId),
+        );
+        expect(restored.project!.data.title, 'Test Project');
+        expect(restored.hasChanges, isFalse);
+        expect(restored.error, isNull);
+      },
+    );
+
+    test(
+      'failed save discards to a concurrently reloaded persisted baseline',
+      () async {
+        final updateResult = Completer<bool>();
+        when(
+          () => mockRepo.updateProject(any()),
+        ).thenAnswer((_) => updateResult.future);
+        final container = await createLoadedContainer();
+        final notifier = container.read(
+          projectDetailControllerProvider(projectId).notifier,
+        );
+        final saveFuture = (notifier..updateTitle('Unsaved optimistic title'))
+            .saveChanges();
+        expect(
+          container.read(projectDetailControllerProvider(projectId)).isSaving,
+          isTrue,
+        );
+
+        final syncedProject = makeTestProject(id: projectId).copyWith(
+          data: makeTestProject(
+            id: projectId,
+          ).data.copyWith(title: 'Title received from sync'),
+        );
+        final syncedTask = makeTestTask(id: 'synced-task');
+        when(
+          () => mockRepo.getProjectById(projectId),
+        ).thenAnswer((_) async => syncedProject);
+        when(
+          () => mockRepo.getTasksForProject(projectId),
+        ).thenAnswer((_) async => [syncedTask]);
+        final reloadObserved = Completer<void>();
+        final subscription = container.listen(
+          projectDetailControllerProvider(projectId),
+          (_, next) {
+            if (next.linkedTasks.any((task) => task.id == syncedTask.id) &&
+                !reloadObserved.isCompleted) {
+              reloadObserved.complete();
+            }
+          },
+        );
+
+        updateStreamController.add({projectId});
+        await reloadObserved.future;
+        subscription.close();
+        expect(
+          container
+              .read(projectDetailControllerProvider(projectId))
+              .project!
+              .data
+              .title,
+          'Unsaved optimistic title',
+        );
+
+        updateResult.complete(false);
+        await saveFuture;
+        notifier.discardChanges();
+
+        final restored = container.read(
+          projectDetailControllerProvider(projectId),
+        );
+        expect(restored.project!.data.title, 'Title received from sync');
+        expect(restored.hasChanges, isFalse);
+        expect(restored.error, isNull);
+      },
+    );
+
+    test('rebases pending fields onto a concurrently synced project', () async {
+      ProjectEntry? persisted;
+      when(() => mockRepo.updateProject(any())).thenAnswer((invocation) async {
+        persisted = invocation.positionalArguments.single as ProjectEntry;
+        return true;
+      });
+      final container = await createLoadedContainer();
+      final notifier = container.read(
+        projectDetailControllerProvider(projectId).notifier,
+      );
+      final localTargetDate = DateTime(2026, 9);
+      notifier
+        ..updateTargetDate(localTargetDate)
+        ..updateDescription('Local draft without persisted entry text');
+
+      final syncedStatus = ProjectStatus.active(
+        id: 'synced-status',
+        createdAt: DateTime(2026, 8, 16),
+        utcOffset: 0,
+      );
+      final syncedProject = makeTestProject(id: projectId).copyWith(
+        data: makeTestProject(id: projectId).data.copyWith(
+          title: 'Synced title',
+          status: syncedStatus,
+        ),
+      );
+      when(
+        () => mockRepo.getProjectById(projectId),
+      ).thenAnswer((_) async => syncedProject);
+      final syncedTask = makeTestTask(id: 'rebased-sync-task');
+      when(
+        () => mockRepo.getTasksForProject(projectId),
+      ).thenAnswer((_) async => [syncedTask]);
+      final reloadObserved = Completer<void>();
+      final subscription = container.listen(
+        projectDetailControllerProvider(projectId),
+        (_, next) {
+          if (next.linkedTasks.any((task) => task.id == syncedTask.id) &&
+              !reloadObserved.isCompleted) {
+            reloadObserved.complete();
+          }
+        },
+      );
+
+      updateStreamController.add({projectId});
+      await reloadObserved.future;
+      subscription.close();
+
+      final rebased = container.read(
+        projectDetailControllerProvider(projectId),
+      );
+      expect(
+        rebased.project!.entryText?.plainText,
+        'Local draft without persisted entry text',
+      );
+      expect(rebased.project!.data.title, 'Synced title');
+      expect(rebased.project!.data.status, syncedStatus);
+      expect(rebased.project!.data.targetDate, localTargetDate);
+      expect(rebased.hasChanges, isTrue);
+
+      await notifier.saveChanges();
+
+      expect(persisted!.data.title, 'Synced title');
+      expect(persisted!.data.status, syncedStatus);
+      expect(persisted!.data.targetDate, localTargetDate);
+
+      final locallyEditedStatus = ProjectStatus.active(
+        id: 'locally-edited-status',
+        createdAt: DateTime(2026, 8, 17),
+        utcOffset: 0,
+      );
+      notifier
+        ..updateTitle('Locally edited title')
+        ..updateDescription('Locally edited description')
+        ..updateCategoryId('local-category')
+        ..updateStatus(locallyEditedStatus);
+      final secondSyncedAt = DateTime(2026, 8, 18);
+      final syncedGeolocation = Geolocation(
+        createdAt: secondSyncedAt,
+        latitude: 59.3293,
+        longitude: 18.0686,
+        geohashString: 'u6sce',
+      );
+      final secondSyncedProject = persisted!.copyWith(
+        meta: persisted!.meta.copyWith(updatedAt: secondSyncedAt),
+        entryText: EntryText(
+          plainText: 'Body received from sync',
+          markdown: '**Synced body**',
+          quill: '[{"insert":"Synced body"}]',
+          geolocation: syncedGeolocation,
+        ),
+      );
+      final secondSyncedTask = makeTestTask(id: 'second-rebased-sync-task');
+      when(
+        () => mockRepo.getProjectById(projectId),
+      ).thenAnswer((_) async => secondSyncedProject);
+      when(
+        () => mockRepo.getTasksForProject(projectId),
+      ).thenAnswer((_) async => [secondSyncedTask]);
+      final secondReloadObserved = Completer<void>();
+      final secondSubscription = container.listen(
+        projectDetailControllerProvider(projectId),
+        (_, next) {
+          if (next.linkedTasks.any(
+                (task) => task.id == secondSyncedTask.id,
+              ) &&
+              !secondReloadObserved.isCompleted) {
+            secondReloadObserved.complete();
+          }
+        },
+      );
+
+      updateStreamController.add({projectId});
+      await secondReloadObserved.future;
+      secondSubscription.close();
+
+      final fullyRebased = container.read(
+        projectDetailControllerProvider(projectId),
+      );
+      expect(fullyRebased.project!.data.title, 'Locally edited title');
+      expect(fullyRebased.project!.meta.categoryId, 'local-category');
+      expect(fullyRebased.project!.data.status, locallyEditedStatus);
+      expect(fullyRebased.project!.data.targetDate, localTargetDate);
+      expect(fullyRebased.project!.meta.updatedAt, secondSyncedAt);
+      expect(
+        fullyRebased.project!.entryText?.plainText,
+        'Locally edited description',
+      );
+      expect(fullyRebased.project!.entryText?.markdown, '**Synced body**');
+      expect(
+        fullyRebased.project!.entryText?.quill,
+        '[{"insert":"Synced body"}]',
+      );
+      expect(
+        fullyRebased.project!.entryText?.geolocation,
+        syncedGeolocation,
+      );
+
+      await notifier.saveChanges();
+      expect(persisted!.entryText?.plainText, 'Locally edited description');
+      expect(persisted!.entryText?.markdown, '**Synced body**');
+      expect(persisted!.entryText?.quill, '[{"insert":"Synced body"}]');
+      expect(persisted!.entryText?.geolocation, syncedGeolocation);
+    });
+
+    test('clears pending edits when a synced deletion is observed', () async {
+      final container = await createLoadedContainer();
+      final notifier = container.read(
+        projectDetailControllerProvider(projectId).notifier,
+      )..updateTitle('Unsaved title');
+      when(
+        () => mockRepo.getProjectById(projectId),
+      ).thenAnswer((_) async => null);
+      final deletionObserved = Completer<void>();
+      final subscription = container.listen(
+        projectDetailControllerProvider(projectId),
+        (_, next) {
+          if (next.project == null && !deletionObserved.isCompleted) {
+            deletionObserved.complete();
+          }
+        },
+      );
+
+      updateStreamController.add({projectId});
+      await deletionObserved.future;
+      subscription.close();
+
+      final deleted = container.read(
+        projectDetailControllerProvider(projectId),
+      );
+      expect(deleted.project, isNull);
+      expect(deleted.hasChanges, isFalse);
+
+      await notifier.saveChanges();
+      verifyNever(() => mockRepo.updateProject(any()));
+    });
+
+    test('applies a synced deletion even when task loading fails', () async {
+      final container = await createLoadedContainer();
+      final subscription = container.listen(
+        projectDetailControllerProvider(projectId),
+        (_, _) {},
+      );
+      final notifier = container.read(
+        projectDetailControllerProvider(projectId).notifier,
+      )..updateTitle('Unsaved title');
+      clearInteractions(mockRepo);
+      when(
+        () => mockRepo.getProjectById(projectId),
+      ).thenAnswer((_) async => null);
+      when(
+        () => mockRepo.getTasksForProject(projectId),
+      ).thenAnswer((_) async => throw StateError('task rollup failed'));
+
+      updateStreamController.add({projectId});
+      await pumpEventQueue();
+      await pumpEventQueue();
+
+      final deleted = container.read(
+        projectDetailControllerProvider(projectId),
+      );
+      expect(deleted.project, isNull);
+      expect(deleted.hasChanges, isFalse);
+
+      await notifier.saveChanges();
+      verifyNever(() => mockRepo.updateProject(any()));
+      subscription.close();
+    });
+
+    test('ignores an older reload that completes after a deletion', () async {
+      final container = await createLoadedContainer();
+      final staleTasks = Completer<List<Task>>();
+      final firstReloadStarted = Completer<void>();
+      var projectReloadCount = 0;
+      var taskReloadCount = 0;
+      final staleProject = makeTestProject(
+        id: projectId,
+        title: 'Stale project',
+      );
+      final staleTask = makeTestTask(id: 'stale-task');
+      when(
+        () => mockRepo.getProjectById(projectId),
+      ).thenAnswer((_) async {
+        projectReloadCount++;
+        return projectReloadCount == 1 ? staleProject : null;
+      });
+      when(
+        () => mockRepo.getTasksForProject(projectId),
+      ).thenAnswer((_) {
+        taskReloadCount++;
+        if (taskReloadCount == 1) {
+          firstReloadStarted.complete();
+          return staleTasks.future;
+        }
+        return Future.value([]);
+      });
+
+      updateStreamController.add({projectId});
+      await firstReloadStarted.future;
+
+      final deletionObserved = Completer<void>();
+      final subscription = container.listen(
+        projectDetailControllerProvider(projectId),
+        (_, next) {
+          if (next.project == null && !deletionObserved.isCompleted) {
+            deletionObserved.complete();
+          }
+        },
+      );
+      updateStreamController.add({projectId});
+      await deletionObserved.future;
+
+      staleTasks.complete([staleTask]);
+      await pumpEventQueue();
+      await pumpEventQueue();
+      subscription.close();
+
+      final state = container.read(
+        projectDetailControllerProvider(projectId),
+      );
+      expect(state.project, isNull);
+      expect(state.linkedTasks, isEmpty);
+      expect(state.hasChanges, isFalse);
+    });
 
     test('saveChanges sets updateFailed on exception', () async {
       when(

--- a/test/features/projects/ui/widgets/project_agent_report_card_test.dart
+++ b/test/features/projects/ui/widgets/project_agent_report_card_test.dart
@@ -390,6 +390,54 @@ void main() {
       ).called(1);
     });
 
+    for (final ineligible in [
+      makeTestTemplate(
+        kind: AgentTemplateKind.projectAgent,
+        categoryIds: const {'another-category'},
+      ),
+      makeTestTemplate(
+        kind: AgentTemplateKind.projectAgent,
+      ).copyWith(deletedAt: DateTime(2026, 9, 4)),
+    ]) {
+      testWidgets(
+        'fallback rejects ineligible template ${ineligible.categoryIds}',
+        (
+          tester,
+        ) async {
+          final templates = MockAgentTemplateService();
+          when(
+            () => templates.listTemplatesForCategory(categoryId),
+          ).thenAnswer((_) async => []);
+          when(templates.listTemplates).thenAnswer((_) async => [ineligible]);
+          await tester.pumpWidget(
+            buildSubject(
+              overrides: [
+                projectAgentProvider(
+                  projectId,
+                ).overrideWith((ref) async => null),
+                projectAgentServiceProvider.overrideWithValue(
+                  MockProjectAgentService(),
+                ),
+                agentTemplateServiceProvider.overrideWithValue(templates),
+                inferenceProfileControllerProvider.overrideWith(
+                  () => _FakeInferenceProfileController([testProfile]),
+                ),
+              ],
+            ),
+          );
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Assign Agent'));
+          await tester.pumpAndSettle();
+          final context = tester.element(find.byType(ProjectAgentReportCard));
+          expect(
+            find.text(context.messages.agentTemplateNoTemplates),
+            findsOneWidget,
+          );
+          expect(find.text('Create Agent'), findsNothing);
+        },
+      );
+    }
+
     testWidgets('create agent button shows snackbar when no templates exist', (
       tester,
     ) async {

--- a/test/features/tasks/ui/pages/tasks_tab_page_test.dart
+++ b/test/features/tasks/ui/pages/tasks_tab_page_test.dart
@@ -535,6 +535,50 @@ void main() {
     );
   });
 
+  for (final failure in ['exception', 'null', 'disposed']) {
+    testWidgets('default FAB handles creation failure: $failure', (
+      tester,
+    ) async {
+      final result = Completer<Task?>();
+      when(
+        () => mockPersistenceLogic.createTaskEntry(
+          data: any(named: 'data'),
+          entryText: any(named: 'entryText'),
+          categoryId: any(named: 'categoryId'),
+          labelIds: any(named: 'labelIds'),
+        ),
+      ).thenAnswer((_) => result.future);
+      await tester.pumpWidget(buildSubject(state: state()));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      final message = tester
+          .element(find.byType(TasksTabPage))
+          .messages
+          .commonError;
+      await tester.tap(find.byIcon(LottiIcons.add));
+      await tester.pump();
+      if (failure == 'disposed') {
+        await tester.pumpWidget(const SizedBox.shrink());
+      }
+      if (failure == 'null') {
+        result.complete();
+      } else {
+        result.completeError(StateError('Task cleanup failed'));
+      }
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(tester.takeException(), isNull);
+      verifyNever(
+        () => mockNavService.beamToNamed(any(), data: any(named: 'data')),
+      );
+      expect(
+        find.text(message),
+        failure == 'disposed' ? findsNothing : findsOneWidget,
+      );
+    });
+  }
+
   testWidgets('default FAB creates task and navigates', (tester) async {
     final createdTask = TestTaskFactory.create(
       id: 'new-task',

--- a/test/logic/create/create_entry_test.dart
+++ b/test/logic/create/create_entry_test.dart
@@ -34,6 +34,34 @@ import '../../helpers/path_provider.dart';
 import '../../mocks/mocks.dart';
 import '../../widget_test_utils.dart';
 
+class _RejectingTaskCleanupPersistenceLogic extends PersistenceLogic {
+  _RejectingTaskCleanupPersistenceLogic({this.commitBeforeFailure = false});
+
+  final bool commitBeforeFailure;
+  @override
+  Future<bool?> updateDbEntity(
+    JournalEntity journalEntity, {
+    String? linkedId,
+    bool enqueueSync = true,
+    bool overrideComparison = false,
+    Future<void> Function()? beforeNotify,
+  }) async {
+    if (journalEntity is Task && journalEntity.meta.deletedAt != null) {
+      if (commitBeforeFailure) {
+        await super.updateDbEntity(journalEntity);
+      }
+      return false;
+    }
+    return super.updateDbEntity(
+      journalEntity,
+      linkedId: linkedId,
+      enqueueSync: enqueueSync,
+      overrideComparison: overrideComparison,
+      beforeNotify: beforeNotify,
+    );
+  }
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   setFakeDocumentsPath();
@@ -280,6 +308,76 @@ void main() {
       expect((persisted as Task).data.status, isA<TaskInProgress>());
     });
 
+    for (final projectPrivate in [false, true]) {
+      test('createTask rejects conflicting linked privacy before writing '
+          '(project private: $projectPrivate)', () async {
+        final project = TestProjectFactory.create(id: 'project');
+        final parent = TestTaskFactory.create(id: 'parent');
+        await getIt<PersistenceLogic>().createDbEntity(
+          project.copyWith(
+            meta: project.meta.copyWith(private: projectPrivate),
+          ),
+        );
+        await getIt<PersistenceLogic>().createDbEntity(
+          parent.copyWith(meta: parent.meta.copyWith(private: !projectPrivate)),
+        );
+        final before = await journalDb.select(journalDb.journal).get();
+
+        expect(
+          await createTask(projectId: 'project', linkedId: 'parent'),
+          isNull,
+        );
+
+        // Include tombstones: a create-and-clean-up cycle is not rejection
+        // before persistence and would still emit sync events.
+        final after = await journalDb.select(journalDb.journal).get();
+        expect(after.map((row) => row.id), before.map((row) => row.id));
+      });
+    }
+
+    for (final privacy in [false, true]) {
+      test('createTask accepts matching linked privacy: $privacy', () async {
+        final project = TestProjectFactory.create(id: 'project');
+        final parent = TestTaskFactory.create(id: 'parent');
+        await getIt<PersistenceLogic>().createDbEntity(
+          project.copyWith(meta: project.meta.copyWith(private: privacy)),
+        );
+        await getIt<PersistenceLogic>().createDbEntity(
+          parent.copyWith(meta: parent.meta.copyWith(private: privacy)),
+        );
+
+        final task = await createTask(projectId: 'project', linkedId: 'parent');
+        expect(task, isNotNull);
+        final stored = await journalDb.journalEntityById(task!.meta.id);
+        expect(stored?.meta.private, privacy);
+        expect(
+          (await journalDb.getProjectForTask(task.meta.id))?.meta.id,
+          'project',
+        );
+      });
+    }
+
+    test('createTask inherits privacy from its explicit project', () async {
+      const projectId = 'private-project';
+      final project = TestProjectFactory.create(
+        id: projectId,
+        categoryId: 'private-category',
+      );
+      await getIt<PersistenceLogic>().createDbEntity(
+        project.copyWith(meta: project.meta.copyWith(private: true)),
+      );
+
+      final task = await createTask(projectId: projectId);
+
+      expect(task, isNotNull);
+      final persisted = await journalDb.journalEntityById(task!.meta.id);
+      expect(persisted?.meta.private, isTrue);
+      expect(
+        (await journalDb.getProjectForTask(task.meta.id))?.meta.id,
+        projectId,
+      );
+    });
+
     test(
       'createTask rejects unresolved explicit projects before writing',
       () async {
@@ -361,6 +459,7 @@ void main() {
         ];
 
         for (final scenario in scenarios) {
+          String? createdTaskId;
           final project = TestProjectFactory.create(
             id: scenario.projectId,
             categoryId: 'project-category',
@@ -372,11 +471,13 @@ void main() {
             projectId: scenario.projectId,
             taskId: any(named: 'taskId'),
           );
-          if (scenario.throws) {
-            when(linkCall).thenThrow(StateError('project assignment failed'));
-          } else {
-            when(linkCall).thenAnswer((_) async => false);
-          }
+          when(linkCall).thenAnswer((invocation) async {
+            createdTaskId = invocation.namedArguments[#taskId]! as String;
+            if (scenario.throws) {
+              throw StateError('project assignment failed');
+            }
+            return false;
+          });
 
           expect(
             await createTask(projectId: scenario.projectId),
@@ -389,7 +490,102 @@ void main() {
               taskId: any(named: 'taskId'),
             ),
           ).called(1);
+          expect(createdTaskId, isNotNull);
+          expect(
+            await journalDb.journalEntityById(createdTaskId!),
+            isNull,
+            reason: 'a failed explicit link must not leave an orphaned task',
+          );
         }
+      },
+    );
+
+    test(
+      'createTask throws when failed project assignment cannot be cleaned up',
+      () async {
+        const projectId = 'cleanup-failure-project';
+        final projectRepository = MockProjectRepository();
+        final project = TestProjectFactory.create(
+          id: projectId,
+          categoryId: 'project-category',
+        );
+        getIt
+          ..registerSingleton<ProjectRepository>(projectRepository)
+          ..unregister<PersistenceLogic>()
+          ..registerSingleton<PersistenceLogic>(
+            _RejectingTaskCleanupPersistenceLogic(),
+          );
+        when(
+          () => projectRepository.getProjectById(projectId),
+        ).thenAnswer((_) async => project);
+        String? createdTaskId;
+        when(
+          () => projectRepository.linkTaskToProject(
+            projectId: projectId,
+            taskId: any(named: 'taskId'),
+          ),
+        ).thenAnswer((invocation) async {
+          createdTaskId = invocation.namedArguments[#taskId]! as String;
+          return false;
+        });
+
+        await expectLater(
+          createTask(projectId: projectId),
+          throwsA(
+            isA<StateError>().having(
+              (error) => error.message,
+              'message',
+              contains('could not be soft-deleted'),
+            ),
+          ),
+        );
+
+        expect(createdTaskId, isNotNull);
+        expect(
+          await journalDb.journalEntityById(createdTaskId!),
+          isA<Task>(),
+          reason: 'the cleanup failure must be observable, not reported gone',
+        );
+      },
+    );
+
+    test(
+      'createTask accepts cleanup committed before a late persistence failure',
+      () async {
+        const projectId = 'cleanup-failure-project';
+        final projectRepository = MockProjectRepository();
+        final project = TestProjectFactory.create(
+          id: projectId,
+          categoryId: 'project-category',
+        );
+        getIt
+          ..registerSingleton<ProjectRepository>(projectRepository)
+          ..unregister<PersistenceLogic>()
+          ..registerSingleton<PersistenceLogic>(
+            _RejectingTaskCleanupPersistenceLogic(commitBeforeFailure: true),
+          );
+        when(
+          () => projectRepository.getProjectById(projectId),
+        ).thenAnswer((_) async => project);
+        String? createdTaskId;
+        when(
+          () => projectRepository.linkTaskToProject(
+            projectId: projectId,
+            taskId: any(named: 'taskId'),
+          ),
+        ).thenAnswer((invocation) async {
+          createdTaskId = invocation.namedArguments[#taskId]! as String;
+          return false;
+        });
+
+        expect(await createTask(projectId: projectId), isNull);
+
+        expect(createdTaskId, isNotNull);
+        expect(
+          await journalDb.journalEntityById(createdTaskId!),
+          isNull,
+          reason: 'the committed tombstone must be recognized',
+        );
       },
     );
 


### PR DESCRIPTION
## Summary

Extracts the non-visual foundation from the closed #3942. The workspace redesign follows in stacked PR #4130; merge this foundation first.

- Validate category, privacy, and the current project link inside the membership write transaction; roll back a failed relink completely.
- Guard project category changes while tasks or live project agents remain attached. Bulk category migration is deliberately excluded.
- Inherit project privacy during task creation and clean up a new task when its explicit project assignment fails.
- Preserve unrelated synced fields in project editor drafts and prevent stale reloads from resurrecting tombstones.
- Serialize project-agent provisioning and scope reconciliation, reject stale scope/template inputs, and retire agents after synced project deletion.
- Notify project consumers after agent deletion and provide exact lifecycle restoration for the separately reviewed deletion flow.

No schema migration or visual redesign is included.

## Validation

Review follow-up: 540 targeted tests passed across scoped runs; regression tests were checked against the unfixed implementation. Latest Codecov patch coverage: 100%.

- Repository-wide Dart MCP analyzer: no errors, warnings, or infos.
- 506 targeted tests passed across the affected service, repository, controller, creation, provider, and workflow files.
- Scope regression tests were rerun with their fixes removed and failed as expected.
- Changed Dart files formatted; `git diff --check` clean.
- `make knowledge_check` and `make changelog_check` passed.

CI, patch coverage, and automated review will be monitored through completion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when linking tasks to projects, including privacy mismatches and failed assignments.
  * Private projects now automatically create private tasks.
  * Project category changes are blocked when they would conflict with linked tasks or active agents.
  * Project agents now stay aligned when projects change categories, disappear, or are restored.

* **Improvements**
  * Project editing preserves unsaved changes during synchronization and prevents stale updates from overwriting newer data.
  * Added safer recovery options for failed saves, including discarding pending edits.
  * Project agent templates now exclude deleted or category-incompatible options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Task-creation review follow-up

Conflicting project/linked privacy is rejected before persistence. The Tasks-tab creation action now handles null results and cleanup errors with a localized error toast and no navigation. Five regression cases were confirmed failing without the fixes; both touched test files now pass all 91 cases. Rebased onto main cbc23f87a.

The screenshot skill was used with the penguin demo harness (no user data). Before: silent null-result failure on the base; after: localized error toast. Captured before the rebase; the rebase does not alter these pixels.

| Variant | Before | After |
| --- | --- | --- |
| mobile light | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-task-creation-failure/3703ffc2af048f5e717da83d2309bea65c63f1d5/before/task_creation_failure_mobile_light.png) | [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-task-creation-failure/3703ffc2af048f5e717da83d2309bea65c63f1d5/after/task_creation_failure_mobile_light.png) |
| mobile dark | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-task-creation-failure/3703ffc2af048f5e717da83d2309bea65c63f1d5/before/task_creation_failure_mobile_dark.png) | [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-task-creation-failure/3703ffc2af048f5e717da83d2309bea65c63f1d5/after/task_creation_failure_mobile_dark.png) |
| desktop light | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-task-creation-failure/3703ffc2af048f5e717da83d2309bea65c63f1d5/before/task_creation_failure_desktop_light.png) | [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-task-creation-failure/3703ffc2af048f5e717da83d2309bea65c63f1d5/after/task_creation_failure_desktop_light.png) |
| desktop dark | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-task-creation-failure/3703ffc2af048f5e717da83d2309bea65c63f1d5/before/task_creation_failure_desktop_dark.png) | [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-task-creation-failure/3703ffc2af048f5e717da83d2309bea65c63f1d5/after/task_creation_failure_desktop_dark.png) |
