### PR TITLE
chore(release): 1.0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.27]
+
+### Changed
+
+- **Projects have a clearer workspace for focused work.** Browse projects by
+  area, hide the desktop list when you need more room, and edit project settings
+  in a dedicated form. Project-agent reports, health assessments, automation
+  controls, and recommended actions now share one consistent detail surface.
+
+### Fixed
+
+- **Project membership stays consistent when tasks or projects change.** Task
+  links now respect category and privacy changes, failed task assignments clean
+  up newly created tasks, and project edits preserve unrelated synced changes.
+  A project's category cannot change while it has linked tasks or a live agent.
+- **Project agents follow synced project changes.** Agents are retired when a
+  synced project disappears, and their category permissions follow synced moves
+  without scheduling an unnecessary report.
+
 ## [1.0.26]
 ### Added
 - **Lotti on Google Play beyond internal testing.** Android builds now reach

--- a/changelog.d/2026-09-04-project-data-integrity.md
+++ b/changelog.d/2026-09-04-project-data-integrity.md
@@ -1,9 +1,0 @@
-### Fixed
-
-- **Project membership stays consistent when tasks or projects change.** Task
-  links now respect category and privacy changes, failed task assignments clean
-  up newly created tasks, and project edits preserve unrelated synced changes.
-  A project's category cannot change while it has linked tasks or a live agent.
-- **Project agents follow synced project changes.** Agents are retired when a
-  synced project disappears, and their category permissions follow synced moves
-  without scheduling an unnecessary report.

--- a/changelog.d/2026-09-04-projects-workspace.md
+++ b/changelog.d/2026-09-04-projects-workspace.md
@@ -1,6 +1,0 @@
-### Changed
-
-- **Projects have a clearer workspace for focused work.** Browse projects by
-  area, hide the desktop list when you need more room, and edit project settings
-  in a dedicated form. Project-agent reports, health assessments, automation
-  controls, and recommended actions now share one consistent detail surface.

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -40,6 +40,13 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="1.0.27" date="2026-09-05">
+      <description>
+        <p>Changed: projects have a clearer workspace for focused work. Browse projects by area, hide the desktop list when you need more room, and edit project settings in a dedicated form. Project-agent reports, health assessments, automation controls, and recommended actions now share one consistent detail surface.</p>
+        <p>Fixed: project membership stays consistent when tasks or projects change. Task links now respect category and privacy changes, failed task assignments clean up newly created tasks, and project edits preserve unrelated synced changes. A project's category cannot change while it has linked tasks or a live agent.</p>
+        <p>Fixed: project agents follow synced project changes. Agents are retired when a synced project disappears, and their category permissions follow synced moves without scheduling an unnecessary report.</p>
+      </description>
+    </release>
     <release version="1.0.26" date="2026-09-04">
       <description>
         <p>Added: Lotti on Google Play beyond internal testing. Android builds now reach Play's closed testing track, and production, as the very same builds that internal testers already had, so Play users on those tracks receive the same build as TestFlight and Flathub users.</p>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.0.26+4370
+version: 1.0.27+4371
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
Prepare **1.0.27+4371** from latest main, including the Projects changes in #4129 and #4130. This PR assembles the release notes and version only; it does not create or push a release tag.

## Changed

- **Projects have a clearer workspace for focused work.** Browse projects by
  area, hide the desktop list when you need more room, and edit project settings
  in a dedicated form. Project-agent reports, health assessments, automation
  controls, and recommended actions now share one consistent detail surface.

## Fixed

- **Project membership stays consistent when tasks or projects change.** Task
  links now respect category and privacy changes, failed task assignments clean
  up newly created tasks, and project edits preserve unrelated synced changes.
  A project's category cannot change while it has linked tasks or a live agent.
- **Project agents follow synced project changes.** Agents are retired when a
  synced project disappears, and their category permissions follow synced moves
  without scheduling an unnecessary report.

## Release assembly

- Add the matching 1.0.27 changelog section and Flathub release dated 2026-09-05.
- Bump 1.0.26+4370 to 1.0.27+4371.
- Remove the two consumed changelog fragments; no application code changes.

## Validation

- Strict fragment validation before assembly; changelog/version validation after assembly.
- XML parses with xmllint; git diff whitespace checks pass.
- All 25 release-guard tests pass via Dart MCP.
- Repository-wide Dart MCP analysis is clean.
