### PR TITLE
refactor(plaza): simplify the plaza — shared frame helpers, scene builders, one capture scheduler

### DIFF
--- a/docs/plaza/DESIGN.md
+++ b/docs/plaza/DESIGN.md
@@ -509,9 +509,9 @@ itself shows it. The values are in the concept.
   row's end it would land on an earlier row's plots, so the plaza frame
   moves to the district's outside, away from the plot centroid. The spec
   drew it on the axis.
-- **No overview beacon dot.** `BeaconKind.overview` exists but nothing
-  creates one; the overview is a computed pose (behind the oldest edge,
-  framing the whole footprint) reached by key, button or the walk. Task
+- **No overview beacon dot.** The overview is a computed pose (behind the
+  oldest edge, framing the whole footprint) reached by key, button or the
+  walk, not a beacon kind. Task
   beacons are not objects either: a facade tap, a billboard tap and a search
   hit fly straight to the computed task pose.
 - **Block beacons stand before the block, not mid-block**, so the first

--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -375,10 +375,9 @@ one **Attention** beacon per anomaly. A block beacon stands `blockBeaconInset`
 (20 m) *before* the block start, looking down it with a 0.05 rad upward
 pitch, so the first pair of facades fits the frame. An attention beacon's
 pose is `taskPoseFor` its building. Markers hang 1.6 m above the road
-(1.8 m for attention). `BeaconKind.overview` exists in the enum but no
-overview beacon is created; the overview is reached by key, button or the
-morning walk. Attention and home beacons are visible within 450 m, block
-and corner within 320 m.
+(1.8 m for attention). There is no overview beacon: the overview is
+reached by key, button or the morning walk. Attention and home beacons are
+visible within 450 m, block and corner within 320 m.
 
 # Camera: walking, flying, landing
 
@@ -388,8 +387,8 @@ stateDiagram-v2
   Walking --> Flying: flyTo from a beacon, facade or billboard tap, Tab, H, M, Backspace, search or a walk stop
   Walking --> Flying: movement key while above eye height plus 1.5 m, a landing flight straight down
   Flying --> Walking: flight lands, onArrived
-  Flying --> Walking: drag look, or a movement key on a flight with no arc or below landing height, cancelled in place
-  Flying --> Flying: movement key mid arc above landing height, replaced by a landing flight
+  Flying --> Walking: drag look, or a movement key below landing height, cancelled in place
+  Flying --> Flying: movement key above landing height (mid arc, or cruising down the street), replaced by a landing flight
   Walking --> Walking: WASD and shift, the collider keeps the walker out of every solid
 ```
 
@@ -420,9 +419,8 @@ A `Flight` is planned once, as a chain of straight **legs** with one
   acceleration starts and ends at zero; a way shorter than one cruise-ramp
   (`cruise × ramp`) shrinks both ramps to `sqrt(length × ramp / cruise)`
   and never reaches the cruise. Duration is `2 × ramp + (length − cruise ×
-  ramp) / cruise`; `timeScale` multiplies the speed and divides the ramp.
-  `distanceAt(t)` is the way covered, `cruiseSpeed` and `rampTime` what
-  was flown.
+  ramp) / cruise`. `distanceAt(t)` is the way covered, `cruiseSpeed` and
+  `rampTime` what was flown.
 - **The lift of a leg**: `arc × profile(s)` over the leg's straight line,
   where `s` is the fraction of the leg and the profile is a smoothstep
   climb over the first `rampStart` of it, a cruise, and a smoothstep
@@ -448,12 +446,14 @@ A `Flight` is planned once, as a chain of straight **legs** with one
   yaw over the last ramp's distance; shorter or mostly vertical trips
   blend yaw directly. On a routed flight the yaw looks at the point
   `lookAhead` (12 m) further along the way, which turns a corner before
-  reaching it. When the stop stands beside the road the last leg is the
-  **arrival** hop off the way: the look-ahead stops where the way leaves
-  the road and the camera holds the road's heading through the hop, then
-  turns onto the stop's own heading over the last ramp, instead of
-  swinging toward the stop and back. Each ramp blends between two *fixed*
-  headings (the way's heading where the ramp ends, or where it starts),
+  reaching it. A routed flight keeps where its way leaves the road as a
+  distance along the flight (`_wayEnd`, the whole length for a stop on
+  the road): the look-ahead never reaches past it, so when the stop stands
+  beside the road the last leg is the **arrival** hop off the way and the
+  camera holds the road's heading through the hop, then turns onto the
+  stop's own heading over the last ramp, instead of swinging toward the
+  stop and back. Each ramp blends between two *fixed* headings (the way's
+  heading where the ramp ends, or where it starts, both computed once),
   so the side the camera turns to is settled for the whole ramp, and a
   blend is a slerp of the two direction vectors (`_blendHeading`), so a
   heading that crosses the ±π seam of `atan2` between two frames is no
@@ -485,8 +485,9 @@ fix is a climb that starts *under* a solid in the air and rises into it;
 no stop stands under a sign or the beam.
 
 Every flight pushes the departure pose onto a back stack in the harness;
-Backspace flies the reverse without pushing. While flying, the LOD manager
-is `suspended` and the destination building of a facade flight is
+Backspace flies the reverse without pushing. While the camera flies
+(`FlyCameraController.flying`, landings included) the LOD manager makes
+no promotions, and the destination building of a facade flight is
 pre-promoted to the sign tier (`prepare`). `Tab` cycles the navigation
 beacons (everything but attention); when cycling toward older weeks a block
 or corner pose is turned round so the walk reads as walking, not reversing.
@@ -528,14 +529,26 @@ sizes), so a box on screen and a box in the list are one thing.
 
 `WalkCollider` keeps the walker out of every solid `atWalkHeight` (bottom
 below eye level) with a `solidClearance` (0.6 m) margin: a
-point-versus-rotated-rectangle push through the nearest face. A solid in
-the air, a pylon's sign or the gantry's beam, is not in it: you walk under
-those, and only a flight has to clear them. Two neighbours in a crowded week can stand closer than twice the margin,
-and resolving them one after the other never settles, so **aligned
-footprints are merged** first (`_mergeAligned`): same facing, same row
-line, same depth, and clearances that overlap become one footprint,
-repeatedly, so the alley between them is solid. `footprints` exposes the
-merged set for the tests.
+point-versus-rotated-rectangle push through the nearest face. Each
+footprint's frame (its sine and cosine, its half extents with the margin)
+is fixed once when the collider is built, and a footprint whose corner is
+nearer its centre than the walker is rejected on the squared distance
+before it is rotated into. A solid in the air, a pylon's sign or the
+gantry's beam, is not in it: you walk under those, and only a flight has
+to clear them. Two neighbours in a crowded week can stand closer than
+twice the margin, and resolving them one after the other never settles,
+so **aligned footprints are merged** first (`_mergeAligned`): same facing,
+same row line, same depth, and clearances that overlap become one
+footprint, repeatedly, so the alley between them is solid. `footprints`
+exposes the merged set for the tests.
+
+Every rotation between a road's or a footprint's frame and the world goes
+through `frameToWorld` / `worldToFrame` (`domain/street_layout.dart`):
+local X is the right-hand normal of the facing, local Z the facing itself.
+`Footprint.local`, `Footprint.toWorld` and `Footprint.contains` wrap them,
+and the layout, the scenery, the tour and the collider build on those
+rather than expanding the rotation by hand. Square posts (spires, pylon
+footings, gantry legs, lamp posts) are `Solid.post`.
 
 # The scenery
 
@@ -629,7 +642,7 @@ fourteen metres away).
 |---|---|---|
 | live facade (at most 4) | `FacadeWidget` live | every frame |
 | sign facade (at most 80) | `FacadeWidget` sign | once |
-| pylon, mounted and roof billboards | `BillboardWidget` | every 100 ms, hidden beyond the plaza range |
+| pylon, mounted and roof billboards | `BillboardWidget` | anomalies every 100 ms, the rest (a still face) every 3 s; hidden beyond the plaza range |
 | mounted, gantry and roofline tickers | `TickerWidget` | every 50 ms, hidden beyond the plaza range |
 | jumbotron | `JumbotronWidget` at 0.5 × px/m | every 1 s |
 | skyline screens | `BillboardWidget` at 0.35 × px/m | every 3 s |
@@ -641,12 +654,20 @@ fourteen metres away).
 The **plaza range** is `max(180 m, distance from the plaza centre to the
 overview pose + 60 m)`, so the map shot still sees the pylons lit. A hidden
 surface is not captured, which is what stops the plaza's animation costing
