### PR TITLE
perf(plaza): take the idle work out of the plaza harness

### DIFF
--- a/docs/plaza/HANDOVER.md
+++ b/docs/plaza/HANDOVER.md
@@ -75,7 +75,7 @@ Implemented, by area (the mechanism behind each is in the concept):
   skyline towers and a hero tower with a screen at the far end of every
   folded row.
 - **Facade tiers.** Far (geometry and lantern), sign (captured once) and
-  live (captured every frame, interactive) with caps, hysteresis, one
+  live (activated by a nearby tap, interactive) with caps, hysteresis, one
   promotion per frame, suspension during flights and pre-capture of a
   flight's destination. The faced building gets a focus ring; its
   checkboxes tick and its details button opens a side panel.
@@ -94,7 +94,7 @@ Implemented, by area (the mechanism behind each is in the concept):
   pylon posts, gantry legs, lamp posts; the signs and the beam are in the
   air, for the flights), and title search. The harness paces its own
   frames: a frame-rate control in the HUD offers auto, 60 and 30, default
-  60, and a Debug box there shows the overlay with painted and engine
+  auto, and a Debug box there shows the overlay with painted and engine
   frame rates.
 - **Morning walk.** Overview, up to three anomalies, home; pausable, and
   abandoned by any movement.
@@ -152,7 +152,8 @@ label, it does nothing). Top right: **Morning walk**, **Overview**,
 the walk's progress; the key legend and the lantern legend sit along the
 bottom edge.
 
-**On a live facade** (the one with the teal ring): the checkboxes tick and
+**Tap a nearby facade to activate it** (the teal ring); walking away or
+turning away returns it to a static sign. On the activated facade: the checkboxes tick and
 strike through, and **DETAILS** opens the side panel with the category,
 title, chip, due and links line and the same checklist. Ticks are shared
 between wall and panel and forgotten when the harness exits.
