### PR TITLE
perf(plaza): improve facade loading and ease camera flights

### DIFF
--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -463,9 +463,18 @@ A `Flight` is planned once, as a chain of straight **legs** with one
   on a smoothstep, holds the cruise, and ramps down the same way, so
   acceleration starts and ends at zero; a way shorter than one cruise-ramp
   (`cruise × ramp`) shrinks both ramps to `sqrt(length × ramp / cruise)`
-  and never reaches the cruise. Duration is `2 × ramp + (length − cruise ×
-  ramp) / cruise`. `distanceAt(t)` is the way covered, `cruiseSpeed` and
-  `rampTime` what was flown.
+  and never reaches the cruise. Base duration is `2 × ramp + (length −
+  cruise × ramp) / cruise`. `cruiseSpeed` and `rampTime` describe this base
+  profile; `distanceAt(t)` includes the extra time for turns.
+- **Turn timing** (`_TurnTiming`): a table samples the original plan at
+  120 Hz, capped at 4096 intervals. Each interval takes at least enough time
+  for its yaw change at 45°/s and pitch change at 30°/s. Only sections that
+  exceed these limits slow down; position still follows the exact lifted
+  path. Heading interpolates between the table's knots, keeping rotation
+  bounded between samples, including at street corners and the ±π seam.
+  A turn in place gets an eased timeline even with zero travel distance.
+  `duration` includes this added time. The table is built once per flight;
+  each frame locates its interval with a binary search.
 - **The lift of a leg**: `arc × profile(s)` over the leg's straight line,
   where `s` is the fraction of the leg and the profile is a smoothstep
   climb over the first `rampStart` of it, a cruise, and a smoothstep
@@ -916,7 +925,10 @@ The builder creates:
   widget quads put their texture's left edge), so the lit part reads as
   progress along a scale.
 - **Texture density**: fifteen window tiles are 480 × 192 px and fifteen
-  shopfront strips are 1584 × 192 px (`_px` 48). These thirty RGBA8 textures
+  shopfront strips are 1584 × 192 px. Both painters keep their original
+  96-unit artwork coordinates and scale the entire canvas by one half, so
+  fine mullions, floor slabs, sign strokes and metre-sized shapes retain
+  their proportions. These thirty RGBA8 textures
   occupy approximately 30 MiB including a full mip chain, versus 121 MiB at
   twice the dimensions. This is a pixel-storage estimate, not a measurement
   of process peak memory. Ground grain, paving and pool textures are separate.
@@ -1092,8 +1104,13 @@ for keyboard and scene navigation is ignored in tour and bench modes.
   interval instead of adding drift. Input cancels the wait and coalesces
   into one immediate frame. There is no repeating idle `Ticker` waking the
   engine on every skipped vsync. `auto` follows the display while moving
-  (flight, walk, held key, drag and 0.6 s afterwards) and caps rest at 30 Hz;
-  `60` and `30` are fixed caps. Tour and bench remain uncapped.
+  (flight, walk, held key or drag) and for 0.6 s after movement or input.
+  With a settled camera, an active live facade retains 30 Hz while purely
+  decorative animation uses 15 Hz. Startup gets the same brief display-rate
+  window so initial captures and promotions can settle promptly. Animation
+  phases still use elapsed time: the lower cadence changes smoothness, not
+  ticker speed or pulse duration. `60` and `30` are fixed caps; tour and bench
+  remain uncapped.
   Hidden/inactive lifecycle states cancel both timer and pending callback;
   resume excludes the hidden duration from the animation clock.
 - **Engine and painted rates are distinct.** The HUD reports harness paints

--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -459,6 +459,8 @@ A `Flight` is planned once, as a chain of straight **legs** with one
   `streetSpeed` (10 m/s) so the facades and the billboards pass by. A
   flight is routed when both ends are no higher than
   `FlyCameraController.groundCeiling` (the street height plus a metre).
+  A target at the current position uses a direct turn, avoiding a trip out
+  to the street and back merely to change heading.
 - **The S-curve** (`_Profile`): speed ramps up over `rampSeconds` (1.6 s)
   on a smoothstep, holds the cruise, and ramps down the same way, so
   acceleration starts and ends at zero; a way shorter than one cruise-ramp

--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -541,10 +541,9 @@ fix is a climb that starts *under* a solid in the air and rises into it;
 no stop stands under a sign or the beam.
 
 Every flight pushes the departure pose onto a back stack in the harness;