-anything from the far end of the street. `PlazaSurfaces.update` re-requests
-the one-off captures until their textures land. `PlazaSurfaces.facingPose`
+anything from the far end of the street. The bookkeeping is
+`SurfaceCaptures` (`scene/surface_captures.dart`), shared by
+`PlazaSurfaces` and the LOD manager: `hostedSurface` builds every widget
+component the same way (manual capture, manual input unless live), a
+`CaptureCadence` holds the surfaces on one interval and the clock their
+widgets read, `requestDue` throttles per surface (the first capture is
+free) and skips a surface the camera cannot see (`TimedSurface.seenFrom`:
+centre behind the eye by more than a few metres, or eye behind the
+surface's front), and `requestPending` re-requests the one-off captures
+until their textures land, then forgets them. `PlazaSurfaces.facingPose`
 gives the pose in front of a billboard slot (14 m by default), used by the
-tour. Billboard and
-ticker animation is driven by `AnimationController`s inside the widgets, so
-the capture interval alone decides how often they re-render.
+tour. No widget owns an animation controller: a billboard's glow, a
+ticker's scroll and the jumbotron's slides all read their cadence's clock,
+which advances only when a capture is requested.
 
 The **sign** facade variant is the category bar, a state marquee band with
 its glyph, the title (up to three lines, shrunk until its longest word fits
@@ -928,19 +949,23 @@ is ignored entirely in tour and bench modes.
   any surface under an `everyFrame` or `interval` capture policy (its
   frame pump; only `manual` does not), and an animation controller inside
   a captured widget ticks on every vsync. So every surface is a **manual
-  capture requested from the pacer**: `PlazaSurfaces.update(eye, seconds)`
-  asks each timed surface in range once its interval is up (billboards
-  `nearInterval` 0.1 s, tickers `tickerInterval` 0.05 s, the jumbotron
-  `jumbotronInterval` 1 s, the skyline screens `farInterval` 3 s; markers,
+  capture requested from the pacer**: `PlazaSurfaces.update(eye, seconds,
+  forward:)` asks each timed surface in range, and in view, once its
+  interval is up (anomalous billboards `nearInterval` 0.1 s, tickers
+  `tickerInterval` 0.05 s, the jumbotron `jumbotronInterval` 1 s, the
+  skyline screens and the still billboards `farInterval` 3 s; markers,
   banners and signs once), and `FacadeLodManager.update(eye, forward:,
-  seconds:)` asks each live wall every `liveInterval` (0.05 s). And the
-  animated widgets read **one clock**, the harness's `ValueNotifier<double>`
-  of elapsed seconds advanced once per painted frame: `TickerWidget`
-  scrolls by it, `BillboardWidget.glowAt` breathes by it, `JumbotronWidget`
-  turns its slides by it; none of them owns an animation controller, so
-  between painted frames nothing in them runs and the engine's frame rate
-  equals the painted one (`engineFps` in the overlay says so).
-  `PLAZA_FPS=auto|60|30` picks the cap at start.
+  seconds:, flying:)` asks each live wall every `liveInterval` (0.05 s),
+  and re-ranks the tiers only when the eye, the view direction, the budget
+  or the flight state moved since a ranking that left nothing undone. And
+  the animated widgets read **their cadence's clock**, a
+  `ValueNotifier<double>` of harness seconds that `requestDue` advances
+  immediately before each capture request: `TickerWidget` scrolls by it,
+  `BillboardWidget.glowAt` breathes by it, `JumbotronWidget` turns its
+  slides by it; none of them owns an animation controller, so a hosted
+  widget rebuilds exactly once per capture, in the frame of the request,
+  and the engine's frame rate equals the painted one (`engineFps` in the
+  overlay says so). `PLAZA_FPS=auto|60|30` picks the cap at start.
 - **Fixtures are the demo world only.** The harness projects
   `ManualDemoWorld.penguinLogistics`; the synthetic generator lives in
   `test/features/plaza/plaza_fixtures.dart` for the tests and nowhere else.

--- a/lib/features/plaza/README.md
+++ b/lib/features/plaza/README.md
@@ -33,7 +33,7 @@ All read at start-up; none is needed for an interactive session.
 | `PLAZA_TOUR=1` | `dev_main.dart` | Screenshot tour: steps through the fixed poses in `ui/plaza_tour.dart`, printing `PLAZA_TOUR ready <i> <name>` lines; input is ignored |
 | `PLAZA_TOUR_ONLY=home,block` | `dev_main.dart` | Restricts the tour to the named stops |
 | `PLAZA_BENCH=1` | `dev_main.dart` | Auto-walk benchmark through six LOD budgets, printing `PLAZA_BENCH result` lines; wins over `PLAZA_TOUR` |
-| `PLAZA_HIDE=gantry,jumbotron,fillers,skyline,pylons,walls` | `scene/plaza_scene.dart` | Leaves those pieces out of the scene, to isolate what a screenshot shows |
+| `PLAZA_HIDE=gantry,jumbotron,fillers,skyline,pylons,walls` | `dev_main.dart` | Leaves those pieces out of the scene (`PlazaSceneController(hidden:)`), to isolate what a screenshot shows |
 | `PLAZA_TRACE=1` | `dev_main.dart` | Prints one line per painted frame: frame time, engine frames since the last line, flight state, pose and how many solids contain the eye |
 | `PLAZA_FPS=auto,60,30` | `dev_main.dart` | The frame-rate cap at start (the HUD control changes it); 60 by default |
 | `PLAZA_CLICK=<stop>:<x>,<y>` | `tool/plaza/capture_tour.py` | After capturing that tour stop, clicks the window-relative point and grabs a second `-ticked` frame |
@@ -79,6 +79,7 @@ lib/features/plaza/
     plaza_scene.dart     the scene graph: sky, road, buildings, fillers, skyline
     facade_lod_manager.dart      far, sign and live facade tiers
     plaza_surfaces.dart  billboards, tickers, markers, signs, banners, jumbotron
+    surface_captures.dart        the shared capture bookkeeping and cadences
     plaza_sprites.dart   lanterns, beacons, lamps, spire and chase lights
     wall_textures.dart   window-grid, light-pool and grain textures
     plaza_picker.dart    tap resolution
@@ -88,7 +89,8 @@ lib/features/plaza/
     ticker_widget.dart, banner_widget.dart, block_marker_widget.dart
     fly_camera_controller.dart   walk camera and flights
     plaza_hud.dart, plaza_search_sheet.dart, task_side_panel.dart,
-    debug_overlay.dart, checklist_ticks.dart, plaza_style.dart
+    debug_overlay.dart, checklist_ticks.dart, plaza_style.dart,
+    plaza_chip.dart
     plaza_tour.dart      the tour stops
 tool/plaza/capture_tour.py       X11 screenshot capture for the tour
 test/features/plaza/             one test file per pure source file

--- a/lib/features/plaza/dev_main.dart
+++ b/lib/features/plaza/dev_main.dart
@@ -73,10 +73,36 @@ class _PlazaHarness extends StatefulWidget {
   State<_PlazaHarness> createState() => _PlazaHarnessState();
 }
 
+/// What the harness is doing: driven by hand, stepping through the tour's
+/// screenshot poses, or running the benchmark. A scripted run takes no
+/// input and paints on every vsync.
+enum HarnessMode {
+  interactive,
+  tour,
+  bench;
+
+  /// `PLAZA_BENCH=1` wins over `PLAZA_TOUR=1`; neither is interactive.
+  static HarnessMode fromEnvironment(Map<String, String> env) {
+    if (env['PLAZA_BENCH'] == '1') return HarnessMode.bench;
+    if (env['PLAZA_TOUR'] == '1') return HarnessMode.tour;
+    return HarnessMode.interactive;
+  }
+
+  bool get scripted => this != HarnessMode.interactive;
+}
+
 class _PlazaHarnessState extends State<_PlazaHarness>
     with SingleTickerProviderStateMixin {
-  static final bool _tourMode = Platform.environment['PLAZA_TOUR'] == '1';
-  static final bool _benchMode = Platform.environment['PLAZA_BENCH'] == '1';
+  static final HarnessMode _mode = HarnessMode.fromEnvironment(
+    Platform.environment,
+  );
+
+  /// Dev-only: `PLAZA_HIDE=gantry,jumbotron,fillers,skyline,pylons,walls`
+  /// leaves those pieces out of the scene, to isolate what a screenshot
+  /// is showing.
+  static final Set<String> _hidden = {
+    ...?Platform.environment['PLAZA_HIDE']?.split(','),
+  };
 
   /// `PLAZA_TRACE=1` prints one line per frame: the frame time, whether a
   /// flight is under way, the pose, and how many solids contain the eye —
@@ -100,10 +126,6 @@ class _PlazaHarnessState extends State<_PlazaHarness>
     );
   }
 
-  /// Elapsed seconds, advanced once per painted frame: the one clock the
-  /// animated surfaces (tickers, billboard glows, the jumbotron's slides)
-  /// read, so between painted frames nothing in them runs.
-  final ValueNotifier<double> _clock = ValueNotifier(0);
   Duration? _lastPaint;
   final ValueNotifier<int> _frame = ValueNotifier(0);
 
@@ -117,7 +139,9 @@ class _PlazaHarnessState extends State<_PlazaHarness>
   /// anything besides the pacer keeps the engine running.
   int _engineFrames = 0;
   int _engineFramesSinceTrace = 0;
-  late final PlazaBench? _bench = _benchMode ? PlazaBench() : null;
+  late final PlazaBench? _bench = _mode == HarnessMode.bench
+      ? PlazaBench()
+      : null;
 
   late PlazaWorld _world;
   late PlazaSceneController _sceneController;
@@ -133,6 +157,9 @@ class _PlazaHarnessState extends State<_PlazaHarness>
 
   Camera? _frameCamera;
   Size _viewSize = const Size(1, 1);
+
+  /// Seconds since boot, advanced once per painted frame: the harness's
+  /// one time value, which the surfaces turn into their capture clocks.
   double _elapsed = 0;
 
   // HUD state.
@@ -178,13 +205,13 @@ class _PlazaHarnessState extends State<_PlazaHarness>
     _walls = await WallTextures.load();
     if (!mounted) return;
     _load();
-    if (_benchMode) {
-      _bench!.start(_config, _camera);
-    } else if (_tourMode) {
-      _applyTourStop(0);
-    } else {
-      _toast = 'Home — ${_world.projectLabel}';
-      _toastUntil = 3.2;
+    switch (_mode) {
+      case HarnessMode.bench:
+        _bench!.start(_config, _camera);
+      case HarnessMode.tour:
+        _applyTourStop(0);
+      case HarnessMode.interactive:
+        _showToast('Home — ${_world.projectLabel}');
     }
     setState(() => _ready = true);
     _pacer = createTicker(_onPace)..start();
@@ -198,15 +225,13 @@ class _PlazaHarnessState extends State<_PlazaHarness>
   void dispose() {
     _pacer?.dispose();
     _frame.dispose();
-    _clock.dispose();
     super.dispose();
   }
 
   /// Whether anything moves the camera: a flight, the walk, a held key or
   /// a drag; the tour and the benchmark always count as moving.
   bool get _moving =>
-      _benchMode ||
-      _tourMode ||
+      _mode.scripted ||
       _camera.flying ||
       _camera.moving ||
       _dragging ||
@@ -216,7 +241,7 @@ class _PlazaHarnessState extends State<_PlazaHarness>
     final last = _lastPaint;
     final seconds = elapsed.inMicroseconds / 1e6;
     if (_moving) _movingUntil = seconds + _movingHold;
-    final cap = _benchMode || _tourMode
+    final cap = _mode.scripted
         ? null
         : _frameRate.capFor(moving: seconds < _movingUntil);
     if (last != null && cap != null) {
@@ -252,7 +277,7 @@ class _PlazaHarnessState extends State<_PlazaHarness>
         maxBuildingHeight: _knobs.maxHeight,
       ),
     );
-    _sceneController = PlazaSceneController(world: _world);
+    _sceneController = PlazaSceneController(world: _world, hidden: _hidden);
     final walls = _walls;
     if (walls != null) _sceneController.attachWallTextures(walls);
     _lod = FacadeLodManager(
@@ -273,7 +298,6 @@ class _PlazaHarnessState extends State<_PlazaHarness>
     unawaited(_sprites.loadGlow());
     _surfaces = PlazaSurfaces(
       scene: _sceneController.scene,
-      clock: _clock,
       world: _world,
       markerAnchors: _sceneController.markerAnchors,
       billboards: _sceneController.billboards,
@@ -297,9 +321,6 @@ class _PlazaHarnessState extends State<_PlazaHarness>
           )
           ..onArrived = _onArrived
           ..onMovement = _endWalk;
-    _camera.onFlightCancelled = () {
-      _lod.suspended = false;
-    };
     _back.clear();
     _beaconCursor = -1;
     _walk = null;
@@ -310,7 +331,7 @@ class _PlazaHarnessState extends State<_PlazaHarness>
   void _applyKnobs() {
     _lod.dispose();
     setState(_load);
-    if (_benchMode) _bench!.resume(_camera);
+    _bench?.resume(_camera);
   }
 
   // ------------------------------------------------------------- flights
@@ -318,7 +339,6 @@ class _PlazaHarnessState extends State<_PlazaHarness>
   void _flyTo(CameraPose pose, String label, {bool push = true}) {
     if (push) _back.add(_camera.pose);
     _camera.flyTo(pose);
-    _lod.suspended = true;
     _showToast(label);
   }
 
@@ -334,10 +354,7 @@ class _PlazaHarnessState extends State<_PlazaHarness>
     if (building != null) _flyToBuilding(building);
   }
 
-  void _onArrived() {
-    _lod.suspended = false;
-    _walk?.arrived();
-  }
+  void _onArrived() => _walk?.arrived();
 
   void _goBack() {
     if (_back.isEmpty) return;
@@ -345,17 +362,15 @@ class _PlazaHarnessState extends State<_PlazaHarness>
     _flyTo(pose, 'Back', push: false);
   }
 
-  void _flyHome() {
+  /// Flies to one of the plaza's own poses, when there is a plaza.
+  void _flyToPlaza(CameraPose Function(FrontierPlaza) pose, String where) {
     final plaza = _world.plaza;
-    if (plaza != null) _flyTo(plaza.home, 'Home — ${_world.projectLabel}');
+    if (plaza != null) _flyTo(pose(plaza), '$where — ${_world.projectLabel}');
   }
 
-  void _flyOverview() {
-    final plaza = _world.plaza;
-    if (plaza != null) {
-      _flyTo(plaza.overview, 'Overview — ${_world.projectLabel}');
-    }
-  }
+  void _flyHome() => _flyToPlaza((p) => p.home, 'Home');
+
+  void _flyOverview() => _flyToPlaza((p) => p.overview, 'Overview');
 
   void _cycleBeacon(int direction) {
     final nav = _world.beacons
@@ -411,7 +426,7 @@ class _PlazaHarnessState extends State<_PlazaHarness>
 
   KeyEventResult _onKey(FocusNode node, KeyEvent event) {
     // A tour is a screenshot run: stray input must not move the camera.
-    if (_tourMode || _benchMode) return KeyEventResult.handled;
+    if (_mode.scripted) return KeyEventResult.handled;
     if (_searchOpen) return KeyEventResult.ignored;
     if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
       return _camera.handleKeyEvent(event)
@@ -444,7 +459,7 @@ class _PlazaHarnessState extends State<_PlazaHarness>
   }
 
   void _onPointerDown(PointerDownEvent event) {
-    if (_tourMode || _benchMode || event.buttons != kPrimaryButton) return;
+    if (_mode.scripted || event.buttons != kPrimaryButton) return;
     _pointerDown = event.localPosition;
     _pointerDownAt = _elapsed;
     _dragging = false;
@@ -505,8 +520,7 @@ class _PlazaHarnessState extends State<_PlazaHarness>
       final pose = stop.pose(_world);
       if (pose != null) {
         _camera.pose = pose;
-        _surfaces.pinJumbotron.value = stop.name == 'jumbotron';
-        _lod.suspended = false;
+        _surfaces.pinJumbotron.value = stop.pinJumbotron;
         _tourStop = index;
         _tourClock = 0;
         _tourAnnounced = false;
@@ -558,17 +572,28 @@ class _PlazaHarnessState extends State<_PlazaHarness>
 
   void _onTick(Duration elapsed, double dt) {
     _elapsed = elapsed.inMicroseconds / 1e6;
-    if (_benchMode) _bench!.tick(dt, _lod, _camera);
-    if (_tourMode && !_benchMode) _tourTick(dt);
+    switch (_mode) {
+      case HarnessMode.bench:
+        _bench!.tick(dt, _lod, _camera);
+      case HarnessMode.tour:
+        _tourTick(dt);
+      case HarnessMode.interactive:
+        break;
+    }
     _walkTick(dt);
     _camera.update(dt);
     if (_traceMode) _trace(dt);
     final camera = _camera.camera();
     _frameCamera = camera;
     final eye = camera.position;
-    _clock.value = _elapsed;
-    _lod.update(eye, forward: _camera.forward, seconds: _elapsed);
-    _surfaces.update(eye, _elapsed);
+    final forward = _camera.forward;
+    _lod.update(
+      eye,
+      forward: forward,
+      seconds: _elapsed,
+      flying: _camera.flying,
+    );
+    _surfaces.update(eye, _elapsed, forward: forward);
     _sceneController.updateForCamera(eye);
     _sprites.update(camera, _viewSize, _elapsed);
 

--- a/lib/features/plaza/domain/attention.dart
+++ b/lib/features/plaza/domain/attention.dart
@@ -29,6 +29,28 @@ const oldAfter = Duration(days: 56);
 /// What lights the roof lantern, in priority order.
 enum LanternState { blocked, overdue, inProgress, open, off }
 
+/// How a lantern's state is written where hue cannot carry it: a glyph
+/// and a word, the same on a ticker band and in the HUD's legend.
+extension LanternStateText on LanternState {
+  /// A cross for blocked, a bang for overdue, a play mark for in
+  /// progress, a ring for open, a tick for a lantern that is off.
+  String get glyph => switch (this) {
+    LanternState.blocked => '✕',
+    LanternState.overdue => '!',
+    LanternState.inProgress => '▶',
+    LanternState.open => '○',
+    LanternState.off => '✓',
+  };
+
+  String get word => switch (this) {
+    LanternState.blocked => 'blocked',
+    LanternState.overdue => 'overdue',
+    LanternState.inProgress => 'in progress',
+    LanternState.open => 'open',
+    LanternState.off => 'done',
+  };
+}
+
 /// The attention verdict for one task.
 class TaskAttention {
   const TaskAttention({
@@ -178,3 +200,10 @@ const _months = [
 
 /// `Jul 18` — the short date used on facades, billboards and tickers.
 String shortDate(DateTime date) => '${_months[date.month - 1]} ${date.day}';
+
+/// The small print under a task's title, on its facade and in the side
+/// panel: the due date and the link count, each only when there is one.
+List<String> taskMetaBits(PlazaTask task) => [
+  if (task.due != null) 'due ${shortDate(task.due!)}',
+  if (task.linkedTaskIds.isNotEmpty) 'links ${task.linkedTaskIds.length}',
+];

--- a/lib/features/plaza/domain/flight.dart
+++ b/lib/features/plaza/domain/flight.dart
@@ -11,6 +11,10 @@ import 'dart:math' as math;
 
 import 'package:lotti/features/plaza/domain/plaza_layout.dart';
 import 'package:lotti/features/plaza/domain/solid.dart';
+import 'package:lotti/features/plaza/domain/street_layout.dart';
+import 'package:meta/meta.dart';
+
+double _lerp(double a, double b, double s) => a + (b - a) * s;
 
 /// A planned camera flight between two poses.
 class Flight {
@@ -20,11 +24,12 @@ class Flight {
     required List<_Leg> legs,
     required _Profile profile,
     required this.routed,
-    this.arrival = false,
+    double? wayEnd,
     // A private field cannot be a named initializing formal.
     // ignore: prefer_initializing_formals
   }) : _legs = legs,
        _profile = profile,
+       _wayEnd = wayEnd ?? profile.length,
        duration = Duration(microseconds: (profile.duration * 1e6).round());
 
   /// Plans the direct flight from [from] to [to]: one straight leg, swept
@@ -32,12 +37,10 @@ class Flight {
   /// ([clearance] above it), climbing before the first solid on the way
   /// and descending after the last; trips over [arcThreshold] metres rise
   /// into an arc proportional to distance regardless, so the route stays
-  /// legible. Cruises at [directSpeed]; [timeScale] speeds the whole
-  /// flight up.
+  /// legible. Cruises at [directSpeed].
   factory Flight.plan(
     CameraPose from,
     CameraPose to, {
-    double timeScale = 1,
     Iterable<Solid> solids = const [],
   }) {
     final leg = _Leg.plan(from, to, solids, districtArc: true);
@@ -47,8 +50,8 @@ class Flight {
       legs: [leg],
       profile: _Profile(
         length: leg.length,
-        cruise: directSpeed * timeScale,
-        ramp: rampSeconds / timeScale,
+        cruise: directSpeed,
+        ramp: rampSeconds,
       ),
       routed: false,
     );
@@ -63,7 +66,6 @@ class Flight {
     CameraPose from,
     CameraPose to, {
     required List<(double, double)> via,
-    double timeScale = 1,
     Iterable<Solid> solids = const [],
   }) {
     final points = <CameraPose>[from];
@@ -73,12 +75,10 @@ class Flight {
     }
     // The stop itself, not a via point a step short of it; otherwise the
     // last leg is the hop off the way to the stop.
-    var arrival = points.length > 1;
-    if (points.length > 1 &&
-        _apart(points.last, to.x, to.z) < viaMergeDistance) {
-      points.removeLast();
-      arrival = false;
-    }
+    final onWay =
+        points.length > 1 && _apart(points.last, to.x, to.z) < viaMergeDistance;
+    if (onWay) points.removeLast();
+    final hop = points.length > 1 && !onWay;
     points.add(to);
     final legs = <_Leg>[
       for (var i = 1; i < points.length; i++)
@@ -94,19 +94,16 @@ class Flight {
       legs: legs,
       profile: _Profile(
         length: length,
-        cruise: streetSpeed * timeScale,
-        ramp: rampSeconds / timeScale,
+        cruise: streetSpeed,
+        ramp: rampSeconds,
       ),
       routed: true,
-      arrival: arrival && legs.length > 1,
+      wayEnd: hop ? length - legs.last.length : length,
     );
   }
 
-  static double _apart(CameraPose p, double x, double z) {
-    final dx = x - p.x;
-    final dz = z - p.z;
-    return math.sqrt(dx * dx + dz * dz);
-  }
+  static double _apart(CameraPose p, double x, double z) =>
+      groundDistanceBetween(p.x, p.z, x, z);
 
   /// Cruise speeds, world metres per second: down a street, and on the
   /// direct line (a climb to the overview, a dive back).
@@ -166,11 +163,16 @@ class Flight {
   /// Whether the flight follows the street (see [Flight.route]).
   final bool routed;
 
+  /// Where the way leaves the road, metres along the flight: the whole
+  /// length when the stop is on the road, else the start of the last leg,
+  /// the hop off the way to a stop beside it.
+  final double _wayEnd;
+
   /// Whether the last leg is the hop off the way to a stop beside it: the
   /// camera holds the road's heading through it and turns onto the stop's
   /// own heading over the last ramp, instead of swinging toward the stop
   /// and back.
-  final bool arrival;
+  bool get arrival => _wayEnd < length;
 
   final List<_Leg> _legs;
   final _Profile _profile;
@@ -179,32 +181,35 @@ class Flight {
   double get length => _profile.length;
 
   /// How many straight legs the way has.
+  @visibleForTesting
   int get legCount => _legs.length;
 
   /// The speed the flight cruises at once its ramp is done, and how long
   /// each ramp takes; both shrink on a hop too short to reach the cruise.
+  @visibleForTesting
   double get cruiseSpeed => _profile.v;
+  @visibleForTesting
   double get rampTime => _profile.t;
 
   /// Peak extra height over the straight line of any leg, world meters.
   double get arc => _legs.fold(0, (m, leg) => math.max(m, leg.arc));
 
   /// The first leg's ramps, as fractions of that leg.
+  @visibleForTesting
   double get rampStart => _legs.first.rampStart;
+  @visibleForTesting
   double get rampEnd => _legs.first.rampEnd;
 
   /// Extra height over the straight line [s] of the way along (0..1).
+  @visibleForTesting
   double liftAt(double s) {
     final (leg, f) = _locate(s.clamp(0.0, 1.0) * length);
     return leg.liftAt(f);
   }
 
   /// Horizontal distance of the trip, end to end.
-  double get groundDistance {
-    final dx = to.x - from.x;
-    final dz = to.z - from.z;
-    return math.sqrt(dx * dx + dz * dz);
-  }
+  double get groundDistance =>
+      groundDistanceBetween(from.x, from.z, to.x, to.z);
 
   /// Fraction of the trip that is horizontal (0 = straight up/down).
   double get horizontalFraction {
@@ -215,16 +220,25 @@ class Flight {
   /// The heading of a direct flight's travel, or null for a short hop or
   /// a mostly vertical trip (a climb to the overview must not whip round
   /// to face its path).
-  double? get travelYaw {
+  late final double? travelYaw = _travelYaw();
+
+  double? _travelYaw() {
     if (groundDistance < lookAlongThreshold) return null;
     if (horizontalFraction < 0.55) return null;
-    final dx = to.x - from.x;
-    final dz = to.z - from.z;
-    return math.atan2(dx, dz);
+    return math.atan2(to.x - from.x, to.z - from.z);
   }
+
+  /// The way's headings where the first ramp ends and where the last one
+  /// starts: fixed for the flight, so the side the camera turns to over a
+  /// ramp is settled once.
+  late final double _rampInHeading = _wayHeadingAt(_profile.rampDistance);
+  late final double _rampOutHeading = _wayHeadingAt(
+    length - _profile.rampDistance,
+  );
 
   Duration _elapsed = Duration.zero;
 
+  @visibleForTesting
   Duration get elapsed => _elapsed;
   bool get done => _elapsed >= duration;
 
@@ -260,10 +274,7 @@ class Flight {
   /// The point [d] metres along the way, on the ground.
   (double, double) _groundAt(double d) {
     final (leg, f) = _locate(d);
-    return (
-      leg.from.x + (leg.to.x - leg.from.x) * f,
-      leg.from.z + (leg.to.z - leg.from.z) * f,
-    );
+    return (_lerp(leg.from.x, leg.to.x, f), _lerp(leg.from.z, leg.to.z, f));
   }
 
   /// The pose at [t] of the flight's time (0..1): along the way on the
@@ -274,10 +285,10 @@ class Flight {
   CameraPose poseAt(double t) {
     final d = distanceAt(t);
     final (leg, f) = _locate(d);
-    final x = leg.from.x + (leg.to.x - leg.from.x) * f;
-    final z = leg.from.z + (leg.to.z - leg.from.z) * f;
+    final x = _lerp(leg.from.x, leg.to.x, f);
+    final z = _lerp(leg.from.z, leg.to.z, f);
     final lift = leg.liftAt(f);
-    final y = leg.from.y + (leg.to.y - leg.from.y) * f + lift;
+    final y = _lerp(leg.from.y, leg.to.y, f) + lift;
 
     final ramp = _profile.rampDistance;
     final total = length;
@@ -296,13 +307,9 @@ class Flight {
     if (along == null) {
       yaw = _blendHeading(from.yaw, to.yaw, _smooth(t));
     } else if (d < ramp) {
-      yaw = _blendHeading(from.yaw, _wayHeadingAt(ramp), _smooth(inRamp));
+      yaw = _blendHeading(from.yaw, _rampInHeading, _smooth(inRamp));
     } else if (d > total - ramp) {
-      yaw = _blendHeading(
-        _wayHeadingAt(total - ramp),
-        to.yaw,
-        _smooth(outRamp),
-      );
+      yaw = _blendHeading(_rampOutHeading, to.yaw, _smooth(outRamp));
     } else {
       yaw = along;
     }
@@ -316,7 +323,7 @@ class Flight {
           ? to.pitch * _smooth(outRamp)
           : 0;
     } else {
-      pitch = from.pitch + (to.pitch - from.pitch) * _smooth(t);
+      pitch = _lerp(from.pitch, to.pitch, _smooth(t));
     }
     final pitchDip = lift == 0 ? 0.0 : -math.atan2(lift, 40) * 0.9;
     return CameraPose(x: x, y: y, z: z, yaw: yaw, pitch: pitch + pitchDip);
@@ -328,19 +335,17 @@ class Flight {
   double _wayHeadingAt(double d) {
     if (!routed) return travelYaw ?? to.yaw;
     final (leg, f) = _locate(d);
-    final x = leg.from.x + (leg.to.x - leg.from.x) * f;
-    final z = leg.from.z + (leg.to.z - leg.from.z) * f;
+    final x = _lerp(leg.from.x, leg.to.x, f);
+    final z = _lerp(leg.from.z, leg.to.z, f);
     return _lookAheadYaw(d, x, z, leg);
   }
 
   /// The heading from ([x], [z]) to the point [lookAhead] metres further
-  /// along the way, which ends where the way leaves the road when the
-  /// flight has an [arrival] hop; past that, the road's last heading.
+  /// along the way, which ends where the way leaves the road; past that,
+  /// the road's last heading.
   double _lookAheadYaw(double d, double x, double z, _Leg leg) {
-    final road = arrival ? _legs[_legs.length - 2] : _legs.last;
-    final wayEnd = arrival ? length - _legs.last.length : length;
-    final ahead = math.min(wayEnd, d + lookAhead);
-    if (ahead <= d + 1e-6) return _heading(road);
+    final ahead = math.min(_wayEnd, d + lookAhead);
+    if (ahead <= d + 1e-6) return _heading(_locate(_wayEnd - 1e-6).$1);
     final (ax, az) = _groundAt(ahead);
     final dx = ax - x;
     final dz = az - z;
@@ -407,9 +412,7 @@ class _Leg {
     required bool districtArc,
   }) {
     final dist = from.distanceTo(to);
-    final dx = to.x - from.x;
-    final dz = to.z - from.z;
-    final ground = math.sqrt(dx * dx + dz * dz);
+    final ground = groundDistanceBetween(from.x, from.z, to.x, to.z);
     // The arc is for crossing the district; a climb is already an arc.
     final horizontal = dist == 0 ? 1.0 : (ground / dist).clamp(0.0, 1.0);
     final baseArc = districtArc && dist > Flight.arcThreshold
@@ -528,8 +531,6 @@ class _Leg {
     );
   }
 
-  static double _lerp(double a, double b, double s) => a + (b - a) * s;
-
   static double _profile(double s, double rampStart, double rampEnd) {
     if (s < rampStart) return Flight._smooth(s / rampStart);
     if (s > 1 - rampEnd) return Flight._smooth((1 - s) / rampEnd);
@@ -565,7 +566,7 @@ class _Span {
   /// band of height anywhere along the stretch.
   bool blocks(CameraPose from, CameraPose to, double Function(double) lift) {
     for (final s in samples) {
-      final y = from.y + (to.y - from.y) * s + lift(s);
+      final y = _lerp(from.y, to.y, s) + lift(s);
       if (y > floor && y < ceiling) return true;
     }
     return false;

--- a/lib/features/plaza/domain/plaza_layout.dart
+++ b/lib/features/plaza/domain/plaza_layout.dart
@@ -45,31 +45,21 @@ class CameraPose {
       'pitch ${pitch.toStringAsFixed(2)})';
 }
 
-/// A world-space point with the street's local frame at the frontier.
-class _Frame {
-  _Frame(this.originX, this.originZ, this.heading, {this.lateralOffset = 0});
-
-  final double originX;
-  final double originZ;
-
-  /// Direction of travel of the last segment.
-  final double heading;
-
-  /// Sideways shift of the whole plaza frame, world metres along the
-  /// lateral axis (see [frontierPlazaFor]).
-  final double lateralOffset;
-
-  /// Local (lateral, along) → world. Lateral is the road's right-hand
-  /// normal; along is the heading.
-  (double, double) toWorld(double lateral, double along) => (
-    originX +
-        math.sin(heading) * along +
-        math.cos(heading) * (lateral + lateralOffset),
-    originZ +
-        math.cos(heading) * along -
-        math.sin(heading) * (lateral + lateralOffset),
-  );
-}
+/// Plaza-local ([lateral], [along]) from the end of [last], the frame
+/// shifted sideways by [lateralOffset] (see [frontierPlazaFor]), to the
+/// world. Lateral is the road's right-hand normal; along is its heading.
+(double, double) _plazaPoint(
+  RoadSegment last,
+  double lateralOffset,
+  double lateral,
+  double along,
+) => frameToWorld(
+  last.endX,
+  last.endZ,
+  last.headingRadians,
+  lateral + lateralOffset,
+  along,
+);
 
 /// How a billboard is mounted.
 enum BillboardMount {
@@ -151,7 +141,7 @@ class TickerSlot {
 }
 
 /// What a beacon is for; drives its look and its visibility range.
-enum BeaconKind { home, block, corner, overview, attention }
+enum BeaconKind { home, block, corner, attention }
 
 /// A beacon: a visible point plus the curated pose it flies you to.
 class Beacon {
@@ -223,6 +213,16 @@ class FrontierPlaza {
 
   /// The four pylon slots, rank order.
   final List<BillboardSlot> pylons;
+
+  /// The square's rectangle on the ground, local Z along the street's
+  /// heading.
+  Footprint get footprint => Footprint(
+    x: centerX,
+    z: centerZ,
+    facingRadians: headingRadians,
+    width: width,
+    depth: depth,
+  );
 }
 
 /// Plaza dimensions, world meters. The plaza starts [plazaSetback] past the
@@ -277,9 +277,13 @@ double plazaLateralOffsetFor(StreetPlan plan) {
   cx /= plan.placements.length;
   cz /= plan.placements.length;
   // Lateral component of (centroid − street end) in the last row's frame.
-  final toCentroid =
-      (cx - last.endX) * math.cos(last.headingRadians) -
-      (cz - last.endZ) * math.sin(last.headingRadians);
+  final (toCentroid, _) = worldToFrame(
+    last.endX,
+    last.endZ,
+    last.headingRadians,
+    cx,
+    cz,
+  );
   return toCentroid >= 0 ? -plazaFoldClearance : plazaFoldClearance;
 }
 
@@ -292,38 +296,21 @@ double plazaLateralOffsetFor(StreetPlan plan) {
 FrontierPlaza? frontierPlazaFor(StreetPlan plan) {
   final last = plan.last;
   if (last == null) return null;
-  final folded = plan.segments.any((s) => s.isConnector);
-  var lateralOffset = 0.0;
-  if (folded && plan.placements.isNotEmpty) {
-    var cx = 0.0;
-    var cz = 0.0;
-    for (final p in plan.placements.values) {
-      cx += p.x;
-      cz += p.z;
-    }
-    cx /= plan.placements.length;
-    cz /= plan.placements.length;
-    // Lateral component of (centroid − street end) in the last row's frame.
-    final toCentroid =
-        (cx - last.endX) * math.cos(last.headingRadians) -
-        (cz - last.endZ) * math.sin(last.headingRadians);
-    lateralOffset = toCentroid >= 0 ? -plazaFoldClearance : plazaFoldClearance;
-  }
-  final frame = _Frame(
-    last.endX,
-    last.endZ,
-    last.headingRadians,
-    lateralOffset: lateralOffset,
-  );
+  final lateralOffset = plazaLateralOffsetFor(plan);
   final lookBack = last.headingRadians + math.pi;
 
-  final (cx, cz) = frame.toWorld(0, plazaSetback + plazaDepth / 2);
-  final (hx, hz) = frame.toWorld(0, _homeAlong);
+  final (cx, cz) = _plazaPoint(
+    last,
+    lateralOffset,
+    0,
+    plazaSetback + plazaDepth / 2,
+  );
+  final (hx, hz) = _plazaPoint(last, lateralOffset, 0, _homeAlong);
 
   final pylons = <BillboardSlot>[];
   for (final (rank, slot) in _pylonSlots.indexed) {
     final (lateral, along, width, height, bottom) = slot;
-    final (px, pz) = frame.toWorld(lateral, along);
+    final (px, pz) = _plazaPoint(last, lateralOffset, lateral, along);
     // Face the plaza's focal point, expressed in the local frame then
     // rotated into the world.
     final localFacing = math.atan2(0 - lateral, _pylonFocusAlong - along);
@@ -384,15 +371,7 @@ CameraPose overviewPoseFor(StreetPlan plan) {
   }
   // Include the plaza and the jumbotron tower in the footprint.
   const plazaFar = plazaSetback + plazaDepth + 20;
-  final plazaLateral = plazaLateralOffsetFor(plan);
-  final fx =
-      last.endX +
-      math.sin(last.headingRadians) * plazaFar +
-      math.cos(last.headingRadians) * plazaLateral;
-  final fz =
-      last.endZ +
-      math.cos(last.headingRadians) * plazaFar -
-      math.sin(last.headingRadians) * plazaLateral;
+  final (fx, fz) = _plazaPoint(last, plazaLateralOffsetFor(plan), 0, plazaFar);
   minX = math.min(minX, fx);
   maxX = math.max(maxX, fx);
   final jumbotron = jumbotronSlotFor(plan);
@@ -428,12 +407,8 @@ CameraPose overviewPoseFor(StreetPlan plan) {
 List<PlotPlacement> plazaMounts(StreetPlan plan) {
   final last = plan.last;
   if (last == null) return const [];
-  double along(PlotPlacement p) {
-    final dx = p.x - last.startX;
-    final dz = p.z - last.startZ;
-    return dx * math.sin(last.headingRadians) +
-        dz * math.cos(last.headingRadians);
-  }
+  double along(PlotPlacement p) =>
+      worldToFrame(last.startX, last.startZ, last.headingRadians, p.x, p.z).$2;
 
   final result = <PlotPlacement>[];
   for (final side in PlotSide.values) {
@@ -461,8 +436,13 @@ List<PlotPlacement> plazaMounts(StreetPlan plan) {
   for (final (i, mount) in plazaMounts(plan).indexed) {
     // The end wall faces along the street heading (toward the plaza).
     final facing = last.headingRadians;
-    final endX = mount.x + math.sin(facing) * (mount.width / 2 + 0.15);
-    final endZ = mount.z + math.cos(facing) * (mount.width / 2 + 0.15);
+    final (endX, endZ) = frameToWorld(
+      mount.x,
+      mount.z,
+      facing,
+      0,
+      mount.width / 2 + 0.15,
+    );
     screens.add(
       BillboardSlot(
         rank: 4 + i,
@@ -503,11 +483,12 @@ List<BillboardSlot> roofBillboardsFor(
     final p = plan.placements[anomaly.task.id];
     if (p == null) continue;
     final height = (2.6 + anomaly.score * 0.45).clamp(3.0, 6.0);
+    final (x, z) = p.footprint.toWorld(0, p.depth / 2 - 0.4);
     slots.add(
       BillboardSlot(
         rank: rank,
-        x: p.x + math.sin(p.facingRadians) * (p.depth / 2 - 0.4),
-        z: p.z + math.cos(p.facingRadians) * (p.depth / 2 - 0.4),
+        x: x,
+        z: z,
         facingRadians: p.facingRadians,
         width: p.width * 0.95,
         height: height,
@@ -554,11 +535,12 @@ List<BannerSlot> bannersFor(StreetPlan plan, {double minHeight = 12}) {
         continue;
       }
       final facing = segment.headingRadians;
+      final (x, z) = frameToWorld(p.x, p.z, facing, 0, p.width / 2 + 0.06);
       slots.add(
         BannerSlot(
           taskId: p.taskId,
-          x: p.x + math.sin(facing) * (p.width / 2 + 0.06),
-          z: p.z + math.cos(facing) * (p.width / 2 + 0.06),
+          x: x,
+          z: z,
           facingRadians: facing,
           width: math.min(1.8, p.depth * 0.3),
           height: p.height * 0.7,
@@ -573,6 +555,9 @@ List<BannerSlot> bannersFor(StreetPlan plan, {double minHeight = 12}) {
 /// Lamp posts stand about this far apart along a kerb.
 const lampRhythm = 18.0;
 
+/// A lamp post needs a gap at least this wide between two buildings.
+const _lampMinGap = 2.5;
+
 /// Lamp posts on the pavement of both kerbs at a [lampRhythm] beat, each
 /// beat snapped to the nearest gap between buildings (never in front of a
 /// facade), plus the head of every built block on the left kerb (the week
@@ -581,16 +566,18 @@ const lampRhythm = 18.0;
 List<(double, double)> lampPostsFor(
   StreetPlan plan, {
   required double roadWidth,
-  double minGap = 2.5,
 }) {
   final posts = <(double, double)>[];
   final lateral = roadWidth / 2 - kerbFixtureInset;
   for (final segment in plan.segments) {
     if (segment.isGap) continue;
-    final sinH = math.sin(segment.headingRadians);
-    final cosH = math.cos(segment.headingRadians);
-    double along(PlotPlacement p) =>
-        (p.x - segment.startX) * sinH + (p.z - segment.startZ) * cosH;
+    double along(PlotPlacement p) => worldToFrame(
+      segment.startX,
+      segment.startZ,
+      segment.headingRadians,
+      p.x,
+      p.z,
+    ).$2;
     for (final side in PlotSide.values) {
       final sign = side == PlotSide.left ? -1.0 : 1.0;
       final plots =
@@ -601,15 +588,17 @@ List<(double, double)> lampPostsFor(
               .toList()
             ..sort((a, b) => along(a).compareTo(along(b)));
       // The gaps a post may stand in: before the first plot, between
-      // neighbours at least [minGap] apart, and after the last.
+      // neighbours at least [_lampMinGap] apart, and after the last.
       final gaps = <(double, double)>[];
       var cursor = 0.0;
       for (final p in plots) {
         final start = along(p) - p.width / 2;
-        if (start - cursor >= minGap) gaps.add((cursor, start));
+        if (start - cursor >= _lampMinGap) gaps.add((cursor, start));
         cursor = along(p) + p.width / 2;
       }
-      if (segment.length - cursor >= minGap) gaps.add((cursor, segment.length));
+      if (segment.length - cursor >= _lampMinGap) {
+        gaps.add((cursor, segment.length));
+      }
       final spots = <double>[if (side == PlotSide.left) blockHeadAlong];
       for (
         var beat = lampRhythm / 2;
@@ -629,10 +618,15 @@ List<(double, double)> lampPostsFor(
         }
       }
       for (final a in spots) {
-        posts.add((
-          segment.startX + sinH * a + cosH * sign * lateral,
-          segment.startZ + cosH * a - sinH * sign * lateral,
-        ));
+        posts.add(
+          frameToWorld(
+            segment.startX,
+            segment.startZ,
+            segment.headingRadians,
+            sign * lateral,
+            a,
+          ),
+        );
       }
     }
   }
@@ -655,15 +649,14 @@ List<(int, double, double, double)> weekSignsFor(
   final signs = <(int, double, double, double)>[];
   for (final segment in plan.segments) {
     if (segment.isGap) continue;
-    final sinH = math.sin(segment.headingRadians);
-    final cosH = math.cos(segment.headingRadians);
-    final lateral = -(roadWidth / 2 - kerbFixtureInset);
-    signs.add((
-      segment.bucketIndex,
-      segment.startX + sinH * blockHeadAlong + cosH * lateral,
-      segment.startZ + cosH * blockHeadAlong - sinH * lateral,
-      segment.headingRadians + math.pi,
-    ));
+    final (x, z) = frameToWorld(
+      segment.startX,
+      segment.startZ,
+      segment.headingRadians,
+      -(roadWidth / 2 - kerbFixtureInset),
+      blockHeadAlong,
+    );
+    signs.add((segment.bucketIndex, x, z, segment.headingRadians + math.pi));
   }
   return signs;
 }
@@ -673,9 +666,16 @@ TickerSlot? gantryTickerFor(StreetPlan plan, {required double roadWidth}) {
   final last = plan.last;
   if (last == null) return null;
   const along = 3.0;
+  final (x, z) = frameToWorld(
+    last.endX,
+    last.endZ,
+    last.headingRadians,
+    0,
+    along,
+  );
   return TickerSlot(
-    x: last.endX + math.sin(last.headingRadians) * along,
-    z: last.endZ + math.cos(last.headingRadians) * along,
+    x: x,
+    z: z,
     facingRadians: last.headingRadians,
     width: roadWidth + 4,
     height: 1.8,
@@ -701,17 +701,13 @@ BillboardSlot? jumbotronSlotFor(StreetPlan plan) {
   if (last == null) return null;
   final offset = plazaLateralOffsetFor(plan);
   final side = offset == 0 ? -1.0 : offset.sign;
-  final frame = _Frame(
-    last.endX,
-    last.endZ,
-    last.headingRadians,
-    lateralOffset: offset,
-  );
-  final (x, z) = frame.toWorld(
+  final (x, z) = _plazaPoint(
+    last,
+    offset,
     side * (plazaWidth / 2 + jumbotronLateralClearance),
     jumbotronAlong,
   );
-  final (hx, hz) = frame.toWorld(0, _homeAlong);
+  final (hx, hz) = _plazaPoint(last, offset, 0, _homeAlong);
   return BillboardSlot(
     rank: 0,
     x: x,
@@ -725,27 +721,31 @@ BillboardSlot? jumbotronSlotFor(StreetPlan plan) {
   );
 }
 
+/// Tallest first, ties by task id, so the order never moves under the
+/// user's feet.
+int tallestFirst(PlotPlacement a, PlotPlacement b) {
+  final byHeight = b.height.compareTo(a.height);
+  return byHeight != 0 ? byHeight : a.taskId.compareTo(b.taskId);
+}
+
 /// The [count] tallest buildings, tallest first: they carry spires with
 /// blinking warning lights.
 List<PlotPlacement> spiresFor(StreetPlan plan, {int count = 2}) =>
-    ([...plan.placements.values]..sort((a, b) {
-          final byHeight = b.height.compareTo(a.height);
-          return byHeight != 0 ? byHeight : a.taskId.compareTo(b.taskId);
-        }))
-        .take(count)
-        .toList();
+    ([...plan.placements.values]..sort(tallestFirst)).take(count).toList();
 
 /// A ticker band along the roofline of [hero]'s street-facing wall.
-TickerSlot rooflineTickerFor(PlotPlacement hero, {required bool fast}) =>
-    TickerSlot(
-      x: hero.x + math.sin(hero.facingRadians) * (hero.depth / 2 + 0.05),
-      z: hero.z + math.cos(hero.facingRadians) * (hero.depth / 2 + 0.05),
-      facingRadians: hero.facingRadians,
-      width: hero.width,
-      height: 1.9,
-      bottom: hero.height + 0.2,
-      speedMetersPerSecond: fast ? 4.2 : 3.4,
-    );
+TickerSlot rooflineTickerFor(PlotPlacement hero, {required bool fast}) {
+  final (x, z) = hero.footprint.toWorld(0, hero.depth / 2 + 0.05);
+  return TickerSlot(
+    x: x,
+    z: z,
+    facingRadians: hero.facingRadians,
+    width: hero.width,
+    height: 1.9,
+    bottom: hero.height + 0.2,
+    speedMetersPerSecond: fast ? 4.2 : 3.4,
+  );
+}
 
 /// The pose that looks straight at a building's facade from the road:
 /// far enough back to frame a wide or tall wall, tilted to keep the
@@ -783,12 +783,12 @@ const double maxTaskPitch = 14 * math.pi / 180;
 CameraPose taskPoseFor(PlotPlacement p) {
   final d = taskStandOffFor(p);
   final facing = p.facingRadians;
-  final facadeX = p.x + math.sin(facing) * (p.depth / 2);
-  final facadeZ = p.z + math.cos(facing) * (p.depth / 2);
+  // In front of the facade, which is half the depth out from the centre.
+  final (x, z) = p.footprint.toWorld(0, p.depth / 2 + d);
   return CameraPose(
-    x: facadeX + math.sin(facing) * d,
+    x: x,
     y: eyeHeight,
-    z: facadeZ + math.cos(facing) * d,
+    z: z,
     yaw: facing + math.pi,
     pitch: math.min(
       math.atan2((p.height + roofSignageHeight) / 2 - eyeHeight, d),
@@ -854,10 +854,13 @@ List<Beacon> beaconsFor(
     if (segment.isGap) continue;
     // Stand just before the block looking down it, so its buildings are
     // ahead on both sides rather than beside and behind the camera.
-    final x =
-        segment.startX + math.sin(segment.headingRadians) * blockBeaconInset;
-    final z =
-        segment.startZ + math.cos(segment.headingRadians) * blockBeaconInset;
+    final (x, z) = frameToWorld(
+      segment.startX,
+      segment.startZ,
+      segment.headingRadians,
+      0,
+      blockBeaconInset,
+    );
     beacons.add(
       Beacon(
         id: 'block-${segment.bucketIndex}',

--- a/lib/features/plaza/domain/scenery.dart
+++ b/lib/features/plaza/domain/scenery.dart
@@ -51,14 +51,11 @@ class SceneryBox {
   /// A thin solid standing on the roof, [size] square and [spireHeight]
   /// tall, at the box's centre.
   Solid spireSolid({required double size, required double spireHeight}) =>
-      Solid(
-        footprint: Footprint(
-          x: x,
-          z: z,
-          facingRadians: yawRadians,
-          width: size,
-          depth: size,
-        ),
+      Solid.post(
+        x: x,
+        z: z,
+        facingRadians: yawRadians,
+        size: size,
         bottom: height,
         top: height + spireHeight,
       );
@@ -212,14 +209,11 @@ Solid plotSolidFor(PlotPlacement p) =>
     Solid(footprint: p.footprint, top: p.height + roofKitHeight);
 
 /// The spire on one of the tallest plots (`spiresFor`).
-Solid plotSpireSolidFor(PlotPlacement p) => Solid(
-  footprint: Footprint(
-    x: p.x,
-    z: p.z,
-    facingRadians: p.facingRadians,
-    width: plotSpireSize,
-    depth: plotSpireSize,
-  ),
+Solid plotSpireSolidFor(PlotPlacement p) => Solid.post(
+  x: p.x,
+  z: p.z,
+  facingRadians: p.facingRadians,
+  size: plotSpireSize,
   bottom: p.height,
   top: p.height + plotSpireHeight,
 );
@@ -242,15 +236,24 @@ Footprint streetCorridorFor(
   RoadSegment segment, {
   required double roadWidth,
   required double plotDepth,
-}) => Footprint(
-  x: segment.startX + math.sin(segment.headingRadians) * segment.length / 2,
-  z: segment.startZ + math.cos(segment.headingRadians) * segment.length / 2,
-  facingRadians: segment.headingRadians,
-  width:
-      (segment.isGap ? roadWidth : roadWidth + 2 * plotDepth) +
-      2 * fillerCorridorMargin,
-  depth: segment.length + 2 * fillerCorridorMargin,
-);
+}) {
+  final (x, z) = frameToWorld(
+    segment.startX,
+    segment.startZ,
+    segment.headingRadians,
+    0,
+    segment.length / 2,
+  );
+  return Footprint(
+    x: x,
+    z: z,
+    facingRadians: segment.headingRadians,
+    width:
+        (segment.isGap ? roadWidth : roadWidth + 2 * plotDepth) +
+        2 * fillerCorridorMargin,
+    depth: segment.length + 2 * fillerCorridorMargin,
+  );
+}
 
 /// A second row of blocks behind the plots with alleys between, so the
 /// street has a back and the overview has texture between the plots and
@@ -270,25 +273,14 @@ List<FillerBlock> fillerBlocksFor(
     for (final segment in plan.segments)
       streetCorridorFor(segment, roadWidth: roadWidth, plotDepth: plotDepth),
   ];
-  bool onPlaza(double x, double z) {
-    if (plaza == null) return false;
-    final dx = x - plaza.centerX;
-    final dz = z - plaza.centerZ;
-    final along =
-        dx * math.sin(plaza.headingRadians) +
-        dz * math.cos(plaza.headingRadians);
-    final lateral =
-        dx * math.cos(plaza.headingRadians) -
-        dz * math.sin(plaza.headingRadians);
-    return along.abs() < plaza.depth / 2 + fillerPlazaMargin &&
-        lateral.abs() < plaza.width / 2 + fillerPlazaMargin;
-  }
+  final plazaGround = plaza?.footprint;
+  bool onPlaza(double x, double z) =>
+      plazaGround != null &&
+      plazaGround.contains(x, z, clearance: fillerPlazaMargin);
 
   final blocks = <FillerBlock>[];
   for (final segment in plan.segments) {
     if (segment.isGap) continue;
-    final sinH = math.sin(segment.headingRadians);
-    final cosH = math.cos(segment.headingRadians);
     for (final side in [-1.0, 1.0]) {
       var along = 2.0;
       var i = 0;
@@ -305,13 +297,19 @@ List<FillerBlock> fillerBlocksFor(
             : 12 + stableUnit(id, 'h') * 22;
         final inner = lateralBase + stableUnit(id, 'l') * 4;
         FillerBlock at(double reach) {
-          final lateral = side * (inner + reach / 2);
+          final (x, z) = frameToWorld(
+            segment.startX,
+            segment.startZ,
+            segment.headingRadians,
+            side * (inner + reach / 2),
+            along + frontage / 2,
+          );
           return FillerBlock(
             id: id,
             bucketIndex: segment.bucketIndex,
             side: side,
-            x: segment.startX + sinH * (along + frontage / 2) + cosH * lateral,
-            z: segment.startZ + cosH * (along + frontage / 2) - sinH * lateral,
+            x: x,
+            z: z,
             yawRadians: segment.headingRadians,
             width: reach,
             depth: frontage,
@@ -351,12 +349,19 @@ List<HeroTower> heroTowersFor(StreetPlan plan) {
     final row = segments[i - 1];
     final id = 'hero-${row.bucketIndex}';
     final width = 26 + stableUnit(id, 'w') * 8;
+    final (x, z) = frameToWorld(
+      row.endX,
+      row.endZ,
+      row.headingRadians,
+      0,
+      heroTowerStandOff,
+    );
     towers.add(
       HeroTower(
         id: id,
         bucketIndex: row.bucketIndex,
-        x: row.endX + math.sin(row.headingRadians) * heroTowerStandOff,
-        z: row.endZ + math.cos(row.headingRadians) * heroTowerStandOff,
+        x: x,
+        z: z,
         yawRadians: row.headingRadians + math.pi,
         width: width,
         depth: width * 0.8,
@@ -378,12 +383,17 @@ const jumbotronTowerCrown = 14.0;
 /// The tower the jumbotron hangs on, behind the plaza.
 JumbotronTower? jumbotronTowerFor(BillboardSlot? jumbotron) {
   if (jumbotron == null) return null;
-  final sinF = math.sin(jumbotron.facingRadians);
-  final cosF = math.cos(jumbotron.facingRadians);
+  final (x, z) = frameToWorld(
+    jumbotron.x,
+    jumbotron.z,
+    jumbotron.facingRadians,
+    0,
+    -jumbotronTowerSetback,
+  );
   return JumbotronTower(
     id: 'jumbotron',
-    x: jumbotron.x - sinF * jumbotronTowerSetback,
-    z: jumbotron.z - cosF * jumbotronTowerSetback,
+    x: x,
+    z: z,
     yawRadians: jumbotron.facingRadians,
     width: jumbotron.width + 2 * jumbotronTowerMargin,
     depth: jumbotronTowerDepth,
@@ -417,14 +427,13 @@ List<SkylineTower> skylineFor(StreetPlan plan, FrontierPlaza? plaza) {
   final (cx, cz) = planCenterOf(plan);
   var radius = 0.0;
   for (final p in plan.placements.values) {
-    final dx = p.x - cx;
-    final dz = p.z - cz;
-    radius = math.max(radius, math.sqrt(dx * dx + dz * dz));
+    radius = math.max(radius, groundDistanceBetween(cx, cz, p.x, p.z));
   }
   if (plaza != null) {
-    final dx = plaza.centerX - cx;
-    final dz = plaza.centerZ - cz;
-    radius = math.max(radius, math.sqrt(dx * dx + dz * dz) + 60);
+    radius = math.max(
+      radius,
+      groundDistanceBetween(cx, cz, plaza.centerX, plaza.centerZ) + 60,
+    );
   }
   radius += skylineRingClearance;
   final towers = <SkylineTower>[];
@@ -478,6 +487,7 @@ const nearHomeLateral = 4.0;
 List<PlazaFurniture> plazaFurnitureFor(FrontierPlaza? plaza) {
   if (plaza == null) return const [];
   final h = plaza.headingRadians;
+  final ground = plaza.footprint;
   final out = <PlazaFurniture>[];
   final lateral = plaza.width / 2 - furnitureInset;
   final reach = plaza.depth / 2 - furnitureInset - furnitureSpacing / 2;
@@ -485,13 +495,7 @@ List<PlazaFurniture> plazaFurnitureFor(FrontierPlaza? plaza) {
     var i = 0;
     for (var along = -reach; along <= reach + 1e-9; along += furnitureSpacing) {
       final bench = i.isEven;
-      final (x, z) = _slotToWorld(
-        plaza.centerX,
-        plaza.centerZ,
-        h,
-        side * lateral,
-        along,
-      );
+      final (x, z) = ground.toWorld(side * lateral, along);
       out.add(
         PlazaFurniture(
           id: 'plaza-${side < 0 ? 'l' : 'r'}-$i',
@@ -508,17 +512,12 @@ List<PlazaFurniture> plazaFurnitureFor(FrontierPlaza? plaza) {
     }
   }
   // Home's along in the plaza frame, from its world pose.
-  final homeAlong =
-      (plaza.home.x - plaza.centerX) * math.sin(h) +
-      (plaza.home.z - plaza.centerZ) * math.cos(h);
+  final (_, homeAlong) = ground.local(plaza.home.x, plaza.home.z);
   for (final (side, kind) in [
     (-1.0, FurnitureKind.bench),
     (1.0, FurnitureKind.planter),
   ]) {
-    final (nx, nz) = _slotToWorld(
-      plaza.centerX,
-      plaza.centerZ,
-      h,
+    final (nx, nz) = ground.toWorld(
       side * nearHomeLateral,
       homeAlong - nearHomeAhead,
     );
@@ -537,13 +536,7 @@ List<PlazaFurniture> plazaFurnitureFor(FrontierPlaza? plaza) {
       ),
     );
   }
-  final (kx, kz) = _slotToWorld(
-    plaza.centerX,
-    plaza.centerZ,
-    h,
-    kioskLateral,
-    kioskAlong,
-  );
+  final (kx, kz) = ground.toWorld(kioskLateral, kioskAlong);
   out.add(
     PlazaFurniture(
       id: 'plaza-kiosk',
@@ -588,19 +581,6 @@ const pylonPostSpread = 0.4;
 const pylonPostSize = 0.6;
 const pylonFootingSize = 1.6;
 
-/// Local (x, z) in a slot's frame to the world.
-(double, double) _slotToWorld(
-  double x,
-  double z,
-  double facing,
-  double lx,
-  double lz,
-) {
-  final sinF = math.sin(facing);
-  final cosF = math.cos(facing);
-  return (x + lx * cosF + lz * sinF, z - lx * sinF + lz * cosF);
-}
-
 /// A billboard's panel, backing and glow, front to back: the depth of a
 /// pylon's sign and of a roof panel as a solid.
 const signDepth = 0.8;
@@ -609,29 +589,28 @@ const signDepth = 0.8;
 /// ground to the panel's bottom, and the sign itself in the air.
 List<Solid> pylonSolidsFor(Iterable<BillboardSlot> pylons) => [
   for (final slot in pylons) ...[
-    for (final side in [-1.0, 1.0])
-      () {
-        final (x, z) = _slotToWorld(
-          slot.x,
-          slot.z,
-          slot.facingRadians,
-          side * slot.width * pylonPostSpread,
-          -pylonPostSetback,
-        );
-        return Solid(
-          footprint: Footprint(
-            x: x,
-            z: z,
-            facingRadians: slot.facingRadians,
-            width: pylonFootingSize,
-            depth: pylonFootingSize,
-          ),
-          top: slot.bottom,
-        );
-      }(),
+    for (final side in [-1.0, 1.0]) _pylonPost(slot, side),
     signSolidFor(slot),
   ],
 ];
+
+/// One of a pylon's posts, on its footing, ground to the panel's bottom.
+Solid _pylonPost(BillboardSlot slot, double side) {
+  final (x, z) = frameToWorld(
+    slot.x,
+    slot.z,
+    slot.facingRadians,
+    side * slot.width * pylonPostSpread,
+    -pylonPostSetback,
+  );
+  return Solid.post(
+    x: x,
+    z: z,
+    facingRadians: slot.facingRadians,
+    size: pylonFootingSize,
+    top: slot.bottom,
+  );
+}
 
 /// A billboard's sign as a solid: the panel's rectangle, [signDepth]
 /// thick, from its bottom edge to its top.
@@ -660,26 +639,7 @@ double gantryTopFor(TickerSlot gantry) =>
 /// The two legs of the ticker gantry, and the band with its beam spanning
 /// the street between them.
 List<Solid> gantrySolidsFor(TickerSlot gantry) => [
-  for (final side in [-1.0, 1.0])
-    () {
-      final (x, z) = _slotToWorld(
-        gantry.x,
-        gantry.z,
-        gantry.facingRadians,
-        side * gantry.width / 2,
-        0,
-      );
-      return Solid(
-        footprint: Footprint(
-          x: x,
-          z: z,
-          facingRadians: gantry.facingRadians,
-          width: gantryLegSize,
-          depth: gantryLegSize,
-        ),
-        top: gantryTopFor(gantry),
-      );
-    }(),
+  for (final side in [-1.0, 1.0]) _gantryLeg(gantry, side),
   Solid(
     footprint: Footprint(
       x: gantry.x,
@@ -693,6 +653,24 @@ List<Solid> gantrySolidsFor(TickerSlot gantry) => [
   ),
 ];
 
+/// One leg of the gantry, at one end of its span.
+Solid _gantryLeg(TickerSlot gantry, double side) {
+  final (x, z) = frameToWorld(
+    gantry.x,
+    gantry.z,
+    gantry.facingRadians,
+    side * gantry.width / 2,
+    0,
+  );
+  return Solid.post(
+    x: x,
+    z: z,
+    facingRadians: gantry.facingRadians,
+    size: gantryLegSize,
+    top: gantryTopFor(gantry),
+  );
+}
+
 /// A lamp post's pole is this square and this tall.
 const lampPostSize = 0.16;
 const lampPostHeight = 5.2;
@@ -700,14 +678,5 @@ const lampPostHeight = 5.2;
 /// One solid per lamp post.
 List<Solid> lampPostSolidsFor(Iterable<(double, double)> posts) => [
   for (final (x, z) in posts)
-    Solid(
-      footprint: Footprint(
-        x: x,
-        z: z,
-        facingRadians: 0,
-        width: lampPostSize,
-        depth: lampPostSize,
-      ),
-      top: lampPostHeight,
-    ),
+    Solid.post(x: x, z: z, size: lampPostSize, top: lampPostHeight),
 ];

--- a/lib/features/plaza/domain/solid.dart
+++ b/lib/features/plaza/domain/solid.dart
@@ -17,6 +17,24 @@ const solidClearance = 0.6;
 class Solid {
   const Solid({required this.footprint, required this.top, this.bottom = 0});
 
+  /// A square post [size] wide at ([x], [z]), turned [facingRadians],
+  /// from [bottom] up to [top]: a spire, a pylon's footing, a gantry's
+  /// leg, a lamp post.
+  Solid.post({
+    required double x,
+    required double z,
+    required double size,
+    required this.top,
+    double facingRadians = 0,
+    this.bottom = 0,
+  }) : footprint = Footprint(
+         x: x,
+         z: z,
+         facingRadians: facingRadians,
+         width: size,
+         depth: size,
+       );
+
   final Footprint footprint;
 
   /// Height of the underside above the ground; 0 for anything standing on
@@ -32,10 +50,8 @@ class Solid {
 
   /// Whether the point is inside, with [clearance] metres of margin on
   /// every side.
-  bool contains(double x, double y, double z, {double clearance = 0}) {
-    if (y <= bottom - clearance || y >= top + clearance) return false;
-    final (u, v) = footprint.local(x, z);
-    return u.abs() < footprint.width / 2 + clearance &&
-        v.abs() < footprint.depth / 2 + clearance;
-  }
+  bool contains(double x, double y, double z, {double clearance = 0}) =>
+      y > bottom - clearance &&
+      y < top + clearance &&
+      footprint.contains(x, z, clearance: clearance);
 }

--- a/lib/features/plaza/domain/street_layout.dart
+++ b/lib/features/plaza/domain/street_layout.dart
@@ -47,6 +47,51 @@ int stableHash(String input) {
 double stableUnit(String id, String salt) =>
     (stableHash('$id:$salt') & 0xFFFF) / 0xFFFF;
 
+/// A seeded pick from [count] choices: 0 to `count - 1`, from [stableUnit].
+int stableIndex(String id, String salt, int count) =>
+    (stableUnit(id, salt) * count).floor().clamp(0, count - 1);
+
+/// The world point [u] along the local X axis and [v] along the local Z
+/// axis of a frame at ([x], [z]) turned [facingRadians] about +Y. Local Z
+/// is `(sin facing, cos facing)`, the heading of a road facing that way;
+/// local X is `(cos facing, -sin facing)`, the road's right-hand normal.
+/// The inverse of [worldToFrame].
+(double, double) frameToWorld(
+  double x,
+  double z,
+  double facingRadians,
+  double u,
+  double v,
+) {
+  final sinF = math.sin(facingRadians);
+  final cosF = math.cos(facingRadians);
+  return (x + u * cosF + v * sinF, z - u * sinF + v * cosF);
+}
+
+/// The world point ([px], [pz]) in the frame at ([x], [z]) turned
+/// [facingRadians]: `u` along local X, `v` along local Z, both from the
+/// frame's origin. The inverse of [frameToWorld].
+(double, double) worldToFrame(
+  double x,
+  double z,
+  double facingRadians,
+  double px,
+  double pz,
+) {
+  final sinF = math.sin(facingRadians);
+  final cosF = math.cos(facingRadians);
+  final dx = px - x;
+  final dz = pz - z;
+  return (dx * cosF - dz * sinF, dx * sinF + dz * cosF);
+}
+
+/// The distance on the ground from ([ax], [az]) to ([bx], [bz]).
+double groundDistanceBetween(double ax, double az, double bx, double bz) {
+  final dx = bx - ax;
+  final dz = bz - az;
+  return math.sqrt(dx * dx + dz * dz);
+}
+
 /// A solid's rectangle on the ground: centre, rotation about +Y, and the
 /// extents along its local X ([width]) and local Z ([depth]). Everything
 /// the scene builds on the ground has one, and the walker collider keeps
@@ -76,12 +121,19 @@ class Footprint {
 
   /// The point in this footprint's frame: `u` along local X (the width),
   /// `v` along local Z (the depth), both from the centre.
-  (double, double) local(double x, double z) {
-    final sinF = math.sin(facingRadians);
-    final cosF = math.cos(facingRadians);
-    final dx = x - this.x;
-    final dz = z - this.z;
-    return (dx * cosF - dz * sinF, dx * sinF + dz * cosF);
+  (double, double) local(double x, double z) =>
+      worldToFrame(this.x, this.z, facingRadians, x, z);
+
+  /// The world point [u] along the width and [v] along the depth from the
+  /// centre.
+  (double, double) toWorld(double u, double v) =>
+      frameToWorld(x, z, facingRadians, u, v);
+
+  /// Whether ([x], [z]) lies inside, with [clearance] metres of margin on
+  /// every side.
+  bool contains(double x, double z, {double clearance = 0}) {
+    final (u, v) = local(x, z);
+    return u.abs() < width / 2 + clearance && v.abs() < depth / 2 + clearance;
   }
 
   /// The interval this footprint covers along the world axis ([ax], [az]).
@@ -436,8 +488,6 @@ class StreetLayout {
     required double heading,
     required Map<String, PlotPlacement> into,
   }) {
-    final sinH = math.sin(heading);
-    final cosH = math.cos(heading);
     final usable = groupLength - 2 * sideMargin;
 
     // The week's landmark: its heaviest task (ties by id) stands taller.
@@ -476,12 +526,19 @@ class StreetLayout {
         final sideSign = side == PlotSide.left ? -1.0 : 1.0;
         final lateral = sideSign * (roadWidth / 2 + plotDepth / 2);
         // Lateral axis is the road's right-hand normal.
+        final (x, z) = frameToWorld(
+          startX,
+          startZ,
+          heading,
+          lateral,
+          centerAlong,
+        );
         into[task.id] = PlotPlacement(
           taskId: task.id,
           bucketIndex: bucket,
           side: side,
-          x: startX + sinH * centerAlong + cosH * lateral,
-          z: startZ + cosH * centerAlong - sinH * lateral,
+          x: x,
+          z: z,
           // Facade faces the road.
           facingRadians:
               heading + (side == PlotSide.left ? math.pi / 2 : -math.pi / 2),

--- a/lib/features/plaza/domain/street_network.dart
+++ b/lib/features/plaza/domain/street_network.dart
@@ -21,7 +21,9 @@ class StreetNetwork {
     assert(vertices.length >= 2, 'a network needs two points');
     final cumulative = <double>[0];
     for (var i = 1; i < vertices.length; i++) {
-      cumulative.add(cumulative.last + _distance(vertices[i - 1], vertices[i]));
+      final (ax, az) = vertices[i - 1];
+      final (bx, bz) = vertices[i];
+      cumulative.add(cumulative.last + groundDistanceBetween(ax, az, bx, bz));
     }
     _cumulative = List.unmodifiable(cumulative);
   }
@@ -60,15 +62,13 @@ class StreetNetwork {
   static List<(double, double)> _distinct(List<(double, double)> points) {
     final out = <(double, double)>[];
     for (final p in points) {
-      if (out.isEmpty || _distance(out.last, p) > mergeDistance) out.add(p);
+      if (out.isEmpty ||
+          groundDistanceBetween(out.last.$1, out.last.$2, p.$1, p.$2) >
+              mergeDistance) {
+        out.add(p);
+      }
     }
     return out;
-  }
-
-  static double _distance((double, double) a, (double, double) b) {
-    final dx = b.$1 - a.$1;
-    final dz = b.$2 - a.$2;
-    return math.sqrt(dx * dx + dz * dz);
   }
 
   /// The point [along] metres from the start, clamped to the ends.

--- a/lib/features/plaza/domain/walk_collider.dart
+++ b/lib/features/plaza/domain/walk_collider.dart
@@ -2,23 +2,28 @@
 /// push against every footprint, with a margin so the camera never clips a
 /// wall.
 ///
-/// Pure Dart, O(footprints) per resolve — trivially cheap at prototype
-/// scale.
+/// Pure Dart, O(footprints) per resolve; each footprint's frame is fixed
+/// once, and a footprint too far away to touch is rejected before it is
+/// rotated into.
 library;
 
 import 'dart:math' as math;
 
 import 'package:lotti/features/plaza/domain/solid.dart';
 import 'package:lotti/features/plaza/domain/street_layout.dart';
+import 'package:meta/meta.dart';
 
 class WalkCollider {
   WalkCollider(Iterable<Footprint> footprints, {this.margin = solidClearance})
-    : _footprints = _mergeAligned(footprints.toList(), margin);
-
-  final List<Footprint> _footprints;
+    : footprints = _mergeAligned(footprints.toList(), margin) {
+    _walls = [for (final p in this.footprints) _Wall(p, margin)];
+  }
 
   /// The footprints the walker is kept out of, after merging.
-  List<Footprint> get footprints => _footprints;
+  @visibleForTesting
+  final List<Footprint> footprints;
+
+  late final List<_Wall> _walls;
 
   /// Two neighbours in a crowded week can stand closer than twice the
   /// margin. Resolved one after the other, the first pushes the walker into
@@ -77,28 +82,52 @@ class WalkCollider {
   (double, double) resolve(double x, double z) {
     var rx = x;
     var rz = z;
-    for (final p in _footprints) {
+    for (final w in _walls) {
+      final dx = rx - w.x;
+      final dz = rz - w.z;
+      // Too far to touch: no point of the box is farther from its centre
+      // than its corner.
+      if (dx * dx + dz * dz >= w.cornerDistanceSquared) continue;
       // Into the footprint's local frame: `u` along its width (local X),
       // `v` along its depth (local Z).
-      final sinF = math.sin(p.facingRadians);
-      final cosF = math.cos(p.facingRadians);
-      final (u, v) = p.local(rx, rz);
-      final halfW = p.width / 2 + margin;
-      final halfD = p.depth / 2 + margin;
-      if (u.abs() >= halfW || v.abs() >= halfD) continue;
+      final u = dx * w.cosF - dz * w.sinF;
+      final v = dx * w.sinF + dz * w.cosF;
+      if (u.abs() >= w.halfW || v.abs() >= w.halfD) continue;
       // Push out through the nearest face.
-      final pushU = halfW - u.abs();
-      final pushV = halfD - v.abs();
+      final pushU = w.halfW - u.abs();
+      final pushV = w.halfD - v.abs();
       var nu = u;
       var nv = v;
       if (pushU < pushV) {
-        nu = u.isNegative ? -halfW : halfW;
+        nu = u.isNegative ? -w.halfW : w.halfW;
       } else {
-        nv = v.isNegative ? -halfD : halfD;
+        nv = v.isNegative ? -w.halfD : w.halfD;
       }
-      rx = p.x + nu * cosF + nv * sinF;
-      rz = p.z - nu * sinF + nv * cosF;
+      rx = w.x + nu * w.cosF + nv * w.sinF;
+      rz = w.z - nu * w.sinF + nv * w.cosF;
     }
     return (rx, rz);
   }
+}
+
+/// A footprint with its margin, its frame fixed once for the walk.
+class _Wall {
+  _Wall(Footprint p, double margin)
+    : x = p.x,
+      z = p.z,
+      sinF = math.sin(p.facingRadians),
+      cosF = math.cos(p.facingRadians),
+      halfW = p.width / 2 + margin,
+      halfD = p.depth / 2 + margin;
+
+  final double x;
+  final double z;
+  final double sinF;
+  final double cosF;
+  final double halfW;
+  final double halfD;
+
+  /// The corner is the box's farthest point from its centre: a point at
+  /// least this far (squared, so no root per footprint) is outside.
+  double get cornerDistanceSquared => halfW * halfW + halfD * halfD;
 }

--- a/lib/features/plaza/scene/facade_lod_manager.dart
+++ b/lib/features/plaza/scene/facade_lod_manager.dart
@@ -1,7 +1,10 @@
 import 'dart:math' as math;
+import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_scene/scene.dart';
 import 'package:lotti/features/plaza/scene/plaza_scene.dart';
+import 'package:lotti/features/plaza/scene/surface_captures.dart';
 import 'package:lotti/features/plaza/ui/checklist_ticks.dart';
 import 'package:lotti/features/plaza/ui/facade_widget.dart';
 import 'package:vector_math/vector_math.dart' show Vector3;
@@ -51,11 +54,19 @@ class FacadeLodStats {
 class _Surface {
   WidgetComponent? component;
   FacadeTier tier = FacadeTier.far;
-  bool captured = false;
-
-  /// When a live wall was last asked for a capture, harness seconds.
-  double lastCapture = double.negativeInfinity;
 }
+
+/// The budget and the suspension a ranking was made under; a change to any
+/// of them makes the ranking stale.
+typedef _Budget = ({
+  int liveCap,
+  int signCap,
+  double liveDistance,
+  double signDistance,
+  int promotionsPerFrame,
+  bool forceAllLive,
+  bool flying,
+});
 
 /// Assigns each facade a tier from camera distance with sticky
 /// hysteresis, enforces the caps by construction, and schedules
@@ -69,7 +80,9 @@ class FacadeLodManager {
     required this.config,
     required this.ticks,
     required this.onOpen,
-  }) : _surfaces = [for (final _ in buildings) _Surface()];
+  }) : _surfaces = [for (final _ in buildings) _Surface()],
+       _distances = Float64List(buildings.length),
+       _order = List<int>.generate(buildings.length, (i) => i);
 
   final List<PlazaBuilding> buildings;
   final FacadeLodConfig config;
@@ -77,6 +90,29 @@ class FacadeLodManager {
   final void Function(PlazaBuilding building) onOpen;
   final List<_Surface> _surfaces;
   final FacadeLodStats stats = FacadeLodStats();
+
+  final SurfaceCaptures _captures = SurfaceCaptures();
+  final CaptureCadence _live = CaptureCadence(liveInterval);
+
+  /// Ranking scratch, allocated once: each building's sticky distance and
+  /// the building indices sorted by it.
+  final Float64List _distances;
+  final List<int> _order;
+
+  /// What the last ranking was made for. It holds until the eye, the view
+  /// direction, the budget or the suspension changes, or until it left
+  /// work undone: a tier it changed (the hysteresis shifts) or a promotion
+  /// it could not afford.
+  final Vector3 _rankedEye = Vector3.zero();
+  final Vector3 _rankedForward = Vector3.zero();
+  bool _rankedWithForward = false;
+  _Budget? _rankedBudget;
+  bool _settled = false;
+  int _rankings = 0;
+
+  /// How many times the tiers have been ranked.
+  @visibleForTesting
+  int get rankings => _rankings;
 
   /// Sticky factor: a surface already at a tier ranks as if 15% closer.
   static const _hysteresis = 0.85;
@@ -101,10 +137,6 @@ class FacadeLodManager {
         .join(' | ');
   }
 
-  /// While true (during flights) no surface is created except the one
-  /// pre-captured by [prepare].
-  bool suspended = false;
-
   PlazaBuilding? _focused;
   PlazaBuilding? get focused => _focused;
 
@@ -113,52 +145,89 @@ class FacadeLodManager {
   void prepare(PlazaBuilding building) {
     final i = buildings.indexOf(building);
     if (i < 0) return;
-    if (_surfaces[i].tier == FacadeTier.far) _apply(i, FacadeTier.sign);
+    if (_surfaces[i].tier == FacadeTier.far) {
+      _apply(i, FacadeTier.sign);
+      _settled = false;
+    }
   }
 
   /// How often a live wall is captured, seconds on the harness clock.
   static const liveInterval = 0.05;
 
-  /// Once per painted frame: assigns the tiers for [eye], then asks every
-  /// live wall for a capture once [liveInterval] has passed since its
-  /// last, at [seconds] on the harness clock. [forward] is the camera's
-  /// view direction: a wall behind the walker never takes a live slot,
-  /// however near — standing 22 m from a landmark puts the opposite row
-  /// 3 m behind your back.
-  void update(Vector3 eye, {Vector3? forward, double seconds = 0}) {
+  /// Once per painted frame: assigns the tiers for [eye] unless the last
+  /// ranking still holds (same eye, [forward], budget and [flying], and
+  /// nothing left undone), then asks every live wall for a capture once
+  /// [liveInterval] has passed since its last, at [seconds] on the harness
+  /// clock, and every sign for its one capture until it lands. [forward]
+  /// is the camera's view direction: a wall behind the walker never takes
+  /// a live slot, however near — standing 22 m from a landmark puts the
+  /// opposite row 3 m behind your back. While [flying] no surface is
+  /// created except the one pre-captured by [prepare].
+  void update(
+    Vector3 eye, {
+    Vector3? forward,
+    double seconds = 0,
+    bool flying = false,
+  }) {
+    if (!_rankingHolds(eye, forward, flying)) _rank(eye, forward, flying);
+    // No culling here: the ranking already demoted every wall the camera
+    // cannot see.
+    _captures
+      ..requestDue(_live, eye, seconds)
+      ..requestPending();
+    _refreshStats();
+  }
+
+  bool _rankingHolds(Vector3 eye, Vector3? forward, bool flying) {
+    if (!_settled || eye != _rankedEye) return false;
+    if (forward == null) {
+      if (_rankedWithForward) return false;
+    } else if (!_rankedWithForward || forward != _rankedForward) {
+      return false;
+    }
+    final b = _rankedBudget;
+    return b != null &&
+        b.liveCap == config.liveCap &&
+        b.signCap == config.signCap &&
+        b.liveDistance == config.liveDistance &&
+        b.signDistance == config.signDistance &&
+        b.promotionsPerFrame == config.promotionsPerFrame &&
+        b.forceAllLive == config.forceAllLive &&
+        b.flying == flying;
+  }
+
+  void _rank(Vector3 eye, Vector3? forward, bool flying) {
+    _rankings++;
     final n = buildings.length;
-    final distances = List<double>.filled(n, 0);
-    final order = List<int>.generate(n, (i) => i);
     for (var i = 0; i < n; i++) {
       final d = buildings[i].groundDistanceTo(eye);
-      distances[i] = _surfaces[i].tier == FacadeTier.far ? d : d * _hysteresis;
+      _distances[i] = _surfaces[i].tier == FacadeTier.far ? d : d * _hysteresis;
+      _order[i] = i;
     }
-    order.sort((a, b) => distances[a].compareTo(distances[b]));
+    _order.sort((a, b) => _distances[a].compareTo(_distances[b]));
 
     var liveLeft = config.forceAllLive ? n : config.liveCap;
     var signLeft = config.forceAllLive ? 0 : config.signCap;
     // The stress switch wants the steady state, not a five-second ramp:
     // it ignores the per-frame promotion budget.
-    var promotionsLeft = suspended
+    var promotionsLeft = flying
         ? 0
         : config.forceAllLive
         ? n
         : config.promotionsPerFrame;
     PlazaBuilding? focused;
+    var changed = false;
+    var waiting = false;
 
-    for (final i in order) {
+    for (final i in _order) {
       final building = buildings[i];
-      final d = distances[i];
-      final inFront = building.facesEye(eye);
-      final ahead =
-          forward == null || (building.facadeCenter - eye).dot(forward) > 0;
+      final d = _distances[i];
       FacadeTier target;
       if (config.forceAllLive) {
         target = FacadeTier.live;
       } else if (liveLeft > 0 &&
           d < math.max(config.liveDistance, building.liveRange) &&
-          inFront &&
-          ahead) {
+          _inView(building, eye, forward)) {
         target = FacadeTier.live;
       } else if (signLeft > 0 && d < config.signDistance) {
         target = FacadeTier.sign;
@@ -172,14 +241,19 @@ class FacadeLodManager {
       if (target == FacadeTier.sign) signLeft--;
 
       final current = _surfaces[i].tier;
+      if (target == current) continue;
       if (target.index > current.index) {
         // Promotion: rate-limited.
         if (promotionsLeft > 0) {
           promotionsLeft--;
           _apply(i, target);
+          changed = true;
+        } else {
+          waiting = true;
         }
       } else {
         _apply(i, target);
+        changed = true;
       }
     }
 
@@ -190,46 +264,48 @@ class FacadeLodManager {
       focused?.neon.visible = false;
       _focused = focused;
     }
-    for (final surface in _surfaces) {
-      if (surface.tier != FacadeTier.live) continue;
-      final controller = surface.component?.controller;
-      if (controller == null) continue;
-      if (seconds - surface.lastCapture < liveInterval - 1e-6) continue;
-      surface.lastCapture = seconds;
-      controller.requestCapture();
-    }
-    _refreshStats();
+
+    _settled = !changed && !waiting;
+    _rankedEye.setFrom(eye);
+    _rankedWithForward = forward != null;
+    if (forward != null) _rankedForward.setFrom(forward);
+    _rankedBudget = (
+      liveCap: config.liveCap,
+      signCap: config.signCap,
+      liveDistance: config.liveDistance,
+      signDistance: config.signDistance,
+      promotionsPerFrame: config.promotionsPerFrame,
+      forceAllLive: config.forceAllLive,
+      flying: flying,
+    );
+  }
+
+  /// Whether the eye is on [building]'s street side and, given [forward],
+  /// the wall is ahead of the camera. Scalar maths from one offset.
+  static bool _inView(PlazaBuilding building, Vector3 eye, Vector3? forward) {
+    final center = building.facadeCenter;
+    final dx = eye.x - center.x;
+    final dy = eye.y - center.y;
+    final dz = eye.z - center.z;
+    final normal = building.facadeNormal;
+    if (dx * normal.x + dy * normal.y + dz * normal.z <= 0) return false;
+    if (forward == null) return true;
+    return dx * forward.x + dy * forward.y + dz * forward.z < 0;
   }
 
   void _apply(int index, FacadeTier target) {
     final surface = _surfaces[index];
-    if (surface.tier == target) {
-      // Sign surfaces capture once; keep asking until the first capture
-      // lands (the host attaches a frame after the component does).
-      if (target == FacadeTier.sign && !surface.captured) {
-        final controller = surface.component?.controller;
-        if (controller != null) {
-          if (controller.texture != null) {
-            surface.captured = true;
-          } else {
-            controller.requestCapture();
-          }
-        }
-      }
-      return;
-    }
-
     final building = buildings[index];
     final existing = surface.component;
     if (existing != null) {
       building.facadeAnchor.removeComponent(existing);
+      _captures.forget(existing.controller, cadence: _live);
       surface.component = null;
     }
 
     if (target != FacadeTier.far) {
       final live = target == FacadeTier.live;
-      final surfaceMaterial = OpaqueSurface();
-      final component = WidgetComponent(
+      final component = hostedSurface(
         child: FacadeWidget(
           task: building.task,
           attention: building.attention,
@@ -239,33 +315,35 @@ class FacadeLodManager {
           ticks: live ? ticks : null,
           onOpen: live ? () => onOpen(building) : null,
         ),
-        size: building.widgetSize,
-        geometry: ccwQuad(
-          building.facadeWorldWidth,
-          building.facadeWorldHeight,
-        ),
-        // Manual for both tiers: a live wall is captured from [update] at
-        // [liveInterval]; an every-frame policy would make flutter_scene
-        // pump an engine frame on every vsync.
-        update: WidgetUpdatePolicy.manual,
+        width: building.facadeWorldWidth,
+        height: building.facadeWorldHeight,
+        pxPerMeter: building.pxPerMeter,
+        // A live wall takes pointer input; a sign does not.
         input: live ? WidgetInput.automatic : WidgetInput.manual,
-        material: surfaceMaterial.material,
-        bind: surfaceMaterial.bind,
       );
       building.facadeAnchor.addComponent(component);
       surface.component = component;
+      if (live) {
+        _captures.timed(
+          _live,
+          TimedSurface(
+            controller: component.controller,
+            node: building.facadeAnchor,
+            center: building.facadeCenter,
+            normal: building.facadeNormal,
+          ),
+        );
+      } else {
+        _captures.once(component.controller);
+      }
       stats.promotions++;
     }
-    surface
-      ..tier = target
-      ..captured = false;
+    surface.tier = target;
   }
 
   void _refreshStats() {
     var live = 0;
     var sign = 0;
-    var captures = 0;
-    var lastCapture = Duration.zero;
     for (final surface in _surfaces) {
       switch (surface.tier) {
         case FacadeTier.live:
@@ -275,20 +353,13 @@ class FacadeLodManager {
         case FacadeTier.far:
           break;
       }
-      final controller = surface.component?.controller;
-      if (controller != null) {
-        captures += controller.captureCount;
-        if (controller.lastCaptureDuration > lastCapture) {
-          lastCapture = controller.lastCaptureDuration;
-        }
-      }
     }
     stats
       ..live = live
       ..sign = sign
       ..far = buildings.length - live - sign
-      ..captures = captures
-      ..lastCapture = lastCapture;
+      ..captures = _captures.captures
+      ..lastCapture = _captures.lastCaptureDuration;
   }
 
   /// Detaches every widget surface (used when tearing a scene down).
@@ -297,8 +368,10 @@ class FacadeLodManager {
       final component = _surfaces[i].component;
       if (component != null) {
         buildings[i].facadeAnchor.removeComponent(component);
+        _captures.forget(component.controller, cadence: _live);
         _surfaces[i].component = null;
       }
     }
+    _settled = false;
   }
 }

--- a/lib/features/plaza/scene/plaza_scene.dart
+++ b/lib/features/plaza/scene/plaza_scene.dart
@@ -1065,7 +1065,6 @@ class PlazaSceneController {
     // Every beacon dot stands on a slim post over a small pool in its own
     // colour, so a marker is a fixture in the street and not a stray orb.
     for (final beacon in world.beacons) {
-      if (beacon.kind == BeaconKind.overview) continue;
       final colour = PlazaStyle.beaconColor(beacon, world);
       scene.add(
         Node(

--- a/lib/features/plaza/scene/plaza_scene.dart
+++ b/lib/features/plaza/scene/plaza_scene.dart
@@ -1,4 +1,3 @@
-import 'dart:io' show Platform;
 import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' show Color, Size;
@@ -281,6 +280,9 @@ class PlazaBillboard {
   Vector3 get center => Vector3(slot.x, slot.centerY, slot.z);
 }
 
+/// The faces of a box in its own frame: front is +Z, right is +X.
+enum _Face { front, back, right, left }
+
 /// Builds and owns the plaza [Scene]: dusk sky, fog, ground, the folded
 /// street, the frontier plaza with its pylons, and every building with its
 /// far-tier plate, focus ring and lantern anchor.
@@ -288,20 +290,19 @@ class PlazaBillboard {
 /// Widget surfaces (facades, billboards, tickers, block markers) and the
 /// screen-clamped sprites are attached by the other scene classes.
 class PlazaSceneController {
-  PlazaSceneController({required this.world, double? pxPerMeter})
-    : pxPerMeter = pxPerMeter ?? world.layout.pxPerMeter {
+  PlazaSceneController({required this.world, this.hidden = const {}})
+    : pxPerMeter = world.layout.pxPerMeter {
     _build();
   }
 
-  /// Dev-only: `PLAZA_HIDE=gantry,jumbotron,fillers,skyline,pylons,walls`
-  /// leaves those pieces out, to isolate what a screenshot is showing.
-  static final Set<String> _hidden = {
-    ...?Platform.environment['PLAZA_HIDE']?.split(','),
-  };
-  static bool _shown(String piece) => !_hidden.contains(piece);
-
   final PlazaWorld world;
   final double pxPerMeter;
+
+  /// Dev-only: pieces left out of the scene (`gantry`, `jumbotron`,
+  /// `fillers`, `skyline`, `pylons`, `walls`), to isolate what a
+  /// screenshot is showing.
+  final Set<String> hidden;
+  bool _shown(String piece) => !hidden.contains(piece);
   final Scene scene = Scene();
   final List<PlazaBuilding> buildings = [];
   final List<PlazaBillboard> billboards = [];
@@ -318,10 +319,11 @@ class PlazaSceneController {
   StreetLayout get layout => world.layout;
   StreetPlan get plan => world.plan;
 
+  /// The ground plane, and the plaza slab flush with it: the paving
+  /// joints set the square apart, not its colour.
   static final Vector4 _ground = linearColor(const Color(0xFF15131E));
   static final Vector4 _road = linearColor(const Color(0xFF1A1D2B));
   static final Vector4 _gap = linearColor(const Color(0xFF15171F));
-  static final Vector4 _plaza = linearColor(const Color(0xFF15131E));
   static final Vector4 _post = linearColor(const Color(0xFF14171F));
   static final Vector4 _tower = linearColor(const Color(0xFF0E0B18));
 
@@ -330,6 +332,13 @@ class PlazaSceneController {
   static final Vector4 _skyline = linearColor(const Color(0xFF161428));
   static final Vector4 _pavement = linearColor(const Color(0xFF232532));
   static final Vector4 _kerb = linearColor(const Color(0xFF5A5E72));
+
+  /// One material per solid colour, shared by every box in it: only the
+  /// pools and washes are ever rewritten by [updateForCamera].
+  static final _postMaterial = UnlitMaterial()..baseColorFactor = _post;
+  static final _towerMaterial = UnlitMaterial()..baseColorFactor = _tower;
+  static final _pavementMaterial = UnlitMaterial()..baseColorFactor = _pavement;
+  static final _kerbMaterial = UnlitMaterial()..baseColorFactor = _kerb;
 
   /// The map layer: road ribbons shown from altitude, in the ticker teal.
   static final Vector4 _ribbon = linearColor(PlazaStyle.teal, alpha: 0.55);
@@ -435,15 +444,14 @@ class PlazaSceneController {
 
   /// How far past white the neon and the lit rooflines go.
   static const neonBoost = 1.6;
+
+  /// The altitude fade last applied, so a camera that has not climbed
+  /// does not rewrite every pool and wash material each frame.
+  double? _lastFadeT;
+
+  /// Shows the map layer once [eye] is above [poolFadeStart], and fades
+  /// the fog, pools and washes with its height.
   void updateForCamera(Vector3 eye) {
-    final t = ((eye.y - poolFadeStart) / (poolFadeTop - poolFadeStart)).clamp(
-      0.0,
-      1.0,
-    );
-    final k = 1 - (1 - poolFloor) * t;
-    scene.fog
-      ..density = fogDensityLow + (fogDensityHigh - fogDensityLow) * t
-      ..maxOpacity = fogOpacityLow + (fogOpacityHigh - fogOpacityLow) * t;
     // Road week markers are for the map: at street level the kerb sign
     // owns the week, and a label under your feet reads backwards.
     for (final anchor in markerAnchors.values) {
@@ -452,37 +460,61 @@ class PlazaSceneController {
     for (final ribbon in _mapRibbons) {
       ribbon.visible = eye.y >= poolFadeStart;
     }
-    for (final (material, alpha) in _pools) {
-      material.baseColorFactor = Vector4(
-        material.baseColorFactor.x,
-        material.baseColorFactor.y,
-        material.baseColorFactor.z,
-        alpha * k,
-      );
+    final t = ((eye.y - poolFadeStart) / (poolFadeTop - poolFadeStart)).clamp(
+      0.0,
+      1.0,
+    );
+    final last = _lastFadeT;
+    if (last != null && (t - last).abs() < 1e-6) return;
+    _lastFadeT = t;
+    scene.fog
+      ..density = fogDensityLow + (fogDensityHigh - fogDensityLow) * t
+      ..maxOpacity = fogOpacityLow + (fogOpacityHigh - fogOpacityLow) * t;
+    void fade(List<(UnlitMaterial, double)> materials, double factor) {
+      for (final (material, alpha) in materials) {
+        material.baseColorFactor = Vector4(
+          material.baseColorFactor.x,
+          material.baseColorFactor.y,
+          material.baseColorFactor.z,
+          alpha * factor,
+        );
+      }
     }
+
+    fade(_pools, 1 - (1 - poolFloor) * t);
     // A streak is a reflection on wet paving: from the air there is none.
-    for (final (material, alpha) in _washes) {
-      material.baseColorFactor = Vector4(
-        material.baseColorFactor.x,
-        material.baseColorFactor.y,
-        material.baseColorFactor.z,
-        alpha * (1 - t),
-      );
-    }
+    fade(_washes, 1 - t);
   }
 
-  /// A grain overlay on a ground slab: a blended tiled quad just above it.
-  void _addGrain(Node parent, double width, double depth, double y) {
+  /// A blended tiled overlay just above a ground slab, one texture tile
+  /// every [tileMeters]: the asphalt grain on a road, the paving joints
+  /// on the plaza. [materials] collects it for [attachWallTextures]; a
+  /// [fading] overlay dims with altitude like a pool.
+  void _addTiledOverlay(
+    Node parent, {
+    required double width,
+    required double depth,
+    required double y,
+    required double tileMeters,
+    required List<UnlitMaterial> materials,
+    bool fading = false,
+  }) {
     final material = UnlitMaterial()
       ..baseColorFactor = Vector4(1, 1, 1, 0.4)
       ..alphaMode = AlphaMode.blend;
-    _grainMaterials.add(material);
+    materials.add(material);
+    if (fading) _pools.add((material, 0.4));
     parent.add(
       Node(
         localTransform: Matrix4.translation(Vector3(0, y, 0))
           ..rotateX(-math.pi / 2),
         mesh: Mesh(
-          tiledQuad(width, depth, uRepeat: width / 2, vRepeat: depth / 2),
+          tiledQuad(
+            width,
+            depth,
+            uRepeat: width / tileMeters,
+            vRepeat: depth / tileMeters,
+          ),
           material,
         ),
       ),
@@ -586,28 +618,89 @@ class PlazaSceneController {
   static final _corniceMaterial = UnlitMaterial()
     ..baseColorFactor = linearColor(const Color(0xFF141220));
 
-  /// Paving joints on the plaza: a blended tiled quad of slab outlines.
-  void _addPaving(Node parent, double width, double depth, double y) {
-    final material = UnlitMaterial()
-      ..baseColorFactor = Vector4(1, 1, 1, 0.4)
-      ..alphaMode = AlphaMode.blend;
-    _pavingMaterials.add(material);
-    _pools.add((material, 0.4));
-    parent.add(
-      Node(
-        localTransform: Matrix4.translation(Vector3(0, y, 0))
-          ..rotateX(-math.pi / 2),
-        mesh: Mesh(
-          tiledQuad(
-            width,
-            depth,
-            uRepeat: width / WallTextures.pavingMeters,
-            vRepeat: depth / WallTextures.pavingMeters,
-          ),
-          material,
-        ),
-      ),
+  /// Windowed walls ([_windowedWall]) on [faces] of the [w] × [d] box
+  /// under [parent], in that order, whose centre sits at half [height].
+  /// Each face tiles from its own hashed offset so it starts at its own
+  /// shop, unless [perFaceOffset] is off and every face shares one.
+  void _windowedBox(
+    Node parent, {
+    required String id,
+    required double w,
+    required double d,
+    required double height,
+    required LanternState state,
+    required Vector4 tint,
+    List<_Face> faces = _Face.values,
+    bool perFaceOffset = true,
+    LanternState? shops,
+    int variant = 0,
+    int family = 0,
+  }) {
+    for (final face in faces) {
+      // A quad's face is +Z before rotation: rotateY(-π/2) turns it to -X
+      // for the left wall, rotateY(π/2) to +X for the right, π for the
+      // back.
+      final (dx, dz, yaw, width) = switch (face) {
+        _Face.front => (0.0, d / 2 + 0.02, 0.0, w),
+        _Face.back => (0.0, -d / 2 - 0.02, math.pi, w),
+        _Face.right => (w / 2 + 0.02, 0.0, math.pi / 2, d),
+        _Face.left => (-w / 2 - 0.02, 0.0, -math.pi / 2, d),
+      };
+      _windowedWall(
+        parent,
+        dx: dx,
+        dz: dz,
+        yaw: yaw,
+        width: width,
+        height: height,
+        state: state,
+        tint: tint,
+        uOffset: stableUnit(id, perFaceOffset ? 'tile$yaw' : 'tile') * 3,
+        shops: shops,
+        variant: variant,
+        family: family,
+      );
+    }
+  }
+
+  /// A [CuboidGeometry] box of [size] centred at [at] under [parent].
+  static Node _box(Node parent, Vector3 at, Vector3 size, Material material) {
+    final node = Node(
+      localTransform: Matrix4.translation(at),
+      mesh: Mesh(CuboidGeometry(size), material),
     );
+    parent.add(node);
+    return node;
+  }
+
+  /// Four strips round the edge of a [w] × [d] rectangle at [y] under
+  /// [parent]: [thickness] wide, [height] tall (default [thickness]),
+  /// [inset] in from the edge (negative pushes them out) and running
+  /// [overhang] longer than the side they lie along.
+  void _rim(
+    Node parent, {
+    required double w,
+    required double d,
+    required double y,
+    required double thickness,
+    required Material material,
+    double inset = 0,
+    double overhang = 0,
+    double? height,
+  }) {
+    for (final (dx, dz, sx, sz) in [
+      (0.0, d / 2 - inset, w + overhang, thickness),
+      (0.0, -d / 2 + inset, w + overhang, thickness),
+      (w / 2 - inset, 0.0, thickness, d + overhang),
+      (-w / 2 + inset, 0.0, thickness, d + overhang),
+    ]) {
+      _box(
+        parent,
+        Vector3(dx, y, dz),
+        Vector3(sx, height ?? thickness, sz),
+        material,
+      );
+    }
   }
 
   static final Vector4 _panelBack = linearColor(PlazaStyle.panel);
@@ -617,14 +710,11 @@ class PlazaSceneController {
 
     final (centerX, centerZ) = planCenterOf(plan);
     final buildSkyline = _shown('skyline');
-    scene.add(
-      Node(
-        localTransform: Matrix4.translation(Vector3(centerX, -0.06, centerZ)),
-        mesh: Mesh(
-          CuboidGeometry(Vector3(6000, 0.1, 6000)),
-          UnlitMaterial()..baseColorFactor = _ground,
-        ),
-      ),
+    _box(
+      scene.root,
+      Vector3(centerX, -0.06, centerZ),
+      Vector3(6000, 0.1, 6000),
+      UnlitMaterial()..baseColorFactor = _ground,
     );
     if (buildSkyline) {
       _buildSkyline();
@@ -651,43 +741,30 @@ class PlazaSceneController {
       // Pavements with a kerb step on both sides, and a dashed centre
       // line: the street section that makes a slab read as a road.
       for (final side in [-1.0, 1.0]) {
-        roadNode
-          ..add(
-            Node(
-              localTransform: Matrix4.translation(
-                Vector3(side * (layout.roadWidth / 2 - 1.5), 0.05, 0),
-              ),
-              mesh: Mesh(
-                CuboidGeometry(Vector3(3, 0.1, segment.length + 0.4)),
-                UnlitMaterial()..baseColorFactor = _pavement,
-              ),
-            ),
-          )
-          ..add(
-            Node(
-              localTransform: Matrix4.translation(
-                Vector3(side * (layout.roadWidth / 2 - 3), 0.09, 0),
-              ),
-              mesh: Mesh(
-                // A kerb you could stub a toe on: a raised stone edge
-                // between the road and the pavement.
-                CuboidGeometry(Vector3(0.35, 0.18, segment.length + 0.4)),
-                UnlitMaterial()..baseColorFactor = _kerb,
-              ),
-            ),
-          );
+        _box(
+          roadNode,
+          Vector3(side * (layout.roadWidth / 2 - 1.5), 0.05, 0),
+          Vector3(3, 0.1, segment.length + 0.4),
+          _pavementMaterial,
+        );
+        // A kerb you could stub a toe on: a raised stone edge between the
+        // road and the pavement.
+        _box(
+          roadNode,
+          Vector3(side * (layout.roadWidth / 2 - 3), 0.09, 0),
+          Vector3(0.35, 0.18, segment.length + 0.4),
+          _kerbMaterial,
+        );
       }
       // The map layer: a teal ribbon down the axis of every segment,
       // connectors included, shown from the air so the overview reads
       // as a route and not a dark render.
-      final ribbon = Node(
-        localTransform: Matrix4.translation(Vector3(0, 0.1, 0)),
-        mesh: Mesh(
-          CuboidGeometry(Vector3(0.9, 0.02, segment.length + 0.4)),
-          UnlitMaterial()..baseColorFactor = _ribbon,
-        ),
+      final ribbon = _box(
+        roadNode,
+        Vector3(0, 0.1, 0),
+        Vector3(0.9, 0.02, segment.length + 0.4),
+        UnlitMaterial()..baseColorFactor = _ribbon,
       )..visible = false;
-      roadNode.add(ribbon);
       _mapRibbons.add(ribbon);
       if (!segment.isGap) {
         for (
@@ -695,18 +772,22 @@ class PlazaSceneController {
           along < segment.length / 2 - 2;
           along += 6
         ) {
-          roadNode.add(
-            Node(
-              localTransform: Matrix4.translation(Vector3(0, 0.045, along)),
-              mesh: Mesh(
-                CuboidGeometry(Vector3(0.18, 0.01, 2.2)),
-                UnlitMaterial()..baseColorFactor = _centreLine,
-              ),
-            ),
+          _box(
+            roadNode,
+            Vector3(0, 0.045, along),
+            Vector3(0.18, 0.01, 2.2),
+            UnlitMaterial()..baseColorFactor = _centreLine,
           );
         }
       }
-      _addGrain(roadNode, layout.roadWidth, segment.length + 0.4, 0.045);
+      _addTiledOverlay(
+        roadNode,
+        width: layout.roadWidth,
+        depth: segment.length + 0.4,
+        y: 0.045,
+        tileMeters: 2,
+        materials: _grainMaterials,
+      );
       scene.add(roadNode);
       if (!segment.isGap) {
         const along = 9.0;
@@ -742,11 +823,26 @@ class PlazaSceneController {
         )..rotateY(plaza.headingRadians),
         mesh: Mesh(
           CuboidGeometry(Vector3(plaza.width, 0.1, plaza.depth)),
-          UnlitMaterial()..baseColorFactor = _plaza,
+          UnlitMaterial()..baseColorFactor = _ground,
         ),
       );
-      _addGrain(slab, plaza.width, plaza.depth, 0.06);
-      _addPaving(slab, plaza.width, plaza.depth, 0.07);
+      _addTiledOverlay(
+        slab,
+        width: plaza.width,
+        depth: plaza.depth,
+        y: 0.06,
+        tileMeters: 2,
+        materials: _grainMaterials,
+      );
+      _addTiledOverlay(
+        slab,
+        width: plaza.width,
+        depth: plaza.depth,
+        y: 0.07,
+        tileMeters: WallTextures.pavingMeters,
+        materials: _pavingMaterials,
+        fading: true,
+      );
       // Home marker ring on the ground.
       scene
         ..add(slab)
@@ -809,7 +905,6 @@ class PlazaSceneController {
         Vector3(plaza.centerX, kerbH / 2, plaza.centerZ),
       )..rotateY(plaza.headingRadians),
     );
-    final material = UnlitMaterial()..baseColorFactor = _kerb;
     final hw = plaza.width / 2;
     final hd = plaza.depth / 2;
     for (final (dx, dz, sx, sz) in [
@@ -820,20 +915,15 @@ class PlazaSceneController {
       ((hw + mouth / 2) / 2, -hd + kerbW / 2, hw - mouth / 2, kerbW),
       (-(hw + mouth / 2) / 2, -hd + kerbW / 2, hw - mouth / 2, kerbW),
     ]) {
-      root.add(
-        Node(
-          localTransform: Matrix4.translation(Vector3(dx, 0, dz)),
-          mesh: Mesh(CuboidGeometry(Vector3(sx, kerbH, sz)), material),
-        ),
-      );
+      _box(root, Vector3(dx, 0, dz), Vector3(sx, kerbH, sz), _kerbMaterial);
     }
     // The threshold: a flush band across the opening, so the step from
     // street to square is a line on the ground you cross.
-    root.add(
-      Node(
-        localTransform: Matrix4.translation(Vector3(0, -kerbH / 2 + 0.05, -hd)),
-        mesh: Mesh(CuboidGeometry(Vector3(mouth, 0.02, 0.7)), material),
-      ),
+    _box(
+      root,
+      Vector3(0, -kerbH / 2 + 0.05, -hd),
+      Vector3(mouth, 0.02, 0.7),
+      _kerbMaterial,
     );
     scene.add(root);
   }
@@ -841,7 +931,6 @@ class PlazaSceneController {
   /// Benches, planters and the kiosk from `Scenery.furniture`: the boxes
   /// are the collider's, the dressing is here.
   void _buildPlazaFurniture() {
-    final dark = UnlitMaterial()..baseColorFactor = _post;
     final seat = UnlitMaterial()
       ..baseColorFactor = linearColor(const Color(0xFF4A3A2E));
     final soil = UnlitMaterial()
@@ -857,105 +946,71 @@ class PlazaSceneController {
         case FurnitureKind.bench:
           // Three slats on a dark frame, a back rail, two end frames.
           for (final dx in [-f.width * 0.34, 0.0, f.width * 0.34]) {
-            root.add(
-              Node(
-                localTransform: Matrix4.translation(
-                  Vector3(dx, f.height * 0.5, 0),
-                ),
-                mesh: Mesh(
-                  CuboidGeometry(Vector3(f.width * 0.28, 0.06, f.depth)),
-                  seat,
-                ),
-              ),
+            _box(
+              root,
+              Vector3(dx, f.height * 0.5, 0),
+              Vector3(f.width * 0.28, 0.06, f.depth),
+              seat,
             );
           }
-          root
-            ..add(
-              Node(
-                localTransform: Matrix4.translation(
-                  Vector3(0, f.height * 0.46, 0),
-                ),
-                mesh: Mesh(
-                  CuboidGeometry(Vector3(f.width * 0.9, 0.04, f.depth * 0.9)),
-                  dark,
-                ),
-              ),
-            )
-            ..add(
-              Node(
-                localTransform: Matrix4.translation(
-                  Vector3(-f.width * 0.55, f.height * 0.75, 0),
-                ),
-                mesh: Mesh(
-                  CuboidGeometry(Vector3(0.06, f.height * 0.5, f.depth)),
-                  seat,
-                ),
-              ),
-            );
+          _box(
+            root,
+            Vector3(0, f.height * 0.46, 0),
+            Vector3(f.width * 0.9, 0.04, f.depth * 0.9),
+            _postMaterial,
+          );
+          _box(
+            root,
+            Vector3(-f.width * 0.55, f.height * 0.75, 0),
+            Vector3(0.06, f.height * 0.5, f.depth),
+            seat,
+          );
           for (final dz in [-f.depth * 0.4, f.depth * 0.4]) {
-            root.add(
-              Node(
-                localTransform: Matrix4.translation(
-                  Vector3(0, f.height * 0.25, dz),
-                ),
-                mesh: Mesh(
-                  CuboidGeometry(Vector3(f.width * 0.9, f.height * 0.5, 0.08)),
-                  dark,
-                ),
-              ),
+            _box(
+              root,
+              Vector3(0, f.height * 0.25, dz),
+              Vector3(f.width * 0.9, f.height * 0.5, 0.08),
+              _postMaterial,
             );
           }
         case FurnitureKind.planter:
-          root
-            ..add(
-              Node(
-                localTransform: Matrix4.translation(
-                  Vector3(0, f.height / 2, 0),
-                ),
-                mesh: Mesh(
-                  shadedCuboid(Vector3(f.width, f.height, f.depth)),
-                  dark,
-                ),
+          root.add(
+            Node(
+              localTransform: Matrix4.translation(Vector3(0, f.height / 2, 0)),
+              mesh: Mesh(
+                shadedCuboid(Vector3(f.width, f.height, f.depth)),
+                _postMaterial,
               ),
-            )
-            ..add(
-              Node(
-                localTransform: Matrix4.translation(
-                  Vector3(0, f.height + 0.02, 0),
-                ),
-                mesh: Mesh(
-                  CuboidGeometry(Vector3(f.width - 0.2, 0.04, f.depth - 0.2)),
-                  soil,
-                ),
+            ),
+          );
+          _box(
+            root,
+            Vector3(0, f.height + 0.02, 0),
+            Vector3(f.width - 0.2, 0.04, f.depth - 0.2),
+            soil,
+          );
+          root.add(
+            Node(
+              localTransform: Matrix4.translation(
+                Vector3(0, f.height + 0.25, 0),
               ),
-            )
-            ..add(
-              Node(
-                localTransform: Matrix4.translation(
-                  Vector3(0, f.height + 0.25, 0),
-                ),
-                mesh: Mesh(
-                  shadedCuboid(Vector3(f.width * 0.72, 0.5, f.depth * 0.72)),
-                  leaves,
-                ),
+              mesh: Mesh(
+                shadedCuboid(Vector3(f.width * 0.72, 0.5, f.depth * 0.72)),
+                leaves,
               ),
-            )
-            // A lit rim along the planter's top edge, in the parade's warm.
-            ..add(
-              Node(
-                localTransform: Matrix4.translation(
-                  Vector3(0, f.height + 0.01, 0),
-                ),
-                mesh: Mesh(
-                  CuboidGeometry(Vector3(f.width + 0.06, 0.03, f.depth + 0.06)),
-                  UnlitMaterial()
-                    ..baseColorFactor = linearColor(
-                      const Color(0xFFFFC46B),
-                      alpha: 0.8,
-                    ),
-                ),
+            ),
+          );
+          // A lit rim along the planter's top edge, in the parade's warm.
+          _box(
+            root,
+            Vector3(0, f.height + 0.01, 0),
+            Vector3(f.width + 0.06, 0.03, f.depth + 0.06),
+            UnlitMaterial()
+              ..baseColorFactor = linearColor(
+                const Color(0xFFFFC46B),
+                alpha: 0.8,
               ),
-            );
+          );
         case FurnitureKind.kiosk:
           final sign = UnlitMaterial()
             ..baseColorFactor = linearColor(const Color(0xFFFFC46B));
@@ -966,49 +1021,36 @@ class PlazaSceneController {
             )
             ..alphaMode = AlphaMode.blend;
           _pools.add((window, 0.75));
-          root
-            ..add(
-              Node(
-                localTransform: Matrix4.translation(
-                  Vector3(0, f.height / 2, 0),
-                ),
-                mesh: Mesh(
-                  shadedCuboid(Vector3(f.width, f.height, f.depth)),
-                  UnlitMaterial()..baseColorFactor = _tower,
-                ),
+          root.add(
+            Node(
+              localTransform: Matrix4.translation(Vector3(0, f.height / 2, 0)),
+              mesh: Mesh(
+                shadedCuboid(Vector3(f.width, f.height, f.depth)),
+                _towerMaterial,
               ),
-            )
-            // The lit sign along the front's top edge, and the hatch.
-            ..add(
-              Node(
-                localTransform: Matrix4.translation(
-                  Vector3(0, f.height - 0.3, f.depth / 2 + 0.03),
-                ),
-                mesh: Mesh(
-                  CuboidGeometry(Vector3(f.width - 0.3, 0.4, 0.06)),
-                  sign,
-                ),
+            ),
+          );
+          // The lit sign along the front's top edge, and the hatch.
+          _box(
+            root,
+            Vector3(0, f.height - 0.3, f.depth / 2 + 0.03),
+            Vector3(f.width - 0.3, 0.4, 0.06),
+            sign,
+          );
+          root.add(
+            Node(
+              localTransform: Matrix4.translation(
+                Vector3(0, f.height * 0.5, f.depth / 2 + 0.02),
               ),
-            )
-            ..add(
-              Node(
-                localTransform: Matrix4.translation(
-                  Vector3(0, f.height * 0.5, f.depth / 2 + 0.02),
-                ),
-                mesh: Mesh(ccwQuad(f.width - 0.8, f.height * 0.42), window),
-              ),
-            )
-            ..add(
-              Node(
-                localTransform: Matrix4.translation(
-                  Vector3(0, f.height + 0.05, 0),
-                ),
-                mesh: Mesh(
-                  CuboidGeometry(Vector3(f.width + 0.4, 0.1, f.depth + 0.4)),
-                  dark,
-                ),
-              ),
-            );
+              mesh: Mesh(ccwQuad(f.width - 0.8, f.height * 0.42), window),
+            ),
+          );
+          _box(
+            root,
+            Vector3(0, f.height + 0.05, 0),
+            Vector3(f.width + 0.4, 0.1, f.depth + 0.4),
+            _postMaterial,
+          );
           _addPool(
             Vector3(
               f.x + math.sin(f.yawRadians) * 2,
@@ -1029,32 +1071,19 @@ class PlazaSceneController {
   /// place.
   void _buildStreetFurniture() {
     for (final (x, z) in world.lampPosts) {
-      final pole = Node(
-        localTransform: Matrix4.translation(
-          Vector3(x, lampPostHeight / 2, z),
-        ),
-        mesh: Mesh(
-          CuboidGeometry(Vector3(lampPostSize, lampPostHeight, lampPostSize)),
-          UnlitMaterial()..baseColorFactor = _post,
-        ),
+      final pole = _box(
+        scene.root,
+        Vector3(x, lampPostHeight / 2, z),
+        Vector3(lampPostSize, lampPostHeight, lampPostSize),
+        _postMaterial,
       );
       // Housing: a small dark head the bulb hangs under.
+      _box(pole, Vector3(0, 2.7, 0), Vector3(0.7, 0.28, 0.7), _postMaterial);
       final lantern = Node(
         localTransform: Matrix4.translation(Vector3(0, 2.45, 0)),
       );
-      pole
-        ..add(
-          Node(
-            localTransform: Matrix4.translation(Vector3(0, 2.7, 0)),
-            mesh: Mesh(
-              CuboidGeometry(Vector3(0.7, 0.28, 0.7)),
-              UnlitMaterial()..baseColorFactor = _post,
-            ),
-          ),
-        )
-        ..add(lantern);
+      pole.add(lantern);
       lampAnchors.add(lantern);
-      scene.add(pole);
       _addPool(
         Vector3(x, 0, z),
         radius: 5,
@@ -1066,16 +1095,11 @@ class PlazaSceneController {
     // colour, so a marker is a fixture in the street and not a stray orb.
     for (final beacon in world.beacons) {
       final colour = PlazaStyle.beaconColor(beacon, world);
-      scene.add(
-        Node(
-          localTransform: Matrix4.translation(
-            Vector3(beacon.markerX, beacon.markerY / 2, beacon.markerZ),
-          ),
-          mesh: Mesh(
-            CuboidGeometry(Vector3(0.08, beacon.markerY, 0.08)),
-            UnlitMaterial()..baseColorFactor = _post,
-          ),
-        ),
+      _box(
+        scene.root,
+        Vector3(beacon.markerX, beacon.markerY / 2, beacon.markerZ),
+        Vector3(0.08, beacon.markerY, 0.08),
+        _postMaterial,
       );
       _addPool(
         Vector3(beacon.markerX, 0, beacon.markerZ),
@@ -1109,42 +1133,29 @@ class PlazaSceneController {
       );
       final top = gantryTopFor(gantry);
       for (final side in [-1.0, 1.0]) {
-        root.add(
-          Node(
-            localTransform: Matrix4.translation(
-              Vector3(side * gantry.width / 2, top / 2, 0),
-            ),
-            mesh: Mesh(
-              CuboidGeometry(Vector3(gantryLegSize, top, gantryLegSize)),
-              UnlitMaterial()..baseColorFactor = _post,
-            ),
-          ),
+        _box(
+          root,
+          Vector3(side * gantry.width / 2, top / 2, 0),
+          Vector3(gantryLegSize, top, gantryLegSize),
+          _postMaterial,
         );
       }
-      root
-        ..add(
-          Node(
-            localTransform: Matrix4.translation(
-              Vector3(0, top - gantryBeamThickness / 2, 0),
-            ),
-            mesh: Mesh(
-              CuboidGeometry(
-                Vector3(
-                  gantry.width + gantryLegSize,
-                  gantryBeamThickness,
-                  gantryBeamDepth,
-                ),
-              ),
-              UnlitMaterial()..baseColorFactor = _post,
-            ),
+      _box(
+        root,
+        Vector3(0, top - gantryBeamThickness / 2, 0),
+        Vector3(
+          gantry.width + gantryLegSize,
+          gantryBeamThickness,
+          gantryBeamDepth,
+        ),
+        _postMaterial,
+      );
+      root.add(
+        _glowQuad(gantry.width + 2, gantry.height + 2.5, PlazaStyle.teal, 0.2)
+          ..localTransform = Matrix4.translation(
+            Vector3(0, gantry.bottom + gantry.height / 2, -0.3),
           ),
-        )
-        ..add(
-          _glowQuad(gantry.width + 2, gantry.height + 2.5, PlazaStyle.teal, 0.2)
-            ..localTransform = Matrix4.translation(
-              Vector3(0, gantry.bottom + gantry.height / 2, -0.3),
-            ),
-        );
+      );
       scene.add(root);
       _addPool(
         Vector3(gantry.x, 0, gantry.z),
@@ -1174,27 +1185,18 @@ class PlazaSceneController {
         ),
         mesh: Mesh(
           shadedCuboid(Vector3(towerW, towerH, towerD)),
-          UnlitMaterial()..baseColorFactor = _tower,
+          _towerMaterial,
         ),
       );
-      for (final (dx, dz, yaw, faceW) in [
-        (0.0, towerD / 2 + 0.02, 0.0, towerW),
-        (0.0, -towerD / 2 - 0.02, math.pi, towerW),
-        (towerW / 2 + 0.02, 0.0, math.pi / 2, towerD),
-        (-towerW / 2 - 0.02, 0.0, -math.pi / 2, towerD),
-      ]) {
-        _windowedWall(
-          tower,
-          dx: dx,
-          dz: dz,
-          yaw: yaw,
-          width: faceW,
-          height: towerH,
-          state: LanternState.inProgress,
-          tint: _tower,
-          uOffset: stableUnit('jumbotron', 'tile$yaw') * 3,
-        );
-      }
+      _windowedBox(
+        tower,
+        id: 'jumbotron',
+        w: towerW,
+        d: towerD,
+        height: towerH,
+        state: LanternState.inProgress,
+        tint: _tower,
+      );
       // The corner strips and crown at a quarter, so the screen's own
       // border is the one teal frame on the tower.
       final corner = UnlitMaterial()
@@ -1202,44 +1204,31 @@ class PlazaSceneController {
           Color.lerp(const Color(0xFF0B0A14), PlazaStyle.teal, 0.3)!,
         );
       for (final side in [-1.0, 1.0]) {
-        tower.add(
-          Node(
-            localTransform: Matrix4.translation(
-              Vector3(side * (towerW / 2 + 0.1), 0, towerD / 2 + 0.1),
-            ),
-            mesh: Mesh(CuboidGeometry(Vector3(0.25, towerH, 0.25)), corner),
-          ),
+        _box(
+          tower,
+          Vector3(side * (towerW / 2 + 0.1), 0, towerD / 2 + 0.1),
+          Vector3(0.25, towerH, 0.25),
+          corner,
         );
       }
       // The crown is four rim strips, not a lid.
-      for (final (dx, dz, sx, sz) in [
-        (0.0, towerD / 2 + 0.1, towerW + 0.4, 0.22),
-        (0.0, -towerD / 2 - 0.1, towerW + 0.4, 0.22),
-        (towerW / 2 + 0.1, 0.0, 0.22, towerD + 0.4),
-        (-towerW / 2 - 0.1, 0.0, 0.22, towerD + 0.4),
-      ]) {
-        tower.add(
-          Node(
-            localTransform: Matrix4.translation(
-              Vector3(dx, towerH / 2 + 0.1, dz),
-            ),
-            mesh: Mesh(CuboidGeometry(Vector3(sx, 0.22, sz)), corner),
-          ),
-        );
-      }
-      root.add(tower);
-      final backing = Node(
-        localTransform: Matrix4.translation(
-          Vector3(0, jumbotron.centerY, -0.2),
-        ),
-        mesh: Mesh(
-          CuboidGeometry(
-            Vector3(jumbotron.width + 0.6, jumbotron.height + 0.6, 0.4),
-          ),
-          UnlitMaterial()..baseColorFactor = linearColor(PlazaStyle.teal),
-        ),
+      _rim(
+        tower,
+        w: towerW,
+        d: towerD,
+        y: towerH / 2 + 0.1,
+        inset: -0.1,
+        overhang: 0.4,
+        thickness: 0.22,
+        material: corner,
       );
-      root.add(backing);
+      root.add(tower);
+      final backing = _box(
+        root,
+        Vector3(0, jumbotron.centerY, -0.2),
+        Vector3(jumbotron.width + 0.6, jumbotron.height + 0.6, 0.4),
+        UnlitMaterial()..baseColorFactor = linearColor(PlazaStyle.teal),
+      );
       final anchor = Node(
         localTransform: Matrix4.translation(
           Vector3(0, jumbotron.centerY, 0.06),
@@ -1275,33 +1264,13 @@ class PlazaSceneController {
         alpha: 0.06,
       );
       // The tower's own spire.
-      final spire = Node(
-        localTransform: Matrix4.translation(
-          Vector3(0, towerH + jumbotronSpireHeight / 2, -jumbotronTowerSetback),
-        ),
-        mesh: Mesh(
-          CuboidGeometry(
-            Vector3(
-              jumbotronSpireSize,
-              jumbotronSpireHeight,
-              jumbotronSpireSize,
-            ),
-          ),
-          UnlitMaterial()..baseColorFactor = _post,
-        ),
+      _spire(
+        root,
+        Vector3(0, towerH, -jumbotronTowerSetback),
+        size: jumbotronSpireSize,
+        height: jumbotronSpireHeight,
+        lightAbove: 0.4,
       );
-      root.add(spire);
-      final light = Node(
-        localTransform: Matrix4.translation(
-          Vector3(
-            0,
-            towerH + jumbotronSpireHeight + 0.4,
-            -jumbotronTowerSetback,
-          ),
-        ),
-      );
-      root.add(light);
-      spireAnchors.add(light);
       scene.add(root);
       final billboard = PlazaBillboard(
         slot: jumbotron,
@@ -1325,31 +1294,20 @@ class PlazaSceneController {
     }
 
     for (final p in world.spires) {
-      final root = Node(
-        localTransform: Matrix4.translation(
-          Vector3(p.x, p.height + plotSpireHeight / 2, p.z),
-        ),
-        mesh: Mesh(
-          CuboidGeometry(
-            Vector3(plotSpireSize, plotSpireHeight, plotSpireSize),
-          ),
-          UnlitMaterial()..baseColorFactor = _post,
-        ),
+      _spire(
+        scene.root,
+        Vector3(p.x, p.height, p.z),
+        size: plotSpireSize,
+        height: plotSpireHeight,
+        lightAbove: 0.3,
       );
-      scene.add(root);
-      final light = Node(
-        localTransform: Matrix4.translation(
-          Vector3(p.x, p.height + plotSpireHeight + 0.3, p.z),
-        ),
-      );
-      scene.add(light);
-      spireAnchors.add(light);
     }
   }
 
   /// Points around a panel's frame, world space, for the chase lights:
   /// evenly along the perimeter.
-  List<Vector3> _frameCorners(BillboardSlot slot, {int perSide = 5}) {
+  List<Vector3> _frameCorners(BillboardSlot slot) {
+    const perSide = 5;
     final sinF = math.sin(slot.facingRadians);
     final cosF = math.cos(slot.facingRadians);
     final hw = slot.width / 2 + 0.18;
@@ -1447,23 +1405,16 @@ class PlazaSceneController {
           ..baseColorFactor = linearColor(PlazaStyle.categoryWall(task)),
       ),
     );
-    final parade = (stableUnit(task.id, 'parade') * WallTextures.paradeVariants)
-        .floor()
-        .clamp(0, WallTextures.paradeVariants - 1);
-    final kit = (stableUnit(task.id, 'kit') * WallTextures.tileFamilies)
-        .floor()
-        .clamp(0, WallTextures.tileFamilies - 1);
+    final parade = stableIndex(task.id, 'parade', WallTextures.paradeVariants);
+    final kit = stableIndex(task.id, 'kit', WallTextures.tileFamilies);
 
     // A pavement apron round the plot, so the building stands on a street
     // and not on a speckled void.
-    node.add(
-      Node(
-        localTransform: Matrix4.translation(Vector3(0, -h / 2 + 0.02, 0)),
-        mesh: Mesh(
-          CuboidGeometry(Vector3(w + 3, 0.04, d + 3)),
-          UnlitMaterial()..baseColorFactor = _pavement,
-        ),
-      ),
+    _box(
+      node,
+      Vector3(0, -h / 2 + 0.02, 0),
+      Vector3(w + 3, 0.04, d + 3),
+      _pavementMaterial,
     );
     // Side and back walls: window grids in the state's lit ratio over
     // the shopfront parade dressed for the state, tiled by the wall's
@@ -1471,25 +1422,16 @@ class PlazaSceneController {
     final wallTint = linearColor(
       Color.lerp(PlazaStyle.categoryWall(task), const Color(0xFF0B0A14), 0.5)!,
     );
-    // A quad's face is +Z before rotation: rotateY(-π/2) turns it to -X
-    // for the left wall, rotateY(π/2) to +X for the right, π for the back.
-    for (final (dx, dz, yaw, width) in [
-      if (_shown('walls')) ...[
-        (-w / 2 - 0.02, 0.0, -math.pi / 2, d), // left side, faces -X
-        (w / 2 + 0.02, 0.0, math.pi / 2, d), // right side, faces +X
-        (0.0, -d / 2 - 0.02, math.pi, w), // back, faces -Z
-      ],
-    ]) {
-      _windowedWall(
+    if (_shown('walls')) {
+      _windowedBox(
         node,
-        dx: dx,
-        dz: dz,
-        yaw: yaw,
-        width: width,
+        id: task.id,
+        w: w,
+        d: d,
         height: h,
+        faces: const [_Face.left, _Face.right, _Face.back],
         state: attention.lantern,
         tint: wallTint,
-        uOffset: stableUnit(task.id, 'tile$yaw') * 3,
         variant: parade,
         family: kit,
       );
@@ -1497,10 +1439,10 @@ class PlazaSceneController {
     // An alarmed building spills its state colour onto the ground round
     // every wall: the coral or amber under the doors is what a walker
     // sees first.
-    final alarmed =
+    final alarm =
         attention.lantern == LanternState.blocked ||
         attention.lantern == LanternState.overdue;
-    if (alarmed) {
+    if (alarm) {
       final spill = PlazaStyle.lantern(attention.lantern);
       final sinF = math.sin(facing);
       final cosF = math.cos(facing);
@@ -1522,15 +1464,11 @@ class PlazaSceneController {
     }
 
     // Contact band: a dark plinth so the box sits on the ground.
-    node.add(
-      Node(
-        localTransform: Matrix4.translation(Vector3(0, -h / 2 + 0.35, 0)),
-        mesh: Mesh(
-          CuboidGeometry(Vector3(w + 0.1, 0.7, d + 0.1)),
-          UnlitMaterial()
-            ..baseColorFactor = linearColor(const Color(0xFF0A0910)),
-        ),
-      ),
+    _box(
+      node,
+      Vector3(0, -h / 2 + 0.35, 0),
+      Vector3(w + 0.1, 0.7, d + 0.1),
+      UnlitMaterial()..baseColorFactor = linearColor(const Color(0xFF0A0910)),
     );
 
     // Tall buildings step back to an upper storey with its own roof.
@@ -1568,42 +1506,37 @@ class PlazaSceneController {
         state: attention.lantern,
         tint: wallTint,
         uOffset: stableUnit(task.id, 'tilefront') * 3,
-        variant:
-            (stableUnit(task.id, 'paradefront') * WallTextures.paradeVariants)
-                .floor()
-                .clamp(0, WallTextures.paradeVariants - 1),
+        variant: stableIndex(
+          task.id,
+          'paradefront',
+          WallTextures.paradeVariants,
+        ),
         family: kit,
       );
     }
 
+    // Roof: a darker slab so the top reads apart from the walls.
+    _box(
+      node,
+      Vector3(0, h / 2 + 0.02, 0),
+      Vector3(w + 0.04, 0.04, d + 0.04),
+      UnlitMaterial()
+        ..baseColorFactor = linearColor(
+          Color.lerp(
+            PlazaStyle.categoryRoof(task),
+            const Color(0xFF07060D),
+            0.5,
+          )!,
+        ),
+    );
     // Far-tier surface: an always-present dark plate; the lantern carries
     // the state colour, the plate only says "there is a facade here".
-    final plate = Node(
-      localTransform: Matrix4.translation(Vector3(0, panelY, d / 2 + 0.03)),
-      mesh: Mesh(
-        CuboidGeometry(Vector3(facadeW, facadeH, 0.02)),
-        UnlitMaterial()..baseColorFactor = _panelBack,
-      ),
+    final plate = _box(
+      node,
+      Vector3(0, panelY, d / 2 + 0.03),
+      Vector3(facadeW, facadeH, 0.02),
+      UnlitMaterial()..baseColorFactor = _panelBack,
     );
-    // Roof: a darker slab so the top reads apart from the walls.
-    node
-      ..add(
-        Node(
-          localTransform: Matrix4.translation(Vector3(0, h / 2 + 0.02, 0)),
-          mesh: Mesh(
-            CuboidGeometry(Vector3(w + 0.04, 0.04, d + 0.04)),
-            UnlitMaterial()
-              ..baseColorFactor = linearColor(
-                Color.lerp(
-                  PlazaStyle.categoryRoof(task),
-                  const Color(0xFF07060D),
-                  0.5,
-                )!,
-              ),
-          ),
-        ),
-      )
-      ..add(plate);
 
     // Progress light bar along the base, visible at every tier.
     final pct = task.state == PlazaTaskState.done
@@ -1617,48 +1550,34 @@ class PlazaSceneController {
     // the dark band, filled from the left, so the lit part is progress
     // along something rather than an orphan block on the wall.
     final plinthY = -h / 2 + 0.35;
-    node.add(
-      Node(
-        localTransform: Matrix4.translation(Vector3(0, plinthY, d / 2 + 0.1)),
-        mesh: Mesh(
-          CuboidGeometry(Vector3(facadeW, 0.28, 0.1)),
-          UnlitMaterial()
-            ..baseColorFactor = linearColor(
-              Color.lerp(PlazaStyle.panel, PlazaStyle.textDim, 0.25)!,
-            ),
+    _box(
+      node,
+      Vector3(0, plinthY, d / 2 + 0.1),
+      Vector3(facadeW, 0.28, 0.1),
+      UnlitMaterial()
+        ..baseColorFactor = linearColor(
+          Color.lerp(PlazaStyle.panel, PlazaStyle.textDim, 0.25)!,
         ),
-      ),
     );
     // Seen from the street a +Z face's +X is the viewer's left (the
     // widget quads map their texture left edge to +X), so the bar fills
     // from +X toward -X: left to right for the walker.
     if (pct > 0) {
-      node.add(
-        Node(
-          localTransform: Matrix4.translation(
-            Vector3(facadeW / 2 - facadeW * pct / 2, plinthY, d / 2 + 0.12),
-          ),
-          mesh: Mesh(
-            CuboidGeometry(Vector3(facadeW * pct, 0.28, 0.12)),
-            UnlitMaterial()
-              ..baseColorFactor = linearColor(PlazaStyle.lightBar(attention)),
-          ),
-        ),
+      _box(
+        node,
+        Vector3(facadeW / 2 - facadeW * pct / 2, plinthY, d / 2 + 0.12),
+        Vector3(facadeW * pct, 0.28, 0.12),
+        UnlitMaterial()
+          ..baseColorFactor = linearColor(PlazaStyle.lightBar(attention)),
       );
     }
     // Quarter ticks so the bar has a scale.
     for (final q in [0.25, 0.5, 0.75]) {
-      node.add(
-        Node(
-          localTransform: Matrix4.translation(
-            Vector3(facadeW / 2 - facadeW * q, plinthY, d / 2 + 0.16),
-          ),
-          mesh: Mesh(
-            CuboidGeometry(Vector3(0.06, 0.28, 0.04)),
-            UnlitMaterial()
-              ..baseColorFactor = linearColor(const Color(0xFF07060D)),
-          ),
-        ),
+      _box(
+        node,
+        Vector3(facadeW / 2 - facadeW * q, plinthY, d / 2 + 0.16),
+        Vector3(0.06, 0.28, 0.04),
+        UnlitMaterial()..baseColorFactor = linearColor(const Color(0xFF07060D)),
       );
     }
 
@@ -1682,9 +1601,6 @@ class PlazaSceneController {
     // One colour rule: on an anomaly the state owns the brightest register
     // (the two verticals and their glow burn in the lantern colour); the
     // category survives on the roofline at half power.
-    final alarm =
-        attention.lantern == LanternState.blocked ||
-        attention.lantern == LanternState.overdue;
     final stateNeon = PlazaStyle.lantern(attention.lantern);
     // Lit neon goes past white so the bloom pass carries it; a dark shop's
     // strips stay under the threshold.
@@ -1708,16 +1624,11 @@ class PlazaSceneController {
       (facadeW / 2 + 0.12, 0.0, strip, facadeH, false),
       (0.0, facadeH / 2 + 0.12, facadeW + 0.4, strip, true),
     ]) {
-      neon.add(
-        Node(
-          localTransform: Matrix4.translation(
-            Vector3(dx, dy + panelY, d / 2 + 0.05),
-          ),
-          mesh: Mesh(
-            CuboidGeometry(Vector3(sw, sh, strip)),
-            isRoofline ? roofline : vertical,
-          ),
-        ),
+      _box(
+        neon,
+        Vector3(dx, dy + panelY, d / 2 + 0.05),
+        Vector3(sw, sh, strip),
+        isRoofline ? roofline : vertical,
       );
       if (emissive > 0.3) {
         neon.add(
@@ -1756,19 +1667,15 @@ class PlazaSceneController {
       ..baseColorFactor = linearColor(
         Color.lerp(const Color(0xFF0B0A14), neonColor, 0.55)!,
       );
-    for (final (dx, dz, sw, sd) in [
-      (0.0, d / 2, w + 0.2, 0.14),
-      (0.0, -d / 2, w + 0.2, 0.14),
-      (w / 2, 0.0, 0.14, d + 0.2),
-      (-w / 2, 0.0, 0.14, d + 0.2),
-    ]) {
-      node.add(
-        Node(
-          localTransform: Matrix4.translation(Vector3(dx, h / 2 + 0.08, dz)),
-          mesh: Mesh(CuboidGeometry(Vector3(sw, 0.14, sd)), roofTrim),
-        ),
-      );
-    }
+    _rim(
+      node,
+      w: w,
+      d: d,
+      y: h / 2 + 0.08,
+      overhang: 0.2,
+      thickness: 0.14,
+      material: roofTrim,
+    );
     _addRoofKit(node, task, w, h, d);
     // Light pool on the street in front of a lit facade: the wet-street
     // reflection, without a reflection. Sits above the pavement so it
@@ -1806,12 +1713,7 @@ class PlazaSceneController {
       (-facadeW / 2 - off, 0.0, t, facadeH + 2 * off),
       (facadeW / 2 + off, 0.0, t, facadeH + 2 * off),
     ]) {
-      ring.add(
-        Node(
-          localTransform: Matrix4.translation(Vector3(dx, dy, 0)),
-          mesh: Mesh(CuboidGeometry(Vector3(sw, sh, t)), ringMaterial),
-        ),
-      );
+      _box(ring, Vector3(dx, dy, 0), Vector3(sw, sh, t), ringMaterial);
     }
     node.add(ring);
 
@@ -1877,16 +1779,11 @@ class PlazaSceneController {
     if (slot.mount == BillboardMount.roof) {
       // Two short struts on the roof.
       for (final side in [-1.0, 1.0]) {
-        root.add(
-          Node(
-            localTransform: Matrix4.translation(
-              Vector3(side * slot.width * 0.4, slot.bottom - 0.25, -0.3),
-            ),
-            mesh: Mesh(
-              CuboidGeometry(Vector3(0.25, 0.5, 0.25)),
-              UnlitMaterial()..baseColorFactor = _post,
-            ),
-          ),
+        _box(
+          root,
+          Vector3(side * slot.width * 0.4, slot.bottom - 0.25, -0.3),
+          Vector3(0.25, 0.5, 0.25),
+          _postMaterial,
         );
       }
     }
@@ -1895,57 +1792,31 @@ class PlazaSceneController {
       // panel.
       for (final side in [-1.0, 1.0]) {
         final px = side * slot.width * pylonPostSpread;
-        root
-          ..add(
-            Node(
-              localTransform: Matrix4.translation(
-                Vector3(px, slot.bottom / 2, -pylonPostSetback),
-              ),
-              mesh: Mesh(
-                CuboidGeometry(
-                  Vector3(pylonPostSize, slot.bottom, pylonPostSize),
-                ),
-                UnlitMaterial()..baseColorFactor = _post,
-              ),
-            ),
-          )
-          ..add(
-            Node(
-              localTransform: Matrix4.translation(
-                Vector3(px, 0.3, -pylonPostSetback),
-              ),
-              mesh: Mesh(
-                CuboidGeometry(
-                  Vector3(pylonFootingSize, 0.6, pylonFootingSize),
-                ),
-                UnlitMaterial()..baseColorFactor = _post,
-              ),
-            ),
-          );
-      }
-      root
-        ..add(
-          Node(
-            localTransform: Matrix4.translation(
-              Vector3(0, slot.bottom * 0.55, -0.6),
-            ),
-            mesh: Mesh(
-              CuboidGeometry(Vector3(slot.width * 0.8, 0.25, 0.25)),
-              UnlitMaterial()..baseColorFactor = _post,
-            ),
-          ),
-        )
-        ..add(
-          Node(
-            localTransform: Matrix4.translation(
-              Vector3(0, slot.bottom - 0.3, 0.5),
-            ),
-            mesh: Mesh(
-              CuboidGeometry(Vector3(slot.width + 0.8, 0.12, 1.2)),
-              UnlitMaterial()..baseColorFactor = _post,
-            ),
-          ),
+        _box(
+          root,
+          Vector3(px, slot.bottom / 2, -pylonPostSetback),
+          Vector3(pylonPostSize, slot.bottom, pylonPostSize),
+          _postMaterial,
         );
+        _box(
+          root,
+          Vector3(px, 0.3, -pylonPostSetback),
+          Vector3(pylonFootingSize, 0.6, pylonFootingSize),
+          _postMaterial,
+        );
+      }
+      _box(
+        root,
+        Vector3(0, slot.bottom * 0.55, -0.6),
+        Vector3(slot.width * 0.8, 0.25, 0.25),
+        _postMaterial,
+      );
+      _box(
+        root,
+        Vector3(0, slot.bottom - 0.3, 0.5),
+        Vector3(slot.width + 0.8, 0.12, 1.2),
+        _postMaterial,
+      );
       // Light pool on the ground in the state colour, and a wide faint
       // wash in front of it so the panel connects to the paving.
       final sinF = math.sin(slot.facingRadians);
@@ -1981,24 +1852,19 @@ class PlazaSceneController {
     // skyline before its widget surface exists and the chase lights have a
     // bezel to sit on.
     final depth = slot.mount == BillboardMount.roof ? 0.4 : 0.7;
-    final backing = Node(
-      localTransform: Matrix4.translation(
-        Vector3(0, slot.centerY, -depth / 2 - 0.02),
-      ),
-      mesh: Mesh(
-        CuboidGeometry(Vector3(slot.width + 0.5, slot.height + 0.5, depth)),
-        UnlitMaterial()..baseColorFactor = _tower,
-      ),
+    final backing = _box(
+      root,
+      Vector3(0, slot.centerY, -depth / 2 - 0.02),
+      Vector3(slot.width + 0.5, slot.height + 0.5, depth),
+      _towerMaterial,
     );
     // Faux bloom: a wide soft glow behind the lightbox.
-    root
-      ..add(backing)
-      ..add(
-        _glowQuad(slot.width + 3, slot.height + 3, frame, 0.3)
-          ..localTransform = Matrix4.translation(
-            Vector3(0, slot.centerY, -depth - 0.06),
-          ),
-      );
+    root.add(
+      _glowQuad(slot.width + 3, slot.height + 3, frame, 0.3)
+        ..localTransform = Matrix4.translation(
+          Vector3(0, slot.centerY, -depth - 0.06),
+        ),
+    );
     // The panel's own border is the one frame; the lightbox bezel and the
     // chase lights sit behind it.
     final anchor = Node(
@@ -2082,6 +1948,64 @@ class PlazaSceneController {
     return Node(mesh: Mesh(ccwQuad(width, height), material));
   }
 
+  /// A spire [size] square and [height] tall standing on [base] under
+  /// [parent], with the anchor for its blinking light [lightAbove] the
+  /// tip. The jumbotron and hero towers hang theirs 0.4 up, a plot 0.3.
+  void _spire(
+    Node parent,
+    Vector3 base, {
+    required double size,
+    required double height,
+    required double lightAbove,
+  }) {
+    _box(
+      parent,
+      Vector3(base.x, base.y + height / 2, base.z),
+      Vector3(size, height, size),
+      _postMaterial,
+    );
+    final light = Node(
+      localTransform: Matrix4.translation(
+        Vector3(base.x, base.y + height + lightAbove, base.z),
+      ),
+    );
+    parent.add(light);
+    spireAnchors.add(light);
+  }
+
+  /// A big screen on a tower's district-facing wall under [parent]: a
+  /// [width] × [height] backing in the [frame] colour at [y], standing
+  /// [front] out from the parent's centre, a glow [glowMargin] wider
+  /// behind it at [glowAlpha], and the anchor the widget for anomaly
+  /// [rank] hangs on, appended to [skylineScreens].
+  void _towerScreen(
+    Node parent, {
+    required double width,
+    required double height,
+    required double y,
+    required double front,
+    required Color frame,
+    required double glowMargin,
+    required double glowAlpha,
+    required int rank,
+  }) {
+    _box(
+      parent,
+      Vector3(0, y, front + 0.3),
+      Vector3(width + 0.8, height + 0.8, 0.6),
+      UnlitMaterial()..baseColorFactor = linearColor(frame),
+    );
+    parent.add(
+      _glowQuad(width + glowMargin, height + glowMargin, frame, glowAlpha)
+        ..localTransform = Matrix4.translation(Vector3(0, y, front + 0.2)),
+    );
+    final anchor = Node(
+      localTransform: Matrix4.translation(Vector3(0, y, front + 0.66)),
+    );
+    parent.add(anchor);
+    skylineScreens.add((anchor, width, height, rank));
+  }
+
   /// Seeded roof clutter: a parapet lip, one or two plant boxes, a water
   /// tank on some, an antenna mast on a third. Hashed from the task id so
   /// it never changes under the user's feet.
@@ -2090,31 +2014,23 @@ class PlazaSceneController {
       ..baseColorFactor = linearColor(const Color(0xFF14121E));
     final top = h / 2;
     // Parapet lip.
-    for (final (dx, dz, sw, sd) in [
-      (0.0, d / 2 - 0.15, w, 0.3),
-      (0.0, -d / 2 + 0.15, w, 0.3),
-      (w / 2 - 0.15, 0.0, 0.3, d),
-      (-w / 2 + 0.15, 0.0, 0.3, d),
-    ]) {
-      node.add(
-        Node(
-          localTransform: Matrix4.translation(Vector3(dx, top + 0.25, dz)),
-          mesh: Mesh(CuboidGeometry(Vector3(sw, 0.5, sd)), dark),
-        ),
-      );
-    }
+    _rim(
+      node,
+      w: w,
+      d: d,
+      y: top + 0.25,
+      inset: 0.15,
+      thickness: 0.3,
+      height: 0.5,
+      material: dark,
+    );
     final plantCount = 1 + (stableUnit(task.id, 'plant') < 0.5 ? 1 : 0);
     for (var i = 0; i < plantCount; i++) {
       final bw = math.min(w * 0.3, 2.4);
       final bd = math.min<double>(d * 0.3, 2);
       final bx = (stableUnit(task.id, 'px$i') - 0.5) * (w - bw - 1);
       final bz = (stableUnit(task.id, 'pz$i') - 0.5) * (d - bd - 1);
-      node.add(
-        Node(
-          localTransform: Matrix4.translation(Vector3(bx, top + 0.7, bz)),
-          mesh: Mesh(CuboidGeometry(Vector3(bw, 1.4, bd)), dark),
-        ),
-      );
+      _box(node, Vector3(bx, top + 0.7, bz), Vector3(bw, 1.4, bd), dark);
     }
     if (stableUnit(task.id, 'tank') < 0.4 && w > 5) {
       final tx = (stableUnit(task.id, 'tx') - 0.5) * (w - 3);
@@ -2136,13 +2052,11 @@ class PlazaSceneController {
     }
     if (stableUnit(task.id, 'mast') < 0.33) {
       final mx = (stableUnit(task.id, 'mx') - 0.5) * (w - 1);
-      node.add(
-        Node(
-          localTransform: Matrix4.translation(
-            Vector3(mx, top + roofKitHeight / 2, 0),
-          ),
-          mesh: Mesh(CuboidGeometry(Vector3(0.12, roofKitHeight, 0.12)), dark),
-        ),
+      _box(
+        node,
+        Vector3(mx, top + roofKitHeight / 2, 0),
+        Vector3(0.12, roofKitHeight, 0.12),
+        dark,
       );
     }
   }
@@ -2162,41 +2076,26 @@ class PlazaSceneController {
       final node = Node(
         localTransform: Matrix4.translation(Vector3(block.x, bh / 2, block.z))
           ..rotateY(block.yawRadians),
-        mesh: Mesh(
-          shadedCuboid(Vector3(bd, bh, bw)),
-          UnlitMaterial()..baseColorFactor = _tower,
-        ),
+        mesh: Mesh(shadedCuboid(Vector3(bd, bh, bw)), _towerMaterial),
       );
-      final parade = (stableUnit(id, 'parade') * WallTextures.paradeVariants)
-          .floor()
-          .clamp(0, WallTextures.paradeVariants - 1);
-      final kit = (stableUnit(id, 'kit') * WallTextures.tileFamilies)
-          .floor()
-          .clamp(0, WallTextures.tileFamilies - 1);
+      final parade = stableIndex(id, 'parade', WallTextures.paradeVariants);
+      final kit = stableIndex(id, 'kit', WallTextures.tileFamilies);
       // Windows on every face: a filler is seen from the street, from
       // the plaza and from above.
-      for (final (dx, dz, yaw, width) in [
-        (bd / 2 + 0.02, 0.0, math.pi / 2, bw),
-        (-bd / 2 - 0.02, 0.0, -math.pi / 2, bw),
-        (0.0, bw / 2 + 0.02, 0.0, bd),
-        (0.0, -bw / 2 - 0.02, math.pi, bd),
-      ]) {
-        _windowedWall(
-          node,
-          dx: dx,
-          dz: dz,
-          yaw: yaw,
-          width: width,
-          height: bh,
-          state: LanternState.open,
-          tint: _tower,
-          uOffset: stableUnit(id, 'tile$yaw') * 3,
-          // The fabric trades all night, whatever its flats are doing.
-          shops: LanternState.inProgress,
-          variant: parade,
-          family: kit,
-        );
-      }
+      _windowedBox(
+        node,
+        id: id,
+        w: bd,
+        d: bw,
+        height: bh,
+        faces: const [_Face.right, _Face.left, _Face.front, _Face.back],
+        state: LanternState.open,
+        tint: _tower,
+        // The fabric trades all night, whatever its flats are doing.
+        shops: LanternState.inProgress,
+        variant: parade,
+        family: kit,
+      );
       // The parade's light on the pavement, on the street side.
       {
         final yaw = block.yawRadians + (side < 0 ? math.pi / 2 : -math.pi / 2);
@@ -2223,9 +2122,7 @@ class PlazaSceneController {
                 .toList()
               ..sort();
         if (weekTasks.isNotEmpty) {
-          final pick = (stableUnit(id, 'pick') * weekTasks.length)
-              .floor()
-              .clamp(0, weekTasks.length - 1);
+          final pick = stableIndex(id, 'pick', weekTasks.length);
           final anchor = Node(
             localTransform: Matrix4.translation(
               Vector3(-side * (bd / 2 + 0.08), bh * 0.15, -bw / 2 + 1.2),
@@ -2256,94 +2153,52 @@ class PlazaSceneController {
       );
       final box = Node(
         localTransform: Matrix4.translation(Vector3(0, height / 2, 0)),
-        mesh: Mesh(
-          shadedCuboid(Vector3(w, height, bd)),
-          UnlitMaterial()..baseColorFactor = _tower,
-        ),
+        mesh: Mesh(shadedCuboid(Vector3(w, height, bd)), _towerMaterial),
       );
-      final parade = (stableUnit(id, 'parade') * WallTextures.paradeVariants)
-          .floor()
-          .clamp(0, WallTextures.paradeVariants - 1);
+      final parade = stableIndex(id, 'parade', WallTextures.paradeVariants);
       root.add(box);
-      for (final (dx, dz, yaw, faceW) in [
-        (0.0, bd / 2 + 0.02, 0.0, w),
-        (0.0, -bd / 2 - 0.02, math.pi, w),
-        (w / 2 + 0.02, 0.0, math.pi / 2, bd),
-        (-w / 2 - 0.02, 0.0, -math.pi / 2, bd),
-      ]) {
-        _windowedWall(
-          box,
-          dx: dx,
-          dz: dz,
-          yaw: yaw,
-          width: faceW,
-          height: height,
-          state: LanternState.inProgress,
-          tint: _tower,
-          uOffset: stableUnit(id, 'tile$yaw') * 3,
-          variant: parade,
-        );
-      }
-      // Crown: a lit trim and a spire with a blinking light.
-      root
-        ..add(
-          Node(
-            localTransform: Matrix4.translation(Vector3(0, height + 0.1, 0)),
-            mesh: Mesh(
-              CuboidGeometry(Vector3(w + 0.3, 0.2, bd + 0.3)),
-              UnlitMaterial()
-                ..baseColorFactor = linearColor(PlazaStyle.teal, alpha: 0.9),
-            ),
-          ),
-        )
-        ..add(
-          Node(
-            localTransform: Matrix4.translation(
-              Vector3(0, height + heroSpireHeight / 2, 0),
-            ),
-            mesh: Mesh(
-              CuboidGeometry(
-                Vector3(heroSpireSize, heroSpireHeight, heroSpireSize),
-              ),
-              UnlitMaterial()..baseColorFactor = _post,
-            ),
-          ),
-        );
-      final light = Node(
-        localTransform: Matrix4.translation(
-          Vector3(0, height + heroSpireHeight + 0.4, 0),
-        ),
+      _windowedBox(
+        box,
+        id: id,
+        w: w,
+        d: bd,
+        height: height,
+        state: LanternState.inProgress,
+        tint: _tower,
+        variant: parade,
       );
-      root.add(light);
-      spireAnchors.add(light);
+      // Crown: a lit trim and a spire with a blinking light.
+      _box(
+        root,
+        Vector3(0, height + 0.1, 0),
+        Vector3(w + 0.3, 0.2, bd + 0.3),
+        UnlitMaterial()
+          ..baseColorFactor = linearColor(PlazaStyle.teal, alpha: 0.9),
+      );
+      _spire(
+        root,
+        Vector3(0, height, 0),
+        size: heroSpireSize,
+        height: heroSpireHeight,
+        lightAbove: 0.4,
+      );
       // The screen, toward the street, and the dome of light behind the
       // tower that the row's vanishing point sits in.
       if (world.anomalies.isNotEmpty) {
         final sw = w * 0.9;
         final sh = sw * 0.62;
-        final sy = height * 0.62;
         final frame = PlazaStyle.lantern(world.anomalies.first.lantern);
-        root
-          ..add(
-            Node(
-              localTransform: Matrix4.translation(Vector3(0, sy, bd / 2 + 0.3)),
-              mesh: Mesh(
-                CuboidGeometry(Vector3(sw + 0.8, sh + 0.8, 0.6)),
-                UnlitMaterial()..baseColorFactor = linearColor(frame),
-              ),
-            ),
-          )
-          ..add(
-            _glowQuad(sw + 8, sh + 8, frame, 0.28)
-              ..localTransform = Matrix4.translation(
-                Vector3(0, sy, bd / 2 + 0.2),
-              ),
-          );
-        final anchor = Node(
-          localTransform: Matrix4.translation(Vector3(0, sy, bd / 2 + 0.66)),
+        _towerScreen(
+          root,
+          width: sw,
+          height: sh,
+          y: height * 0.62,
+          front: bd / 2,
+          frame: frame,
+          glowMargin: 8,
+          glowAlpha: 0.28,
+          rank: 0,
         );
-        root.add(anchor);
-        skylineScreens.add((anchor, sw, sh, 0));
         // The screen's wash on the ground before the tower.
         _addPool(
           Vector3(
@@ -2386,29 +2241,19 @@ class PlazaSceneController {
       // A lit roofline along the district-facing edge, warm and teal by
       // turns, so the ring is a glowing horizon and not a row of dots.
       final roofline = i.isEven ? const Color(0xFFFFC46B) : PlazaStyle.teal;
-      node
-        ..add(
-          Node(
-            localTransform: Matrix4.translation(
-              Vector3(0, h / 2 + 0.1, tower.depth / 2 - 0.1),
-            ),
-            mesh: Mesh(
-              CuboidGeometry(Vector3(w + 0.2, 0.25, 0.25)),
-              UnlitMaterial()
-                ..baseColorFactor = emissiveColor(
-                  roofline,
-                  neonBoost,
-                  alpha: 0.95,
-                ),
-            ),
+      _box(
+        node,
+        Vector3(0, h / 2 + 0.1, tower.depth / 2 - 0.1),
+        Vector3(w + 0.2, 0.25, 0.25),
+        UnlitMaterial()
+          ..baseColorFactor = emissiveColor(roofline, neonBoost, alpha: 0.95),
+      );
+      node.add(
+        _glowQuad(w + 4, 3, roofline, 0.16)
+          ..localTransform = Matrix4.translation(
+            Vector3(0, h / 2 + 0.6, tower.depth / 2 + 0.05),
           ),
-        )
-        ..add(
-          _glowQuad(w + 4, 3, roofline, 0.16)
-            ..localTransform = Matrix4.translation(
-              Vector3(0, h / 2 + 0.6, tower.depth / 2 + 0.05),
-            ),
-        );
+      );
       // Every fourth tower carries a big screen on its district-facing
       // face: the hi-rises behind Times Square are where the screens are.
       if (i % 4 == 1 && world.anomalies.isNotEmpty) {
@@ -2416,50 +2261,30 @@ class PlazaSceneController {
         final sh = sw * 0.5;
         final sy = h * 0.55;
         final rank = (i ~/ 4) % world.anomalies.length;
-        final frame = PlazaStyle.lantern(world.anomalies[rank].lantern);
-        node
-          ..add(
-            Node(
-              localTransform: Matrix4.translation(
-                Vector3(0, sy - h / 2, tower.depth / 2 + 0.3),
-              ),
-              mesh: Mesh(
-                CuboidGeometry(Vector3(sw + 0.8, sh + 0.8, 0.6)),
-                UnlitMaterial()..baseColorFactor = linearColor(frame),
-              ),
-            ),
-          )
-          ..add(
-            _glowQuad(sw + 6, sh + 6, frame, 0.25)
-              ..localTransform = Matrix4.translation(
-                Vector3(0, sy - h / 2, tower.depth / 2 + 0.2),
-              ),
-          );
-        final anchor = Node(
-          localTransform: Matrix4.translation(
-            Vector3(0, sy - h / 2, tower.depth / 2 + 0.66),
-          ),
-        );
-        node.add(anchor);
-        skylineScreens.add((anchor, sw, sh, rank));
-      }
-      // Two windowed faces toward the district.
-      for (final (dx, dz, yaw, faceW) in [
-        (0.0, tower.depth / 2 + 0.02, 0.0, w),
-        (-w / 2 - 0.02, 0.0, -math.pi / 2, tower.depth),
-      ]) {
-        _windowedWall(
+        _towerScreen(
           node,
-          dx: dx,
-          dz: dz,
-          yaw: yaw,
-          width: faceW,
-          height: h,
-          state: LanternState.off,
-          tint: _tower,
-          uOffset: stableUnit(id, 'tile') * 3,
+          width: sw,
+          height: sh,
+          y: sy - h / 2,
+          front: tower.depth / 2,
+          frame: PlazaStyle.lantern(world.anomalies[rank].lantern),
+          glowMargin: 6,
+          glowAlpha: 0.25,
+          rank: rank,
         );
       }
+      // Two windowed faces toward the district, tiled from one offset.
+      _windowedBox(
+        node,
+        id: id,
+        w: w,
+        d: tower.depth,
+        height: h,
+        faces: const [_Face.front, _Face.left],
+        state: LanternState.off,
+        tint: _tower,
+        perFaceOffset: false,
+      );
       scene.add(node);
     }
   }

--- a/lib/features/plaza/scene/plaza_sprites.dart
+++ b/lib/features/plaza/scene/plaza_sprites.dart
@@ -17,7 +17,8 @@ import 'package:vector_math/vector_math.dart' hide Colors;
 /// frame from their distance, so a lantern never shrinks below a few pixels
 /// from the overview pose and a beacon reads the same from across the
 /// district as from up close. Anomalous lanterns and attention beacons
-/// pulse on a fixed cycle.
+/// pulse on a fixed cycle. A sprite is only written when its size or
+/// colour actually moved: every [Sprite] setter re-commits its quad.
 class PlazaSprites {
   PlazaSprites({
     required this.scene,
@@ -28,15 +29,35 @@ class PlazaSprites {
     Map<PlazaBillboard, List<Vector3>> chaseLightPoints = const {},
   }) {
     for (final anchor in lampAnchors) {
-      final bulb = Sprite(color: linearColor(PlazaStyle.lamp));
-      final halo = Sprite(color: linearColor(PlazaStyle.lamp, alpha: 0.35));
+      final bulb = Sprite(
+        color: linearColor(PlazaStyle.lamp),
+        width: lampBulbSize,
+        height: lampBulbSize,
+      );
+      final halo = Sprite(
+        color: linearColor(PlazaStyle.lamp, alpha: 0.35),
+        width: lampHaloSize,
+        height: lampHaloSize,
+      );
       anchor
         ..add(Node(mesh: bulb.mesh)..raycastable = false)
         ..add(Node(mesh: halo.mesh)..raycastable = false);
-      _lamps.add(_Lamp(bulb: bulb, halo: halo, anchor: anchor));
+      // A lamp post never moves: its world position is read once, here,
+      // so the anchor must already stand in its final pose.
+      _lamps.add(
+        _Lamp(
+          bulb: bulb,
+          halo: halo,
+          worldPosition: anchor.globalTransform.getTranslation(),
+        ),
+      );
     }
     for (final anchor in spireAnchors) {
-      final sprite = Sprite(color: linearColor(PlazaStyle.warning));
+      final sprite = Sprite(
+        color: linearColor(PlazaStyle.warning),
+        width: spireLightSize,
+        height: spireLightSize,
+      );
       anchor.add(Node(mesh: sprite.mesh)..raycastable = false);
       _spireLights.add(sprite);
     }
@@ -51,7 +72,7 @@ class PlazaSprites {
           Node(localTransform: Matrix4.translation(point), mesh: sprite.mesh)
             ..raycastable = false,
         );
-        run.add(_ChaseLight(sprite: sprite, position: point, color: color));
+        run.add(_ChaseLight(sprite: sprite, color: color));
       }
       _chases.add(
         _Chase(
@@ -82,11 +103,10 @@ class PlazaSprites {
     }
     for (final beacon in world.beacons) {
       final teal = linearColor(PlazaStyle.beaconColor(beacon, world));
+      final position = Vector3(beacon.markerX, beacon.markerY, beacon.markerZ);
       final dot = Sprite(color: teal);
       final dotNode = Node(
-        localTransform: Matrix4.translation(
-          Vector3(beacon.markerX, beacon.markerY, beacon.markerZ),
-        ),
+        localTransform: Matrix4.translation(position),
         mesh: dot.mesh,
       )..raycastable = false;
       scene.add(dotNode);
@@ -95,9 +115,7 @@ class PlazaSprites {
       if (beacon.kind == BeaconKind.attention) {
         ring = Sprite(color: Vector4(teal.x, teal.y, teal.z, 0.8));
         ringNode = Node(
-          localTransform: Matrix4.translation(
-            Vector3(beacon.markerX, beacon.markerY, beacon.markerZ),
-          ),
+          localTransform: Matrix4.translation(position),
           mesh: ring.mesh,
         )..raycastable = false;
         scene.add(ringNode);
@@ -105,6 +123,7 @@ class PlazaSprites {
       _beacons.add(
         _BeaconSprite(
           beacon: beacon,
+          worldPosition: position,
           dot: dot,
           dotNode: dotNode,
           ring: ring,
@@ -201,7 +220,41 @@ class PlazaSprites {
   static const lampHaloFadeStart = 8.0;
   static const lampHaloFadeEnd = 30.0;
 
+  /// World sizes of the fixed dots, set once at construction.
+  static const lampBulbSize = 0.5;
+  static const lampHaloSize = 2.0;
+  static const spireLightSize = 2.4;
+
+  /// Below this a size or colour change is invisible and is not written:
+  /// every [Sprite] setter re-commits its quad, and at rest most frames
+  /// change nothing.
+  static const _epsilon = 1e-6;
+
+  /// Sets a square sprite's [size] when it moved.
+  static void _resize(Sprite sprite, double size) {
+    if ((sprite.width - size).abs() <= _epsilon &&
+        (sprite.height - size).abs() <= _epsilon) {
+      return;
+    }
+    sprite
+      ..width = size
+      ..height = size;
+  }
+
+  /// Sets a sprite's colour when a channel moved.
+  static void _tint(Sprite sprite, double r, double g, double b, double a) {
+    final c = sprite.color;
+    if ((c.x - r).abs() <= _epsilon &&
+        (c.y - g).abs() <= _epsilon &&
+        (c.z - b).abs() <= _epsilon &&
+        (c.w - a).abs() <= _epsilon) {
+      return;
+    }
+    sprite.color = Vector4(r, g, b, a);
+  }
+
   /// Per-frame update: sizes from distance, pulses from [elapsedSeconds].
+  /// Only what changed since the last frame is written to a sprite.
   void update(Camera camera, ui.Size viewSize, double elapsedSeconds) {
     final eye = camera.position;
     final fov = switch (camera.projection) {
@@ -214,54 +267,34 @@ class PlazaSprites {
     final lanternPulse =
         0.35 + 0.65 * (0.5 + 0.5 * math.sin(elapsedSeconds * 2 * math.pi / 3));
     for (final l in _lanterns) {
-      final d = (l.worldPosition - eye).length;
+      final d = eye.distanceTo(l.worldPosition);
       final px = (lanternNominalPx * 60 / math.max(d, 1)).clamp(
         lanternMinPx,
         lanternMaxPx,
       );
       final size = px * d * metersPerPxAtUnit * (l.lit ? 2.2 : 1.2);
-      l.sprite
-        ..width = size
-        ..height = size;
+      _resize(l.sprite, size);
       if (l.pulses) {
-        l.sprite.color = Vector4(
-          l.color.x,
-          l.color.y,
-          l.color.z,
-          lanternPulse,
-        );
+        _tint(l.sprite, l.color.x, l.color.y, l.color.z, lanternPulse);
       }
     }
 
-    // Lamps: a hard bulb that reads at every range, and a halo that fades
-    // away as the walker comes close so it never sits on a facade.
+    // Lamps: a hard bulb that reads at every range (its size is fixed),
+    // and a halo that fades away as the walker comes close so it never
+    // sits on a facade.
     for (final l in _lamps) {
-      final pos = l.anchor.globalTransform.getTranslation();
-      final d = (pos - eye).length;
+      final d = eye.distanceTo(l.worldPosition);
       final haloAlpha =
           ((d - lampHaloFadeStart) / (lampHaloFadeEnd - lampHaloFadeStart))
               .clamp(0.0, 1.0) *
           0.22;
-      l.bulb
-        ..width = 0.5
-        ..height = 0.5;
-      l.halo
-        ..width = 2
-        ..height = 2
-        ..color = Vector4(
-          l.halo.color.x,
-          l.halo.color.y,
-          l.halo.color.z,
-          haloAlpha,
-        );
+      final c = l.halo.color;
+      _tint(l.halo, c.x, c.y, c.z, haloAlpha);
     }
     // Spire lights blink: on for a third of a 1.6 s cycle.
     final blink = (elapsedSeconds % 1.6) < 0.55 ? 1.0 : 0.12;
     for (final l in _spireLights) {
-      l
-        ..width = 2.4
-        ..height = 2.4
-        ..color = Vector4(l.color.x, l.color.y, l.color.z, blink);
+      _tint(l, l.color.x, l.color.y, l.color.z, blink);
     }
     // Chase lights run round each billboard frame: a bright head with a
     // fading tail, faster for the more agitated panels.
@@ -284,21 +317,20 @@ class PlazaSprites {
             : behind < 2
             ? 0.36
             : 0.3;
-        light.sprite
-          ..width = size
-          ..height = size
-          ..color = Vector4(
-            light.color.x * boost,
-            light.color.y * boost,
-            light.color.z * boost,
-            alpha,
-          );
+        _resize(light.sprite, size);
+        _tint(
+          light.sprite,
+          light.color.x * boost,
+          light.color.y * boost,
+          light.color.z * boost,
+          alpha,
+        );
       }
     }
 
     final ringPhase = (elapsedSeconds % 2.2) / 2.2;
     for (final b in _beacons) {
-      final pos = Vector3(b.beacon.markerX, b.beacon.markerY, b.beacon.markerZ);
+      final pos = b.worldPosition;
       final dx = pos.x - eye.x;
       final dz = pos.z - eye.z;
       final ground = math.sqrt(dx * dx + dz * dz);
@@ -307,28 +339,25 @@ class PlazaSprites {
       b.dotNode.visible = visible;
       b.ringNode?.visible = visible;
       if (!visible) continue;
-      final d = (pos - eye).length;
+      final d = eye.distanceTo(pos);
       // Shrinks gently with distance so a row of stops reads as a sequence
       // rather than one blob at the vanishing point.
       final px = beaconPx * (1 - 0.5 * (d / range).clamp(0.0, 1.0));
       final size = px * d * metersPerPxAtUnit * 2.0;
       final alpha = 0.9 - 0.6 * (d / range).clamp(0.0, 1.0);
-      b.dot
-        ..width = size
-        ..height = size
-        ..color = Vector4(b.dot.color.x, b.dot.color.y, b.dot.color.z, alpha);
+      _resize(b.dot, size);
+      _tint(b.dot, b.dot.color.x, b.dot.color.y, b.dot.color.z, alpha);
       final ring = b.ring;
       if (ring != null) {
         final scale = 0.5 + 1.9 * ringPhase;
-        ring
-          ..width = size * scale
-          ..height = size * scale
-          ..color = Vector4(
-            ring.color.x,
-            ring.color.y,
-            ring.color.z,
-            0.8 * (1 - ringPhase),
-          );
+        _resize(ring, size * scale);
+        _tint(
+          ring,
+          ring.color.x,
+          ring.color.y,
+          ring.color.z,
+          0.8 * (1 - ringPhase),
+        );
       }
     }
   }
@@ -340,10 +369,7 @@ class PlazaSprites {
   ) sync* {
     for (final b in _beacons) {
       if (!b.dotNode.visible) continue;
-      final screen = camera.worldToScreen(
-        Vector3(b.beacon.markerX, b.beacon.markerY, b.beacon.markerZ),
-        viewSize,
-      );
+      final screen = camera.worldToScreen(b.worldPosition, viewSize);
       if (screen != null) yield (b.beacon, screen);
     }
   }
@@ -370,6 +396,7 @@ class _Lantern {
 class _BeaconSprite {
   _BeaconSprite({
     required this.beacon,
+    required this.worldPosition,
     required this.dot,
     required this.dotNode,
     required this.ring,
@@ -377,6 +404,7 @@ class _BeaconSprite {
   });
 
   final Beacon beacon;
+  final Vector3 worldPosition;
   final Sprite dot;
   final Node dotNode;
   final Sprite? ring;
@@ -384,22 +412,21 @@ class _BeaconSprite {
 }
 
 class _Lamp {
-  _Lamp({required this.bulb, required this.halo, required this.anchor});
+  _Lamp({
+    required this.bulb,
+    required this.halo,
+    required this.worldPosition,
+  });
 
   final Sprite bulb;
   final Sprite halo;
-  final Node anchor;
+  final Vector3 worldPosition;
 }
 
 class _ChaseLight {
-  _ChaseLight({
-    required this.sprite,
-    required this.position,
-    required this.color,
-  });
+  _ChaseLight({required this.sprite, required this.color});
 
   final Sprite sprite;
-  final Vector3 position;
   final Vector4 color;
 }
 

--- a/lib/features/plaza/scene/plaza_surfaces.dart
+++ b/lib/features/plaza/scene/plaza_surfaces.dart
@@ -347,14 +347,16 @@ class PlazaSurfaces {
         );
       }
       scene.add(anchor);
-      final origin = Vector3(slot.x, slot.bottom, slot.z);
-      _ranged.add((origin, anchor));
+      // The band's centre, where the anchor stands: what the range and the
+      // view culling measure against.
+      final center = Vector3(slot.x, slot.bottom + slot.height / 2, slot.z);
+      _ranged.add((center, anchor));
       _captures.timed(
         _tickers,
         TimedSurface.facing(
           controller: component.controller,
           node: anchor,
-          center: origin,
+          center: center,
           facingRadians: slot.facingRadians,
         ),
       );

--- a/lib/features/plaza/scene/plaza_surfaces.dart
+++ b/lib/features/plaza/scene/plaza_surfaces.dart
@@ -1,5 +1,5 @@
 import 'dart:math' as math;
-import 'dart:ui' show Color, Size;
+import 'dart:ui' show Color;
 
 import 'package:flutter/foundation.dart' show ValueListenable, ValueNotifier;
 
@@ -7,6 +7,7 @@ import 'package:flutter_scene/scene.dart';
 import 'package:lotti/features/plaza/domain/plaza_layout.dart';
 import 'package:lotti/features/plaza/scene/plaza_scene.dart';
 import 'package:lotti/features/plaza/scene/plaza_world.dart';
+import 'package:lotti/features/plaza/scene/surface_captures.dart';
 import 'package:lotti/features/plaza/ui/banner_widget.dart';
 import 'package:lotti/features/plaza/ui/billboard_widget.dart';
 import 'package:lotti/features/plaza/ui/block_marker_widget.dart';
@@ -21,12 +22,15 @@ import 'package:vector_math/vector_math.dart' show Matrix4, Vector3;
 /// Budget (spec): billboards ≤ 6, captured at [nearInterval] within the
 /// plaza's range; tickers at [tickerInterval] within range and not at all
 /// beyond it; the jumbotron at [jumbotronInterval]; the skyline screens at
-/// [farInterval]; block markers, banners and signs captured once at build.
+/// [farInterval]; block markers, banners, signs and the billboards that do
+/// not animate captured once at build.
 ///
-/// Every capture is manual, requested from [update] on the harness clock:
-/// an interval policy would make flutter_scene pump an engine frame on
-/// every vsync, whatever the harness paints, and the widgets themselves
-/// read the same clock, so between painted frames nothing runs.
+/// Every capture is manual, requested from [update] on the harness clock
+/// through [SurfaceCaptures]: an interval policy would make flutter_scene
+/// pump an engine frame on every vsync, whatever the harness paints. Each
+/// cadence owns the clock its widgets read ([nearClock], [tickerClock],
+/// [farClock], [jumbotronClock]), advanced only when that cadence asks for
+/// a capture, so between captures nothing in them runs.
 class PlazaSurfaces {
   PlazaSurfaces({
     required this.scene,
@@ -34,15 +38,14 @@ class PlazaSurfaces {
     required this.markerAnchors,
     required this.billboards,
     required this.pxPerMeter,
-    required this.clock,
     Map<String, Node> bannerAnchors = const {},
     Node? jumbotronAnchor,
     Map<int, Node> weekSignAnchors = const {},
     List<(Node, double, double, int)> skylineScreens = const [],
     List<(Node, double, double, String)> fillerSigns = const [],
   }) {
-    _attachMarkers();
-    _attachWeekSigns(weekSignAnchors);
+    _attachLabels(markerAnchors, markerWidth, markerHeight);
+    _attachLabels(weekSignAnchors, signWidth, signHeight);
     _attachSkylineScreens(skylineScreens);
     _attachFillerSigns(fillerSigns);
     _attachBillboards();
@@ -57,20 +60,31 @@ class PlazaSurfaces {
   final List<PlazaBillboard> billboards;
   final double pxPerMeter;
 
-  /// Elapsed seconds, advanced by the harness once per painted frame;
-  /// the animated surfaces read it.
-  final ValueListenable<double> clock;
+  final SurfaceCaptures _captures = SurfaceCaptures();
+  final CaptureCadence _near = CaptureCadence(nearInterval);
+  final CaptureCadence _tickers = CaptureCadence(tickerInterval);
+  final CaptureCadence _far = CaptureCadence(farInterval);
+  final CaptureCadence _jumbotron = CaptureCadence(jumbotronInterval);
 
-  final List<WidgetComponent> _markers = [];
-  final List<WidgetComponent> _banners = [];
-  final List<WidgetComponent> _skylineScreens = [];
+  /// Elapsed harness seconds as of the billboards' last capture request:
+  /// the clock the anomaly billboards breathe by.
+  ValueListenable<double> get nearClock => _near.clock;
 
-  /// When each timed surface was last asked for a capture, seconds on the
-  /// harness clock.
-  final Map<WidgetComponent, double> _lastCapture = {};
-  WidgetComponent? _jumbotron;
-  final List<(Vector3, WidgetComponent, Node)> _billboardSurfaces = [];
-  final List<(Vector3, WidgetComponent, Node)> _tickerSurfaces = [];
+  /// Elapsed harness seconds as of the tickers' last capture request: the
+  /// clock the bands scroll by.
+  ValueListenable<double> get tickerClock => _tickers.clock;
+
+  /// Elapsed harness seconds as of the skyline screens' last capture
+  /// request.
+  ValueListenable<double> get farClock => _far.clock;
+
+  /// Elapsed harness seconds as of the jumbotron's last capture request:
+  /// the clock it turns its slides by.
+  ValueListenable<double> get jumbotronClock => _jumbotron.clock;
+
+  /// The plaza's animated surfaces, hidden beyond [plazaRange]: where each
+  /// stands and the node that hides it.
+  final List<(Vector3, Node)> _ranged = [];
 
   /// Beyond this distance the plaza's animated surfaces are hidden: far
   /// enough that the map shot still sees the pylons lit.
@@ -100,24 +114,29 @@ class PlazaSurfaces {
   static const signWidth = 5.0;
   static const signHeight = 1.4;
 
-  void _attachWeekSigns(Map<int, Node> anchors) {
-    for (final entry in anchors.entries) {
-      final surface = OpaqueSurface();
-      final component = WidgetComponent(
-        child: BlockMarkerWidget(
-          label: world.weekLabel(entry.key),
-          heightMeters: signHeight,
+  /// Hangs a capture-once [component] on [anchor].
+  void _once(Node anchor, WidgetComponent component) {
+    anchor.addComponent(component);
+    _captures.once(component.controller);
+  }
+
+  /// Week labels on the road ([markerWidth] × [markerHeight]) and the week
+  /// signs ([signWidth] × [signHeight]): a [BlockMarkerWidget] per bucket.
+  void _attachLabels(Map<int, Node> anchors, double width, double height) {
+    for (final MapEntry(key: bucket, value: anchor) in anchors.entries) {
+      _once(
+        anchor,
+        hostedSurface(
+          child: BlockMarkerWidget(
+            label: world.weekLabel(bucket),
+            heightMeters: height,
+            pxPerMeter: pxPerMeter,
+          ),
+          width: width,
+          height: height,
           pxPerMeter: pxPerMeter,
         ),
-        size: Size(signWidth * pxPerMeter, signHeight * pxPerMeter),
-        geometry: ccwQuad(signWidth, signHeight),
-        update: WidgetUpdatePolicy.manual,
-        input: WidgetInput.manual,
-        material: surface.material,
-        bind: surface.bind,
       );
-      entry.value.addComponent(component);
-      _markers.add(component);
     }
   }
 
@@ -126,25 +145,22 @@ class PlazaSurfaces {
   void _attachSkylineScreens(List<(Node, double, double, int)> screens) {
     for (final (anchor, w, h, rank) in screens) {
       if (rank >= world.anomalies.length) continue;
-      final surface = OpaqueSurface();
-      final component = WidgetComponent(
+      final component = hostedSurface(
         child: BillboardWidget(
           attention: world.anomalies[rank],
           widthMeters: w,
           heightMeters: h,
           pxPerMeter: pxPerMeter * 0.35,
           pulseSeconds: 4,
-          clock: clock,
+          clock: _far.clock,
         ),
-        size: Size(w * pxPerMeter * 0.35, h * pxPerMeter * 0.35),
-        geometry: ccwQuad(w, h),
-        update: WidgetUpdatePolicy.manual,
-        input: WidgetInput.manual,
-        material: surface.material,
-        bind: surface.bind,
+        width: w,
+        height: h,
+        pxPerMeter: pxPerMeter,
+        scale: 0.35,
       );
       anchor.addComponent(component);
-      _skylineScreens.add(component);
+      _captures.timed(_far, TimedSurface.posed(component.controller, anchor));
     }
   }
 
@@ -157,24 +173,22 @@ class PlazaSurfaces {
       final label = world.categoryLabels.isEmpty
           ? 'open late'
           : world.categoryLabelOf(task);
-      final surface = OpaqueSurface();
-      final component = WidgetComponent(
-        child: BannerWidget(
-          label: label,
-          color: PlazaStyle.neon(PlazaStyle.categoryBright(task)),
-          widthMeters: w,
-          heightMeters: h,
-          pxPerMeter: pxPerMeter * 0.6,
+      _once(
+        anchor,
+        hostedSurface(
+          child: BannerWidget(
+            label: label,
+            color: PlazaStyle.neon(PlazaStyle.categoryBright(task)),
+            widthMeters: w,
+            heightMeters: h,
+            pxPerMeter: pxPerMeter * 0.6,
+          ),
+          width: w,
+          height: h,
+          pxPerMeter: pxPerMeter,
+          scale: 0.6,
         ),
-        size: Size(w * pxPerMeter * 0.6, h * pxPerMeter * 0.6),
-        geometry: ccwQuad(w, h),
-        update: WidgetUpdatePolicy.manual,
-        input: WidgetInput.manual,
-        material: surface.material,
-        bind: surface.bind,
       );
-      anchor.addComponent(component);
-      _banners.add(component);
     }
   }
 
@@ -187,36 +201,32 @@ class PlazaSurfaces {
       final label = world.categoryLabels.isEmpty
           ? PlazaStyle.chip(world.attentionOf(task)).label
           : world.categoryLabelOf(task);
-      final surface = OpaqueSurface();
-      final component = WidgetComponent(
-        child: BannerWidget(
-          label: label,
-          color: PlazaStyle.neon(PlazaStyle.categoryBright(task)),
-          widthMeters: banner.width,
-          heightMeters: banner.height,
+      _once(
+        anchor,
+        hostedSurface(
+          child: BannerWidget(
+            label: label,
+            color: PlazaStyle.neon(PlazaStyle.categoryBright(task)),
+            widthMeters: banner.width,
+            heightMeters: banner.height,
+            pxPerMeter: pxPerMeter,
+          ),
+          width: banner.width,
+          height: banner.height,
           pxPerMeter: pxPerMeter,
         ),
-        size: Size(banner.width * pxPerMeter, banner.height * pxPerMeter),
-        geometry: ccwQuad(banner.width, banner.height),
-        update: WidgetUpdatePolicy.manual,
-        input: WidgetInput.manual,
-        material: surface.material,
-        bind: surface.bind,
       );
-      anchor.addComponent(component);
-      _banners.add(component);
     }
   }
 
-  /// While true the jumbotron holds its project card: the tour and a
-  /// fly-to set it on arrival so the masthead is what you land on.
+  /// While true the jumbotron holds its project card: the tour's
+  /// jumbotron stop sets it so the masthead is what the capture shows.
   final pinJumbotron = ValueNotifier<bool>(false);
 
   void _attachJumbotron(Node? anchor) {
     final slot = world.jumbotron;
     if (anchor == null || slot == null) return;
-    final surface = OpaqueSurface();
-    final component = WidgetComponent(
+    final component = hostedSurface(
       child: JumbotronWidget(
         projectLabel: world.projectLabel,
         taskCount: world.liveTaskCount,
@@ -229,45 +239,29 @@ class PlazaSurfaces {
         ],
         widthMeters: slot.width,
         pxPerMeter: pxPerMeter * 0.5,
-        clock: clock,
+        clock: _jumbotron.clock,
       ),
-      size: Size(slot.width * pxPerMeter * 0.5, slot.height * pxPerMeter * 0.5),
-      geometry: ccwQuad(slot.width, slot.height),
-      update: WidgetUpdatePolicy.manual,
-      input: WidgetInput.manual,
-      material: surface.material,
-      bind: surface.bind,
+      width: slot.width,
+      height: slot.height,
+      pxPerMeter: pxPerMeter,
+      scale: 0.5,
     );
     anchor.addComponent(component);
-    _jumbotron = component;
-  }
-
-  void _attachMarkers() {
-    for (final entry in markerAnchors.entries) {
-      final surface = OpaqueSurface();
-      final component = WidgetComponent(
-        child: BlockMarkerWidget(
-          label: world.weekLabel(entry.key),
-          heightMeters: markerHeight,
-          pxPerMeter: pxPerMeter,
-        ),
-        size: Size(markerWidth * pxPerMeter, markerHeight * pxPerMeter),
-        geometry: ccwQuad(markerWidth, markerHeight),
-        update: WidgetUpdatePolicy.manual,
-        input: WidgetInput.manual,
-        material: surface.material,
-        bind: surface.bind,
-      );
-      entry.value.addComponent(component);
-      _markers.add(component);
-    }
+    _captures.timed(
+      _jumbotron,
+      TimedSurface.facing(
+        controller: component.controller,
+        node: anchor,
+        center: Vector3(slot.x, slot.centerY, slot.z),
+        facingRadians: slot.facingRadians,
+      ),
+    );
   }
 
   void _attachBillboards() {
     for (final billboard in billboards) {
       final slot = billboard.slot;
-      final surface = OpaqueSurface();
-      final component = WidgetComponent(
+      final component = hostedSurface(
         child: BillboardWidget(
           attention: billboard.attention,
           widthMeters: slot.width,
@@ -277,17 +271,28 @@ class PlazaSurfaces {
           // A roof panel sits over its own facade, which carries the
           // title: the panel leads with the reason instead.
           reasonFirst: slot.mount == BillboardMount.roof,
-          clock: clock,
+          clock: _near.clock,
         ),
-        size: Size(slot.width * pxPerMeter, slot.height * pxPerMeter),
-        geometry: ccwQuad(slot.width, slot.height),
-        update: WidgetUpdatePolicy.manual,
-        input: WidgetInput.manual,
-        material: surface.material,
-        bind: surface.bind,
+        width: slot.width,
+        height: slot.height,
+        pxPerMeter: pxPerMeter,
       );
       billboard.anchor.addComponent(component);
-      _billboardSurfaces.add((billboard.center, component, billboard.anchor));
+      final center = billboard.center;
+      _ranged.add((center, billboard.anchor));
+      // Only an anomaly breathes ([BillboardWidget] renders a still face
+      // below the threshold): the rest take the far cadence, seldom
+      // enough to cost nothing and often enough that a cover image that
+      // decodes after the first capture still lands on the panel.
+      _captures.timed(
+        billboard.attention.anomalous ? _near : _far,
+        TimedSurface.facing(
+          controller: component.controller,
+          node: billboard.anchor,
+          center: center,
+          facingRadians: slot.facingRadians,
+        ),
+      );
     }
   }
 
@@ -298,21 +303,17 @@ class PlazaSurfaces {
           Vector3(slot.x, slot.bottom + slot.height / 2, slot.z),
         )..rotateY(slot.facingRadians),
       );
-      final surface = OpaqueSurface();
-      final component = WidgetComponent(
+      final component = hostedSurface(
         child: TickerWidget(
           text: world.tickerTexts[slot] ?? world.tickerText,
           heightMeters: slot.height,
           pxPerMeter: pxPerMeter,
           speedMetersPerSecond: slot.speedMetersPerSecond,
-          clock: clock,
+          clock: _tickers.clock,
         ),
-        size: Size(slot.width * pxPerMeter, slot.height * pxPerMeter),
-        geometry: ccwQuad(slot.width, slot.height),
-        update: WidgetUpdatePolicy.manual,
-        input: WidgetInput.manual,
-        material: surface.material,
-        bind: surface.bind,
+        width: slot.width,
+        height: slot.height,
+        pxPerMeter: pxPerMeter,
       );
       anchor.addComponent(component);
       // Housing: a dark track behind the band with a thin teal rim and
@@ -346,65 +347,42 @@ class PlazaSurfaces {
         );
       }
       scene.add(anchor);
-      _tickerSurfaces.add((
-        Vector3(slot.x, slot.bottom, slot.z),
-        component,
-        anchor,
-      ));
+      final origin = Vector3(slot.x, slot.bottom, slot.z);
+      _ranged.add((origin, anchor));
+      _captures.timed(
+        _tickers,
+        TimedSurface.facing(
+          controller: component.controller,
+          node: anchor,
+          center: origin,
+          facingRadians: slot.facingRadians,
+        ),
+      );
     }
   }
 
   /// Once per painted frame, at [seconds] on the harness clock: keeps
   /// asking for the one-off captures until they land, hides the plaza's
-  /// animated surfaces when they are out of range, and asks every timed
-  /// surface in range for a capture once its interval is up.
-  void update(Vector3 eye, double seconds) {
-    for (final once in [..._markers, ..._banners]) {
-      final controller = once.controller;
-      if (controller.texture == null) controller.requestCapture();
+  /// animated surfaces beyond [plazaRange], and asks every timed surface
+  /// in view for a capture once its interval is up, advancing that
+  /// cadence's clock first so its widgets rebuild in the same frame.
+  /// [forward] is the camera's view direction: with it a surface behind
+  /// the eye or facing away from it is not captured; without it nothing is
+  /// culled.
+  void update(Vector3 eye, double seconds, {Vector3? forward}) {
+    _captures.requestPending();
+    for (final (center, node) in _ranged) {
+      node.visible = eye.distanceTo(center) <= plazaRange;
     }
-    for (final (center, component, node) in _billboardSurfaces) {
-      node.visible = (center - eye).length <= plazaRange;
-      if (node.visible) _captureDue(component, seconds, nearInterval);
-    }
-    for (final (origin, component, node) in _tickerSurfaces) {
-      node.visible = (origin - eye).length <= plazaRange;
-      if (node.visible) _captureDue(component, seconds, tickerInterval);
-    }
-    for (final screen in _skylineScreens) {
-      _captureDue(screen, seconds, farInterval);
-    }
-    if (_jumbotron case final jumbotron?) {
-      _captureDue(jumbotron, seconds, jumbotronInterval);
-    }
-  }
-
-  /// Asks [component] for a capture when [interval] seconds have passed
-  /// since the last request (or none was ever made).
-  void _captureDue(WidgetComponent component, double seconds, double interval) {
-    final last = _lastCapture[component];
-    if (last != null && seconds - last < interval - 1e-6) return;
-    _lastCapture[component] = seconds;
-    component.controller.requestCapture();
+    _captures
+      ..requestDue(_near, eye, seconds, forward: forward)
+      ..requestDue(_tickers, eye, seconds, forward: forward)
+      ..requestDue(_far, eye, seconds, forward: forward)
+      ..requestDue(_jumbotron, eye, seconds, forward: forward);
   }
 
   /// Total captures across these surfaces, for the debug overlay.
-  int get captures {
-    var n = 0;
-    for (final m in _markers) {
-      n += m.controller.captureCount;
-    }
-    for (final (_, c, _) in _billboardSurfaces) {
-      n += c.controller.captureCount;
-    }
-    for (final (_, c, _) in _tickerSurfaces) {
-      n += c.controller.captureCount;
-    }
-    for (final b in [..._banners, ..._skylineScreens]) {
-      n += b.controller.captureCount;
-    }
-    return n + (_jumbotron?.controller.captureCount ?? 0);
-  }
+  int get captures => _captures.captures;
 
   /// The pose in front of a billboard, for the tour and for taps on it.
   static CameraPose facingPose(BillboardSlot slot, {double? distance}) {

--- a/lib/features/plaza/scene/plaza_world.dart
+++ b/lib/features/plaza/scene/plaza_world.dart
@@ -42,23 +42,18 @@ class PlazaWorld {
     weekSigns = weekSignsFor(plan, roadWidth: layout.roadWidth);
     final mounted = mountedSlotsFor(plan);
     mountedScreens = mounted.screens;
-    tickers = [
-      ...mounted.tickers,
-      ?gantry,
-      for (final (i, hero) in heroes.indexed)
-        rooflineTickerFor(plan.placements[hero.task.id]!, fast: i.isEven),
-    ];
     // A band on a building speaks for that building; the gantry counts
     // the district; the hero rooflines carry the headlines.
     final mountTasks = plazaMounts(plan);
-    tickerTexts = {
+    tickerTexts = Map.unmodifiable({
       for (final (i, slot) in mounted.tickers.indexed)
         slot: _ownTickerText(mountTasks[i].taskId),
       ?gantry: countsText,
-      for (final hero in heroes)
-        tickers[tickers.length - heroes.length + heroes.indexOf(hero)]:
+      for (final (i, hero) in heroes.indexed)
+        rooflineTickerFor(plan.placements[hero.task.id]!, fast: i.isEven):
             tickerText,
-    };
+    });
+    tickers = List.unmodifiable(tickerTexts.keys);
     scenery = sceneryFor(
       plan,
       plaza: plaza,
@@ -90,8 +85,15 @@ class PlazaWorld {
   /// Category names keyed by colour hex, for the side panel.
   final Map<String, String> categoryLabels;
 
-  /// What each ticker band scrolls.
+  /// What each ticker band scrolls, in band order: the mounted bands, the
+  /// gantry, the hero rooflines.
   late final Map<TickerSlot, String> tickerTexts;
+
+  /// The bands, in the order of [tickerTexts].
+  late final List<TickerSlot> tickers;
+
+  /// What separates the items on a band.
+  static const _separator = '   ·   ';
 
   /// A building's own band: its state word with the glyph, then the
   /// reason or the due date — short, so a narrow band never cuts a word
@@ -100,30 +102,14 @@ class PlazaWorld {
     final a = attention[taskId];
     if (a == null) return countsText;
     final parts = <String>[
-      '${_glyph(a.lantern)} ${_stateWord(a.lantern)}',
+      '${a.lantern.glyph} ${a.lantern.word}',
       if (a.reason.isNotEmpty)
         a.reason
       else if (a.task.due != null)
         'due ${shortDate(a.task.due!)}',
     ];
-    return parts.join('   ·   ');
+    return parts.join(_separator);
   }
-
-  static String _glyph(LanternState state) => switch (state) {
-    LanternState.blocked => '✕',
-    LanternState.overdue => '!',
-    LanternState.inProgress => '▶',
-    LanternState.open => '○',
-    LanternState.off => '✓',
-  };
-
-  static String _stateWord(LanternState state) => switch (state) {
-    LanternState.blocked => 'blocked',
-    LanternState.overdue => 'overdue',
-    LanternState.inProgress => 'in progress',
-    LanternState.open => 'open',
-    LanternState.off => 'done',
-  };
 
   late final StreetPlan plan;
   late final FrontierPlaza? plaza;
@@ -171,7 +157,6 @@ class PlazaWorld {
 
   /// Eye-level week signs at each block head: (bucket, x, z, facing).
   late final List<(int, double, double, double)> weekSigns;
-  late final List<TickerSlot> tickers;
 
   /// Attention verdict for each roof billboard, in slot order.
   List<TaskAttention> get roofBillboardTasks => [
@@ -180,7 +165,9 @@ class PlazaWorld {
 
   /// The two tallest buildings that carry no roof billboard take the
   /// roofline tickers, so a ticker never covers a billboard.
-  List<TaskAttention> get heroes {
+  late final List<TaskAttention> heroes = _heroes();
+
+  List<TaskAttention> _heroes() {
     final roofed = {for (final s in roofBillboards) anomalies[s.rank].task.id};
     final candidates =
         plan.placements.values
@@ -189,11 +176,10 @@ class PlazaWorld {
                   !roofed.contains(p.taskId) && attention.containsKey(p.taskId),
             )
             .toList()
-          ..sort((a, b) {
-            final byHeight = b.height.compareTo(a.height);
-            return byHeight != 0 ? byHeight : a.taskId.compareTo(b.taskId);
-          });
-    return [for (final p in candidates.take(2)) attention[p.taskId]!];
+          ..sort(tallestFirst);
+    return List.unmodifiable([
+      for (final p in candidates.take(2)) attention[p.taskId]!,
+    ]);
   }
 
   /// The billboard slots in rank order: four pylons, then the mounted
@@ -226,37 +212,33 @@ class PlazaWorld {
 
   int get liveTaskCount => tasks.where((t) => !t.deleted).length;
 
-  /// The gantry's line: the project's numbers, no headlines (those are on
-  /// the pylons and the mounted screens already).
-  String get countsText {
+  /// The project and its attention count: how every district band opens.
+  List<String> get _opening => [
+    projectLabel,
+    '${anomalies.length} need attention',
+  ];
+
+  /// The progress counts every district band carries.
+  List<String> get _progress {
     final inProgress = tasks
         .where((t) => t.state == PlazaTaskState.inProgress)
         .length;
     final done = tasks.where((t) => t.state == PlazaTaskState.done).length;
-    return [
-      projectLabel,
-      '${anomalies.length} need attention',
-      '$inProgress in progress',
-      '$done of $liveTaskCount done',
-      'W$builtWeeks',
-    ].join('   ·   ');
+    return ['$inProgress in progress', '$done of $liveTaskCount done'];
   }
+
+  /// The gantry's line: the project's numbers, no headlines (those are on
+  /// the pylons and the mounted screens already).
+  String get countsText =>
+      [..._opening, ..._progress, 'W$builtWeeks'].join(_separator);
 
   /// The scrolling headline: project, attention count, the top three
   /// reasons, progress counts.
-  String get tickerText {
-    final inProgress = tasks
-        .where((t) => t.state == PlazaTaskState.inProgress)
-        .length;
-    final done = tasks.where((t) => t.state == PlazaTaskState.done).length;
-    return [
-      projectLabel,
-      '${anomalies.length} need attention',
-      for (final a in anomalies.take(3)) '${a.task.title} — ${a.reason}',
-      '$inProgress in progress',
-      '$done of $liveTaskCount done',
-    ].join('   ·   ');
-  }
+  String get tickerText => [
+    ..._opening,
+    for (final a in anomalies.take(3)) '${a.task.title} — ${a.reason}',
+    ..._progress,
+  ].join(_separator);
 
   /// The morning walk's stops, or null for a street with no plaza.
   List<WalkStop>? get walkStops {

--- a/lib/features/plaza/scene/surface_captures.dart
+++ b/lib/features/plaza/scene/surface_captures.dart
@@ -1,0 +1,220 @@
+import 'dart:math' as math;
+import 'dart:ui' show Size;
+
+import 'package:flutter/foundation.dart' show ValueListenable, ValueNotifier;
+import 'package:flutter/widgets.dart' show Widget;
+import 'package:flutter_scene/scene.dart';
+import 'package:lotti/features/plaza/scene/plaza_scene.dart';
+import 'package:vector_math/vector_math.dart' show Vector3;
+
+/// A widget surface for the plaza: [child] laid out at [pxPerMeter] ×
+/// [scale] logical pixels a metre on a [ccwQuad] of [width] × [height]
+/// metres, over an [OpaqueSurface].
+///
+/// Every plaza surface is a [WidgetUpdatePolicy.manual] component: an
+/// interval policy would make flutter_scene pump an engine frame on every
+/// vsync, whatever the harness paints, so captures are requested from the
+/// harness clock through [SurfaceCaptures]. [input] is manual unless the
+/// surface takes pointer input (a live facade).
+WidgetComponent hostedSurface({
+  required Widget child,
+  required double width,
+  required double height,
+  required double pxPerMeter,
+  double scale = 1,
+  WidgetInput input = WidgetInput.manual,
+}) {
+  final surface = OpaqueSurface();
+  return WidgetComponent(
+    child: child,
+    size: Size(width * pxPerMeter * scale, height * pxPerMeter * scale),
+    geometry: ccwQuad(width, height),
+    update: WidgetUpdatePolicy.manual,
+    input: input,
+    material: surface.material,
+    bind: surface.bind,
+  );
+}
+
+/// A surface captured on a [CaptureCadence]: its capture controller, the
+/// node whose visibility gates it, and where it stands and faces, so a
+/// capture the camera cannot see is not requested.
+class TimedSurface {
+  TimedSurface({
+    required this.controller,
+    required this.node,
+    required this.center,
+    required this.normal,
+  });
+
+  /// A vertical surface at [center] whose front faces [facingRadians]
+  /// (the plaza's yaw convention: the front is at `+sin`, `+cos`).
+  TimedSurface.facing({
+    required WidgetTextureController controller,
+    required Node node,
+    required Vector3 center,
+    required double facingRadians,
+  }) : this(
+         controller: controller,
+         node: node,
+         center: center,
+         normal: Vector3(math.sin(facingRadians), 0, math.cos(facingRadians)),
+       );
+
+  /// A surface read off [node]'s world transform as it stands now: its
+  /// translation is the centre and its local `+z` axis is the front, the
+  /// way a [ccwQuad] faces. The node must be in its final pose.
+  factory TimedSurface.posed(WidgetTextureController controller, Node node) {
+    final transform = node.globalTransform;
+    return TimedSurface(
+      controller: controller,
+      node: node,
+      center: transform.getTranslation(),
+      normal: Vector3(
+        transform.entry(0, 2),
+        transform.entry(1, 2),
+        transform.entry(2, 2),
+      )..normalize(),
+    );
+  }
+
+  final WidgetTextureController controller;
+
+  /// The node the surface hangs on: hidden nodes are not captured.
+  final Node node;
+
+  /// World position of the surface.
+  final Vector3 center;
+
+  /// Unit outward normal of the front.
+  final Vector3 normal;
+
+  /// Harness seconds of the last capture request; the first is free.
+  double lastRequest = double.negativeInfinity;
+
+  /// A surface whose centre has passed the eye by no more than this is
+  /// still in view: a wide band overhead (the gantry) or one the walker
+  /// is passing shows its near end after its centre has gone by.
+  static const behindMargin = 4.0;
+
+  /// Whether a camera at [eye] looking along [forward] can see the front:
+  /// the surface is not behind the eye (by more than [behindMargin]), and
+  /// the eye is not behind the surface. Scalar maths; nothing is
+  /// allocated.
+  bool seenFrom(Vector3 eye, Vector3 forward) {
+    final dx = center.x - eye.x;
+    final dy = center.y - eye.y;
+    final dz = center.z - eye.z;
+    return dx * forward.x + dy * forward.y + dz * forward.z >= -behindMargin &&
+        dx * normal.x + dy * normal.y + dz * normal.z <= 0;
+  }
+}
+
+/// The surfaces captured every [interval] seconds and the clock their
+/// widgets read.
+///
+/// The clock is advanced to the harness time only when a capture is
+/// requested ([SurfaceCaptures.requestDue]), so a hosted widget rebuilds
+/// once per capture, in the frame of the request, instead of once per
+/// painted frame with most of the work thrown away.
+class CaptureCadence {
+  CaptureCadence(this.interval);
+
+  final double interval;
+  final List<TimedSurface> surfaces = [];
+  final ValueNotifier<double> _clock = ValueNotifier(0);
+
+  /// Elapsed harness seconds as of this cadence's last capture request.
+  ValueListenable<double> get clock => _clock;
+}
+
+/// Manual capture bookkeeping for a set of widget surfaces, shared by
+/// `PlazaSurfaces` and `FacadeLodManager`: one-off captures re-requested
+/// until they land, cadenced captures throttled per surface and skipped
+/// while the camera cannot see them, and the counters the overlay shows.
+class SurfaceCaptures {
+  final List<WidgetTextureController> _pendingOnce = [];
+  final Set<WidgetTextureController> _tracked = {};
+
+  /// A capture request is due once this much of the interval has passed:
+  /// a frame landing a hair early still counts.
+  static const _slack = 1e-6;
+
+  /// Registers a surface captured once. The host attaches a frame after
+  /// the component does, so [requestPending] keeps asking until the first
+  /// capture lands.
+  void once(WidgetTextureController controller) {
+    _tracked.add(controller);
+    _pendingOnce.add(controller);
+  }
+
+  /// Registers [surface] on [cadence].
+  void timed(CaptureCadence cadence, TimedSurface surface) {
+    _tracked.add(surface.controller);
+    cadence.surfaces.add(surface);
+  }
+
+  /// Drops a surface that was detached from its node: it is no longer
+  /// requested or counted. [cadence] is the one it was registered on.
+  void forget(WidgetTextureController controller, {CaptureCadence? cadence}) {
+    _tracked.remove(controller);
+    _pendingOnce.remove(controller);
+    cadence?.surfaces.removeWhere((s) => s.controller == controller);
+  }
+
+  /// Re-requests every one-off capture that has not landed yet, and stops
+  /// asking for those that have, so the list empties after the first
+  /// frames.
+  void requestPending() {
+    for (var i = _pendingOnce.length - 1; i >= 0; i--) {
+      final controller = _pendingOnce[i];
+      if (controller.captureCount > 0) {
+        _pendingOnce.removeAt(i);
+      } else {
+        controller.requestCapture();
+      }
+    }
+  }
+
+  /// Asks every visible surface of [cadence] for a capture once its
+  /// interval is up at [seconds], advancing the cadence's clock to
+  /// [seconds] immediately before each request so the widget rebuilds in
+  /// the same frame. With [forward] (the camera's view direction) a
+  /// surface behind the eye or facing away from it is skipped; without it
+  /// nothing is culled.
+  void requestDue(
+    CaptureCadence cadence,
+    Vector3 eye,
+    double seconds, {
+    Vector3? forward,
+  }) {
+    for (final surface in cadence.surfaces) {
+      if (!surface.node.visible) continue;
+      if (forward != null && !surface.seenFrom(eye, forward)) continue;
+      if (seconds - surface.lastRequest < cadence.interval - _slack) continue;
+      surface.lastRequest = seconds;
+      cadence._clock.value = seconds;
+      surface.controller.requestCapture();
+    }
+  }
+
+  /// Total captures across every registered surface.
+  int get captures {
+    var n = 0;
+    for (final controller in _tracked) {
+      n += controller.captureCount;
+    }
+    return n;
+  }
+
+  /// The longest of the registered surfaces' most recent captures.
+  Duration get lastCaptureDuration {
+    var longest = Duration.zero;
+    for (final controller in _tracked) {
+      if (controller.lastCaptureDuration > longest) {
+        longest = controller.lastCaptureDuration;
+      }
+    }
+    return longest;
+  }
+}

--- a/lib/features/plaza/scene/wall_textures.dart
+++ b/lib/features/plaza/scene/wall_textures.dart
@@ -73,7 +73,9 @@ class WallTextures {
     final shops = <(LanternState, int), Texture2D>{};
     for (final state in LanternState.values) {
       for (var f = 0; f < tileFamilies; f++) {
-        map[(state, f)] = await Texture2D.fromImage(_paint(state, family: f));
+        map[(state, f)] = await Texture2D.fromImage(
+          paintWindows(state, family: f),
+        );
       }
       for (var v = 0; v < paradeVariants; v++) {
         shops[(state, v)] = await Texture2D.fromImage(
@@ -1157,17 +1159,14 @@ class WallTextures {
   /// Paints the window tile for [state] in tile [family]; public so the
   /// occupancy contract can be checked without a GPU.
   @visibleForTesting
-  static ui.Image paintWindows(LanternState state, {int family = 0}) =>
-      _paint(state, family: family);
-
-  static ui.Image _paint(LanternState state, {int family = 0}) {
+  static ui.Image paintWindows(LanternState state, {int family = 0}) {
     const w = bays * _px;
     const h = floors * _px;
     final recorder = ui.PictureRecorder();
     final canvas = ui.Canvas(recorder)
       ..drawRect(
         ui.Rect.fromLTWH(0, 0, w.toDouble(), h.toDouble()),
-        ui.Paint()..color = const ui.Color(0xFF0B0A14),
+        ui.Paint()..color = _night,
       );
     final rng = math.Random(state.index * 7919 + 17 + family * 101);
     final tint = _tints[state]!;
@@ -1202,7 +1201,7 @@ class WallTextures {
             : 0.14 + rng.nextDouble() * 0.1;
         // Reveal: a dark frame around the pane; then the pane with a
         // sill-to-lintel gradient; then mullion and transom.
-        final mullion = ui.Paint()..color = const ui.Color(0xFF07060D);
+        final mullion = ui.Paint()..color = _frame;
         canvas
           ..drawRect(
             rect.inflate(_px * 0.03),
@@ -1250,7 +1249,7 @@ class WallTextures {
       canvas
         ..drawRect(
           ui.Rect.fromLTWH(0, floor * _px.toDouble(), w.toDouble(), 6),
-          ui.Paint()..color = const ui.Color(0xFF07060D),
+          ui.Paint()..color = _frame,
         )
         ..drawRect(
           ui.Rect.fromLTWH(0, floor * _px.toDouble() + 6, w.toDouble(), 3),

--- a/lib/features/plaza/ui/billboard_widget.dart
+++ b/lib/features/plaza/ui/billboard_widget.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart' show ValueListenable;
 import 'package:flutter/material.dart';
 import 'package:lotti/features/plaza/domain/attention.dart';
+import 'package:lotti/features/plaza/ui/plaza_chip.dart';
 import 'package:lotti/features/plaza/ui/plaza_style.dart';
 
 /// A frontier-plaza billboard: the headline for one task that needs
@@ -117,25 +118,11 @@ class _BillboardFace extends StatelessWidget {
             child: FittedBox(
               fit: BoxFit.scaleDown,
               alignment: Alignment.centerLeft,
-              child: Container(
-                padding: EdgeInsets.symmetric(
-                  horizontal: chipPx * 0.8,
-                  vertical: chipPx * 0.25,
-                ),
-                decoration: BoxDecoration(
-                  color: chip.fill,
-                  borderRadius: BorderRadius.circular(chipPx * 0.35),
-                ),
-                child: Text(
-                  '${PlazaStyle.glyph(attention)}  ${chip.label}',
-                  style: TextStyle(
-                    fontFamily: PlazaStyle.fontText,
-                    fontSize: chipPx,
-                    fontWeight: FontWeight.w700,
-                    letterSpacing: chipPx * 0.05,
-                    color: chip.ink,
-                  ),
-                ),
+              child: PlazaChip(
+                label: '${PlazaStyle.glyph(attention)}  ${chip.label}',
+                fill: chip.fill,
+                ink: chip.ink,
+                fontPx: chipPx,
               ),
             ),
           ),
@@ -143,25 +130,11 @@ class _BillboardFace extends StatelessWidget {
         if (!reasonFirst) SizedBox(width: chipPx * 0.6),
         if (!reasonFirst)
           // The call to action is a chip like the state, not loose type.
-          Container(
-            padding: EdgeInsets.symmetric(
-              horizontal: chipPx * 0.8,
-              vertical: chipPx * 0.25,
-            ),
-            decoration: BoxDecoration(
-              color: PlazaStyle.teal,
-              borderRadius: BorderRadius.circular(chipPx * 0.35),
-            ),
-            child: Text(
-              'fly there ›',
-              style: TextStyle(
-                fontFamily: PlazaStyle.fontText,
-                fontSize: chipPx,
-                fontWeight: FontWeight.w700,
-                letterSpacing: chipPx * 0.05,
-                color: const Color(0xFF0D0D0D),
-              ),
-            ),
+          PlazaChip(
+            label: 'fly there ›',
+            fill: PlazaStyle.teal,
+            ink: const Color(0xFF0D0D0D),
+            fontPx: chipPx,
           ),
       ],
     );

--- a/lib/features/plaza/ui/facade_widget.dart
+++ b/lib/features/plaza/ui/facade_widget.dart
@@ -5,6 +5,7 @@ import 'package:lotti/features/design_system/theme/icon_tokens.dart';
 import 'package:lotti/features/plaza/domain/attention.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/features/plaza/ui/checklist_ticks.dart';
+import 'package:lotti/features/plaza/ui/plaza_chip.dart';
 import 'package:lotti/features/plaza/ui/plaza_style.dart';
 
 /// Which range a facade is drawn for.
@@ -85,10 +86,7 @@ class FacadeWidget extends StatelessWidget {
     final tickedCount = t?.tickedCount(task.id) ?? 0;
     final total = task.checklistItems;
     final done = task.checklistItems - items.length + tickedCount;
-    final metaBits = <String>[
-      if (task.due != null) 'due ${shortDate(task.due!)}',
-      if (task.linkedTaskIds.isNotEmpty) 'links ${task.linkedTaskIds.length}',
-    ];
+    final metaBits = taskMetaBits(task);
 
     // A finished shop is dark: everything on it steps down.
     final quiet = attention.lantern == LanternState.off;
@@ -321,7 +319,7 @@ class FacadeWidget extends StatelessWidget {
                                               child: Row(
                                                 mainAxisSize: MainAxisSize.min,
                                                 children: [
-                                                  _Chip(
+                                                  PlazaChip(
                                                     label:
                                                         '${PlazaStyle.glyph(attention)} '
                                                         '${chip.label}',
@@ -331,7 +329,7 @@ class FacadeWidget extends StatelessWidget {
                                                   ),
                                                   if (onOpen != null) ...[
                                                     SizedBox(width: m(0.3)),
-                                                    _Chip(
+                                                    PlazaChip(
                                                       label: 'DETAILS ›',
                                                       fill: PlazaStyle.teal,
                                                       ink: const Color(
@@ -478,54 +476,6 @@ class _Item extends StatelessWidget {
           ],
         ),
       ),
-    );
-  }
-}
-
-/// A state chip (or the OPEN button when [onTap] is set).
-class _Chip extends StatelessWidget {
-  const _Chip({
-    required this.label,
-    required this.fill,
-    required this.ink,
-    required this.fontPx,
-    this.onTap,
-  });
-
-  final String label;
-  final Color fill;
-  final Color ink;
-  final double fontPx;
-  final VoidCallback? onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final child = Container(
-      padding: EdgeInsets.symmetric(
-        horizontal: fontPx * 0.8,
-        vertical: fontPx * 0.25,
-      ),
-      decoration: BoxDecoration(
-        color: fill,
-        borderRadius: BorderRadius.circular(fontPx * 0.35),
-      ),
-      child: Text(
-        label,
-        style: TextStyle(
-          fontFamily: PlazaStyle.fontText,
-          fontSize: fontPx,
-          fontWeight: FontWeight.w700,
-          letterSpacing: fontPx * 0.05,
-          color: ink,
-        ),
-      ),
-    );
-    if (onTap == null) return child;
-    return InkWell(
-      onTap: onTap,
-      hoverColor: PlazaStyle.tealHover,
-      borderRadius: BorderRadius.circular(fontPx * 0.35),
-      child: child,
     );
   }
 }

--- a/lib/features/plaza/ui/fly_camera_controller.dart
+++ b/lib/features/plaza/ui/fly_camera_controller.dart
@@ -61,9 +61,6 @@ class FlyCameraController {
   /// Called when a flight lands.
   void Function()? onArrived;
 
-  /// Called when movement input cancels a flight.
-  void Function()? onFlightCancelled;
-
   /// Called on any movement input (used to abandon the morning walk).
   void Function()? onMovement;
 
@@ -153,20 +150,10 @@ class FlyCameraController {
   static const double _landingAbove = eyeHeight + 1.5;
 
   void _movementInput() {
-    if (_flight != null) {
-      final flight = _flight!;
-      _flight = null;
-      onFlightCancelled?.call();
-      // Cancelled mid-arc: come down before walking.
-      if (flight.arc > 0 && _pose.y > _landingAbove) {
-        _land();
-        onMovement?.call();
-        return;
-      }
-    } else if (_pose.y > _landingAbove) {
-      // From the overview: a short landing flight, not a one-frame drop.
-      _land();
-    }
+    _flight = null;
+    // Aloft — from the overview, or a flight cut short over the street or
+    // mid-arc — a short landing flight, not a one-frame drop.
+    if (_pose.y > _landingAbove) _land();
     onMovement?.call();
   }
 
@@ -186,10 +173,7 @@ class FlyCameraController {
 
   /// Mouse-drag look, in logical pixels. Cancels a flight in place.
   void addLookDelta(double dx, double dy) {
-    if (_flight != null) {
-      _flight = null;
-      onFlightCancelled?.call();
-    }
+    _flight = null;
     _pose = CameraPose(
       x: _pose.x,
       y: _pose.y,

--- a/lib/features/plaza/ui/fly_camera_controller.dart
+++ b/lib/features/plaza/ui/fly_camera_controller.dart
@@ -101,7 +101,7 @@ class FlyCameraController {
   /// From one stop on the ground to another the flight follows the street
   /// network; a climb, a dive or a world without a street takes the direct
   /// line. Both are swept over every solid on the way.
-  Flight flyTo(CameraPose target, {double timeScale = 1}) {
+  Flight flyTo(CameraPose target) {
     final network = _network;
     final onGround = _pose.y <= groundCeiling && target.y <= groundCeiling;
     final flight = network != null && onGround
@@ -113,10 +113,9 @@ class FlyCameraController {
               (target.x, target.z),
               join: Flight.joinDistance,
             ),
-            timeScale: timeScale,
             solids: _solids,
           )
-        : Flight.plan(_pose, target, timeScale: timeScale, solids: _solids);
+        : Flight.plan(_pose, target, solids: _solids);
     _flight = flight;
     return flight;
   }

--- a/lib/features/plaza/ui/fly_camera_controller.dart
+++ b/lib/features/plaza/ui/fly_camera_controller.dart
@@ -68,6 +68,7 @@ class FlyCameraController {
   set pose(CameraPose value) {
     _pose = value;
     _flight = null;
+    _landing = false;
     _vForward = 0;
     _vStrafe = 0;
   }
@@ -114,6 +115,7 @@ class FlyCameraController {
           )
         : Flight.plan(_pose, target, solids: _solids);
     _flight = flight;
+    _landing = false;
     return flight;
   }
 
@@ -149,7 +151,12 @@ class FlyCameraController {
   /// Above this height a movement key lands the camera first.
   static const double _landingAbove = eyeHeight + 1.5;
 
+  /// Whether the flight under way is a landing: a held key's repeats
+  /// must not restart it from rest every few milliseconds.
+  bool _landing = false;
+
   void _movementInput() {
+    if (_landing) return;
     _flight = null;
     // Aloft — from the overview, or a flight cut short over the street or
     // mid-arc — a short landing flight, not a one-frame drop.
@@ -169,11 +176,13 @@ class FlyCameraController {
       CameraPose(x: x, y: eyeHeight, z: z, yaw: _pose.yaw),
       solids: _solids,
     );
+    _landing = true;
   }
 
   /// Mouse-drag look, in logical pixels. Cancels a flight in place.
   void addLookDelta(double dx, double dy) {
     _flight = null;
+    _landing = false;
     _pose = CameraPose(
       x: _pose.x,
       y: _pose.y,
@@ -195,6 +204,7 @@ class FlyCameraController {
       );
       if (flight.done) {
         _flight = null;
+        _landing = false;
         onArrived?.call();
       }
       return;

--- a/lib/features/plaza/ui/jumbotron_widget.dart
+++ b/lib/features/plaza/ui/jumbotron_widget.dart
@@ -17,7 +17,6 @@ class JumbotronWidget extends StatelessWidget {
     required this.widthMeters,
     required this.pxPerMeter,
     required this.clock,
-    this.coverSeconds = 5,
     this.pinProjectCard,
     super.key,
   });
@@ -37,7 +36,9 @@ class JumbotronWidget extends StatelessWidget {
   final List<String> covers;
   final double widthMeters;
   final double pxPerMeter;
-  final double coverSeconds;
+
+  /// How long each cover holds before the next.
+  static const coverSeconds = 5.0;
 
   /// Elapsed seconds, advanced by the harness once per painted frame.
   final ValueListenable<double> clock;

--- a/lib/features/plaza/ui/plaza_chip.dart
+++ b/lib/features/plaza/ui/plaza_chip.dart
@@ -6,7 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:lotti/features/plaza/ui/plaza_style.dart';
 
 /// A chip of [label] in [ink] on [fill]; every measure is a fraction of
-/// [fontPx]. With [onTap] it is a button with the teal hover.
+/// [fontPx]. With [onTap] it is a button with the teal hover, and needs a
+/// [Material] ancestor to paint its fill on.
 class PlazaChip extends StatelessWidget {
   const PlazaChip({
     required this.label,
@@ -25,32 +26,32 @@ class PlazaChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final child = Container(
-      padding: EdgeInsets.symmetric(
-        horizontal: fontPx * 0.8,
-        vertical: fontPx * 0.25,
-      ),
-      decoration: BoxDecoration(
-        color: fill,
-        borderRadius: BorderRadius.circular(fontPx * 0.35),
-      ),
-      child: Text(
-        label,
-        style: TextStyle(
-          fontFamily: PlazaStyle.fontText,
-          fontSize: fontPx,
-          fontWeight: FontWeight.w700,
-          letterSpacing: fontPx * 0.05,
-          color: ink,
-        ),
+    final padding = EdgeInsets.symmetric(
+      horizontal: fontPx * 0.8,
+      vertical: fontPx * 0.25,
+    );
+    final radius = BorderRadius.circular(fontPx * 0.35);
+    final decoration = BoxDecoration(color: fill, borderRadius: radius);
+    final text = Text(
+      label,
+      style: TextStyle(
+        fontFamily: PlazaStyle.fontText,
+        fontSize: fontPx,
+        fontWeight: FontWeight.w700,
+        letterSpacing: fontPx * 0.05,
+        color: ink,
       ),
     );
-    if (onTap == null) return child;
+    if (onTap == null) {
+      return Container(padding: padding, decoration: decoration, child: text);
+    }
+    // Ink, not a Container: the fill goes on the Material's ink layer, so
+    // the hover wash and the splash show over it instead of under it.
     return InkWell(
       onTap: onTap,
       hoverColor: PlazaStyle.tealHover,
-      borderRadius: BorderRadius.circular(fontPx * 0.35),
-      child: child,
+      borderRadius: radius,
+      child: Ink(padding: padding, decoration: decoration, child: text),
     );
   }
 }

--- a/lib/features/plaza/ui/plaza_chip.dart
+++ b/lib/features/plaza/ui/plaza_chip.dart
@@ -1,0 +1,56 @@
+/// The plaza's chip: a state word on its fill, or a call to action, sized
+/// from the font it carries so it scales with the surface it sits on.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:lotti/features/plaza/ui/plaza_style.dart';
+
+/// A chip of [label] in [ink] on [fill]; every measure is a fraction of
+/// [fontPx]. With [onTap] it is a button with the teal hover.
+class PlazaChip extends StatelessWidget {
+  const PlazaChip({
+    required this.label,
+    required this.fill,
+    required this.ink,
+    required this.fontPx,
+    this.onTap,
+    super.key,
+  });
+
+  final String label;
+  final Color fill;
+  final Color ink;
+  final double fontPx;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final child = Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: fontPx * 0.8,
+        vertical: fontPx * 0.25,
+      ),
+      decoration: BoxDecoration(
+        color: fill,
+        borderRadius: BorderRadius.circular(fontPx * 0.35),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontFamily: PlazaStyle.fontText,
+          fontSize: fontPx,
+          fontWeight: FontWeight.w700,
+          letterSpacing: fontPx * 0.05,
+          color: ink,
+        ),
+      ),
+    );
+    if (onTap == null) return child;
+    return InkWell(
+      onTap: onTap,
+      hoverColor: PlazaStyle.tealHover,
+      borderRadius: BorderRadius.circular(fontPx * 0.35),
+      child: child,
+    );
+  }
+}

--- a/lib/features/plaza/ui/plaza_hud.dart
+++ b/lib/features/plaza/ui/plaza_hud.dart
@@ -262,7 +262,7 @@ class _KeyLegend extends StatelessWidget {
                   style: const TextStyle(
                     fontFamily: PlazaStyle.fontMono,
                     fontSize: 12,
-                    color: Color(0x8CFFFFFF),
+                    color: PlazaStyle.textFaint,
                   ),
                 ),
               ),
@@ -272,7 +272,7 @@ class _KeyLegend extends StatelessWidget {
                 style: const TextStyle(
                   fontFamily: PlazaStyle.fontText,
                   fontSize: 12,
-                  color: Color(0x8CFFFFFF),
+                  color: PlazaStyle.textFaint,
                 ),
               ),
             ],
@@ -290,12 +290,12 @@ class _LanternLegend extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        for (final (state, label) in const [
-          (LanternState.inProgress, 'in progress'),
-          (LanternState.open, 'open'),
-          (LanternState.blocked, 'blocked'),
-          (LanternState.overdue, 'overdue'),
-          (LanternState.off, 'done'),
+        for (final state in const [
+          LanternState.inProgress,
+          LanternState.open,
+          LanternState.blocked,
+          LanternState.overdue,
+          LanternState.off,
         ])
           Padding(
             padding: const EdgeInsets.only(top: 5),
@@ -319,7 +319,7 @@ class _LanternLegend extends StatelessWidget {
                 ),
                 const SizedBox(width: 8),
                 Text(
-                  label,
+                  state.word,
                   style: const TextStyle(
                     fontFamily: PlazaStyle.fontText,
                     fontSize: 11,

--- a/lib/features/plaza/ui/plaza_style.dart
+++ b/lib/features/plaza/ui/plaza_style.dart
@@ -123,7 +123,6 @@ abstract final class PlazaStyle {
         return attention == null ? teal : lantern(attention.lantern);
       case BeaconKind.block:
       case BeaconKind.corner:
-      case BeaconKind.overview:
         return teal;
     }
   }

--- a/lib/features/plaza/ui/plaza_tour.dart
+++ b/lib/features/plaza/ui/plaza_tour.dart
@@ -85,25 +85,19 @@ CameraPose? jumbotronStopPose(PlazaWorld world) {
   final plaza = world.plaza;
   final slot = world.jumbotron;
   if (plaza == null || slot == null) return null;
-  final h = plaza.headingRadians;
-  final sinH = math.sin(h);
-  final cosH = math.cos(h);
+  final ground = plaza.footprint;
   // Which side of the plaza the tower stands on, in the plaza's frame.
-  final towerLateral =
-      (slot.x - plaza.centerX) * cosH - (slot.z - plaza.centerZ) * sinH;
-  final side = towerLateral.sign;
-  final lateral = side * (plaza.width / 2 + jumbotronStopClearance);
-  final along = plaza.depth / 2 - jumbotronStopBack;
-  final x = plaza.centerX + lateral * cosH + along * sinH;
-  final z = plaza.centerZ - lateral * sinH + along * cosH;
-  final dx = slot.x - x;
-  final dz = slot.z - z;
-  final d = math.sqrt(dx * dx + dz * dz);
+  final (towerLateral, _) = ground.local(slot.x, slot.z);
+  final (x, z) = ground.toWorld(
+    towerLateral.sign * (plaza.width / 2 + jumbotronStopClearance),
+    plaza.depth / 2 - jumbotronStopBack,
+  );
+  final d = groundDistanceBetween(x, z, slot.x, slot.z);
   return CameraPose(
     x: x,
     y: eyeHeight,
     z: z,
-    yaw: math.atan2(dx, dz),
+    yaw: math.atan2(slot.x - x, slot.z - z),
     pitch: math.min(
       math.atan2(slot.centerY - eyeHeight, d),
       jumbotronStopPitch,
@@ -166,10 +160,13 @@ CameraPose? shopfrontPose(PlazaWorld world) {
   (PlotPlacement, RoadSegment)? best;
   for (final segment in world.plan.segments) {
     if (segment.isGap || segment.isConnector) continue;
-    final sinH = math.sin(segment.headingRadians);
-    final cosH = math.cos(segment.headingRadians);
-    double along(PlotPlacement p) =>
-        (p.x - segment.startX) * sinH + (p.z - segment.startZ) * cosH;
+    double along(PlotPlacement p) => worldToFrame(
+      segment.startX,
+      segment.startZ,
+      segment.headingRadians,
+      p.x,
+      p.z,
+    ).$2;
     for (final side in PlotSide.values) {
       final row =
           world.plan.placements.values
@@ -188,25 +185,34 @@ CameraPose? shopfrontPose(PlazaWorld world) {
   }
   if (best == null) return null;
   final (head, segment) = best;
-  final sinH = math.sin(segment.headingRadians);
-  final cosH = math.cos(segment.headingRadians);
-  final along =
-      (head.x - segment.startX) * sinH + (head.z - segment.startZ) * cosH;
-  final lateral =
-      (head.x - segment.startX) * cosH - (head.z - segment.startZ) * sinH;
+  final (lateral, along) = worldToFrame(
+    segment.startX,
+    segment.startZ,
+    segment.headingRadians,
+    head.x,
+    head.z,
+  );
   // The near corner: the end wall meets the facade on the road side.
   final toRoad = lateral < 0 ? 1.0 : -1.0;
   final cornerAlong = along - head.width / 2;
   final cornerLateral = lateral + toRoad * head.depth / 2;
   final eyeAlong = cornerAlong - shopfrontStandOff;
   final eyeLateral = cornerLateral + toRoad * shopfrontRoadOffset;
-  final ex = segment.startX + sinH * eyeAlong + cosH * eyeLateral;
-  final ez = segment.startZ + cosH * eyeAlong - sinH * eyeLateral;
-  final cx = segment.startX + sinH * cornerAlong + cosH * cornerLateral;
-  final cz = segment.startZ + cosH * cornerAlong - sinH * cornerLateral;
-  final reach = math.sqrt(
-    math.pow(shopfrontStandOff, 2) + math.pow(shopfrontRoadOffset, 2),
+  final (ex, ez) = frameToWorld(
+    segment.startX,
+    segment.startZ,
+    segment.headingRadians,
+    eyeLateral,
+    eyeAlong,
   );
+  final (cx, cz) = frameToWorld(
+    segment.startX,
+    segment.startZ,
+    segment.headingRadians,
+    cornerLateral,
+    cornerAlong,
+  );
+  final reach = groundDistanceBetween(ex, ez, cx, cz);
   return CameraPose(
     x: ex,
     y: eyeHeight,

--- a/lib/features/plaza/ui/plaza_tour.dart
+++ b/lib/features/plaza/ui/plaza_tour.dart
@@ -18,10 +18,17 @@ import 'package:lotti/features/plaza/scene/plaza_world.dart';
 /// null when the world lacks the thing (no anomalies, no plaza); the
 /// harness skips those stops.
 class TourStop {
-  const TourStop({required this.name, required this.pose});
+  const TourStop({
+    required this.name,
+    required this.pose,
+    this.pinJumbotron = false,
+  });
 
   final String name;
   final CameraPose? Function(PlazaWorld world) pose;
+
+  /// Whether the jumbotron holds the project card at this stop.
+  final bool pinJumbotron;
 }
 
 /// The tour, in order: the landing, the project card on the jumbotron,
@@ -32,7 +39,11 @@ final List<TourStop> plazaTourStops = [
     name: 'home',
     pose: (w) => w.plaza?.home,
   ),
-  const TourStop(name: 'jumbotron', pose: jumbotronStopPose),
+  const TourStop(
+    name: 'jumbotron',
+    pose: jumbotronStopPose,
+    pinJumbotron: true,
+  ),
   TourStop(
     name: 'overview',
     pose: (w) => w.plaza?.overview,

--- a/lib/features/plaza/ui/task_side_panel.dart
+++ b/lib/features/plaza/ui/task_side_panel.dart
@@ -24,10 +24,7 @@ class TaskSidePanel extends StatelessWidget {
   Widget build(BuildContext context) {
     final task = attention.task;
     final chip = PlazaStyle.chip(attention);
-    final meta = <String>[
-      if (task.due != null) 'due ${shortDate(task.due!)}',
-      if (task.linkedTaskIds.isNotEmpty) 'links ${task.linkedTaskIds.length}',
-    ].join(' · ');
+    final meta = taskMetaBits(task).join(' · ');
     return Positioned(
       right: 16,
       top: 60,
@@ -60,7 +57,7 @@ class TaskSidePanel extends StatelessWidget {
                           fontSize: 11,
                           fontWeight: FontWeight.w700,
                           letterSpacing: 2,
-                          color: Color(0x8CFFFFFF),
+                          color: PlazaStyle.textFaint,
                         ),
                       ),
                     ),

--- a/test/README.md
+++ b/test/README.md
@@ -147,6 +147,22 @@ page tests and screenshot harnesses; do not replace them with test-only UI.
 
 For broader test conventions — centralized mocks/fallbacks (`test/mocks/mocks.dart`, `test/helpers/fallbacks.dart`), `setUpTestGetIt()` / `makeTestableWidget()`, the "every test must assert something meaningful" rule, and one-test-file-per-source-file — see the **Testing Guidelines** section of `AGENTS.md`.
 
+## flutter_scene needs a GPU; test the plaza's scheduling, not its geometry
+
+`Scene()`, every geometry (`ccwQuad`, `CuboidGeometry`, `MeshGeometry.fromArrays`)
+and `Sprite` (its `BillboardGeometry` wants the base shader bundle) throw under
+`flutter test`: there is no Impeller context, and flutter_scene's own suite
+`markTestSkipped`s without one. So `PlazaSurfaces`, `PlazaSprites` and any
+`FacadeLodManager` path that promotes a tier cannot be constructed headless.
+What can: `Node` (transforms included), `WidgetTextureController`, and the
+GPU-free scheduling in `lib/features/plaza/scene/surface_captures.dart`.
+`WidgetTextureController` is a plain subclassable class, so a test fake that
+overrides `requestCapture`, `captureCount` and `lastCaptureDuration` observes
+every request the scheduler makes and lands a capture on demand
+(`test/features/plaza/scene/surface_captures_test.dart`). The LOD manager is
+testable as long as nothing is promoted: buildings beyond `signDistance`, or a
+promotion that is wanted but withheld (`flying: true`, `promotionsPerFrame: 0`).
+
 ## Hover-divider tests: `test_utils/hover_divider_harness.dart`
 
 The settings lists that mix in `HoverDividerIndex` fade the hairlines

--- a/test/features/plaza/domain/attention_test.dart
+++ b/test/features/plaza/domain/attention_test.dart
@@ -243,4 +243,25 @@ void main() {
     expect(shortDate(DateTime.utc(2026, 1, 3)), 'Jan 3');
     expect(shortDate(DateTime.utc(2026, 12, 25)), 'Dec 25');
   });
+
+  test('every lantern state has its own glyph and word', () {
+    final glyphs = {for (final s in LanternState.values) s.glyph};
+    final words = {for (final s in LanternState.values) s.word};
+    expect(glyphs, hasLength(LanternState.values.length));
+    expect(words, hasLength(LanternState.values.length));
+    expect(LanternState.blocked.glyph, '✕');
+    expect(LanternState.overdue.word, 'overdue');
+    expect(LanternState.inProgress.word, 'in progress');
+    expect(LanternState.off.word, 'done');
+  });
+
+  test('the meta bits name only what the task has', () {
+    expect(taskMetaBits(_task()), isEmpty);
+    expect(taskMetaBits(_task(due: DateTime.utc(2026, 8, 2))), ['due Aug 2']);
+    expect(taskMetaBits(_task(links: const ['a', 'b'])), ['links 2']);
+    expect(
+      taskMetaBits(_task(due: DateTime.utc(2026, 8, 2), links: const ['a'])),
+      ['due Aug 2', 'links 1'],
+    );
+  });
 }

--- a/test/features/plaza/domain/flight_test.dart
+++ b/test/features/plaza/domain/flight_test.dart
@@ -83,14 +83,6 @@ void main() {
     expect(seconds(edge), closeTo(3.2, 1e-6));
   });
 
-  test('timeScale speeds the whole flight up', () {
-    const to = CameraPose(x: 0, y: 2.2, z: 36, yaw: 0);
-    expect(
-      seconds(Flight.plan(a, to, timeScale: 2)),
-      closeTo(seconds(Flight.plan(a, to)) / 2, 1e-6),
-    );
-  });
-
   test('short flights stay level; long ones arc up and land level', () {
     final short = Flight.plan(
       a,

--- a/test/features/plaza/domain/solid_test.dart
+++ b/test/features/plaza/domain/solid_test.dart
@@ -37,6 +37,28 @@ void main() {
     expect(wall.contains(10, 12.6, 0, clearance: 0.5), isFalse);
   });
 
+  test('a post is a square solid, turned with its owner', () {
+    final post = Solid.post(
+      x: 4,
+      z: 6,
+      facingRadians: math.pi / 4,
+      size: 2,
+      bottom: 10,
+      top: 14,
+    );
+    expect(post.footprint.width, 2);
+    expect(post.footprint.depth, 2);
+    expect(post.footprint.facingRadians, math.pi / 4);
+    expect(post.bottom, 10);
+    expect(post.top, 14);
+    expect(post.atWalkHeight, isFalse);
+    // Half a square's diagonal is 1.41 m: inside at 1.3, outside at 1.5.
+    expect(post.contains(4 + 1.3, 12, 6), isTrue);
+    expect(post.contains(4 + 1.5, 12, 6), isFalse);
+    expect(post.contains(4, 9, 6), isFalse);
+    expect(Solid.post(x: 0, z: 0, size: 1, top: 5).atWalkHeight, isTrue);
+  });
+
   test('a solid above eye level is for flights, not the walker', () {
     const footprint = Footprint(
       x: 0,

--- a/test/features/plaza/domain/street_layout_test.dart
+++ b/test/features/plaza/domain/street_layout_test.dart
@@ -70,7 +70,77 @@ void main() {
         (stableHash('a:w') & 0xFFFF) / 0xFFFF,
       );
     });
+
+    test('stableIndex picks from the unit, never past the last choice', () {
+      for (var i = 0; i < 200; i++) {
+        final unit = stableUnit('id-$i', 'k');
+        final index = stableIndex('id-$i', 'k', 7);
+        expect(index, inInclusiveRange(0, 6));
+        expect(index, (unit * 7).floor().clamp(0, 6));
+      }
+      expect(stableIndex('a', 'w', 1), 0);
+    });
   });
+
+  group('the frame', () {
+    // A frame at (10, 20) facing +X: local Z runs along +X, local X along
+    // -Z (the right-hand normal of a road heading +X).
+    const h = math.pi / 2;
+
+    test('frameToWorld turns local axes onto the heading and its normal', () {
+      final (ax, az) = frameToWorld(10, 20, h, 0, 5);
+      expect(ax, closeTo(15, 1e-9));
+      expect(az, closeTo(20, 1e-9));
+      final (lx, lz) = frameToWorld(10, 20, h, 3, 0);
+      expect(lx, closeTo(10, 1e-9));
+      expect(lz, closeTo(17, 1e-9));
+      // Facing +Z the frame is the world.
+      expect(frameToWorld(1, 2, 0, 3, 4), (4, 6));
+    });
+
+    test('worldToFrame is the inverse of frameToWorld', () {
+      final (u, v) = worldToFrame(10, 20, h, 15, 17);
+      expect(u, closeTo(3, 1e-9));
+      expect(v, closeTo(5, 1e-9));
+      const f = Footprint(x: 10, z: 20, facingRadians: h, width: 4, depth: 8);
+      final (wx, wz) = f.toWorld(3, 5);
+      expect(f.local(wx, wz).$1, closeTo(3, 1e-9));
+      expect(f.local(wx, wz).$2, closeTo(5, 1e-9));
+    });
+
+    test('a footprint contains the points in its box, with clearance', () {
+      const f = Footprint(x: 10, z: 20, facingRadians: h, width: 4, depth: 8);
+      // Along +X the depth reaches 4 m: (13.9, 20) is in, (14.1, 20) out.
+      expect(f.contains(13.9, 20), isTrue);
+      expect(f.contains(14.1, 20), isFalse);
+      expect(f.contains(14.1, 20, clearance: 0.5), isTrue);
+      // Along Z the width reaches 2 m.
+      expect(f.contains(10, 21.9), isTrue);
+      expect(f.contains(10, 22.1), isFalse);
+    });
+
+    test('groundDistanceBetween ignores nothing but height', () {
+      expect(groundDistanceBetween(0, 0, 3, 4), 5);
+      expect(groundDistanceBetween(3, 4, 0, 0), 5);
+      expect(groundDistanceBetween(1, 1, 1, 1), 0);
+    });
+  });
+
+  glados.Glados2<double, double>(
+    glados.any.doubleInRange(-50, 50),
+    glados.any.doubleInRange(-math.pi, math.pi),
+    glados.ExploreConfig(),
+  ).test('every point survives the round trip through a frame', (d, facing) {
+    final (wx, wz) = frameToWorld(7, -3, facing, d, -d / 2);
+    final (u, v) = worldToFrame(7, -3, facing, wx, wz);
+    expect(u, closeTo(d, 1e-9));
+    expect(v, closeTo(-d / 2, 1e-9));
+    // The frame turns, never scales: distances are kept.
+    expect(
+      groundDistanceBetween(7, -3, wx, wz),
+      closeTo(d.abs() * math.sqrt(1.25), 1e-9),
+    );
+  }, tags: 'glados');
 
   test('PlotPlacement.footprint is the plot rectangle', () {
     const p = PlotPlacement(

--- a/test/features/plaza/domain/walk_collider_test.dart
+++ b/test/features/plaza/domain/walk_collider_test.dart
@@ -20,6 +20,20 @@ Footprint _box({
 );
 
 void main() {
+  test('a long box turned 45° still pushes out near its far corner', () {
+    // Width 20 along local X, depth 2: the far corner is 10.05 m from the
+    // centre, well past the |dx| + |dz| a square box of that reach would
+    // allow. A point just inside that corner must still be pushed out.
+    final c = WalkCollider([_box(width: 20, depth: 2, facing: math.pi / 4)]);
+    final (cx, cz) = frameToWorld(0, 0, math.pi / 4, 9.5, 0.8);
+    final (rx, rz) = c.resolve(cx, cz);
+    expect((rx, rz), isNot((cx, cz)));
+    // Out through the nearest face, the long side: to v = 1 + margin.
+    final (u, v) = _box(width: 20, depth: 2, facing: math.pi / 4).local(rx, rz);
+    expect(u, closeTo(9.5, 1e-9));
+    expect(v, closeTo(1.6, 1e-9));
+  });
+
   test('a point outside every footprint is untouched', () {
     final c = WalkCollider([_box()]);
     expect(c.resolve(20, 20), (20, 20));

--- a/test/features/plaza/scene/facade_lod_manager_test.dart
+++ b/test/features/plaza/scene/facade_lod_manager_test.dart
@@ -1,0 +1,150 @@
+import 'dart:math' as math;
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/plaza/domain/attention.dart';
+import 'package:lotti/features/plaza/domain/plaza_task.dart';
+import 'package:lotti/features/plaza/domain/street_layout.dart';
+import 'package:lotti/features/plaza/scene/facade_lod_manager.dart';
+import 'package:lotti/features/plaza/scene/plaza_scene.dart';
+import 'package:lotti/features/plaza/ui/checklist_ticks.dart';
+import 'package:vector_math/vector_math.dart' show Vector3;
+
+final _now = DateTime.utc(2026, 7, 15);
+
+/// A building whose facade stands at ([x], [z]) facing [facing]; no
+/// geometry, so nothing here needs a GPU as long as no tier is promoted.
+PlazaBuilding _building(String id, double x, double z, {double facing = 0}) {
+  final task = PlazaTask(
+    id: id,
+    createdAt: DateTime.utc(2026, 7),
+    title: 'Building $id on the street',
+    state: PlazaTaskState.open,
+    progress: 0,
+    checklistItems: 0,
+    linkedTaskIds: const [],
+    categoryColor: 0xFF4AB6E8,
+  );
+  return PlazaBuilding(
+    task: task,
+    attention: attentionFor(task, _now),
+    placement: PlotPlacement(
+      taskId: id,
+      bucketIndex: 0,
+      side: PlotSide.left,
+      x: x,
+      z: z,
+      facingRadians: facing,
+      width: 8,
+      depth: 10,
+      height: 12,
+    ),
+    node: Node(),
+    facadeAnchor: Node(),
+    ring: Node(),
+    neon: Node(),
+    lanternAnchor: Node(),
+    facadeCenter: Vector3(x, 6, z),
+    facadeNormal: Vector3(math.sin(facing), 0, math.cos(facing)),
+    facadeWorldWidth: 8,
+    facadeWorldHeight: 12,
+    liveRange: 14,
+    pxPerMeter: 90,
+  );
+}
+
+FacadeLodManager _manager(
+  List<PlazaBuilding> buildings, {
+  FacadeLodConfig? config,
+}) => FacadeLodManager(
+  buildings: buildings,
+  config: config ?? FacadeLodConfig(),
+  ticks: ChecklistTicks(),
+  onOpen: (_) {},
+);
+
+void main() {
+  final eye = Vector3(0, 1.7, 0);
+  final forward = Vector3(0, 0, 1);
+
+  group('ranking', () {
+    test('runs once while the camera and the budget hold still', () {
+      // Every building is beyond the sign distance: the ranking settles
+      // at once and nothing is promoted (which would need a GPU).
+      final lod = _manager([
+        _building('a', 0, 200),
+        _building('b', 0, -300),
+        _building('c', 250, 0),
+      ]);
+      expect(lod.rankings, 0);
+
+      lod.update(eye, forward: forward);
+      expect(lod.rankings, 1);
+      expect((lod.stats.far, lod.stats.promotions), (3, 0));
+
+      lod
+        ..update(eye, forward: forward, seconds: 0.016)
+        ..update(eye, forward: forward, seconds: 0.033);
+      expect(lod.rankings, 1, reason: 'nothing changed');
+
+      lod.update(Vector3(1, 1.7, 0), forward: forward, seconds: 0.05);
+      expect(lod.rankings, 2, reason: 'the eye moved');
+
+      lod.update(Vector3(1, 1.7, 0), forward: Vector3(1, 0, 0), seconds: 0.07);
+      expect(lod.rankings, 3, reason: 'the view direction changed');
+
+      lod.update(Vector3(1, 1.7, 0), seconds: 0.08);
+      expect(lod.rankings, 4, reason: 'the view direction was dropped');
+
+      lod.config.liveCap = 6;
+      lod.update(Vector3(1, 1.7, 0), seconds: 0.1);
+      expect(lod.rankings, 5, reason: 'the budget changed');
+
+      lod.update(Vector3(1, 1.7, 0), seconds: 0.12, flying: true);
+      expect(lod.rankings, 6, reason: 'a flight started');
+      lod.update(Vector3(1, 1.7, 0), seconds: 0.14, flying: true);
+      expect(lod.rankings, 6);
+    });
+
+    test('keeps ranking while a promotion is waiting', () {
+      // Within the sign distance but flying: the sign is wanted every
+      // frame and never granted, so the ranking is never settled.
+      final lod = _manager([_building('near', 0, 50)]);
+      for (var frame = 0; frame < 3; frame++) {
+        lod.update(
+          eye,
+          forward: forward,
+          seconds: frame * 0.016,
+          flying: true,
+        );
+      }
+      expect(lod.rankings, 3);
+      expect((lod.stats.sign, lod.stats.far), (0, 1));
+
+      // The same holds when the per-frame promotion budget is zero.
+      final starved = _manager(
+        [_building('near', 0, 50)],
+        config: FacadeLodConfig(promotionsPerFrame: 0),
+      );
+      for (var frame = 0; frame < 3; frame++) {
+        starved.update(eye, forward: forward, seconds: frame * 0.016);
+      }
+      expect(starved.rankings, 3);
+      expect(starved.stats.promotions, 0);
+    });
+  });
+
+  test('describeNearest lists buildings nearest first with their tier', () {
+    final lod = _manager([
+      _building('far', 0, 400),
+      _building('near', 0, 200),
+      _building('mid', 0, 300),
+    ])..update(eye, forward: forward);
+    final described = lod.describeNearest(eye, count: 2);
+    expect(
+      described,
+      'Building near on: far d=200.0 range=14.0 front=false | '
+      'Building mid on: far d=300.0 range=14.0 front=false',
+    );
+  });
+}

--- a/test/features/plaza/scene/surface_captures_test.dart
+++ b/test/features/plaza/scene/surface_captures_test.dart
@@ -1,0 +1,323 @@
+import 'dart:math' as math;
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
+import 'package:lotti/features/plaza/scene/surface_captures.dart';
+import 'package:vector_math/vector_math.dart' show Matrix4, Vector3;
+
+/// A capture controller with no host: counts the requests the scheduler
+/// makes, and lands a capture when the test says so.
+class _FakeController extends WidgetTextureController {
+  int requests = 0;
+  int landed = 0;
+  Duration duration = Duration.zero;
+
+  @override
+  void requestCapture() => requests++;
+
+  @override
+  int get captureCount => landed;
+
+  @override
+  Duration get lastCaptureDuration => duration;
+}
+
+/// A vertical surface at the origin whose front faces +z.
+TimedSurface _atOrigin(_FakeController controller, {Node? node}) =>
+    TimedSurface.facing(
+      controller: controller,
+      node: node ?? Node(),
+      center: Vector3.zero(),
+      facingRadians: 0,
+    );
+
+/// An eye ten metres in front of the origin surface, looking at it.
+final _inFront = Vector3(0, 1.7, 10);
+final _towardsOrigin = Vector3(0, 0, -1);
+
+void main() {
+  group('requestDue', () {
+    test('the first capture is free and the next waits for the interval', () {
+      final captures = SurfaceCaptures();
+      final cadence = CaptureCadence(0.1);
+      final controller = _FakeController();
+      captures.timed(cadence, _atOrigin(controller));
+      expect(controller.requests, 0, reason: 'registering asks nothing');
+
+      captures.requestDue(cadence, _inFront, 0.5);
+      expect(controller.requests, 1, reason: 'the first capture is free');
+      captures.requestDue(cadence, _inFront, 0.55);
+      expect(controller.requests, 1);
+      captures.requestDue(cadence, _inFront, 0.5999);
+      expect(controller.requests, 1, reason: '0.0999 s is short of 0.1 s');
+      captures.requestDue(cadence, _inFront, 0.5999995);
+      expect(
+        controller.requests,
+        2,
+        reason: 'a hair under the interval still counts',
+      );
+      captures.requestDue(cadence, _inFront, 0.6);
+      expect(controller.requests, 2, reason: 'the last request was just made');
+      captures.requestDue(cadence, _inFront, 0.7);
+      expect(controller.requests, 3);
+    });
+
+    test('advances the cadence clock only when a capture is requested', () {
+      final captures = SurfaceCaptures();
+      final cadence = CaptureCadence(0.1);
+      final controller = _FakeController();
+      final node = Node();
+      captures.timed(cadence, _atOrigin(controller, node: node));
+      var notifications = 0;
+      cadence.clock.addListener(() => notifications++);
+
+      expect(cadence.clock.value, 0);
+      captures.requestDue(cadence, _inFront, 1);
+      expect(cadence.clock.value, 1);
+      expect(notifications, 1);
+
+      // Between captures the widgets are not rebuilt.
+      captures.requestDue(cadence, _inFront, 1.05);
+      expect(cadence.clock.value, 1);
+      expect(notifications, 1);
+
+      captures.requestDue(cadence, _inFront, 1.1);
+      expect(cadence.clock.value, 1.1);
+      expect(notifications, 2);
+      expect(controller.requests, 2);
+
+      // A hidden surface neither rebuilds nor captures.
+      node.visible = false;
+      captures.requestDue(cadence, _inFront, 5);
+      expect(cadence.clock.value, 1.1);
+      expect(controller.requests, 2);
+    });
+
+    test('a surface behind the eye is not captured', () {
+      final captures = SurfaceCaptures();
+      final cadence = CaptureCadence(0.1);
+      final controller = _FakeController();
+      captures.timed(cadence, _atOrigin(controller));
+      expect(controller.requests, 0);
+
+      // Standing in front of the panel but looking away from it.
+      captures.requestDue(cadence, _inFront, 0, forward: Vector3(0, 0, 1));
+      expect(controller.requests, 0);
+      expect(cadence.clock.value, 0);
+
+      // Turn round: it is ahead, so it is captured.
+      captures.requestDue(cadence, _inFront, 0, forward: _towardsOrigin);
+      expect(controller.requests, 1);
+    });
+
+    test('a wide band whose centre has just passed the eye is captured', () {
+      // Under the gantry, looking down the street: the band's centre is
+      // two metres behind the eye's plane and its near end still in view.
+      final captures = SurfaceCaptures();
+      final cadence = CaptureCadence(0.1);
+      final controller = _FakeController();
+      captures.timed(cadence, _atOrigin(controller));
+      final justPast = Vector3(0, 1.7, 2);
+      captures.requestDue(cadence, justPast, 0, forward: Vector3(0, 0, 1));
+      expect(controller.requests, 1);
+      // Past the margin it is gone for good.
+      final wellPast = Vector3(0, 1.7, TimedSurface.behindMargin + 1);
+      captures.requestDue(cadence, wellPast, 1, forward: Vector3(0, 0, 1));
+      expect(controller.requests, 1);
+    });
+
+    test('a surface whose front faces away from the eye is not captured', () {
+      final captures = SurfaceCaptures();
+      final cadence = CaptureCadence(0.1);
+      final controller = _FakeController();
+      captures.timed(cadence, _atOrigin(controller));
+
+      // Behind the panel, looking at its back.
+      final behind = Vector3(0, 1.7, -10);
+      captures.requestDue(cadence, behind, 0, forward: Vector3(0, 0, 1));
+      expect(controller.requests, 0);
+
+      // Without a view direction nothing is culled.
+      captures.requestDue(cadence, behind, 0);
+      expect(controller.requests, 1);
+    });
+
+    test('a culled surface is captured as soon as it comes into view', () {
+      final captures = SurfaceCaptures();
+      final cadence = CaptureCadence(3);
+      final controller = _FakeController();
+      captures.timed(cadence, _atOrigin(controller));
+      expect(controller.requests, 0);
+
+      captures.requestDue(cadence, _inFront, 0, forward: _towardsOrigin);
+      expect(controller.requests, 1);
+      // Looking away for a while does not restart the interval.
+      captures.requestDue(cadence, _inFront, 4, forward: Vector3(0, 0, 1));
+      expect(controller.requests, 1);
+      captures.requestDue(cadence, _inFront, 4.5, forward: _towardsOrigin);
+      expect(controller.requests, 2);
+    });
+
+    test('each surface keeps its own interval within a cadence', () {
+      final captures = SurfaceCaptures();
+      final cadence = CaptureCadence(0.1);
+      final a = _FakeController();
+      final b = _FakeController();
+      final bNode = Node();
+      captures
+        ..timed(cadence, _atOrigin(a))
+        ..timed(cadence, _atOrigin(b, node: bNode));
+
+      bNode.visible = false;
+      captures.requestDue(cadence, _inFront, 0);
+      expect((a.requests, b.requests), (1, 0));
+      bNode.visible = true;
+      captures.requestDue(cadence, _inFront, 0.05);
+      expect((a.requests, b.requests), (1, 1), reason: 'b was never asked');
+      captures.requestDue(cadence, _inFront, 0.1);
+      expect((a.requests, b.requests), (2, 1));
+      captures.requestDue(cadence, _inFront, 0.15);
+      expect((a.requests, b.requests), (2, 2));
+    });
+  });
+
+  group('once', () {
+    test('re-requested every frame until the capture lands, then dropped', () {
+      final captures = SurfaceCaptures();
+      final controller = _FakeController();
+      captures.once(controller);
+      expect(controller.requests, 0, reason: 'registering asks nothing');
+
+      captures
+        ..requestPending()
+        ..requestPending()
+        ..requestPending();
+      expect(controller.requests, 3);
+
+      controller.landed = 1;
+      captures
+        ..requestPending()
+        ..requestPending();
+      expect(
+        controller.requests,
+        3,
+        reason: 'a landed capture is not re-asked',
+      );
+      expect(captures.captures, 1);
+    });
+
+    test('a landed surface leaves the pending list, others stay', () {
+      final captures = SurfaceCaptures();
+      final first = _FakeController();
+      final second = _FakeController();
+      captures
+        ..once(first)
+        ..once(second)
+        ..requestPending();
+      first.landed = 1;
+      captures.requestPending();
+      expect((first.requests, second.requests), (1, 2));
+    });
+  });
+
+  group('counters', () {
+    test('sum the captures and take the longest recent capture', () {
+      final captures = SurfaceCaptures();
+      final cadence = CaptureCadence(0.1);
+      final once = _FakeController()
+        ..landed = 2
+        ..duration = const Duration(milliseconds: 3);
+      final timed = _FakeController()
+        ..landed = 5
+        ..duration = const Duration(milliseconds: 7);
+      captures
+        ..once(once)
+        ..timed(cadence, _atOrigin(timed));
+      expect(captures.captures, 7);
+      expect(captures.lastCaptureDuration, const Duration(milliseconds: 7));
+    });
+
+    test('a forgotten surface is neither counted nor requested again', () {
+      final captures = SurfaceCaptures();
+      final cadence = CaptureCadence(0.1);
+      final timed = _FakeController()..landed = 4;
+      final once = _FakeController();
+      captures
+        ..timed(cadence, _atOrigin(timed))
+        ..once(once)
+        ..forget(timed, cadence: cadence)
+        ..forget(once);
+      expect(captures.captures, 0);
+      expect(cadence.surfaces, isEmpty);
+      captures
+        ..requestDue(cadence, _inFront, 1)
+        ..requestPending();
+      expect((timed.requests, once.requests), (0, 0));
+    });
+  });
+
+  group('TimedSurface', () {
+    test('posed reads the centre and the front from the node transform', () {
+      final parent = Node(
+        localTransform: Matrix4.translation(Vector3(10, 0, 20))
+          ..rotateY(math.pi / 2),
+      );
+      final anchor = Node(
+        localTransform: Matrix4.translation(Vector3(0, 5, 3)),
+      );
+      parent.add(anchor);
+      final surface = TimedSurface.posed(_FakeController(), anchor);
+      // Local +z under a quarter turn about y points along world +x.
+      expect(surface.center.x, closeTo(13, 1e-6));
+      expect(surface.center.y, closeTo(5, 1e-6));
+      expect(surface.center.z, closeTo(20, 1e-6));
+      expect(surface.normal.x, closeTo(1, 1e-6));
+      expect(surface.normal.y, closeTo(0, 1e-6));
+      expect(surface.normal.z, closeTo(0, 1e-6));
+      // The front is seen from +x looking back, not from -x.
+      expect(surface.seenFrom(Vector3(30, 5, 20), Vector3(-1, 0, 0)), isTrue);
+      expect(surface.seenFrom(Vector3(0, 5, 20), Vector3(1, 0, 0)), isFalse);
+    });
+
+    glados.Glados3(
+      glados.any.doubleInRange(-math.pi, math.pi),
+      glados.any.doubleInRange(-1.2, 1.2),
+      glados.any.doubleInRange(TimedSurface.behindMargin + 0.01, 500),
+    ).test(
+      'is seen straight ahead facing the eye, never behind or from its back',
+      (yaw, pitch, distance) {
+        final eye = Vector3(3, 1.7, -8);
+        final forward = Vector3(
+          math.sin(yaw) * math.cos(pitch),
+          math.sin(pitch),
+          math.cos(yaw) * math.cos(pitch),
+        );
+        final controller = _FakeController();
+        final ahead = eye + forward * distance;
+        final facingEye = TimedSurface(
+          controller: controller,
+          node: Node(),
+          center: ahead,
+          normal: -forward,
+        );
+        final backToEye = TimedSurface(
+          controller: controller,
+          node: Node(),
+          center: ahead,
+          normal: forward,
+        );
+        final behindEye = TimedSurface(
+          controller: controller,
+          node: Node(),
+          center: eye - forward * distance,
+          normal: -forward,
+        );
+        expect(facingEye.seenFrom(eye, forward), isTrue);
+        expect(backToEye.seenFrom(eye, forward), isFalse);
+        expect(behindEye.seenFrom(eye, forward), isFalse);
+      },
+      tags: ['glados'],
+    );
+  });
+}

--- a/test/features/plaza/ui/facade_widget_test.dart
+++ b/test/features/plaza/ui/facade_widget_test.dart
@@ -281,13 +281,10 @@ void main() {
       _host(_task(state: PlazaTaskState.blocked), onOpen: () {}),
     );
     expect(find.textContaining('BLOCKED'), findsOneWidget);
-    final open = tester.widget<Container>(
-      find
-          .ancestor(
-            of: find.text('DETAILS ›'),
-            matching: find.byType(Container),
-          )
-          .first,
+    // The button's fill is ink on the wall's Material, so the hover wash
+    // shows over it.
+    final open = tester.widget<Ink>(
+      find.ancestor(of: find.text('DETAILS ›'), matching: find.byType(Ink)),
     );
     expect((open.decoration! as BoxDecoration).color, PlazaStyle.teal);
   });

--- a/test/features/plaza/ui/fly_camera_controller_test.dart
+++ b/test/features/plaza/ui/fly_camera_controller_test.dart
@@ -242,12 +242,8 @@ void main() {
     });
 
     test('movement input cancels a flight in place', () {
-      var cancelled = 0;
       var moved = 0;
       final camera = _controller()
-        ..onFlightCancelled = () {
-          cancelled++;
-        }
         ..onMovement = () {
           moved++;
         };
@@ -261,7 +257,6 @@ void main() {
         _down(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
       );
       expect(camera.flying, isFalse);
-      expect(cancelled, 1);
       expect(moved, 1);
       camera.update(1); // no hardware key → stands still
       expect(camera.pose.z, closeTo(midway, 1e-6));
@@ -275,7 +270,7 @@ void main() {
       camera.handleKeyEvent(
         _down(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
       );
-      expect(cancelled, 2);
+      expect(moved, 2);
       expect(camera.flying, isTrue); // the landing
       for (var i = 0; i < 40; i++) {
         camera.update(0.1);
@@ -283,23 +278,42 @@ void main() {
       expect(camera.pose.y, closeTo(eyeHeight, 1e-6));
     });
 
-    test('drag look cancels a flight too, and pose set clears it', () {
-      var cancelled = 0;
-      void onCancelled() {
-        cancelled++;
+    test('a street flight cut short comes down before walking', () {
+      // A routed flight cruises at street height with no arc at all; a
+      // key mid-street must still land the camera, not drop it.
+      final camera = FlyCameraController(
+        pose: const CameraPose(x: 0, y: eyeHeight, z: 10, yaw: 0),
+        network: StreetNetwork(const [(0, 0), (0, 200)]),
+      );
+      final flight = camera.flyTo(
+        const CameraPose(x: 0, y: eyeHeight, z: 120, yaw: 0),
+      );
+      expect(flight.routed, isTrue);
+      expect(flight.arc, 0);
+      camera.update(flight.duration.inMicroseconds / 2e6);
+      expect(camera.pose.y, closeTo(Flight.streetFlightHeight, 1e-6));
+      camera.handleKeyEvent(
+        _down(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
+      );
+      expect(camera.flying, isTrue); // the landing
+      camera.update(0.05);
+      expect(camera.pose.y, greaterThan(eyeHeight + 2));
+      for (var i = 0; i < 40; i++) {
+        camera.update(0.1);
       }
+      expect(camera.flying, isFalse);
+      expect(camera.pose.y, closeTo(eyeHeight, 1e-6));
+    });
 
+    test('drag look cancels a flight too, and pose set clears it', () {
       final camera = _controller()
-        ..onFlightCancelled = onCancelled
         ..flyTo(const CameraPose(x: 0, y: eyeHeight, z: 100, yaw: 0))
         ..addLookDelta(5, 0);
       expect(camera.flying, isFalse);
-      expect(cancelled, 1);
       camera
         ..flyTo(const CameraPose(x: 0, y: eyeHeight, z: 100, yaw: 0))
         ..pose = _origin;
       expect(camera.flying, isFalse);
-      expect(cancelled, 1);
     });
   });
 

--- a/test/features/plaza/ui/fly_camera_controller_test.dart
+++ b/test/features/plaza/ui/fly_camera_controller_test.dart
@@ -19,6 +19,15 @@ KeyDownEvent _down(LogicalKeyboardKey logical, PhysicalKeyboardKey physical) =>
       timeStamp: Duration.zero,
     );
 
+KeyRepeatEvent _repeat(
+  LogicalKeyboardKey logical,
+  PhysicalKeyboardKey physical,
+) => KeyRepeatEvent(
+  logicalKey: logical,
+  physicalKey: physical,
+  timeStamp: Duration.zero,
+);
+
 KeyUpEvent _up(LogicalKeyboardKey logical, PhysicalKeyboardKey physical) =>
     KeyUpEvent(
       logicalKey: logical,
@@ -303,6 +312,31 @@ void main() {
       }
       expect(camera.flying, isFalse);
       expect(camera.pose.y, closeTo(eyeHeight, 1e-6));
+    });
+
+    test("a held key's repeats do not restart the landing", () {
+      final camera = _controller()
+        ..pose = const CameraPose(x: 0, y: 40, z: 0, yaw: 0)
+        ..handleKeyEvent(
+          _down(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
+        );
+      expect(camera.flying, isTrue);
+      camera.update(0.1);
+      // Repeats every tenth of a second, as a held key sends them: the
+      // landing keeps its speed and finishes in its own time.
+      var steps = 0;
+      while (camera.flying && steps < 60) {
+        camera
+          ..handleKeyEvent(
+            _repeat(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
+          )
+          ..update(0.1);
+        steps++;
+      }
+      expect(camera.flying, isFalse);
+      expect(camera.pose.y, closeTo(eyeHeight, 1e-6));
+      // Under four seconds for a 38 m descent on the direct profile.
+      expect(steps, lessThan(40));
     });
 
     test('drag look cancels a flight too, and pose set clears it', () {

--- a/test/features/plaza/ui/plaza_chip_test.dart
+++ b/test/features/plaza/ui/plaza_chip_test.dart
@@ -55,6 +55,14 @@ void main() {
     final ink = tester.widget<InkWell>(find.byType(InkWell));
     expect(ink.hoverColor, PlazaStyle.tealHover);
     expect(ink.borderRadius!.topLeft.x, closeTo(4.2, 1e-9));
+    // The fill is ink on the Material, under the hover wash, not a
+    // Container over it.
+    expect(find.byType(Container), findsNothing);
+    final fill = tester.widget<Ink>(find.byType(Ink));
+    expect((fill.decoration! as BoxDecoration).color, PlazaStyle.teal);
+    final padding = fill.padding! as EdgeInsets;
+    expect(padding.left, closeTo(9.6, 1e-9));
+    expect(padding.top, closeTo(3, 1e-9));
     await tester.tap(find.text('fly there'));
     expect(taps, 1);
   });

--- a/test/features/plaza/ui/plaza_chip_test.dart
+++ b/test/features/plaza/ui/plaza_chip_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/plaza/ui/plaza_chip.dart';
+import 'package:lotti/features/plaza/ui/plaza_style.dart';
+
+void main() {
+  Widget host(Widget child) => MaterialApp(
+    home: Scaffold(body: Center(child: child)),
+  );
+
+  testWidgets('every measure is a fraction of the font size', (tester) async {
+    await tester.pumpWidget(
+      host(
+        const PlazaChip(
+          label: 'OPEN',
+          fill: Color(0xFF123456),
+          ink: Color(0xFFABCDEF),
+          fontPx: 20,
+        ),
+      ),
+    );
+    final container = tester.widget<Container>(find.byType(Container));
+    expect(
+      container.padding,
+      const EdgeInsets.symmetric(horizontal: 16, vertical: 5),
+    );
+    final decoration = container.decoration! as BoxDecoration;
+    expect(decoration.color, const Color(0xFF123456));
+    expect(decoration.borderRadius, BorderRadius.circular(7));
+    final text = tester.widget<Text>(find.text('OPEN'));
+    expect(text.style!.fontSize, 20);
+    expect(text.style!.fontWeight, FontWeight.w700);
+    expect(text.style!.letterSpacing, 1);
+    expect(text.style!.color, const Color(0xFFABCDEF));
+    expect(text.style!.fontFamily, PlazaStyle.fontText);
+    // A plain chip is not a button.
+    expect(find.byType(InkWell), findsNothing);
+  });
+
+  testWidgets('with onTap it is a button that reports the tap', (
+    tester,
+  ) async {
+    var taps = 0;
+    await tester.pumpWidget(
+      host(
+        PlazaChip(
+          label: 'fly there',
+          fill: PlazaStyle.teal,
+          ink: Colors.black,
+          fontPx: 12,
+          onTap: () => taps++,
+        ),
+      ),
+    );
+    final ink = tester.widget<InkWell>(find.byType(InkWell));
+    expect(ink.hoverColor, PlazaStyle.tealHover);
+    expect(ink.borderRadius!.topLeft.x, closeTo(4.2, 1e-9));
+    await tester.tap(find.text('fly there'));
+    expect(taps, 1);
+  });
+}

--- a/test/features/plaza/ui/plaza_style_test.dart
+++ b/test/features/plaza/ui/plaza_style_test.dart
@@ -60,11 +60,7 @@ void main() {
       PlazaStyle.beaconColor(byKind[BeaconKind.home]!, world),
       const Color(0xFFF2FFFA),
     );
-    for (final kind in [
-      BeaconKind.block,
-      BeaconKind.corner,
-      BeaconKind.overview,
-    ]) {
+    for (final kind in [BeaconKind.block, BeaconKind.corner]) {
       final beacon = byKind[kind];
       if (beacon == null) continue;
       expect(
@@ -90,17 +86,6 @@ void main() {
       taskId: 'missing',
     );
     expect(PlazaStyle.beaconColor(orphan, world), PlazaStyle.teal);
-    // The layout emits no overview beacon; the kind still has a colour.
-    final overview = Beacon(
-      id: 'overview',
-      kind: BeaconKind.overview,
-      label: 'map',
-      pose: world.plaza!.overview,
-      markerX: 0,
-      markerY: 0,
-      markerZ: 0,
-    );
-    expect(PlazaStyle.beaconColor(overview, world), PlazaStyle.teal);
   });
 
   test('category colours: the category itself, then two darker tints', () {


### PR DESCRIPTION
## What

A cleanup pass over the plaza feature from four review angles (reuse, simplification, efficiency, altitude), applied with no intended change in what the harness shows. Four commits, each reviewable on its own:

1. **Domain** — the local-to-world rotation was written by hand in two private helpers and a dozen call sites; it is `frameToWorld` / `worldToFrame` beside `Footprint` now, which gains `toWorld` and `contains`. `frontierPlazaFor` calls `plazaLateralOffsetFor` instead of repeating it. Square posts are `Solid.post`, ground distances one helper, the seeded pick `stableIndex`. The walk collider fixes each footprint's frame once and rejects far footprints by corner distance before rotating. A flight keeps where its way leaves the road as a distance (`_wayEnd`) instead of an arrival flag plus a last-leg lookup, and fixes its ramp headings once. Dead surface removed: `BeaconKind.overview` (never built), `timeScale`, `lampPostsFor(minGap:)`; test-only `Flight` getters are marked.
2. **Scene** — `plaza_scene.dart` built ~50 cuboid nodes, five four-face windowed-wall loops, three rim loops, three spire assemblies and two tower screens by hand. They are `_box`, `_rim`, `_spire`, `_towerScreen`, `_windowedBox` now; `updateForCamera` returns early when the fade factor has not moved; `PLAZA_HIDE` is a constructor parameter instead of a `dart:io` static. 2466 → 2291 lines.
3. **Capture scheduling** — `SurfaceCaptures` (`scene/surface_captures.dart`) owns what `PlazaSurfaces` and the LOD manager each had a copy of. Each capture cadence carries the clock its widgets read, advanced only when a capture is requested, so a hosted widget rebuilds once per capture instead of once per painted frame; surfaces the camera cannot see are not captured; still billboards take the 3 s cadence. The LOD manager keeps its ranking while the camera, budget and flight state hold, and reads the flight state from the camera instead of a hand-set flag. Sprites write only what moved. The harness has one mode enum; a movement key on any flight above landing height lands first, street cruises included (previously a routed flight cut short hovered at 5 m).
4. **Shared UI + world** — `PlazaChip`, `LanternState.glyph/word`, `taskMetaBits`; `PlazaWorld` builds its ticker bands in one pass and memoises the heroes.

Docs follow the code (`knowledge/features/plaza.md`, `docs/plaza/DESIGN.md`, the feature README, `test/README.md`).

## Verification

- `fvm dart analyze lib/features/plaza test/features/plaza`: no issues. `make knowledge_check` passes.
- `fvm flutter test test/features/plaza`: 277 tests pass, of which ~35 are new (frame helpers with a Glados round-trip, `Solid.post`, the collider's rotated-box reject, the landing rule, the capture scheduler with a Glados property on `seenFrom`, the LOD ranking skip, `PlazaChip`, lantern text). Every new regression test was run against the old code and fails there.
- **Tour capture before/after** (the seven documentation stops, main vs this branch, same Linux harness): every stop differs only in animation phase — jumbotron slide, billboard glow rims and chase lights, ticker text positions, blinking spire lights. Buildings, rims, spires, benches, lamps and the skyline are pixel-identical. Worst stop (home) 2.7 % of pixels differ, all on those animated surfaces.

## Reviewer findings deliberately not applied

- Deriving `maxTaskStandOff`, `plazaFoldClearance` and `connectorLength` from the layout's road width (they are hand-derived from the 18 m default while the harness runs 25 m): would move stops and connectors, so it is a product change for its own PR.
- Ticker slots carrying their own text and speed; the lantern-keyed ticker glyph versus the verdict-keyed facade glyph (a cancelled task reads `✓` on a band and `—` on a wall); the side panel's checklist row versus the facade's (different measures at panel scale); the `anomalyList` alias; two colour constants with one value in `wall_textures.dart`; the pool painter versus the sprite radial; `_refreshStats` gating in the LOD manager. Each is either a visible change or not worth its own abstraction.
- `SceneView` re-diffs its hosted subtree on every repaint with `autoTick: false`; the fix is an upstream `repaint:` listenable on flutter_scene, not app-side.

No changelog fragment: the plaza is reachable only through its dev entrypoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable, consistently styled interface chips across plaza panels and billboards.
  * Added visibility-aware surface updates for billboards, screens, tickers, and the jumbotron.
  * Added support for hiding selected plaza elements in development views.

* **Improvements**
  * Refined camera flight, landing, facade detail-level, collision, sprite, and rendering behavior.
  * Improved plaza labels, task metadata, layout consistency, and visual presentation.

* **Documentation**
  * Updated plaza design, feature, development, and testing documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->