@@ -267,9 +268,11 @@ sources you touched (repository rule), for example:
 fvm flutter test test/features/plaza/domain/plaza_layout_test.dart
 ```
 
-`PlazaSceneController`, `FacadeLodManager`, `PlazaSurfaces`, `PlazaSprites`,
-`PlazaPicker`, `WallTextures` and `PlazaBench` need a GPU context and are
-exercised only by running the harness; `codecov.yml` excludes `scene/**` and
+Scene geometry needs a GPU context and is exercised by the harness.
+`FacadeLodManager` tests inject bind-only components to exercise tier changes,
+activation and capture scheduling without a GPU; `SurfaceCaptures` tests use
+fake capture controllers. The pointer state and cover-completion callbacks
+also have headless regression tests. See `test/README.md` for these seams; `codecov.yml` excludes `scene/**` and
 `dev_main.dart`.
 
 ## 7. What is still missing
@@ -307,8 +310,8 @@ still open.
 
 ## 8. Known limits
 
-- The harness needs a GPU context; of the `scene/` classes only `PlazaWorld`
-  and the shopfront strip painter have unit tests.
+- The harness needs a GPU context; scheduling and activation are tested
+  headlessly, while actual scene geometry is checked with the harness.
 - Cover art is loaded over HTTP from the public demo media catalogue, so an
   offline run shows facades and billboards without pictures.
 - Capturing under Xvfb yields blank widget surfaces (section 4.1).

--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -839,7 +839,12 @@ until it lands.
   is the one frame, and the glow quad behind the lightbox is what breathes:
   `PlazaSurfaces.update` writes its alpha once per frame from the slot's
   pulse (`BillboardSlot.glowAt`, floor 0.55) times the scene's `poolFade`,
-  and only when it moved, so a billboard costs no capture at rest. A roof
+  and only when it moved, so a billboard costs no capture at rest. A
+  pylon's or a roof panel's lightbox is translucent: its back is a
+  `backQuad` (the front's vertices and UVs wound the other way, so the
+  eye reads the picture mirrored) sharing the panel's capture through
+  `OpaqueSurface.shared`, dimmed to `PlazaBillboard.backTint`; a wall
+  screen and the jumbotron have no back to see. A roof
   panel sits over its own facade,
   which carries the title, so it leads with the reason on a solid band in
   the state colour across its top, panel-dark ink, the title small on the
@@ -934,6 +939,14 @@ for keyboard and scene navigation is ignored in tour and bench modes.
   washed out.
 - **Alpha-blended widget surfaces sort unreliably.** Use `OpaqueSurface` for
   every widget quad; keep `AlphaMode.blend` for pools and glow quads only.
+- **Layers centimetres apart fight in the depth buffer far out.** A
+  facade's window wall, far plate, neon glows and widget surface sit 1–3 cm
+  apart along the wall's normal; past ~200 m the depth buffer (near plane
+  0.3 m, far 1400 m) cannot separate them and they flicker as the camera
+  flies. Each layer carries a `Material.depthBias` (world metres toward
+  the eye: plate `plateDepthBias` 0.05, glows and ring `glowDepthBias`
+  0.1, every widget surface `widgetDepthBias` 0.15) so the order is fixed
+  at any distance. Raise the bias, not the spacing, when adding a layer.
 - **Sprites are skipped by the raycaster**, so the picker resolves beacons in
   screen space first.
 - **The harness clock is the demo fixture clock**, not `DateTime.now()`; the

--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -5,7 +5,7 @@ description: "The developer-only 3D project map: a merge-stable street folded in
 resource: ../../lib/features/plaza
 tags: [plaza, 3d, flutter-scene, flutter-gpu, tasks, visualization, prototype]
 status: draft
-generated: { by: claude-code/fable-5.1, at: 2026-09-04T12:00:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-04T22:05:04Z }
 stale_after: 2027-03-01
 sources:
   - id: street
@@ -76,6 +76,10 @@ sources:
     resource: ../../lib/features/plaza/dev_main.dart
     title: The dev harness, input, flights, walk, tour, bench
     last_modified: 2026-09-04
+  - id: pointer
+    resource: ../../lib/features/plaza/ui/plaza_pointer_controller.dart
+    title: Tap, drag and pointer cancellation state
+    last_modified: 2026-09-05
   - id: tour
     resource: ../../lib/features/plaza/ui/plaza_tour.dart
     title: The tour stops
@@ -399,7 +403,10 @@ clamped to ±1.25 rad. Walking always happens at `eyeHeight`; a pose set from
 above (overview, tour) keeps its height until the next step, and that step
 first plans a **landing flight** to eye height rather than dropping in one
 frame. Pressed keys are reconciled with `HardwareKeyboard` every frame so a
-key-up lost to a focus change cannot latch the camera walking.
+key-up lost to a focus change cannot latch the camera walking. Starting a
+flight clears the previous walking velocity; arriving at the overview cannot
+resume stale momentum and drop the camera. Drag look notifies `onMovement`,
+which abandons the morning walk whether it is flying or holding at a stop.
 
 A `Flight` is planned once, as a chain of straight **legs** with one
 **speed profile** over the whole way, and is evaluated by normalised time:
@@ -603,30 +610,38 @@ task data.
 
 ```mermaid
 flowchart TD
-  Far["far<br/>plate, neon strips, light bar, lantern<br/>no widget"] -->|"within 140 m and sign cap 80, one promotion per frame"| Sign["sign<br/>FacadeWidget sign variant<br/>captured once, manual input"]
-  Far -->|"within 26 m (or the building's own stand-off), on the wall's street side and ahead of the camera, live cap 4"| Live["live<br/>FacadeWidget live variant<br/>captured every frame, automatic input"]
-  Sign -->|"within 26 m (or the building's own stand-off), on the wall's street side and ahead of the camera, live cap 4"| Live
+  Far["far<br/>plate, neon strips, light bar, lantern<br/>no widget"] -->|"within 140 m and sign cap 80, one promotion per frame"| Sign["sign<br/>FacadeWidget sign variant<br/>initial capture and cover completion, manual input"]
+  Far -->|"tapped within live range, in front and in view, live budget available"| Live["live<br/>FacadeWidget live variant<br/>captured every 50 ms, automatic input"]
+  Sign -->|"tapped within live range, in front and in view, live budget available"| Live
   Live -->|"immediately when out of budget or range"| Sign
   Sign -->|"immediately"| Far
   Far -->|"prepare on flight start, the destination only"| Sign
 ```
 
 `FacadeLodConfig` defaults: `liveCap` 4, `signCap` 80, `liveDistance` 26 m,
-`signDistance` 140 m, `promotionsPerFrame` 1. Each frame the buildings are
-ranked by ground distance to the eye with a sticky factor (a surface already
+`signDistance` 140 m, `promotionsPerFrame` 1. When the camera or budget changes,
+or a promotion remains pending, the buildings are ranked by ground distance to the eye with a sticky factor (a surface already
 above far ranks as if 15 % closer), and the budget is handed out in that
-order. Live needs the eye on the street side of the wall (`facesEye`).
+order. A nearby tap activates one building via `activate`; merely walking
+up to it leaves its sign static. Live also needs the eye on the street side
+of the wall and the wall ahead of the camera. Leaving live range, turning
+away or activating another wall disarms the previous one; returning needs
+a new tap. A distant tap still flies to the building first.
 Promotions are rate-limited to one per frame and suspended while
-`suspended` is set (flights); demotions are immediate. `forceAllLive` (the
+`flying` is set; demotions are immediate. `forceAllLive` (the
 overlay's stress switch) makes every facade live and ignores the per-frame
 budget. The nearest live building is the **focused** one: its teal ring
 node is shown, and it is the wall whose checkboxes and details button
 work. Ticks live in a shared `ChecklistTicks` so the wall and the side
 panel agree; nothing is persisted.
 
-A sign surface captures once (`WidgetUpdatePolicy.manual`); the manager keeps
-requesting the capture until the first texture lands, because the host
-attaches a frame after the component does. Widget subtrees are sized at the
+A sign surface takes an initial capture (`WidgetUpdatePolicy.manual`); the
+manager keeps requesting it until the texture lands, because the host
+attaches a frame after the component does. `FacadeWidget.onCoverChanged`
+invalidates that texture after its image has painted or failed, so a late
+network image reaches the sign without a tier change or continuous polling.
+`SurfaceCaptures.invalidate` tracks the next capture count; callbacks from
+a detached component are ignored. Widget subtrees are sized at the
 facade's world size × `pxPerMeter` (the plate is `0.92 × width` by
 `0.9 × height`).
 
@@ -640,8 +655,8 @@ fourteen metres away).
 
 | Surface | Widget | Capture |
 |---|---|---|
-| live facade (at most 4) | `FacadeWidget` live | every frame |
-| sign facade (at most 80) | `FacadeWidget` sign | once |
+| activated facade (one normally; all in stress mode) | `FacadeWidget` live | every 50 ms, preserving press feedback |
+| sign facade (at most 80) | `FacadeWidget` sign | initially and after cover completion |
 | pylon, mounted and roof billboards | `BillboardWidget` | anomalies every 100 ms, the rest (a still face) every 3 s; hidden beyond the plaza range |
 | mounted, gantry and roofline tickers | `TickerWidget` | every 50 ms, hidden beyond the plaza range |
 | jumbotron | `JumbotronWidget` at 0.5 × px/m | every 1 s |
@@ -663,7 +678,7 @@ widgets read, `requestDue` throttles per surface (the first capture is
 free) and skips a surface the camera cannot see (`TimedSurface.seenFrom`:
 centre behind the eye by more than a few metres, or eye behind the
 surface's front), and `requestPending` re-requests the one-off captures
-until their textures land, then forgets them. `PlazaSurfaces.facingPose`
+until their requested capture counts land, then removes the pending requests. `PlazaSurfaces.facingPose`
 gives the pose in front of a billboard slot (14 m by default), used by the
 tour. No widget owns an animation controller: a billboard's glow, a
 ticker's scroll and the jumbotron's slides all read their cadence's clock,
@@ -850,15 +865,18 @@ shows.
 
 # Picking and input
 
-Pointer handling lives in the harness: a press that moves more than 6 px is a
-drag (look), a release within 0.25 s that never dragged is a tap.
+The harness delegates gesture state to `PlazaPointerController`: a primary
+press that moves more than 6 px is a drag (look); a release within 0.25 s
+that never dragged is a tap. Release, cancellation and loss of pressed
+buttons clear the active pointer and drag flag. Unrelated pointers cannot
+end the gesture. Auto pacing can therefore settle back to its idle cap.
 `PlazaPicker.pick` resolves beacon dots first in screen space (within
 `beaconHitPx` 14), because sprites are skipped by the raycaster, then casts a
 ray up to `maxTapDistance` (160 m) and walks up from the hit node to a
 billboard backing or a facade plate. A beacon tap flies to its pose, a
-building tap to its task pose unless it is already the focused building, a
-billboard tap to the task it shows. Only the primary button is used; input
-is ignored entirely in tour and bench modes.
+nearby building tap activates its facade, a distant building tap flies to
+its task pose, and a billboard tap flies to the task it shows. Only the primary button is used; input
+for keyboard and scene navigation is ignored in tour and bench modes.
 
 # Tour, bench and capture
 
@@ -938,7 +956,7 @@ is ignored entirely in tour and bench modes.
   the view (which repaints it once) at most `PlazaFrameRate` frames a
   second: `auto` is the display's rate while anything moves (a flight, the
   walk, a held key, a drag, and 0.6 s after) and 30 Hz at rest, `60` and
-  `30` are caps; the default is 60, the benchmark and the tour are never
+  `30` are caps; the default is `auto`, the benchmark and the tour are never
   capped. The HUD carries the control (a design-system segmented toggle)
   and a Debug box that shows the overlay; the backquote key toggles the
   overlay too, where a keyboard sends it. The overlay reports two rates:
@@ -962,10 +980,11 @@ is ignored entirely in tour and bench modes.
   `ValueNotifier<double>` of harness seconds that `requestDue` advances
   immediately before each capture request: `TickerWidget` scrolls by it,
   `BillboardWidget.glowAt` breathes by it, `JumbotronWidget` turns its
-  slides by it; none of them owns an animation controller, so a hosted
-  widget rebuilds exactly once per capture, in the frame of the request,
-  and the engine's frame rate equals the painted one (`engineFps` in the
-  overlay says so). `PLAZA_FPS=auto|60|30` picks the cap at start.
+  slides by it; none of them owns an animation controller, so a clock notification rebuilds its listeners in the frame of the request.
+  These clocks are shared per cadence, so even a culled surface can rebuild
+  when another surface advances that clock; only its capture is culled.
+  The pacer's `Ticker` still wakes on every vsync even when `_onPace` skips
+  a scene frame, so `engineFps` need not equal the painted rate. `PLAZA_FPS=auto|60|30` picks the cap at start.
 - **Fixtures are the demo world only.** The harness projects
   `ManualDemoWorld.penguinLogistics`; the synthetic generator lives in
   `test/features/plaza/plaza_fixtures.dart` for the tests and nowhere else.

--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -658,10 +658,10 @@ fourteen metres away).
 | activated facade (one normally; all in stress mode) | `FacadeWidget` live | every 50 ms, preserving press feedback |
 | sign facade (at most 80) | `FacadeWidget` sign | initially and after cover completion |
 | pylon, mounted and roof billboards | `BillboardWidget` | once, and again when the cover lands; hidden beyond the plaza range. The frame's breathing is the scene's glow quad, not the widget |
-| mounted, gantry and roofline tickers | `TickerWidget` | every 50 ms, hidden beyond the plaza range |
+| mounted, gantry and roofline tickers | `TickerWidget`, one period of text | once; the band's material scrolls the texture by UV offset every frame (`PlazaSurfaces.update`) and repeats it, on a `fadedQuad` whose ends darken by vertex colour; hidden beyond the plaza range |
 | jumbotron | `JumbotronWidget` at 0.5 × px/m | every 1 s |
 | skyline screens | `BillboardWidget` at 0.35 × px/m | once, and again when the cover lands |
-| ticker housing | a dark track and a teal rim with end caps behind every band (geometry, not a widget); the type fades in and out at the housing's ends | — |
+| ticker housing | a dark track and a teal rim with end caps behind every band (geometry, not a widget) | — |
 | block markers, week signs | `BlockMarkerWidget` | once |
 | banners | `BannerWidget` | once |
 | filler signs | `BannerWidget` at 0.6 × px/m | once |
@@ -973,17 +973,18 @@ for keyboard and scene navigation is ignored in tour and bench modes.
   a captured widget ticks on every vsync. So every surface is a **manual
   capture requested from the pacer**: `PlazaSurfaces.update(eye, seconds,
   forward:)` asks each timed surface in range, and in view, once its
-  interval is up (tickers `tickerInterval` 0.05 s, the jumbotron
-  `jumbotronInterval` 1 s; billboards, skyline screens, markers, banners
-  and signs once, a cover that lands later asking for one more), and
+  interval is up (the jumbotron `jumbotronInterval` 1 s; tickers,
+  billboards, skyline screens, markers, banners and signs once, a cover
+  that lands later asking for one more; a ticker is one captured period
+  that the band's material scrolls by UV offset, its texture never wider
+  than `maxTickerTexturePx`), and
   `FacadeLodManager.update(eye, forward:,
   seconds:, flying:)` asks each live wall every `liveInterval` (0.05 s),
   and re-ranks the tiers only when the eye, the view direction, the budget
   or the flight state moved since a ranking that left nothing undone. And
-  the animated widgets read **their cadence's clock**, a
+  the one animated widget left reads **its cadence's clock**, a
   `ValueNotifier<double>` of harness seconds that `requestDue` advances
-  immediately before each capture request: `TickerWidget` scrolls by it,
-  `JumbotronWidget` turns its
+  immediately before each capture request: `JumbotronWidget` turns its
   slides by it; none of them owns an animation controller, so a clock notification rebuilds its listeners in the frame of the request.
   These clocks are shared per cadence, so even a culled surface can rebuild
   when another surface advances that clock; only its capture is culled.

--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -657,10 +657,10 @@ fourteen metres away).
 |---|---|---|
 | activated facade (one normally; all in stress mode) | `FacadeWidget` live | every 50 ms, preserving press feedback |
 | sign facade (at most 80) | `FacadeWidget` sign | initially and after cover completion |
-| pylon, mounted and roof billboards | `BillboardWidget` | anomalies every 100 ms, the rest (a still face) every 3 s; hidden beyond the plaza range |
+| pylon, mounted and roof billboards | `BillboardWidget` | once, and again when the cover lands; hidden beyond the plaza range. The frame's breathing is the scene's glow quad, not the widget |
 | mounted, gantry and roofline tickers | `TickerWidget` | every 50 ms, hidden beyond the plaza range |
 | jumbotron | `JumbotronWidget` at 0.5 × px/m | every 1 s |
-| skyline screens | `BillboardWidget` at 0.35 × px/m | every 3 s |
+| skyline screens | `BillboardWidget` at 0.35 × px/m | once, and again when the cover lands |
 | ticker housing | a dark track and a teal rim with end caps behind every band (geometry, not a widget); the type fades in and out at the housing's ends | — |
 | block markers, week signs | `BlockMarkerWidget` | once |
 | banners | `BannerWidget` | once |
@@ -835,8 +835,12 @@ until it lands.
   the jumbotron tower always trade: they are the city, not tasks.
 - **Billboards**: pylons get two braced posts on footings and a catwalk; roof
   panels get two struts; every panel gets a dark lightbox, a glow quad and
-  chase-light points around the frame; the panel's own border (the widget's,
-  which breathes) is the one frame. A roof panel sits over its own facade,
+  chase-light points around the frame; the panel's own border (the widget's)
+  is the one frame, and the glow quad behind the lightbox is what breathes:
+  `PlazaSurfaces.update` writes its alpha once per frame from the slot's
+  pulse (`BillboardSlot.glowAt`, floor 0.55) times the scene's `poolFade`,
+  and only when it moved, so a billboard costs no capture at rest. A roof
+  panel sits over its own facade,
   which carries the title, so it leads with the reason on a solid band in
   the state colour across its top, panel-dark ink, the title small on the
   scrim, and drops its 'fly there' (`BillboardWidget.reasonFirst`). On a
@@ -969,17 +973,17 @@ for keyboard and scene navigation is ignored in tour and bench modes.
   a captured widget ticks on every vsync. So every surface is a **manual
   capture requested from the pacer**: `PlazaSurfaces.update(eye, seconds,
   forward:)` asks each timed surface in range, and in view, once its
-  interval is up (anomalous billboards `nearInterval` 0.1 s, tickers
-  `tickerInterval` 0.05 s, the jumbotron `jumbotronInterval` 1 s, the
-  skyline screens and the still billboards `farInterval` 3 s; markers,
-  banners and signs once), and `FacadeLodManager.update(eye, forward:,
+  interval is up (tickers `tickerInterval` 0.05 s, the jumbotron
+  `jumbotronInterval` 1 s; billboards, skyline screens, markers, banners
+  and signs once, a cover that lands later asking for one more), and
+  `FacadeLodManager.update(eye, forward:,
   seconds:, flying:)` asks each live wall every `liveInterval` (0.05 s),
   and re-ranks the tiers only when the eye, the view direction, the budget
   or the flight state moved since a ranking that left nothing undone. And
   the animated widgets read **their cadence's clock**, a
   `ValueNotifier<double>` of harness seconds that `requestDue` advances
   immediately before each capture request: `TickerWidget` scrolls by it,
-  `BillboardWidget.glowAt` breathes by it, `JumbotronWidget` turns its
+  `JumbotronWidget` turns its
   slides by it; none of them owns an animation controller, so a clock notification rebuilds its listeners in the frame of the request.
   These clocks are shared per cadence, so even a culled surface can rebuild
   when another surface advances that clock; only its capture is culled.

--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -5,7 +5,7 @@ description: "The developer-only 3D project map: a merge-stable street folded in
 resource: ../../lib/features/plaza
 tags: [plaza, 3d, flutter-scene, flutter-gpu, tasks, visualization, prototype]
 status: draft
-generated: { by: codex/gpt-6, at: 2026-09-04T22:05:04Z }
+generated: { by: codex/gpt-6, at: 2026-09-04T23:15:00Z }
 stale_after: 2027-03-01
 sources:
   - id: street
@@ -56,6 +56,10 @@ sources:
     resource: ../../lib/features/plaza/scene/plaza_scene.dart
     title: PlazaSceneController, the scene graph builder
     last_modified: 2026-09-04
+  - id: boxes
+    resource: ../../lib/features/plaza/scene/plaza_boxes.dart
+    title: Shared unit geometry and immutable solid materials
+    last_modified: 2026-09-05
   - id: surfaces
     resource: ../../lib/features/plaza/scene/plaza_surfaces.dart
     title: PlazaSurfaces, the non-facade widget surfaces and their capture intervals
@@ -716,6 +720,14 @@ until it lands.
 
 `PlazaSceneController` builds the `Scene` on construction:
 
+- **Shared box resources**: `PlazaBoxes` owns one plain unit cube and one
+  face-tinted unit cube per scene. Every box has an unscaled logical anchor
+  and a scaled mesh child, so attachments and ancestor-based picking keep
+  their coordinates. Matching solid colours and depth biases reuse material
+  instances, allowing the renderer to instance compatible opaque draws.
+  Shared materials are never animated or textured; surfaces with changing
+  material state keep their own instances. The helper accepts only unlit
+  materials, avoiding lighting changes from nonuniform normal transforms.
 - **Post-processing**: real HDR **bloom** (`scene.postProcess.bloom`,
   threshold `bloomThreshold` 1.0, intensity `bloomIntensity` 0.3, scatter
   0.6) and a soft **vignette** (0.32 at radius 0.82). Widget whites sit at

--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -5,7 +5,7 @@ description: "The developer-only 3D project map: a merge-stable street folded in
 resource: ../../lib/features/plaza
 tags: [plaza, 3d, flutter-scene, flutter-gpu, tasks, visualization, prototype]
 status: draft
-generated: { by: codex/gpt-6, at: 2026-09-04T23:15:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-04T22:54:16Z }
 stale_after: 2027-03-01
 sources:
   - id: street
@@ -696,7 +696,16 @@ chip, a details button (opens the side panel) and the done count.
 
 # Sprites
 
-`PlazaSprites` owns the camera-facing dots, all with `raycastable = false`:
+`PlazaSprites` keeps lanterns, beacons, lamp bulbs/halos and spire lights
+as individually sorted sprites (`raycastable = false`). The chase bulbs
+around each billboard share one `BillboardGeometry` and `SpriteMaterial`:
+one draw per frame instead of twenty. Each batch stays local to its panel,
+so its bounds and translucent draw order remain tied to that lightbox;
+unrelated alpha-blended halos and beacons are not merged into global batches.
+`PlazaLightBuffer` stores the fixed world positions and updates only size and
+HDR colour. Bounds are committed once using `maxChaseBulbSize` (0.45 m),
+then the actual sizes are restored; the geometry uploads the current buffer
+on each draw without a bounds refit.
 
 - **Lanterns**, one per building at roof + 0.7 m, coloured by lantern state,
   sized to `clamp(9 × 60 / d, 5, 22)` logical pixels, scaled by 2.2 when

--- a/lib/features/plaza/README.md
+++ b/lib/features/plaza/README.md
@@ -78,6 +78,7 @@ lib/features/plaza/
   scene/                 flutter_scene, needs a GPU context
     plaza_world.dart     everything derived from tasks and the clock (pure)
     plaza_scene.dart     the scene graph: sky, road, buildings, fillers, skyline
+    plaza_boxes.dart     shared unit geometry and solid materials for boxes
     facade_lod_manager.dart      far, sign and live facade tiers
     plaza_surfaces.dart  billboards, tickers, markers, signs, banners, jumbotron
     surface_captures.dart        the shared capture bookkeeping and cadences

--- a/lib/features/plaza/README.md
+++ b/lib/features/plaza/README.md
@@ -35,7 +35,7 @@ All read at start-up; none is needed for an interactive session.
 | `PLAZA_TOUR_ONLY=home,block` | `dev_main.dart` | Restricts the tour to the named stops |
 | `PLAZA_BENCH=1` | `dev_main.dart` | Auto-walk benchmark through six LOD budgets, printing `PLAZA_BENCH result` lines; wins over `PLAZA_TOUR` |
 | `PLAZA_HIDE=gantry,jumbotron,fillers,skyline,pylons,walls` | `dev_main.dart` | Leaves those pieces out of the scene (`PlazaSceneController(hidden:)`), to isolate what a screenshot shows |
-| `PLAZA_TRACE=1` | `dev_main.dart` | Prints one line per painted frame: frame time, engine frames since the last line, flight state, pose and how many solids contain the eye |
+| `PLAZA_TRACE=1` | `dev_main.dart` | Prints one line per painted frame: frame time, engine frames since the last line, flight state, pose, how many solids contain the eye and the running widget-capture count |
 | `PLAZA_FPS=auto,60,30` | `dev_main.dart` | The frame-rate cap at start (the HUD control changes it); auto by default |
 | `PLAZA_CLICK=<stop>:<x>,<y>` | `tool/plaza/capture_tour.py` | After capturing that tour stop, clicks the window-relative point and grabs a second `-ticked` frame |
 | `LOTTI_WINDOW_SIZE=WxH` | `linux/runner/my_application.cc` | Linux runner window size (a generic Lotti runner feature the capture script uses) |
@@ -92,7 +92,7 @@ lib/features/plaza/
     plaza_pointer_controller.dart   tap, drag and cancellation
     plaza_hud.dart, plaza_search_sheet.dart, task_side_panel.dart,
     debug_overlay.dart, checklist_ticks.dart, plaza_style.dart,
-    plaza_chip.dart
+    plaza_chip.dart, cover_image.dart
     plaza_tour.dart      the tour stops
 tool/plaza/capture_tour.py       X11 screenshot capture for the tour
 test/features/plaza/             one test file per pure source file

--- a/lib/features/plaza/README.md
+++ b/lib/features/plaza/README.md
@@ -6,7 +6,8 @@ needs attention is lit where it stands and repeated on a Times-Square-like
 frontier plaza of billboards, tickers and a jumbotron; roof lanterns show
 project health from the sky; beacons fly the camera to curated poses; a
 morning walk visits the anomalies; search and a side panel get you to any
-task. Built on `flutter_scene` (Flutter GPU / Impeller). It is the
+task. Tap a nearby facade to enable its checklist and details; moving away
+returns it to a static sign. Built on `flutter_scene` (Flutter GPU / Impeller). It is the
 exploration meant to replace the knowledge-graph hairball with a spatial,
 memorable map of a project.
 
@@ -35,7 +36,7 @@ All read at start-up; none is needed for an interactive session.
 | `PLAZA_BENCH=1` | `dev_main.dart` | Auto-walk benchmark through six LOD budgets, printing `PLAZA_BENCH result` lines; wins over `PLAZA_TOUR` |
 | `PLAZA_HIDE=gantry,jumbotron,fillers,skyline,pylons,walls` | `dev_main.dart` | Leaves those pieces out of the scene (`PlazaSceneController(hidden:)`), to isolate what a screenshot shows |
 | `PLAZA_TRACE=1` | `dev_main.dart` | Prints one line per painted frame: frame time, engine frames since the last line, flight state, pose and how many solids contain the eye |
-| `PLAZA_FPS=auto,60,30` | `dev_main.dart` | The frame-rate cap at start (the HUD control changes it); 60 by default |
+| `PLAZA_FPS=auto,60,30` | `dev_main.dart` | The frame-rate cap at start (the HUD control changes it); auto by default |
 | `PLAZA_CLICK=<stop>:<x>,<y>` | `tool/plaza/capture_tour.py` | After capturing that tour stop, clicks the window-relative point and grabs a second `-ticked` frame |
 | `LOTTI_WINDOW_SIZE=WxH` | `linux/runner/my_application.cc` | Linux runner window size (a generic Lotti runner feature the capture script uses) |
 
@@ -88,6 +89,7 @@ lib/features/plaza/
     facade_widget.dart, billboard_widget.dart, jumbotron_widget.dart,
     ticker_widget.dart, banner_widget.dart, block_marker_widget.dart
     fly_camera_controller.dart   walk camera and flights
+    plaza_pointer_controller.dart   tap, drag and cancellation
     plaza_hud.dart, plaza_search_sheet.dart, task_side_panel.dart,
     debug_overlay.dart, checklist_ticks.dart, plaza_style.dart,
     plaza_chip.dart

--- a/lib/features/plaza/dev_main.dart
+++ b/lib/features/plaza/dev_main.dart
@@ -23,7 +23,6 @@ import 'dart:async' show unawaited;
 import 'dart:io' show Platform;
 import 'dart:math' as math;
 
-import 'package:flutter/gestures.dart' show kPrimaryButton;
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart' show SchedulerBinding, Ticker;
 import 'package:flutter/services.dart';
@@ -47,6 +46,7 @@ import 'package:lotti/features/plaza/ui/checklist_ticks.dart';
 import 'package:lotti/features/plaza/ui/debug_overlay.dart';
 import 'package:lotti/features/plaza/ui/fly_camera_controller.dart';
 import 'package:lotti/features/plaza/ui/plaza_hud.dart';
+import 'package:lotti/features/plaza/ui/plaza_pointer_controller.dart';
 import 'package:lotti/features/plaza/ui/plaza_search_sheet.dart';
 import 'package:lotti/features/plaza/ui/plaza_tour.dart';
 import 'package:lotti/features/plaza/ui/task_side_panel.dart';
@@ -114,17 +114,10 @@ class _PlazaHarnessState extends State<_PlazaHarness>
   /// its own, a ticker here paints at most [_frameRate] frames a second
   /// (the benchmark and the tour paint on every vsync). Every painted
   /// frame runs [_onTick] first.
-  PlazaFrameRate _frameRate = _initialFrameRate();
+  PlazaFrameRate _frameRate = PlazaFrameRate.fromEnvironment(
+    Platform.environment,
+  );
   Ticker? _pacer;
-
-  /// `PLAZA_FPS=auto|60|30` picks the cap at start; 60 otherwise.
-  static PlazaFrameRate _initialFrameRate() {
-    final wanted = Platform.environment['PLAZA_FPS'];
-    return PlazaFrameRate.values.firstWhere(
-      (rate) => rate.label == wanted,
-      orElse: () => PlazaFrameRate.sixty,
-    );
-  }
 
   Duration? _lastPaint;
   final ValueNotifier<int> _frame = ValueNotifier(0);
@@ -173,9 +166,7 @@ class _PlazaHarnessState extends State<_PlazaHarness>
   int _beaconCursor = -1;
 
   // Tap-versus-drag.
-  Offset? _pointerDown;
-  double _pointerDownAt = 0;
-  bool _dragging = false;
+  final _pointer = PlazaPointerController();
 
   // Rolling frame-time window.
   final List<double> _frameMs = [];
@@ -234,7 +225,7 @@ class _PlazaHarnessState extends State<_PlazaHarness>
       _mode.scripted ||
       _camera.flying ||
       _camera.moving ||
-      _dragging ||
+      _pointer.dragging ||
       _walk != null;
 
   void _onPace(Duration elapsed) {
@@ -459,33 +450,31 @@ class _PlazaHarnessState extends State<_PlazaHarness>
   }
 
   void _onPointerDown(PointerDownEvent event) {
-    if (_mode.scripted || event.buttons != kPrimaryButton) return;
-    _pointerDown = event.localPosition;
-    _pointerDownAt = _elapsed;
-    _dragging = false;
+    if (_mode.scripted) return;
+    _pointer.down(event, _elapsed);
   }
 
   void _onPointerMove(PointerMoveEvent event) {
-    final down = _pointerDown;
-    if (down == null || event.buttons == 0) return;
-    if (!_dragging && (event.localPosition - down).distance > 6) {
-      _dragging = true;
-    }
-    if (_dragging) _camera.addLookDelta(event.delta.dx, event.delta.dy);
+    final delta = _pointer.move(event);
+    if (delta != null) _camera.addLookDelta(delta.dx, delta.dy);
   }
 
   void _onPointerUp(PointerUpEvent event) {
-    final down = _pointerDown;
-    _pointerDown = null;
-    if (down == null || _dragging) return;
-    if (_elapsed - _pointerDownAt > 0.25) return;
+    final point = _pointer.up(event, _elapsed);
+    if (point == null) return;
     final camera = _frameCamera;
     if (camera == null) return;
-    switch (_picker.pick(camera, _viewSize, event.localPosition)) {
+    switch (_picker.pick(camera, _viewSize, point)) {
       case PickedBeacon(:final beacon):
         _flyTo(beacon.pose, beacon.label);
       case PickedBuilding(:final building):
-        if (_lod.focused != building) _flyToBuilding(building);
+        if (!_lod.activate(
+          building,
+          _camera.position,
+          forward: _camera.forward,
+        )) {
+          _flyToBuilding(building);
+        }
       case PickedBillboard(:final billboard):
         _flyToTask(billboard.attention.task);
       case null:
@@ -650,6 +639,7 @@ class _PlazaHarnessState extends State<_PlazaHarness>
                 onPointerDown: _onPointerDown,
                 onPointerMove: _onPointerMove,
                 onPointerUp: _onPointerUp,
+                onPointerCancel: (event) => _pointer.cancel(event.pointer),
                 child: LayoutBuilder(
                   builder: (context, constraints) {
                     _viewSize = constraints.biggest;

--- a/lib/features/plaza/dev_main.dart
+++ b/lib/features/plaza/dev_main.dart
@@ -105,9 +105,10 @@ class _PlazaHarnessState extends State<_PlazaHarness>
   };
 
   /// `PLAZA_TRACE=1` prints one line per frame: the frame time, whether a
-  /// flight is under way, the pose, and how many solids contain the eye —
-  /// the ground truth for a stall, a missing flight or a wall flown
-  /// through, read off the running harness rather than a unit test.
+  /// flight is under way, the pose, how many solids contain the eye and
+  /// the running count of widget captures — the ground truth for a stall,
+  /// a missing flight, a wall flown through or a surface captured too
+  /// often, read off the running harness rather than a unit test.
   static final bool _traceMode = Platform.environment['PLAZA_TRACE'] == '1';
 
   /// The harness owns the frame pacing: the scene view does not tick on
@@ -555,7 +556,8 @@ class _PlazaHarnessState extends State<_PlazaHarness>
       'dt=${(dt * 1000).toStringAsFixed(1)} engine=$engine '
       'flying=${_camera.flying} walk=${_walk?.index} '
       'x=${p.x.toStringAsFixed(2)} y=${p.y.toStringAsFixed(2)} '
-      'z=${p.z.toStringAsFixed(2)} inside=$inside',
+      'z=${p.z.toStringAsFixed(2)} inside=$inside '
+      'captures=${_lod.stats.captures + _surfaces.captures}',
     );
   }
 
@@ -582,7 +584,12 @@ class _PlazaHarnessState extends State<_PlazaHarness>
       seconds: _elapsed,
       flying: _camera.flying,
     );
-    _surfaces.update(eye, _elapsed, forward: forward);
+    _surfaces.update(
+      eye,
+      _elapsed,
+      forward: forward,
+      glowFade: _sceneController.poolFade,
+    );
     _sceneController.updateForCamera(eye);
     _sprites.update(camera, _viewSize, _elapsed);
 

--- a/lib/features/plaza/domain/plaza_layout.dart
+++ b/lib/features/plaza/domain/plaza_layout.dart
@@ -116,6 +116,20 @@ class BillboardSlot {
 
   /// World-space centre of the panel.
   double get centerY => bottom + height / 2;
+
+  /// The frame's glow at [seconds] of an anomaly's breathing: up over half
+  /// a [pulseSeconds] cycle and down over the other half, eased at both
+  /// ends, between [glowFloor] and 1.
+  double glowAt(double seconds) {
+    final half = pulseSeconds / 2;
+    final cycle = (seconds / half) % 2;
+    final phase = cycle <= 1 ? cycle : 2 - cycle;
+    final eased = phase * phase * (3 - 2 * phase);
+    return glowFloor + (1 - glowFloor) * eased;
+  }
+
+  /// The glow at the bottom of a breath.
+  static const glowFloor = 0.55;
 }
 
 /// Where a ticker band runs: on the plaza-facing wall under a mounted

--- a/lib/features/plaza/scene/facade_lod_manager.dart
+++ b/lib/features/plaza/scene/facade_lod_manager.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter/widgets.dart' show Widget;
 import 'package:flutter_scene/scene.dart';
 import 'package:lotti/features/plaza/scene/plaza_scene.dart';
 import 'package:lotti/features/plaza/scene/surface_captures.dart';
@@ -10,7 +11,8 @@ import 'package:lotti/features/plaza/ui/facade_widget.dart';
 import 'package:vector_math/vector_math.dart' show Vector3;
 
 /// Surface tier of one facade: live = interactive widget captured every
-/// frame, sign = captured once, far = the plate and the lantern only.
+/// 50 ms, sign = captured initially and after cover completion, far = the
+/// plate and the lantern only.
 enum FacadeTier { far, sign, live }
 
 /// The tier budget. Defaults are the design's numbers; the debug overlay
@@ -25,7 +27,7 @@ class FacadeLodConfig {
     this.forceAllLive = false,
   });
 
-  /// Hard cap on live (every-frame) surfaces: the faced building and its
+  /// Hard cap on live (interactive) surfaces: the faced building and its
   /// nearest neighbours.
   int liveCap;
 
@@ -68,18 +70,30 @@ typedef _Budget = ({
   bool flying,
 });
 
+/// Builds the GPU surface separately from the tier and capture scheduling.
+/// Tests supply a bind-only component to exercise promotions without a GPU.
+typedef FacadeSurfaceBuilder =
+    WidgetComponent Function({
+      required Widget child,
+      required double width,
+      required double height,
+      required double pxPerMeter,
+      WidgetInput input,
+    });
+
 /// Assigns each facade a tier from camera distance with sticky
 /// hysteresis, enforces the caps by construction, and schedules
 /// promotions one per frame so walking into a busy block never spikes.
 ///
-/// The faced building (nearest live facade the walker is in front of) gets
-/// the focus ring and is the one whose checkboxes work.
+/// A nearby facade becomes live only after a tap, gets the focus ring,
+/// and remains interactive until the walker leaves its range or view.
 class FacadeLodManager {
   FacadeLodManager({
     required this.buildings,
     required this.config,
     required this.ticks,
     required this.onOpen,
+    this.surfaceBuilder = hostedSurface,
   }) : _surfaces = [for (final _ in buildings) _Surface()],
        _distances = Float64List(buildings.length),
        _order = List<int>.generate(buildings.length, (i) => i);
@@ -88,6 +102,7 @@ class FacadeLodManager {
   final FacadeLodConfig config;
   final ChecklistTicks ticks;
   final void Function(PlazaBuilding building) onOpen;
+  final FacadeSurfaceBuilder surfaceBuilder;
   final List<_Surface> _surfaces;
   final FacadeLodStats stats = FacadeLodStats();
 
@@ -135,6 +150,26 @@ class FacadeLodManager {
               'front=${r.$2.facesEye(eye)}',
         )
         .join(' | ');
+  }
+
+  PlazaBuilding? _activated;
+
+  /// Activates a nearby facade after a tap. A distant tap should navigate
+  /// first. Only the selected wall is interactive; leaving its live range
+  /// or turning away disarms it, so idle signs do not keep capturing.
+  bool activate(PlazaBuilding building, Vector3 eye, {Vector3? forward}) {
+    if (!buildings.contains(building) ||
+        config.liveCap <= 0 ||
+        building.groundDistanceTo(eye) >=
+            math.max(config.liveDistance, building.liveRange) ||
+        !_inView(building, eye, forward)) {
+      return false;
+    }
+    if (_activated != building) {
+      _activated = building;
+      _settled = false;
+    }
+    return true;
   }
 
   PlazaBuilding? _focused;
@@ -225,7 +260,8 @@ class FacadeLodManager {
       FacadeTier target;
       if (config.forceAllLive) {
         target = FacadeTier.live;
-      } else if (liveLeft > 0 &&
+      } else if (building == _activated &&
+          liveLeft > 0 &&
           d < math.max(config.liveDistance, building.liveRange) &&
           _inView(building, eye, forward)) {
         target = FacadeTier.live;
@@ -256,6 +292,8 @@ class FacadeLodManager {
         changed = true;
       }
     }
+
+    if (!config.forceAllLive && focused == null) _activated = null;
 
     if (focused != _focused) {
       _focused?.ring.visible = false;
@@ -305,7 +343,8 @@ class FacadeLodManager {
 
     if (target != FacadeTier.far) {
       final live = target == FacadeTier.live;
-      final component = hostedSurface(
+      late final WidgetComponent component;
+      component = surfaceBuilder(
         child: FacadeWidget(
           task: building.task,
           attention: building.attention,
@@ -313,6 +352,7 @@ class FacadeLodManager {
           widthMeters: building.facadeWorldWidth,
           pxPerMeter: building.pxPerMeter,
           ticks: live ? ticks : null,
+          onCoverChanged: () => _captures.invalidate(component.controller),
           onOpen: live ? () => onOpen(building) : null,
         ),
         width: building.facadeWorldWidth,
@@ -364,6 +404,7 @@ class FacadeLodManager {
 
   /// Detaches every widget surface (used when tearing a scene down).
   void dispose() {
+    _activated = null;
     for (var i = 0; i < buildings.length; i++) {
       final component = _surfaces[i].component;
       if (component != null) {

--- a/lib/features/plaza/scene/plaza_boxes.dart
+++ b/lib/features/plaza/scene/plaza_boxes.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart';
+
+/// Scene-owned unit boxes and immutable solid materials. Sharing geometry
+/// and material identity lets flutter_scene instance compatible opaque draws.
+/// The caller supplies GPU geometry; node transforms and material reuse can
+/// therefore be tested without uploading any vertices.
+class PlazaBoxes {
+  PlazaBoxes({required this.cube, required this.shadedCube});
+
+  final Geometry cube;
+  final Geometry shadedCube;
+  final Map<(double, double, double, double, double), UnlitMaterial> _solids =
+      {};
+
+  /// Reuses an untextured solid colour, including its depth bias. Returned
+  /// materials must not be mutated: animated or textured materials belong
+  /// to their individual surfaces instead. The colour is copied so later
+  /// writes to the caller's vector cannot change an already shared material.
+  UnlitMaterial solid(Vector4 color, {double depthBias = 0}) =>
+      _solids.putIfAbsent(
+        (color.x, color.y, color.z, color.w, depthBias),
+        () => UnlitMaterial()
+          ..baseColorFactor = Vector4.copy(color)
+          ..depthBias = depthBias,
+      );
+
+  /// Builds an unscaled anchor with a scaled unit mesh underneath it.
+  /// Children added to the anchor retain their original local coordinates;
+  /// ray hits on the mesh can still resolve a pick target on the anchor.
+  /// Only unlit materials are accepted: nonuniform scale must not change
+  /// lighting through the renderer's normal transform.
+  Node node(
+    Vector3 size,
+    UnlitMaterial material, {
+    Matrix4? transform,
+    bool shaded = false,
+  }) => Node(localTransform: transform)
+    ..add(
+      Node(
+        localTransform: Matrix4.diagonal3(size),
+        mesh: Mesh(shaded ? shadedCube : cube, material),
+      ),
+    );
+}

--- a/lib/features/plaza/scene/plaza_scene.dart
+++ b/lib/features/plaza/scene/plaza_scene.dart
@@ -43,6 +43,24 @@ Geometry ccwQuad(double width, double height) {
   );
 }
 
+/// A [ccwQuad] wound the other way: the same vertices and texture
+/// coordinates facing -Z, so the picture on it is the front's seen from
+/// behind, mirrored — the back of a translucent lightbox.
+Geometry backQuad(double width, double height) {
+  final hw = width / 2;
+  final hh = height / 2;
+  return MeshGeometry.fromArrays(
+    positions: Float32List.fromList([
+      hw, -hh, 0, //
+      -hw, -hh, 0, //
+      -hw, hh, 0, //
+      hw, hh, 0, //
+    ]),
+    texCoords: Float32List.fromList([0, 1, 1, 1, 1, 0, 0, 0]),
+    indices: [0, 1, 3, 3, 1, 2],
+  );
+}
+
 /// A [ccwQuad] whose two ends, each [fade] of its width, darken to black
 /// through the vertex colour the unlit material multiplies in: a ticker
 /// band's type fades into its housing instead of being sliced mid-glyph.
@@ -220,12 +238,21 @@ Vector4 emissiveColor(Color color, double boost, {double? alpha}) {
 /// alpha-blended surface sorts unreliably against other surfaces (a banner
 /// sixty metres away drew over a pylon fourteen metres away).
 class OpaqueSurface {
-  OpaqueSurface() : material = UnlitMaterial()..alphaMode = AlphaMode.opaque;
+  OpaqueSurface({this.shared = const []})
+    : material = UnlitMaterial()..alphaMode = AlphaMode.opaque;
 
   final UnlitMaterial material;
 
+  /// Other materials that show the same capture: the darker, mirrored back
+  /// of a translucent lightbox.
+  final List<UnlitMaterial> shared;
+
   void bind(gpu.Texture texture) {
-    material.baseColorTexture = GpuTextureSource(texture);
+    final source = GpuTextureSource(texture);
+    material.baseColorTexture = source;
+    for (final other in shared) {
+      other.baseColorTexture = source;
+    }
   }
 }
 
@@ -308,12 +335,22 @@ class PlazaBillboard {
     required this.backing,
     required this.anchor,
     this.glow,
+    this.back,
   });
 
   final BillboardSlot slot;
   final TaskAttention attention;
   final Node backing;
   final Node anchor;
+
+  /// The lightbox's back, on a pylon or a roof: the panel's own capture,
+  /// mirrored by the view and dimmed to [backTint], as light through a
+  /// translucent box. Null on a wall or the jumbotron, which have no
+  /// back to see.
+  final UnlitMaterial? back;
+
+  /// How much of the picture comes through the back.
+  static const backTint = 0.42;
 
   /// The soft bloom behind the lightbox: an anomaly breathes by it. The
   /// jumbotron has none of its own here; its bloom is a pool of the scene.
@@ -1594,11 +1631,18 @@ class PlazaSceneController {
     );
     // Far-tier surface: an always-present dark plate; the lantern carries
     // the state colour, the plate only says "there is a facade here".
+    // The plate, the neon glows and the widget surface stand 1–3 cm apart
+    // along the wall's normal, which the depth buffer cannot separate a
+    // few hundred metres out; each layer is biased toward the eye a
+    // little more than the one behind it (`Material.depthBias`), so a
+    // facade never flickers between its layers during a flight.
     final plate = _box(
       node,
       Vector3(0, panelY, d / 2 + 0.03),
       Vector3(facadeW, facadeH, 0.02),
-      UnlitMaterial()..baseColorFactor = _panelBack,
+      UnlitMaterial()
+        ..baseColorFactor = _panelBack
+        ..depthBias = plateDepthBias,
     );
 
     // Progress light bar along the base, visible at every tier.
@@ -1700,6 +1744,7 @@ class PlazaSceneController {
               sh + 1.1,
               alarm && !isRoofline ? stateNeon : categoryNeon,
               (alarm && isRoofline ? 0.08 : 0.16) * emissive,
+              depthBias: glowDepthBias,
             )
             ..localTransform = Matrix4.translation(
               Vector3(dx, dy + panelY, d / 2 + 0.04),
@@ -1767,7 +1812,8 @@ class PlazaSceneController {
       ..baseColorFactor = emissiveColor(
         PlazaStyle.lantern(attention.lantern),
         neonBoost,
-      );
+      )
+      ..depthBias = glowDepthBias;
     const t = 0.12;
     const off = 0.25;
     for (final (dx, dy, sw, sh) in [
@@ -1921,6 +1967,29 @@ class PlazaSceneController {
       Vector3(slot.width + 0.5, slot.height + 0.5, depth),
       _towerMaterial,
     );
+    // A pylon's or a roof panel's back is open to the street: the same
+    // capture shows through, mirrored ([backQuad] keeps the front's UVs
+    // and faces the other way, so the eye reads them backwards) and
+    // dimmed, inside the box's rim.
+    UnlitMaterial? back;
+    if (slot.mount != BillboardMount.wall) {
+      back = UnlitMaterial()
+        ..baseColorFactor = Vector4(
+          PlazaBillboard.backTint,
+          PlazaBillboard.backTint,
+          PlazaBillboard.backTint,
+          1,
+        )
+        ..alphaMode = AlphaMode.opaque;
+      root.add(
+        Node(
+          localTransform: Matrix4.translation(
+            Vector3(0, slot.centerY, -depth - 0.03),
+          ),
+          mesh: Mesh(backQuad(slot.width, slot.height), back),
+        ),
+      );
+    }
     // Faux bloom: a wide soft glow behind the lightbox. Not a pool: the
     // surfaces breathe it and fade it with [poolFade] themselves.
     final glow = UnlitMaterial()
@@ -1947,6 +2016,7 @@ class PlazaSceneController {
       backing: backing,
       anchor: anchor,
       glow: glow,
+      back: back,
     );
     billboards.add(billboard);
     pickableBillboards[backing] = billboard;
@@ -2010,10 +2080,23 @@ class PlazaSceneController {
 
   /// A soft glow quad behind an emitter: the faux bloom that makes neon
   /// and lightboxes read as lit rather than painted.
-  Node _glowQuad(double width, double height, Color color, double alpha) {
+  /// Depth biases, world metres toward the eye, for the layers on a
+  /// facade: the plate over the window wall, the neon glows and the focus
+  /// ring over the plate; the widget surface (`widgetDepthBias`) over all.
+  static const plateDepthBias = 0.05;
+  static const glowDepthBias = 0.1;
+
+  Node _glowQuad(
+    double width,
+    double height,
+    Color color,
+    double alpha, {
+    double depthBias = 0,
+  }) {
     final material = UnlitMaterial()
       ..baseColorFactor = linearColor(color, alpha: alpha)
-      ..alphaMode = AlphaMode.blend;
+      ..alphaMode = AlphaMode.blend
+      ..depthBias = depthBias;
     _pools.add((material, alpha));
     return Node(mesh: Mesh(ccwQuad(width, height), material));
   }

--- a/lib/features/plaza/scene/plaza_scene.dart
+++ b/lib/features/plaza/scene/plaza_scene.dart
@@ -270,12 +270,33 @@ class PlazaBillboard {
     required this.attention,
     required this.backing,
     required this.anchor,
+    this.glow,
   });
 
   final BillboardSlot slot;
   final TaskAttention attention;
   final Node backing;
   final Node anchor;
+
+  /// The soft bloom behind the lightbox: an anomaly breathes by it. The
+  /// jumbotron has none of its own here; its bloom is a pool of the scene.
+  final UnlitMaterial? glow;
+
+  /// The bloom's alpha at eye level, at the top of a breath.
+  static const glowAlpha = 0.3;
+
+  double _glowAlpha = glowAlpha;
+
+  /// The bloom's current alpha; written to the material only when it
+  /// moved, so a still billboard costs nothing per frame.
+  double get currentGlow => _glowAlpha;
+  set currentGlow(double value) {
+    final glow = this.glow;
+    if (glow == null || (value - _glowAlpha).abs() < 1e-3) return;
+    _glowAlpha = value;
+    final c = glow.baseColorFactor;
+    glow.baseColorFactor = Vector4(c.x, c.y, c.z, value);
+  }
 
   Vector3 get center => Vector3(slot.x, slot.centerY, slot.z);
 }
@@ -448,6 +469,11 @@ class PlazaSceneController {
   /// The altitude fade last applied, so a camera that has not climbed
   /// does not rewrite every pool and wash material each frame.
   double? _lastFadeT;
+
+  /// What is left of a pool's alpha at the camera's height: 1 at eye
+  /// level, [poolFloor] above [poolFadeTop]. The billboards' bloom fades
+  /// by it too.
+  double get poolFade => 1 - (1 - poolFloor) * (_lastFadeT ?? 0);
 
   /// Shows the map layer once [eye] is above [poolFadeStart], and fades
   /// the fog, pools and washes with its height.
@@ -1858,12 +1884,18 @@ class PlazaSceneController {
       Vector3(slot.width + 0.5, slot.height + 0.5, depth),
       _towerMaterial,
     );
-    // Faux bloom: a wide soft glow behind the lightbox.
+    // Faux bloom: a wide soft glow behind the lightbox. Not a pool: the
+    // surfaces breathe it and fade it with [poolFade] themselves.
+    final glow = UnlitMaterial()
+      ..baseColorFactor = linearColor(frame, alpha: PlazaBillboard.glowAlpha)
+      ..alphaMode = AlphaMode.blend;
     root.add(
-      _glowQuad(slot.width + 3, slot.height + 3, frame, 0.3)
-        ..localTransform = Matrix4.translation(
+      Node(
+        localTransform: Matrix4.translation(
           Vector3(0, slot.centerY, -depth - 0.06),
         ),
+        mesh: Mesh(ccwQuad(slot.width + 3, slot.height + 3), glow),
+      ),
     );
     // The panel's own border is the one frame; the lightbox bezel and the
     // chase lights sit behind it.
@@ -1877,6 +1909,7 @@ class PlazaSceneController {
       attention: attention,
       backing: backing,
       anchor: anchor,
+      glow: glow,
     );
     billboards.add(billboard);
     pickableBillboards[backing] = billboard;

--- a/lib/features/plaza/scene/plaza_scene.dart
+++ b/lib/features/plaza/scene/plaza_scene.dart
@@ -9,6 +9,7 @@ import 'package:lotti/features/plaza/domain/plaza_layout.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/features/plaza/domain/scenery.dart';
 import 'package:lotti/features/plaza/domain/street_layout.dart';
+import 'package:lotti/features/plaza/scene/plaza_boxes.dart';
 import 'package:lotti/features/plaza/scene/plaza_world.dart';
 import 'package:lotti/features/plaza/scene/wall_textures.dart';
 import 'package:lotti/features/plaza/ui/plaza_style.dart';
@@ -399,6 +400,10 @@ class PlazaSceneController {
   final Set<String> hidden;
   bool _shown(String piece) => !hidden.contains(piece);
   final Scene scene = Scene();
+  late final _boxes = PlazaBoxes(
+    cube: CuboidGeometry(Vector3.all(1)),
+    shadedCube: shadedCuboid(Vector3.all(1)),
+  );
   final List<PlazaBuilding> buildings = [];
   final List<PlazaBillboard> billboards = [];
 
@@ -763,11 +768,13 @@ class PlazaSceneController {
     }
   }
 
-  /// A [CuboidGeometry] box of [size] centred at [at] under [parent].
-  static Node _box(Node parent, Vector3 at, Vector3 size, Material material) {
-    final node = Node(
-      localTransform: Matrix4.translation(at),
-      mesh: Mesh(CuboidGeometry(size), material),
+  /// A shared unit box scaled to [size], with an unscaled anchor centred
+  /// at [at] under [parent] so attached decorations retain their placement.
+  Node _box(Node parent, Vector3 at, Vector3 size, UnlitMaterial material) {
+    final node = _boxes.node(
+      size,
+      material,
+      transform: Matrix4.translation(at),
     );
     parent.add(node);
     return node;
@@ -783,7 +790,7 @@ class PlazaSceneController {
     required double d,
     required double y,
     required double thickness,
-    required Material material,
+    required UnlitMaterial material,
     double inset = 0,
     double overhang = 0,
     double? height,
@@ -814,7 +821,7 @@ class PlazaSceneController {
       scene.root,
       Vector3(centerX, -0.06, centerZ),
       Vector3(6000, 0.1, 6000),
-      UnlitMaterial()..baseColorFactor = _ground,
+      _boxes.solid(_ground),
     );
     if (buildSkyline) {
       _buildSkyline();
@@ -828,15 +835,10 @@ class PlazaSceneController {
         0,
         segment.startZ + math.cos(segment.headingRadians) * midAlong,
       );
-      final roadNode = Node(
-        localTransform: Matrix4.translation(mid)
-          ..rotateY(segment.headingRadians),
-        mesh: Mesh(
-          CuboidGeometry(
-            Vector3(layout.roadWidth, 0.08, segment.length + 0.4),
-          ),
-          UnlitMaterial()..baseColorFactor = segment.isGap ? _gap : _road,
-        ),
+      final roadNode = _boxes.node(
+        Vector3(layout.roadWidth, 0.08, segment.length + 0.4),
+        _boxes.solid(segment.isGap ? _gap : _road),
+        transform: Matrix4.translation(mid)..rotateY(segment.headingRadians),
       );
       // Pavements with a kerb step on both sides, and a dashed centre
       // line: the street section that makes a slab read as a road.
@@ -863,7 +865,7 @@ class PlazaSceneController {
         roadNode,
         Vector3(0, 0.1, 0),
         Vector3(0.9, 0.02, segment.length + 0.4),
-        UnlitMaterial()..baseColorFactor = _ribbon,
+        _boxes.solid(_ribbon),
       )..visible = false;
       _mapRibbons.add(ribbon);
       if (!segment.isGap) {
@@ -876,7 +878,7 @@ class PlazaSceneController {
             roadNode,
             Vector3(0, 0.045, along),
             Vector3(0.18, 0.01, 2.2),
-            UnlitMaterial()..baseColorFactor = _centreLine,
+            _boxes.solid(_centreLine),
           );
         }
       }
@@ -917,14 +919,12 @@ class PlazaSceneController {
 
     final plaza = world.plaza;
     if (plaza != null) {
-      final slab = Node(
-        localTransform: Matrix4.translation(
+      final slab = _boxes.node(
+        Vector3(plaza.width, 0.1, plaza.depth),
+        _boxes.solid(_ground),
+        transform: Matrix4.translation(
           Vector3(plaza.centerX, 0.01, plaza.centerZ),
         )..rotateY(plaza.headingRadians),
-        mesh: Mesh(
-          CuboidGeometry(Vector3(plaza.width, 0.1, plaza.depth)),
-          UnlitMaterial()..baseColorFactor = _ground,
-        ),
       );
       _addTiledOverlay(
         slab,
@@ -1075,12 +1075,11 @@ class PlazaSceneController {
           }
         case FurnitureKind.planter:
           root.add(
-            Node(
-              localTransform: Matrix4.translation(Vector3(0, f.height / 2, 0)),
-              mesh: Mesh(
-                shadedCuboid(Vector3(f.width, f.height, f.depth)),
-                _postMaterial,
-              ),
+            _boxes.node(
+              Vector3(f.width, f.height, f.depth),
+              _postMaterial,
+              transform: Matrix4.translation(Vector3(0, f.height / 2, 0)),
+              shaded: true,
             ),
           );
           _box(
@@ -1090,14 +1089,13 @@ class PlazaSceneController {
             soil,
           );
           root.add(
-            Node(
-              localTransform: Matrix4.translation(
+            _boxes.node(
+              Vector3(f.width * 0.72, 0.5, f.depth * 0.72),
+              leaves,
+              transform: Matrix4.translation(
                 Vector3(0, f.height + 0.25, 0),
               ),
-              mesh: Mesh(
-                shadedCuboid(Vector3(f.width * 0.72, 0.5, f.depth * 0.72)),
-                leaves,
-              ),
+              shaded: true,
             ),
           );
           // A lit rim along the planter's top edge, in the parade's warm.
@@ -1105,11 +1103,12 @@ class PlazaSceneController {
             root,
             Vector3(0, f.height + 0.01, 0),
             Vector3(f.width + 0.06, 0.03, f.depth + 0.06),
-            UnlitMaterial()
-              ..baseColorFactor = linearColor(
+            _boxes.solid(
+              linearColor(
                 const Color(0xFFFFC46B),
                 alpha: 0.8,
               ),
+            ),
           );
         case FurnitureKind.kiosk:
           final sign = UnlitMaterial()
@@ -1122,12 +1121,11 @@ class PlazaSceneController {
             ..alphaMode = AlphaMode.blend;
           _pools.add((window, 0.75));
           root.add(
-            Node(
-              localTransform: Matrix4.translation(Vector3(0, f.height / 2, 0)),
-              mesh: Mesh(
-                shadedCuboid(Vector3(f.width, f.height, f.depth)),
-                _towerMaterial,
-              ),
+            _boxes.node(
+              Vector3(f.width, f.height, f.depth),
+              _towerMaterial,
+              transform: Matrix4.translation(Vector3(0, f.height / 2, 0)),
+              shaded: true,
             ),
           );
           // The lit sign along the front's top edge, and the hatch.
@@ -1279,14 +1277,13 @@ class PlazaSceneController {
       // The tower is a building, not a slab: windowed on every face, a
       // lit crown, neon on its front corners. Its box is the scenery's,
       // so the collider knows it.
-      final tower = Node(
-        localTransform: Matrix4.translation(
+      final tower = _boxes.node(
+        Vector3(towerW, towerH, towerD),
+        _towerMaterial,
+        transform: Matrix4.translation(
           Vector3(0, towerH / 2, -jumbotronTowerSetback),
         ),
-        mesh: Mesh(
-          shadedCuboid(Vector3(towerW, towerH, towerD)),
-          _towerMaterial,
-        ),
+        shaded: true,
       );
       _windowedBox(
         tower,
@@ -1327,7 +1324,7 @@ class PlazaSceneController {
         root,
         Vector3(0, jumbotron.centerY, -0.2),
         Vector3(jumbotron.width + 0.6, jumbotron.height + 0.6, 0.4),
-        UnlitMaterial()..baseColorFactor = linearColor(PlazaStyle.teal),
+        _boxes.solid(linearColor(PlazaStyle.teal)),
       );
       final anchor = Node(
         localTransform: Matrix4.translation(
@@ -1491,19 +1488,17 @@ class PlazaSceneController {
     final facing = placement.facingRadians;
     final normal = Vector3(math.sin(facing), 0, math.cos(facing));
 
-    final node = Node(
-      localTransform: Matrix4.translation(
+    final node = _boxes.node(
+      Vector3(w, h, d),
+      _boxes.solid(linearColor(PlazaStyle.categoryWall(task))),
+      transform: Matrix4.translation(
         Vector3(
           placement.x + normal.x * setback,
           h / 2,
           placement.z + normal.z * setback,
         ),
       )..rotateY(facing),
-      mesh: Mesh(
-        shadedCuboid(Vector3(w, h, d)),
-        UnlitMaterial()
-          ..baseColorFactor = linearColor(PlazaStyle.categoryWall(task)),
-      ),
+      shaded: true,
     );
     final parade = stableIndex(task.id, 'parade', WallTextures.paradeVariants);
     final kit = stableIndex(task.id, 'kit', WallTextures.tileFamilies);
@@ -1568,22 +1563,20 @@ class PlazaSceneController {
       node,
       Vector3(0, -h / 2 + 0.35, 0),
       Vector3(w + 0.1, 0.7, d + 0.1),
-      UnlitMaterial()..baseColorFactor = linearColor(const Color(0xFF0A0910)),
+      _boxes.solid(linearColor(const Color(0xFF0A0910))),
     );
 
     // Tall buildings step back to an upper storey with its own roof.
     if (h >= 14) {
       final upperH = h * 0.22;
       node.add(
-        Node(
-          localTransform: Matrix4.translation(
+        _boxes.node(
+          Vector3(w * 0.68, upperH, d * 0.7),
+          _boxes.solid(linearColor(PlazaStyle.categoryRoof(task))),
+          transform: Matrix4.translation(
             Vector3(0, h / 2 + upperH / 2, -d * 0.12),
           ),
-          mesh: Mesh(
-            shadedCuboid(Vector3(w * 0.68, upperH, d * 0.7)),
-            UnlitMaterial()
-              ..baseColorFactor = linearColor(PlazaStyle.categoryRoof(task)),
-          ),
+          shaded: true,
         ),
       );
     }
@@ -1620,14 +1613,15 @@ class PlazaSceneController {
       node,
       Vector3(0, h / 2 + 0.02, 0),
       Vector3(w + 0.04, 0.04, d + 0.04),
-      UnlitMaterial()
-        ..baseColorFactor = linearColor(
+      _boxes.solid(
+        linearColor(
           Color.lerp(
             PlazaStyle.categoryRoof(task),
             const Color(0xFF07060D),
             0.5,
           )!,
         ),
+      ),
     );
     // Far-tier surface: an always-present dark plate; the lantern carries
     // the state colour, the plate only says "there is a facade here".
@@ -1640,9 +1634,7 @@ class PlazaSceneController {
       node,
       Vector3(0, panelY, d / 2 + 0.03),
       Vector3(facadeW, facadeH, 0.02),
-      UnlitMaterial()
-        ..baseColorFactor = _panelBack
-        ..depthBias = plateDepthBias,
+      _boxes.solid(_panelBack, depthBias: plateDepthBias),
     );
 
     // Progress light bar along the base, visible at every tier.
@@ -1661,10 +1653,11 @@ class PlazaSceneController {
       node,
       Vector3(0, plinthY, d / 2 + 0.1),
       Vector3(facadeW, 0.28, 0.1),
-      UnlitMaterial()
-        ..baseColorFactor = linearColor(
+      _boxes.solid(
+        linearColor(
           Color.lerp(PlazaStyle.panel, PlazaStyle.textDim, 0.25)!,
         ),
+      ),
     );
     // Seen from the street a +Z face's +X is the viewer's left (the
     // widget quads map their texture left edge to +X), so the bar fills
@@ -1674,8 +1667,7 @@ class PlazaSceneController {
         node,
         Vector3(facadeW / 2 - facadeW * pct / 2, plinthY, d / 2 + 0.12),
         Vector3(facadeW * pct, 0.28, 0.12),
-        UnlitMaterial()
-          ..baseColorFactor = linearColor(PlazaStyle.lightBar(attention)),
+        _boxes.solid(linearColor(PlazaStyle.lightBar(attention))),
       );
     }
     // Quarter ticks so the bar has a scale.
@@ -1684,7 +1676,7 @@ class PlazaSceneController {
         node,
         Vector3(facadeW / 2 - facadeW * q, plinthY, d / 2 + 0.16),
         Vector3(0.06, 0.28, 0.04),
-        UnlitMaterial()..baseColorFactor = linearColor(const Color(0xFF07060D)),
+        _boxes.solid(linearColor(const Color(0xFF07060D))),
       );
     }
 
@@ -1866,15 +1858,12 @@ class PlazaSceneController {
   void _buildEmptyLot(PlotPlacement placement) {
     // Fenced empty lot: foundations visible, street never closes up.
     scene.add(
-      Node(
-        localTransform: Matrix4.translation(
+      _boxes.node(
+        Vector3(placement.width, 0.5, placement.depth),
+        _boxes.solid(linearColor(const Color(0xFF14161C))),
+        transform: Matrix4.translation(
           Vector3(placement.x, 0.25, placement.z),
         )..rotateY(placement.facingRadians),
-        mesh: Mesh(
-          CuboidGeometry(Vector3(placement.width, 0.5, placement.depth)),
-          UnlitMaterial()
-            ..baseColorFactor = linearColor(const Color(0xFF14161C)),
-        ),
       ),
     );
   }
@@ -2146,7 +2135,7 @@ class PlazaSceneController {
       parent,
       Vector3(0, y, front + 0.3),
       Vector3(width + 0.8, height + 0.8, 0.6),
-      UnlitMaterial()..baseColorFactor = linearColor(frame),
+      _boxes.solid(linearColor(frame)),
     );
     parent.add(
       _glowQuad(width + glowMargin, height + glowMargin, frame, glowAlpha)
@@ -2226,10 +2215,12 @@ class PlazaSceneController {
       final bh = block.height;
       // Local x is lateral, local z runs along the road: the block is
       // bw long along the street and bd deep away from it.
-      final node = Node(
-        localTransform: Matrix4.translation(Vector3(block.x, bh / 2, block.z))
+      final node = _boxes.node(
+        Vector3(bd, bh, bw),
+        _towerMaterial,
+        transform: Matrix4.translation(Vector3(block.x, bh / 2, block.z))
           ..rotateY(block.yawRadians),
-        mesh: Mesh(shadedCuboid(Vector3(bd, bh, bw)), _towerMaterial),
+        shaded: true,
       );
       final parade = stableIndex(id, 'parade', WallTextures.paradeVariants);
       final kit = stableIndex(id, 'kit', WallTextures.tileFamilies);
@@ -2304,9 +2295,11 @@ class PlazaSceneController {
         localTransform: Matrix4.translation(Vector3(tower.x, 0, tower.z))
           ..rotateY(tower.yawRadians),
       );
-      final box = Node(
-        localTransform: Matrix4.translation(Vector3(0, height / 2, 0)),
-        mesh: Mesh(shadedCuboid(Vector3(w, height, bd)), _towerMaterial),
+      final box = _boxes.node(
+        Vector3(w, height, bd),
+        _towerMaterial,
+        transform: Matrix4.translation(Vector3(0, height / 2, 0)),
+        shaded: true,
       );
       final parade = stableIndex(id, 'parade', WallTextures.paradeVariants);
       root.add(box);
@@ -2325,8 +2318,7 @@ class PlazaSceneController {
         root,
         Vector3(0, height + 0.1, 0),
         Vector3(w + 0.3, 0.2, bd + 0.3),
-        UnlitMaterial()
-          ..baseColorFactor = linearColor(PlazaStyle.teal, alpha: 0.9),
+        _boxes.solid(linearColor(PlazaStyle.teal, alpha: 0.9)),
       );
       _spire(
         root,
@@ -2383,13 +2375,12 @@ class PlazaSceneController {
       final i = tower.index;
       final w = tower.width;
       final h = tower.height;
-      final node = Node(
-        localTransform: Matrix4.translation(Vector3(tower.x, h / 2, tower.z))
+      final node = _boxes.node(
+        Vector3(w, h, tower.depth),
+        _boxes.solid(_skyline),
+        transform: Matrix4.translation(Vector3(tower.x, h / 2, tower.z))
           ..rotateY(tower.yawRadians),
-        mesh: Mesh(
-          shadedCuboid(Vector3(w, h, tower.depth)),
-          UnlitMaterial()..baseColorFactor = _skyline,
-        ),
+        shaded: true,
       );
       // A lit roofline along the district-facing edge, warm and teal by
       // turns, so the ring is a glowing horizon and not a row of dots.
@@ -2398,8 +2389,7 @@ class PlazaSceneController {
         node,
         Vector3(0, h / 2 + 0.1, tower.depth / 2 - 0.1),
         Vector3(w + 0.2, 0.25, 0.25),
-        UnlitMaterial()
-          ..baseColorFactor = emissiveColor(roofline, neonBoost, alpha: 0.95),
+        _boxes.solid(emissiveColor(roofline, neonBoost, alpha: 0.95)),
       );
       node.add(
         _glowQuad(w + 4, 3, roofline, 0.16)

--- a/lib/features/plaza/scene/plaza_scene.dart
+++ b/lib/features/plaza/scene/plaza_scene.dart
@@ -43,6 +43,43 @@ Geometry ccwQuad(double width, double height) {
   );
 }
 
+/// A [ccwQuad] whose two ends, each [fade] of its width, darken to black
+/// through the vertex colour the unlit material multiplies in: a ticker
+/// band's type fades into its housing instead of being sliced mid-glyph.
+Geometry fadedQuad(double width, double height, {required double fade}) {
+  final hw = width / 2;
+  final hh = height / 2;
+  // Columns from +X to -X, the way [ccwQuad] orders its vertices, each
+  // with a bottom and a top vertex.
+  final xs = [hw, hw - width * fade, -hw + width * fade, -hw];
+  final us = [0.0, fade, 1 - fade, 1.0];
+  final positions = <double>[];
+  final texCoords = <double>[];
+  final colors = <double>[];
+  for (var c = 0; c < xs.length; c++) {
+    final lit = c == 1 || c == 2 ? 1.0 : 0.0;
+    for (final (y, v) in [(-hh, 1.0), (hh, 0.0)]) {
+      positions.addAll([xs[c], y, 0]);
+      texCoords.addAll([us[c], v]);
+      colors.addAll([lit, lit, lit, 1]);
+    }
+  }
+  final indices = <int>[];
+  for (var c = 0; c + 1 < xs.length; c++) {
+    final bottomA = 2 * c;
+    final topA = bottomA + 1;
+    final bottomB = bottomA + 2;
+    final topB = bottomB + 1;
+    indices.addAll([topA, bottomB, bottomA, topB, bottomB, topA]);
+  }
+  return MeshGeometry.fromArrays(
+    positions: Float32List.fromList(positions),
+    texCoords: Float32List.fromList(texCoords),
+    colors: Float32List.fromList(colors),
+    indices: indices,
+  );
+}
+
 /// A CCW quad whose texture coordinates repeat [uRepeat] × [vRepeat] times
 /// (textures sample with wrap-around), offset by [uOffset] so tiled walls
 /// do not all show the same windows.

--- a/lib/features/plaza/scene/plaza_sprites.dart
+++ b/lib/features/plaza/scene/plaza_sprites.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'dart:ui' show Color;
@@ -17,8 +18,9 @@ import 'package:vector_math/vector_math.dart' hide Colors;
 /// frame from their distance, so a lantern never shrinks below a few pixels
 /// from the overview pose and a beacon reads the same from across the
 /// district as from up close. Anomalous lanterns and attention beacons
-/// pulse on a fixed cycle. A sprite is only written when its size or
-/// colour actually moved: every [Sprite] setter re-commits its quad.
+/// pulse on a fixed cycle. Lanterns, beacons and halos retain separate
+/// sprites for depth sorting; the non-overlapping chase bulbs on each
+/// billboard share one instanced draw with fixed bounds.
 class PlazaSprites {
   PlazaSprites({
     required this.scene,
@@ -65,18 +67,21 @@ class PlazaSprites {
       // Warm-white bulbs read against any bezel colour; the tail goes
       // near-black so the chase is a chase.
       final color = linearColor(const Color(0xFFFFF1C8));
-      final run = <_ChaseLight>[];
-      for (final point in entry.value) {
-        final sprite = Sprite(color: color);
-        scene.add(
-          Node(localTransform: Matrix4.translation(point), mesh: sprite.mesh)
-            ..raycastable = false,
-        );
-        run.add(_ChaseLight(sprite: sprite, color: color));
+      final points = entry.value;
+      if (points.isEmpty) continue;
+      final geometry = BillboardGeometry(capacity: points.length);
+      final material = SpriteMaterial();
+      final instances = PlazaLightBuffer(geometry.instanceData);
+      for (final point in points) {
+        instances.add(point, size: 0.3, color: color);
       }
+      instances.commitBounds(geometry.commit, pad: maxChaseBulbSize);
+      scene.add(Node(mesh: Mesh(geometry, material))..raycastable = false);
       _chases.add(
         _Chase(
-          lights: run,
+          instances: instances,
+          material: material,
+          color: color,
           periodSeconds: entry.key.slot.pulseSeconds.clamp(1.2, 4.0),
         ),
       );
@@ -200,10 +205,8 @@ class PlazaSprites {
     for (final l in _spireLights) {
       l.material.colorTexture = _bulb;
     }
-    for (final c in _chases) {
-      for (final l in c.lights) {
-        l.sprite.material.colorTexture = _bulb;
-      }
+    for (final chase in _chases) {
+      chase.material.colorTexture = _bulb;
     }
   }
 
@@ -224,6 +227,9 @@ class PlazaSprites {
   static const lampBulbSize = 0.5;
   static const lampHaloSize = 2.0;
   static const spireLightSize = 2.4;
+
+  /// The largest chase bulb, also the conservative padding of its batch.
+  static const maxChaseBulbSize = 0.45;
 
   /// Below this a size or colour change is invisible and is not written:
   /// every [Sprite] setter re-commits its quad, and at rest most frames
@@ -299,10 +305,9 @@ class PlazaSprites {
     // Chase lights run round each billboard frame: a bright head with a
     // fading tail, faster for the more agitated panels.
     for (final chase in _chases) {
-      final n = chase.lights.length;
-      if (n == 0) continue;
+      final n = chase.instances.count;
       final head = (elapsedSeconds / chase.periodSeconds * n) % n;
-      for (final (i, light) in chase.lights.indexed) {
+      for (var i = 0; i < n; i++) {
         final behind = (head - i + n) % n;
         // A five-bulb head over a near-dark tail, so the chase reads in a
         // still frame and not only in motion; the head goes past white for
@@ -313,17 +318,16 @@ class PlazaSprites {
         final alpha = behind < 5 ? 1 - behind * 0.14 : 0.3;
         final boost = behind < 2 ? 1.6 : 1.0;
         final size = behind < 1
-            ? 0.45
+            ? maxChaseBulbSize
             : behind < 2
             ? 0.36
             : 0.3;
-        _resize(light.sprite, size);
-        _tint(
-          light.sprite,
-          light.color.x * boost,
-          light.color.y * boost,
-          light.color.z * boost,
-          alpha,
+        chase.instances.write(
+          i,
+          size: size,
+          color: chase.color,
+          alpha: alpha,
+          boost: boost,
         );
       }
     }
@@ -423,16 +427,77 @@ class _Lamp {
   final Vector3 worldPosition;
 }
 
-class _ChaseLight {
-  _ChaseLight({required this.sprite, required this.color});
+class _Chase {
+  _Chase({
+    required this.instances,
+    required this.material,
+    required this.color,
+    required this.periodSeconds,
+  });
 
-  final Sprite sprite;
+  final PlazaLightBuffer instances;
+  final SpriteMaterial material;
   final Vector4 color;
+  final double periodSeconds;
 }
 
-class _Chase {
-  _Chase({required this.lights, required this.periodSeconds});
+/// CPU-side instance data for a fixed group of chase bulbs. Geometry uploads
+/// this buffer on each draw; changing only size and colour needs no bounds
+/// refit after [commitBounds] reserves the maximum bulb size.
+class PlazaLightBuffer {
+  PlazaLightBuffer(this.data);
 
-  final List<_ChaseLight> lights;
-  final double periodSeconds;
+  final Float32List data;
+  int _count = 0;
+  int get count => _count;
+
+  /// Adds one stationary bulb, copying its position and colour into the
+  /// billboard layout. The rest of the record remains at its zero defaults.
+  void add(Vector3 center, {required double size, required Vector4 color}) {
+    final offset = _count * BillboardGeometry.floatsPerInstance;
+    data[offset] = center.x;
+    data[offset + 1] = center.y;
+    data[offset + 2] = center.z;
+    write(_count, size: size, color: color, alpha: color.w);
+    _count++;
+  }
+
+  /// Commits bounds with each bulb at its largest [pad], then restores the
+  /// display sizes even if the geometry's commit fails.
+  void commitBounds(void Function(int) commit, {required double pad}) {
+    const stride = BillboardGeometry.floatsPerInstance;
+    final sizes = Float32List(_count * 2);
+    for (var i = 0; i < _count; i++) {
+      sizes[2 * i] = data[i * stride + 3];
+      sizes[2 * i + 1] = data[i * stride + 4];
+      data[i * stride + 3] = pad;
+      data[i * stride + 4] = pad;
+    }
+    try {
+      commit(_count);
+    } finally {
+      for (var i = 0; i < _count; i++) {
+        data[i * stride + 3] = sizes[2 * i];
+        data[i * stride + 4] = sizes[2 * i + 1];
+      }
+    }
+  }
+
+  /// Updates the bulb's size and linear HDR colour while retaining its
+  /// centre, rotation, flipbook frame and velocity.
+  void write(
+    int index, {
+    required double size,
+    required Vector4 color,
+    required double alpha,
+    double boost = 1,
+  }) {
+    final offset = index * BillboardGeometry.floatsPerInstance;
+    data[offset + 3] = size;
+    data[offset + 4] = size;
+    data[offset + 6] = color.x * boost;
+    data[offset + 7] = color.y * boost;
+    data[offset + 8] = color.z * boost;
+    data[offset + 9] = alpha;
+  }
 }

--- a/lib/features/plaza/scene/plaza_surfaces.dart
+++ b/lib/features/plaza/scene/plaza_surfaces.dart
@@ -20,17 +20,17 @@ import 'package:vector_math/vector_math.dart' show Matrix4, Vector3;
 /// ticker bands and the week markers on the road.
 ///
 /// Budget (spec): billboards ≤ 6, still faces captured once (and again
-/// when a cover lands), their bloom breathing in the scene; tickers at
-/// [tickerInterval] within the plaza's range and not at all beyond it; the
-/// jumbotron at [jumbotronInterval]; the skyline screens, block markers,
-/// banners and signs captured once at build.
+/// when a cover lands), their bloom breathing in the scene; tickers one
+/// period each captured once and scrolled by UV offset; the jumbotron at
+/// [jumbotronInterval]; the skyline screens, block markers, banners and
+/// signs captured once at build.
 ///
 /// Every capture is manual, requested from [update] on the harness clock
 /// through [SurfaceCaptures]: an interval policy would make flutter_scene
 /// pump an engine frame on every vsync, whatever the harness paints. Each
-/// cadence owns the clock its widgets read ([tickerClock],
-/// [jumbotronClock]), advanced only when that cadence asks for
-/// a capture, so between captures nothing in them runs.
+/// cadence owns the clock its widgets read ([jumbotronClock]), advanced
+/// only when that cadence asks for a capture, so between captures nothing
+/// in them runs.
 class PlazaSurfaces {
   PlazaSurfaces({
     required this.scene,
@@ -61,12 +61,7 @@ class PlazaSurfaces {
   final double pxPerMeter;
 
   final SurfaceCaptures _captures = SurfaceCaptures();
-  final CaptureCadence _tickers = CaptureCadence(tickerInterval);
   final CaptureCadence _jumbotron = CaptureCadence(jumbotronInterval);
-
-  /// Elapsed harness seconds as of the tickers' last capture request: the
-  /// clock the bands scroll by.
-  ValueListenable<double> get tickerClock => _tickers.clock;
 
   /// Elapsed harness seconds as of the jumbotron's last capture request:
   /// the clock it turns its slides by.
@@ -92,8 +87,6 @@ class PlazaSurfaces {
     );
     return math.max(plazaRangeFloor, reach + 60);
   }
-
-  static const tickerInterval = 0.05;
 
   static const markerWidth = 16.0;
   static const markerHeight = 5.2;
@@ -280,18 +273,30 @@ class PlazaSurfaces {
           Vector3(slot.x, slot.bottom + slot.height / 2, slot.z),
         )..rotateY(slot.facingRadians),
       );
+      // One period of the band is captured, once, at a density that keeps
+      // the texture under [maxTickerTexturePx] wide; the band's quad shows
+      // [slot.width] of it and the scene slides the offset each frame.
+      final text = world.tickerTexts[slot] ?? world.tickerText;
+      final period = TickerWidget.periodMeters(text, slot.height, slot.width);
+      final density = math.min(pxPerMeter, maxTickerTexturePx / period);
+      final surface = OpaqueSurface();
       final component = hostedSurface(
         child: TickerWidget(
-          text: world.tickerTexts[slot] ?? world.tickerText,
+          text: text,
           heightMeters: slot.height,
-          pxPerMeter: pxPerMeter,
-          speedMetersPerSecond: slot.speedMetersPerSecond,
-          clock: _tickers.clock,
+          pxPerMeter: density,
         ),
-        width: slot.width,
+        width: period,
         height: slot.height,
-        pxPerMeter: pxPerMeter,
+        pxPerMeter: density,
+        geometry: fadedQuad(slot.width, slot.height, fade: tickerFade),
+        surface: surface,
       );
+      surface.material.baseColorTextureTransform.scale.x = slot.width / period;
+      _tickerBands.add((
+        surface.material,
+        slot.speedMetersPerSecond / period,
+      ));
       anchor.addComponent(component);
       // Housing: a dark track behind the band with a thin teal rim and
       // end caps, so the ticker is a fixture on the wall and not a strip
@@ -328,17 +333,21 @@ class PlazaSurfaces {
       // view culling measure against.
       final center = Vector3(slot.x, slot.bottom + slot.height / 2, slot.z);
       _ranged.add((center, anchor));
-      _captures.timed(
-        _tickers,
-        TimedSurface.facing(
-          controller: component.controller,
-          node: anchor,
-          center: center,
-          facingRadians: slot.facingRadians,
-        ),
-      );
+      _captures.once(component.controller);
     }
   }
+
+  /// Each ticker band's material and its scroll speed in periods a
+  /// second: the UV offset the scene slides every frame.
+  final List<(UnlitMaterial, double)> _tickerBands = [];
+
+  /// A ticker texture is never wider than this: the long headline bands
+  /// are captured at a lower density instead.
+  static const maxTickerTexturePx = 8192.0;
+
+  /// The fraction of a band's width over which its type fades in and out
+  /// at the housing's ends.
+  static const tickerFade = 0.06;
 
   /// Once per painted frame, at [seconds] on the harness clock: keeps
   /// asking for the one-off captures until they land, hides the plaza's
@@ -367,9 +376,13 @@ class PlazaSurfaces {
           : 1.0;
       billboard.currentGlow = PlazaBillboard.glowAlpha * glowFade * pulse;
     }
-    _captures
-      ..requestDue(_tickers, eye, seconds, forward: forward)
-      ..requestDue(_jumbotron, eye, seconds, forward: forward);
+    // The bands scroll: the texture's offset along the band, in periods,
+    // wrapping every period. Leftward on the band is +u on the quad.
+    for (final (material, periodsPerSecond) in _tickerBands) {
+      material.baseColorTextureTransform.offset.x =
+          (seconds * periodsPerSecond) % 1;
+    }
+    _captures.requestDue(_jumbotron, eye, seconds, forward: forward);
   }
 
   /// Total captures across these surfaces, for the debug overlay.

--- a/lib/features/plaza/scene/plaza_surfaces.dart
+++ b/lib/features/plaza/scene/plaza_surfaces.dart
@@ -19,17 +19,17 @@ import 'package:vector_math/vector_math.dart' show Matrix4, Vector3;
 /// The plaza's mid-tier widget surfaces that are not facades: billboards,
 /// ticker bands and the week markers on the road.
 ///
-/// Budget (spec): billboards ≤ 6, captured at [nearInterval] within the
-/// plaza's range; tickers at [tickerInterval] within range and not at all
-/// beyond it; the jumbotron at [jumbotronInterval]; the skyline screens at
-/// [farInterval]; block markers, banners, signs and the billboards that do
-/// not animate captured once at build.
+/// Budget (spec): billboards ≤ 6, still faces captured once (and again
+/// when a cover lands), their bloom breathing in the scene; tickers at
+/// [tickerInterval] within the plaza's range and not at all beyond it; the
+/// jumbotron at [jumbotronInterval]; the skyline screens, block markers,
+/// banners and signs captured once at build.
 ///
 /// Every capture is manual, requested from [update] on the harness clock
 /// through [SurfaceCaptures]: an interval policy would make flutter_scene
 /// pump an engine frame on every vsync, whatever the harness paints. Each
-/// cadence owns the clock its widgets read ([nearClock], [tickerClock],
-/// [farClock], [jumbotronClock]), advanced only when that cadence asks for
+/// cadence owns the clock its widgets read ([tickerClock],
+/// [jumbotronClock]), advanced only when that cadence asks for
 /// a capture, so between captures nothing in them runs.
 class PlazaSurfaces {
   PlazaSurfaces({
@@ -61,22 +61,12 @@ class PlazaSurfaces {
   final double pxPerMeter;
 
   final SurfaceCaptures _captures = SurfaceCaptures();
-  final CaptureCadence _near = CaptureCadence(nearInterval);
   final CaptureCadence _tickers = CaptureCadence(tickerInterval);
-  final CaptureCadence _far = CaptureCadence(farInterval);
   final CaptureCadence _jumbotron = CaptureCadence(jumbotronInterval);
-
-  /// Elapsed harness seconds as of the billboards' last capture request:
-  /// the clock the anomaly billboards breathe by.
-  ValueListenable<double> get nearClock => _near.clock;
 
   /// Elapsed harness seconds as of the tickers' last capture request: the
   /// clock the bands scroll by.
   ValueListenable<double> get tickerClock => _tickers.clock;
-
-  /// Elapsed harness seconds as of the skyline screens' last capture
-  /// request.
-  ValueListenable<double> get farClock => _far.clock;
 
   /// Elapsed harness seconds as of the jumbotron's last capture request:
   /// the clock it turns its slides by.
@@ -103,9 +93,7 @@ class PlazaSurfaces {
     return math.max(plazaRangeFloor, reach + 60);
   }
 
-  static const nearInterval = 0.1;
   static const tickerInterval = 0.05;
-  static const farInterval = 3.0;
 
   static const markerWidth = 16.0;
   static const markerHeight = 5.2;
@@ -140,19 +128,19 @@ class PlazaSurfaces {
     }
   }
 
-  /// Big screens on the skyline: the anomalies again, at a slow capture
-  /// rate — they are far, and repetition is the Times Square idiom.
+  /// Big screens on the skyline: the anomalies again, captured once —
+  /// they are far, and repetition is the Times Square idiom.
   void _attachSkylineScreens(List<(Node, double, double, int)> screens) {
     for (final (anchor, w, h, rank) in screens) {
       if (rank >= world.anomalies.length) continue;
-      final component = hostedSurface(
+      late final WidgetComponent component;
+      component = hostedSurface(
         child: BillboardWidget(
           attention: world.anomalies[rank],
           widthMeters: w,
           heightMeters: h,
           pxPerMeter: pxPerMeter * 0.35,
-          pulseSeconds: 4,
-          clock: _far.clock,
+          onCoverChanged: () => _captures.invalidate(component.controller),
         ),
         width: w,
         height: h,
@@ -160,7 +148,7 @@ class PlazaSurfaces {
         scale: 0.35,
       );
       anchor.addComponent(component);
-      _captures.timed(_far, TimedSurface.posed(component.controller, anchor));
+      _captures.once(component.controller);
     }
   }
 
@@ -261,38 +249,27 @@ class PlazaSurfaces {
   void _attachBillboards() {
     for (final billboard in billboards) {
       final slot = billboard.slot;
-      final component = hostedSurface(
+      late final WidgetComponent component;
+      component = hostedSurface(
         child: BillboardWidget(
           attention: billboard.attention,
           widthMeters: slot.width,
           heightMeters: slot.height,
           pxPerMeter: pxPerMeter,
-          pulseSeconds: slot.pulseSeconds,
           // A roof panel sits over its own facade, which carries the
           // title: the panel leads with the reason instead.
           reasonFirst: slot.mount == BillboardMount.roof,
-          clock: _near.clock,
+          onCoverChanged: () => _captures.invalidate(component.controller),
         ),
         width: slot.width,
         height: slot.height,
         pxPerMeter: pxPerMeter,
       );
       billboard.anchor.addComponent(component);
-      final center = billboard.center;
-      _ranged.add((center, billboard.anchor));
-      // Only an anomaly breathes ([BillboardWidget] renders a still face
-      // below the threshold): the rest take the far cadence, seldom
-      // enough to cost nothing and often enough that a cover image that
-      // decodes after the first capture still lands on the panel.
-      _captures.timed(
-        billboard.attention.anomalous ? _near : _far,
-        TimedSurface.facing(
-          controller: component.controller,
-          node: billboard.anchor,
-          center: center,
-          facingRadians: slot.facingRadians,
-        ),
-      );
+      _ranged.add((billboard.center, billboard.anchor));
+      // A still face: captured once, and once more when its cover lands.
+      // The breathing is the glow quad's, in [update].
+      _captures.once(component.controller);
     }
   }
 
@@ -371,15 +348,27 @@ class PlazaSurfaces {
   /// [forward] is the camera's view direction: with it a surface behind
   /// the eye or facing away from it is not captured; without it nothing is
   /// culled.
-  void update(Vector3 eye, double seconds, {Vector3? forward}) {
+  void update(
+    Vector3 eye,
+    double seconds, {
+    Vector3? forward,
+    double glowFade = 1,
+  }) {
     _captures.requestPending();
     for (final (center, node) in _ranged) {
       node.visible = eye.distanceTo(center) <= plazaRange;
     }
+    // An anomaly's bloom breathes on its slot's pulse; every bloom fades
+    // with the camera's height like a pool. One material write per
+    // billboard, and only when the alpha moved.
+    for (final billboard in billboards) {
+      final pulse = billboard.attention.anomalous
+          ? billboard.slot.glowAt(seconds)
+          : 1.0;
+      billboard.currentGlow = PlazaBillboard.glowAlpha * glowFade * pulse;
+    }
     _captures
-      ..requestDue(_near, eye, seconds, forward: forward)
       ..requestDue(_tickers, eye, seconds, forward: forward)
-      ..requestDue(_far, eye, seconds, forward: forward)
       ..requestDue(_jumbotron, eye, seconds, forward: forward);
   }
 

--- a/lib/features/plaza/scene/plaza_surfaces.dart
+++ b/lib/features/plaza/scene/plaza_surfaces.dart
@@ -257,6 +257,8 @@ class PlazaSurfaces {
         width: slot.width,
         height: slot.height,
         pxPerMeter: pxPerMeter,
+        // The lightbox's back shows the same capture, dimmed.
+        surface: OpaqueSurface(shared: [?billboard.back]),
       );
       billboard.anchor.addComponent(component);
       _ranged.add((billboard.center, billboard.anchor));

--- a/lib/features/plaza/scene/surface_captures.dart
+++ b/lib/features/plaza/scene/surface_captures.dart
@@ -133,7 +133,7 @@ class CaptureCadence {
 /// until they land, cadenced captures throttled per surface and skipped
 /// while the camera cannot see them, and the counters the overlay shows.
 class SurfaceCaptures {
-  final List<WidgetTextureController> _pendingOnce = [];
+  final Map<WidgetTextureController, int> _pendingOnce = {};
   final Set<WidgetTextureController> _tracked = {};
 
   /// A capture request is due once this much of the interval has passed:
@@ -141,11 +141,18 @@ class SurfaceCaptures {
   static const _slack = 1e-6;
 
   /// Registers a surface captured once. The host attaches a frame after
-  /// the component does, so [requestPending] keeps asking until the first
+  /// the component does, so [requestPending] keeps asking until the requested
   /// capture lands.
   void once(WidgetTextureController controller) {
     _tracked.add(controller);
-    _pendingOnce.add(controller);
+    invalidate(controller);
+  }
+
+  /// Requests a fresh texture after content changes, even when the initial
+  /// capture already landed. Forgotten surfaces ignore late image callbacks.
+  void invalidate(WidgetTextureController controller) {
+    if (!_tracked.contains(controller)) return;
+    _pendingOnce[controller] = controller.captureCount + 1;
   }
 
   /// Registers [surface] on [cadence].
@@ -166,14 +173,11 @@ class SurfaceCaptures {
   /// asking for those that have, so the list empties after the first
   /// frames.
   void requestPending() {
-    for (var i = _pendingOnce.length - 1; i >= 0; i--) {
-      final controller = _pendingOnce[i];
-      if (controller.captureCount > 0) {
-        _pendingOnce.removeAt(i);
-      } else {
-        controller.requestCapture();
-      }
-    }
+    _pendingOnce.removeWhere((controller, target) {
+      if (controller.captureCount >= target) return true;
+      controller.requestCapture();
+      return false;
+    });
   }
 
   /// Asks every visible surface of [cadence] for a capture once its

--- a/lib/features/plaza/scene/surface_captures.dart
+++ b/lib/features/plaza/scene/surface_captures.dart
@@ -7,6 +7,10 @@ import 'package:flutter_scene/scene.dart';
 import 'package:lotti/features/plaza/scene/plaza_scene.dart';
 import 'package:vector_math/vector_math.dart' show Vector3;
 
+/// World metres a widget surface is pulled toward the eye in the depth
+/// test (see [hostedSurface]).
+const widgetDepthBias = 0.15;
+
 /// A widget surface for the plaza: [child] laid out at [pxPerMeter] ×
 /// [scale] logical pixels a metre on a [ccwQuad] of [width] × [height]
 /// metres (or the [geometry] given, when the texture is not the quad's
@@ -29,6 +33,11 @@ WidgetComponent hostedSurface({
   OpaqueSurface? surface,
 }) {
   surface ??= OpaqueSurface();
+  // Every widget surface hangs a few centimetres in front of something
+  // (a facade's plate, a lightbox, a ticker's track): biased toward the
+  // eye so it wins the depth test at any distance instead of fighting the
+  // backing frame by frame as the camera flies.
+  surface.material.depthBias = widgetDepthBias;
   return WidgetComponent(
     child: child,
     size: Size(width * pxPerMeter * scale, height * pxPerMeter * scale),

--- a/lib/features/plaza/scene/surface_captures.dart
+++ b/lib/features/plaza/scene/surface_captures.dart
@@ -9,7 +9,9 @@ import 'package:vector_math/vector_math.dart' show Vector3;
 
 /// A widget surface for the plaza: [child] laid out at [pxPerMeter] ×
 /// [scale] logical pixels a metre on a [ccwQuad] of [width] × [height]
-/// metres, over an [OpaqueSurface].
+/// metres (or the [geometry] given, when the texture is not the quad's
+/// size: a ticker's period on its band), over an [OpaqueSurface] — the
+/// caller's [surface], when it keeps the material to drive it.
 ///
 /// Every plaza surface is a [WidgetUpdatePolicy.manual] component: an
 /// interval policy would make flutter_scene pump an engine frame on every
@@ -23,12 +25,14 @@ WidgetComponent hostedSurface({
   required double pxPerMeter,
   double scale = 1,
   WidgetInput input = WidgetInput.manual,
+  Geometry? geometry,
+  OpaqueSurface? surface,
 }) {
-  final surface = OpaqueSurface();
+  surface ??= OpaqueSurface();
   return WidgetComponent(
     child: child,
     size: Size(width * pxPerMeter * scale, height * pxPerMeter * scale),
-    geometry: ccwQuad(width, height),
+    geometry: geometry ?? ccwQuad(width, height),
     update: WidgetUpdatePolicy.manual,
     input: input,
     material: surface.material,

--- a/lib/features/plaza/ui/billboard_widget.dart
+++ b/lib/features/plaza/ui/billboard_widget.dart
@@ -1,27 +1,25 @@
 import 'dart:math' as math;
 
-import 'package:flutter/foundation.dart' show ValueListenable;
 import 'package:flutter/material.dart';
 import 'package:lotti/features/plaza/domain/attention.dart';
+import 'package:lotti/features/plaza/ui/cover_image.dart';
 import 'package:lotti/features/plaza/ui/plaza_chip.dart';
 import 'package:lotti/features/plaza/ui/plaza_style.dart';
 
 /// A frontier-plaza billboard: the headline for one task that needs
 /// attention, framed in its state colour.
 ///
-/// Mid tier (captured on an interval). For anomalies the frame glow
-/// breathes on a [pulseSeconds] cycle, read off the harness [clock] so the
-/// panel changes only when the harness paints a frame; nothing here ticks
-/// on its own.
+/// A still face, captured once (and again when its cover lands, through
+/// [onCoverChanged]): nothing here animates. An anomaly's frame breathes
+/// in the scene, on the glow quad behind the lightbox, not in the widget.
 class BillboardWidget extends StatelessWidget {
   const BillboardWidget({
     required this.attention,
     required this.widthMeters,
     required this.heightMeters,
     required this.pxPerMeter,
-    required this.clock,
-    this.pulseSeconds = 3,
     this.reasonFirst = false,
+    this.onCoverChanged,
     super.key,
   });
 
@@ -36,55 +34,9 @@ class BillboardWidget extends StatelessWidget {
   final double heightMeters;
   final double pxPerMeter;
 
-  /// Full glow cycle for anomalies; shorter is more agitated.
-  final double pulseSeconds;
-
-  /// Elapsed seconds, advanced by the harness once per painted frame.
-  final ValueListenable<double> clock;
-
-  /// The glow at [seconds]: up over half a cycle, down over the other
-  /// half, eased at both ends, between 0.55 and 1.
-  double glowAt(double seconds) {
-    final half = pulseSeconds / 2;
-    final cycle = (seconds / half) % 2;
-    final phase = Curves.easeInOut.transform(cycle <= 1 ? cycle : 2 - cycle);
-    return 0.55 + 0.45 * phase;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    Widget face(double glow) => _BillboardFace(
-      attention: attention,
-      widthMeters: widthMeters,
-      heightMeters: heightMeters,
-      pxPerMeter: pxPerMeter,
-      glow: glow,
-      reasonFirst: reasonFirst,
-    );
-    if (!attention.anomalous) return face(1);
-    return ValueListenableBuilder<double>(
-      valueListenable: clock,
-      builder: (context, seconds, _) => face(glowAt(seconds)),
-    );
-  }
-}
-
-class _BillboardFace extends StatelessWidget {
-  const _BillboardFace({
-    required this.attention,
-    required this.widthMeters,
-    required this.heightMeters,
-    required this.pxPerMeter,
-    required this.glow,
-    required this.reasonFirst,
-  });
-
-  final TaskAttention attention;
-  final double widthMeters;
-  final double heightMeters;
-  final double pxPerMeter;
-  final double glow;
-  final bool reasonFirst;
+  /// Called once the cover art has decoded or failed, so the panel's
+  /// texture is captured again with the picture on it.
+  final VoidCallback? onCoverChanged;
 
   /// Aspect threshold: below [reasonAspect] the reason goes and the title
   /// gets one line. The cover always stays: it is the backdrop, and a
@@ -195,13 +147,10 @@ class _BillboardFace extends StatelessWidget {
       color: PlazaStyle.panel,
       child: Container(
         decoration: BoxDecoration(
-          border: Border.all(
-            color: frame.withValues(alpha: glow),
-            width: m(0.15),
-          ),
+          border: Border.all(color: frame, width: m(0.15)),
           boxShadow: [
             BoxShadow(
-              color: frame.withValues(alpha: 0.6 * glow),
+              color: frame.withValues(alpha: 0.6),
               blurRadius: m(1.3),
             ),
           ],
@@ -211,11 +160,7 @@ class _BillboardFace extends StatelessWidget {
           fit: StackFit.expand,
           children: [
             if (showCover)
-              Image.network(
-                task.coverImageUrl!,
-                fit: BoxFit.cover,
-                errorBuilder: (_, _, _) => const SizedBox(),
-              ),
+              CoverImage(url: task.coverImageUrl!, onLoaded: onCoverChanged),
             if (showCover)
               DecoratedBox(
                 decoration: BoxDecoration(

--- a/lib/features/plaza/ui/cover_image.dart
+++ b/lib/features/plaza/ui/cover_image.dart
@@ -1,0 +1,66 @@
+/// A task's cover art on a plaza surface, with one callback once the
+/// picture has landed or failed, so the surface's texture can be captured
+/// again: a network image decodes after the first capture.
+library;
+
+import 'package:flutter/material.dart';
+
+class CoverImage extends StatefulWidget {
+  const CoverImage({
+    required this.url,
+    this.opacity = 1,
+    this.onLoaded,
+    super.key,
+  });
+
+  final String url;
+
+  /// Dimmed on a finished shop.
+  final double opacity;
+
+  /// Called once, after the frame that paints the decoded image (or the
+  /// error fallback), and again only for a new [url].
+  final VoidCallback? onLoaded;
+
+  @override
+  State<CoverImage> createState() => _CoverImageState();
+}
+
+class _CoverImageState extends State<CoverImage> {
+  bool _notified = false;
+
+  @override
+  void didUpdateWidget(CoverImage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.url != widget.url) _notified = false;
+  }
+
+  void _loaded() {
+    if (_notified || widget.onLoaded == null) return;
+    _notified = true;
+    // Capture after this frame paints the decoded image (or the fallback).
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) widget.onLoaded?.call();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Opacity(
+      opacity: widget.opacity,
+      child: Image.network(
+        widget.url,
+        width: double.infinity,
+        fit: BoxFit.cover,
+        frameBuilder: (_, child, frame, _) {
+          if (frame != null) _loaded();
+          return child;
+        },
+        errorBuilder: (_, _, _) {
+          _loaded();
+          return const SizedBox();
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/plaza/ui/debug_overlay.dart
+++ b/lib/features/plaza/ui/debug_overlay.dart
@@ -33,6 +33,13 @@ enum PlazaFrameRate {
   sixty,
   thirty;
 
+  /// Uses the explicit development override, or saves idle work by default.
+  static PlazaFrameRate fromEnvironment(Map<String, String> environment) =>
+      values.firstWhere(
+        (rate) => rate.label == environment['PLAZA_FPS'],
+        orElse: () => auto,
+      );
+
   String get label => switch (this) {
     PlazaFrameRate.auto => 'auto',
     PlazaFrameRate.sixty => '60',

--- a/lib/features/plaza/ui/facade_widget.dart
+++ b/lib/features/plaza/ui/facade_widget.dart
@@ -5,6 +5,7 @@ import 'package:lotti/features/design_system/theme/icon_tokens.dart';
 import 'package:lotti/features/plaza/domain/attention.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/features/plaza/ui/checklist_ticks.dart';
+import 'package:lotti/features/plaza/ui/cover_image.dart';
 import 'package:lotti/features/plaza/ui/plaza_chip.dart';
 import 'package:lotti/features/plaza/ui/plaza_style.dart';
 
@@ -246,11 +247,13 @@ class FacadeWidget extends StatelessWidget {
                                   ),
                                   child: SizedBox(
                                     width: double.infinity,
-                                    child: _Cover(
+                                    child: CoverImage(
                                       url: task.coverImageUrl!,
-                                      onChanged: onCoverChanged,
-                                      quiet:
-                                          attention.lantern == LanternState.off,
+                                      onLoaded: onCoverChanged,
+                                      opacity:
+                                          attention.lantern == LanternState.off
+                                          ? 0.45
+                                          : 1,
                                     ),
                                   ),
                                 ),
@@ -393,56 +396,6 @@ class FacadeWidget extends StatelessWidget {
             ),
           ],
         ),
-      ),
-    );
-  }
-}
-
-class _Cover extends StatefulWidget {
-  const _Cover({required this.url, required this.quiet, this.onChanged});
-
-  final String url;
-  final bool quiet;
-  final VoidCallback? onChanged;
-
-  @override
-  State<_Cover> createState() => _CoverState();
-}
-
-class _CoverState extends State<_Cover> {
-  bool _notified = false;
-
-  @override
-  void didUpdateWidget(_Cover oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.url != widget.url) _notified = false;
-  }
-
-  void _changed() {
-    if (_notified || widget.onChanged == null) return;
-    _notified = true;
-    // Capture after this frame paints the decoded image (or error fallback).
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) widget.onChanged?.call();
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Opacity(
-      opacity: widget.quiet ? 0.45 : 1,
-      child: Image.network(
-        widget.url,
-        width: double.infinity,
-        fit: BoxFit.cover,
-        frameBuilder: (_, child, frame, _) {
-          if (frame != null) _changed();
-          return child;
-        },
-        errorBuilder: (_, _, _) {
-          _changed();
-          return const SizedBox();
-        },
       ),
     );
   }

--- a/lib/features/plaza/ui/facade_widget.dart
+++ b/lib/features/plaza/ui/facade_widget.dart
@@ -33,6 +33,7 @@ class FacadeWidget extends StatelessWidget {
     required this.pxPerMeter,
     this.ticks,
     this.onOpen,
+    this.onCoverChanged,
     this.focused = false,
     super.key,
   });
@@ -48,6 +49,9 @@ class FacadeWidget extends StatelessWidget {
   /// Shared tick state; required for the live variant to be interactive.
   final ChecklistTicks? ticks;
   final VoidCallback? onOpen;
+
+  /// Invalidates a hosted texture once asynchronous cover loading settles.
+  final VoidCallback? onCoverChanged;
 
   /// Draws the teal focus ring (the faced building is the live one).
   final bool focused;
@@ -244,6 +248,7 @@ class FacadeWidget extends StatelessWidget {
                                     width: double.infinity,
                                     child: _Cover(
                                       url: task.coverImageUrl!,
+                                      onChanged: onCoverChanged,
                                       quiet:
                                           attention.lantern == LanternState.off,
                                     ),
@@ -393,21 +398,51 @@ class FacadeWidget extends StatelessWidget {
   }
 }
 
-class _Cover extends StatelessWidget {
-  const _Cover({required this.url, required this.quiet});
+class _Cover extends StatefulWidget {
+  const _Cover({required this.url, required this.quiet, this.onChanged});
 
   final String url;
   final bool quiet;
+  final VoidCallback? onChanged;
+
+  @override
+  State<_Cover> createState() => _CoverState();
+}
+
+class _CoverState extends State<_Cover> {
+  bool _notified = false;
+
+  @override
+  void didUpdateWidget(_Cover oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.url != widget.url) _notified = false;
+  }
+
+  void _changed() {
+    if (_notified || widget.onChanged == null) return;
+    _notified = true;
+    // Capture after this frame paints the decoded image (or error fallback).
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) widget.onChanged?.call();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return Opacity(
-      opacity: quiet ? 0.45 : 1,
+      opacity: widget.quiet ? 0.45 : 1,
       child: Image.network(
-        url,
+        widget.url,
         width: double.infinity,
         fit: BoxFit.cover,
-        errorBuilder: (_, _, _) => const SizedBox(),
+        frameBuilder: (_, child, frame, _) {
+          if (frame != null) _changed();
+          return child;
+        },
+        errorBuilder: (_, _, _) {
+          _changed();
+          return const SizedBox();
+        },
       ),
     );
   }

--- a/lib/features/plaza/ui/fly_camera_controller.dart
+++ b/lib/features/plaza/ui/fly_camera_controller.dart
@@ -274,6 +274,10 @@ class FlyCameraController {
       position: eye,
       target: eye + forward * 10,
       fovRadiansY: fovRadiansY,
+      // The walker's clearance keeps every solid 0.6 m off; a near plane
+      // three times the default triples the depth precision far out,
+      // where a facade's layers are centimetres apart.
+      fovNear: 0.3,
       fovFar: 1400,
     );
   }

--- a/lib/features/plaza/ui/fly_camera_controller.dart
+++ b/lib/features/plaza/ui/fly_camera_controller.dart
@@ -95,7 +95,8 @@ class FlyCameraController {
   bool get moving =>
       _vForward != 0 || _vStrafe != 0 || _pressed.any(_movementKeys.contains);
 
-  /// Starts a flight to [target]; the current flight, if any, is replaced.
+  /// Starts a flight to [target], discarding walking momentum; the current
+  /// flight, if any, is replaced.
   /// From one stop on the ground to another the flight follows the street
   /// network; a climb, a dive or a world without a street takes the direct
   /// line. Both are swept over every solid on the way.
@@ -116,6 +117,8 @@ class FlyCameraController {
         : Flight.plan(_pose, target, solids: _solids);
     _flight = flight;
     _landing = false;
+    _vForward = 0;
+    _vStrafe = 0;
     return flight;
   }
 
@@ -179,7 +182,8 @@ class FlyCameraController {
     _landing = true;
   }
 
-  /// Mouse-drag look, in logical pixels. Cancels a flight in place.
+  /// Mouse-drag look, in logical pixels. Cancels a flight in place and
+  /// notifies the owner to abandon any guided walk.
   void addLookDelta(double dx, double dy) {
     _flight = null;
     _landing = false;
@@ -190,6 +194,7 @@ class FlyCameraController {
       yaw: _pose.yaw - dx * 0.0032,
       pitch: (_pose.pitch - dy * 0.0028).clamp(-1.25, 1.25),
     );
+    onMovement?.call();
   }
 
   bool _down(LogicalKeyboardKey a, LogicalKeyboardKey b) =>

--- a/lib/features/plaza/ui/plaza_pointer_controller.dart
+++ b/lib/features/plaza/ui/plaza_pointer_controller.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/gestures.dart';
+
+/// Distinguishes a short primary-button tap from a camera drag. Owns the
+/// active pointer so release and cancellation always end movement.
+class PlazaPointerController {
+  int? _pointer;
+  Offset? _down;
+  double _downAt = 0;
+  bool _dragging = false;
+
+  bool get dragging => _dragging;
+
+  void down(PointerDownEvent event, double seconds) {
+    if (event.buttons != kPrimaryButton || _pointer != null) return;
+    _pointer = event.pointer;
+    _down = event.localPosition;
+    _downAt = seconds;
+    _dragging = false;
+  }
+
+  /// The look delta after crossing the existing six-pixel drag threshold.
+  Offset? move(PointerMoveEvent event) {
+    final down = _down;
+    if (event.pointer != _pointer || down == null) return null;
+    if (event.buttons == 0) {
+      cancel(event.pointer);
+      return null;
+    }
+    if ((event.localPosition - down).distance > 6) _dragging = true;
+    return _dragging ? event.delta : null;
+  }
+
+  /// Returns the tap position, if any, and releases all gesture state.
+  Offset? up(PointerUpEvent event, double seconds) {
+    if (event.pointer != _pointer) return null;
+    final tap = !_dragging && seconds - _downAt <= 0.25;
+    cancel(event.pointer);
+    return tap ? event.localPosition : null;
+  }
+
+  void cancel(int pointer) {
+    if (pointer != _pointer) return;
+    _pointer = null;
+    _down = null;
+    _dragging = false;
+  }
+}

--- a/lib/features/plaza/ui/ticker_widget.dart
+++ b/lib/features/plaza/ui/ticker_widget.dart
@@ -1,42 +1,66 @@
 import 'dart:math' as math;
 
-import 'package:flutter/foundation.dart' show ValueListenable;
 import 'package:flutter/material.dart';
 import 'package:lotti/features/plaza/ui/plaza_style.dart';
 
-/// An LED ticker band: [text] scrolls leftward forever at
-/// [speedMetersPerSecond], two copies back to back so the loop is seamless.
+/// One period of an LED ticker band: [text] once, followed by the gap
+/// before it comes round again. Captured once; the scene scrolls the
+/// texture along the band by its UV offset and repeats it, so the band
+/// runs forever without another capture, and the housing's end fade is
+/// in the band's own geometry.
 ///
-/// The scroll is a pure function of the harness [clock] (elapsed seconds),
-/// so the band moves only when the harness paints a frame and the scene
-/// decides how often it is captured; nothing here ticks on its own.
+/// Lay it out at [periodMeters] × [heightMeters] (times the px/m of the
+/// capture); the text starts at the left edge and the gap fills the rest.
 class TickerWidget extends StatelessWidget {
   const TickerWidget({
     required this.text,
     required this.heightMeters,
     required this.pxPerMeter,
-    required this.speedMetersPerSecond,
-    required this.clock,
     super.key,
   });
 
   final String text;
   final double heightMeters;
   final double pxPerMeter;
-  final double speedMetersPerSecond;
 
-  /// Elapsed seconds, advanced by the harness once per painted frame.
-  final ValueListenable<double> clock;
+  /// The type's height as a fraction of the band's.
+  static const glyphFraction = 0.62;
+
+  static TextStyle _style(double fontPx) => TextStyle(
+    fontFamily: PlazaStyle.fontMono,
+    fontSize: fontPx,
+    fontWeight: FontWeight.w500,
+    color: PlazaStyle.teal,
+  );
+
+  /// The width of [text] set for a band [heightMeters] tall, in metres.
+  static double textMeters(String text, double heightMeters) {
+    // Laid out at a reference size; type scales with its size.
+    const referencePx = 100.0;
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: _style(referencePx)),
+      textDirection: TextDirection.ltr,
+      maxLines: 1,
+    )..layout();
+    return painter.width / referencePx * heightMeters * glyphFraction;
+  }
+
+  /// One period of the band: the text and a gap of at least four glyph
+  /// heights or half of [bandWidthMeters], so a phrase is read whole
+  /// before the next one arrives.
+  static double periodMeters(
+    String text,
+    double heightMeters,
+    double bandWidthMeters,
+  ) {
+    final glyph = heightMeters * glyphFraction;
+    final gap = math.max(glyph * 4, bandWidthMeters * 0.5);
+    return textMeters(text, heightMeters) + gap;
+  }
 
   @override
   Widget build(BuildContext context) {
-    final fontPx = heightMeters * pxPerMeter * 0.62;
-    final style = TextStyle(
-      fontFamily: PlazaStyle.fontMono,
-      fontSize: fontPx,
-      fontWeight: FontWeight.w500,
-      color: PlazaStyle.teal,
-    );
+    final fontPx = heightMeters * pxPerMeter * glyphFraction;
     final border = BorderSide(
       color: PlazaStyle.teal.withValues(alpha: 0.45),
       width: fontPx * 0.08,
@@ -48,58 +72,8 @@ class TickerWidget extends StatelessWidget {
           border: Border(top: border, bottom: border),
         ),
         clipBehavior: Clip.hardEdge,
-        // The type fades in and out at the housing's ends instead of
-        // being sliced mid-glyph.
-        child: ShaderMask(
-          shaderCallback: (bounds) => const LinearGradient(
-            colors: [
-              Color(0x00000000),
-              Color(0xFF000000),
-              Color(0xFF000000),
-              Color(0x00000000),
-            ],
-            stops: [0, 0.06, 0.94, 1],
-          ).createShader(bounds),
-          blendMode: BlendMode.dstIn,
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              final painter = TextPainter(
-                text: TextSpan(text: text, style: style),
-                textDirection: TextDirection.ltr,
-                maxLines: 1,
-              )..layout();
-              // A gap of at least half the band between copies, so a phrase
-              // is read whole before the next one arrives.
-              final gap = math.max(fontPx * 4, constraints.maxWidth * 0.5);
-              final copyWidth = painter.width + gap;
-              final pxPerSecond = speedMetersPerSecond * pxPerMeter;
-              return ValueListenableBuilder<double>(
-                valueListenable: clock,
-                builder: (context, seconds, _) {
-                  final offset = (seconds * pxPerSecond) % copyWidth;
-                  return Stack(
-                    children: [
-                      for (var i = 0; i < 2; i++)
-                        Positioned(
-                          left: -offset + i * copyWidth,
-                          top: 0,
-                          bottom: 0,
-                          child: Center(
-                            child: Text(
-                              text,
-                              maxLines: 1,
-                              softWrap: false,
-                              style: style,
-                            ),
-                          ),
-                        ),
-                    ],
-                  );
-                },
-              );
-            },
-          ),
-        ),
+        alignment: Alignment.centerLeft,
+        child: Text(text, maxLines: 1, softWrap: false, style: _style(fontPx)),
       ),
     );
   }

--- a/test/README.md
+++ b/test/README.md
@@ -159,9 +159,10 @@ GPU-free scheduling in `lib/features/plaza/scene/surface_captures.dart`.
 `WidgetTextureController` is a plain subclassable class, so a test fake that
 overrides `requestCapture`, `captureCount` and `lastCaptureDuration` observes
 every request the scheduler makes and lands a capture on demand
-(`test/features/plaza/scene/surface_captures_test.dart`). The LOD manager is
-testable as long as nothing is promoted: buildings beyond `signDistance`, or a
-promotion that is wanted but withheld (`flying: true`, `promotionsPerFrame: 0`).
+(`test/features/plaza/scene/surface_captures_test.dart`). The LOD manager's `surfaceBuilder` seam accepts a `WidgetComponent.bindOnly`
+with a fake capture controller, so activation, promotions, demotions and
+cover invalidation can be tested without geometry. Capture controller fakes
+are shared in `test/features/plaza/scene/test_utils.dart`.
 
 ## Hover-divider tests: `test_utils/hover_divider_harness.dart`
 

--- a/test/README.md
+++ b/test/README.md
@@ -163,6 +163,9 @@ every request the scheduler makes and lands a capture on demand
 with a fake capture controller, so activation, promotions, demotions and
 cover invalidation can be tested without geometry. Capture controller fakes
 are shared in `test/features/plaza/scene/test_utils.dart`.
+An empty `UnskinnedGeometry` with explicit local bounds also needs no GPU
+upload: `plaza_boxes_test.dart` uses it to verify shared geometry and material
+identity and the placement of scaled meshes under unscaled anchors.
 
 ## Hover-divider tests: `test_utils/hover_divider_harness.dart`
 

--- a/test/features/plaza/domain/plaza_layout_test.dart
+++ b/test/features/plaza/domain/plaza_layout_test.dart
@@ -430,6 +430,44 @@ void main() {
         expect(s.pulseSeconds, inInclusiveRange(1.2, 3));
       }
     });
+
+    test('the glow breathes on the pulse: floor to full and back, eased', () {
+      const slot = BillboardSlot(
+        rank: 0,
+        x: 0,
+        z: 0,
+        facingRadians: 0,
+        width: 10,
+        height: 5,
+        bottom: 4,
+        mount: BillboardMount.pylon,
+        pulseSeconds: 2,
+      );
+      expect(slot.glowAt(0), BillboardSlot.glowFloor);
+      expect(slot.glowAt(1), closeTo(1, 1e-9));
+      expect(slot.glowAt(2), closeTo(BillboardSlot.glowFloor, 1e-9));
+      expect(slot.glowAt(0.5), closeTo(slot.glowAt(1.5), 1e-9));
+      // Eased: slow at the turns, fast through the middle.
+      final start = slot.glowAt(0.1) - slot.glowAt(0);
+      final middle = slot.glowAt(0.55) - slot.glowAt(0.45);
+      expect(middle, greaterThan(start));
+      for (var t = 0.0; t < 6; t += 0.05) {
+        expect(slot.glowAt(t), inInclusiveRange(BillboardSlot.glowFloor, 1));
+      }
+      // A shorter pulse is further through its breath after 0.6 s.
+      const quick = BillboardSlot(
+        rank: 0,
+        x: 0,
+        z: 0,
+        facingRadians: 0,
+        width: 10,
+        height: 5,
+        bottom: 4,
+        mount: BillboardMount.roof,
+        pulseSeconds: 1.2,
+      );
+      expect(quick.glowAt(0.6), greaterThan(slot.glowAt(0.6)));
+    });
   });
 
   group('street furniture', () {

--- a/test/features/plaza/scene/facade_lod_manager_test.dart
+++ b/test/features/plaza/scene/facade_lod_manager_test.dart
@@ -75,8 +75,10 @@ class _TestSurface extends WidgetComponent {
     required super.input,
   }) : super.bindOnly(bind: (_) {}, update: WidgetUpdatePolicy.manual);
 
+  final _controller = FakeWidgetTextureController();
+
   @override
-  final FakeWidgetTextureController controller = FakeWidgetTextureController();
+  FakeWidgetTextureController get controller => _controller;
 }
 
 FacadeSurfaceBuilder _surfaceBuilder(List<_TestSurface> surfaces) =>

--- a/test/features/plaza/scene/facade_lod_manager_test.dart
+++ b/test/features/plaza/scene/facade_lod_manager_test.dart
@@ -1,5 +1,7 @@
 import 'dart:math' as math;
 
+import 'package:flutter/widgets.dart';
+
 import 'package:flutter_scene/scene.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/plaza/domain/attention.dart';
@@ -8,7 +10,10 @@ import 'package:lotti/features/plaza/domain/street_layout.dart';
 import 'package:lotti/features/plaza/scene/facade_lod_manager.dart';
 import 'package:lotti/features/plaza/scene/plaza_scene.dart';
 import 'package:lotti/features/plaza/ui/checklist_ticks.dart';
+import 'package:lotti/features/plaza/ui/facade_widget.dart';
 import 'package:vector_math/vector_math.dart' show Vector3;
+
+import 'test_utils.dart';
 
 final _now = DateTime.utc(2026, 7, 15);
 
@@ -63,9 +68,150 @@ FacadeLodManager _manager(
   onOpen: (_) {},
 );
 
+class _TestSurface extends WidgetComponent {
+  _TestSurface({
+    required super.child,
+    required super.size,
+    required super.input,
+  }) : super.bindOnly(bind: (_) {}, update: WidgetUpdatePolicy.manual);
+
+  @override
+  final FakeWidgetTextureController controller = FakeWidgetTextureController();
+}
+
+FacadeSurfaceBuilder _surfaceBuilder(List<_TestSurface> surfaces) =>
+    ({
+      required child,
+      required width,
+      required height,
+      required pxPerMeter,
+      input = WidgetInput.manual,
+    }) {
+      final surface = _TestSurface(
+        child: child,
+        size: Size(width * pxPerMeter, height * pxPerMeter),
+        input: input,
+      );
+      surfaces.add(surface);
+      return surface;
+    };
+
 void main() {
   final eye = Vector3(0, 1.7, 0);
   final forward = Vector3(0, 0, 1);
+
+  testWidgets('nearby facades stay static until tapped and disarm on leaving', (
+    tester,
+  ) async {
+    final building = _building('near', 0, 10, facing: math.pi);
+    final surfaces = <_TestSurface>[];
+    final ticks = ChecklistTicks();
+    addTearDown(ticks.dispose);
+    final lod = FacadeLodManager(
+      buildings: [building],
+      config: FacadeLodConfig(),
+      ticks: ticks,
+      onOpen: (_) {},
+      surfaceBuilder: _surfaceBuilder(surfaces),
+    );
+    addTearDown(lod.dispose);
+    lod.update(eye, forward: forward);
+    expect((lod.stats.live, lod.stats.sign), (0, 1));
+    expect(surfaces.single.input, WidgetInput.manual);
+    final sign = surfaces.single;
+    sign.controller.landed = 1;
+    lod.update(eye, forward: forward, seconds: 3);
+    expect(sign.controller.requests, 1, reason: 'a static sign does not poll');
+    (sign.child as FacadeWidget).onCoverChanged!();
+    lod.update(eye, forward: forward, seconds: 4);
+    expect(
+      sign.controller.requests,
+      2,
+      reason: 'late cover completion refreshes the sign',
+    );
+    sign.controller.landed = 2;
+
+    expect(lod.activate(building, eye, forward: forward), isTrue);
+    lod.update(eye, forward: forward, seconds: 5);
+    expect((lod.stats.live, lod.stats.sign), (1, 0));
+    expect(lod.focused, building);
+    final live = surfaces.last;
+    expect(live.input, WidgetInput.automatic);
+    expect((live.child as FacadeWidget).ticks, same(ticks));
+    expect(live.controller.requests, 1);
+    lod.update(eye, forward: forward, seconds: 5.1);
+    expect(
+      live.controller.requests,
+      2,
+      reason: 'interactive feedback keeps its cadence',
+    );
+
+    lod.update(Vector3(0, 1.7, -60), forward: forward, seconds: 6);
+    expect((lod.stats.live, lod.stats.sign), (0, 1));
+    expect(lod.focused, isNull);
+    lod.update(eye, forward: forward, seconds: 7);
+    expect(lod.stats.live, 0, reason: 'returning needs another tap');
+    expect(
+      live.controller.requests,
+      2,
+      reason: 'the old live texture stopped capturing',
+    );
+    (live.child as FacadeWidget).onCoverChanged!();
+    lod.update(eye, forward: forward, seconds: 8);
+    expect(
+      live.controller.requests,
+      2,
+      reason: 'detached cover callbacks are ignored',
+    );
+    expect(
+      lod.activate(building, Vector3(0, 1.7, -100), forward: forward),
+      isFalse,
+    );
+    expect(lod.activate(building, eye, forward: -forward), isFalse);
+  });
+
+  test(
+    'activation switches walls, disarms on turning, and respects the budget',
+    () {
+      final a = _building('a', -5, 10, facing: math.pi);
+      final b = _building('b', 5, 10, facing: math.pi);
+      final config = FacadeLodConfig(promotionsPerFrame: 2);
+      final ticks = ChecklistTicks();
+      addTearDown(ticks.dispose);
+      final lod = FacadeLodManager(
+        buildings: [a, b],
+        config: config,
+        ticks: ticks,
+        onOpen: (_) {},
+        surfaceBuilder: _surfaceBuilder([]),
+      );
+      addTearDown(lod.dispose);
+      lod.update(eye, forward: forward);
+      expect(lod.stats.sign, 2);
+      expect(lod.activate(a, eye, forward: forward), isTrue);
+      lod.update(eye, forward: forward);
+      expect(lod.focused, a);
+      expect(lod.activate(a, eye, forward: forward), isTrue);
+      expect(lod.activate(b, eye, forward: forward), isTrue);
+      lod.update(eye, forward: forward);
+      expect((lod.stats.live, lod.stats.sign), (1, 1));
+      expect(lod.focused, b);
+      lod.update(eye, forward: -forward);
+      expect(lod.stats.live, 0);
+      lod.update(eye, forward: forward);
+      expect(lod.stats.live, 0);
+      config.liveCap = 0;
+      expect(lod.activate(a, eye, forward: forward), isFalse);
+      expect(lod.activate(_building('other', 0, 10), eye), isFalse);
+      config.forceAllLive = true;
+      lod.update(eye, forward: forward);
+      expect(
+        lod.stats.live,
+        2,
+        reason: 'explicit stress mode still bypasses activation',
+      );
+    },
+  );
 
   group('ranking', () {
     test('runs once while the camera and the budget hold still', () {

--- a/test/features/plaza/scene/plaza_boxes_test.dart
+++ b/test/features/plaza/scene/plaza_boxes_test.dart
@@ -1,0 +1,97 @@
+import 'dart:math' as math;
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/plaza/scene/plaza_boxes.dart';
+import 'package:vector_math/vector_math.dart';
+
+void main() {
+  late PlazaBoxes boxes;
+
+  setUp(() {
+    // Empty geometry needs no GPU upload; bounds suffice to verify placement.
+    Geometry unitBox() => UnskinnedGeometry()
+      ..setLocalBounds(Aabb3.minMax(Vector3.all(-0.5), Vector3.all(0.5)), null);
+    boxes = PlazaBoxes(cube: unitBox(), shadedCube: unitBox());
+  });
+
+  test(
+    'different sizes share geometry and equal solid colours share material',
+    () {
+      final a = boxes.node(Vector3(2, 3, 4), boxes.solid(Vector4(1, 0, 0, 1)));
+      final b = boxes.node(Vector3(7, 8, 9), boxes.solid(Vector4(1, 0, 0, 1)));
+      final aMesh = a.children.single.mesh!;
+      final bMesh = b.children.single.mesh!;
+      expect(
+        aMesh.primitives.single.geometry,
+        same(bMesh.primitives.single.geometry),
+      );
+      expect(
+        aMesh.primitives.single.material,
+        same(bMesh.primitives.single.material),
+      );
+      expect(a.children.single.localTransform.entry(0, 0), 2);
+      expect(b.children.single.localTransform.entry(0, 0), 7);
+    },
+  );
+
+  test('shaded boxes share their own geometry and retain the material', () {
+    final material = boxes.solid(Vector4(0.1, 0.2, 0.3, 1));
+    final a = boxes.node(Vector3(2, 3, 4), material, shaded: true);
+    final b = boxes.node(Vector3.all(5), material, shaded: true);
+    expect(
+      a.children.single.mesh!.primitives.single.geometry,
+      same(boxes.shadedCube),
+    );
+    expect(
+      b.children.single.mesh!.primitives.single.geometry,
+      same(boxes.shadedCube),
+    );
+    expect(boxes.shadedCube, isNot(same(boxes.cube)));
+    expect(a.children.single.mesh!.primitives.single.material, same(material));
+  });
+
+  test('mesh scale preserves rotated parent and attached child positions', () {
+    final pose = Matrix4.translation(Vector3(10, 20, 30))..rotateY(math.pi / 2);
+    final anchor = boxes.node(
+      Vector3(2, 4, 6),
+      boxes.solid(Vector4.all(1)),
+      transform: pose,
+    );
+    final mesh = anchor.children.single;
+    final child = Node(localTransform: Matrix4.translation(Vector3(0, 2.7, 1)));
+    anchor.add(child);
+    final position = child.globalTransform.getTranslation();
+    expect(position.x, closeTo(11, 1e-5));
+    expect(position.y, closeTo(22.7, 1e-5));
+    expect(position.z, closeTo(30, 1e-5));
+    final corner = mesh.globalTransform.transform3(Vector3.all(0.5));
+    expect(corner.x, closeTo(13, 1e-5));
+    expect(corner.y, closeTo(22, 1e-5));
+    expect(corner.z, closeTo(29, 1e-5));
+    // The picker walks from the mesh to this same logical anchor.
+    expect(mesh.parent, same(anchor));
+  });
+
+  test(
+    'solid cache distinguishes alpha and depth bias, and owns its colour',
+    () {
+      final color = Vector4(0.1, 0.2, 0.3, 1);
+      final solid = boxes.solid(color);
+      final biased = boxes.solid(color, depthBias: 0.05);
+      final faded = boxes.solid(Vector4(0.1, 0.2, 0.3, 0.5));
+      color.x = 0.9;
+      expect(solid.baseColorFactor.x, closeTo(0.1, 1e-6));
+      expect(biased, isNot(same(solid)));
+      expect(biased.depthBias, 0.05);
+      expect(faded, isNot(same(solid)));
+      expect(faded.baseColorFactor.w, 0.5);
+      expect(boxes.solid(Vector4(0.1, 0.2, 0.3, 1)), same(solid));
+      final otherScene = PlazaBoxes(
+        cube: boxes.cube,
+        shadedCube: boxes.shadedCube,
+      );
+      expect(otherScene.solid(Vector4(0.1, 0.2, 0.3, 1)), isNot(same(solid)));
+    },
+  );
+}

--- a/test/features/plaza/scene/plaza_sprites_test.dart
+++ b/test/features/plaza/scene/plaza_sprites_test.dart
@@ -1,0 +1,119 @@
+import 'dart:typed_data';
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/plaza/scene/plaza_sprites.dart';
+import 'package:vector_math/vector_math.dart';
+
+void main() {
+  const stride = BillboardGeometry.floatsPerInstance;
+
+  test(
+    'bulbs occupy separate records with copied world positions and colours',
+    () {
+      final data = Float32List(2 * stride);
+      final bulbs = PlazaLightBuffer(data);
+      final center = Vector3(10, 20, 30);
+      final color = Vector4(1, 2, 3, 0.5);
+      bulbs
+        ..add(center, size: 0.25, color: color)
+        ..add(Vector3(40, 50, 60), size: 0.5, color: Vector4.all(1));
+      center.x = 99;
+      color.y = 99;
+      expect(bulbs.count, 2);
+      expect(data.take(stride), [
+        10,
+        20,
+        30,
+        0.25,
+        0.25,
+        0,
+        1,
+        2,
+        3,
+        0.5,
+        0,
+        0,
+        0,
+        0,
+      ]);
+      expect(data.skip(stride), [
+        40,
+        50,
+        60,
+        0.5,
+        0.5,
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0,
+      ]);
+    },
+  );
+
+  test('animation updates only its bulb size and HDR colour', () {
+    final data = Float32List.fromList(
+      List.generate(2 * stride, (i) => i.toDouble()),
+    );
+    final original = List<double>.of(data);
+    PlazaLightBuffer(data).write(
+      1,
+      size: 0.5,
+      color: Vector4(1, 2, 3, 1),
+      alpha: 0.25,
+      boost: 2,
+    );
+    final expected = [...original];
+    expected[stride + 3] = 0.5;
+    expected[stride + 4] = 0.5;
+    expected[stride + 6] = 2;
+    expected[stride + 7] = 4;
+    expected[stride + 8] = 6;
+    expected[stride + 9] = 0.25;
+    expect(data, expected);
+  });
+
+  for (final failCommit in [false, true]) {
+    test(
+      'bounds cover maximum sizes and restore display sizes, failure=$failCommit',
+      () {
+        final data = Float32List(2 * stride);
+        final bulbs = PlazaLightBuffer(data)
+          ..add(Vector3(1, 2, 3), size: 0.25, color: Vector4.all(1))
+          ..add(Vector3(4, 5, 6), size: 0.125, color: Vector4.all(0.5));
+        final original = List<double>.of(data);
+        var commits = 0;
+        void commit() => bulbs.commitBounds((count) {
+          commits++;
+          expect(count, 2);
+          for (var i = 0; i < count; i++) {
+            expect(data[i * stride + 3], 0.5);
+            expect(data[i * stride + 4], 0.5);
+            expect(data[i * stride], original[i * stride]);
+          }
+          if (failCommit) throw StateError('upload failed');
+        }, pad: 0.5);
+        if (failCommit) {
+          expect(commit, throwsStateError);
+        } else {
+          commit();
+        }
+        expect(commits, 1);
+        expect(data, original);
+      },
+    );
+  }
+
+  test('empty buffer commits zero live instances', () {
+    final bulbs = PlazaLightBuffer(Float32List(0));
+    int? committed;
+    bulbs.commitBounds((count) => committed = count, pad: 0.5);
+    expect(committed, 0);
+    expect(bulbs.count, 0);
+  });
+}

--- a/test/features/plaza/scene/surface_captures_test.dart
+++ b/test/features/plaza/scene/surface_captures_test.dart
@@ -6,25 +6,10 @@ import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/plaza/scene/surface_captures.dart';
 import 'package:vector_math/vector_math.dart' show Matrix4, Vector3;
 
-/// A capture controller with no host: counts the requests the scheduler
-/// makes, and lands a capture when the test says so.
-class _FakeController extends WidgetTextureController {
-  int requests = 0;
-  int landed = 0;
-  Duration duration = Duration.zero;
-
-  @override
-  void requestCapture() => requests++;
-
-  @override
-  int get captureCount => landed;
-
-  @override
-  Duration get lastCaptureDuration => duration;
-}
+import 'test_utils.dart';
 
 /// A vertical surface at the origin whose front faces +z.
-TimedSurface _atOrigin(_FakeController controller, {Node? node}) =>
+TimedSurface _atOrigin(FakeWidgetTextureController controller, {Node? node}) =>
     TimedSurface.facing(
       controller: controller,
       node: node ?? Node(),
@@ -41,7 +26,7 @@ void main() {
     test('the first capture is free and the next waits for the interval', () {
       final captures = SurfaceCaptures();
       final cadence = CaptureCadence(0.1);
-      final controller = _FakeController();
+      final controller = FakeWidgetTextureController();
       captures.timed(cadence, _atOrigin(controller));
       expect(controller.requests, 0, reason: 'registering asks nothing');
 
@@ -66,7 +51,7 @@ void main() {
     test('advances the cadence clock only when a capture is requested', () {
       final captures = SurfaceCaptures();
       final cadence = CaptureCadence(0.1);
-      final controller = _FakeController();
+      final controller = FakeWidgetTextureController();
       final node = Node();
       captures.timed(cadence, _atOrigin(controller, node: node));
       var notifications = 0;
@@ -97,7 +82,7 @@ void main() {
     test('a surface behind the eye is not captured', () {
       final captures = SurfaceCaptures();
       final cadence = CaptureCadence(0.1);
-      final controller = _FakeController();
+      final controller = FakeWidgetTextureController();
       captures.timed(cadence, _atOrigin(controller));
       expect(controller.requests, 0);
 
@@ -116,7 +101,7 @@ void main() {
       // two metres behind the eye's plane and its near end still in view.
       final captures = SurfaceCaptures();
       final cadence = CaptureCadence(0.1);
-      final controller = _FakeController();
+      final controller = FakeWidgetTextureController();
       captures.timed(cadence, _atOrigin(controller));
       final justPast = Vector3(0, 1.7, 2);
       captures.requestDue(cadence, justPast, 0, forward: Vector3(0, 0, 1));
@@ -130,7 +115,7 @@ void main() {
     test('a surface whose front faces away from the eye is not captured', () {
       final captures = SurfaceCaptures();
       final cadence = CaptureCadence(0.1);
-      final controller = _FakeController();
+      final controller = FakeWidgetTextureController();
       captures.timed(cadence, _atOrigin(controller));
 
       // Behind the panel, looking at its back.
@@ -146,7 +131,7 @@ void main() {
     test('a culled surface is captured as soon as it comes into view', () {
       final captures = SurfaceCaptures();
       final cadence = CaptureCadence(3);
-      final controller = _FakeController();
+      final controller = FakeWidgetTextureController();
       captures.timed(cadence, _atOrigin(controller));
       expect(controller.requests, 0);
 
@@ -162,8 +147,8 @@ void main() {
     test('each surface keeps its own interval within a cadence', () {
       final captures = SurfaceCaptures();
       final cadence = CaptureCadence(0.1);
-      final a = _FakeController();
-      final b = _FakeController();
+      final a = FakeWidgetTextureController();
+      final b = FakeWidgetTextureController();
       final bNode = Node();
       captures
         ..timed(cadence, _atOrigin(a))
@@ -185,7 +170,7 @@ void main() {
   group('once', () {
     test('re-requested every frame until the capture lands, then dropped', () {
       final captures = SurfaceCaptures();
-      final controller = _FakeController();
+      final controller = FakeWidgetTextureController();
       captures.once(controller);
       expect(controller.requests, 0, reason: 'registering asks nothing');
 
@@ -209,8 +194,8 @@ void main() {
 
     test('a landed surface leaves the pending list, others stay', () {
       final captures = SurfaceCaptures();
-      final first = _FakeController();
-      final second = _FakeController();
+      final first = FakeWidgetTextureController();
+      final second = FakeWidgetTextureController();
       captures
         ..once(first)
         ..once(second)
@@ -221,14 +206,52 @@ void main() {
     });
   });
 
+  group('content invalidation', () {
+    test('recaptures a decoded cover after the initial texture landed', () {
+      final captures = SurfaceCaptures();
+      final controller = FakeWidgetTextureController();
+      captures
+        ..once(controller)
+        ..requestPending();
+      controller.landed = 1;
+      captures.requestPending();
+      expect(controller.requests, 1);
+      captures
+        ..invalidate(controller)
+        ..invalidate(controller)
+        ..requestPending();
+      expect(controller.requests, 2);
+      // Keep retrying while the host has not delivered the new texture.
+      captures.requestPending();
+      expect(controller.requests, 3);
+      controller.landed = 2;
+      captures
+        ..requestPending()
+        ..requestPending();
+      expect(controller.requests, 3);
+    });
+
+    test('late image callbacks cannot revive a detached surface', () {
+      final captures = SurfaceCaptures();
+      final controller = FakeWidgetTextureController();
+      captures
+        ..once(controller)
+        ..forget(controller)
+        ..invalidate(controller)
+        ..requestPending();
+      expect(controller.requests, 0);
+      expect(captures.captures, 0);
+    });
+  });
+
   group('counters', () {
     test('sum the captures and take the longest recent capture', () {
       final captures = SurfaceCaptures();
       final cadence = CaptureCadence(0.1);
-      final once = _FakeController()
+      final once = FakeWidgetTextureController()
         ..landed = 2
         ..duration = const Duration(milliseconds: 3);
-      final timed = _FakeController()
+      final timed = FakeWidgetTextureController()
         ..landed = 5
         ..duration = const Duration(milliseconds: 7);
       captures
@@ -241,8 +264,8 @@ void main() {
     test('a forgotten surface is neither counted nor requested again', () {
       final captures = SurfaceCaptures();
       final cadence = CaptureCadence(0.1);
-      final timed = _FakeController()..landed = 4;
-      final once = _FakeController();
+      final timed = FakeWidgetTextureController()..landed = 4;
+      final once = FakeWidgetTextureController();
       captures
         ..timed(cadence, _atOrigin(timed))
         ..once(once)
@@ -267,7 +290,7 @@ void main() {
         localTransform: Matrix4.translation(Vector3(0, 5, 3)),
       );
       parent.add(anchor);
-      final surface = TimedSurface.posed(_FakeController(), anchor);
+      final surface = TimedSurface.posed(FakeWidgetTextureController(), anchor);
       // Local +z under a quarter turn about y points along world +x.
       expect(surface.center.x, closeTo(13, 1e-6));
       expect(surface.center.y, closeTo(5, 1e-6));
@@ -293,7 +316,7 @@ void main() {
           math.sin(pitch),
           math.cos(yaw) * math.cos(pitch),
         );
-        final controller = _FakeController();
+        final controller = FakeWidgetTextureController();
         final ahead = eye + forward * distance;
         final facingEye = TimedSurface(
           controller: controller,

--- a/test/features/plaza/scene/test_utils.dart
+++ b/test/features/plaza/scene/test_utils.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_scene/scene.dart';
+
+/// Counts requested captures and lets a test finish them without a GPU host.
+class FakeWidgetTextureController extends WidgetTextureController {
+  int requests = 0;
+  int landed = 0;
+  Duration duration = Duration.zero;
+
+  @override
+  void requestCapture() => requests++;
+
+  @override
+  int get captureCount => landed;
+
+  @override
+  Duration get lastCaptureDuration => duration;
+}

--- a/test/features/plaza/ui/billboard_widget_test.dart
+++ b/test/features/plaza/ui/billboard_widget_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/plaza/domain/attention.dart';
@@ -28,32 +31,54 @@ PlazaTask _task({
 
 Widget _host(
   PlazaTask task, {
-  double pulseSeconds = 3,
   double heightMeters = 8.5,
   bool reasonFirst = false,
+  VoidCallback? onCoverChanged,
 }) => makeTestableWidget2(
   Center(
     child: SizedBox(
       width: 600,
       height: heightMeters * 40,
       child: BillboardWidget(
-        clock: clock,
         attention: attentionFor(task, _now),
         widthMeters: 15,
         heightMeters: heightMeters,
         pxPerMeter: 40,
-        pulseSeconds: pulseSeconds,
         reasonFirst: reasonFirst,
+        onCoverChanged: onCoverChanged,
       ),
     ),
   ),
 );
 
-/// The harness clock the widget reads; each test starts it at zero.
-final clock = ValueNotifier<double>(0);
+/// A cover the test decodes when it chooses.
+Completer<ImageInfo> _pendingCover(String url) {
+  final provider = NetworkImage(url);
+  final decoded = Completer<ImageInfo>();
+  PaintingBinding.instance.imageCache.putIfAbsent(
+    provider,
+    () => OneFrameImageStreamCompleter(decoded.future),
+  );
+  addTearDown(provider.evict);
+  return decoded;
+}
+
+double _frameAlpha(WidgetTester tester) => tester
+    .widgetList<Container>(find.byType(Container))
+    .map((c) => c.decoration)
+    .whereType<BoxDecoration>()
+    .firstWhere((d) => d.border != null)
+    .border!
+    .top
+    .color
+    .a;
 
 void main() {
-  setUp(() => clock.value = 0);
+  late ui.Image coverImage;
+  setUpAll(() async {
+    coverImage = await createTestImage();
+  });
+  tearDownAll(() => coverImage.dispose());
 
   testWidgets('a roof panel leads with the reason and has no fly-there', (
     tester,
@@ -109,43 +134,41 @@ void main() {
     );
   });
 
-  testWidgets('an anomaly breathes: the frame alpha changes over 1.5 s', (
+  testWidgets("the face is still: an anomaly's frame is at full glow", (
     tester,
   ) async {
     await tester.pumpWidget(_host(_task(state: PlazaTaskState.blocked)));
-    double alpha() => tester
-        .widgetList<Container>(find.byType(Container))
-        .map((c) => c.decoration)
-        .whereType<BoxDecoration>()
-        .firstWhere((d) => d.border != null)
-        .border!
-        .top
-        .color
-        .a;
-    final start = alpha();
-    clock.value += 1.5;
-    await tester.pump();
-    expect(alpha(), isNot(closeTo(start, 0.05)));
+    expect(_frameAlpha(tester), 1);
+    await tester.pump(const Duration(seconds: 2));
+    expect(_frameAlpha(tester), 1);
+    // Nothing on the panel listens to anything.
+    expect(find.byType(ValueListenableBuilder<double>), findsNothing);
   });
 
-  testWidgets('a due-soon task does not pulse and shows its date', (
-    tester,
-  ) async {
+  testWidgets('a due-soon task shows its date at full glow', (tester) async {
     await tester.pumpWidget(_host(_task(due: _now)));
     expect(find.text('due today — finish it'), findsOneWidget);
-    double alpha() => tester
-        .widgetList<Container>(find.byType(Container))
-        .map((c) => c.decoration)
-        .whereType<BoxDecoration>()
-        .firstWhere((d) => d.border != null)
-        .border!
-        .top
-        .color
-        .a;
-    expect(alpha(), 1);
-    clock.value += 1.5;
+    expect(_frameAlpha(tester), 1);
+  });
+
+  testWidgets('a cover that lands late asks for one more capture', (
+    tester,
+  ) async {
+    const url = 'https://demo.invalid/late-cover.webp';
+    final decoded = _pendingCover(url);
+    var changes = 0;
+    await tester.pumpWidget(
+      _host(
+        _task(state: PlazaTaskState.blocked, cover: url),
+        onCoverChanged: () => changes++,
+      ),
+    );
+    expect(changes, 0);
+    decoded.complete(ImageInfo(image: coverImage.clone()));
     await tester.pump();
-    expect(alpha(), 1);
+    expect(changes, 1);
+    await tester.pump();
+    expect(changes, 1, reason: 'a rebuild is not a new cover');
   });
 
   testWidgets('cover art gets the middle of the panel', (tester) async {
@@ -157,30 +180,6 @@ void main() {
     expect(find.byType(Image), findsOneWidget);
     await tester.pump();
     expect(tester.takeException(), isNull);
-  });
-
-  testWidgets('a shorter pulse is more agitated', (tester) async {
-    double alphaOf(WidgetTester t) => t
-        .widgetList<Container>(find.byType(Container))
-        .map((c) => c.decoration)
-        .whereType<BoxDecoration>()
-        .firstWhere((d) => d.border != null)
-        .border!
-        .top
-        .color
-        .a;
-    await tester.pumpWidget(
-      _host(_task(state: PlazaTaskState.blocked), pulseSeconds: 1.2),
-    );
-    clock.value += 0.6;
-    await tester.pump();
-    final fast = alphaOf(tester);
-    await tester.pumpWidget(_host(_task(state: PlazaTaskState.blocked)));
-    clock.value += 0.6;
-    await tester.pump();
-    final slow = alphaOf(tester);
-    // After 0.6 s the 1.2 s cycle is at its peak; the 3 s cycle is not.
-    expect(fast, greaterThan(slow));
   });
 
   testWidgets('a squat roof panel keeps the cover, then drops the reason', (

--- a/test/features/plaza/ui/cover_image_test.dart
+++ b/test/features/plaza/ui/cover_image_test.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/plaza/ui/cover_image.dart';
+
+import '../../../widget_test_utils.dart';
+
+Completer<ImageInfo> _pendingCover(String url) {
+  final provider = NetworkImage(url);
+  final decoded = Completer<ImageInfo>();
+  PaintingBinding.instance.imageCache.putIfAbsent(
+    provider,
+    () => OneFrameImageStreamCompleter(decoded.future),
+  );
+  addTearDown(provider.evict);
+  return decoded;
+}
+
+Widget _host(String url, {double opacity = 1, VoidCallback? onLoaded}) =>
+    makeTestableWidget2(
+      SizedBox(
+        width: 200,
+        height: 100,
+        child: CoverImage(url: url, opacity: opacity, onLoaded: onLoaded),
+      ),
+    );
+
+void main() {
+  late ui.Image image;
+  setUpAll(() async {
+    image = await createTestImage();
+  });
+  tearDownAll(() => image.dispose());
+
+  testWidgets('reports once, after the frame that paints the picture', (
+    tester,
+  ) async {
+    const url = 'https://demo.invalid/cover.webp';
+    final decoded = _pendingCover(url);
+    var loads = 0;
+    await tester.pumpWidget(_host(url, opacity: 0.45, onLoaded: () => loads++));
+    expect(loads, 0);
+    expect(tester.widget<Opacity>(find.byType(Opacity)).opacity, 0.45);
+    decoded.complete(ImageInfo(image: image.clone()));
+    await tester.pump();
+    expect(tester.widget<RawImage>(find.byType(RawImage)).image, isNotNull);
+    expect(loads, 1);
+    await tester.pump();
+    await tester.pumpWidget(_host(url, opacity: 0.45, onLoaded: () => loads++));
+    await tester.pump();
+    expect(loads, 1, reason: 'a rebuild with the same picture is not a load');
+  });
+
+  testWidgets('a picture that fails still reports, and a new url again', (
+    tester,
+  ) async {
+    const first = 'https://demo.invalid/first.webp';
+    const second = 'https://demo.invalid/second.webp';
+    final failing = _pendingCover(first);
+    final landing = _pendingCover(second);
+    var loads = 0;
+    await tester.pumpWidget(_host(first, onLoaded: () => loads++));
+    failing.completeError(StateError('no such cover'));
+    await tester.pump();
+    expect(loads, 1);
+    expect(find.byType(RawImage), findsNothing);
+    await tester.pumpWidget(_host(second, onLoaded: () => loads++));
+    landing.complete(ImageInfo(image: image.clone()));
+    await tester.pump();
+    expect(loads, 2);
+  });
+}

--- a/test/features/plaza/ui/debug_overlay_test.dart
+++ b/test/features/plaza/ui/debug_overlay_test.dart
@@ -6,6 +6,24 @@ import 'package:lotti/features/plaza/ui/debug_overlay.dart';
 import '../../../widget_test_utils.dart';
 
 void main() {
+  test(
+    'default frame pacing rests at 30 fps and preserves explicit overrides',
+    () {
+      for (final environment in <Map<String, String>>[
+        {},
+        {'PLAZA_FPS': 'invalid'},
+      ]) {
+        final rate = PlazaFrameRate.fromEnvironment(environment);
+        expect(rate, PlazaFrameRate.auto);
+        expect(rate.capFor(moving: false), 30);
+        expect(rate.capFor(moving: true), isNull);
+      }
+      for (final rate in PlazaFrameRate.values) {
+        expect(PlazaFrameRate.fromEnvironment({'PLAZA_FPS': rate.label}), rate);
+      }
+    },
+  );
+
   late PlazaHarnessStats stats;
   late FacadeLodConfig config;
   late PlazaLayoutKnobs knobs;

--- a/test/features/plaza/ui/facade_widget_test.dart
+++ b/test/features/plaza/ui/facade_widget_test.dart
@@ -75,7 +75,7 @@ Completer<ImageInfo> _pendingCover(String url) {
     provider,
     () => OneFrameImageStreamCompleter(decoded.future),
   );
-  addTearDown(() => provider.evict());
+  addTearDown(provider.evict);
   return decoded;
 }
 

--- a/test/features/plaza/ui/facade_widget_test.dart
+++ b/test/features/plaza/ui/facade_widget_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/plaza/domain/attention.dart';
@@ -39,6 +42,7 @@ Widget _host(
   FacadeVariant variant = FacadeVariant.live,
   ChecklistTicks? ticks,
   VoidCallback? onOpen,
+  VoidCallback? onCoverChanged,
   bool focused = false,
   double widthMeters = 12,
   double heightMeters = 16,
@@ -56,6 +60,7 @@ Widget _host(
           pxPerMeter: 45,
           ticks: ticks,
           onOpen: onOpen,
+          onCoverChanged: onCoverChanged,
           focused: focused,
         ),
       ),
@@ -63,7 +68,92 @@ Widget _host(
   );
 }
 
+Completer<ImageInfo> _pendingCover(String url) {
+  final provider = NetworkImage(url);
+  final decoded = Completer<ImageInfo>();
+  PaintingBinding.instance.imageCache.putIfAbsent(
+    provider,
+    () => OneFrameImageStreamCompleter(decoded.future),
+  );
+  addTearDown(() => provider.evict());
+  return decoded;
+}
+
 void main() {
+  late ui.Image coverImage;
+  setUpAll(() async {
+    coverImage = await createTestImage();
+  });
+  tearDownAll(() => coverImage.dispose());
+
+  testWidgets('a late decoded cover invalidates its sign texture once', (
+    tester,
+  ) async {
+    const url = 'https://demo.invalid/delayed-cover.webp';
+    final decoded = _pendingCover(url);
+    var invalidations = 0;
+    final task = _task(coverUrl: url);
+    await tester.pumpWidget(
+      _host(
+        task,
+        variant: FacadeVariant.sign,
+        onCoverChanged: () => invalidations++,
+      ),
+    );
+    expect(invalidations, 0);
+    expect(tester.widget<RawImage>(find.byType(RawImage)).image, isNull);
+    decoded.complete(ImageInfo(image: coverImage.clone()));
+    await tester.pump();
+    expect(tester.widget<RawImage>(find.byType(RawImage)).image, isNotNull);
+    expect(invalidations, 1);
+    await tester.pumpWidget(
+      _host(
+        task,
+        variant: FacadeVariant.sign,
+        onCoverChanged: () => invalidations++,
+      ),
+    );
+    await tester.pump();
+    expect(
+      invalidations,
+      1,
+      reason: 'ordinary rebuilds do not re-capture a static sign',
+    );
+  });
+
+  testWidgets('a replacement cover failure invalidates the previous picture', (
+    tester,
+  ) async {
+    const firstUrl = 'https://demo.invalid/first-cover.webp';
+    const nextUrl = 'https://demo.invalid/next-cover.webp';
+    final first = _pendingCover(firstUrl);
+    final next = _pendingCover(nextUrl);
+    var invalidations = 0;
+    await tester.pumpWidget(
+      _host(
+        _task(coverUrl: firstUrl),
+        variant: FacadeVariant.sign,
+        onCoverChanged: () => invalidations++,
+      ),
+    );
+    first.complete(ImageInfo(image: coverImage.clone()));
+    await tester.pump();
+    expect(invalidations, 1);
+    await tester.pumpWidget(
+      _host(
+        _task(coverUrl: nextUrl),
+        variant: FacadeVariant.sign,
+        onCoverChanged: () => invalidations++,
+      ),
+    );
+    next.completeError(StateError('cover unavailable'));
+    await tester.pump();
+    await tester.pump();
+    expect(invalidations, 2);
+    expect(find.byType(RawImage), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('a tall live wall never overflows its checklist', (
     tester,
   ) async {

--- a/test/features/plaza/ui/fly_camera_controller_test.dart
+++ b/test/features/plaza/ui/fly_camera_controller_test.dart
@@ -247,10 +247,9 @@ void main() {
       const target = CameraPose(x: 20, y: 90, z: 40, yaw: 1);
       final flight = camera.flyTo(target);
       await simulateKeyUpEvent(LogicalKeyboardKey.keyW);
-      camera.handleKeyEvent(
-        _up(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
-      );
-      camera.update(flight.duration.inMicroseconds / 1e6 + 0.01);
+      camera
+        ..handleKeyEvent(_up(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW))
+        ..update(flight.duration.inMicroseconds / 1e6 + 0.01);
       expect(camera.pose.y, target.y);
       camera.update(1 / 60);
       expect(camera.pose.y, target.y);

--- a/test/features/plaza/ui/fly_camera_controller_test.dart
+++ b/test/features/plaza/ui/fly_camera_controller_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_scene/scene.dart'
     show PerspectiveCamera, PerspectiveProjection;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/plaza/domain/flight.dart';
+import 'package:lotti/features/plaza/domain/morning_walk.dart';
 import 'package:lotti/features/plaza/domain/plaza_layout.dart';
 import 'package:lotti/features/plaza/domain/solid.dart';
 import 'package:lotti/features/plaza/domain/street_layout.dart';
@@ -232,6 +233,59 @@ void main() {
   });
 
   group('flights', () {
+    testWidgets('a flight discards walking momentum before overview arrival', (
+      tester,
+    ) async {
+      final camera = _controller();
+      await simulateKeyDownEvent(LogicalKeyboardKey.keyW);
+      camera
+        ..handleKeyEvent(
+          _down(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
+        )
+        ..update(0.1);
+      expect(camera.pose.z, greaterThan(0));
+      const target = CameraPose(x: 20, y: 90, z: 40, yaw: 1);
+      final flight = camera.flyTo(target);
+      await simulateKeyUpEvent(LogicalKeyboardKey.keyW);
+      camera.handleKeyEvent(
+        _up(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
+      );
+      camera.update(flight.duration.inMicroseconds / 1e6 + 0.01);
+      expect(camera.pose.y, target.y);
+      camera.update(1 / 60);
+      expect(camera.pose.y, target.y);
+      expect(camera.pose.x, target.x);
+      expect(camera.pose.z, target.z);
+      expect(camera.moving, isFalse);
+    });
+
+    for (final holding in [false, true]) {
+      test('drag abandons a morning walk (holding: $holding)', () {
+        final walk = MorningWalk([
+          const WalkStop(
+            pose: _origin,
+            label: 'Home',
+            hold: Duration(seconds: 1),
+          ),
+          const WalkStop(
+            pose: _origin,
+            label: 'Next',
+            hold: Duration(seconds: 1),
+          ),
+        ]);
+        final camera = _controller()..onMovement = walk.abandon;
+        if (holding) {
+          walk.arrived();
+        } else {
+          camera.flyTo(const CameraPose(x: 0, y: 30, z: 20, yaw: 0));
+        }
+        camera.addLookDelta(10, 0);
+        expect(camera.flying, isFalse);
+        expect(walk.finished, isTrue);
+        expect(walk.tick(const Duration(seconds: 5)), isNull);
+      });
+    }
+
     test('flyTo moves the camera along the flight and lands exactly', () {
       var arrivals = 0;
       final camera = _controller()..onArrived = () => arrivals++;

--- a/test/features/plaza/ui/plaza_pointer_controller_test.dart
+++ b/test/features/plaza/ui/plaza_pointer_controller_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/plaza/ui/debug_overlay.dart';
+import 'package:lotti/features/plaza/ui/plaza_pointer_controller.dart';
+
+void main() {
+  test('releasing a drag allows auto mode to return to its idle cap', () {
+    final pointer = PlazaPointerController()
+      ..down(const PointerDownEvent(pointer: 1), 0);
+    expect(
+      pointer.move(
+        const PointerMoveEvent(
+          pointer: 1,
+          position: Offset(10, 0),
+          delta: Offset(10, 0),
+        ),
+      ),
+      const Offset(10, 0),
+    );
+    expect(PlazaFrameRate.auto.capFor(moving: pointer.dragging), isNull);
+    expect(pointer.up(const PointerUpEvent(pointer: 1), 0.1), isNull);
+    expect(pointer.dragging, isFalse);
+    expect(PlazaFrameRate.auto.capFor(moving: pointer.dragging), 30);
+  });
+
+  test('a short tap is returned once; a long press is ignored', () {
+    final pointer = PlazaPointerController()
+      ..down(const PointerDownEvent(pointer: 1), 0);
+    expect(
+      pointer.move(const PointerMoveEvent(pointer: 1, position: Offset(3, 0))),
+      isNull,
+    );
+    const up = PointerUpEvent(pointer: 1, position: Offset(3, 0));
+    expect(pointer.up(up, 0.1), const Offset(3, 0));
+    expect(pointer.up(up, 0.1), isNull);
+    pointer.down(const PointerDownEvent(pointer: 1), 1);
+    expect(pointer.up(up, 2), isNull);
+  });
+
+  for (final lostButtons in [false, true]) {
+    test('cancellation clears a drag (lost buttons: $lostButtons)', () {
+      final pointer = PlazaPointerController()
+        ..down(const PointerDownEvent(pointer: 1), 0)
+        ..move(const PointerMoveEvent(pointer: 1, position: Offset(10, 0)));
+      expect(pointer.dragging, isTrue);
+      if (lostButtons) {
+        pointer.move(const PointerMoveEvent(pointer: 1, buttons: 0));
+      } else {
+        pointer.cancel(1);
+      }
+      expect(pointer.dragging, isFalse);
+      expect(pointer.up(const PointerUpEvent(pointer: 1), 0.1), isNull);
+      pointer.down(const PointerDownEvent(pointer: 2), 1);
+      expect(pointer.up(const PointerUpEvent(pointer: 2), 1.1), Offset.zero);
+    });
+  }
+
+  test('secondary buttons and unrelated pointers cannot change a drag', () {
+    final pointer = PlazaPointerController()
+      ..down(const PointerDownEvent(pointer: 2, buttons: kSecondaryButton), 0);
+    expect(pointer.up(const PointerUpEvent(pointer: 2), 0.1), isNull);
+    pointer
+      ..down(const PointerDownEvent(pointer: 1), 1)
+      ..move(const PointerMoveEvent(pointer: 1, position: Offset(10, 0)))
+      ..down(const PointerDownEvent(pointer: 2), 1.1)
+      ..cancel(2);
+    expect(pointer.up(const PointerUpEvent(pointer: 2), 1.2), isNull);
+    expect(pointer.move(const PointerMoveEvent(pointer: 2)), isNull);
+    expect(pointer.dragging, isTrue);
+    pointer.up(const PointerUpEvent(pointer: 1), 1.2);
+    expect(pointer.dragging, isFalse);
+  });
+}

--- a/test/features/plaza/ui/ticker_widget_test.dart
+++ b/test/features/plaza/ui/ticker_widget_test.dart
@@ -1,58 +1,60 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/plaza/ui/plaza_style.dart';
 import 'package:lotti/features/plaza/ui/ticker_widget.dart';
 
 import '../../../widget_test_utils.dart';
 
-/// The harness clock the widget reads; each test starts it at zero.
-final clock = ValueNotifier<double>(0);
+const _text = 'Project Waddle   ·   7 need attention   ·   3 in progress';
 
-void main() {
-  setUp(() => clock.value = 0);
-
-  Widget host() => makeTestableWidget2(
-    Center(
-      child: SizedBox(
-        width: 400,
-        height: 60,
-        child: TickerWidget(
-          clock: clock,
-          text: 'Project Waddle · 4 need attention',
-          heightMeters: 1.3,
-          pxPerMeter: 40,
-          speedMetersPerSecond: 3,
+Widget _host({double heightMeters = 1.9, double pxPerMeter = 40}) =>
+    makeTestableWidget2(
+      Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width:
+              TickerWidget.periodMeters(_text, heightMeters, 12) * pxPerMeter,
+          height: heightMeters * pxPerMeter,
+          child: TickerWidget(
+            text: _text,
+            heightMeters: heightMeters,
+            pxPerMeter: pxPerMeter,
+          ),
         ),
       ),
-    ),
-  );
+    );
 
-  testWidgets('draws two copies of the text and scrolls them leftward', (
+void main() {
+  testWidgets('one period: the text once, from the left, and nothing moves', (
     tester,
   ) async {
-    await tester.pumpWidget(host());
-    final copies = find.text('Project Waddle · 4 need attention');
-    expect(copies, findsNWidgets(2));
-    double leftOf(int i) =>
-        tester.widget<Positioned>(find.byType(Positioned).at(i)).left!;
-    final a0 = leftOf(0);
-    final b0 = leftOf(1);
-    expect(b0, greaterThan(a0)); // second copy trails the first
-    clock.value += 0.5;
-    await tester.pump();
-    final a1 = leftOf(0);
-    // 3 m/s × 40 px/m × 0.5 s = 60 px to the left.
-    expect(a0 - a1, closeTo(60, 1));
-    expect(leftOf(1) - a1, closeTo(b0 - a0, 1e-6)); // gap preserved
+    await tester.pumpWidget(_host());
+    expect(find.text(_text), findsOneWidget);
+    final text = tester.widget<Text>(find.text(_text));
+    expect(text.style!.fontSize, closeTo(1.9 * 40 * 0.62, 1e-9));
+    expect(text.style!.color, PlazaStyle.teal);
+    expect(text.maxLines, 1);
+    expect(text.softWrap, isFalse);
+    // Flush left: the gap is on the right, where the next period begins.
+    expect(tester.getTopLeft(find.text(_text)).dx, 0);
+    expect(find.byType(ValueListenableBuilder<double>), findsNothing);
+    expect(find.byType(ShaderMask), findsNothing);
+    await tester.pump(const Duration(seconds: 3));
+    expect(tester.getTopLeft(find.text(_text)).dx, 0);
   });
 
-  testWidgets('wraps around instead of drifting off forever', (tester) async {
-    await tester.pumpWidget(host());
-    double leftOf(int i) =>
-        tester.widget<Positioned>(find.byType(Positioned).at(i)).left!;
-    final gap = leftOf(1) - leftOf(0); // one copy width
-    clock.value += 30;
-    await tester.pump();
-    expect(leftOf(0), greaterThan(-gap));
-    expect(leftOf(0), lessThanOrEqualTo(0));
+  test('the period is the text plus a gap: four glyphs or half the band', () {
+    final text = TickerWidget.textMeters(_text, 1.9);
+    expect(text, greaterThan(0));
+    // A narrow band: the gap is four glyph heights.
+    expect(
+      TickerWidget.periodMeters(_text, 1.9, 4),
+      closeTo(text + 4 * 1.9 * TickerWidget.glyphFraction, 1e-9),
+    );
+    // A wide band: half its width.
+    expect(TickerWidget.periodMeters(_text, 1.9, 40), closeTo(text + 20, 1e-9));
+    // Type scales with the band: twice the height, twice the width.
+    expect(TickerWidget.textMeters(_text, 3.8), closeTo(2 * text, 1e-6));
+    expect(TickerWidget.textMeters('', 1.9), 0);
   });
 }


### PR DESCRIPTION
## What

The plaza harness idled at over 200 % CPU on an M4 Max at the home pose. This branch takes the idle work out, fixes two things noticed on the way, and adds a translucent look to the lightboxes. Eight commits, by two agents on one branch, each self-contained:

1. **Facades go live only when tapped** (a4892f473): a nearby facade becomes interactive on a tap instead of whenever the walker is near, sign textures are re-captured once their cover image lands, pointer handling moves into `PlazaPointerController`, `PLAZA_FPS` defaults to `auto`, and a flight drops walking momentum.
2. **Billboards are still faces** (63398133d): the panel was re-rendered ten times a second, a 117 px blur included, only because its border breathed inside the widget. The widget is captured once (and again when its cover lands, through the shared `CoverImage`); the breathing is one material write per frame on the glow quad behind the lightbox. Skyline screens are captured once. `PLAZA_TRACE` prints the running capture count.
3. **Tickers are one captured period scrolled by UV offset** (fe801610d): each band is captured once at a density that keeps the texture under 8192 px and scrolled by the material's texture offset, its end fade baked into vertex colours.
4. **Translucent lightboxes** (9b2bd420a, fb69967e0): a pylon's or roof panel's back shows the panel's own capture mirrored and dimmed instead of a black box.
5. **Flicker in flight** (fb69967e0): the far plate, neon glows and sign surface sit 1–3 cm apart on a wall, which the depth buffer cannot separate past ~200 m. Each layer carries a `Material.depthBias`, and the camera's near plane is 0.3 m.
6. **Shared unit boxes and solid materials** (ef2020f95): `PlazaBoxes` lets flutter_scene instance identical opaque draws.
7. **The sprite layer is two instanced batches** (72116a25a, aee00ed6c): 366 one-quad sprites, a hundred of them re-committing their bounds every frame, became one batch for bulbs and one for glows with bounds committed once.

## Measured

Widget captures per second at the home pose, read off `PLAZA_TRACE` on the Linux harness:

| Head | Captures/s |
|---|---|
| main | ~190 (modelled; ~157 measured, frame-limited on the VM) |
| after 2 | ~95 |
| after 3 | 1 (the jumbotron) |

Idle CPU on the M4 Max, reported by the author: 213–231 % on main → 110–150 % after 1 → 84–104 % after 2. Steps 3 and 7 are not yet measured there.

## Verification

- `fvm dart analyze lib/features/plaza test/features/plaza`: no issues; `make knowledge_check` passes; 301 plaza tests pass.
- Tour captures at home, block, billboard, overview and the attention close-up after each step: billboards, tickers (scrolling leftward, fading at the housing's ends), lanterns, chase bulbs, beacons and lamp halos render as before; the overview shows the pylon backs mirrored and dimmed.
- The flicker fix addresses the cause established from the code; a still capture cannot show flicker, so it wants a look on the Mac.

No changelog fragment: the plaza is reachable only through its dev entrypoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Nearby plaza facades become interactive after a tap, showing live checklists and details while in view.
  - Facades return to static signs when the camera moves away.
  - Cover-image updates refresh displayed facade and billboard content automatically.
  - Chase lights, billboard glow, and ticker displays have improved rendering and animation.

- **Improvements**
  - Plaza frame-rate default is now automatic, adapting to activity.
  - Camera flights and drag-look interactions now transition more smoothly.
  - Added depth and visual refinements for facade panels, glows, and focus indicators.

- **Documentation**
  - Updated plaza behavior, performance settings, testing guidance, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->