-Backspace flies the reverse without pushing. While the camera flies
-(`FlyCameraController.flying`, landings included) the LOD manager makes
-no promotions, and the destination building of a facade flight is
-pre-promoted to the sign tier (`prepare`). `Tab` cycles the navigation
+Backspace flies the reverse without pushing. The destination building of a
+facade flight is pre-promoted to the sign tier (`prepare`); nearby signs
+also load under the [flight promotion budget](#facade-tiers-and-the-budget). `Tab` cycles the navigation
 beacons (everything but attention); when cycling toward older weeks a block
 or corner pose is turned round so the walk reads as walking, not reversing.
 
@@ -659,10 +658,10 @@ task data.
 
 ```mermaid
 flowchart TD
-  Far["far<br/>plate, neon strips, light bar, lantern<br/>no widget"] -->|"within 140 m and sign cap 80, one promotion per frame"| Sign["sign<br/>FacadeWidget sign variant<br/>initial capture and cover completion, manual input"]
+  Far["far<br/>plate, neon strips, light bar, lantern<br/>no widget"] -->|"within 140 m, sign cap 80, paced promotions"| Sign["sign<br/>FacadeWidget sign variant<br/>initial capture and cover completion, manual input"]
   Far -->|"tapped within live range, in front and in view, live budget available"| Live["live<br/>FacadeWidget live variant<br/>captured every 50 ms, automatic input"]
   Sign -->|"tapped within live range, in front and in view, live budget available"| Live
-  Live -->|"immediately when out of budget or range"| Sign
+  Live -->|"on flight start, or out of budget, range or view"| Sign
   Sign -->|"immediately"| Far
   Far -->|"prepare on flight start, the destination only"| Sign
 ```
@@ -676,8 +675,12 @@ up to it leaves its sign static. Live also needs the eye on the street side
 of the wall and the wall ahead of the camera. Leaving live range, turning
 away or activating another wall disarms the previous one; returning needs
 a new tap. A distant tap still flies to the building first.
-Promotions are rate-limited to one per frame and suspended while
-`flying` is set; demotions are immediate. `forceAllLive` (the
+Promotions are rate-limited to one per frame. During flight only static
+signs are created, at most one every 100 ms (`flightPromotionInterval`),
+within the same distance and surface caps. This starts cover loading before
+an approaching facade is reached without creating a frame-time burst.
+Starting a flight disarms the active wall; landing requires a new tap.
+Demotions are immediate. `forceAllLive` (the
 overlay's stress switch) makes every facade live and ignores the per-frame
 budget. The nearest live building is the **focused** one: its teal ring
 node is shown, and it is the wall whose checkboxes and details button
@@ -755,11 +758,15 @@ tour. No widget owns an animation controller: a billboard's glow, a
 ticker's scroll and the jumbotron's slides all read their cadence's clock,
 which advances only when a capture is requested.
 
-The **sign** facade variant is the category bar, a state marquee band with
-its glyph, the title (up to three lines, shrunk until its longest word fits
-the wall) and the cover art. The **live** variant adds the due and links
-line, as many open checklist items as the wall has room for, the state
-chip, a details button (opens the side panel) and the done count.
+The **sign** facade variant reuses `BillboardWidget` as a photo-led poster:
+cover art fills the panel, including short ground-floor signs, with its
+existing scrim behind the title, reason and compact state chip. It hides the
+billboard navigation hint because a nearby facade activates in place.
+Finished posters retain readable titles and use the subdued done chip and
+frame. The **live** variant uses its checklist layout with the due and links
+line, as many open checklist items as the wall has room for, a smaller cover
+band when space permits, the state chip, a details button (opens the side
+panel) and the done count.
 
 # Sprites
 

--- a/lib/features/plaza/dev_main.dart
+++ b/lib/features/plaza/dev_main.dart
@@ -117,7 +117,7 @@ class _PlazaHarnessState extends State<_PlazaHarness>
   static final bool _traceMode = Platform.environment['PLAZA_TRACE'] == '1';
 
   /// The harness owns the frame pacing: the scene view does not tick on
-  /// its own, a ticker here paints at most [_frameRate] frames a second
+  /// its own; the pacer paints at most [_frameRate] frames a second
   /// (the benchmark and the tour paint on every vsync). Every painted
   /// frame runs [_onTick] first.
   PlazaFrameRate _frameRate = PlazaFrameRate.fromEnvironment(
@@ -128,10 +128,10 @@ class _PlazaHarnessState extends State<_PlazaHarness>
   Duration? _lastPaint;
   final ValueNotifier<int> _frame = ValueNotifier(0);
 
-  /// Movement keeps the display's rate on `auto` for this long after it
-  /// stops, so a coast to a halt is smooth.
+  /// Movement and input keep the display's rate on `auto` for this long,
+  /// so a coast to a halt and direct widget interaction stay smooth.
   static const _movingHold = 0.6;
-  double _movingUntil = 0;
+  double _movingUntil = _movingHold;
 
   /// Frames the engine produced since the stats were last published,
   /// counted from engine frame timings: the number that shows whether
@@ -216,7 +216,10 @@ class _PlazaHarnessState extends State<_PlazaHarness>
       onFrame: _onPace,
       cap: () => _mode.scripted
           ? null
-          : _frameRate.capFor(moving: _moving || _elapsed < _movingUntil),
+          : _frameRate.capFor(
+              moving: _moving || _elapsed < _movingUntil,
+              activeSurface: _lod.stats.live > 0,
+            ),
     );
     if (WidgetsBinding.instance.lifecycleState == null ||
         WidgetsBinding.instance.lifecycleState == AppLifecycleState.resumed) {
@@ -259,6 +262,12 @@ class _PlazaHarnessState extends State<_PlazaHarness>
     _lastPaint = elapsed;
     _onTick(elapsed, dt);
     _frame.value++;
+  }
+
+  /// Cancels the idle wait and lets interaction settle at display cadence.
+  void _wakeForInput() {
+    _movingUntil = _elapsed + _movingHold;
+    _pacer?.requestFrame();
   }
 
   @override
@@ -348,7 +357,7 @@ class _PlazaHarnessState extends State<_PlazaHarness>
   void _flyTo(CameraPose pose, String label, {bool push = true}) {
     if (push) _back.add(_camera.pose);
     _camera.flyTo(pose);
-    _pacer?.requestFrame();
+    _wakeForInput();
     _showToast(label);
   }
 
@@ -443,7 +452,7 @@ class _PlazaHarnessState extends State<_PlazaHarness>
           ? KeyEventResult.handled
           : KeyEventResult.ignored;
     }
-    _pacer?.requestFrame();
+    _wakeForInput();
     final key = event.logicalKey;
     if (key == LogicalKeyboardKey.slash) {
       setState(() => _searchOpen = true);
@@ -472,14 +481,14 @@ class _PlazaHarnessState extends State<_PlazaHarness>
   void _onPointerDown(PointerDownEvent event) {
     if (_mode.scripted) return;
     _pointer.down(event, _elapsed);
-    _pacer?.requestFrame();
+    _wakeForInput();
   }
 
   void _onPointerMove(PointerMoveEvent event) {
     final delta = _pointer.move(event);
     if (delta != null) {
       _camera.addLookDelta(delta.dx, delta.dy);
-      _pacer?.requestFrame();
+      _wakeForInput();
     }
   }
 
@@ -691,7 +700,7 @@ class _PlazaHarnessState extends State<_PlazaHarness>
               frameRate: _frameRate,
               onFrameRateChanged: (rate) {
                 setState(() => _frameRate = rate);
-                _pacer?.requestFrame();
+                _wakeForInput();
               },
               showDebug: _showDebug,
               onShowDebugChanged: (show) => setState(() => _showDebug = show),

--- a/lib/features/plaza/domain/flight.dart
+++ b/lib/features/plaza/domain/flight.dart
@@ -8,6 +8,7 @@
 library;
 
 import 'dart:math' as math;
+import 'dart:typed_data';
 
 import 'package:lotti/features/plaza/domain/plaza_layout.dart';
 import 'package:lotti/features/plaza/domain/solid.dart';
@@ -29,8 +30,7 @@ class Flight {
     // ignore: prefer_initializing_formals
   }) : _legs = legs,
        _profile = profile,
-       _wayEnd = wayEnd ?? profile.length,
-       duration = Duration(microseconds: (profile.duration * 1e6).round());
+       _wayEnd = wayEnd ?? profile.length;
 
   /// Plans the direct flight from [from] to [to]: one straight leg, swept
   /// against [solids] and lifted over whatever it would pass through
@@ -115,6 +115,11 @@ class Flight {
   /// shortens both ramps and never reaches the cruise.
   static const rampSeconds = 1.6;
 
+  /// Maximum rotation rates, radians per second. Turning stretches only
+  /// the affected sections of the flight, preserving its collision-safe path.
+  static const double maxYawSpeed = math.pi / 4;
+  static const double maxPitchSpeed = math.pi / 6;
+
   /// A street flight cruises this high above the road: over the parade,
   /// level with the screens, under every sign and the gantry.
   static const streetFlightHeight = 5.0;
@@ -158,7 +163,16 @@ class Flight {
 
   final CameraPose from;
   final CameraPose to;
-  final Duration duration;
+
+  /// Travel time including the extra time needed for gentle turns.
+  late final Duration duration = Duration(
+    microseconds: (_timing.seconds * 1e6).ceil(),
+  );
+
+  late final _TurnTiming _timing = _TurnTiming(
+    _profile.duration,
+    _basePoseAt,
+  );
 
   /// Whether the flight follows the street (see [Flight.route]).
   final bool routed;
@@ -256,7 +270,7 @@ class Flight {
 
   /// How far along the way the flight is at [t] of its time (0..1).
   double distanceAt(double t) =>
-      _profile.distanceAt(t.clamp(0.0, 1.0) * _profile.duration);
+      _profile.distanceAt(_timing.at(t).progress * _profile.duration);
 
   /// The leg [d] metres along the way is on, and the fraction of it.
   (_Leg, double) _locate(double d) {
@@ -283,12 +297,34 @@ class Flight {
   /// heading during the last; the pitch dips while lifted so the camera
   /// looks down at what it crosses.
   CameraPose poseAt(double t) {
-    final d = distanceAt(t);
+    final sample = _timing.at(t);
+    return _basePoseAt(
+      sample.progress,
+      orientation: (yaw: sample.yaw, pitch: sample.pitch),
+    );
+  }
+
+  /// Original spatial plan. The timing table changes when each point is
+  /// reached; its interpolated orientation bounds rotation between samples.
+  CameraPose _basePoseAt(
+    double t, {
+    ({double yaw, double pitch})? orientation,
+  }) {
+    final d = _profile.distanceAt(t * _profile.duration);
     final (leg, f) = _locate(d);
     final x = _lerp(leg.from.x, leg.to.x, f);
     final z = _lerp(leg.from.z, leg.to.z, f);
     final lift = leg.liftAt(f);
     final y = _lerp(leg.from.y, leg.to.y, f) + lift;
+    if (orientation != null) {
+      return CameraPose(
+        x: x,
+        y: y,
+        z: z,
+        yaw: orientation.yaw,
+        pitch: orientation.pitch,
+      );
+    }
 
     final ramp = _profile.rampDistance;
     final total = length;
@@ -303,7 +339,11 @@ class Flight {
     // is settled for the whole ramp; between them the camera looks down
     // the way.
     final double yaw;
-    final along = routed ? _lookAheadYaw(d, x, z, leg) : travelYaw;
+    final along = total == 0
+        ? null
+        : routed
+        ? _lookAheadYaw(d, x, z, leg)
+        : travelYaw;
     if (along == null) {
       yaw = _blendHeading(from.yaw, to.yaw, _smooth(t));
     } else if (d < ramp) {
@@ -315,7 +355,7 @@ class Flight {
     }
 
     final double pitch;
-    if (routed) {
+    if (routed && total > 0) {
       // Level down the street; the stop's own pitch on arrival.
       pitch = d < ramp
           ? from.pitch * (1 - _smooth(inRamp))
@@ -387,6 +427,84 @@ class Flight {
       d += 2 * math.pi;
     }
     return a + d * s;
+  }
+}
+
+/// A bounded table computed once per flight. Each original time interval
+/// takes at least enough time to rotate between its endpoints at the limits.
+/// Position remains on the original curve; orientation interpolates between
+/// knots, so even a sharp look-ahead corner cannot exceed the rotation limits.
+class _TurnTiming {
+  factory _TurnTiming(
+    double travelSeconds,
+    CameraPose Function(double) poseAt,
+  ) {
+    final first = poseAt(0);
+    final last = poseAt(1);
+    // A pure turn still needs an eased timeline when translation takes no time.
+    final baseSeconds = travelSeconds == 0
+        ? 1.5 *
+              math.max(
+                _angle(last.yaw - first.yaw).abs() / Flight.maxYawSpeed,
+                (last.pitch - first.pitch).abs() / Flight.maxPitchSpeed,
+              )
+        : travelSeconds;
+    final steps = (baseSeconds * 120).ceil().clamp(1, 4096);
+    final times = Float64List(steps + 1);
+    final yaws = Float64List(steps + 1)..[0] = first.yaw;
+    final pitches = Float64List(steps + 1)..[0] = first.pitch;
+    var previous = first;
+    for (var i = 1; i <= steps; i++) {
+      final pose = poseAt(i / steps);
+      final yaw = _angle(pose.yaw - previous.yaw);
+      final pitch = pose.pitch - previous.pitch;
+      times[i] =
+          times[i - 1] +
+          math.max(
+            baseSeconds / steps,
+            math.max(
+              yaw.abs() / Flight.maxYawSpeed,
+              pitch.abs() / Flight.maxPitchSpeed,
+            ),
+          );
+      yaws[i] = yaws[i - 1] + yaw;
+      pitches[i] = pose.pitch;
+      previous = pose;
+    }
+    return _TurnTiming._(times, yaws, pitches);
+  }
+
+  const _TurnTiming._(this._times, this._yaws, this._pitches);
+
+  final Float64List _times;
+  final Float64List _yaws;
+  final Float64List _pitches;
+
+  double get seconds => _times.last;
+
+  static double _angle(double radians) =>
+      math.atan2(math.sin(radians), math.cos(radians));
+
+  ({double progress, double yaw, double pitch}) at(double t) {
+    final progress = t.clamp(0.0, 1.0);
+    final time = progress * seconds;
+    var lo = 0;
+    var hi = _times.length - 1;
+    while (hi - lo > 1) {
+      final mid = (lo + hi) ~/ 2;
+      if (_times[mid] <= time) {
+        lo = mid;
+      } else {
+        hi = mid;
+      }
+    }
+    final span = _times[hi] - _times[lo];
+    final f = span == 0 ? progress : (time - _times[lo]) / span;
+    return (
+      progress: (lo + f) / (_times.length - 1),
+      yaw: _lerp(_yaws[lo], _yaws[hi], f),
+      pitch: _lerp(_pitches[lo], _pitches[hi], f),
+    );
   }
 }
 

--- a/lib/features/plaza/scene/facade_lod_manager.dart
+++ b/lib/features/plaza/scene/facade_lod_manager.dart
@@ -26,8 +26,7 @@ class FacadeLodConfig {
     this.forceAllLive = false,
   });
 
-  /// Hard cap on live (interactive) surfaces: the faced building and its
-  /// nearest neighbours.
+  /// Hard cap on live surfaces; normal interaction activates one wall.
   int liveCap;
 
   /// Hard cap on hosted sign surfaces.
@@ -71,7 +70,7 @@ class _Surface {
   FacadeTier tier = FacadeTier.far;
 }
 
-/// The budget and the suspension a ranking was made under; a change to any
+/// The budget and flight mode a ranking was made under; a change to any
 /// of them makes the ranking stale.
 typedef _Budget = ({
   int liveCap,
@@ -125,7 +124,7 @@ class FacadeLodManager {
   late final List<_Surface> _rankedSurfaces = List.of(_surfaces);
 
   /// What the last ranking was made for. It holds until the eye, the view
-  /// direction, the budget or the suspension changes, or until it left
+  /// direction, the budget or flight mode changes, or until it left
   /// work undone: a tier it changed (the hysteresis shifts) or a promotion
   /// it could not afford.
   final Vector3 _rankedEye = Vector3.zero();
@@ -203,6 +202,11 @@ class FacadeLodManager {
   /// How often a live wall is captured, seconds on the harness clock.
   static const liveInterval = 0.05;
 
+  /// During flight, start at most one new sign per interval. This gives
+  /// approaching facades time to decode without a burst of hosted widgets.
+  static const flightPromotionInterval = 0.1;
+  double _nextFlightPromotion = 0;
+
   /// Once per painted frame: assigns the tiers for [eye] unless the last
   /// ranking still holds (same eye, [forward], budget and [flying], and
   /// nothing left undone), then asks every live wall for a capture once
@@ -210,15 +214,18 @@ class FacadeLodManager {
   /// clock, and every sign for its one capture until it lands. [forward]
   /// is the camera's view direction: a wall behind the walker never takes
   /// a live slot, however near — standing 22 m from a landmark puts the
-  /// opposite row 3 m behind your back. While [flying] no surface is
-  /// created except the one pre-captured by [prepare].
+  /// opposite row 3 m behind your back. While [flying], static signs are
+  /// prepared at [flightPromotionInterval] intervals; live interaction waits
+  /// until the camera settles and the facade is tapped.
   void update(
     Vector3 eye, {
     Vector3? forward,
     double seconds = 0,
     bool flying = false,
   }) {
-    if (!_rankingHolds(eye, forward, flying)) _rank(eye, forward, flying);
+    if (!_rankingHolds(eye, forward, flying)) {
+      _rank(eye, forward, flying, seconds);
+    }
     // No culling here: the ranking already demoted every wall the camera
     // cannot see.
     _captures
@@ -237,7 +244,7 @@ class FacadeLodManager {
     return _rankedBudget == config._budget(flying);
   }
 
-  void _rank(Vector3 eye, Vector3? forward, bool flying) {
+  void _rank(Vector3 eye, Vector3? forward, bool flying, double seconds) {
     _rankings++;
     final n = buildings.length;
     for (final surface in _surfaces) {
@@ -250,10 +257,12 @@ class FacadeLodManager {
     var signLeft = config.forceAllLive ? 0 : config.signCap;
     // The stress switch wants the steady state, not a five-second ramp:
     // it ignores the per-frame promotion budget.
-    var promotionsLeft = flying
-        ? 0
-        : config.forceAllLive
+    var promotionsLeft = config.forceAllLive
         ? n
+        : flying
+        ? seconds >= _nextFlightPromotion
+              ? math.min(1, config.promotionsPerFrame)
+              : 0
         : config.promotionsPerFrame;
     PlazaBuilding? focused;
     var changed = false;
@@ -265,7 +274,8 @@ class FacadeLodManager {
       FacadeTier target;
       if (config.forceAllLive) {
         target = FacadeTier.live;
-      } else if (building == _activated &&
+      } else if (!flying &&
+          building == _activated &&
           liveLeft > 0 &&
           d < math.max(config.liveDistance, building.liveRange) &&
           _inView(building, eye, forward)) {
@@ -288,6 +298,7 @@ class FacadeLodManager {
         if (promotionsLeft > 0) {
           promotionsLeft--;
           _apply(surface, target);
+          if (flying) _nextFlightPromotion = seconds + flightPromotionInterval;
           changed = true;
         } else {
           waiting = true;

--- a/lib/features/plaza/scene/wall_textures.dart
+++ b/lib/features/plaza/scene/wall_textures.dart
@@ -30,7 +30,10 @@ class WallTextures {
 
   /// One storey of the window tile, metres: walls stack whole storeys.
   static const double storeyHeight = tileHeight / floors;
-  static const _px = 48;
+  // Keep the authored coordinate space: both metre-sized shapes and fine
+  // pixel details scale together when rasterized into the smaller texture.
+  static const _px = 96;
+  static const _textureScale = 0.5;
 
   /// One paving tile covers this many metres of plaza: a 2 × 2 grid of
   /// slabs with a joint between.
@@ -147,6 +150,7 @@ class WallTextures {
     const h = shopfrontHeight * _px;
     final recorder = ui.PictureRecorder();
     final canvas = ui.Canvas(recorder)
+      ..scale(_textureScale)
       ..drawRect(
         const ui.Rect.fromLTWH(0, 0, w, h),
         ui.Paint()..color = _night,
@@ -158,7 +162,10 @@ class WallTextures {
       _paintShop(canvas, rng, shop, left, _m(shop.width), dressing);
       left += _m(shop.width);
     }
-    return recorder.endRecording().toImageSync(w.toInt(), h.toInt());
+    return recorder.endRecording().toImageSync(
+      (w * _textureScale).round(),
+      (h * _textureScale).round(),
+    );
   }
 
   /// Text on a sign or a notice: capitals, letter-spaced, centred in
@@ -1164,6 +1171,7 @@ class WallTextures {
     const h = floors * _px;
     final recorder = ui.PictureRecorder();
     final canvas = ui.Canvas(recorder)
+      ..scale(_textureScale)
       ..drawRect(
         ui.Rect.fromLTWH(0, 0, w.toDouble(), h.toDouble()),
         ui.Paint()..color = _night,
@@ -1256,7 +1264,10 @@ class WallTextures {
           ui.Paint()..color = const ui.Color(0xFF1C1A2A),
         );
     }
-    return recorder.endRecording().toImageSync(w, h);
+    return recorder.endRecording().toImageSync(
+      (w * _textureScale).round(),
+      (h * _textureScale).round(),
+    );
   }
 }
 

--- a/lib/features/plaza/ui/billboard_widget.dart
+++ b/lib/features/plaza/ui/billboard_widget.dart
@@ -6,8 +6,8 @@ import 'package:lotti/features/plaza/ui/cover_image.dart';
 import 'package:lotti/features/plaza/ui/plaza_chip.dart';
 import 'package:lotti/features/plaza/ui/plaza_style.dart';
 
-/// A frontier-plaza billboard: the headline for one task that needs
-/// attention, framed in its state colour.
+/// A photo-led plaza poster, used by billboards and static facades:
+/// one task's headline and cover, framed in its state colour.
 ///
 /// A still face, captured once (and again when its cover lands, through
 /// [onCoverChanged]): nothing here animates. An anomaly's frame breathes
@@ -19,6 +19,7 @@ class BillboardWidget extends StatelessWidget {
     required this.heightMeters,
     required this.pxPerMeter,
     this.reasonFirst = false,
+    this.showNavigationHint = true,
     this.onCoverChanged,
     super.key,
   });
@@ -27,10 +28,13 @@ class BillboardWidget extends StatelessWidget {
   /// already carries the title) and drops its 'fly there'.
   final bool reasonFirst;
 
+  /// Navigation panels offer a flight; a facade poster is activated in place.
+  final bool showNavigationHint;
+
   final TaskAttention attention;
   final double widthMeters;
 
-  /// Panel height; a squat roof panel drops the cover, then the reason.
+  /// Panel height; a squat panel keeps its cover but drops the reason.
   final double heightMeters;
   final double pxPerMeter;
 
@@ -79,8 +83,8 @@ class BillboardWidget extends StatelessWidget {
             ),
           ),
         ),
-        if (!reasonFirst) SizedBox(width: chipPx * 0.6),
-        if (!reasonFirst)
+        if (!reasonFirst && showNavigationHint) SizedBox(width: chipPx * 0.6),
+        if (!reasonFirst && showNavigationHint)
           // The call to action is a chip like the state, not loose type.
           PlazaChip(
             label: 'fly there ›',

--- a/lib/features/plaza/ui/debug_overlay.dart
+++ b/lib/features/plaza/ui/debug_overlay.dart
@@ -29,7 +29,7 @@ class PlazaHarnessStats extends ChangeNotifier {
 /// glows), so without a cap it paints on every vsync, 120 times a second
 /// on a ProMotion display, and re-encodes the whole district each time.
 enum PlazaFrameRate {
-  /// The display's rate while the camera moves, 30 Hz while it stands.
+  /// Display rate on movement/input, 30 Hz for live facades, 15 Hz at rest.
   auto,
   sixty,
   thirty;
@@ -48,11 +48,17 @@ enum PlazaFrameRate {
   };
 
   /// The cap, frames per second, or null for the display's rate.
-  double? capFor({required bool moving}) => switch (this) {
-    PlazaFrameRate.auto => moving ? null : 30,
-    PlazaFrameRate.sixty => 60,
-    PlazaFrameRate.thirty => 30,
-  };
+  double? capFor({required bool moving, bool activeSurface = false}) =>
+      switch (this) {
+        PlazaFrameRate.auto =>
+          moving
+              ? null
+              : activeSurface
+              ? 30
+              : 15,
+        PlazaFrameRate.sixty => 60,
+        PlazaFrameRate.thirty => 30,
+      };
 }
 
 /// World-scale tuning knobs. Changing one rebuilds the scene (they are

--- a/lib/features/plaza/ui/facade_widget.dart
+++ b/lib/features/plaza/ui/facade_widget.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:lotti/features/design_system/theme/icon_tokens.dart';
 import 'package:lotti/features/plaza/domain/attention.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
+import 'package:lotti/features/plaza/ui/billboard_widget.dart';
 import 'package:lotti/features/plaza/ui/checklist_ticks.dart';
 import 'package:lotti/features/plaza/ui/cover_image.dart';
 import 'package:lotti/features/plaza/ui/plaza_chip.dart';
@@ -11,8 +12,8 @@ import 'package:lotti/features/plaza/ui/plaza_style.dart';
 
 /// Which range a facade is drawn for.
 enum FacadeVariant {
-  /// Street range, captured: category bar, big title, cover art, state
-  /// chip, light bar. Nothing that cannot be read at 100 m.
+  /// Street range, captured: a photo-led poster with title and state chip.
+  /// The cover stays visible even on short ground-floor panels.
   sign,
 
   /// Shopfront range, live: everything, with working checkboxes and OPEN.
@@ -21,10 +22,10 @@ enum FacadeVariant {
 
 /// The signage on one building's street-facing wall.
 ///
-/// Laid out in world metres scaled by [pxPerMeter], so the type reads the
-/// same on a 5 m shop and a 15 m tower: the title is roughly a tenth of the
-/// wall's width tall, the interactive strip sits at the bottom where a 2.2 m
-/// walker looks, and the progress light bar runs along the base.
+/// The static sign uses the billboard poster layout with cover art behind
+/// its headline. After activation, the live layout uses world metres scaled
+/// by [pxPerMeter], with checklist controls near the bottom where a walker
+/// looks. The progress light bar is separate scene geometry.
 class FacadeWidget extends StatelessWidget {
   const FacadeWidget({
     required this.task,
@@ -57,22 +58,32 @@ class FacadeWidget extends StatelessWidget {
   /// Draws the teal focus ring (the faced building is the live one).
   final bool focused;
 
-  bool get _live => variant == FacadeVariant.live;
-
   @override
   Widget build(BuildContext context) {
+    if (variant == FacadeVariant.sign) {
+      return LayoutBuilder(
+        builder: (context, constraints) => BillboardWidget(
+          attention: attention,
+          widthMeters: widthMeters,
+          heightMeters: constraints.maxHeight / pxPerMeter,
+          pxPerMeter: pxPerMeter,
+          showNavigationHint: false,
+          onCoverChanged: onCoverChanged,
+        ),
+      );
+    }
     final t = ticks;
-    if (t == null) return _build(context, null);
+    if (t == null) return _buildLive(context, null);
     return ListenableBuilder(
       listenable: t,
-      builder: (context, _) => _build(context, t),
+      builder: (context, _) => _buildLive(context, t),
     );
   }
 
-  Widget _build(BuildContext context, ChecklistTicks? t) {
+  Widget _buildLive(BuildContext context, ChecklistTicks? t) {
     double m(double meters) => meters * pxPerMeter;
     final w = widthMeters;
-    var titleM = (0.1 * w).clamp(0.9, 2.0) * (_live ? 1 : 1.35);
+    var titleM = (0.1 * w).clamp(0.9, 2.0);
     // Never break a word in the middle of a wall: shrink the title until
     // its longest word fits the measure.
     final innerPx = (w - 2 * 0.08 * w) * pxPerMeter;
@@ -101,13 +112,11 @@ class FacadeWidget extends StatelessWidget {
     return Material(
       color: quiet
           ? const Color(0xFF0E0D16)
-          : _live
-          ? Color.lerp(
+          : Color.lerp(
               PlazaStyle.panel,
               PlazaStyle.lantern(attention.lantern),
               0.12,
-            )!
-          : PlazaStyle.panel,
+            )!,
       child: Container(
         foregroundDecoration: focused
             ? BoxDecoration(
@@ -120,37 +129,6 @@ class FacadeWidget extends StatelessWidget {
             Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                // The category band belongs to the sign tier; a live wall
-                // has the state rim and the focus ring for its frame.
-                if (!_live)
-                  Container(
-                    height: m(0.4),
-                    color: quiet
-                        ? Color.lerp(
-                            PlazaStyle.categoryBright(task),
-                            const Color(0xFF07060B),
-                            0.6,
-                          )
-                        : PlazaStyle.categoryBright(task),
-                  ),
-                if (!_live)
-                  // Street range: the state is a marquee band at the top,
-                  // where the street cannot hide it, with its glyph.
-                  Container(
-                    padding: EdgeInsets.symmetric(vertical: m(chipM) * 0.4),
-                    color: chip.fill,
-                    child: Text(
-                      '${PlazaStyle.glyph(attention)}  ${chip.label}',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontFamily: PlazaStyle.fontText,
-                        fontSize: m(chipM * 1.5),
-                        fontWeight: FontWeight.w800,
-                        letterSpacing: m(chipM) * 0.12,
-                        color: chip.ink,
-                      ),
-                    ),
-                  ),
                 Expanded(
                   child: Padding(
                     padding: EdgeInsets.all(pad),
@@ -179,7 +157,7 @@ class FacadeWidget extends StatelessWidget {
                                     box.maxHeight *
                                     (tight
                                         ? 0.5
-                                        : _live && items.isNotEmpty
+                                        : items.isNotEmpty
                                         ? 0.4
                                         : 0.6),
                               ),
@@ -193,8 +171,7 @@ class FacadeWidget extends StatelessWidget {
                                     // A live wall with a list keeps the
                                     // title to two lines; the list is what
                                     // you flew here to tick.
-                                    maxLines:
-                                        quiet || (_live && items.isNotEmpty)
+                                    maxLines: quiet || (items.isNotEmpty)
                                         ? 2
                                         : 3,
                                     overflow: TextOverflow.ellipsis,
@@ -212,9 +189,7 @@ class FacadeWidget extends StatelessWidget {
                                 ),
                               ),
                             ),
-                            if (_live &&
-                                attention.reason.isNotEmpty &&
-                                !tight) ...[
+                            if (attention.reason.isNotEmpty && !tight) ...[
                               SizedBox(height: gap),
                               // The wall you fly to says what the billboard
                               // said, as loudly: the reason leads, in the
@@ -238,12 +213,10 @@ class FacadeWidget extends StatelessWidget {
                               // third of a live wall: the checklist keeps
                               // its rows.
                               Flexible(
-                                flex: _live ? 5 : 10,
+                                flex: 5,
                                 child: ConstrainedBox(
                                   constraints: BoxConstraints(
-                                    maxHeight: _live
-                                        ? box.maxHeight * 0.26
-                                        : double.infinity,
+                                    maxHeight: box.maxHeight * 0.26,
                                   ),
                                   child: SizedBox(
                                     width: double.infinity,
@@ -259,7 +232,7 @@ class FacadeWidget extends StatelessWidget {
                                 ),
                               ),
                             ],
-                            if (_live && items.isNotEmpty && !tight) ...[
+                            if (items.isNotEmpty && !tight) ...[
                               SizedBox(height: gap),
                               // Only as many items as the wall has room for:
                               // a short building shows fewer, never overflows.
@@ -305,87 +278,85 @@ class FacadeWidget extends StatelessWidget {
                               ),
                             ],
                             const Spacer(),
-                            if (_live)
-                              // A firm band, never squeezed: the checklist
-                              // above yields, the chips keep their size.
-                              SizedBox(
-                                height: m(chipM) * 2.4,
-                                child: LayoutBuilder(
-                                  builder: (context, row) => FittedBox(
-                                    fit: BoxFit.scaleDown,
-                                    alignment: Alignment.bottomLeft,
-                                    child: SizedBox(
-                                      width: row.maxWidth,
-                                      child: Row(
-                                        children: [
-                                          // Chips scale down together on a narrow
-                                          // wall rather than overflowing the row.
-                                          Flexible(
-                                            child: FittedBox(
-                                              fit: BoxFit.scaleDown,
-                                              alignment: Alignment.centerLeft,
-                                              child: Row(
-                                                mainAxisSize: MainAxisSize.min,
-                                                children: [
+                            // A firm band, never squeezed: the checklist
+                            // above yields, the chips keep their size.
+                            SizedBox(
+                              height: m(chipM) * 2.4,
+                              child: LayoutBuilder(
+                                builder: (context, row) => FittedBox(
+                                  fit: BoxFit.scaleDown,
+                                  alignment: Alignment.bottomLeft,
+                                  child: SizedBox(
+                                    width: row.maxWidth,
+                                    child: Row(
+                                      children: [
+                                        // Chips scale down together on a narrow
+                                        // wall rather than overflowing the row.
+                                        Flexible(
+                                          child: FittedBox(
+                                            fit: BoxFit.scaleDown,
+                                            alignment: Alignment.centerLeft,
+                                            child: Row(
+                                              mainAxisSize: MainAxisSize.min,
+                                              children: [
+                                                PlazaChip(
+                                                  label:
+                                                      '${PlazaStyle.glyph(attention)} '
+                                                      '${chip.label}',
+                                                  fill: chip.fill,
+                                                  ink: chip.ink,
+                                                  fontPx: m(chipM),
+                                                ),
+                                                if (onOpen != null) ...[
+                                                  SizedBox(width: m(0.3)),
                                                   PlazaChip(
-                                                    label:
-                                                        '${PlazaStyle.glyph(attention)} '
-                                                        '${chip.label}',
-                                                    fill: chip.fill,
-                                                    ink: chip.ink,
-                                                    fontPx: m(chipM),
-                                                  ),
-                                                  if (onOpen != null) ...[
-                                                    SizedBox(width: m(0.3)),
-                                                    PlazaChip(
-                                                      label: 'DETAILS ›',
-                                                      fill: PlazaStyle.teal,
-                                                      ink: const Color(
-                                                        0xFF0D0D0D,
-                                                      ),
-                                                      fontPx: m(chipM),
-                                                      onTap: onOpen,
+                                                    label: 'DETAILS ›',
+                                                    fill: PlazaStyle.teal,
+                                                    ink: const Color(
+                                                      0xFF0D0D0D,
                                                     ),
-                                                  ],
+                                                    fontPx: m(chipM),
+                                                    onTap: onOpen,
+                                                  ),
                                                 ],
-                                              ),
+                                              ],
                                             ),
                                           ),
-                                          if (total > 0) ...[
-                                            SizedBox(width: m(0.3)),
-                                            Text(
-                                              '$done/$total',
+                                        ),
+                                        if (total > 0) ...[
+                                          SizedBox(width: m(0.3)),
+                                          Text(
+                                            '$done/$total',
+                                            style: TextStyle(
+                                              fontFamily: PlazaStyle.fontMono,
+                                              fontSize: m(metaM),
+                                              color: PlazaStyle.textDim,
+                                            ),
+                                          ),
+                                        ],
+                                        if (metaBits.isNotEmpty) ...[
+                                          SizedBox(width: m(0.4)),
+                                          Flexible(
+                                            child: Text(
+                                              metaBits.join('  ·  '),
+                                              maxLines: 1,
+                                              overflow: TextOverflow.ellipsis,
                                               style: TextStyle(
                                                 fontFamily: PlazaStyle.fontMono,
                                                 fontSize: m(metaM),
-                                                color: PlazaStyle.textDim,
+                                                color: quiet
+                                                    ? PlazaStyle.textDim
+                                                    : PlazaStyle.textMed,
                                               ),
                                             ),
-                                          ],
-                                          if (metaBits.isNotEmpty) ...[
-                                            SizedBox(width: m(0.4)),
-                                            Flexible(
-                                              child: Text(
-                                                metaBits.join('  ·  '),
-                                                maxLines: 1,
-                                                overflow: TextOverflow.ellipsis,
-                                                style: TextStyle(
-                                                  fontFamily:
-                                                      PlazaStyle.fontMono,
-                                                  fontSize: m(metaM),
-                                                  color: quiet
-                                                      ? PlazaStyle.textDim
-                                                      : PlazaStyle.textMed,
-                                                ),
-                                              ),
-                                            ),
-                                          ],
+                                          ),
                                         ],
-                                      ),
+                                      ],
                                     ),
                                   ),
                                 ),
                               ),
+                            ),
                           ],
                         );
                       },

--- a/lib/features/plaza/ui/fly_camera_controller.dart
+++ b/lib/features/plaza/ui/fly_camera_controller.dart
@@ -99,11 +99,13 @@ class FlyCameraController {
   /// flight, if any, is replaced.
   /// From one stop on the ground to another the flight follows the street
   /// network; a climb, a dive or a world without a street takes the direct
-  /// line. Both are swept over every solid on the way.
+  /// line. A heading change at the current position stays in place.
+  /// Both travel paths are swept over every solid on the way.
   Flight flyTo(CameraPose target) {
     final network = _network;
     final onGround = _pose.y <= groundCeiling && target.y <= groundCeiling;
-    final flight = network != null && onGround
+    final travels = _pose.distanceTo(target) > 0;
+    final flight = network != null && onGround && travels
         ? Flight.route(
             _pose,
             target,

--- a/lib/features/plaza/ui/plaza_frame_window.dart
+++ b/lib/features/plaza/ui/plaza_frame_window.dart
@@ -4,8 +4,11 @@ import 'dart:typed_data';
 /// A bounded frame-time window: insertion overwrites one sample instead of
 /// shifting a list. Aggregate stats are read only when the HUD is published.
 class PlazaFrameWindow {
-  PlazaFrameWindow({int capacity = 120}) : _samples = Float64List(capacity) {
+  PlazaFrameWindow({int capacity = 120}) : _samples = _allocate(capacity);
+
+  static Float64List _allocate(int capacity) {
     if (capacity < 1) throw ArgumentError.value(capacity, 'capacity');
+    return Float64List(capacity);
   }
 
   final Float64List _samples;

--- a/test/features/plaza/domain/flight_test.dart
+++ b/test/features/plaza/domain/flight_test.dart
@@ -41,6 +41,90 @@ void main() {
 
   double seconds(Flight f) => f.duration.inMicroseconds / 1e6;
 
+  test('turning speed is bounded across departures, corners and arrivals', () {
+    final flights = [
+      Flight.plan(a, const CameraPose(x: 50, y: 2.2, z: 0, yaw: 0)),
+      Flight.plan(a, const CameraPose(x: 0, y: 2.2, z: -100, yaw: 0)),
+      Flight.plan(a, const CameraPose(x: 1, y: 2.2, z: 0, yaw: 3, pitch: -1)),
+      Flight.plan(a, const CameraPose(x: 0, y: 2.2, z: 0, yaw: 0, pitch: -1)),
+      Flight.plan(
+        const CameraPose(x: 0, y: 2.2, z: 0, yaw: 3.1),
+        const CameraPose(x: 1, y: 2.2, z: 0, yaw: -3.1),
+      ),
+      Flight.route(
+        a,
+        const CameraPose(x: 50, y: 2.2, z: 50, yaw: 2.5, pitch: -0.5),
+        via: const [(0.0, 0.0), (50.0, 0.0), (50.0, 50.0)],
+      ),
+    ];
+    for (final flight in flights) {
+      final steps = (seconds(flight) * 120).ceil();
+      final dt = seconds(flight) / steps;
+      var previous = flight.poseAt(0);
+      var maxYaw = 0.0;
+      var maxPitch = 0.0;
+      for (var step = 1; step <= steps; step++) {
+        final pose = flight.poseAt(step / steps);
+        final yaw = pose.yaw - previous.yaw;
+        final turn = math.atan2(math.sin(yaw), math.cos(yaw)).abs();
+        maxYaw = math.max(maxYaw, turn / dt);
+        maxPitch = math.max(maxPitch, (pose.pitch - previous.pitch).abs() / dt);
+        previous = pose;
+      }
+      expect(maxYaw, lessThanOrEqualTo(math.pi / 4 + 1e-5));
+      expect(maxPitch, lessThanOrEqualTo(math.pi / 6 + 1e-5));
+    }
+  });
+
+  test('turning in place takes time and still lands exactly', () {
+    final flight = Flight.plan(
+      a,
+      const CameraPose(x: 0, y: 2.2, z: 0, yaw: math.pi, pitch: -0.6),
+    );
+    expect(seconds(flight), greaterThanOrEqualTo(4));
+    final first = flight.advance(const Duration(seconds: 1));
+    expect(flight.done, isFalse);
+    expect((first.x, first.y, first.z), (a.x, a.y, a.z));
+    expect(first.yaw.abs(), lessThanOrEqualTo(math.pi / 4));
+    final last = flight.advance(const Duration(seconds: 30));
+    expect(flight.done, isTrue);
+    expect(math.cos(last.yaw), closeTo(-1, 1e-9));
+    expect(last.pitch, closeTo(-0.6, 1e-9));
+  });
+
+  test('a routed turn in place also respects rotation time', () {
+    final flight = Flight.route(
+      a,
+      const CameraPose(x: 0, y: 2.2, z: 0, yaw: math.pi, pitch: -0.6),
+      via: const [],
+    );
+    expect(seconds(flight), greaterThanOrEqualTo(4));
+    expect(flight.poseAt(0).yaw, 0);
+    expect(
+      flight.advance(const Duration(seconds: 1)).yaw.abs(),
+      lessThanOrEqualTo(math.pi / 4),
+    );
+    expect(flight.done, isFalse);
+    final last = flight.advance(const Duration(seconds: 30));
+    expect(math.cos(last.yaw), closeTo(-1, 1e-9));
+    expect(last.pitch, closeTo(-0.6, 1e-9));
+    expect(flight.done, isTrue);
+  });
+
+  test(
+    'an unchanged pose completes immediately without invalid coordinates',
+    () {
+      final flight = Flight.plan(a, a);
+      expect(flight.duration, Duration.zero);
+      expect(flight.done, isTrue);
+      final pose = flight.advance(Duration.zero);
+      expect(
+        (pose.x, pose.y, pose.z, pose.yaw, pose.pitch),
+        (a.x, a.y, a.z, a.yaw, a.pitch),
+      );
+    },
+  );
+
   test('a long flight ramps up, cruises at the direct speed, ramps down', () {
     final f = Flight.plan(a, const CameraPose(x: 0, y: 2.2, z: 1000, yaw: 0));
     expect(f.cruiseSpeed, Flight.directSpeed);
@@ -395,7 +479,14 @@ void main() {
       expect(f.length, closeTo(hop + 50 + 50 + hop, 1e-9));
       expect(f.cruiseSpeed, Flight.streetSpeed);
       expect(f.rampTime, Flight.rampSeconds);
-      expect(seconds(f), closeTo(f.length / 10 + 1.6, 1e-6));
+      // Departure, corner and arrival turns add time to the base profile.
+      expect(seconds(f), greaterThan(f.length / 10 + 1.6));
+      final midStreet = timeAt(f, 30);
+      final dt = 0.01 / seconds(f);
+      expect(
+        (f.distanceAt(midStreet + dt) - f.distanceAt(midStreet - dt)) / 0.02,
+        closeTo(Flight.streetSpeed, 1e-6),
+      );
       for (final (x, z) in via) {
         expect(visits(f, x, z), isTrue, reason: '$x, $z');
       }

--- a/test/features/plaza/domain/scenery_test.dart
+++ b/test/features/plaza/domain/scenery_test.dart
@@ -411,7 +411,7 @@ void main() {
             (f.width, f.depth, f.height),
             (
               FurnitureKind.planter.width,
-              FurnitureKind.planter.width,
+              FurnitureKind.planter.depth,
               FurnitureKind.planter.height,
             ),
           );

--- a/test/features/plaza/scene/facade_lod_manager_test.dart
+++ b/test/features/plaza/scene/facade_lod_manager_test.dart
@@ -105,6 +105,49 @@ void main() {
   final eye = Vector3(0, 1.7, 0);
   final forward = Vector3(0, 0, 1);
 
+  testWidgets('flight prepares signs gradually without activating them', (
+    tester,
+  ) async {
+    final surfaces = <_TestSurface>[];
+    final ticks = ChecklistTicks();
+    addTearDown(ticks.dispose);
+    final lod = FacadeLodManager(
+      buildings: [
+        _building('first', 0, 40, facing: math.pi),
+        _building('next', 0, 60, facing: math.pi),
+        _building('later', 0, 80, facing: math.pi),
+      ],
+      config: FacadeLodConfig(promotionsPerFrame: 4),
+      ticks: ticks,
+      onOpen: (_) {},
+      surfaceBuilder: _surfaceBuilder(surfaces),
+    );
+    addTearDown(lod.dispose);
+    lod.update(eye, forward: forward, flying: true);
+    expect((lod.stats.sign, lod.stats.far, lod.stats.live), (1, 2, 0));
+    expect(surfaces.single.input, WidgetInput.manual);
+    surfaces.single.controller.landed = 1;
+    for (final seconds in [0.016, 0.05, 0.099]) {
+      lod.update(eye, forward: forward, seconds: seconds, flying: true);
+      expect(lod.stats.promotions, 1, reason: 'no flight-time loading burst');
+    }
+    lod.update(eye, forward: forward, seconds: 0.1, flying: true);
+    expect((lod.stats.sign, lod.stats.far, lod.stats.live), (2, 1, 0));
+    // Late image completion still refreshes a sign during travel.
+    final first = surfaces.first;
+    first.controller.landed = 1;
+    (first.child as FacadeWidget).onCoverChanged!();
+    lod.update(eye, forward: forward, seconds: 0.15, flying: true);
+    expect(first.controller.requests, 2);
+    expect(lod.stats.promotions, 2);
+    lod.update(eye, forward: forward, seconds: 0.2, flying: true);
+    expect((lod.stats.sign, lod.stats.far, lod.stats.live), (3, 0, 0));
+    lod.config.signCap = 1;
+    lod.update(eye, forward: forward, seconds: 0.21, flying: true);
+    expect((lod.stats.sign, lod.stats.far, lod.stats.live), (1, 2, 0));
+    expect(lod.stats.promotions, 3, reason: 'the surface cap still applies');
+  });
+
   testWidgets('nearby facades stay static until tapped and disarm on leaving', (
     tester,
   ) async {
@@ -265,21 +308,7 @@ void main() {
     });
 
     test('keeps ranking while a promotion is waiting', () {
-      // Within the sign distance but flying: the sign is wanted every
-      // frame and never granted, so the ranking is never settled.
-      final lod = _manager([_building('near', 0, 50)]);
-      for (var frame = 0; frame < 3; frame++) {
-        lod.update(
-          eye,
-          forward: forward,
-          seconds: frame * 0.016,
-          flying: true,
-        );
-      }
-      expect(lod.rankings, 3);
-      expect((lod.stats.sign, lod.stats.far), (0, 1));
-
-      // The same holds when the per-frame promotion budget is zero.
+      // A zero promotion budget must leave the wanted sign pending.
       final starved = _manager(
         [_building('near', 0, 50)],
         config: FacadeLodConfig(promotionsPerFrame: 0),

--- a/test/features/plaza/scene/wall_textures_test.dart
+++ b/test/features/plaza/scene/wall_textures_test.dart
@@ -104,6 +104,29 @@ void main() {
     expect(texels * 4 * 4 / 3, lessThan(32 * 1024 * 1024));
   });
 
+  test(
+    'window floor details scale with the reduced texture resolution',
+    () async {
+      final image = WallTextures.paintWindows(LanternState.open);
+      addTearDown(image.dispose);
+      final pixels = (await image.toByteData())!;
+      // At the left edge there are no panes: the slab is a three-pixel dark
+      // band, then a 1.5-pixel lit edge, then the wall. These were authored as
+      // six and three pixels at twice the raster resolution.
+      List<int> rgbAt(int y) {
+        final offset = y * image.width * 4;
+        return [
+          for (var channel = 0; channel < 3; channel++)
+            pixels.getUint8(offset + channel),
+        ];
+      }
+
+      expect(rgbAt(2), [7, 6, 13]);
+      expect(rgbAt(3), [28, 26, 42]);
+      expect(rgbAt(5), [11, 10, 20]);
+    },
+  );
+
   late final Map<LanternState, _Strip> strips;
   setUpAll(() async {
     strips = {

--- a/test/features/plaza/ui/debug_overlay_test.dart
+++ b/test/features/plaza/ui/debug_overlay_test.dart
@@ -7,7 +7,7 @@ import '../../../widget_test_utils.dart';
 
 void main() {
   test(
-    'default frame pacing rests at 30 fps and preserves explicit overrides',
+    'default frame pacing rests at 15 fps and preserves explicit overrides',
     () {
       for (final environment in <Map<String, String>>[
         {},
@@ -15,7 +15,7 @@ void main() {
       ]) {
         final rate = PlazaFrameRate.fromEnvironment(environment);
         expect(rate, PlazaFrameRate.auto);
-        expect(rate.capFor(moving: false), 30);
+        expect(rate.capFor(moving: false), 15);
         expect(rate.capFor(moving: true), isNull);
       }
       for (final rate in PlazaFrameRate.values) {
@@ -142,7 +142,23 @@ void main() {
     expect(PlazaFrameRate.sixty.capFor(moving: false), 60);
     expect(PlazaFrameRate.thirty.capFor(moving: true), 30);
     expect(PlazaFrameRate.auto.capFor(moving: true), isNull);
-    expect(PlazaFrameRate.auto.capFor(moving: false), 30);
+    expect(PlazaFrameRate.auto.capFor(moving: false), 15);
+    expect(
+      PlazaFrameRate.auto.capFor(moving: false, activeSurface: true),
+      30,
+    );
+    expect(
+      PlazaFrameRate.auto.capFor(moving: true, activeSurface: true),
+      isNull,
+    );
+    for (final rate in [PlazaFrameRate.thirty, PlazaFrameRate.sixty]) {
+      for (final moving in [false, true]) {
+        expect(
+          rate.capFor(moving: moving, activeSurface: true),
+          rate.capFor(moving: moving),
+        );
+      }
+    }
     expect(PlazaFrameRate.values.map((r) => r.label), ['auto', '60', '30']);
   });
 }

--- a/test/features/plaza/ui/facade_widget_test.dart
+++ b/test/features/plaza/ui/facade_widget_test.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/plaza/domain/attention.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/features/plaza/ui/checklist_ticks.dart';
 import 'package:lotti/features/plaza/ui/facade_widget.dart';
+import 'package:lotti/features/plaza/ui/plaza_chip.dart';
 import 'package:lotti/features/plaza/ui/plaza_style.dart';
 
 import '../../../widget_test_utils.dart';
@@ -85,6 +86,34 @@ void main() {
     coverImage = await createTestImage();
   });
   tearDownAll(() => coverImage.dispose());
+
+  testWidgets('a short street facade keeps its photo across the panel', (
+    tester,
+  ) async {
+    const url = 'https://demo.invalid/short-facade.webp';
+    final decoded = _pendingCover(url);
+    await tester.pumpWidget(
+      _host(
+        _task(coverUrl: url),
+        variant: FacadeVariant.sign,
+        heightMeters: 4,
+      ),
+    );
+    decoded.complete(ImageInfo(image: coverImage.clone()));
+    await tester.pump();
+    await tester.pump();
+    final image = find.byType(Image);
+    expect(image, findsOneWidget);
+    final art = tester.getRect(image);
+    final facade = tester.getRect(find.byType(FacadeWidget));
+    expect(art.width, greaterThan(facade.width * 0.9));
+    expect(art.height, greaterThan(facade.height * 0.9));
+    final title = tester.getRect(find.text('Negotiate sardine futures'));
+    expect(facade.contains(title.topLeft), isTrue);
+    expect(facade.contains(title.bottomRight), isTrue);
+    expect(find.text('fly there ›'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets('a late decoded cover invalidates its sign texture once', (
     tester,
@@ -182,25 +211,36 @@ void main() {
     }
   });
 
-  testWidgets('a finished task is a quiet, small sign', (tester) async {
-    double titlePx(PlazaTaskState state, FacadeVariant variant) {
-      final text = tester.widget<Text>(find.text('Negotiate sardine futures'));
-      return text.style!.fontSize!;
-    }
+  testWidgets(
+    'finished facades retain a readable poster and quiet live title',
+    (tester) async {
+      double titlePx(PlazaTaskState state, FacadeVariant variant) {
+        final text = tester.widget<Text>(
+          find.text('Negotiate sardine futures'),
+        );
+        return text.style!.fontSize!;
+      }
 
-    for (final variant in FacadeVariant.values) {
-      await tester.pumpWidget(
-        _host(_task(), variant: variant),
-      );
-      final open = titlePx(PlazaTaskState.open, variant);
-      await tester.pumpWidget(
-        _host(_task(state: PlazaTaskState.done), variant: variant),
-      );
-      final done = titlePx(PlazaTaskState.done, variant);
-      expect(done, closeTo(open * 0.55, 1e-6), reason: '$variant');
-      expect(tester.takeException(), isNull);
-    }
-  });
+      for (final variant in FacadeVariant.values) {
+        await tester.pumpWidget(
+          _host(_task(), variant: variant),
+        );
+        final open = titlePx(PlazaTaskState.open, variant);
+        await tester.pumpWidget(
+          _host(_task(state: PlazaTaskState.done), variant: variant),
+        );
+        final done = titlePx(PlazaTaskState.done, variant);
+        expect(
+          done,
+          closeTo(open * (variant == FacadeVariant.sign ? 1 : 0.55), 1e-6),
+          reason: '$variant',
+        );
+        expect(find.textContaining('DONE'), findsOneWidget);
+        expect(find.textContaining('OPEN'), findsNothing);
+        expect(tester.takeException(), isNull);
+      }
+    },
+  );
 
   testWidgets('live facade shows title, chip, meta and progress', (
     tester,
@@ -226,7 +266,7 @@ void main() {
     expect(find.byType(FractionallySizedBox), findsNothing);
   });
 
-  testWidgets('sign facade keeps title, cover, chip and bar only', (
+  testWidgets('sign facade keeps its poster free of interactive controls', (
     tester,
   ) async {
     await tester.pumpWidget(
@@ -248,11 +288,11 @@ void main() {
     expect(find.text('DETAILS ›'), findsNothing);
     // Cover art stays: it is what makes a street read from a distance.
     expect(find.byType(Image), findsOneWidget);
-    // Bigger type than the live variant for the same wall.
-    final sign = tester.widget<Text>(find.text('Negotiate sardine futures'));
-    await tester.pumpWidget(_host(_task()));
-    final live = tester.widget<Text>(find.text('Negotiate sardine futures'));
-    expect(sign.style!.fontSize, greaterThan(live.style!.fontSize!));
+    final art = tester.getRect(find.byType(Image));
+    final poster = tester.getRect(find.byType(FacadeWidget));
+    expect(art.width, greaterThan(poster.width * 0.9));
+    expect(art.height, greaterThan(poster.height * 0.9));
+    expect(find.text('fly there ›'), findsNothing);
   });
 
   testWidgets('overdue overrides the chip', (tester) async {
@@ -261,18 +301,21 @@ void main() {
     expect(find.textContaining('OPEN'), findsNothing);
   });
 
-  testWidgets('the sign variant carries the state as a full-width band', (
+  testWidgets('the poster keeps status in a compact chip over the photo', (
     tester,
   ) async {
-    await tester.pumpWidget(
-      _host(_task(state: PlazaTaskState.blocked), variant: FacadeVariant.sign),
-    );
-    final band = tester.widget<Text>(find.textContaining('BLOCKED'));
-    expect(band.textAlign, TextAlign.center);
-    expect(band.data, startsWith('✕'));
-    await tester.pumpWidget(_host(_task(state: PlazaTaskState.blocked)));
-    final chip = tester.widget<Text>(find.textContaining('BLOCKED'));
-    expect(band.style!.fontSize, greaterThan(chip.style!.fontSize!));
+    final task = _task(state: PlazaTaskState.blocked);
+    await tester.pumpWidget(_host(task, variant: FacadeVariant.sign));
+    final chip = tester.widget<PlazaChip>(find.byType(PlazaChip));
+    final expected = PlazaStyle.chip(attentionFor(task, _now));
+    expect(chip.label, startsWith('✕'));
+    expect(chip.label, contains('BLOCKED'));
+    expect((chip.fill, chip.ink), (expected.fill, expected.ink));
+    final bounds = tester.getRect(find.byType(PlazaChip));
+    final poster = tester.getRect(find.byType(FacadeWidget));
+    expect(bounds.width, lessThan(poster.width * 0.5));
+    expect(poster.contains(bounds.topLeft), isTrue);
+    expect(poster.contains(bounds.bottomRight), isTrue);
   });
 
   testWidgets('a long word shrinks the title instead of breaking mid-word', (

--- a/test/features/plaza/ui/fly_camera_controller_test.dart
+++ b/test/features/plaza/ui/fly_camera_controller_test.dart
@@ -406,6 +406,35 @@ void main() {
     });
   });
 
+  test('a target at the current position turns without a street detour', () {
+    const start = CameraPose(x: -8, y: eyeHeight, z: 20, yaw: 0);
+    for (final yaw in [0.0, math.pi]) {
+      final camera = FlyCameraController(
+        pose: start,
+        network: StreetNetwork(const [(0, 0), (0, 200)]),
+      );
+      final flight = camera.flyTo(
+        CameraPose(x: start.x, y: start.y, z: start.z, yaw: yaw),
+      );
+      expect(flight.length, 0, reason: 'a heading change must stay in place');
+      camera.update(1);
+      expect(
+        (camera.pose.x, camera.pose.y, camera.pose.z),
+        (start.x, start.y, start.z),
+      );
+      if (yaw == 0) {
+        expect(flight.duration, Duration.zero);
+        expect(camera.flying, isFalse);
+      } else {
+        expect(camera.flying, isTrue);
+        expect(camera.pose.yaw.abs(), lessThanOrEqualTo(math.pi / 4));
+        camera.update(30);
+        expect(camera.flying, isFalse);
+        expect(math.cos(camera.pose.yaw), closeTo(-1, 1e-9));
+      }
+    }
+  });
+
   group('over solids', () {
     const building = Solid(
       footprint: Footprint(x: 0, z: 25, facingRadians: 0, width: 10, depth: 10),

--- a/test/features/plaza/ui/fly_camera_controller_test.dart
+++ b/test/features/plaza/ui/fly_camera_controller_test.dart
@@ -293,7 +293,9 @@ void main() {
       expect(camera.flying, isTrue);
       expect(camera.flight, same(flight));
       camera.update(flight.duration.inMicroseconds / 2e6);
-      expect(camera.pose.z, closeTo(10, 1e-6));
+      // The arrival turn takes extra time: halfway through the clock is
+      // past the spatial midpoint, still approaching the destination.
+      expect(camera.pose.z, inExclusiveRange(10, 20));
       expect(camera.flying, isTrue);
       camera.update(flight.duration.inMicroseconds / 2e6 + 0.01);
       expect(camera.flying, isFalse);

--- a/test/features/plaza/ui/plaza_frame_pacer_test.dart
+++ b/test/features/plaza/ui/plaza_frame_pacer_test.dart
@@ -1,6 +1,7 @@
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/plaza/ui/debug_overlay.dart';
 import 'package:lotti/features/plaza/ui/plaza_frame_pacer.dart';
 
 void main() {
@@ -22,6 +23,66 @@ void main() {
     expect(tester.binding.transientCallbackCount, 0);
     await tester.pump(const Duration(seconds: 1));
     expect(painted.length, 2);
+  });
+
+  test('ambient waits wake on input and preserve live facade cadence', () {
+    fakeAsync((async) {
+      final pending = <int, FrameCallback>{};
+      final painted = <Duration>[];
+      var id = 0;
+      var moving = false;
+      var activeSurface = false;
+      final pacer = PlazaFramePacer(
+        onFrame: painted.add,
+        nowMicros: () => async.elapsed.inMicroseconds,
+        cap: () => PlazaFrameRate.auto.capFor(
+          moving: moving,
+          activeSurface: activeSurface,
+        ),
+        schedule: (callback) {
+          pending[++id] = callback;
+          return id;
+        },
+        cancel: pending.remove,
+      )..start();
+      void frame() {
+        final callback = pending.values.single;
+        pending.clear();
+        callback(async.elapsed);
+      }
+
+      frame();
+      async.elapse(const Duration(milliseconds: 10));
+      expect(pending, isEmpty);
+      moving = true;
+      pacer.requestFrame();
+      expect(pending.length, 1, reason: 'input must cancel the idle wait');
+      frame();
+      async.elapse(const Duration(milliseconds: 16));
+      frame();
+      moving = false;
+      activeSurface = true;
+      async.elapse(const Duration(milliseconds: 16));
+      frame();
+      async.elapse(const Duration(microseconds: 17332));
+      expect(pending, isEmpty);
+      async.elapse(const Duration(microseconds: 1));
+      expect(pending.length, 1, reason: 'live facades retain a 30 Hz deadline');
+      activeSurface = false;
+      frame();
+      async.elapse(const Duration(microseconds: 66666));
+      expect(pending, isEmpty, reason: 'ambient animation waits for 15 Hz');
+      async.elapse(const Duration(microseconds: 1));
+      expect(pending.length, 1);
+      expect(painted.map((t) => t.inMicroseconds), [
+        0,
+        10000,
+        26000,
+        42000,
+        59333,
+      ]);
+      pacer.dispose();
+    });
   });
 
   test('idle waits without scheduling engine frames, input wakes once', () {

--- a/test/features/plaza/ui/plaza_frame_window_test.dart
+++ b/test/features/plaza/ui/plaza_frame_window_test.dart
@@ -31,6 +31,15 @@ void main() {
     expect((window.count, window.average, window.worst), (0, 0, 0));
     window.add(16);
     expect((window.count, window.average, window.worst), (1, 16, 16));
-    expect(() => PlazaFrameWindow(capacity: 0), throwsArgumentError);
+    for (final capacity in [0, -1]) {
+      expect(
+        () => PlazaFrameWindow(capacity: capacity),
+        throwsA(
+          isA<ArgumentError>()
+              .having((error) => error.name, 'name', 'capacity')
+              .having((error) => error.invalidValue, 'invalidValue', capacity),
+        ),
+      );
+    }
   });
 }

--- a/test/features/plaza/ui/plaza_pointer_controller_test.dart
+++ b/test/features/plaza/ui/plaza_pointer_controller_test.dart
@@ -20,7 +20,7 @@ void main() {
     expect(PlazaFrameRate.auto.capFor(moving: pointer.dragging), isNull);
     expect(pointer.up(const PointerUpEvent(pointer: 1), 0.1), isNull);
     expect(pointer.dragging, isFalse);
-    expect(PlazaFrameRate.auto.capFor(moving: pointer.dragging), 30);
+    expect(PlazaFrameRate.auto.capFor(moving: pointer.dragging), 15);
   });
 
   test('a short tap is returned once; a long press is ignored', () {


### PR DESCRIPTION
Ground-floor facades now use the same photo-led poster layout as the large billboards. The cover fills even a short panel, with the title and compact status over the existing scrim. A nearby touch switches to the working checklist.

Previously, short facade layouts omitted cover art, and new facade creation was completely suspended during flight. Static signs now load at most one every 100 ms during travel, within the existing distance and surface caps, so approaching walls can decode before the camera reaches them. Live surfaces are disarmed during flights.

Plaza flights now limit yaw to 45°/s and pitch to 30°/s. Large departure, corner and arrival turns get more time along the existing collision-safe path; straight sections retain their cruise speed. Turns in place are animated too, and targeting the current position no longer takes a detour through the street.

Automatic frame pacing uses 15 fps for settled decorative animation, 30 fps while a facade is live, and display cadence during camera motion and for 0.6 s after input. Input cancels an idle wait immediately. Explicit 30/60 settings remain available. The tradeoff is less smooth decorative animation while idle; animation time still advances normally.

Also addresses late review findings from #4134: validate frame-window capacity before allocation, correct the planter depth assertion, and scale wall texture detail uniformly within the reduced texture budget.

Validation: 139 targeted tests across eleven files; new regression tests failed without their fixes. Root Dart MCP analysis reports no diagnostics. Native Linux profile build and knowledge checks pass. Native checks confirmed the static-to-live facade switch; checkbox behavior is covered by widget tests. Full-suite checks run in CI.

In repeated 8-second stationary samples of the 3084×2028 penguin home view in a Linux VM profile build, process CPU fell from 56.4% to roughly 29–31% (one core = 100%). Render cadence fell from ~27 fps to ~14–15 fps. These are diagnostic local samples; macOS still needs a device check.

Penguin demo screenshots captured outside the repository:

| Surface | Before | After |
| --- | --- | --- |
| Home | ![Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-facades-and-flights/315b500115b1bad296f19cebd68d3de791adcb63/before/plaza_home_desktop.png) | ![After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-facades-and-flights/315b500115b1bad296f19cebd68d3de791adcb63/after/plaza_home_desktop.png) |
| Ground-floor facade | ![Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-facades-and-flights/315b500115b1bad296f19cebd68d3de791adcb63/before/plaza_facade_desktop.png) | ![After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-facades-and-flights/315b500115b1bad296f19cebd68d3de791adcb63/after/plaza_facade_desktop.png) |
