### PR TITLE
feat(projects): rebuild the AI next-steps band with labelled, undoable decisions

### DIFF
--- a/changelog.d/2026-09-05-project-next-steps-band.md
+++ b/changelog.d/2026-09-05-project-next-steps-band.md
@@ -1,0 +1,20 @@
+### Changed
+- **The project agent's next steps now say what each button does, and what
+  happened after you pressed it.** Each recommended step offers a labelled
+  **Add task**, which creates a project task and links the step to it, and a
+  labelled **Dismiss**; the unlabelled check mark and plus icons are gone.
+  A decided step stays in place with an *Added*, *Done* or *Dismissed* tag
+  instead of disappearing, an added step opens its task from the tag, and
+  both decisions can be undone — an addition for eight seconds, a dismissal
+  as long as the list is current. A failed addition keeps the step with a
+  Retry and says why. **Add all as tasks** and **Dismiss all** replace
+  "Confirm all". The agent's proposed changes, such as a status change, now sit
+  in their own band under the steps. Phones show three steps at a time with a
+  "Show more" link, a list you finished earlier collapses to a one-line
+  summary with its history, and an empty list says when the agent last
+  looked.
+
+### Fixed
+- **Deciding a project suggestion no longer re-renders the whole project
+  page.** The AI card, its report and the task list stay put while a step is
+  added or dismissed.

--- a/knowledge/features/projects.md
+++ b/knowledge/features/projects.md
@@ -334,12 +334,47 @@ run-now action and setup route as Task Details. Project health and durable
 recommendation/change-set actions remain project-owned content inside that one
 surface instead of becoming competing cards or duplicating the report in the
 editor. The AI surface appears above the task list. `ProjectRecommendationsPanel`
-combines current next steps and other pending proposals in one compact action
-band, using Task Details' `RowActions` and confirm-all button pattern. Each step
-can be confirmed, dismissed, or turned into a project-linked task. A shared busy
-guard serializes row and batch actions; failed rows remain available while
-successful rows disappear. Provider reloads retain the last displayed data.
-The replacement and migration lifecycle lives in
+renders two bands inside the card: the newest run's **recommended next steps**
+(`ProjectNextStepRow`, one per step) and the agent's **proposed changes**
+(`ProjectProposalRow`, reusing Task Details' `RowActions` rail). A step offers
+**Add task** and **Dismiss** as labelled controls; a decided step keeps its
+place with an *Added* (linking to the task), *Done* or *Dismissed* tag and an
+Undo — eight seconds for an addition, as long as the run is current for a
+dismissal. A failed creation keeps the row with Retry and the failure copy.
+Phones show three rows before "Show N more"; more than one open step adds
+**Add all as tasks** and **Dismiss all**.
+
+The band never invalidates the agent's update stream. The service notifies
+after each write, `projectNextStepsProvider` re-reads, and the row changes
+state where it stands; per-row busy and failure state plus an optimistic
+overlay cover the gap until the snapshot catches up, so a row never flickers
+through "pending". A proposal decision refreshes only
+`projectPendingChangeSetsProvider`. The card keeps the bands mounted while the
+page mutates and hands the panel `enabled: false` instead, so an in-flight
+decision keeps its row state.
+
+```mermaid
+stateDiagram-v2
+  [*] --> pending
+  pending --> busy: Add task / Retry
+  busy --> added: task created
+  busy --> done: created without a task id
+  busy --> failed: creation refused
+  failed --> busy: Retry
+  pending --> dismissed: Dismiss
+  failed --> dismissed: Dismiss
+  added --> pending: Undo (within eight seconds)
+  dismissed --> pending: Undo
+  done --> pending: Undo
+```
+
+A run whose every step was already decided when the page opened collapses to
+`ProjectNextStepsSummary` — one line with the tally and when the agent last
+looked, plus a history disclosure — while decisions made on the page stay
+inline until the next visit. An empty run renders `ProjectNextStepsEmpty`
+with the same "last looked" age. The pure pieces (outcome mapping, tally,
+phone cap, age buckets) live in `project_next_steps_model.dart`. The
+replacement, undo and migration lifecycle lives in
 [project and event agents](agents/project-and-event-agents.md#tools-and-recommendations).
 
 **There is no aggregator object** — each surface watches the providers it needs.

--- a/knowledge/features/projects.md
+++ b/knowledge/features/projects.md
@@ -349,9 +349,16 @@ after each write, `projectNextStepsProvider` re-reads, and the row changes
 state where it stands; per-row busy and failure state plus an optimistic
 overlay cover the gap until the snapshot catches up, so a row never flickers
 through "pending". A proposal decision refreshes only
-`projectPendingChangeSetsProvider`. The card keeps the bands mounted while the
-page mutates and hands the panel `enabled: false` instead, so an in-flight
-decision keeps its row state.
+`projectPendingChangeSetsProvider`; the proposal band shows the live sets'
+open items plus the rows decided in this session, never siblings decided in
+an earlier one. The card keeps the bands mounted while the page mutates and
+hands the panel `enabled: false` instead, so an in-flight decision keeps its
+row state; a disabled rail is inert with disabled semantics, not a no-op.
+While a bulk action runs every other row is disabled too, so a manual tap
+cannot race the sweep. A creation the service reports as consumed
+(`nonRetryable`: the task exists but linking and rollback both failed) keeps
+the row with the service's message and no Retry. A refused Undo leaves the
+row, its undo window and its task link exactly as they were.
 
 ```mermaid
 stateDiagram-v2

--- a/lib/features/agents/ui/ai_summary_card/proposal_row_widgets_part.dart
+++ b/lib/features/agents/ui/ai_summary_card/proposal_row_widgets_part.dart
@@ -9,12 +9,19 @@ class RowActions extends StatelessWidget {
     required this.busy,
     required this.onReject,
     required this.onConfirm,
+    this.enabled = true,
     super.key,
   });
 
   final bool busy;
   final Future<void> Function() onReject;
   final Future<void> Function() onConfirm;
+
+  /// `false` renders both discs inert and dimmed, with disabled semantics.
+  /// A host that cannot take a decision right now (a page mutation in
+  /// flight) keeps the rail on screen so the row holds its shape, without
+  /// a button that looks pressable and does nothing.
+  final bool enabled;
 
   /// The hit target of one action: 48×48, the visible disc centred inside.
   static const double buttonSize = 48;
@@ -57,14 +64,14 @@ class RowActions extends StatelessWidget {
         _SquareIconButton(
           icon: LottiIcons.close,
           tooltip: context.messages.changeSetSwipeReject,
-          onPressed: onReject,
+          onPressed: enabled ? onReject : null,
           variant: _SquareIconVariant.outline,
         ),
         SizedBox(width: context.designTokens.spacing.step2),
         _SquareIconButton(
           icon: LottiIcons.confirm,
           tooltip: context.messages.changeSetSwipeConfirm,
-          onPressed: onConfirm,
+          onPressed: enabled ? onConfirm : null,
           variant: _SquareIconVariant.accent,
         ),
       ],
@@ -84,7 +91,9 @@ class _SquareIconButton extends StatelessWidget {
 
   final IconData icon;
   final String tooltip;
-  final Future<void> Function() onPressed;
+
+  /// Null renders the disc inert and dimmed.
+  final Future<void> Function()? onPressed;
   final _SquareIconVariant variant;
 
   @override
@@ -102,9 +111,11 @@ class _SquareIconButton extends StatelessWidget {
     // navigation finds them — rather than leaning on the tooltip surfacing as
     // a label (which gives no role). The visual tooltip stays for pointer users
     // but is excluded from semantics to avoid a duplicate label.
+    final disabled = onPressed == null;
     return MergeSemantics(
       child: Semantics(
         button: true,
+        enabled: !disabled,
         label: tooltip,
         child: Tooltip(
           message: tooltip,
@@ -114,7 +125,7 @@ class _SquareIconButton extends StatelessWidget {
           // square around it. The disc answers hover/focus/press itself with
           // a border in its own hue family.
           child: DsQuietInk(
-            onTap: onPressed.call,
+            onTap: onPressed,
             borderRadius: BorderRadius.circular(tokens.radii.s),
             builder: (context, highlighted) => SizedBox(
               width: RowActions.buttonSize,
@@ -125,7 +136,11 @@ class _SquareIconButton extends StatelessWidget {
                   height: tokens.spacing.step7,
                   alignment: Alignment.center,
                   decoration: BoxDecoration(
-                    color: isAccent ? ai.accentSoft : ai.subtleWashStrong,
+                    color: disabled
+                        ? ai.subtleWash
+                        : isAccent
+                        ? ai.accentSoft
+                        : ai.subtleWashStrong,
                     shape: BoxShape.circle,
                     border: highlighted
                         ? Border.all(
@@ -136,7 +151,11 @@ class _SquareIconButton extends StatelessWidget {
                   child: Icon(
                     icon,
                     size: tokens.spacing.step5,
-                    color: isAccent ? ai.accent : ai.metaText,
+                    color: disabled
+                        ? ai.faintMeta
+                        : isAccent
+                        ? ai.accent
+                        : ai.metaText,
                   ),
                 ),
               ),

--- a/lib/features/projects/README.md
+++ b/lib/features/projects/README.md
@@ -33,10 +33,14 @@ project agent is attached — a summary and health read that the agent maintains
   hidden after a project is selected and restored without losing its filters,
   search or scroll position. The embedded detail has no misleading Back action.
 - **Keeps agent output actionable.** The AI report leads the task list with
-  current next steps. Confirm or dismiss them individually, confirm all, or
-  create a project-linked task from a suggestion. Each successful analysis
-  replaces stale suggestions, and other proposed changes share the same compact
-  action list.
+  the agent's current next steps. Each step offers two labelled actions: **Add
+  task** creates a project-linked task and links the step to it, **Dismiss**
+  sets it aside; both can be undone, and a decided step stays in place with its
+  tag instead of vanishing. Bulk actions add or dismiss every open step. The
+  agent's proposed changes (a status change, a task it wants to create) sit in
+  their own band under the steps. Each successful analysis replaces the list;
+  a run that was already fully decided collapses to a one-line summary with its
+  history, and an empty run says when the agent last looked.
 
 The whole visible experience is behind a feature flag; with it off there is no
 projects tab, no category projects section, and no project chip on tasks.

--- a/lib/features/projects/ui/pages/project_details_page.dart
+++ b/lib/features/projects/ui/pages/project_details_page.dart
@@ -165,9 +165,13 @@ class ProjectDetailsPage extends ConsumerWidget {
                   ? () => _assignProjectAgent(context, ref, record.project)
                   : null,
               agentIdentity: identity,
-              agentActions: identity == null
+              agentActionsBuilder: identity == null
                   ? null
-                  : ProjectRecommendationsPanel(projectId: projectId),
+                  : ({required enabled}) => ProjectRecommendationsPanel(
+                      projectId: projectId,
+                      enabled: enabled,
+                      onOpenTask: (taskId) => beamToNamed('/tasks/$taskId'),
+                    ),
               hasProjectAgent: identity != null || agentAsync.isLoading,
               isRefreshingReport: isRefreshingReport,
               isSaving: detailState.isSaving,

--- a/lib/features/projects/ui/widgets/next_steps/project_next_step_row.dart
+++ b/lib/features/projects/ui/widgets/next_steps/project_next_step_row.dart
@@ -1,0 +1,358 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/tools/project_tool_definitions.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_inline_action.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/tasks/ui/widgets/task_showcase_chips.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+
+/// What the row is doing right now, layered over the step's durable outcome:
+/// [busy] and [failed] are transient states of the current attempt, the rest
+/// mirror `projectNextStepOutcome`.
+enum ProjectNextStepRowState { pending, busy, added, done, dismissed, failed }
+
+/// One recommended next step inside the project AI card.
+///
+/// The title, rationale and priority stay put whatever happens to the step;
+/// only the action strip changes. A pending step offers one labelled primary
+/// (**Add task**) and one labelled secondary (**Dismiss**), never a bare
+/// glyph. A decided step keeps its place with a quiet tag — *Added* with a
+/// link to the task, *Done*, or *Dismissed* — and, while the decision is still
+/// reversible, an Undo. A failed attempt shows what went wrong under the
+/// controls and offers Retry instead of leaving the row blank.
+///
+/// Above [wideBreakpoint] the strip sits beside the text; below it the strip
+/// stacks under the text so a phone title keeps the full row width instead
+/// of wrapping around a control rail.
+class ProjectNextStepRow extends StatelessWidget {
+  const ProjectNextStepRow({
+    required this.step,
+    required this.state,
+    this.enabled = true,
+    this.canUndo = false,
+    this.failureMessage,
+    this.onAddTask,
+    this.onDismiss,
+    this.onUndo,
+    this.onOpenTask,
+    super.key,
+  });
+
+  /// Content width from which the action strip sits beside the text.
+  static const double wideBreakpoint = 560;
+
+  final ProjectRecommendationEntity step;
+  final ProjectNextStepRowState state;
+
+  /// Disables every control without hiding it — the host passes `false`
+  /// while the page runs a mutation of its own.
+  final bool enabled;
+
+  /// Whether the decided step still offers Undo.
+  final bool canUndo;
+
+  /// Shown under the controls in the [ProjectNextStepRowState.failed] state;
+  /// falls back to the generic creation failure copy.
+  final String? failureMessage;
+
+  /// Add task, and Retry after a failure.
+  final VoidCallback? onAddTask;
+  final VoidCallback? onDismiss;
+  final VoidCallback? onUndo;
+  final VoidCallback? onOpenTask;
+
+  bool get _decided => switch (state) {
+    ProjectNextStepRowState.added ||
+    ProjectNextStepRowState.done ||
+    ProjectNextStepRowState.dismissed => true,
+    ProjectNextStepRowState.pending ||
+    ProjectNextStepRowState.busy ||
+    ProjectNextStepRowState.failed => false,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final ai = tokens.colors.aiCard;
+    final dismissed = state == ProjectNextStepRowState.dismissed;
+    final rationale = step.rationale?.trim() ?? '';
+    final priority = parseTaskPriority(step.priority);
+
+    final text = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          step.title,
+          style: tokens.typography.styles.body.bodyMedium.copyWith(
+            color: dismissed ? ai.metaText : ai.titleText,
+            decoration: dismissed ? TextDecoration.lineThrough : null,
+            decorationColor: ai.metaText,
+          ),
+        ),
+        if (rationale.isNotEmpty) ...[
+          SizedBox(height: tokens.spacing.step1),
+          Text(
+            rationale,
+            style: tokens.typography.styles.body.bodySmall.copyWith(
+              color: ai.metaText,
+            ),
+          ),
+        ],
+        if (priority != null) ...[
+          SizedBox(height: tokens.spacing.step2),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TaskShowcasePriorityGlyph(priority: priority, size: IconSizes.xs),
+              SizedBox(width: tokens.spacing.step2),
+              Text(
+                priority.localizedLabel(context),
+                style: tokens.typography.styles.others.caption.copyWith(
+                  color: ai.metaText,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ],
+    );
+    final actions = _ActionStrip(row: this);
+    final failure = state == ProjectNextStepRowState.failed
+        ? _FailureLine(
+            message:
+                failureMessage ?? context.messages.projectNextStepCreateFailed,
+          )
+        : null;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: _decided ? ai.subtleWash : ai.row,
+        borderRadius: BorderRadius.circular(tokens.radii.s),
+        border: Border.all(color: ai.rowBorder),
+      ),
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: tokens.spacing.step4,
+          vertical: tokens.spacing.step3,
+        ),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final wide = constraints.maxWidth >= wideBreakpoint;
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (wide)
+                  Row(
+                    children: [
+                      Expanded(child: text),
+                      SizedBox(width: tokens.spacing.step4),
+                      actions,
+                    ],
+                  )
+                else ...[
+                  text,
+                  SizedBox(height: tokens.spacing.step2),
+                  Align(
+                    alignment: AlignmentDirectional.centerStart,
+                    child: actions,
+                  ),
+                ],
+                if (failure != null) ...[
+                  SizedBox(height: tokens.spacing.step2),
+                  failure,
+                ],
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _ActionStrip extends StatelessWidget {
+  const _ActionStrip({required this.row});
+
+  final ProjectNextStepRow row;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final ai = tokens.colors.aiCard;
+    final messages = context.messages;
+    final enabled = row.enabled;
+
+    Widget addButton(String label, IconData icon) => DesignSystemButton(
+      label: label,
+      leadingIcon: icon,
+      variant: DesignSystemButtonVariant.secondary,
+      size: DesignSystemButtonSize.dense,
+      tapTargetSize: MaterialTapTargetSize.padded,
+      onPressed: enabled ? row.onAddTask : null,
+    );
+    // An inline action aligns itself and fills whatever width a Wrap offers,
+    // which would push every neighbour onto the next run; the intrinsic box
+    // hands it its own width instead.
+    final dismiss = IntrinsicWidth(
+      child: DesignSystemInlineAction(
+        onTap: enabled ? row.onDismiss : null,
+        semanticsLabel: messages.projectNextStepDismiss,
+        label: messages.projectNextStepDismiss,
+        leadingIcon: LottiIcons.close,
+      ),
+    );
+    final undo = IntrinsicWidth(
+      child: DesignSystemInlineAction(
+        onTap: enabled ? row.onUndo : null,
+        semanticsLabel: messages.designSystemUndoLabel,
+        label: messages.designSystemUndoLabel,
+        leadingIcon: LottiIcons.undo,
+      ),
+    );
+
+    final children = switch (row.state) {
+      ProjectNextStepRowState.pending => [
+        addButton(messages.projectActionAddTask, LottiIcons.add),
+        dismiss,
+      ],
+      ProjectNextStepRowState.failed => [
+        addButton(messages.projectNextStepRetry, LottiIcons.refresh),
+        dismiss,
+      ],
+      ProjectNextStepRowState.busy => [
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox.square(
+              dimension: IconSizes.xs,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                color: ai.accent,
+              ),
+            ),
+            SizedBox(width: tokens.spacing.step3),
+            Text(
+              messages.projectNextStepCreating,
+              style: tokens.typography.styles.others.caption.copyWith(
+                color: ai.metaText,
+              ),
+            ),
+          ],
+        ),
+      ],
+      ProjectNextStepRowState.added => [
+        _OutcomeTag(
+          icon: LottiIcons.confirm,
+          iconColor: ai.accent,
+          label: messages.projectNextStepAdded,
+        ),
+        IntrinsicWidth(
+          child: DesignSystemInlineAction(
+            onTap: enabled ? row.onOpenTask : null,
+            semanticsLabel: messages.projectNextStepOpenTask,
+            label: messages.projectNextStepOpenTask,
+            trailingIcon: LottiIcons.chevronRight,
+            ink: tokens.colors.interactive.enabled,
+          ),
+        ),
+        if (row.canUndo) undo,
+      ],
+      ProjectNextStepRowState.done => [
+        _OutcomeTag(
+          icon: LottiIcons.confirm,
+          iconColor: ai.accent,
+          label: messages.projectNextStepDone,
+        ),
+        if (row.canUndo) undo,
+      ],
+      ProjectNextStepRowState.dismissed => [
+        _OutcomeTag(
+          icon: LottiIcons.close,
+          iconColor: ai.metaText,
+          label: messages.projectNextStepDismissed,
+        ),
+        if (row.canUndo) undo,
+      ],
+    };
+
+    return Wrap(
+      spacing: tokens.spacing.step3,
+      runSpacing: tokens.spacing.step2,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: children,
+    );
+  }
+}
+
+/// The quiet history tag a decided row keeps: glyph plus a plain word, never
+/// colour alone, in the same register as the task agent's resolved tag.
+class _OutcomeTag extends StatelessWidget {
+  const _OutcomeTag({
+    required this.icon,
+    required this.iconColor,
+    required this.label,
+  });
+
+  final IconData icon;
+  final Color iconColor;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final ai = tokens.colors.aiCard;
+    return MergeSemantics(
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: IconSizes.xs, color: iconColor),
+          SizedBox(width: tokens.spacing.step2),
+          Text(
+            label,
+            style: tokens.typography.styles.others.caption.copyWith(
+              color: ai.metaText,
+              fontWeight: tokens.typography.weight.semiBold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FailureLine extends StatelessWidget {
+  const _FailureLine({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final ink = tokens.colors.alert.error.ink;
+    return Semantics(
+      liveRegion: true,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: EdgeInsets.only(top: tokens.spacing.step1),
+            child: Icon(LottiIcons.warning, size: IconSizes.xs, color: ink),
+          ),
+          SizedBox(width: tokens.spacing.step2),
+          Expanded(
+            child: Text(
+              message,
+              style: tokens.typography.styles.others.caption.copyWith(
+                color: ink,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/projects/ui/widgets/next_steps/project_next_step_row.dart
+++ b/lib/features/projects/ui/widgets/next_steps/project_next_step_row.dart
@@ -57,7 +57,8 @@ class ProjectNextStepRow extends StatelessWidget {
   /// falls back to the generic creation failure copy.
   final String? failureMessage;
 
-  /// Add task, and Retry after a failure.
+  /// Add task, and Retry after a failure. Null in the failed state means the
+  /// failure is final — the step was consumed — so no Retry is offered.
   final VoidCallback? onAddTask;
   final VoidCallback? onDismiss;
   final VoidCallback? onUndo;
@@ -220,7 +221,8 @@ class _ActionStrip extends StatelessWidget {
         dismiss,
       ],
       ProjectNextStepRowState.failed => [
-        addButton(messages.projectNextStepRetry, LottiIcons.refresh),
+        if (row.onAddTask != null)
+          addButton(messages.projectNextStepRetry, LottiIcons.refresh),
         dismiss,
       ],
       ProjectNextStepRowState.busy => [

--- a/lib/features/projects/ui/widgets/next_steps/project_next_steps_model.dart
+++ b/lib/features/projects/ui/widgets/next_steps/project_next_steps_model.dart
@@ -1,0 +1,104 @@
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+
+/// What the band shows for one step: the durable status, read the way the
+/// user decided it. A resolved step that recorded its task was *added*; a
+/// resolved step without one was marked done by an older surface.
+enum ProjectNextStepOutcome { pending, added, done, dismissed }
+
+/// The outcome the band shows for [step].
+ProjectNextStepOutcome projectNextStepOutcome(
+  ProjectRecommendationEntity step,
+) => switch (step.status) {
+  ProjectRecommendationStatus.active => ProjectNextStepOutcome.pending,
+  ProjectRecommendationStatus.dismissed => ProjectNextStepOutcome.dismissed,
+  ProjectRecommendationStatus.resolved when step.createdTaskId != null =>
+    ProjectNextStepOutcome.added,
+  ProjectRecommendationStatus.resolved => ProjectNextStepOutcome.done,
+  // Superseded rows never reach the band; a stale one reads as decided so
+  // it can neither be acted on nor block the run summary.
+  ProjectRecommendationStatus.superseded => ProjectNextStepOutcome.done,
+};
+
+/// How many steps of a run ended up in each outcome.
+class ProjectNextStepsTally {
+  const ProjectNextStepsTally({
+    required this.pending,
+    required this.added,
+    required this.done,
+    required this.dismissed,
+  });
+
+  factory ProjectNextStepsTally.of(
+    Iterable<ProjectRecommendationEntity> steps,
+  ) {
+    var pending = 0;
+    var added = 0;
+    var done = 0;
+    var dismissed = 0;
+    for (final step in steps) {
+      switch (projectNextStepOutcome(step)) {
+        case ProjectNextStepOutcome.pending:
+          pending++;
+        case ProjectNextStepOutcome.added:
+          added++;
+        case ProjectNextStepOutcome.done:
+          done++;
+        case ProjectNextStepOutcome.dismissed:
+          dismissed++;
+      }
+    }
+    return ProjectNextStepsTally(
+      pending: pending,
+      added: added,
+      done: done,
+      dismissed: dismissed,
+    );
+  }
+
+  final int pending;
+  final int added;
+  final int done;
+  final int dismissed;
+
+  int get total => pending + added + done + dismissed;
+
+  /// Every step of the run has been decided (and there was at least one).
+  bool get allDecided => total > 0 && pending == 0;
+}
+
+/// The steps a phone shows before "Show N more" — the first [cap] rows in the
+/// agent's order, regardless of outcome, so a decided row keeps its place
+/// instead of pushing an open one out of view. [cap] is ignored once the
+/// user asked for all of them, and a run that fits the cap never truncates.
+List<T> visibleProjectNextSteps<T>(
+  List<T> steps, {
+  required int cap,
+  required bool showAll,
+}) {
+  assert(cap > 0, 'cap must be positive');
+  if (showAll || steps.length <= cap) return steps;
+  return steps.sublist(0, cap);
+}
+
+/// The coarse units of "when the agent last looked".
+enum ProjectNextStepsAgeUnit { justNow, minutes, hours, days }
+
+typedef ProjectNextStepsAge = ({ProjectNextStepsAgeUnit unit, int count});
+
+/// Buckets [elapsed] into the coarse "when the agent last looked" wording
+/// the band uses: anything under a minute is *just now*, then whole minutes,
+/// whole hours, whole days. Negative elapsed (clock skew after sync) reads as
+/// just now rather than as a time in the future.
+ProjectNextStepsAge projectNextStepsAge(Duration elapsed) {
+  if (elapsed < const Duration(minutes: 1)) {
+    return (unit: ProjectNextStepsAgeUnit.justNow, count: 0);
+  }
+  if (elapsed < const Duration(hours: 1)) {
+    return (unit: ProjectNextStepsAgeUnit.minutes, count: elapsed.inMinutes);
+  }
+  if (elapsed < const Duration(days: 1)) {
+    return (unit: ProjectNextStepsAgeUnit.hours, count: elapsed.inHours);
+  }
+  return (unit: ProjectNextStepsAgeUnit.days, count: elapsed.inDays);
+}

--- a/lib/features/projects/ui/widgets/next_steps/project_next_steps_summary.dart
+++ b/lib/features/projects/ui/widgets/next_steps/project_next_steps_summary.dart
@@ -1,0 +1,220 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_inline_action.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/projects/ui/widgets/next_steps/project_next_steps_model.dart';
+import 'package:lotti/l10n/app_localizations.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+
+/// "just now", "40 min ago", "2 h ago", "3 days ago" — the coarse age the
+/// band uses for when the agent last looked.
+String formatProjectNextStepsAge(AppLocalizations messages, Duration elapsed) {
+  final age = projectNextStepsAge(elapsed);
+  return switch (age.unit) {
+    ProjectNextStepsAgeUnit.justNow => messages.projectNextStepsAgoJustNow,
+    ProjectNextStepsAgeUnit.minutes => messages.projectNextStepsAgoMinutes(
+      age.count,
+    ),
+    ProjectNextStepsAgeUnit.hours => messages.projectNextStepsAgoHours(
+      age.count,
+    ),
+    ProjectNextStepsAgeUnit.days => messages.projectNextStepsAgoDays(age.count),
+  };
+}
+
+/// The one-line stand-in for a run whose every step has been decided: what
+/// happened, when the agent last looked, and a disclosure to the per-step
+/// history. Replaces the full row list only once the user comes back to the
+/// page; the decisions they just made stay inline until then.
+class ProjectNextStepsSummary extends StatelessWidget {
+  const ProjectNextStepsSummary({
+    required this.steps,
+    required this.runCreatedAt,
+    required this.now,
+    required this.historyOpen,
+    required this.onToggleHistory,
+    super.key,
+  });
+
+  final List<ProjectRecommendationEntity> steps;
+  final DateTime? runCreatedAt;
+  final DateTime now;
+  final bool historyOpen;
+  final VoidCallback onToggleHistory;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final ai = tokens.colors.aiCard;
+    final messages = context.messages;
+    final tally = ProjectNextStepsTally.of(steps);
+    final parts = [
+      if (tally.added > 0) messages.projectNextStepsCountAdded(tally.added),
+      if (tally.done > 0) messages.projectNextStepsCountDone(tally.done),
+      if (tally.dismissed > 0)
+        messages.projectNextStepsCountDismissed(tally.dismissed),
+    ].join(', ');
+    // A legacy run without a snapshot dates itself by its newest step.
+    final lookedAt =
+        runCreatedAt ??
+        steps
+            .map((step) => step.createdAt)
+            .reduce(
+              (a, b) => a.isAfter(b) ? a : b,
+            );
+    final line = messages.projectNextStepsLastRun(
+      parts,
+      formatProjectNextStepsAge(messages, now.difference(lookedAt)),
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          children: [
+            Icon(LottiIcons.tip, size: IconSizes.s, color: ai.titleText),
+            SizedBox(width: tokens.spacing.step3),
+            Expanded(
+              child: Text(
+                line,
+                style: tokens.typography.styles.body.bodySmall.copyWith(
+                  color: ai.metaText,
+                ),
+              ),
+            ),
+            SizedBox(width: tokens.spacing.step3),
+            IntrinsicWidth(
+              child: DesignSystemInlineAction(
+                onTap: onToggleHistory,
+                semanticsLabel: historyOpen
+                    ? messages.projectNextStepsHideHistory
+                    : messages.projectNextStepsShowHistory,
+                label: historyOpen
+                    ? messages.projectNextStepsHideHistory
+                    : messages.projectNextStepsShowHistory,
+                leadingIcon: historyOpen
+                    ? LottiIcons.chevronUp
+                    : LottiIcons.chevronDown,
+                ink: tokens.colors.interactive.enabled,
+              ),
+            ),
+          ],
+        ),
+        if (historyOpen) ...[
+          SizedBox(height: tokens.spacing.step2),
+          for (final step in steps) _HistoryRow(step: step),
+        ],
+      ],
+    );
+  }
+}
+
+class _HistoryRow extends StatelessWidget {
+  const _HistoryRow({required this.step});
+
+  final ProjectRecommendationEntity step;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final ai = tokens.colors.aiCard;
+    final messages = context.messages;
+    final (icon, color, tag) = switch (projectNextStepOutcome(step)) {
+      ProjectNextStepOutcome.added => (
+        LottiIcons.confirm,
+        ai.accent,
+        messages.projectNextStepAdded,
+      ),
+      ProjectNextStepOutcome.done => (
+        LottiIcons.confirm,
+        ai.accent,
+        messages.projectNextStepDone,
+      ),
+      ProjectNextStepOutcome.dismissed => (
+        LottiIcons.close,
+        ai.metaText,
+        messages.projectNextStepDismissed,
+      ),
+      // A pending row cannot appear in a fully decided run; render it as
+      // plain history rather than inventing a state.
+      ProjectNextStepOutcome.pending => (
+        LottiIcons.tip,
+        ai.metaText,
+        messages.changeSetPendingCount(1),
+      ),
+    };
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border(top: BorderSide(color: ai.borderSoft)),
+      ),
+      child: Padding(
+        padding: EdgeInsets.symmetric(vertical: tokens.spacing.step2),
+        child: Row(
+          children: [
+            Icon(icon, size: IconSizes.xs, color: color),
+            SizedBox(width: tokens.spacing.step3),
+            Expanded(
+              child: Text(
+                step.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: tokens.typography.styles.body.bodySmall.copyWith(
+                  color: ai.titleText,
+                ),
+              ),
+            ),
+            SizedBox(width: tokens.spacing.step3),
+            Text(
+              tag,
+              style: tokens.typography.styles.others.caption.copyWith(
+                color: ai.metaText,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The band when the newest run has nothing open: says so, and when the agent
+/// last looked, instead of leaving an unexplained gap under the report.
+class ProjectNextStepsEmpty extends StatelessWidget {
+  const ProjectNextStepsEmpty({
+    required this.runCreatedAt,
+    required this.now,
+    super.key,
+  });
+
+  final DateTime? runCreatedAt;
+  final DateTime now;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final ai = tokens.colors.aiCard;
+    final messages = context.messages;
+    final text = [
+      messages.projectNextStepsEmpty,
+      if (runCreatedAt case final lookedAt?)
+        messages.projectNextStepsLastLooked(
+          formatProjectNextStepsAge(messages, now.difference(lookedAt)),
+        ),
+    ].join(' ');
+    return Row(
+      children: [
+        Icon(LottiIcons.tip, size: IconSizes.s, color: ai.titleText),
+        SizedBox(width: tokens.spacing.step3),
+        Expanded(
+          child: Text(
+            text,
+            style: tokens.typography.styles.body.bodySmall.copyWith(
+              color: ai.metaText,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/projects/ui/widgets/next_steps/project_proposal_row.dart
+++ b/lib/features/projects/ui/widgets/next_steps/project_proposal_row.dart
@@ -21,6 +21,7 @@ class ProjectProposalRow extends StatelessWidget {
     required this.busy,
     required this.onConfirm,
     required this.onReject,
+    this.enabled = true,
     super.key,
   });
 
@@ -32,6 +33,9 @@ class ProjectProposalRow extends StatelessWidget {
   final bool busy;
   final Future<void> Function() onConfirm;
   final Future<void> Function() onReject;
+
+  /// `false` keeps the rail visible but inert.
+  final bool enabled;
 
   ChangeItem get item => changeSet.items[itemIndex];
 
@@ -74,6 +78,7 @@ class ProjectProposalRow extends StatelessWidget {
             else
               RowActions(
                 busy: busy,
+                enabled: enabled,
                 onReject: onReject,
                 onConfirm: onConfirm,
               ),

--- a/lib/features/projects/ui/widgets/next_steps/project_proposal_row.dart
+++ b/lib/features/projects/ui/widgets/next_steps/project_proposal_row.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_widgets_part.dart';
+import 'package:lotti/features/agents/ui/localized_change_summary.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+
+/// One proposed mutation from the project agent — a status change or a task
+/// it wants to create — inside the AI card's "Proposed changes" band.
+///
+/// A pending row carries the task agent's reject/confirm disc rail, so the
+/// same gesture applies the same kind of change on a task page and a project
+/// page. A decided row keeps its place with the shared resolved tag instead of
+/// leaving the band, so what was just done stays legible.
+class ProjectProposalRow extends StatelessWidget {
+  const ProjectProposalRow({
+    required this.changeSet,
+    required this.itemIndex,
+    required this.busy,
+    required this.onConfirm,
+    required this.onReject,
+    super.key,
+  });
+
+  final ChangeSetEntity changeSet;
+  final int itemIndex;
+
+  /// The rail shows a spinner instead of its buttons while the decision is
+  /// being applied.
+  final bool busy;
+  final Future<void> Function() onConfirm;
+  final Future<void> Function() onReject;
+
+  ChangeItem get item => changeSet.items[itemIndex];
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final ai = tokens.colors.aiCard;
+    final decided = item.status != ChangeItemStatus.pending;
+    final summary =
+        localizedChangeSummary(context.messages, item.toolName, item.args) ??
+        item.humanSummary;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: decided ? ai.subtleWash : ai.row,
+        borderRadius: BorderRadius.circular(tokens.radii.s),
+        border: Border.all(color: ai.rowBorder),
+      ),
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: tokens.spacing.step4,
+          vertical: tokens.spacing.step2,
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Padding(
+                padding: EdgeInsets.symmetric(vertical: tokens.spacing.step2),
+                child: Text(
+                  summary,
+                  style: tokens.typography.styles.body.bodyMedium.copyWith(
+                    color: decided ? ai.metaText : ai.titleText,
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(width: tokens.spacing.step3),
+            if (decided)
+              ResolvedTag(status: item.status)
+            else
+              RowActions(
+                busy: busy,
+                onReject: onReject,
+                onConfirm: onConfirm,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/projects/ui/widgets/project_agent_summary_card.dart
+++ b/lib/features/projects/ui/widgets/project_agent_summary_card.dart
@@ -56,6 +56,10 @@ class ProjectAgentSummaryCard extends ConsumerStatefulWidget {
   final VoidCallback? onViewBlocker;
   final VoidCallback? onRefresh;
   final VoidCallback? onCancelScheduledWake;
+
+  /// The action bands under the report. Stays mounted while the host
+  /// mutates — the host hands it a disabled build instead of dropping it, so
+  /// an in-flight decision keeps its row state.
   final Widget? actions;
   final bool isRefreshing;
 
@@ -120,7 +124,7 @@ class _ProjectAgentSummaryCardState
       if (widget.hasProjectAgent) {
         return _ProjectReportSummary(
           record: widget.record,
-          actions: widget.isMutating ? null : widget.actions,
+          actions: widget.actions,
           onViewBlocker: widget.isMutating ? null : widget.onViewBlocker,
         );
       }
@@ -216,7 +220,7 @@ class _ProjectAgentSummaryCardState
       agentName: agentName,
       onOpenInternals: openInternals,
       onViewBlocker: widget.isMutating ? null : widget.onViewBlocker,
-      actions: widget.isMutating ? null : widget.actions,
+      actions: widget.actions,
       footer: footer,
     );
   }

--- a/lib/features/projects/ui/widgets/project_mobile_detail_content.dart
+++ b/lib/features/projects/ui/widgets/project_mobile_detail_content.dart
@@ -53,7 +53,7 @@ class ProjectMobileDetailContent extends StatefulWidget {
     this.onCancelScheduledReportWake,
     this.onAssignAgent,
     this.agentIdentity,
-    this.agentActions,
+    this.agentActionsBuilder,
     this.hasProjectAgent = true,
     this.isRefreshingReport = false,
     this.isSaving = false,
@@ -75,7 +75,11 @@ class ProjectMobileDetailContent extends StatefulWidget {
   final VoidCallback? onCancelScheduledReportWake;
   final Future<void> Function()? onAssignAgent;
   final AgentIdentityEntity? agentIdentity;
-  final Widget? agentActions;
+
+  /// Builds the agent's action bands for the AI card. `enabled` is false
+  /// while this surface runs a mutation of its own, so the bands stay
+  /// mounted (no decision state is lost) but every control is disabled.
+  final Widget Function({required bool enabled})? agentActionsBuilder;
   final bool hasProjectAgent;
   final bool isRefreshingReport;
   final bool isSaving;
@@ -275,7 +279,9 @@ class _ProjectMobileDetailContentState
                                         widget.onTaskTap == null
                                     ? null
                                     : () => widget.onTaskTap!(firstBlockedTask),
-                                actions: widget.agentActions,
+                                actions: widget.agentActionsBuilder?.call(
+                                  enabled: !isMutating,
+                                ),
                                 isRefreshing: widget.isRefreshingReport,
                               ),
                             ),

--- a/lib/features/projects/ui/widgets/project_recommendations_panel.dart
+++ b/lib/features/projects/ui/widgets/project_recommendations_panel.dart
@@ -1,29 +1,59 @@
+import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
-import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/agents/service/project_recommendation_service.dart';
 import 'package:lotti/features/agents/state/change_set_providers.dart';
 import 'package:lotti/features/agents/tools/project_tool_definitions.dart';
-import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_widgets_part.dart';
 import 'package:lotti/features/agents/ui/ai_summary_card/tldr_section_part.dart';
-import 'package:lotti/features/agents/ui/localized_change_summary.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
-import 'package:lotti/features/design_system/components/buttons/design_system_icon_action.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_inline_action.dart';
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
 import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/projects/state/project_detail_record_provider.dart';
+import 'package:lotti/features/projects/ui/widgets/next_steps/project_next_step_row.dart';
+import 'package:lotti/features/projects/ui/widgets/next_steps/project_next_steps_model.dart';
+import 'package:lotti/features/projects/ui/widgets/next_steps/project_next_steps_summary.dart';
+import 'package:lotti/features/projects/ui/widgets/next_steps/project_proposal_row.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 
-/// One compact action band inside the project AI card. Next steps and pending
-/// mutations share individual decisions and one confirm-all rail, following the
-/// task agent's controls without rendering a card for every analyst run.
+/// The action bands inside the project AI card: the newest run's
+/// **recommended next steps** and the agent's **proposed changes**, each under
+/// its own heading because they ask different questions — advice the user
+/// may turn into a task, versus a mutation the user authorises.
+///
+/// Every decision leaves its row in place with a tag; nothing is removed on
+/// tap and nothing on the page is invalidated by hand. The service notifies
+/// the agent's update stream, the snapshot provider re-reads, and the row
+/// changes state where it stands. A run whose every step was already decided
+/// when the page opened collapses to a one-line summary with a history
+/// disclosure; decisions made while the page is open stay inline.
 class ProjectRecommendationsPanel extends ConsumerStatefulWidget {
-  const ProjectRecommendationsPanel({required this.projectId, super.key});
+  const ProjectRecommendationsPanel({
+    required this.projectId,
+    this.enabled = true,
+    this.onOpenTask,
+    super.key,
+  });
+
+  /// How long an added step keeps its Undo before the creation is final.
+  static const Duration undoWindow = Duration(seconds: 8);
+
+  /// Steps a phone shows before "Show N more".
+  static const int phoneStepCap = 3;
 
   final String projectId;
+
+  /// `false` disables every control while the page runs a mutation of its
+  /// own; the bands stay mounted so no decision state is lost.
+  final bool enabled;
+
+  /// Opens the task an added step created.
+  final ValueChanged<String>? onOpenTask;
 
   @override
   ConsumerState<ProjectRecommendationsPanel> createState() =>
@@ -32,66 +62,171 @@ class ProjectRecommendationsPanel extends ConsumerStatefulWidget {
 
 class _ProjectRecommendationsPanelState
     extends ConsumerState<ProjectRecommendationsPanel> {
-  bool _busy = false;
-  final _consumed = <String>{};
+  final _busySteps = <String>{};
+  final _failedSteps = <String>{};
 
-  Future<bool> _apply(_ProjectAction row, _Action action) async {
-    final recommendation = row.recommendation;
-    if (recommendation != null) {
-      final service = ref.read(projectRecommendationServiceProvider);
-      switch (action) {
-        case _Action.confirm:
-          return service.markResolved(recommendation.id);
-        case _Action.dismiss:
-          return service.dismissRecommendation(recommendation.id);
-        case _Action.createTask:
-          final result = await service.createTask(recommendation.id);
-          if (result.success && result.errorMessage != null && mounted) {
-            context.showToast(
-              tone: DesignSystemToastTone.warning,
-              title: context.messages.changeSetItemConfirmedWithWarning(
-                result.errorMessage!,
-              ),
-            );
-          }
-          return result.success;
-      }
+  /// Row states the user just produced, shown until the snapshot catches up
+  /// so a decided row never flickers back through "pending".
+  final _optimistic = <String, ProjectNextStepRowState>{};
+  final _undoDeadlines = <String, DateTime>{};
+  final _undoTimers = <String, Timer>{};
+
+  /// Task ids created this session, so "Open task" works before the snapshot
+  /// carries the id.
+  final _createdTasks = <String, String>{};
+  final _busyProposals = <String>{};
+
+  /// Proposals decided this session, kept visible with their tag after the
+  /// pending read stops returning their change set.
+  final _decidedProposals = <String, (ChangeSetEntity, int)>{};
+
+  bool _showAllSteps = false;
+  bool _bulkBusy = false;
+  bool _historyOpen = false;
+
+  /// The run the collapse decision below was made for, and the decision.
+  bool _collapseDecided = false;
+  DateTime? _collapseRun;
+  bool _collapsed = false;
+
+  @override
+  void dispose() {
+    for (final timer in _undoTimers.values) {
+      timer.cancel();
     }
-    final service = ref.read(projectChangeSetConfirmationServiceProvider);
-    return action == _Action.dismiss
-        ? service.rejectItem(row.changeSet!, row.itemIndex!)
-        : (await service.confirmItem(row.changeSet!, row.itemIndex!)).success;
+    super.dispose();
   }
 
-  Future<void> _run(List<_ProjectAction> rows, _Action action) async {
-    if (_busy) return;
-    setState(() => _busy = true);
-    var failed = false;
-    for (final row in rows) {
-      try {
-        if (await _apply(row, action)) {
-          _consumed.add(row.id);
-        } else {
-          failed = true;
-        }
-      } catch (error, stackTrace) {
-        failed = true;
-        developer.log(
-          'Failed to apply project suggestion',
-          name: 'ProjectRecommendationsPanel',
-          error: error,
-          stackTrace: stackTrace,
-        );
-      }
+  DateTime get _now => ref.read(projectDetailNowProvider)();
+
+  // ---------------------------------------------------------------- steps --
+
+  ProjectNextStepRowState _rowState(ProjectRecommendationEntity step) {
+    if (_busySteps.contains(step.id)) return ProjectNextStepRowState.busy;
+    if (_failedSteps.contains(step.id)) return ProjectNextStepRowState.failed;
+    final durable = switch (projectNextStepOutcome(step)) {
+      ProjectNextStepOutcome.pending => ProjectNextStepRowState.pending,
+      ProjectNextStepOutcome.added => ProjectNextStepRowState.added,
+      ProjectNextStepOutcome.done => ProjectNextStepRowState.done,
+      ProjectNextStepOutcome.dismissed => ProjectNextStepRowState.dismissed,
+    };
+    final optimistic = _optimistic[step.id];
+    if (optimistic == null) return durable;
+    if (optimistic == durable) {
+      // The snapshot caught up; the overlay has done its job.
+      _optimistic.remove(step.id);
+      return durable;
+    }
+    return optimistic;
+  }
+
+  bool _canUndo(ProjectRecommendationEntity step, ProjectNextStepRowState s) {
+    if (!widget.enabled) return false;
+    return switch (s) {
+      ProjectNextStepRowState.dismissed || ProjectNextStepRowState.done => true,
+      ProjectNextStepRowState.added =>
+        _undoDeadlines[step.id]?.isAfter(_now) ?? false,
+      ProjectNextStepRowState.pending ||
+      ProjectNextStepRowState.busy ||
+      ProjectNextStepRowState.failed => false,
+    };
+  }
+
+  void _armUndo(String stepId) {
+    _undoTimers.remove(stepId)?.cancel();
+    _undoDeadlines[stepId] = _now.add(ProjectRecommendationsPanel.undoWindow);
+    _undoTimers[stepId] = Timer(ProjectRecommendationsPanel.undoWindow, () {
+      _undoTimers.remove(stepId);
       if (!mounted) return;
-      ref.invalidate(agentUpdateStreamProvider(row.agentId));
+      setState(() => _undoDeadlines.remove(stepId));
+    });
+  }
+
+  Future<void> _addTask(ProjectRecommendationEntity step) async {
+    if (_busySteps.contains(step.id)) return;
+    setState(() {
+      _busySteps.add(step.id);
+      _failedSteps.remove(step.id);
+    });
+    try {
+      final result = await ref
+          .read(projectRecommendationServiceProvider)
+          .createTask(step.id);
+      if (!mounted) return;
+      if (result.success) {
+        final taskId = result.mutatedEntityId;
+        _optimistic[step.id] = taskId == null
+            ? ProjectNextStepRowState.done
+            : ProjectNextStepRowState.added;
+        if (taskId != null) _createdTasks[step.id] = taskId;
+        _armUndo(step.id);
+        if (result.errorMessage case final warning?) {
+          context.showToast(
+            tone: DesignSystemToastTone.warning,
+            title: context.messages.changeSetItemConfirmedWithWarning(warning),
+          );
+        }
+      } else {
+        _failedSteps.add(step.id);
+      }
+    } catch (error, stackTrace) {
+      _log(
+        'Failed to create a task from a project suggestion',
+        error,
+        stackTrace,
+      );
+      if (!mounted) return;
+      _failedSteps.add(step.id);
+    } finally {
+      if (mounted) setState(() => _busySteps.remove(step.id));
+    }
+  }
+
+  Future<void> _dismiss(ProjectRecommendationEntity step) async {
+    await _transition(
+      step,
+      () => ref
+          .read(projectRecommendationServiceProvider)
+          .dismissRecommendation(step.id),
+      settled: ProjectNextStepRowState.dismissed,
+    );
+  }
+
+  Future<void> _undo(ProjectRecommendationEntity step) async {
+    _undoTimers.remove(step.id)?.cancel();
+    _undoDeadlines.remove(step.id);
+    _createdTasks.remove(step.id);
+    await _transition(
+      step,
+      () => ref
+          .read(projectRecommendationServiceProvider)
+          .restoreRecommendation(step.id),
+      settled: ProjectNextStepRowState.pending,
+    );
+  }
+
+  Future<void> _transition(
+    ProjectRecommendationEntity step,
+    Future<bool> Function() run, {
+    required ProjectNextStepRowState settled,
+  }) async {
+    if (_busySteps.contains(step.id)) return;
+    setState(() {
+      _busySteps.add(step.id);
+      _failedSteps.remove(step.id);
+    });
+    var succeeded = false;
+    try {
+      succeeded = await run();
+    } catch (error, stackTrace) {
+      _log('Failed to update a project suggestion', error, stackTrace);
     }
     if (!mounted) return;
-    ref
-      ..invalidate(projectNextStepsProvider(widget.projectId))
-      ..invalidate(projectPendingChangeSetsProvider(widget.projectId));
-    setState(() => _busy = false);
-    if (failed) {
+    setState(() {
+      _busySteps.remove(step.id);
+      if (succeeded) _optimistic[step.id] = settled;
+    });
+    if (!succeeded) {
       context.showToast(
         tone: DesignSystemToastTone.error,
         title: context.messages.projectRecommendationUpdateError,
@@ -99,152 +234,375 @@ class _ProjectRecommendationsPanelState
     }
   }
 
+  Future<void> _runBulk(
+    Iterable<ProjectRecommendationEntity> steps,
+    Future<void> Function(ProjectRecommendationEntity step) action,
+  ) async {
+    if (_bulkBusy) return;
+    setState(() => _bulkBusy = true);
+    try {
+      for (final step in steps.toList()) {
+        if (!mounted) return;
+        await action(step);
+      }
+    } finally {
+      if (mounted) setState(() => _bulkBusy = false);
+    }
+  }
+
+  // ------------------------------------------------------------ proposals --
+
+  String _proposalKey(ChangeSetEntity set, int index) => '${set.id}:$index';
+
+  Future<void> _decideProposal(
+    ChangeSetEntity set,
+    int index, {
+    required bool confirm,
+  }) async {
+    final key = _proposalKey(set, index);
+    if (_busyProposals.contains(key)) return;
+    setState(() => _busyProposals.add(key));
+    var succeeded = false;
+    try {
+      final service = ref.read(projectChangeSetConfirmationServiceProvider);
+      succeeded = confirm
+          ? (await service.confirmItem(set, index)).success
+          : await service.rejectItem(set, index);
+    } catch (error, stackTrace) {
+      _log('Failed to apply a project proposal', error, stackTrace);
+    }
+    if (!mounted) return;
+    setState(() {
+      _busyProposals.remove(key);
+      if (succeeded) {
+        final items = [...set.items];
+        items[index] = items[index].copyWith(
+          status: confirm
+              ? ChangeItemStatus.confirmed
+              : ChangeItemStatus.rejected,
+        );
+        _decidedProposals[key] = (set.copyWith(items: items), index);
+      }
+    });
+    // Only the proposal read moves; the agent's update stream is left alone
+    // so the report, health and footer never reload for a row decision.
+    ref.invalidate(projectPendingChangeSetsProvider(widget.projectId));
+    if (!succeeded) {
+      context.showToast(
+        tone: DesignSystemToastTone.error,
+        title: context.messages.projectRecommendationUpdateError,
+      );
+    }
+  }
+
+  void _log(String message, Object error, StackTrace stackTrace) {
+    developer.log(
+      message,
+      name: 'ProjectRecommendationsPanel',
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+
+  // ----------------------------------------------------------------- build --
+
   @override
   Widget build(BuildContext context) {
-    final recommendations =
-        ref
-            .watch(projectNextStepsProvider(widget.projectId))
-            .value
-            ?.pending
-            .toList() ??
-        const <ProjectRecommendationEntity>[];
+    final snapshot = ref
+        .watch(projectNextStepsProvider(widget.projectId))
+        .value;
     final sets =
-        ref
-            .watch(
-              projectPendingChangeSetsProvider(widget.projectId),
-            )
-            .value ??
+        ref.watch(projectPendingChangeSetsProvider(widget.projectId)).value ??
         const <AgentDomainEntity>[];
-    final rows = [
-      for (final recommendation in recommendations)
-        _ProjectAction.recommendation(recommendation),
-      for (final set in sets.whereType<ChangeSetEntity>())
-        for (final entry in set.items.indexed)
-          if (entry.$2.status == ChangeItemStatus.pending &&
-              entry.$2.toolName != ProjectAgentToolNames.recommendNextSteps)
-            _ProjectAction.change(set, entry.$1),
-    ].where((row) => !_consumed.contains(row.id)).toList();
-    if (rows.isEmpty) return const SizedBox.shrink();
+    final proposals = _proposalRows(sets);
+    if (snapshot == null && proposals.isEmpty) return const SizedBox.shrink();
 
     final tokens = context.designTokens;
     final ai = tokens.colors.aiCard;
-    return Container(
-      decoration: BoxDecoration(
-        border: Border(top: BorderSide(color: ai.borderSoft)),
-      ),
-      padding: EdgeInsets.symmetric(
-        horizontal: tokens.spacing.cardPadding,
-        vertical: tokens.spacing.step3,
-      ),
-      alignment: Alignment.centerLeft,
+    final messages = context.messages;
+    final now = ref.watch(projectDetailNowProvider)();
+    // Counted from the rows' effective state, so a step added or dismissed a
+    // moment ago leaves the count and the bulk rail before the snapshot
+    // catches up.
+    final openSteps = snapshot == null
+        ? const <ProjectRecommendationEntity>[]
+        : snapshot.steps
+              .where(
+                (step) => _rowState(step) == ProjectNextStepRowState.pending,
+              )
+              .toList();
+
+    return Align(
+      alignment: AlignmentDirectional.centerStart,
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: TldrBody.maxReadingWidth),
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
           children: [
-            Row(
-              children: [
-                Icon(LottiIcons.tip, size: IconSizes.s, color: ai.titleText),
-                SizedBox(width: tokens.spacing.step3),
-                Expanded(
-                  child: Text(
-                    recommendations.isEmpty
-                        ? context.messages.changeSetCardTitle
-                        : context.messages.projectRecommendationsTitle,
-                    style: tokens.typography.styles.subtitle.subtitle2.copyWith(
-                      color: ai.titleText,
-                    ),
-                  ),
-                ),
-                Text(
-                  context.messages.changeSetPendingCount(rows.length),
-                  style: tokens.typography.styles.others.caption.copyWith(
-                    color: ai.metaText,
-                  ),
-                ),
-              ],
-            ),
-            SizedBox(height: tokens.spacing.step3),
-            for (final row in rows)
-              Padding(
-                key: ValueKey(row.id),
-                padding: EdgeInsets.only(bottom: tokens.spacing.step3),
-                child: Row(
+            if (snapshot != null)
+              _Band(
+                icon: LottiIcons.tip,
+                title: messages.projectRecommendationsTitle,
+                count: openSteps.length,
+                child: _stepsBody(context, snapshot, now, openSteps),
+              ),
+            if (proposals.isNotEmpty)
+              _Band(
+                icon: LottiIcons.factCheck,
+                title: messages.changeSetCardTitle,
+                count: proposals
+                    .where(
+                      (row) =>
+                          row.$1.items[row.$2].status ==
+                          ChangeItemStatus.pending,
+                    )
+                    .length,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  mainAxisSize: MainAxisSize.min,
                   children: [
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            row.title(context),
-                            style: tokens.typography.styles.body.bodyMedium
-                                .copyWith(color: ai.titleText),
+                    for (final (set, index) in proposals)
+                      Padding(
+                        key: ValueKey('proposal-${_proposalKey(set, index)}'),
+                        padding: EdgeInsets.only(bottom: tokens.spacing.step2),
+                        child: ProjectProposalRow(
+                          changeSet: set,
+                          itemIndex: index,
+                          busy: _busyProposals.contains(
+                            _proposalKey(set, index),
                           ),
-                          if (row.recommendation?.rationale
-                              case final String rationale)
-                            if (rationale.trim().isNotEmpty)
-                              Text(
-                                rationale,
-                                style: tokens.typography.styles.body.bodySmall
-                                    .copyWith(color: ai.metaText),
-                              ),
-                        ],
+                          onConfirm: () => widget.enabled
+                              ? _decideProposal(set, index, confirm: true)
+                              : Future<void>.value(),
+                          onReject: () => widget.enabled
+                              ? _decideProposal(set, index, confirm: false)
+                              : Future<void>.value(),
+                        ),
                       ),
-                    ),
-                    if (row.recommendation != null)
-                      DesignSystemIconAction(
-                        icon: LottiIcons.add,
-                        tooltip: context.messages.projectActionAddTask,
-                        onPressed: _busy
-                            ? null
-                            : () => _run([row], _Action.createTask),
-                      ),
-                    RowActions(
-                      busy: _busy,
-                      onReject: () => _run([row], _Action.dismiss),
-                      onConfirm: () => _run([row], _Action.confirm),
-                    ),
                   ],
                 ),
               ),
-            if (rows.length > 1)
-              Align(
-                alignment: Alignment.centerRight,
-                child: DesignSystemButton(
-                  label: context.messages.changeSetConfirmAll,
-                  leadingIcon: LottiIcons.confirmAll,
-                  variant: DesignSystemButtonVariant.outlined,
-                  isLoading: _busy,
-                  onPressed: _busy ? null : () => _run(rows, _Action.confirm),
-                ),
+            if (snapshot == null && proposals.isNotEmpty)
+              SizedBox(
+                height: tokens.spacing.step1,
+                child: ColoredBox(color: ai.background),
               ),
           ],
         ),
       ),
     );
   }
+
+  /// Every proposal row to show: the live sets' items in order, plus rows
+  /// decided this session whose set the pending read no longer returns.
+  List<(ChangeSetEntity, int)> _proposalRows(List<AgentDomainEntity> sets) {
+    final rows = <(ChangeSetEntity, int)>[];
+    final seen = <String>{};
+    for (final set in sets.whereType<ChangeSetEntity>()) {
+      for (final (index, item) in set.items.indexed) {
+        if (item.toolName == ProjectAgentToolNames.recommendNextSteps) continue;
+        final key = _proposalKey(set, index);
+        seen.add(key);
+        final decided = _decidedProposals[key];
+        rows.add(
+          item.status == ChangeItemStatus.pending && decided != null
+              ? decided
+              : (set, index),
+        );
+      }
+    }
+    for (final entry in _decidedProposals.entries) {
+      if (!seen.contains(entry.key)) rows.add(entry.value);
+    }
+    return rows;
+  }
+
+  Widget _stepsBody(
+    BuildContext context,
+    ProjectNextStepsSnapshot snapshot,
+    DateTime now,
+    List<ProjectRecommendationEntity> pending,
+  ) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    final steps = snapshot.steps;
+    final tally = ProjectNextStepsTally.of(steps);
+
+    if (!_collapseDecided || _collapseRun != snapshot.runCreatedAt) {
+      _collapseDecided = true;
+      _collapseRun = snapshot.runCreatedAt;
+      _collapsed = tally.allDecided;
+      _showAllSteps = false;
+      _historyOpen = false;
+    }
+
+    if (steps.isEmpty) {
+      return ProjectNextStepsEmpty(
+        runCreatedAt: snapshot.runCreatedAt,
+        now: now,
+      );
+    }
+    if (_collapsed) {
+      return ProjectNextStepsSummary(
+        steps: steps,
+        runCreatedAt: snapshot.runCreatedAt,
+        now: now,
+        historyOpen: _historyOpen,
+        onToggleHistory: () => setState(() => _historyOpen = !_historyOpen),
+      );
+    }
+
+    final phone =
+        MediaQuery.sizeOf(context).width < ProjectNextStepRow.wideBreakpoint;
+    final visible = visibleProjectNextSteps(
+      steps,
+      cap: phone ? ProjectRecommendationsPanel.phoneStepCap : steps.length,
+      showAll: _showAllSteps,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (final step in visible)
+          Padding(
+            key: ValueKey('step-${step.id}'),
+            padding: EdgeInsets.only(bottom: tokens.spacing.step2),
+            child: Builder(
+              builder: (context) {
+                final state = _rowState(step);
+                final taskId = step.createdTaskId ?? _createdTasks[step.id];
+                final openTask = widget.onOpenTask;
+                return ProjectNextStepRow(
+                  step: step,
+                  state: state,
+                  enabled: widget.enabled,
+                  canUndo: _canUndo(step, state),
+                  onAddTask: () => unawaited(_addTask(step)),
+                  onDismiss: () => unawaited(_dismiss(step)),
+                  onUndo: () => unawaited(_undo(step)),
+                  onOpenTask: taskId == null || openTask == null
+                      ? null
+                      : () => openTask(taskId),
+                );
+              },
+            ),
+          ),
+        if (visible.length < steps.length)
+          Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: DesignSystemInlineAction(
+              onTap: () => setState(() => _showAllSteps = true),
+              semanticsLabel: messages.projectNextStepsShowMore(
+                steps.length - visible.length,
+              ),
+              label: messages.projectNextStepsShowMore(
+                steps.length - visible.length,
+              ),
+              leadingIcon: LottiIcons.chevronDown,
+              ink: tokens.colors.interactive.enabled,
+            ),
+          ),
+        if (pending.length > 1) ...[
+          SizedBox(height: tokens.spacing.step2),
+          Wrap(
+            alignment: WrapAlignment.end,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            spacing: tokens.spacing.step3,
+            runSpacing: tokens.spacing.step2,
+            children: [
+              IntrinsicWidth(
+                child: DesignSystemInlineAction(
+                  onTap: widget.enabled && !_bulkBusy
+                      ? () => unawaited(_runBulk(pending, _dismiss))
+                      : null,
+                  semanticsLabel: messages.projectNextStepsDismissAll,
+                  label: messages.projectNextStepsDismissAll,
+                  leadingIcon: LottiIcons.close,
+                ),
+              ),
+              DesignSystemButton(
+                label: messages.projectNextStepsAddAll,
+                leadingIcon: LottiIcons.add,
+                variant: DesignSystemButtonVariant.outlined,
+                size: DesignSystemButtonSize.dense,
+                tapTargetSize: MaterialTapTargetSize.padded,
+                isLoading: _bulkBusy,
+                onPressed: widget.enabled && !_bulkBusy
+                    ? () => unawaited(_runBulk(pending, _addTask))
+                    : null,
+              ),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
 }
 
-enum _Action { confirm, dismiss, createTask }
+/// One titled band inside the AI card: a hairline above, the heading with
+/// its pending count, then the band's rows.
+class _Band extends StatelessWidget {
+  const _Band({
+    required this.icon,
+    required this.title,
+    required this.count,
+    required this.child,
+  });
 
-class _ProjectAction {
-  const _ProjectAction.recommendation(this.recommendation)
-    : changeSet = null,
-      itemIndex = null;
-  const _ProjectAction.change(this.changeSet, this.itemIndex)
-    : recommendation = null;
+  final IconData icon;
+  final String title;
+  final int count;
+  final Widget child;
 
-  final ProjectRecommendationEntity? recommendation;
-  final ChangeSetEntity? changeSet;
-  final int? itemIndex;
-
-  String get id => recommendation?.id ?? '${changeSet!.id}:$itemIndex';
-  String get agentId => recommendation?.agentId ?? changeSet!.agentId;
-
-  String title(BuildContext context) {
-    if (recommendation case final recommendation?) return recommendation.title;
-    final item = changeSet!.items[itemIndex!];
-    return localizedChangeSummary(context.messages, item.toolName, item.args) ??
-        item.humanSummary;
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final ai = tokens.colors.aiCard;
+    return Container(
+      decoration: BoxDecoration(
+        border: Border(top: BorderSide(color: ai.borderSoft)),
+      ),
+      padding: EdgeInsets.fromLTRB(
+        tokens.spacing.cardPadding,
+        tokens.spacing.step3,
+        tokens.spacing.cardPadding,
+        tokens.spacing.step4,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Icon(icon, size: IconSizes.s, color: ai.titleText),
+              SizedBox(width: tokens.spacing.step3),
+              Expanded(
+                child: Text(
+                  title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: tokens.typography.styles.subtitle.subtitle2.copyWith(
+                    color: ai.titleText,
+                  ),
+                ),
+              ),
+              if (count > 0) ...[
+                SizedBox(width: tokens.spacing.step3),
+                Text(
+                  context.messages.changeSetPendingCount(count),
+                  style: tokens.typography.styles.others.caption.copyWith(
+                    color: ai.metaText,
+                  ),
+                ),
+              ],
+            ],
+          ),
+          SizedBox(height: tokens.spacing.step3),
+          child,
+        ],
+      ),
+    );
   }
 }

--- a/lib/features/projects/ui/widgets/project_recommendations_panel.dart
+++ b/lib/features/projects/ui/widgets/project_recommendations_panel.dart
@@ -63,7 +63,11 @@ class ProjectRecommendationsPanel extends ConsumerStatefulWidget {
 class _ProjectRecommendationsPanelState
     extends ConsumerState<ProjectRecommendationsPanel> {
   final _busySteps = <String>{};
-  final _failedSteps = <String>{};
+
+  /// Steps whose last attempt failed: whether a retry can help, and the
+  /// message to show when it cannot (the step was consumed and a task may
+  /// need cleaning up).
+  final _failures = <String, ({bool retryable, String? message})>{};
 
   /// Row states the user just produced, shown until the snapshot catches up
   /// so a decided row never flickers back through "pending".
@@ -103,7 +107,7 @@ class _ProjectRecommendationsPanelState
 
   ProjectNextStepRowState _rowState(ProjectRecommendationEntity step) {
     if (_busySteps.contains(step.id)) return ProjectNextStepRowState.busy;
-    if (_failedSteps.contains(step.id)) return ProjectNextStepRowState.failed;
+    if (_failures.containsKey(step.id)) return ProjectNextStepRowState.failed;
     final durable = switch (projectNextStepOutcome(step)) {
       ProjectNextStepOutcome.pending => ProjectNextStepRowState.pending,
       ProjectNextStepOutcome.added => ProjectNextStepRowState.added,
@@ -146,7 +150,7 @@ class _ProjectRecommendationsPanelState
     if (_busySteps.contains(step.id)) return;
     setState(() {
       _busySteps.add(step.id);
-      _failedSteps.remove(step.id);
+      _failures.remove(step.id);
     });
     try {
       final result = await ref
@@ -167,7 +171,12 @@ class _ProjectRecommendationsPanelState
           );
         }
       } else {
-        _failedSteps.add(step.id);
+        // A consumed claim (task created, link and rollback both failed)
+        // cannot be retried: every retry would report "no longer active".
+        _failures[step.id] = (
+          retryable: !result.nonRetryable,
+          message: result.nonRetryable ? result.errorMessage : null,
+        );
       }
     } catch (error, stackTrace) {
       _log(
@@ -176,7 +185,7 @@ class _ProjectRecommendationsPanelState
         stackTrace,
       );
       if (!mounted) return;
-      _failedSteps.add(step.id);
+      _failures[step.id] = (retryable: true, message: null);
     } finally {
       if (mounted) setState(() => _busySteps.remove(step.id));
     }
@@ -193,15 +202,19 @@ class _ProjectRecommendationsPanelState
   }
 
   Future<void> _undo(ProjectRecommendationEntity step) async {
-    _undoTimers.remove(step.id)?.cancel();
-    _undoDeadlines.remove(step.id);
-    _createdTasks.remove(step.id);
     await _transition(
       step,
       () => ref
           .read(projectRecommendationServiceProvider)
           .restoreRecommendation(step.id),
       settled: ProjectNextStepRowState.pending,
+      // Only a successful restore forfeits the undo window and the task
+      // link; a refused undo leaves the row exactly as it was.
+      onSuccess: () {
+        _undoTimers.remove(step.id)?.cancel();
+        _undoDeadlines.remove(step.id);
+        _createdTasks.remove(step.id);
+      },
     );
   }
 
@@ -209,11 +222,12 @@ class _ProjectRecommendationsPanelState
     ProjectRecommendationEntity step,
     Future<bool> Function() run, {
     required ProjectNextStepRowState settled,
+    VoidCallback? onSuccess,
   }) async {
     if (_busySteps.contains(step.id)) return;
     setState(() {
       _busySteps.add(step.id);
-      _failedSteps.remove(step.id);
+      _failures.remove(step.id);
     });
     var succeeded = false;
     try {
@@ -224,7 +238,10 @@ class _ProjectRecommendationsPanelState
     if (!mounted) return;
     setState(() {
       _busySteps.remove(step.id);
-      if (succeeded) _optimistic[step.id] = settled;
+      if (succeeded) {
+        _optimistic[step.id] = settled;
+        onSuccess?.call();
+      }
     });
     if (!succeeded) {
       context.showToast(
@@ -318,7 +335,6 @@ class _ProjectRecommendationsPanelState
     if (snapshot == null && proposals.isEmpty) return const SizedBox.shrink();
 
     final tokens = context.designTokens;
-    final ai = tokens.colors.aiCard;
     final messages = context.messages;
     final now = ref.watch(projectDetailNowProvider)();
     // Counted from the rows' effective state, so a step added or dismissed a
@@ -372,21 +388,15 @@ class _ProjectRecommendationsPanelState
                           busy: _busyProposals.contains(
                             _proposalKey(set, index),
                           ),
-                          onConfirm: () => widget.enabled
-                              ? _decideProposal(set, index, confirm: true)
-                              : Future<void>.value(),
-                          onReject: () => widget.enabled
-                              ? _decideProposal(set, index, confirm: false)
-                              : Future<void>.value(),
+                          enabled: widget.enabled && !_bulkBusy,
+                          onConfirm: () =>
+                              _decideProposal(set, index, confirm: true),
+                          onReject: () =>
+                              _decideProposal(set, index, confirm: false),
                         ),
                       ),
                   ],
                 ),
-              ),
-            if (snapshot == null && proposals.isNotEmpty)
-              SizedBox(
-                height: tokens.spacing.step1,
-                child: ColoredBox(color: ai.background),
               ),
           ],
         ),
@@ -394,8 +404,9 @@ class _ProjectRecommendationsPanelState
     );
   }
 
-  /// Every proposal row to show: the live sets' items in order, plus rows
-  /// decided this session whose set the pending read no longer returns.
+  /// Every proposal row to show: the live sets' open items in order, plus
+  /// rows decided this session — whether their set still comes back from the
+  /// pending read or not. Items decided in an earlier session stay out.
   List<(ChangeSetEntity, int)> _proposalRows(List<AgentDomainEntity> sets) {
     final rows = <(ChangeSetEntity, int)>[];
     final seen = <String>{};
@@ -403,13 +414,16 @@ class _ProjectRecommendationsPanelState
       for (final (index, item) in set.items.indexed) {
         if (item.toolName == ProjectAgentToolNames.recommendNextSteps) continue;
         final key = _proposalKey(set, index);
-        seen.add(key);
         final decided = _decidedProposals[key];
-        rows.add(
-          item.status == ChangeItemStatus.pending && decided != null
-              ? decided
-              : (set, index),
-        );
+        if (decided != null) {
+          seen.add(key);
+          rows.add(decided);
+          continue;
+        }
+        // A sibling decided in an earlier session is history, not a row.
+        if (item.status != ChangeItemStatus.pending) continue;
+        seen.add(key);
+        rows.add((set, index));
       }
     }
     for (final entry in _decidedProposals.entries) {
@@ -474,12 +488,16 @@ class _ProjectRecommendationsPanelState
                 final state = _rowState(step);
                 final taskId = step.createdTaskId ?? _createdTasks[step.id];
                 final openTask = widget.onOpenTask;
+                final failure = _failures[step.id];
                 return ProjectNextStepRow(
                   step: step,
                   state: state,
-                  enabled: widget.enabled,
+                  enabled: widget.enabled && !_bulkBusy,
                   canUndo: _canUndo(step, state),
-                  onAddTask: () => unawaited(_addTask(step)),
+                  failureMessage: failure?.message,
+                  onAddTask: failure?.retryable == false
+                      ? null
+                      : () => unawaited(_addTask(step)),
                   onDismiss: () => unawaited(_dismiss(step)),
                   onUndo: () => unawaited(_undo(step)),
                   onOpenTask: taskId == null || openTask == null

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -3941,8 +3941,8 @@
   "projectNextStepAdded": "Přidáno",
   "projectNextStepCreateFailed": "Úkol se nepodařilo vytvořit. Aktualizuj teď, aby se načetl aktuální seznam, nebo to zkus znovu.",
   "projectNextStepCreating": "Vytvářím úkol…",
-  "projectNextStepDismiss": "Zamítnout",
-  "projectNextStepDismissed": "Zamítnuto",
+  "projectNextStepDismiss": "Zahodit",
+  "projectNextStepDismissed": "Zahozeno",
   "projectNextStepDone": "Hotovo",
   "projectNextStepOpenTask": "Otevřít úkol",
   "projectNextStepRetry": "Zkusit znovu",
@@ -3972,7 +3972,7 @@
       }
     }
   },
-  "projectNextStepsCountAdded": "{count, plural, =1{1 přidán} few{{count} přidány} other{{count} přidáno}}",
+  "projectNextStepsCountAdded": "{count, plural, =1{1 přidaný} few{{count} přidané} many{{count} přidaných} other{{count} přidaných}}",
   "@projectNextStepsCountAdded": {
     "placeholders": {
       "count": {
@@ -3980,7 +3980,7 @@
       }
     }
   },
-  "projectNextStepsCountDismissed": "{count, plural, =1{1 zamítnut} few{{count} zamítnuty} other{{count} zamítnuto}}",
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 zahozený} few{{count} zahozené} many{{count} zahozených} other{{count} zahozených}}",
   "@projectNextStepsCountDismissed": {
     "placeholders": {
       "count": {
@@ -3988,7 +3988,7 @@
       }
     }
   },
-  "projectNextStepsCountDone": "{count, plural, =1{1 hotov} few{{count} hotovy} other{{count} hotovo}}",
+  "projectNextStepsCountDone": "{count, plural, =1{1 hotový} few{{count} hotové} many{{count} hotových} other{{count} hotových}}",
   "@projectNextStepsCountDone": {
     "placeholders": {
       "count": {
@@ -3996,9 +3996,9 @@
       }
     }
   },
-  "projectNextStepsDismissAll": "Zamítnout vše",
+  "projectNextStepsDismissAll": "Zahodit vše",
   "projectNextStepsEmpty": "Žádné otevřené návrhy.",
-  "projectNextStepsHideHistory": "Skrýt",
+  "projectNextStepsHideHistory": "Skrýt historii",
   "projectNextStepsLastLooked": "Naposledy zkontrolováno {ago}.",
   "@projectNextStepsLastLooked": {
     "placeholders": {
@@ -4018,8 +4018,8 @@
       }
     }
   },
-  "projectNextStepsShowHistory": "Zobrazit",
-  "projectNextStepsShowMore": "Zobrazit {count} dalších",
+  "projectNextStepsShowHistory": "Zobrazit historii",
+  "projectNextStepsShowMore": "{count, plural, =1{Zobrazit 1 další} few{Zobrazit {count} další} many{Zobrazit {count} dalších} other{Zobrazit {count} dalších}}",
   "@projectNextStepsShowMore": {
     "placeholders": {
       "count": {

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -3938,14 +3938,101 @@
   },
   "projectLinkedTasks": "Propojené úkoly",
   "projectManageTooltip": "Správa projektů",
+  "projectNextStepAdded": "Přidáno",
+  "projectNextStepCreateFailed": "Úkol se nepodařilo vytvořit. Aktualizuj teď, aby se načetl aktuální seznam, nebo to zkus znovu.",
+  "projectNextStepCreating": "Vytvářím úkol…",
+  "projectNextStepDismiss": "Zamítnout",
+  "projectNextStepDismissed": "Zamítnuto",
+  "projectNextStepDone": "Hotovo",
+  "projectNextStepOpenTask": "Otevřít úkol",
+  "projectNextStepRetry": "Zkusit znovu",
+  "projectNextStepsAddAll": "Přidat vše jako úkoly",
+  "projectNextStepsAgoDays": "{count, plural, =1{před 1 dnem} other{před {count} dny}}",
+  "@projectNextStepsAgoDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoHours": "{count, plural, =1{před 1 h} other{před {count} h}}",
+  "@projectNextStepsAgoHours": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoJustNow": "právě teď",
+  "projectNextStepsAgoMinutes": "{count, plural, =1{před 1 min} other{před {count} min}}",
+  "@projectNextStepsAgoMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountAdded": "{count, plural, =1{1 přidán} few{{count} přidány} other{{count} přidáno}}",
+  "@projectNextStepsCountAdded": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 zamítnut} few{{count} zamítnuty} other{{count} zamítnuto}}",
+  "@projectNextStepsCountDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDone": "{count, plural, =1{1 hotov} few{{count} hotovy} other{{count} hotovo}}",
+  "@projectNextStepsCountDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsDismissAll": "Zamítnout vše",
+  "projectNextStepsEmpty": "Žádné otevřené návrhy.",
+  "projectNextStepsHideHistory": "Skrýt",
+  "projectNextStepsLastLooked": "Naposledy zkontrolováno {ago}.",
+  "@projectNextStepsLastLooked": {
+    "placeholders": {
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsLastRun": "Poslední běh: {summary} · {ago}",
+  "@projectNextStepsLastRun": {
+    "placeholders": {
+      "summary": {
+        "type": "String"
+      },
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsShowHistory": "Zobrazit",
+  "projectNextStepsShowMore": "Zobrazit {count} dalších",
+  "@projectNextStepsShowMore": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "projectNoLinkedTasks": "Zatím žádné propojené úkoly",
   "projectNoProjects": "Zatím žádné projekty",
   "projectNotFound": "Projekt nenalezen",
   "projectPickerLabel": "Projekt",
   "projectPickerUnassigned": "Žádný projekt",
   "projectPickerUpdateFailed": "Projekt úkolu se nepodařilo změnit. Zkontroluj kategorii a soukromí a zkus to znovu.",
-  "projectRecommendationDismissTooltip": "Zahodit",
-  "projectRecommendationResolveTooltip": "Označit jako vyřešené",
   "projectRecommendationsTitle": "Doporučené další kroky",
   "projectRecommendationUpdateError": "Doporučení se nepodařilo aktualizovat. Zkus to prosím znovu.",
   "projectsClearFilters": "Vymazat filtry",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4405,14 +4405,101 @@
   },
   "projectLinkedTasks": "Sammenkoblede opgaver",
   "projectManageTooltip": "Styr projekter",
+  "projectNextStepAdded": "Tilføjet",
+  "projectNextStepCreateFailed": "Opgaven kunne ikke oprettes. Opdater nu for at hente den aktuelle liste, eller prøv igen.",
+  "projectNextStepCreating": "Opretter opgave…",
+  "projectNextStepDismiss": "Afvis",
+  "projectNextStepDismissed": "Afvist",
+  "projectNextStepDone": "Færdig",
+  "projectNextStepOpenTask": "Åbn opgave",
+  "projectNextStepRetry": "Prøv igen",
+  "projectNextStepsAddAll": "Tilføj alle som opgaver",
+  "projectNextStepsAgoDays": "{count, plural, =1{1 dag siden} other{{count} dage siden}}",
+  "@projectNextStepsAgoDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoHours": "{count, plural, =1{1 t siden} other{{count} t siden}}",
+  "@projectNextStepsAgoHours": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoJustNow": "lige nu",
+  "projectNextStepsAgoMinutes": "{count, plural, =1{1 min siden} other{{count} min siden}}",
+  "@projectNextStepsAgoMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountAdded": "{count, plural, =1{1 tilføjet} other{{count} tilføjet}}",
+  "@projectNextStepsCountAdded": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 afvist} other{{count} afvist}}",
+  "@projectNextStepsCountDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDone": "{count, plural, =1{1 færdig} other{{count} færdige}}",
+  "@projectNextStepsCountDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsDismissAll": "Afvis alle",
+  "projectNextStepsEmpty": "Ingen åbne forslag.",
+  "projectNextStepsHideHistory": "Skjul",
+  "projectNextStepsLastLooked": "Sidst kigget {ago}.",
+  "@projectNextStepsLastLooked": {
+    "placeholders": {
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsLastRun": "Seneste kørsel: {summary} · {ago}",
+  "@projectNextStepsLastRun": {
+    "placeholders": {
+      "summary": {
+        "type": "String"
+      },
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsShowHistory": "Vis",
+  "projectNextStepsShowMore": "Vis {count} mere",
+  "@projectNextStepsShowMore": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "projectNoLinkedTasks": "Ingen opgaver er linket endnu",
   "projectNoProjects": "Ingen projekter endnu",
   "projectNotFound": "Projekt ikke fundet",
   "projectPickerLabel": "Projekt",
   "projectPickerUnassigned": "Intet projekt",
   "projectPickerUpdateFailed": "Opgavens projekt kunne ikke ændres. Kontrollér kategori og privatliv, og prøv igen.",
-  "projectRecommendationDismissTooltip": "Afvist",
-  "projectRecommendationResolveTooltip": "Mark besluttede sig",
   "projectRecommendationsTitle": "Anbefalede næste skridt",
   "projectRecommendationUpdateError": "Kunne ikke opdatere anbefalingen. Prøv venligst igen.",
   "projectsClearFilters": "Ryd filtre",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4465,7 +4465,7 @@
   },
   "projectNextStepsDismissAll": "Afvis alle",
   "projectNextStepsEmpty": "Ingen åbne forslag.",
-  "projectNextStepsHideHistory": "Skjul",
+  "projectNextStepsHideHistory": "Skjul historik",
   "projectNextStepsLastLooked": "Sidst kigget {ago}.",
   "@projectNextStepsLastLooked": {
     "placeholders": {
@@ -4485,7 +4485,7 @@
       }
     }
   },
-  "projectNextStepsShowHistory": "Vis",
+  "projectNextStepsShowHistory": "Vis historik",
   "projectNextStepsShowMore": "Vis {count} mere",
   "@projectNextStepsShowMore": {
     "placeholders": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3934,8 +3934,8 @@
   "projectNextStepAdded": "Hinzugefügt",
   "projectNextStepCreateFailed": "Die Aufgabe konnte nicht erstellt werden. Aktualisiere jetzt, um die aktuelle Liste zu laden, oder versuche es erneut.",
   "projectNextStepCreating": "Aufgabe wird erstellt…",
-  "projectNextStepDismiss": "Verwerfen",
-  "projectNextStepDismissed": "Verworfen",
+  "projectNextStepDismiss": "Übergehen",
+  "projectNextStepDismissed": "Übergangen",
   "projectNextStepDone": "Erledigt",
   "projectNextStepOpenTask": "Aufgabe öffnen",
   "projectNextStepRetry": "Erneut versuchen",
@@ -3973,7 +3973,7 @@
       }
     }
   },
-  "projectNextStepsCountDismissed": "{count, plural, =1{1 verworfen} other{{count} verworfen}}",
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 übergangen} other{{count} übergangen}}",
   "@projectNextStepsCountDismissed": {
     "placeholders": {
       "count": {
@@ -3989,9 +3989,9 @@
       }
     }
   },
-  "projectNextStepsDismissAll": "Alle verwerfen",
+  "projectNextStepsDismissAll": "Alle übergehen",
   "projectNextStepsEmpty": "Keine offenen Vorschläge.",
-  "projectNextStepsHideHistory": "Ausblenden",
+  "projectNextStepsHideHistory": "Verlauf ausblenden",
   "projectNextStepsLastLooked": "Zuletzt geprüft {ago}.",
   "@projectNextStepsLastLooked": {
     "placeholders": {
@@ -4011,7 +4011,7 @@
       }
     }
   },
-  "projectNextStepsShowHistory": "Anzeigen",
+  "projectNextStepsShowHistory": "Verlauf anzeigen",
   "projectNextStepsShowMore": "{count} weitere anzeigen",
   "@projectNextStepsShowMore": {
     "placeholders": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3931,14 +3931,101 @@
   },
   "projectLinkedTasks": "Verknüpfte Aufgaben",
   "projectManageTooltip": "Projekte verwalten",
+  "projectNextStepAdded": "Hinzugefügt",
+  "projectNextStepCreateFailed": "Die Aufgabe konnte nicht erstellt werden. Aktualisiere jetzt, um die aktuelle Liste zu laden, oder versuche es erneut.",
+  "projectNextStepCreating": "Aufgabe wird erstellt…",
+  "projectNextStepDismiss": "Verwerfen",
+  "projectNextStepDismissed": "Verworfen",
+  "projectNextStepDone": "Erledigt",
+  "projectNextStepOpenTask": "Aufgabe öffnen",
+  "projectNextStepRetry": "Erneut versuchen",
+  "projectNextStepsAddAll": "Alle als Aufgaben hinzufügen",
+  "projectNextStepsAgoDays": "{count, plural, =1{vor 1 Tag} other{vor {count} Tagen}}",
+  "@projectNextStepsAgoDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoHours": "{count, plural, =1{vor 1 Std.} other{vor {count} Std.}}",
+  "@projectNextStepsAgoHours": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoJustNow": "gerade eben",
+  "projectNextStepsAgoMinutes": "{count, plural, =1{vor 1 Min.} other{vor {count} Min.}}",
+  "@projectNextStepsAgoMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountAdded": "{count, plural, =1{1 hinzugefügt} other{{count} hinzugefügt}}",
+  "@projectNextStepsCountAdded": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 verworfen} other{{count} verworfen}}",
+  "@projectNextStepsCountDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDone": "{count, plural, =1{1 erledigt} other{{count} erledigt}}",
+  "@projectNextStepsCountDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsDismissAll": "Alle verwerfen",
+  "projectNextStepsEmpty": "Keine offenen Vorschläge.",
+  "projectNextStepsHideHistory": "Ausblenden",
+  "projectNextStepsLastLooked": "Zuletzt geprüft {ago}.",
+  "@projectNextStepsLastLooked": {
+    "placeholders": {
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsLastRun": "Letzter Lauf: {summary} · {ago}",
+  "@projectNextStepsLastRun": {
+    "placeholders": {
+      "summary": {
+        "type": "String"
+      },
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsShowHistory": "Anzeigen",
+  "projectNextStepsShowMore": "{count} weitere anzeigen",
+  "@projectNextStepsShowMore": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "projectNoLinkedTasks": "Noch keine Aufgaben verknüpft",
   "projectNoProjects": "Noch keine Projekte",
   "projectNotFound": "Projekt nicht gefunden",
   "projectPickerLabel": "Projekt",
   "projectPickerUnassigned": "Kein Projekt",
   "projectPickerUpdateFailed": "Das Projekt der Aufgabe konnte nicht geändert werden. Prüfe Kategorie und Datenschutz und versuche es erneut.",
-  "projectRecommendationDismissTooltip": "Ausblenden",
-  "projectRecommendationResolveTooltip": "Als erledigt markieren",
   "projectRecommendationsTitle": "Empfohlene nächste Schritte",
   "projectRecommendationUpdateError": "Die Empfehlung konnte nicht aktualisiert werden. Bitte versuche es erneut.",
   "projectsClearFilters": "Filter löschen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5916,7 +5916,7 @@
   },
   "projectNextStepsDismissAll": "Dismiss all",
   "projectNextStepsEmpty": "No open suggestions.",
-  "projectNextStepsHideHistory": "Hide",
+  "projectNextStepsHideHistory": "Hide history",
   "projectNextStepsLastLooked": "Last looked {ago}.",
   "@projectNextStepsLastLooked": {
     "placeholders": {
@@ -5936,7 +5936,7 @@
       }
     }
   },
-  "projectNextStepsShowHistory": "Show",
+  "projectNextStepsShowHistory": "Show history",
   "projectNextStepsShowMore": "Show {count} more",
   "@projectNextStepsShowMore": {
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5856,6 +5856,95 @@
   },
   "projectLinkedTasks": "Linked Tasks",
   "projectManageTooltip": "Manage projects",
+  "projectNextStepAdded": "Added",
+  "projectNextStepCreateFailed": "Couldn't create the task. Update now to load the current list, or retry.",
+  "projectNextStepCreating": "Creating task…",
+  "projectNextStepDismiss": "Dismiss",
+  "projectNextStepDismissed": "Dismissed",
+  "projectNextStepDone": "Done",
+  "projectNextStepOpenTask": "Open task",
+  "projectNextStepRetry": "Retry",
+  "projectNextStepsAddAll": "Add all as tasks",
+  "projectNextStepsAgoDays": "{count, plural, =1{1 day ago} other{{count} days ago}}",
+  "@projectNextStepsAgoDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoHours": "{count, plural, =1{1 h ago} other{{count} h ago}}",
+  "@projectNextStepsAgoHours": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoJustNow": "just now",
+  "projectNextStepsAgoMinutes": "{count, plural, =1{1 min ago} other{{count} min ago}}",
+  "@projectNextStepsAgoMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountAdded": "{count, plural, =1{1 added} other{{count} added}}",
+  "@projectNextStepsCountAdded": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 dismissed} other{{count} dismissed}}",
+  "@projectNextStepsCountDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDone": "{count, plural, =1{1 done} other{{count} done}}",
+  "@projectNextStepsCountDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsDismissAll": "Dismiss all",
+  "projectNextStepsEmpty": "No open suggestions.",
+  "projectNextStepsHideHistory": "Hide",
+  "projectNextStepsLastLooked": "Last looked {ago}.",
+  "@projectNextStepsLastLooked": {
+    "placeholders": {
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsLastRun": "Last run: {summary} · {ago}",
+  "@projectNextStepsLastRun": {
+    "placeholders": {
+      "summary": {
+        "type": "String"
+      },
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsShowHistory": "Show",
+  "projectNextStepsShowMore": "Show {count} more",
+  "@projectNextStepsShowMore": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "projectNoLinkedTasks": "No tasks linked yet",
   "projectNoProjects": "No projects yet",
   "projectNotFound": "Project not found",
@@ -5865,8 +5954,6 @@
   "@projectPickerUpdateFailed": {
     "description": "Error shown when a task-project assignment is rejected after the picker was opened."
   },
-  "projectRecommendationDismissTooltip": "Dismiss",
-  "projectRecommendationResolveTooltip": "Mark resolved",
   "projectRecommendationsTitle": "Recommended next steps",
   "projectRecommendationUpdateError": "Couldn't update the recommendation. Please try again.",
   "projectsClearFilters": "Clear filters",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -3991,7 +3991,7 @@
   },
   "projectNextStepsDismissAll": "Descartar todos",
   "projectNextStepsEmpty": "No hay sugerencias abiertas.",
-  "projectNextStepsHideHistory": "Ocultar",
+  "projectNextStepsHideHistory": "Ocultar historial",
   "projectNextStepsLastLooked": "Última revisión {ago}.",
   "@projectNextStepsLastLooked": {
     "placeholders": {
@@ -4011,7 +4011,7 @@
       }
     }
   },
-  "projectNextStepsShowHistory": "Mostrar",
+  "projectNextStepsShowHistory": "Mostrar historial",
   "projectNextStepsShowMore": "Mostrar {count} más",
   "@projectNextStepsShowMore": {
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -3931,14 +3931,101 @@
   },
   "projectLinkedTasks": "Tareas vinculadas",
   "projectManageTooltip": "Gestionar proyectos",
+  "projectNextStepAdded": "Añadido",
+  "projectNextStepCreateFailed": "No se pudo crear la tarea. Actualiza ahora para cargar la lista actual o vuelve a intentarlo.",
+  "projectNextStepCreating": "Creando tarea…",
+  "projectNextStepDismiss": "Descartar",
+  "projectNextStepDismissed": "Descartado",
+  "projectNextStepDone": "Hecho",
+  "projectNextStepOpenTask": "Abrir tarea",
+  "projectNextStepRetry": "Reintentar",
+  "projectNextStepsAddAll": "Añadir todos como tareas",
+  "projectNextStepsAgoDays": "{count, plural, =1{hace 1 día} other{hace {count} días}}",
+  "@projectNextStepsAgoDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoHours": "{count, plural, =1{hace 1 h} other{hace {count} h}}",
+  "@projectNextStepsAgoHours": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoJustNow": "ahora mismo",
+  "projectNextStepsAgoMinutes": "{count, plural, =1{hace 1 min} other{hace {count} min}}",
+  "@projectNextStepsAgoMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountAdded": "{count, plural, =1{1 añadido} other{{count} añadidos}}",
+  "@projectNextStepsCountAdded": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 descartado} other{{count} descartados}}",
+  "@projectNextStepsCountDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDone": "{count, plural, =1{1 hecho} other{{count} hechos}}",
+  "@projectNextStepsCountDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsDismissAll": "Descartar todos",
+  "projectNextStepsEmpty": "No hay sugerencias abiertas.",
+  "projectNextStepsHideHistory": "Ocultar",
+  "projectNextStepsLastLooked": "Última revisión {ago}.",
+  "@projectNextStepsLastLooked": {
+    "placeholders": {
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsLastRun": "Última ejecución: {summary} · {ago}",
+  "@projectNextStepsLastRun": {
+    "placeholders": {
+      "summary": {
+        "type": "String"
+      },
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsShowHistory": "Mostrar",
+  "projectNextStepsShowMore": "Mostrar {count} más",
+  "@projectNextStepsShowMore": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "projectNoLinkedTasks": "Aún no hay tareas vinculadas",
   "projectNoProjects": "Aún no hay proyectos",
   "projectNotFound": "Proyecto no encontrado",
   "projectPickerLabel": "Proyecto",
   "projectPickerUnassigned": "Sin proyecto",
   "projectPickerUpdateFailed": "No se pudo cambiar el proyecto de la tarea. Comprueba la categoría y la privacidad e inténtalo de nuevo.",
-  "projectRecommendationDismissTooltip": "Descartar",
-  "projectRecommendationResolveTooltip": "Marcar como resuelto",
   "projectRecommendationsTitle": "Siguientes pasos recomendados",
   "projectRecommendationUpdateError": "No se pudo actualizar la recomendación. Inténtalo de nuevo.",
   "projectsClearFilters": "Borrar filtros",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3931,14 +3931,101 @@
   },
   "projectLinkedTasks": "Tâches liées",
   "projectManageTooltip": "Gérer les projets",
+  "projectNextStepAdded": "Ajouté",
+  "projectNextStepCreateFailed": "Impossible de créer la tâche. Mets à jour maintenant pour charger la liste actuelle, ou réessaie.",
+  "projectNextStepCreating": "Création de la tâche…",
+  "projectNextStepDismiss": "Ignorer",
+  "projectNextStepDismissed": "Ignoré",
+  "projectNextStepDone": "Fait",
+  "projectNextStepOpenTask": "Ouvrir la tâche",
+  "projectNextStepRetry": "Réessayer",
+  "projectNextStepsAddAll": "Tout ajouter comme tâches",
+  "projectNextStepsAgoDays": "{count, plural, =1{il y a 1 jour} other{il y a {count} jours}}",
+  "@projectNextStepsAgoDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoHours": "{count, plural, =1{il y a 1 h} other{il y a {count} h}}",
+  "@projectNextStepsAgoHours": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoJustNow": "à l'instant",
+  "projectNextStepsAgoMinutes": "{count, plural, =1{il y a 1 min} other{il y a {count} min}}",
+  "@projectNextStepsAgoMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountAdded": "{count, plural, =1{1 ajouté} other{{count} ajoutés}}",
+  "@projectNextStepsCountAdded": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 ignoré} other{{count} ignorés}}",
+  "@projectNextStepsCountDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDone": "{count, plural, =1{1 fait} other{{count} faits}}",
+  "@projectNextStepsCountDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsDismissAll": "Tout ignorer",
+  "projectNextStepsEmpty": "Aucune suggestion ouverte.",
+  "projectNextStepsHideHistory": "Masquer",
+  "projectNextStepsLastLooked": "Dernière vérification {ago}.",
+  "@projectNextStepsLastLooked": {
+    "placeholders": {
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsLastRun": "Dernière exécution : {summary} · {ago}",
+  "@projectNextStepsLastRun": {
+    "placeholders": {
+      "summary": {
+        "type": "String"
+      },
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsShowHistory": "Afficher",
+  "projectNextStepsShowMore": "Afficher {count} de plus",
+  "@projectNextStepsShowMore": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "projectNoLinkedTasks": "Aucune tâche liée pour le moment",
   "projectNoProjects": "Pas encore de projets",
   "projectNotFound": "Projet introuvable",
   "projectPickerLabel": "Projet",
   "projectPickerUnassigned": "Aucun projet",
   "projectPickerUpdateFailed": "Impossible de modifier le projet de la tâche. Vérifie la catégorie et la confidentialité, puis réessaie.",
-  "projectRecommendationDismissTooltip": "Ignorer",
-  "projectRecommendationResolveTooltip": "Marquer comme résolue",
   "projectRecommendationsTitle": "Prochaines étapes recommandées",
   "projectRecommendationUpdateError": "Impossible de mettre à jour la recommandation. Réessaie.",
   "projectsClearFilters": "Effacer les filtres",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3931,12 +3931,12 @@
   },
   "projectLinkedTasks": "Tâches liées",
   "projectManageTooltip": "Gérer les projets",
-  "projectNextStepAdded": "Ajouté",
+  "projectNextStepAdded": "Ajoutée",
   "projectNextStepCreateFailed": "Impossible de créer la tâche. Mets à jour maintenant pour charger la liste actuelle, ou réessaie.",
   "projectNextStepCreating": "Création de la tâche…",
   "projectNextStepDismiss": "Ignorer",
-  "projectNextStepDismissed": "Ignoré",
-  "projectNextStepDone": "Fait",
+  "projectNextStepDismissed": "Ignorée",
+  "projectNextStepDone": "Faite",
   "projectNextStepOpenTask": "Ouvrir la tâche",
   "projectNextStepRetry": "Réessayer",
   "projectNextStepsAddAll": "Tout ajouter comme tâches",
@@ -3965,7 +3965,7 @@
       }
     }
   },
-  "projectNextStepsCountAdded": "{count, plural, =1{1 ajouté} other{{count} ajoutés}}",
+  "projectNextStepsCountAdded": "{count, plural, =1{1 ajoutée} other{{count} ajoutées}}",
   "@projectNextStepsCountAdded": {
     "placeholders": {
       "count": {
@@ -3973,7 +3973,7 @@
       }
     }
   },
-  "projectNextStepsCountDismissed": "{count, plural, =1{1 ignoré} other{{count} ignorés}}",
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 ignorée} other{{count} ignorées}}",
   "@projectNextStepsCountDismissed": {
     "placeholders": {
       "count": {
@@ -3981,7 +3981,7 @@
       }
     }
   },
-  "projectNextStepsCountDone": "{count, plural, =1{1 fait} other{{count} faits}}",
+  "projectNextStepsCountDone": "{count, plural, =1{1 faite} other{{count} faites}}",
   "@projectNextStepsCountDone": {
     "placeholders": {
       "count": {
@@ -3991,7 +3991,7 @@
   },
   "projectNextStepsDismissAll": "Tout ignorer",
   "projectNextStepsEmpty": "Aucune suggestion ouverte.",
-  "projectNextStepsHideHistory": "Masquer",
+  "projectNextStepsHideHistory": "Masquer l'historique",
   "projectNextStepsLastLooked": "Dernière vérification {ago}.",
   "@projectNextStepsLastLooked": {
     "placeholders": {
@@ -4011,7 +4011,7 @@
       }
     }
   },
-  "projectNextStepsShowHistory": "Afficher",
+  "projectNextStepsShowHistory": "Afficher l'historique",
   "projectNextStepsShowMore": "Afficher {count} de plus",
   "@projectNextStepsShowMore": {
     "placeholders": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4465,7 +4465,7 @@
   },
   "projectNextStepsDismissAll": "Ignora tutti",
   "projectNextStepsEmpty": "Nessun suggerimento aperto.",
-  "projectNextStepsHideHistory": "Nascondi",
+  "projectNextStepsHideHistory": "Nascondi cronologia",
   "projectNextStepsLastLooked": "Ultimo controllo {ago}.",
   "@projectNextStepsLastLooked": {
     "placeholders": {
@@ -4485,7 +4485,7 @@
       }
     }
   },
-  "projectNextStepsShowHistory": "Mostra",
+  "projectNextStepsShowHistory": "Mostra cronologia",
   "projectNextStepsShowMore": "Mostra altri {count}",
   "@projectNextStepsShowMore": {
     "placeholders": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4405,14 +4405,101 @@
   },
   "projectLinkedTasks": "Compiti collegati",
   "projectManageTooltip": "Gestione dei progetti",
+  "projectNextStepAdded": "Aggiunto",
+  "projectNextStepCreateFailed": "Impossibile creare l'attività. Aggiorna ora per caricare l'elenco attuale oppure riprova.",
+  "projectNextStepCreating": "Creazione attività…",
+  "projectNextStepDismiss": "Ignora",
+  "projectNextStepDismissed": "Ignorato",
+  "projectNextStepDone": "Fatto",
+  "projectNextStepOpenTask": "Apri attività",
+  "projectNextStepRetry": "Riprova",
+  "projectNextStepsAddAll": "Aggiungi tutti come attività",
+  "projectNextStepsAgoDays": "{count, plural, =1{1 giorno fa} other{{count} giorni fa}}",
+  "@projectNextStepsAgoDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoHours": "{count, plural, =1{1 h fa} other{{count} h fa}}",
+  "@projectNextStepsAgoHours": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoJustNow": "proprio ora",
+  "projectNextStepsAgoMinutes": "{count, plural, =1{1 min fa} other{{count} min fa}}",
+  "@projectNextStepsAgoMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountAdded": "{count, plural, =1{1 aggiunto} other{{count} aggiunti}}",
+  "@projectNextStepsCountAdded": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 ignorato} other{{count} ignorati}}",
+  "@projectNextStepsCountDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDone": "{count, plural, =1{1 fatto} other{{count} fatti}}",
+  "@projectNextStepsCountDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsDismissAll": "Ignora tutti",
+  "projectNextStepsEmpty": "Nessun suggerimento aperto.",
+  "projectNextStepsHideHistory": "Nascondi",
+  "projectNextStepsLastLooked": "Ultimo controllo {ago}.",
+  "@projectNextStepsLastLooked": {
+    "placeholders": {
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsLastRun": "Ultima esecuzione: {summary} · {ago}",
+  "@projectNextStepsLastRun": {
+    "placeholders": {
+      "summary": {
+        "type": "String"
+      },
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsShowHistory": "Mostra",
+  "projectNextStepsShowMore": "Mostra altri {count}",
+  "@projectNextStepsShowMore": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "projectNoLinkedTasks": "Nessun compito ancora collegato",
   "projectNoProjects": "Nessun progetto ancora",
   "projectNotFound": "Progetto non trovato",
   "projectPickerLabel": "Progetto",
   "projectPickerUnassigned": "Nessun progetto",
   "projectPickerUpdateFailed": "Impossibile modificare il progetto dell'attività. Controlla categoria e privacy e riprova.",
-  "projectRecommendationDismissTooltip": "Discorso",
-  "projectRecommendationResolveTooltip": "Mark risolto",
   "projectRecommendationsTitle": "Prossimi passi consigliati",
   "projectRecommendationUpdateError": "Non ho potuto aggiornare la raccomandazione, si prega di riprovare.",
   "projectsClearFilters": "Cancella filtri",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -17506,7 +17506,7 @@ abstract class AppLocalizations {
   /// No description provided for @projectNextStepsHideHistory.
   ///
   /// In en, this message translates to:
-  /// **'Hide'**
+  /// **'Hide history'**
   String get projectNextStepsHideHistory;
 
   /// No description provided for @projectNextStepsLastLooked.
@@ -17524,7 +17524,7 @@ abstract class AppLocalizations {
   /// No description provided for @projectNextStepsShowHistory.
   ///
   /// In en, this message translates to:
-  /// **'Show'**
+  /// **'Show history'**
   String get projectNextStepsShowHistory;
 
   /// No description provided for @projectNextStepsShowMore.

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -17395,6 +17395,144 @@ abstract class AppLocalizations {
   /// **'Manage projects'**
   String get projectManageTooltip;
 
+  /// No description provided for @projectNextStepAdded.
+  ///
+  /// In en, this message translates to:
+  /// **'Added'**
+  String get projectNextStepAdded;
+
+  /// No description provided for @projectNextStepCreateFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t create the task. Update now to load the current list, or retry.'**
+  String get projectNextStepCreateFailed;
+
+  /// No description provided for @projectNextStepCreating.
+  ///
+  /// In en, this message translates to:
+  /// **'Creating task…'**
+  String get projectNextStepCreating;
+
+  /// No description provided for @projectNextStepDismiss.
+  ///
+  /// In en, this message translates to:
+  /// **'Dismiss'**
+  String get projectNextStepDismiss;
+
+  /// No description provided for @projectNextStepDismissed.
+  ///
+  /// In en, this message translates to:
+  /// **'Dismissed'**
+  String get projectNextStepDismissed;
+
+  /// No description provided for @projectNextStepDone.
+  ///
+  /// In en, this message translates to:
+  /// **'Done'**
+  String get projectNextStepDone;
+
+  /// No description provided for @projectNextStepOpenTask.
+  ///
+  /// In en, this message translates to:
+  /// **'Open task'**
+  String get projectNextStepOpenTask;
+
+  /// No description provided for @projectNextStepRetry.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry'**
+  String get projectNextStepRetry;
+
+  /// No description provided for @projectNextStepsAddAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Add all as tasks'**
+  String get projectNextStepsAddAll;
+
+  /// No description provided for @projectNextStepsAgoDays.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 day ago} other{{count} days ago}}'**
+  String projectNextStepsAgoDays(int count);
+
+  /// No description provided for @projectNextStepsAgoHours.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 h ago} other{{count} h ago}}'**
+  String projectNextStepsAgoHours(int count);
+
+  /// No description provided for @projectNextStepsAgoJustNow.
+  ///
+  /// In en, this message translates to:
+  /// **'just now'**
+  String get projectNextStepsAgoJustNow;
+
+  /// No description provided for @projectNextStepsAgoMinutes.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 min ago} other{{count} min ago}}'**
+  String projectNextStepsAgoMinutes(int count);
+
+  /// No description provided for @projectNextStepsCountAdded.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 added} other{{count} added}}'**
+  String projectNextStepsCountAdded(int count);
+
+  /// No description provided for @projectNextStepsCountDismissed.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 dismissed} other{{count} dismissed}}'**
+  String projectNextStepsCountDismissed(int count);
+
+  /// No description provided for @projectNextStepsCountDone.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 done} other{{count} done}}'**
+  String projectNextStepsCountDone(int count);
+
+  /// No description provided for @projectNextStepsDismissAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Dismiss all'**
+  String get projectNextStepsDismissAll;
+
+  /// No description provided for @projectNextStepsEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No open suggestions.'**
+  String get projectNextStepsEmpty;
+
+  /// No description provided for @projectNextStepsHideHistory.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide'**
+  String get projectNextStepsHideHistory;
+
+  /// No description provided for @projectNextStepsLastLooked.
+  ///
+  /// In en, this message translates to:
+  /// **'Last looked {ago}.'**
+  String projectNextStepsLastLooked(String ago);
+
+  /// No description provided for @projectNextStepsLastRun.
+  ///
+  /// In en, this message translates to:
+  /// **'Last run: {summary} · {ago}'**
+  String projectNextStepsLastRun(String summary, String ago);
+
+  /// No description provided for @projectNextStepsShowHistory.
+  ///
+  /// In en, this message translates to:
+  /// **'Show'**
+  String get projectNextStepsShowHistory;
+
+  /// No description provided for @projectNextStepsShowMore.
+  ///
+  /// In en, this message translates to:
+  /// **'Show {count} more'**
+  String projectNextStepsShowMore(int count);
+
   /// No description provided for @projectNoLinkedTasks.
   ///
   /// In en, this message translates to:
@@ -17430,18 +17568,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not change this task\'s project. Check its category and privacy, then try again.'**
   String get projectPickerUpdateFailed;
-
-  /// No description provided for @projectRecommendationDismissTooltip.
-  ///
-  /// In en, this message translates to:
-  /// **'Dismiss'**
-  String get projectRecommendationDismissTooltip;
-
-  /// No description provided for @projectRecommendationResolveTooltip.
-  ///
-  /// In en, this message translates to:
-  /// **'Mark resolved'**
-  String get projectRecommendationResolveTooltip;
 
   /// No description provided for @projectRecommendationsTitle.
   ///

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -10392,10 +10392,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get projectNextStepCreating => 'Vytvářím úkol…';
 
   @override
-  String get projectNextStepDismiss => 'Zamítnout';
+  String get projectNextStepDismiss => 'Zahodit';
 
   @override
-  String get projectNextStepDismissed => 'Zamítnuto';
+  String get projectNextStepDismissed => 'Zahozeno';
 
   @override
   String get projectNextStepDone => 'Hotovo';
@@ -10450,9 +10450,10 @@ class AppLocalizationsCs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count přidáno',
-      few: '$count přidány',
-      one: '1 přidán',
+      other: '$count přidaných',
+      many: '$count přidaných',
+      few: '$count přidané',
+      one: '1 přidaný',
     );
     return '$_temp0';
   }
@@ -10462,9 +10463,10 @@ class AppLocalizationsCs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count zamítnuto',
-      few: '$count zamítnuty',
-      one: '1 zamítnut',
+      other: '$count zahozených',
+      many: '$count zahozených',
+      few: '$count zahozené',
+      one: '1 zahozený',
     );
     return '$_temp0';
   }
@@ -10474,21 +10476,22 @@ class AppLocalizationsCs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count hotovo',
-      few: '$count hotovy',
-      one: '1 hotov',
+      other: '$count hotových',
+      many: '$count hotových',
+      few: '$count hotové',
+      one: '1 hotový',
     );
     return '$_temp0';
   }
 
   @override
-  String get projectNextStepsDismissAll => 'Zamítnout vše';
+  String get projectNextStepsDismissAll => 'Zahodit vše';
 
   @override
   String get projectNextStepsEmpty => 'Žádné otevřené návrhy.';
 
   @override
-  String get projectNextStepsHideHistory => 'Skrýt';
+  String get projectNextStepsHideHistory => 'Skrýt historii';
 
   @override
   String projectNextStepsLastLooked(String ago) {
@@ -10501,11 +10504,19 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get projectNextStepsShowHistory => 'Zobrazit';
+  String get projectNextStepsShowHistory => 'Zobrazit historii';
 
   @override
   String projectNextStepsShowMore(int count) {
-    return 'Zobrazit $count dalších';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Zobrazit $count dalších',
+      many: 'Zobrazit $count dalších',
+      few: 'Zobrazit $count další',
+      one: 'Zobrazit 1 další',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -10382,6 +10382,133 @@ class AppLocalizationsCs extends AppLocalizations {
   String get projectManageTooltip => 'Správa projektů';
 
   @override
+  String get projectNextStepAdded => 'Přidáno';
+
+  @override
+  String get projectNextStepCreateFailed =>
+      'Úkol se nepodařilo vytvořit. Aktualizuj teď, aby se načetl aktuální seznam, nebo to zkus znovu.';
+
+  @override
+  String get projectNextStepCreating => 'Vytvářím úkol…';
+
+  @override
+  String get projectNextStepDismiss => 'Zamítnout';
+
+  @override
+  String get projectNextStepDismissed => 'Zamítnuto';
+
+  @override
+  String get projectNextStepDone => 'Hotovo';
+
+  @override
+  String get projectNextStepOpenTask => 'Otevřít úkol';
+
+  @override
+  String get projectNextStepRetry => 'Zkusit znovu';
+
+  @override
+  String get projectNextStepsAddAll => 'Přidat vše jako úkoly';
+
+  @override
+  String projectNextStepsAgoDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'před $count dny',
+      one: 'před 1 dnem',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsAgoHours(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'před $count h',
+      one: 'před 1 h',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsAgoJustNow => 'právě teď';
+
+  @override
+  String projectNextStepsAgoMinutes(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'před $count min',
+      one: 'před 1 min',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountAdded(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count přidáno',
+      few: '$count přidány',
+      one: '1 přidán',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDismissed(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count zamítnuto',
+      few: '$count zamítnuty',
+      one: '1 zamítnut',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count hotovo',
+      few: '$count hotovy',
+      one: '1 hotov',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsDismissAll => 'Zamítnout vše';
+
+  @override
+  String get projectNextStepsEmpty => 'Žádné otevřené návrhy.';
+
+  @override
+  String get projectNextStepsHideHistory => 'Skrýt';
+
+  @override
+  String projectNextStepsLastLooked(String ago) {
+    return 'Naposledy zkontrolováno $ago.';
+  }
+
+  @override
+  String projectNextStepsLastRun(String summary, String ago) {
+    return 'Poslední běh: $summary · $ago';
+  }
+
+  @override
+  String get projectNextStepsShowHistory => 'Zobrazit';
+
+  @override
+  String projectNextStepsShowMore(int count) {
+    return 'Zobrazit $count dalších';
+  }
+
+  @override
   String get projectNoLinkedTasks => 'Zatím žádné propojené úkoly';
 
   @override
@@ -10399,12 +10526,6 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get projectPickerUpdateFailed =>
       'Projekt úkolu se nepodařilo změnit. Zkontroluj kategorii a soukromí a zkus to znovu.';
-
-  @override
-  String get projectRecommendationDismissTooltip => 'Zahodit';
-
-  @override
-  String get projectRecommendationResolveTooltip => 'Označit jako vyřešené';
 
   @override
   String get projectRecommendationsTitle => 'Doporučené další kroky';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -10353,7 +10353,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get projectNextStepsEmpty => 'Ingen åbne forslag.';
 
   @override
-  String get projectNextStepsHideHistory => 'Skjul';
+  String get projectNextStepsHideHistory => 'Skjul historik';
 
   @override
   String projectNextStepsLastLooked(String ago) {
@@ -10366,7 +10366,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get projectNextStepsShowHistory => 'Vis';
+  String get projectNextStepsShowHistory => 'Vis historik';
 
   @override
   String projectNextStepsShowMore(int count) {

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -10250,6 +10250,130 @@ class AppLocalizationsDa extends AppLocalizations {
   String get projectManageTooltip => 'Styr projekter';
 
   @override
+  String get projectNextStepAdded => 'Tilføjet';
+
+  @override
+  String get projectNextStepCreateFailed =>
+      'Opgaven kunne ikke oprettes. Opdater nu for at hente den aktuelle liste, eller prøv igen.';
+
+  @override
+  String get projectNextStepCreating => 'Opretter opgave…';
+
+  @override
+  String get projectNextStepDismiss => 'Afvis';
+
+  @override
+  String get projectNextStepDismissed => 'Afvist';
+
+  @override
+  String get projectNextStepDone => 'Færdig';
+
+  @override
+  String get projectNextStepOpenTask => 'Åbn opgave';
+
+  @override
+  String get projectNextStepRetry => 'Prøv igen';
+
+  @override
+  String get projectNextStepsAddAll => 'Tilføj alle som opgaver';
+
+  @override
+  String projectNextStepsAgoDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dage siden',
+      one: '1 dag siden',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsAgoHours(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count t siden',
+      one: '1 t siden',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsAgoJustNow => 'lige nu';
+
+  @override
+  String projectNextStepsAgoMinutes(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count min siden',
+      one: '1 min siden',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountAdded(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count tilføjet',
+      one: '1 tilføjet',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDismissed(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count afvist',
+      one: '1 afvist',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count færdige',
+      one: '1 færdig',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsDismissAll => 'Afvis alle';
+
+  @override
+  String get projectNextStepsEmpty => 'Ingen åbne forslag.';
+
+  @override
+  String get projectNextStepsHideHistory => 'Skjul';
+
+  @override
+  String projectNextStepsLastLooked(String ago) {
+    return 'Sidst kigget $ago.';
+  }
+
+  @override
+  String projectNextStepsLastRun(String summary, String ago) {
+    return 'Seneste kørsel: $summary · $ago';
+  }
+
+  @override
+  String get projectNextStepsShowHistory => 'Vis';
+
+  @override
+  String projectNextStepsShowMore(int count) {
+    return 'Vis $count mere';
+  }
+
+  @override
   String get projectNoLinkedTasks => 'Ingen opgaver er linket endnu';
 
   @override
@@ -10267,12 +10391,6 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get projectPickerUpdateFailed =>
       'Opgavens projekt kunne ikke ændres. Kontrollér kategori og privatliv, og prøv igen.';
-
-  @override
-  String get projectRecommendationDismissTooltip => 'Afvist';
-
-  @override
-  String get projectRecommendationResolveTooltip => 'Mark besluttede sig';
 
   @override
   String get projectRecommendationsTitle => 'Anbefalede næste skridt';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -10321,6 +10321,130 @@ class AppLocalizationsDe extends AppLocalizations {
   String get projectManageTooltip => 'Projekte verwalten';
 
   @override
+  String get projectNextStepAdded => 'Hinzugefügt';
+
+  @override
+  String get projectNextStepCreateFailed =>
+      'Die Aufgabe konnte nicht erstellt werden. Aktualisiere jetzt, um die aktuelle Liste zu laden, oder versuche es erneut.';
+
+  @override
+  String get projectNextStepCreating => 'Aufgabe wird erstellt…';
+
+  @override
+  String get projectNextStepDismiss => 'Verwerfen';
+
+  @override
+  String get projectNextStepDismissed => 'Verworfen';
+
+  @override
+  String get projectNextStepDone => 'Erledigt';
+
+  @override
+  String get projectNextStepOpenTask => 'Aufgabe öffnen';
+
+  @override
+  String get projectNextStepRetry => 'Erneut versuchen';
+
+  @override
+  String get projectNextStepsAddAll => 'Alle als Aufgaben hinzufügen';
+
+  @override
+  String projectNextStepsAgoDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'vor $count Tagen',
+      one: 'vor 1 Tag',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsAgoHours(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'vor $count Std.',
+      one: 'vor 1 Std.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsAgoJustNow => 'gerade eben';
+
+  @override
+  String projectNextStepsAgoMinutes(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'vor $count Min.',
+      one: 'vor 1 Min.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountAdded(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count hinzugefügt',
+      one: '1 hinzugefügt',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDismissed(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count verworfen',
+      one: '1 verworfen',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count erledigt',
+      one: '1 erledigt',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsDismissAll => 'Alle verwerfen';
+
+  @override
+  String get projectNextStepsEmpty => 'Keine offenen Vorschläge.';
+
+  @override
+  String get projectNextStepsHideHistory => 'Ausblenden';
+
+  @override
+  String projectNextStepsLastLooked(String ago) {
+    return 'Zuletzt geprüft $ago.';
+  }
+
+  @override
+  String projectNextStepsLastRun(String summary, String ago) {
+    return 'Letzter Lauf: $summary · $ago';
+  }
+
+  @override
+  String get projectNextStepsShowHistory => 'Anzeigen';
+
+  @override
+  String projectNextStepsShowMore(int count) {
+    return '$count weitere anzeigen';
+  }
+
+  @override
   String get projectNoLinkedTasks => 'Noch keine Aufgaben verknüpft';
 
   @override
@@ -10338,12 +10462,6 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get projectPickerUpdateFailed =>
       'Das Projekt der Aufgabe konnte nicht geändert werden. Prüfe Kategorie und Datenschutz und versuche es erneut.';
-
-  @override
-  String get projectRecommendationDismissTooltip => 'Ausblenden';
-
-  @override
-  String get projectRecommendationResolveTooltip => 'Als erledigt markieren';
 
   @override
   String get projectRecommendationsTitle => 'Empfohlene nächste Schritte';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -10331,10 +10331,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get projectNextStepCreating => 'Aufgabe wird erstellt…';
 
   @override
-  String get projectNextStepDismiss => 'Verwerfen';
+  String get projectNextStepDismiss => 'Übergehen';
 
   @override
-  String get projectNextStepDismissed => 'Verworfen';
+  String get projectNextStepDismissed => 'Übergangen';
 
   @override
   String get projectNextStepDone => 'Erledigt';
@@ -10400,8 +10400,8 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count verworfen',
-      one: '1 verworfen',
+      other: '$count übergangen',
+      one: '1 übergangen',
     );
     return '$_temp0';
   }
@@ -10418,13 +10418,13 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get projectNextStepsDismissAll => 'Alle verwerfen';
+  String get projectNextStepsDismissAll => 'Alle übergehen';
 
   @override
   String get projectNextStepsEmpty => 'Keine offenen Vorschläge.';
 
   @override
-  String get projectNextStepsHideHistory => 'Ausblenden';
+  String get projectNextStepsHideHistory => 'Verlauf ausblenden';
 
   @override
   String projectNextStepsLastLooked(String ago) {
@@ -10437,7 +10437,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get projectNextStepsShowHistory => 'Anzeigen';
+  String get projectNextStepsShowHistory => 'Verlauf anzeigen';
 
   @override
   String projectNextStepsShowMore(int count) {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -10307,7 +10307,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectNextStepsEmpty => 'No open suggestions.';
 
   @override
-  String get projectNextStepsHideHistory => 'Hide';
+  String get projectNextStepsHideHistory => 'Hide history';
 
   @override
   String projectNextStepsLastLooked(String ago) {
@@ -10320,7 +10320,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get projectNextStepsShowHistory => 'Show';
+  String get projectNextStepsShowHistory => 'Show history';
 
   @override
   String projectNextStepsShowMore(int count) {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -10204,6 +10204,130 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectManageTooltip => 'Manage projects';
 
   @override
+  String get projectNextStepAdded => 'Added';
+
+  @override
+  String get projectNextStepCreateFailed =>
+      'Couldn\'t create the task. Update now to load the current list, or retry.';
+
+  @override
+  String get projectNextStepCreating => 'Creating task…';
+
+  @override
+  String get projectNextStepDismiss => 'Dismiss';
+
+  @override
+  String get projectNextStepDismissed => 'Dismissed';
+
+  @override
+  String get projectNextStepDone => 'Done';
+
+  @override
+  String get projectNextStepOpenTask => 'Open task';
+
+  @override
+  String get projectNextStepRetry => 'Retry';
+
+  @override
+  String get projectNextStepsAddAll => 'Add all as tasks';
+
+  @override
+  String projectNextStepsAgoDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count days ago',
+      one: '1 day ago',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsAgoHours(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count h ago',
+      one: '1 h ago',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsAgoJustNow => 'just now';
+
+  @override
+  String projectNextStepsAgoMinutes(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count min ago',
+      one: '1 min ago',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountAdded(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count added',
+      one: '1 added',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDismissed(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dismissed',
+      one: '1 dismissed',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count done',
+      one: '1 done',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsDismissAll => 'Dismiss all';
+
+  @override
+  String get projectNextStepsEmpty => 'No open suggestions.';
+
+  @override
+  String get projectNextStepsHideHistory => 'Hide';
+
+  @override
+  String projectNextStepsLastLooked(String ago) {
+    return 'Last looked $ago.';
+  }
+
+  @override
+  String projectNextStepsLastRun(String summary, String ago) {
+    return 'Last run: $summary · $ago';
+  }
+
+  @override
+  String get projectNextStepsShowHistory => 'Show';
+
+  @override
+  String projectNextStepsShowMore(int count) {
+    return 'Show $count more';
+  }
+
+  @override
   String get projectNoLinkedTasks => 'No tasks linked yet';
 
   @override
@@ -10221,12 +10345,6 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get projectPickerUpdateFailed =>
       'Could not change this task\'s project. Check its category and privacy, then try again.';
-
-  @override
-  String get projectRecommendationDismissTooltip => 'Dismiss';
-
-  @override
-  String get projectRecommendationResolveTooltip => 'Mark resolved';
 
   @override
   String get projectRecommendationsTitle => 'Recommended next steps';
@@ -14520,9 +14638,6 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
 
   @override
   String get goalDetailTimelineTitle => 'Interactions';
-
-  @override
-  String get goalPendingProposalBadge => 'Proposal awaiting review';
 
   @override
   String get goalStatusAchieved => 'Achieved';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -10504,7 +10504,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get projectNextStepsEmpty => 'No hay sugerencias abiertas.';
 
   @override
-  String get projectNextStepsHideHistory => 'Ocultar';
+  String get projectNextStepsHideHistory => 'Ocultar historial';
 
   @override
   String projectNextStepsLastLooked(String ago) {
@@ -10517,7 +10517,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get projectNextStepsShowHistory => 'Mostrar';
+  String get projectNextStepsShowHistory => 'Mostrar historial';
 
   @override
   String projectNextStepsShowMore(int count) {

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -10401,6 +10401,130 @@ class AppLocalizationsEs extends AppLocalizations {
   String get projectManageTooltip => 'Gestionar proyectos';
 
   @override
+  String get projectNextStepAdded => 'Añadido';
+
+  @override
+  String get projectNextStepCreateFailed =>
+      'No se pudo crear la tarea. Actualiza ahora para cargar la lista actual o vuelve a intentarlo.';
+
+  @override
+  String get projectNextStepCreating => 'Creando tarea…';
+
+  @override
+  String get projectNextStepDismiss => 'Descartar';
+
+  @override
+  String get projectNextStepDismissed => 'Descartado';
+
+  @override
+  String get projectNextStepDone => 'Hecho';
+
+  @override
+  String get projectNextStepOpenTask => 'Abrir tarea';
+
+  @override
+  String get projectNextStepRetry => 'Reintentar';
+
+  @override
+  String get projectNextStepsAddAll => 'Añadir todos como tareas';
+
+  @override
+  String projectNextStepsAgoDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'hace $count días',
+      one: 'hace 1 día',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsAgoHours(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'hace $count h',
+      one: 'hace 1 h',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsAgoJustNow => 'ahora mismo';
+
+  @override
+  String projectNextStepsAgoMinutes(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'hace $count min',
+      one: 'hace 1 min',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountAdded(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count añadidos',
+      one: '1 añadido',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDismissed(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count descartados',
+      one: '1 descartado',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count hechos',
+      one: '1 hecho',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsDismissAll => 'Descartar todos';
+
+  @override
+  String get projectNextStepsEmpty => 'No hay sugerencias abiertas.';
+
+  @override
+  String get projectNextStepsHideHistory => 'Ocultar';
+
+  @override
+  String projectNextStepsLastLooked(String ago) {
+    return 'Última revisión $ago.';
+  }
+
+  @override
+  String projectNextStepsLastRun(String summary, String ago) {
+    return 'Última ejecución: $summary · $ago';
+  }
+
+  @override
+  String get projectNextStepsShowHistory => 'Mostrar';
+
+  @override
+  String projectNextStepsShowMore(int count) {
+    return 'Mostrar $count más';
+  }
+
+  @override
   String get projectNoLinkedTasks => 'Aún no hay tareas vinculadas';
 
   @override
@@ -10418,12 +10542,6 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get projectPickerUpdateFailed =>
       'No se pudo cambiar el proyecto de la tarea. Comprueba la categoría y la privacidad e inténtalo de nuevo.';
-
-  @override
-  String get projectRecommendationDismissTooltip => 'Descartar';
-
-  @override
-  String get projectRecommendationResolveTooltip => 'Marcar como resuelto';
 
   @override
   String get projectRecommendationsTitle => 'Siguientes pasos recomendados';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -10430,6 +10430,130 @@ class AppLocalizationsFr extends AppLocalizations {
   String get projectManageTooltip => 'Gérer les projets';
 
   @override
+  String get projectNextStepAdded => 'Ajouté';
+
+  @override
+  String get projectNextStepCreateFailed =>
+      'Impossible de créer la tâche. Mets à jour maintenant pour charger la liste actuelle, ou réessaie.';
+
+  @override
+  String get projectNextStepCreating => 'Création de la tâche…';
+
+  @override
+  String get projectNextStepDismiss => 'Ignorer';
+
+  @override
+  String get projectNextStepDismissed => 'Ignoré';
+
+  @override
+  String get projectNextStepDone => 'Fait';
+
+  @override
+  String get projectNextStepOpenTask => 'Ouvrir la tâche';
+
+  @override
+  String get projectNextStepRetry => 'Réessayer';
+
+  @override
+  String get projectNextStepsAddAll => 'Tout ajouter comme tâches';
+
+  @override
+  String projectNextStepsAgoDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'il y a $count jours',
+      one: 'il y a 1 jour',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsAgoHours(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'il y a $count h',
+      one: 'il y a 1 h',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsAgoJustNow => 'à l\'instant';
+
+  @override
+  String projectNextStepsAgoMinutes(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'il y a $count min',
+      one: 'il y a 1 min',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountAdded(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ajoutés',
+      one: '1 ajouté',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDismissed(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ignorés',
+      one: '1 ignoré',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count faits',
+      one: '1 fait',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsDismissAll => 'Tout ignorer';
+
+  @override
+  String get projectNextStepsEmpty => 'Aucune suggestion ouverte.';
+
+  @override
+  String get projectNextStepsHideHistory => 'Masquer';
+
+  @override
+  String projectNextStepsLastLooked(String ago) {
+    return 'Dernière vérification $ago.';
+  }
+
+  @override
+  String projectNextStepsLastRun(String summary, String ago) {
+    return 'Dernière exécution : $summary · $ago';
+  }
+
+  @override
+  String get projectNextStepsShowHistory => 'Afficher';
+
+  @override
+  String projectNextStepsShowMore(int count) {
+    return 'Afficher $count de plus';
+  }
+
+  @override
   String get projectNoLinkedTasks => 'Aucune tâche liée pour le moment';
 
   @override
@@ -10447,12 +10571,6 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get projectPickerUpdateFailed =>
       'Impossible de modifier le projet de la tâche. Vérifie la catégorie et la confidentialité, puis réessaie.';
-
-  @override
-  String get projectRecommendationDismissTooltip => 'Ignorer';
-
-  @override
-  String get projectRecommendationResolveTooltip => 'Marquer comme résolue';
 
   @override
   String get projectRecommendationsTitle => 'Prochaines étapes recommandées';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -10430,7 +10430,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get projectManageTooltip => 'Gérer les projets';
 
   @override
-  String get projectNextStepAdded => 'Ajouté';
+  String get projectNextStepAdded => 'Ajoutée';
 
   @override
   String get projectNextStepCreateFailed =>
@@ -10443,10 +10443,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get projectNextStepDismiss => 'Ignorer';
 
   @override
-  String get projectNextStepDismissed => 'Ignoré';
+  String get projectNextStepDismissed => 'Ignorée';
 
   @override
-  String get projectNextStepDone => 'Fait';
+  String get projectNextStepDone => 'Faite';
 
   @override
   String get projectNextStepOpenTask => 'Ouvrir la tâche';
@@ -10498,8 +10498,8 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ajoutés',
-      one: '1 ajouté',
+      other: '$count ajoutées',
+      one: '1 ajoutée',
     );
     return '$_temp0';
   }
@@ -10509,8 +10509,8 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count ignorés',
-      one: '1 ignoré',
+      other: '$count ignorées',
+      one: '1 ignorée',
     );
     return '$_temp0';
   }
@@ -10520,8 +10520,8 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count faits',
-      one: '1 fait',
+      other: '$count faites',
+      one: '1 faite',
     );
     return '$_temp0';
   }
@@ -10533,7 +10533,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get projectNextStepsEmpty => 'Aucune suggestion ouverte.';
 
   @override
-  String get projectNextStepsHideHistory => 'Masquer';
+  String get projectNextStepsHideHistory => 'Masquer l\'historique';
 
   @override
   String projectNextStepsLastLooked(String ago) {
@@ -10546,7 +10546,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get projectNextStepsShowHistory => 'Afficher';
+  String get projectNextStepsShowHistory => 'Afficher l\'historique';
 
   @override
   String projectNextStepsShowMore(int count) {

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -10387,6 +10387,130 @@ class AppLocalizationsIt extends AppLocalizations {
   String get projectManageTooltip => 'Gestione dei progetti';
 
   @override
+  String get projectNextStepAdded => 'Aggiunto';
+
+  @override
+  String get projectNextStepCreateFailed =>
+      'Impossibile creare l\'attività. Aggiorna ora per caricare l\'elenco attuale oppure riprova.';
+
+  @override
+  String get projectNextStepCreating => 'Creazione attività…';
+
+  @override
+  String get projectNextStepDismiss => 'Ignora';
+
+  @override
+  String get projectNextStepDismissed => 'Ignorato';
+
+  @override
+  String get projectNextStepDone => 'Fatto';
+
+  @override
+  String get projectNextStepOpenTask => 'Apri attività';
+
+  @override
+  String get projectNextStepRetry => 'Riprova';
+
+  @override
+  String get projectNextStepsAddAll => 'Aggiungi tutti come attività';
+
+  @override
+  String projectNextStepsAgoDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count giorni fa',
+      one: '1 giorno fa',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsAgoHours(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count h fa',
+      one: '1 h fa',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsAgoJustNow => 'proprio ora';
+
+  @override
+  String projectNextStepsAgoMinutes(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count min fa',
+      one: '1 min fa',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountAdded(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count aggiunti',
+      one: '1 aggiunto',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDismissed(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ignorati',
+      one: '1 ignorato',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count fatti',
+      one: '1 fatto',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsDismissAll => 'Ignora tutti';
+
+  @override
+  String get projectNextStepsEmpty => 'Nessun suggerimento aperto.';
+
+  @override
+  String get projectNextStepsHideHistory => 'Nascondi';
+
+  @override
+  String projectNextStepsLastLooked(String ago) {
+    return 'Ultimo controllo $ago.';
+  }
+
+  @override
+  String projectNextStepsLastRun(String summary, String ago) {
+    return 'Ultima esecuzione: $summary · $ago';
+  }
+
+  @override
+  String get projectNextStepsShowHistory => 'Mostra';
+
+  @override
+  String projectNextStepsShowMore(int count) {
+    return 'Mostra altri $count';
+  }
+
+  @override
   String get projectNoLinkedTasks => 'Nessun compito ancora collegato';
 
   @override
@@ -10404,12 +10528,6 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get projectPickerUpdateFailed =>
       'Impossibile modificare il progetto dell\'attività. Controlla categoria e privacy e riprova.';
-
-  @override
-  String get projectRecommendationDismissTooltip => 'Discorso';
-
-  @override
-  String get projectRecommendationResolveTooltip => 'Mark risolto';
 
   @override
   String get projectRecommendationsTitle => 'Prossimi passi consigliati';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -10490,7 +10490,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get projectNextStepsEmpty => 'Nessun suggerimento aperto.';
 
   @override
-  String get projectNextStepsHideHistory => 'Nascondi';
+  String get projectNextStepsHideHistory => 'Nascondi cronologia';
 
   @override
   String projectNextStepsLastLooked(String ago) {
@@ -10503,7 +10503,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get projectNextStepsShowHistory => 'Mostra';
+  String get projectNextStepsShowHistory => 'Mostra cronologia';
 
   @override
   String projectNextStepsShowMore(int count) {

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -10268,6 +10268,130 @@ class AppLocalizationsNl extends AppLocalizations {
   String get projectManageTooltip => 'Projecten beheren';
 
   @override
+  String get projectNextStepAdded => 'Toegevoegd';
+
+  @override
+  String get projectNextStepCreateFailed =>
+      'De taak kon niet worden aangemaakt. Werk nu bij om de actuele lijst te laden, of probeer het opnieuw.';
+
+  @override
+  String get projectNextStepCreating => 'Taak wordt aangemaakt…';
+
+  @override
+  String get projectNextStepDismiss => 'Afwijzen';
+
+  @override
+  String get projectNextStepDismissed => 'Afgewezen';
+
+  @override
+  String get projectNextStepDone => 'Klaar';
+
+  @override
+  String get projectNextStepOpenTask => 'Taak openen';
+
+  @override
+  String get projectNextStepRetry => 'Opnieuw proberen';
+
+  @override
+  String get projectNextStepsAddAll => 'Alles als taken toevoegen';
+
+  @override
+  String projectNextStepsAgoDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dagen geleden',
+      one: '1 dag geleden',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsAgoHours(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count u geleden',
+      one: '1 u geleden',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsAgoJustNow => 'zojuist';
+
+  @override
+  String projectNextStepsAgoMinutes(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count min geleden',
+      one: '1 min geleden',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountAdded(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count toegevoegd',
+      one: '1 toegevoegd',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDismissed(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count afgewezen',
+      one: '1 afgewezen',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count klaar',
+      one: '1 klaar',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsDismissAll => 'Alles afwijzen';
+
+  @override
+  String get projectNextStepsEmpty => 'Geen open suggesties.';
+
+  @override
+  String get projectNextStepsHideHistory => 'Verbergen';
+
+  @override
+  String projectNextStepsLastLooked(String ago) {
+    return 'Laatst bekeken $ago.';
+  }
+
+  @override
+  String projectNextStepsLastRun(String summary, String ago) {
+    return 'Laatste run: $summary · $ago';
+  }
+
+  @override
+  String get projectNextStepsShowHistory => 'Tonen';
+
+  @override
+  String projectNextStepsShowMore(int count) {
+    return 'Nog $count tonen';
+  }
+
+  @override
   String get projectNoLinkedTasks => 'Nog geen taken verbonden';
 
   @override
@@ -10285,12 +10409,6 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get projectPickerUpdateFailed =>
       'Het project van de taak kon niet worden gewijzigd. Controleer de categorie en privacy en probeer het opnieuw.';
-
-  @override
-  String get projectRecommendationDismissTooltip => 'Ingerukt';
-
-  @override
-  String get projectRecommendationResolveTooltip => 'Markering is opgelost';
 
   @override
   String get projectRecommendationsTitle => 'Aanbevolen volgende stappen';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -10278,10 +10278,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get projectNextStepCreating => 'Taak wordt aangemaakt…';
 
   @override
-  String get projectNextStepDismiss => 'Afwijzen';
+  String get projectNextStepDismiss => 'Negeren';
 
   @override
-  String get projectNextStepDismissed => 'Afgewezen';
+  String get projectNextStepDismissed => 'Genegeerd';
 
   @override
   String get projectNextStepDone => 'Klaar';
@@ -10347,8 +10347,8 @@ class AppLocalizationsNl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count afgewezen',
-      one: '1 afgewezen',
+      other: '$count genegeerd',
+      one: '1 genegeerd',
     );
     return '$_temp0';
   }
@@ -10365,13 +10365,13 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get projectNextStepsDismissAll => 'Alles afwijzen';
+  String get projectNextStepsDismissAll => 'Alles negeren';
 
   @override
   String get projectNextStepsEmpty => 'Geen open suggesties.';
 
   @override
-  String get projectNextStepsHideHistory => 'Verbergen';
+  String get projectNextStepsHideHistory => 'Geschiedenis verbergen';
 
   @override
   String projectNextStepsLastLooked(String ago) {
@@ -10384,7 +10384,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get projectNextStepsShowHistory => 'Tonen';
+  String get projectNextStepsShowHistory => 'Geschiedenis tonen';
 
   @override
   String projectNextStepsShowMore(int count) {

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -10451,7 +10451,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get projectNextStepsEmpty => 'Nenhuma sugestão aberta.';
 
   @override
-  String get projectNextStepsHideHistory => 'Ocultar';
+  String get projectNextStepsHideHistory => 'Ocultar histórico';
 
   @override
   String projectNextStepsLastLooked(String ago) {
@@ -10464,7 +10464,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get projectNextStepsShowHistory => 'Mostrar';
+  String get projectNextStepsShowHistory => 'Mostrar histórico';
 
   @override
   String projectNextStepsShowMore(int count) {

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -10348,6 +10348,130 @@ class AppLocalizationsPt extends AppLocalizations {
   String get projectManageTooltip => 'Gerenciar projetos';
 
   @override
+  String get projectNextStepAdded => 'Adicionado';
+
+  @override
+  String get projectNextStepCreateFailed =>
+      'Não foi possível criar a tarefa. Atualiza agora para carregar a lista atual ou tenta de novo.';
+
+  @override
+  String get projectNextStepCreating => 'Criando tarefa…';
+
+  @override
+  String get projectNextStepDismiss => 'Descartar';
+
+  @override
+  String get projectNextStepDismissed => 'Descartado';
+
+  @override
+  String get projectNextStepDone => 'Concluído';
+
+  @override
+  String get projectNextStepOpenTask => 'Abrir tarefa';
+
+  @override
+  String get projectNextStepRetry => 'Tentar de novo';
+
+  @override
+  String get projectNextStepsAddAll => 'Adicionar todos como tarefas';
+
+  @override
+  String projectNextStepsAgoDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'há $count dias',
+      one: 'há 1 dia',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsAgoHours(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'há $count h',
+      one: 'há 1 h',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsAgoJustNow => 'agora mesmo';
+
+  @override
+  String projectNextStepsAgoMinutes(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'há $count min',
+      one: 'há 1 min',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountAdded(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count adicionados',
+      one: '1 adicionado',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDismissed(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count descartados',
+      one: '1 descartado',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count concluídos',
+      one: '1 concluído',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsDismissAll => 'Descartar todos';
+
+  @override
+  String get projectNextStepsEmpty => 'Nenhuma sugestão aberta.';
+
+  @override
+  String get projectNextStepsHideHistory => 'Ocultar';
+
+  @override
+  String projectNextStepsLastLooked(String ago) {
+    return 'Última verificação $ago.';
+  }
+
+  @override
+  String projectNextStepsLastRun(String summary, String ago) {
+    return 'Última execução: $summary · $ago';
+  }
+
+  @override
+  String get projectNextStepsShowHistory => 'Mostrar';
+
+  @override
+  String projectNextStepsShowMore(int count) {
+    return 'Mostrar mais $count';
+  }
+
+  @override
   String get projectNoLinkedTasks => 'Nenhuma tarefa vinculada ainda';
 
   @override
@@ -10365,12 +10489,6 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get projectPickerUpdateFailed =>
       'Não foi possível alterar o projeto da tarefa. Verifica a categoria e a privacidade e tenta novamente.';
-
-  @override
-  String get projectRecommendationDismissTooltip => 'Dispensar';
-
-  @override
-  String get projectRecommendationResolveTooltip => 'Marcar como resolvido';
 
   @override
   String get projectRecommendationsTitle => 'Próximas etapas recomendadas';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -10452,6 +10452,134 @@ class AppLocalizationsRo extends AppLocalizations {
   String get projectManageTooltip => 'Gestionați proiectele';
 
   @override
+  String get projectNextStepAdded => 'Adăugat';
+
+  @override
+  String get projectNextStepCreateFailed =>
+      'Sarcina nu a putut fi creată. Actualizați acum pentru a încărca lista curentă sau reîncercați.';
+
+  @override
+  String get projectNextStepCreating => 'Se creează sarcina…';
+
+  @override
+  String get projectNextStepDismiss => 'Respingeți';
+
+  @override
+  String get projectNextStepDismissed => 'Respins';
+
+  @override
+  String get projectNextStepDone => 'Finalizat';
+
+  @override
+  String get projectNextStepOpenTask => 'Deschideți sarcina';
+
+  @override
+  String get projectNextStepRetry => 'Reîncercați';
+
+  @override
+  String get projectNextStepsAddAll => 'Adăugați toate ca sarcini';
+
+  @override
+  String projectNextStepsAgoDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'acum $count de zile',
+      few: 'acum $count zile',
+      one: 'acum 1 zi',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsAgoHours(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'acum $count h',
+      one: 'acum 1 h',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsAgoJustNow => 'chiar acum';
+
+  @override
+  String projectNextStepsAgoMinutes(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'acum $count min',
+      one: 'acum 1 min',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountAdded(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count de adăugate',
+      few: '$count adăugate',
+      one: '1 adăugat',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDismissed(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count de respinse',
+      few: '$count respinse',
+      one: '1 respins',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count de finalizate',
+      few: '$count finalizate',
+      one: '1 finalizat',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsDismissAll => 'Respingeți toate';
+
+  @override
+  String get projectNextStepsEmpty => 'Nicio sugestie deschisă.';
+
+  @override
+  String get projectNextStepsHideHistory => 'Ascundeți';
+
+  @override
+  String projectNextStepsLastLooked(String ago) {
+    return 'Ultima verificare $ago.';
+  }
+
+  @override
+  String projectNextStepsLastRun(String summary, String ago) {
+    return 'Ultima rulare: $summary · $ago';
+  }
+
+  @override
+  String get projectNextStepsShowHistory => 'Afișați';
+
+  @override
+  String projectNextStepsShowMore(int count) {
+    return 'Afișați încă $count';
+  }
+
+  @override
   String get projectNoLinkedTasks => 'Nicio sarcină asociată încă';
 
   @override
@@ -10469,12 +10597,6 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get projectPickerUpdateFailed =>
       'Proiectul sarcinii nu a putut fi schimbat. Verificați categoria și confidențialitatea, apoi încercați din nou.';
-
-  @override
-  String get projectRecommendationDismissTooltip => 'Respinge';
-
-  @override
-  String get projectRecommendationResolveTooltip => 'Marcați ca rezolvat';
 
   @override
   String get projectRecommendationsTitle => 'Pași următori recomandați';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -10521,8 +10521,8 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count de adăugate',
-      few: '$count adăugate',
+      other: '$count de adăugați',
+      few: '$count adăugați',
       one: '1 adăugat',
     );
     return '$_temp0';
@@ -10533,8 +10533,8 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count de respinse',
-      few: '$count respinse',
+      other: '$count de respinși',
+      few: '$count respinși',
       one: '1 respins',
     );
     return '$_temp0';
@@ -10545,8 +10545,8 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count de finalizate',
-      few: '$count finalizate',
+      other: '$count de finalizați',
+      few: '$count finalizați',
       one: '1 finalizat',
     );
     return '$_temp0';
@@ -10559,7 +10559,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get projectNextStepsEmpty => 'Nicio sugestie deschisă.';
 
   @override
-  String get projectNextStepsHideHistory => 'Ascundeți';
+  String get projectNextStepsHideHistory => 'Ascundeți istoricul';
 
   @override
   String projectNextStepsLastLooked(String ago) {
@@ -10572,7 +10572,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get projectNextStepsShowHistory => 'Afișați';
+  String get projectNextStepsShowHistory => 'Afișați istoricul';
 
   @override
   String projectNextStepsShowMore(int count) {

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -10263,6 +10263,130 @@ class AppLocalizationsSv extends AppLocalizations {
   String get projectManageTooltip => 'Hantera projekt';
 
   @override
+  String get projectNextStepAdded => 'Tillagd';
+
+  @override
+  String get projectNextStepCreateFailed =>
+      'Uppgiften kunde inte skapas. Uppdatera nu för att läsa in den aktuella listan, eller försök igen.';
+
+  @override
+  String get projectNextStepCreating => 'Skapar uppgift…';
+
+  @override
+  String get projectNextStepDismiss => 'Avfärda';
+
+  @override
+  String get projectNextStepDismissed => 'Avfärdad';
+
+  @override
+  String get projectNextStepDone => 'Klar';
+
+  @override
+  String get projectNextStepOpenTask => 'Öppna uppgift';
+
+  @override
+  String get projectNextStepRetry => 'Försök igen';
+
+  @override
+  String get projectNextStepsAddAll => 'Lägg till alla som uppgifter';
+
+  @override
+  String projectNextStepsAgoDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dagar sedan',
+      one: '1 dag sedan',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsAgoHours(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count h sedan',
+      one: '1 h sedan',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsAgoJustNow => 'nyss';
+
+  @override
+  String projectNextStepsAgoMinutes(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count min sedan',
+      one: '1 min sedan',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountAdded(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count tillagda',
+      one: '1 tillagd',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDismissed(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count avfärdade',
+      one: '1 avfärdad',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String projectNextStepsCountDone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count klara',
+      one: '1 klar',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get projectNextStepsDismissAll => 'Avfärda alla';
+
+  @override
+  String get projectNextStepsEmpty => 'Inga öppna förslag.';
+
+  @override
+  String get projectNextStepsHideHistory => 'Dölj';
+
+  @override
+  String projectNextStepsLastLooked(String ago) {
+    return 'Senast kontrollerat $ago.';
+  }
+
+  @override
+  String projectNextStepsLastRun(String summary, String ago) {
+    return 'Senaste körning: $summary · $ago';
+  }
+
+  @override
+  String get projectNextStepsShowHistory => 'Visa';
+
+  @override
+  String projectNextStepsShowMore(int count) {
+    return 'Visa $count till';
+  }
+
+  @override
   String get projectNoLinkedTasks => 'Inga uppgifter är länkade än';
 
   @override
@@ -10280,12 +10404,6 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get projectPickerUpdateFailed =>
       'Det gick inte att ändra uppgiftens projekt. Kontrollera kategori och sekretess och försök igen.';
-
-  @override
-  String get projectRecommendationDismissTooltip => 'Avslut';
-
-  @override
-  String get projectRecommendationResolveTooltip => 'Mark bestämde sig';
 
   @override
   String get projectRecommendationsTitle => 'Rekommenderade nästa steg';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -10263,7 +10263,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get projectManageTooltip => 'Hantera projekt';
 
   @override
-  String get projectNextStepAdded => 'Tillagd';
+  String get projectNextStepAdded => 'Tillagt';
 
   @override
   String get projectNextStepCreateFailed =>
@@ -10276,10 +10276,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get projectNextStepDismiss => 'Avfärda';
 
   @override
-  String get projectNextStepDismissed => 'Avfärdad';
+  String get projectNextStepDismissed => 'Avfärdat';
 
   @override
-  String get projectNextStepDone => 'Klar';
+  String get projectNextStepDone => 'Klart';
 
   @override
   String get projectNextStepOpenTask => 'Öppna uppgift';
@@ -10332,7 +10332,7 @@ class AppLocalizationsSv extends AppLocalizations {
       count,
       locale: localeName,
       other: '$count tillagda',
-      one: '1 tillagd',
+      one: '1 tillagt',
     );
     return '$_temp0';
   }
@@ -10343,7 +10343,7 @@ class AppLocalizationsSv extends AppLocalizations {
       count,
       locale: localeName,
       other: '$count avfärdade',
-      one: '1 avfärdad',
+      one: '1 avfärdat',
     );
     return '$_temp0';
   }
@@ -10354,7 +10354,7 @@ class AppLocalizationsSv extends AppLocalizations {
       count,
       locale: localeName,
       other: '$count klara',
-      one: '1 klar',
+      one: '1 klart',
     );
     return '$_temp0';
   }
@@ -10366,7 +10366,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get projectNextStepsEmpty => 'Inga öppna förslag.';
 
   @override
-  String get projectNextStepsHideHistory => 'Dölj';
+  String get projectNextStepsHideHistory => 'Dölj historik';
 
   @override
   String projectNextStepsLastLooked(String ago) {
@@ -10379,7 +10379,7 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get projectNextStepsShowHistory => 'Visa';
+  String get projectNextStepsShowHistory => 'Visa historik';
 
   @override
   String projectNextStepsShowMore(int count) {

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4404,14 +4404,101 @@
   },
   "projectLinkedTasks": "Gekoppelde taken",
   "projectManageTooltip": "Projecten beheren",
+  "projectNextStepAdded": "Toegevoegd",
+  "projectNextStepCreateFailed": "De taak kon niet worden aangemaakt. Werk nu bij om de actuele lijst te laden, of probeer het opnieuw.",
+  "projectNextStepCreating": "Taak wordt aangemaakt…",
+  "projectNextStepDismiss": "Afwijzen",
+  "projectNextStepDismissed": "Afgewezen",
+  "projectNextStepDone": "Klaar",
+  "projectNextStepOpenTask": "Taak openen",
+  "projectNextStepRetry": "Opnieuw proberen",
+  "projectNextStepsAddAll": "Alles als taken toevoegen",
+  "projectNextStepsAgoDays": "{count, plural, =1{1 dag geleden} other{{count} dagen geleden}}",
+  "@projectNextStepsAgoDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoHours": "{count, plural, =1{1 u geleden} other{{count} u geleden}}",
+  "@projectNextStepsAgoHours": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoJustNow": "zojuist",
+  "projectNextStepsAgoMinutes": "{count, plural, =1{1 min geleden} other{{count} min geleden}}",
+  "@projectNextStepsAgoMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountAdded": "{count, plural, =1{1 toegevoegd} other{{count} toegevoegd}}",
+  "@projectNextStepsCountAdded": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 afgewezen} other{{count} afgewezen}}",
+  "@projectNextStepsCountDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDone": "{count, plural, =1{1 klaar} other{{count} klaar}}",
+  "@projectNextStepsCountDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsDismissAll": "Alles afwijzen",
+  "projectNextStepsEmpty": "Geen open suggesties.",
+  "projectNextStepsHideHistory": "Verbergen",
+  "projectNextStepsLastLooked": "Laatst bekeken {ago}.",
+  "@projectNextStepsLastLooked": {
+    "placeholders": {
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsLastRun": "Laatste run: {summary} · {ago}",
+  "@projectNextStepsLastRun": {
+    "placeholders": {
+      "summary": {
+        "type": "String"
+      },
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsShowHistory": "Tonen",
+  "projectNextStepsShowMore": "Nog {count} tonen",
+  "@projectNextStepsShowMore": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "projectNoLinkedTasks": "Nog geen taken verbonden",
   "projectNoProjects": "Nog geen projecten",
   "projectNotFound": "Project niet gevonden",
   "projectPickerLabel": "Project",
   "projectPickerUnassigned": "Geen project",
   "projectPickerUpdateFailed": "Het project van de taak kon niet worden gewijzigd. Controleer de categorie en privacy en probeer het opnieuw.",
-  "projectRecommendationDismissTooltip": "Ingerukt",
-  "projectRecommendationResolveTooltip": "Markering is opgelost",
   "projectRecommendationsTitle": "Aanbevolen volgende stappen",
   "projectRecommendationUpdateError": "Ik kon de aanbeveling niet bijwerken.",
   "projectsClearFilters": "Filters wissen",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4407,8 +4407,8 @@
   "projectNextStepAdded": "Toegevoegd",
   "projectNextStepCreateFailed": "De taak kon niet worden aangemaakt. Werk nu bij om de actuele lijst te laden, of probeer het opnieuw.",
   "projectNextStepCreating": "Taak wordt aangemaakt…",
-  "projectNextStepDismiss": "Afwijzen",
-  "projectNextStepDismissed": "Afgewezen",
+  "projectNextStepDismiss": "Negeren",
+  "projectNextStepDismissed": "Genegeerd",
   "projectNextStepDone": "Klaar",
   "projectNextStepOpenTask": "Taak openen",
   "projectNextStepRetry": "Opnieuw proberen",
@@ -4446,7 +4446,7 @@
       }
     }
   },
-  "projectNextStepsCountDismissed": "{count, plural, =1{1 afgewezen} other{{count} afgewezen}}",
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 genegeerd} other{{count} genegeerd}}",
   "@projectNextStepsCountDismissed": {
     "placeholders": {
       "count": {
@@ -4462,9 +4462,9 @@
       }
     }
   },
-  "projectNextStepsDismissAll": "Alles afwijzen",
+  "projectNextStepsDismissAll": "Alles negeren",
   "projectNextStepsEmpty": "Geen open suggesties.",
-  "projectNextStepsHideHistory": "Verbergen",
+  "projectNextStepsHideHistory": "Geschiedenis verbergen",
   "projectNextStepsLastLooked": "Laatst bekeken {ago}.",
   "@projectNextStepsLastLooked": {
     "placeholders": {
@@ -4484,7 +4484,7 @@
       }
     }
   },
-  "projectNextStepsShowHistory": "Tonen",
+  "projectNextStepsShowHistory": "Geschiedenis tonen",
   "projectNextStepsShowMore": "Nog {count} tonen",
   "@projectNextStepsShowMore": {
     "placeholders": {

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4464,7 +4464,7 @@
   },
   "projectNextStepsDismissAll": "Descartar todos",
   "projectNextStepsEmpty": "Nenhuma sugestão aberta.",
-  "projectNextStepsHideHistory": "Ocultar",
+  "projectNextStepsHideHistory": "Ocultar histórico",
   "projectNextStepsLastLooked": "Última verificação {ago}.",
   "@projectNextStepsLastLooked": {
     "placeholders": {
@@ -4484,7 +4484,7 @@
       }
     }
   },
-  "projectNextStepsShowHistory": "Mostrar",
+  "projectNextStepsShowHistory": "Mostrar histórico",
   "projectNextStepsShowMore": "Mostrar mais {count}",
   "@projectNextStepsShowMore": {
     "placeholders": {

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4404,14 +4404,101 @@
   },
   "projectLinkedTasks": "Tarefas Vinculadas",
   "projectManageTooltip": "Gerenciar projetos",
+  "projectNextStepAdded": "Adicionado",
+  "projectNextStepCreateFailed": "Não foi possível criar a tarefa. Atualiza agora para carregar a lista atual ou tenta de novo.",
+  "projectNextStepCreating": "Criando tarefa…",
+  "projectNextStepDismiss": "Descartar",
+  "projectNextStepDismissed": "Descartado",
+  "projectNextStepDone": "Concluído",
+  "projectNextStepOpenTask": "Abrir tarefa",
+  "projectNextStepRetry": "Tentar de novo",
+  "projectNextStepsAddAll": "Adicionar todos como tarefas",
+  "projectNextStepsAgoDays": "{count, plural, =1{há 1 dia} other{há {count} dias}}",
+  "@projectNextStepsAgoDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoHours": "{count, plural, =1{há 1 h} other{há {count} h}}",
+  "@projectNextStepsAgoHours": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoJustNow": "agora mesmo",
+  "projectNextStepsAgoMinutes": "{count, plural, =1{há 1 min} other{há {count} min}}",
+  "@projectNextStepsAgoMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountAdded": "{count, plural, =1{1 adicionado} other{{count} adicionados}}",
+  "@projectNextStepsCountAdded": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 descartado} other{{count} descartados}}",
+  "@projectNextStepsCountDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDone": "{count, plural, =1{1 concluído} other{{count} concluídos}}",
+  "@projectNextStepsCountDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsDismissAll": "Descartar todos",
+  "projectNextStepsEmpty": "Nenhuma sugestão aberta.",
+  "projectNextStepsHideHistory": "Ocultar",
+  "projectNextStepsLastLooked": "Última verificação {ago}.",
+  "@projectNextStepsLastLooked": {
+    "placeholders": {
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsLastRun": "Última execução: {summary} · {ago}",
+  "@projectNextStepsLastRun": {
+    "placeholders": {
+      "summary": {
+        "type": "String"
+      },
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsShowHistory": "Mostrar",
+  "projectNextStepsShowMore": "Mostrar mais {count}",
+  "@projectNextStepsShowMore": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "projectNoLinkedTasks": "Nenhuma tarefa vinculada ainda",
   "projectNoProjects": "Ainda não há projetos",
   "projectNotFound": "Projeto não encontrado",
   "projectPickerLabel": "Projeto",
   "projectPickerUnassigned": "Nenhum projeto",
   "projectPickerUpdateFailed": "Não foi possível alterar o projeto da tarefa. Verifica a categoria e a privacidade e tenta novamente.",
-  "projectRecommendationDismissTooltip": "Dispensar",
-  "projectRecommendationResolveTooltip": "Marcar como resolvido",
   "projectRecommendationsTitle": "Próximas etapas recomendadas",
   "projectRecommendationUpdateError": "Não foi possível atualizar a recomendação. Por favor, tente novamente.",
   "projectsClearFilters": "Limpar filtros",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -3965,7 +3965,7 @@
       }
     }
   },
-  "projectNextStepsCountAdded": "{count, plural, =1{1 adăugat} few{{count} adăugate} other{{count} de adăugate}}",
+  "projectNextStepsCountAdded": "{count, plural, =1{1 adăugat} few{{count} adăugați} other{{count} de adăugați}}",
   "@projectNextStepsCountAdded": {
     "placeholders": {
       "count": {
@@ -3973,7 +3973,7 @@
       }
     }
   },
-  "projectNextStepsCountDismissed": "{count, plural, =1{1 respins} few{{count} respinse} other{{count} de respinse}}",
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 respins} few{{count} respinși} other{{count} de respinși}}",
   "@projectNextStepsCountDismissed": {
     "placeholders": {
       "count": {
@@ -3981,7 +3981,7 @@
       }
     }
   },
-  "projectNextStepsCountDone": "{count, plural, =1{1 finalizat} few{{count} finalizate} other{{count} de finalizate}}",
+  "projectNextStepsCountDone": "{count, plural, =1{1 finalizat} few{{count} finalizați} other{{count} de finalizați}}",
   "@projectNextStepsCountDone": {
     "placeholders": {
       "count": {
@@ -3991,7 +3991,7 @@
   },
   "projectNextStepsDismissAll": "Respingeți toate",
   "projectNextStepsEmpty": "Nicio sugestie deschisă.",
-  "projectNextStepsHideHistory": "Ascundeți",
+  "projectNextStepsHideHistory": "Ascundeți istoricul",
   "projectNextStepsLastLooked": "Ultima verificare {ago}.",
   "@projectNextStepsLastLooked": {
     "placeholders": {
@@ -4011,7 +4011,7 @@
       }
     }
   },
-  "projectNextStepsShowHistory": "Afișați",
+  "projectNextStepsShowHistory": "Afișați istoricul",
   "projectNextStepsShowMore": "Afișați încă {count}",
   "@projectNextStepsShowMore": {
     "placeholders": {

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -3931,14 +3931,101 @@
   },
   "projectLinkedTasks": "Sarcini asociate",
   "projectManageTooltip": "Gestionați proiectele",
+  "projectNextStepAdded": "Adăugat",
+  "projectNextStepCreateFailed": "Sarcina nu a putut fi creată. Actualizați acum pentru a încărca lista curentă sau reîncercați.",
+  "projectNextStepCreating": "Se creează sarcina…",
+  "projectNextStepDismiss": "Respingeți",
+  "projectNextStepDismissed": "Respins",
+  "projectNextStepDone": "Finalizat",
+  "projectNextStepOpenTask": "Deschideți sarcina",
+  "projectNextStepRetry": "Reîncercați",
+  "projectNextStepsAddAll": "Adăugați toate ca sarcini",
+  "projectNextStepsAgoDays": "{count, plural, =1{acum 1 zi} few{acum {count} zile} other{acum {count} de zile}}",
+  "@projectNextStepsAgoDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoHours": "{count, plural, =1{acum 1 h} other{acum {count} h}}",
+  "@projectNextStepsAgoHours": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoJustNow": "chiar acum",
+  "projectNextStepsAgoMinutes": "{count, plural, =1{acum 1 min} other{acum {count} min}}",
+  "@projectNextStepsAgoMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountAdded": "{count, plural, =1{1 adăugat} few{{count} adăugate} other{{count} de adăugate}}",
+  "@projectNextStepsCountAdded": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 respins} few{{count} respinse} other{{count} de respinse}}",
+  "@projectNextStepsCountDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDone": "{count, plural, =1{1 finalizat} few{{count} finalizate} other{{count} de finalizate}}",
+  "@projectNextStepsCountDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsDismissAll": "Respingeți toate",
+  "projectNextStepsEmpty": "Nicio sugestie deschisă.",
+  "projectNextStepsHideHistory": "Ascundeți",
+  "projectNextStepsLastLooked": "Ultima verificare {ago}.",
+  "@projectNextStepsLastLooked": {
+    "placeholders": {
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsLastRun": "Ultima rulare: {summary} · {ago}",
+  "@projectNextStepsLastRun": {
+    "placeholders": {
+      "summary": {
+        "type": "String"
+      },
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsShowHistory": "Afișați",
+  "projectNextStepsShowMore": "Afișați încă {count}",
+  "@projectNextStepsShowMore": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "projectNoLinkedTasks": "Nicio sarcină asociată încă",
   "projectNoProjects": "Niciun proiect încă",
   "projectNotFound": "Proiectul nu a fost găsit",
   "projectPickerLabel": "Proiect",
   "projectPickerUnassigned": "Fără proiect",
   "projectPickerUpdateFailed": "Proiectul sarcinii nu a putut fi schimbat. Verificați categoria și confidențialitatea, apoi încercați din nou.",
-  "projectRecommendationDismissTooltip": "Respinge",
-  "projectRecommendationResolveTooltip": "Marcați ca rezolvat",
   "projectRecommendationsTitle": "Pași următori recomandați",
   "projectRecommendationUpdateError": "Recomandarea nu a putut fi actualizată. Vă rugăm să încercați din nou.",
   "projectsClearFilters": "Ștergeți filtrele",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4405,12 +4405,12 @@
   },
   "projectLinkedTasks": "Länkade uppgifter",
   "projectManageTooltip": "Hantera projekt",
-  "projectNextStepAdded": "Tillagd",
+  "projectNextStepAdded": "Tillagt",
   "projectNextStepCreateFailed": "Uppgiften kunde inte skapas. Uppdatera nu för att läsa in den aktuella listan, eller försök igen.",
   "projectNextStepCreating": "Skapar uppgift…",
   "projectNextStepDismiss": "Avfärda",
-  "projectNextStepDismissed": "Avfärdad",
-  "projectNextStepDone": "Klar",
+  "projectNextStepDismissed": "Avfärdat",
+  "projectNextStepDone": "Klart",
   "projectNextStepOpenTask": "Öppna uppgift",
   "projectNextStepRetry": "Försök igen",
   "projectNextStepsAddAll": "Lägg till alla som uppgifter",
@@ -4439,7 +4439,7 @@
       }
     }
   },
-  "projectNextStepsCountAdded": "{count, plural, =1{1 tillagd} other{{count} tillagda}}",
+  "projectNextStepsCountAdded": "{count, plural, =1{1 tillagt} other{{count} tillagda}}",
   "@projectNextStepsCountAdded": {
     "placeholders": {
       "count": {
@@ -4447,7 +4447,7 @@
       }
     }
   },
-  "projectNextStepsCountDismissed": "{count, plural, =1{1 avfärdad} other{{count} avfärdade}}",
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 avfärdat} other{{count} avfärdade}}",
   "@projectNextStepsCountDismissed": {
     "placeholders": {
       "count": {
@@ -4455,7 +4455,7 @@
       }
     }
   },
-  "projectNextStepsCountDone": "{count, plural, =1{1 klar} other{{count} klara}}",
+  "projectNextStepsCountDone": "{count, plural, =1{1 klart} other{{count} klara}}",
   "@projectNextStepsCountDone": {
     "placeholders": {
       "count": {
@@ -4465,7 +4465,7 @@
   },
   "projectNextStepsDismissAll": "Avfärda alla",
   "projectNextStepsEmpty": "Inga öppna förslag.",
-  "projectNextStepsHideHistory": "Dölj",
+  "projectNextStepsHideHistory": "Dölj historik",
   "projectNextStepsLastLooked": "Senast kontrollerat {ago}.",
   "@projectNextStepsLastLooked": {
     "placeholders": {
@@ -4485,7 +4485,7 @@
       }
     }
   },
-  "projectNextStepsShowHistory": "Visa",
+  "projectNextStepsShowHistory": "Visa historik",
   "projectNextStepsShowMore": "Visa {count} till",
   "@projectNextStepsShowMore": {
     "placeholders": {

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4405,14 +4405,101 @@
   },
   "projectLinkedTasks": "Länkade uppgifter",
   "projectManageTooltip": "Hantera projekt",
+  "projectNextStepAdded": "Tillagd",
+  "projectNextStepCreateFailed": "Uppgiften kunde inte skapas. Uppdatera nu för att läsa in den aktuella listan, eller försök igen.",
+  "projectNextStepCreating": "Skapar uppgift…",
+  "projectNextStepDismiss": "Avfärda",
+  "projectNextStepDismissed": "Avfärdad",
+  "projectNextStepDone": "Klar",
+  "projectNextStepOpenTask": "Öppna uppgift",
+  "projectNextStepRetry": "Försök igen",
+  "projectNextStepsAddAll": "Lägg till alla som uppgifter",
+  "projectNextStepsAgoDays": "{count, plural, =1{1 dag sedan} other{{count} dagar sedan}}",
+  "@projectNextStepsAgoDays": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoHours": "{count, plural, =1{1 h sedan} other{{count} h sedan}}",
+  "@projectNextStepsAgoHours": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsAgoJustNow": "nyss",
+  "projectNextStepsAgoMinutes": "{count, plural, =1{1 min sedan} other{{count} min sedan}}",
+  "@projectNextStepsAgoMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountAdded": "{count, plural, =1{1 tillagd} other{{count} tillagda}}",
+  "@projectNextStepsCountAdded": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDismissed": "{count, plural, =1{1 avfärdad} other{{count} avfärdade}}",
+  "@projectNextStepsCountDismissed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsCountDone": "{count, plural, =1{1 klar} other{{count} klara}}",
+  "@projectNextStepsCountDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "projectNextStepsDismissAll": "Avfärda alla",
+  "projectNextStepsEmpty": "Inga öppna förslag.",
+  "projectNextStepsHideHistory": "Dölj",
+  "projectNextStepsLastLooked": "Senast kontrollerat {ago}.",
+  "@projectNextStepsLastLooked": {
+    "placeholders": {
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsLastRun": "Senaste körning: {summary} · {ago}",
+  "@projectNextStepsLastRun": {
+    "placeholders": {
+      "summary": {
+        "type": "String"
+      },
+      "ago": {
+        "type": "String"
+      }
+    }
+  },
+  "projectNextStepsShowHistory": "Visa",
+  "projectNextStepsShowMore": "Visa {count} till",
+  "@projectNextStepsShowMore": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "projectNoLinkedTasks": "Inga uppgifter är länkade än",
   "projectNoProjects": "Inga projekt än",
   "projectNotFound": "Projekt ej hittat",
   "projectPickerLabel": "Projekt",
   "projectPickerUnassigned": "Inget projekt",
   "projectPickerUpdateFailed": "Det gick inte att ändra uppgiftens projekt. Kontrollera kategori och sekretess och försök igen.",
-  "projectRecommendationDismissTooltip": "Avslut",
-  "projectRecommendationResolveTooltip": "Mark bestämde sig",
   "projectRecommendationsTitle": "Rekommenderade nästa steg",
   "projectRecommendationUpdateError": "Kunde inte uppdatera rekommendationen. Försök igen, tack.",
   "projectsClearFilters": "Rensa filter",

--- a/test/features/agents/ui/ai_summary_card/proposal_row_widgets_part_test.dart
+++ b/test/features/agents/ui/ai_summary_card/proposal_row_widgets_part_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui' show Tristate;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -193,6 +194,35 @@ void main() {
         );
       },
     );
+  });
+
+  group('AiSummaryCard – RowActions disabled', () {
+    testWidgets('a disabled rail keeps its footprint but takes no taps', (
+      tester,
+    ) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          Center(
+            child: RowActions(
+              busy: false,
+              enabled: false,
+              onReject: () async => taps++,
+              onConfirm: () async => taps++,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byTooltip('Confirm'));
+      await tester.tap(find.byTooltip('Reject'));
+      expect(taps, 0);
+      final size = tester.getSize(find.byType(RowActions));
+      expect(size.width, RowActions.buttonSize * 2 + 4);
+      final semantics = tester.getSemantics(find.byTooltip('Confirm'));
+      expect(semantics.flagsCollection.isEnabled, Tristate.isFalse);
+      expect(semantics.flagsCollection.isButton, isTrue);
+    });
   });
 
   group('AiSummaryCard – RowActions footprint', () {

--- a/test/features/projects/ui/pages/project_details_page_test.dart
+++ b/test/features/projects/ui/pages/project_details_page_test.dart
@@ -1185,6 +1185,11 @@ void main() {
                 .enabled,
             isFalse,
           );
+          final opened = <String>[];
+          beamToNamedOverride = opened.add;
+          addTearDown(() => beamToNamedOverride = null);
+          panel.onOpenTask!('task-42');
+          expect(opened, ['/tasks/task-42']);
 
           // Invoking the wired callbacks must dispatch to the project
           // agent service for the resolved agent ID, with the cancel path

--- a/test/features/projects/ui/pages/project_details_page_test.dart
+++ b/test/features/projects/ui/pages/project_details_page_test.dart
@@ -1176,7 +1176,15 @@ void main() {
           );
           expect(content.onRefreshReport, isNotNull);
           expect(content.onCancelScheduledReportWake, isNotNull);
-          expect(content.agentActions, isA<ProjectRecommendationsPanel>());
+          final panel = content.agentActionsBuilder!(enabled: true);
+          expect(panel, isA<ProjectRecommendationsPanel>());
+          expect((panel as ProjectRecommendationsPanel).enabled, isTrue);
+          expect(
+            (content.agentActionsBuilder!(enabled: false)
+                    as ProjectRecommendationsPanel)
+                .enabled,
+            isFalse,
+          );
 
           // Invoking the wired callbacks must dispatch to the project
           // agent service for the resolved agent ID, with the cancel path

--- a/test/features/projects/ui/widgets/next_steps/project_next_step_row_test.dart
+++ b/test/features/projects/ui/widgets/next_steps/project_next_step_row_test.dart
@@ -208,10 +208,17 @@ void main() {
           step: step,
           state: ProjectNextStepRowState.failed,
           failureMessage: 'Project lookup failed',
+          onDismiss: () {},
         ),
       ),
     );
     expect(find.text('Project lookup failed'), findsOneWidget);
+    expect(
+      find.text('Retry'),
+      findsNothing,
+      reason: 'A final failure offers no Retry, only Dismiss.',
+    );
+    expect(find.text('Dismiss'), findsOneWidget);
   });
 
   testWidgets('priority reads the way the created task would carry it', (

--- a/test/features/projects/ui/widgets/next_steps/project_next_step_row_test.dart
+++ b/test/features/projects/ui/widgets/next_steps/project_next_step_row_test.dart
@@ -1,0 +1,284 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_inline_action.dart';
+import 'package:lotti/features/projects/ui/widgets/next_steps/project_next_step_row.dart';
+
+import '../../../../../widget_test_utils.dart';
+import '../../../../agents/test_data/change_set_factories.dart';
+
+void main() {
+  const title = 'Recalibrate the zero-gravity fish feeder';
+  const rationale = 'It is the only launch blocker.';
+  final step = makeTestProjectRecommendation(
+    id: 'step-1',
+    title: title,
+    rationale: rationale,
+  );
+
+  Widget subject(
+    ProjectNextStepRow row, {
+    double width = 340,
+  }) => makeTestableWidget2(
+    Align(
+      alignment: Alignment.topLeft,
+      child: SizedBox(width: width, child: row),
+    ),
+    mediaQueryData: const MediaQueryData(size: Size(1000, 900)),
+  );
+
+  testWidgets('a pending step offers labelled Add task and Dismiss', (
+    tester,
+  ) async {
+    var added = 0;
+    var dismissed = 0;
+    await tester.pumpWidget(
+      subject(
+        ProjectNextStepRow(
+          step: step,
+          state: ProjectNextStepRowState.pending,
+          onAddTask: () => added++,
+          onDismiss: () => dismissed++,
+        ),
+      ),
+    );
+
+    expect(find.text(title), findsOneWidget);
+    expect(find.text(rationale), findsOneWidget);
+    expect(find.text('High'), findsOneWidget);
+    await tester.tap(find.text('Add task'));
+    await tester.tap(find.text('Dismiss'));
+    expect(added, 1);
+    expect(dismissed, 1);
+    expect(find.text('Undo'), findsNothing);
+    expect(find.text('Creating task…'), findsNothing);
+  });
+
+  testWidgets('a disabled row keeps its controls visible but inert', (
+    tester,
+  ) async {
+    var added = 0;
+    await tester.pumpWidget(
+      subject(
+        ProjectNextStepRow(
+          step: step,
+          state: ProjectNextStepRowState.pending,
+          enabled: false,
+          onAddTask: () => added++,
+          onDismiss: () => added++,
+        ),
+      ),
+    );
+
+    expect(
+      tester
+          .widget<DesignSystemButton>(find.byType(DesignSystemButton))
+          .onPressed,
+      isNull,
+    );
+    expect(
+      tester
+          .widget<DesignSystemInlineAction>(
+            find.byType(DesignSystemInlineAction),
+          )
+          .onTap,
+      isNull,
+    );
+    await tester.tap(find.text('Add task'), warnIfMissed: false);
+    await tester.tap(find.text('Dismiss'), warnIfMissed: false);
+    expect(added, 0);
+  });
+
+  testWidgets('a busy row says it is creating the task and hides the buttons', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      subject(
+        ProjectNextStepRow(step: step, state: ProjectNextStepRowState.busy),
+      ),
+    );
+
+    expect(find.text('Creating task…'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('Add task'), findsNothing);
+    expect(find.text('Dismiss'), findsNothing);
+  });
+
+  testWidgets('an added step links to its task and offers Undo while allowed', (
+    tester,
+  ) async {
+    var opened = 0;
+    var undone = 0;
+    await tester.pumpWidget(
+      subject(
+        ProjectNextStepRow(
+          step: step,
+          state: ProjectNextStepRowState.added,
+          canUndo: true,
+          onOpenTask: () => opened++,
+          onUndo: () => undone++,
+        ),
+      ),
+    );
+
+    expect(find.text('Added'), findsOneWidget);
+    await tester.tap(find.text('Open task'));
+    await tester.tap(find.text('Undo'));
+    expect(opened, 1);
+    expect(undone, 1);
+    expect(find.text('Add task'), findsNothing);
+
+    await tester.pumpWidget(
+      subject(
+        ProjectNextStepRow(step: step, state: ProjectNextStepRowState.added),
+      ),
+    );
+    expect(find.text('Undo'), findsNothing, reason: 'The undo window closed.');
+    expect(find.text('Added'), findsOneWidget);
+  });
+
+  testWidgets('a done step shows its tag without a task link', (tester) async {
+    await tester.pumpWidget(
+      subject(
+        ProjectNextStepRow(
+          step: step,
+          state: ProjectNextStepRowState.done,
+          canUndo: true,
+          onUndo: () {},
+        ),
+      ),
+    );
+
+    expect(find.text('Done'), findsOneWidget);
+    expect(find.text('Open task'), findsNothing);
+    expect(find.text('Undo'), findsOneWidget);
+  });
+
+  testWidgets('a dismissed step strikes its title and offers Undo', (
+    tester,
+  ) async {
+    var undone = 0;
+    await tester.pumpWidget(
+      subject(
+        ProjectNextStepRow(
+          step: step,
+          state: ProjectNextStepRowState.dismissed,
+          canUndo: true,
+          onUndo: () => undone++,
+        ),
+      ),
+    );
+
+    final titleStyle = tester.widget<Text>(find.text(title)).style;
+    expect(titleStyle?.decoration, TextDecoration.lineThrough);
+    expect(find.text('Dismissed'), findsOneWidget);
+    await tester.tap(find.text('Undo'));
+    expect(undone, 1);
+  });
+
+  testWidgets('a failed attempt explains itself and offers Retry', (
+    tester,
+  ) async {
+    var retried = 0;
+    await tester.pumpWidget(
+      subject(
+        ProjectNextStepRow(
+          step: step,
+          state: ProjectNextStepRowState.failed,
+          onAddTask: () => retried++,
+          onDismiss: () {},
+        ),
+      ),
+    );
+
+    expect(
+      find.text(
+        "Couldn't create the task. Update now to load the current list, "
+        'or retry.',
+      ),
+      findsOneWidget,
+    );
+    await tester.tap(find.text('Retry'));
+    expect(retried, 1);
+    expect(find.text('Dismiss'), findsOneWidget);
+
+    await tester.pumpWidget(
+      subject(
+        ProjectNextStepRow(
+          step: step,
+          state: ProjectNextStepRowState.failed,
+          failureMessage: 'Project lookup failed',
+        ),
+      ),
+    );
+    expect(find.text('Project lookup failed'), findsOneWidget);
+  });
+
+  testWidgets('priority reads the way the created task would carry it', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      subject(
+        ProjectNextStepRow(
+          step: makeTestProjectRecommendation(
+            id: 'no-priority',
+            title: 'Untriaged',
+            rationale: null,
+            priority: null,
+          ),
+          state: ProjectNextStepRowState.pending,
+        ),
+      ),
+    );
+    expect(
+      find.text('Medium'),
+      findsOneWidget,
+      reason: 'A step without a priority creates a medium task.',
+    );
+
+    await tester.pumpWidget(
+      subject(
+        ProjectNextStepRow(
+          step: makeTestProjectRecommendation(
+            id: 'odd-priority',
+            title: 'Untriaged',
+            priority: 'WHENEVER',
+          ),
+          state: ProjectNextStepRowState.pending,
+        ),
+      ),
+    );
+    for (final label in ['Urgent', 'High', 'Medium', 'Low']) {
+      expect(find.text(label), findsNothing);
+    }
+  });
+
+  testWidgets('the action strip sits beside the text only when wide', (
+    tester,
+  ) async {
+    ProjectNextStepRow row() => ProjectNextStepRow(
+      step: step,
+      state: ProjectNextStepRowState.pending,
+      onAddTask: () {},
+      onDismiss: () {},
+    );
+
+    await tester.pumpWidget(subject(row()));
+    expect(
+      tester.getTopLeft(find.text('Add task')).dy,
+      greaterThan(tester.getBottomLeft(find.text(rationale)).dy),
+      reason: 'On a phone the strip stacks under the text.',
+    );
+
+    await tester.pumpWidget(subject(row(), width: 900));
+    expect(
+      tester.getTopLeft(find.text('Add task')).dy,
+      lessThan(tester.getBottomLeft(find.text(rationale)).dy),
+      reason: 'On a wide row the strip shares the line with the text.',
+    );
+    expect(
+      tester.getTopLeft(find.text('Add task')).dx,
+      greaterThan(tester.getTopRight(find.text(title)).dx),
+    );
+  });
+}

--- a/test/features/projects/ui/widgets/next_steps/project_next_steps_model_test.dart
+++ b/test/features/projects/ui/widgets/next_steps/project_next_steps_model_test.dart
@@ -1,0 +1,194 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/projects/ui/widgets/next_steps/project_next_steps_model.dart';
+
+import '../../../../agents/test_data/change_set_factories.dart';
+
+void main() {
+  group('projectNextStepOutcome', () {
+    test('reads the outcome the user produced, not just the status', () {
+      expect(
+        projectNextStepOutcome(makeTestProjectRecommendation()),
+        ProjectNextStepOutcome.pending,
+      );
+      expect(
+        projectNextStepOutcome(
+          makeTestProjectRecommendation(
+            status: ProjectRecommendationStatus.dismissed,
+          ),
+        ),
+        ProjectNextStepOutcome.dismissed,
+      );
+      expect(
+        projectNextStepOutcome(
+          makeTestProjectRecommendation(
+            status: ProjectRecommendationStatus.resolved,
+            createdTaskId: 'task-1',
+          ),
+        ),
+        ProjectNextStepOutcome.added,
+        reason: 'A resolved step that recorded its task was added.',
+      );
+      expect(
+        projectNextStepOutcome(
+          makeTestProjectRecommendation(
+            status: ProjectRecommendationStatus.resolved,
+          ),
+        ),
+        ProjectNextStepOutcome.done,
+        reason: 'A resolved step without a task was marked done elsewhere.',
+      );
+      expect(
+        projectNextStepOutcome(
+          makeTestProjectRecommendation(
+            status: ProjectRecommendationStatus.superseded,
+          ),
+        ),
+        ProjectNextStepOutcome.done,
+        reason: 'A stale row can neither be acted on nor block a summary.',
+      );
+    });
+  });
+
+  group('ProjectNextStepsTally', () {
+    test('counts every outcome and knows when a run is fully decided', () {
+      final tally = ProjectNextStepsTally.of([
+        makeTestProjectRecommendation(id: 'a'),
+        makeTestProjectRecommendation(
+          id: 'b',
+          status: ProjectRecommendationStatus.resolved,
+          createdTaskId: 'task-b',
+        ),
+        makeTestProjectRecommendation(
+          id: 'c',
+          status: ProjectRecommendationStatus.resolved,
+        ),
+        makeTestProjectRecommendation(
+          id: 'd',
+          status: ProjectRecommendationStatus.dismissed,
+        ),
+        makeTestProjectRecommendation(
+          id: 'e',
+          status: ProjectRecommendationStatus.dismissed,
+        ),
+      ]);
+
+      expect(tally.pending, 1);
+      expect(tally.added, 1);
+      expect(tally.done, 1);
+      expect(tally.dismissed, 2);
+      expect(tally.total, 5);
+      expect(tally.allDecided, isFalse);
+
+      expect(ProjectNextStepsTally.of(const []).allDecided, isFalse);
+      expect(
+        ProjectNextStepsTally.of([
+          makeTestProjectRecommendation(
+            status: ProjectRecommendationStatus.dismissed,
+          ),
+        ]).allDecided,
+        isTrue,
+      );
+    });
+  });
+
+  group('visibleProjectNextSteps', () {
+    test('caps a long run to the first rows in the agent order', () {
+      final steps = List.generate(5, (i) => 'step-$i');
+      expect(visibleProjectNextSteps(steps, cap: 3, showAll: false), [
+        'step-0',
+        'step-1',
+        'step-2',
+      ]);
+      expect(visibleProjectNextSteps(steps, cap: 3, showAll: true), steps);
+      expect(visibleProjectNextSteps(steps, cap: 5, showAll: false), steps);
+      expect(
+        visibleProjectNextSteps(<String>[], cap: 3, showAll: false),
+        isEmpty,
+      );
+    });
+
+    glados.Glados3(
+      glados.any.list(glados.any.int),
+      glados.any.positiveInt,
+      glados.any.bool,
+    ).test('always yields a prefix whose length is the cap unless shown all', (
+      steps,
+      cap,
+      showAll,
+    ) {
+      final visible = visibleProjectNextSteps(
+        steps,
+        cap: cap,
+        showAll: showAll,
+      );
+      expect(visible, steps.sublist(0, visible.length));
+      if (showAll || steps.length <= cap) {
+        expect(visible, steps);
+      } else {
+        expect(visible.length, cap);
+      }
+    }, tags: 'glados');
+  });
+
+  group('projectNextStepsAge', () {
+    test('buckets at the minute, hour and day boundaries', () {
+      expect(projectNextStepsAge(Duration.zero), (
+        unit: ProjectNextStepsAgeUnit.justNow,
+        count: 0,
+      ));
+      expect(
+        projectNextStepsAge(const Duration(seconds: 59)).unit,
+        ProjectNextStepsAgeUnit.justNow,
+      );
+      expect(projectNextStepsAge(const Duration(minutes: 1)), (
+        unit: ProjectNextStepsAgeUnit.minutes,
+        count: 1,
+      ));
+      expect(projectNextStepsAge(const Duration(minutes: 59, seconds: 30)), (
+        unit: ProjectNextStepsAgeUnit.minutes,
+        count: 59,
+      ));
+      expect(projectNextStepsAge(const Duration(hours: 1)), (
+        unit: ProjectNextStepsAgeUnit.hours,
+        count: 1,
+      ));
+      expect(projectNextStepsAge(const Duration(hours: 23, minutes: 59)), (
+        unit: ProjectNextStepsAgeUnit.hours,
+        count: 23,
+      ));
+      expect(projectNextStepsAge(const Duration(days: 1)), (
+        unit: ProjectNextStepsAgeUnit.days,
+        count: 1,
+      ));
+      expect(projectNextStepsAge(const Duration(days: -2)), (
+        unit: ProjectNextStepsAgeUnit.justNow,
+        count: 0,
+      ));
+    });
+
+    glados.Glados(glados.any.int).test(
+      'never reports a count outside its unit and never a future age',
+      (seconds) {
+        final elapsed = Duration(seconds: seconds);
+        final age = projectNextStepsAge(elapsed);
+        switch (age.unit) {
+          case ProjectNextStepsAgeUnit.justNow:
+            expect(age.count, 0);
+            expect(elapsed, lessThan(const Duration(minutes: 1)));
+          case ProjectNextStepsAgeUnit.minutes:
+            expect(age.count, inInclusiveRange(1, 59));
+            expect(age.count, elapsed.inMinutes);
+          case ProjectNextStepsAgeUnit.hours:
+            expect(age.count, inInclusiveRange(1, 23));
+            expect(age.count, elapsed.inHours);
+          case ProjectNextStepsAgeUnit.days:
+            expect(age.count, greaterThanOrEqualTo(1));
+            expect(age.count, elapsed.inDays);
+        }
+      },
+      tags: 'glados',
+    );
+  });
+}

--- a/test/features/projects/ui/widgets/next_steps/project_next_steps_summary_test.dart
+++ b/test/features/projects/ui/widgets/next_steps/project_next_steps_summary_test.dart
@@ -62,7 +62,7 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Confirm the escort'), findsNothing);
-    await tester.tap(find.text('Show'));
+    await tester.tap(find.text('Show history'));
     expect(toggles, 1);
   });
 
@@ -81,7 +81,7 @@ void main() {
       ),
     );
 
-    expect(find.text('Hide'), findsOneWidget);
+    expect(find.text('Hide history'), findsOneWidget);
     for (final title in [
       'Confirm the escort',
       'Split the first wave',
@@ -94,6 +94,26 @@ void main() {
     expect(find.text('Done'), findsOneWidget);
     expect(find.text('Dismissed'), findsOneWidget);
     expect(find.textContaining('5 h ago'), findsOneWidget);
+  });
+
+  testWidgets('an open step in the history reads as pending', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidget2(
+        ProjectNextStepsSummary(
+          steps: [
+            ...steps,
+            makeTestProjectRecommendation(id: 'open', title: 'Still open'),
+          ],
+          runCreatedAt: now,
+          now: now,
+          historyOpen: true,
+          onToggleHistory: () {},
+        ),
+      ),
+    );
+
+    expect(find.text('Still open'), findsOneWidget);
+    expect(find.text('1 pending'), findsOneWidget);
   });
 
   testWidgets('a legacy run without a snapshot dates itself by its newest '

--- a/test/features/projects/ui/widgets/next_steps/project_next_steps_summary_test.dart
+++ b/test/features/projects/ui/widgets/next_steps/project_next_steps_summary_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/projects/ui/widgets/next_steps/project_next_steps_summary.dart';
+import 'package:lotti/l10n/app_localizations.dart';
+
+import '../../../../../widget_test_utils.dart';
+import '../../../../agents/test_data/change_set_factories.dart';
+
+void main() {
+  final now = DateTime(2026, 9, 5, 12);
+  final steps = [
+    makeTestProjectRecommendation(
+      id: 'added-1',
+      title: 'Confirm the escort',
+      status: ProjectRecommendationStatus.resolved,
+      createdTaskId: 'task-1',
+      createdAt: now.subtract(const Duration(hours: 3)),
+    ),
+    makeTestProjectRecommendation(
+      id: 'added-2',
+      title: 'Split the first wave',
+      position: 1,
+      status: ProjectRecommendationStatus.resolved,
+      createdTaskId: 'task-2',
+      createdAt: now.subtract(const Duration(hours: 3)),
+    ),
+    makeTestProjectRecommendation(
+      id: 'done-1',
+      title: 'Brief the elders',
+      position: 2,
+      status: ProjectRecommendationStatus.resolved,
+      createdAt: now.subtract(const Duration(hours: 2)),
+    ),
+    makeTestProjectRecommendation(
+      id: 'dismissed-1',
+      title: 'Retire the April tasks',
+      position: 3,
+      status: ProjectRecommendationStatus.dismissed,
+      createdAt: now.subtract(const Duration(hours: 3)),
+    ),
+  ];
+
+  testWidgets('the summary line tallies the run and dates the agent', (
+    tester,
+  ) async {
+    var toggles = 0;
+    await tester.pumpWidget(
+      makeTestableWidget2(
+        ProjectNextStepsSummary(
+          steps: steps,
+          runCreatedAt: now.subtract(const Duration(minutes: 40)),
+          now: now,
+          historyOpen: false,
+          onToggleHistory: () => toggles++,
+        ),
+      ),
+    );
+
+    expect(
+      find.text('Last run: 2 added, 1 done, 1 dismissed · 40 min ago'),
+      findsOneWidget,
+    );
+    expect(find.text('Confirm the escort'), findsNothing);
+    await tester.tap(find.text('Show'));
+    expect(toggles, 1);
+  });
+
+  testWidgets('open history lists every step with its outcome', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      makeTestableWidget2(
+        ProjectNextStepsSummary(
+          steps: steps,
+          runCreatedAt: now.subtract(const Duration(hours: 5)),
+          now: now,
+          historyOpen: true,
+          onToggleHistory: () {},
+        ),
+      ),
+    );
+
+    expect(find.text('Hide'), findsOneWidget);
+    for (final title in [
+      'Confirm the escort',
+      'Split the first wave',
+      'Brief the elders',
+      'Retire the April tasks',
+    ]) {
+      expect(find.text(title), findsOneWidget);
+    }
+    expect(find.text('Added'), findsNWidgets(2));
+    expect(find.text('Done'), findsOneWidget);
+    expect(find.text('Dismissed'), findsOneWidget);
+    expect(find.textContaining('5 h ago'), findsOneWidget);
+  });
+
+  testWidgets('a legacy run without a snapshot dates itself by its newest '
+      'step', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidget2(
+        ProjectNextStepsSummary(
+          steps: steps,
+          runCreatedAt: null,
+          now: now,
+          historyOpen: false,
+          onToggleHistory: () {},
+        ),
+      ),
+    );
+
+    expect(find.textContaining('· 2 h ago'), findsOneWidget);
+  });
+
+  testWidgets('the empty band says when the agent last looked', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      makeTestableWidget2(
+        ProjectNextStepsEmpty(
+          runCreatedAt: now.subtract(const Duration(days: 3)),
+          now: now,
+        ),
+      ),
+    );
+    expect(
+      find.text('No open suggestions. Last looked 3 days ago.'),
+      findsOneWidget,
+    );
+
+    await tester.pumpWidget(
+      makeTestableWidget2(ProjectNextStepsEmpty(runCreatedAt: null, now: now)),
+    );
+    expect(find.text('No open suggestions.'), findsOneWidget);
+  });
+
+  test('formatProjectNextStepsAge buckets into the band wording', () async {
+    final messages = await AppLocalizations.delegate.load(const Locale('en'));
+    String age(Duration elapsed) =>
+        formatProjectNextStepsAge(messages, elapsed);
+
+    expect(age(Duration.zero), 'just now');
+    expect(age(const Duration(seconds: 59)), 'just now');
+    expect(age(const Duration(seconds: -30)), 'just now');
+    expect(age(const Duration(minutes: 1)), '1 min ago');
+    expect(age(const Duration(minutes: 59, seconds: 59)), '59 min ago');
+    expect(age(const Duration(hours: 1)), '1 h ago');
+    expect(age(const Duration(hours: 23, minutes: 59)), '23 h ago');
+    expect(age(const Duration(days: 1)), '1 day ago');
+    expect(age(const Duration(days: 45)), '45 days ago');
+  });
+}

--- a/test/features/projects/ui/widgets/next_steps/project_proposal_row_test.dart
+++ b/test/features/projects/ui/widgets/next_steps/project_proposal_row_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_widgets_part.dart';
+import 'package:lotti/features/projects/ui/widgets/next_steps/project_proposal_row.dart';
+
+import '../../../../../widget_test_utils.dart';
+import '../../../../agents/test_data/change_set_factories.dart';
+
+void main() {
+  final changeSet = makeTestChangeSet(
+    id: 'set-1',
+    taskId: 'project-1',
+    items: const [
+      ChangeItem(
+        toolName: 'create_task',
+        args: {'title': 'Pack fish'},
+        humanSummary: 'Create task',
+      ),
+      ChangeItem(
+        toolName: 'update_project_status',
+        args: {'status': 'monitoring'},
+        humanSummary: 'Set status',
+        status: ChangeItemStatus.confirmed,
+      ),
+      ChangeItem(
+        toolName: 'update_project_status',
+        args: {'status': 'on_hold'},
+        humanSummary: 'Set status',
+        status: ChangeItemStatus.rejected,
+      ),
+    ],
+  );
+
+  Widget subject(ProjectProposalRow row) => makeTestableWidget2(
+    Align(alignment: Alignment.topLeft, child: row),
+    mediaQueryData: const MediaQueryData(size: Size(600, 400)),
+  );
+
+  testWidgets('a pending proposal reads its localized summary and decides '
+      'through the shared rail', (tester) async {
+    var confirmed = 0;
+    var rejected = 0;
+    await tester.pumpWidget(
+      subject(
+        ProjectProposalRow(
+          changeSet: changeSet,
+          itemIndex: 0,
+          busy: false,
+          onConfirm: () async => confirmed++,
+          onReject: () async => rejected++,
+        ),
+      ),
+    );
+
+    expect(find.text('Create task: Pack fish'), findsOneWidget);
+    expect(find.byType(RowActions), findsOneWidget);
+    await tester.tap(find.byTooltip('Confirm'));
+    await tester.tap(find.byTooltip('Reject'));
+    expect(confirmed, 1);
+    expect(rejected, 1);
+    expect(find.byType(ResolvedTag), findsNothing);
+  });
+
+  testWidgets('a busy proposal shows the rail spinner instead of buttons', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      subject(
+        ProjectProposalRow(
+          changeSet: changeSet,
+          itemIndex: 0,
+          busy: true,
+          onConfirm: () async {},
+          onReject: () async {},
+        ),
+      ),
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byTooltip('Confirm'), findsNothing);
+  });
+
+  testWidgets('a decided proposal keeps its place with the resolved tag', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      subject(
+        ProjectProposalRow(
+          changeSet: changeSet,
+          itemIndex: 1,
+          busy: false,
+          onConfirm: () async {},
+          onReject: () async {},
+        ),
+      ),
+    );
+    expect(find.text('Update project status to Monitoring'), findsOneWidget);
+    expect(find.text('Confirmed'), findsOneWidget);
+    expect(find.byType(RowActions), findsNothing);
+
+    await tester.pumpWidget(
+      subject(
+        ProjectProposalRow(
+          changeSet: changeSet,
+          itemIndex: 2,
+          busy: false,
+          onConfirm: () async {},
+          onReject: () async {},
+        ),
+      ),
+    );
+    expect(find.text('Dismissed'), findsOneWidget);
+    expect(find.byType(RowActions), findsNothing);
+  });
+}

--- a/test/features/projects/ui/widgets/next_steps/project_proposal_row_test.dart
+++ b/test/features/projects/ui/widgets/next_steps/project_proposal_row_test.dart
@@ -63,6 +63,56 @@ void main() {
     expect(find.byType(ResolvedTag), findsNothing);
   });
 
+  testWidgets('a disabled proposal keeps its rail inert', (tester) async {
+    var decided = 0;
+    await tester.pumpWidget(
+      subject(
+        ProjectProposalRow(
+          changeSet: changeSet,
+          itemIndex: 0,
+          busy: false,
+          enabled: false,
+          onConfirm: () async => decided++,
+          onReject: () async => decided++,
+        ),
+      ),
+    );
+
+    expect(tester.widget<RowActions>(find.byType(RowActions)).enabled, isFalse);
+    await tester.tap(find.byTooltip('Confirm'));
+    await tester.tap(find.byTooltip('Reject'));
+    expect(decided, 0);
+  });
+
+  testWidgets('an unknown tool falls back to the persisted summary', (
+    tester,
+  ) async {
+    final exotic = makeTestChangeSet(
+      id: 'set-2',
+      taskId: 'project-1',
+      items: const [
+        ChangeItem(
+          toolName: 'rename_project',
+          args: {'title': 'Waddle II'},
+          humanSummary: 'Rename the project to Waddle II',
+        ),
+      ],
+    );
+    await tester.pumpWidget(
+      subject(
+        ProjectProposalRow(
+          changeSet: exotic,
+          itemIndex: 0,
+          busy: false,
+          onConfirm: () async {},
+          onReject: () async {},
+        ),
+      ),
+    );
+
+    expect(find.text('Rename the project to Waddle II'), findsOneWidget);
+  });
+
   testWidgets('a busy proposal shows the rail spinner instead of buttons', (
     tester,
   ) async {

--- a/test/features/projects/ui/widgets/project_agent_summary_card_test.dart
+++ b/test/features/projects/ui/widgets/project_agent_summary_card_test.dart
@@ -142,7 +142,7 @@ void main() {
   });
 
   testWidgets(
-    'read-only report expands and suppresses actions during mutation',
+    'read-only report expands and keeps actions mounted during mutation',
     (
       tester,
     ) async {
@@ -185,7 +185,13 @@ void main() {
       expect(blockerOpens, 1);
 
       await pumpCard(mutating: true);
-      expect(find.text('Review proposed changes'), findsNothing);
+      expect(
+        find.text('Review proposed changes'),
+        findsOneWidget,
+        reason:
+            'The host disables the bands; the card must not drop them, '
+            'or an in-flight decision loses its row state.',
+      );
       await tester.tap(blocker);
       expect(blockerOpens, 1);
       expect(find.byType(TaskAgentControlsFooter), findsNothing);

--- a/test/features/projects/ui/widgets/project_mobile_detail_content_test.dart
+++ b/test/features/projects/ui/widgets/project_mobile_detail_content_test.dart
@@ -74,7 +74,8 @@ void main() {
           ProjectMobileDetailContent(
             record: makeTestProjectRecord(),
             currentTime: DateTime(2026, 3, 28, 1, 18),
-            agentActions: const Text('Agent decisions'),
+            agentActionsBuilder: ({required enabled}) =>
+                const Text('Agent decisions'),
           ),
           size: const Size(430, 1400),
         ),
@@ -192,30 +193,35 @@ void main() {
       expect(addRequests, 0);
     });
 
-    testWidgets('hides agent proposal actions while a mutation runs', (
-      tester,
-    ) async {
-      Widget subject({required bool isSaving}) => ProjectMobileDetailContent(
-        record: makeTestProjectRecord(),
-        currentTime: DateTime(2026, 3, 28, 1, 18),
-        agentActions: const Text('Agent decisions'),
-        isSaving: isSaving,
-      );
+    testWidgets(
+      'keeps agent actions mounted but disabled while a mutation runs',
+      (
+        tester,
+      ) async {
+        Widget subject({required bool isSaving}) => ProjectMobileDetailContent(
+          record: makeTestProjectRecord(),
+          currentTime: DateTime(2026, 3, 28, 1, 18),
+          agentActionsBuilder: ({required enabled}) =>
+              Text(enabled ? 'Agent decisions' : 'Agent decisions (disabled)'),
+          isSaving: isSaving,
+        );
 
-      await tester.pumpWidget(
-        wrap(subject(isSaving: true), size: const Size(430, 1200)),
-      );
-      await tester.pump();
+        await tester.pumpWidget(
+          wrap(subject(isSaving: true), size: const Size(430, 1200)),
+        );
+        await tester.pump();
 
-      expect(find.text('Agent decisions'), findsNothing);
+        expect(find.text('Agent decisions (disabled)'), findsOneWidget);
+        expect(find.text('Agent decisions'), findsNothing);
 
-      await tester.pumpWidget(
-        wrap(subject(isSaving: false), size: const Size(430, 1200)),
-      );
-      await tester.pump();
+        await tester.pumpWidget(
+          wrap(subject(isSaving: false), size: const Size(430, 1200)),
+        );
+        await tester.pump();
 
-      expect(find.text('Agent decisions'), findsOneWidget);
-    });
+        expect(find.text('Agent decisions'), findsOneWidget);
+      },
+    );
 
     testWidgets('rejects a stale Add task callback after saving starts', (
       tester,

--- a/test/features/projects/ui/widgets/project_recommendations_panel_test.dart
+++ b/test/features/projects/ui/widgets/project_recommendations_panel_test.dart
@@ -8,6 +8,7 @@ import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/service/project_recommendation_service.dart';
 import 'package:lotti/features/agents/state/change_set_providers.dart';
 import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
+import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_widgets_part.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/projects/state/project_detail_record_provider.dart';
 import 'package:lotti/features/projects/ui/widgets/project_recommendations_panel.dart';
@@ -429,7 +430,7 @@ void main() {
 
     await pumpSubject(tester, subject(width: 1000));
     expect(find.text('Tag the pathfinders'), findsOneWidget);
-    expect(find.textContaining('Show'), findsNothing);
+    expect(find.textContaining('Show '), findsNothing);
   });
 
   testWidgets(
@@ -463,11 +464,11 @@ void main() {
       expect(find.text('Confirm the escort'), findsNothing);
       expect(find.textContaining('pending'), findsNothing);
 
-      await tester.tap(find.text('Show'));
+      await tester.tap(find.text('Show history'));
       await tester.pump();
       expect(find.text('Confirm the escort'), findsOneWidget);
       expect(find.text('Split the first wave'), findsOneWidget);
-      expect(find.text('Hide'), findsOneWidget);
+      expect(find.text('Hide history'), findsOneWidget);
     },
   );
 
@@ -596,9 +597,167 @@ void main() {
       findsNothing,
       reason: 'Nothing is undoable while disabled.',
     );
+    expect(
+      tester.widget<RowActions>(find.byType(RowActions)).enabled,
+      isFalse,
+      reason: 'The proposal rail is inert, not a no-op.',
+    );
     await tester.tap(find.byTooltip('Confirm'));
     await tester.pump();
     verifyNever(() => confirmation.confirmItem(any(), any()));
+  });
+
+  testWidgets('bulk work disables the other rows until it finishes', (
+    tester,
+  ) async {
+    final first = Completer<ToolExecutionResult>();
+    when(() => service.createTask('s1')).thenAnswer((_) => first.future);
+    when(() => service.createTask('s2')).thenAnswer(
+      (_) async => const ToolExecutionResult(
+        success: true,
+        output: '',
+        mutatedEntityId: 'task-2',
+      ),
+    );
+    await pumpSubject(
+      tester,
+      subject(width: 1000, items: steps.sublist(0, 2), sets: [proposals]),
+    );
+
+    await tester.tap(find.text('Add all as tasks'));
+    await tester.pump();
+
+    expect(find.text('Creating task…'), findsOneWidget);
+    final buttons = tester.widgetList<DesignSystemButton>(
+      find.byType(DesignSystemButton),
+    );
+    expect(buttons.map((b) => b.onPressed), everyElement(isNull));
+    expect(
+      tester.widget<RowActions>(find.byType(RowActions)).enabled,
+      isFalse,
+    );
+
+    first.complete(
+      const ToolExecutionResult(
+        success: true,
+        output: '',
+        mutatedEntityId: 'task-1',
+      ),
+    );
+    await settle(tester);
+    await settle(tester);
+    expect(find.text('Added'), findsNWidgets(2));
+    expect(
+      tester.widget<RowActions>(find.byType(RowActions)).enabled,
+      isTrue,
+    );
+  });
+
+  testWidgets('a consumed creation failure shows its message without Retry', (
+    tester,
+  ) async {
+    when(() => service.createTask('s1')).thenAnswer(
+      (_) async => const ToolExecutionResult(
+        success: false,
+        output: 'rollback failed',
+        errorMessage: 'Failed to link the new task; rollback failed for t-9',
+        nonRetryable: true,
+      ),
+    );
+    await pumpSubject(tester, subject(items: steps.sublist(0, 1)));
+
+    await tester.tap(find.text('Add task'));
+    await settle(tester);
+
+    expect(
+      find.text('Failed to link the new task; rollback failed for t-9'),
+      findsOneWidget,
+    );
+    expect(find.text('Retry'), findsNothing);
+    expect(find.text('Dismiss'), findsOneWidget);
+  });
+
+  testWidgets('a refused Undo of an addition keeps the window and the link', (
+    tester,
+  ) async {
+    when(() => service.createTask('s1')).thenAnswer(
+      (_) async => const ToolExecutionResult(
+        success: true,
+        output: '',
+        mutatedEntityId: 'task-1',
+      ),
+    );
+    when(
+      () => service.restoreRecommendation('s1'),
+    ).thenAnswer((_) async => false);
+    final opened = <String>[];
+    await pumpSubject(
+      tester,
+      subject(items: steps.sublist(0, 1), onOpenTask: opened.add),
+    );
+    await tester.tap(find.text('Add task'));
+    await settle(tester);
+
+    await tester.tap(find.text('Undo'));
+    await settle(tester);
+
+    expect(find.text('Added'), findsOneWidget);
+    expect(find.text('Undo'), findsOneWidget);
+    await tester.tap(find.text('Open task'));
+    expect(opened, ['task-1']);
+    expect(find.text(updateError), findsOneWidget);
+  });
+
+  testWidgets('proposals decided in an earlier session stay out of the band', (
+    tester,
+  ) async {
+    final mixed = makeTestChangeSet(
+      id: 'set-2',
+      agentId: 'agent-1',
+      taskId: projectId,
+      items: const [
+        ChangeItem(
+          toolName: 'create_task',
+          args: {'title': 'Old decision'},
+          humanSummary: 'Create task',
+          status: ChangeItemStatus.confirmed,
+        ),
+        ChangeItem(
+          toolName: 'create_task',
+          args: {'title': 'Still open'},
+          humanSummary: 'Create task',
+        ),
+      ],
+    );
+    await pumpSubject(tester, subject(items: const [], sets: [mixed]));
+
+    expect(find.text('Create task: Still open'), findsOneWidget);
+    expect(find.text('Create task: Old decision'), findsNothing);
+    expect(find.text('1 pending'), findsOneWidget);
+  });
+
+  testWidgets('thrown service calls are reported without a crash', (
+    tester,
+  ) async {
+    when(() => service.createTask('s1')).thenThrow(StateError('offline'));
+    when(
+      () => confirmation.confirmItem(any(), any()),
+    ).thenThrow(StateError('offline'));
+    await pumpSubject(
+      tester,
+      subject(width: 1000, items: steps.sublist(0, 1), sets: [proposals]),
+    );
+
+    await tester.tap(find.text('Add task'));
+    await settle(tester);
+    expect(tester.takeException(), isNull);
+    expect(find.text('Retry'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Confirm'));
+    await settle(tester);
+    expect(tester.takeException(), isNull);
+    expect(find.byTooltip('Confirm'), findsOneWidget);
+    expect(find.text(updateError), findsOneWidget);
   });
 
   testWidgets(

--- a/test/features/projects/ui/widgets/project_recommendations_panel_test.dart
+++ b/test/features/projects/ui/widgets/project_recommendations_panel_test.dart
@@ -3,52 +3,68 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/service/project_recommendation_service.dart';
-import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/change_set_providers.dart';
 import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
-import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_widgets_part.dart';
-import 'package:lotti/features/design_system/components/buttons/design_system_icon_action.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/projects/state/project_detail_record_provider.dart';
 import 'package:lotti/features/projects/ui/widgets/project_recommendations_panel.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../helpers/fallbacks.dart';
 import '../../../../mocks/mocks.dart';
 import '../../../../widget_test_utils.dart';
-import '../../../agents/test_utils.dart';
+import '../../../agents/test_data/change_set_factories.dart';
 
 void main() {
   const projectId = 'project-1';
+  final now = DateTime(2026, 9, 5, 12);
+  final runCreatedAt = now.subtract(const Duration(hours: 2));
   late MockProjectRecommendationService service;
   late MockChangeSetConfirmationService confirmation;
+  late int pendingReads;
+
   setUpAll(registerAllFallbackValues);
   setUp(() {
     service = MockProjectRecommendationService();
     confirmation = MockChangeSetConfirmationService();
+    pendingReads = 0;
   });
 
-  final recommendations = [
-    makeTestProjectRecommendation(
-      id: 'recommendation-1',
-      agentId: 'agent-1',
-      projectId: projectId,
-      title: 'Unblock launch QA',
-      rationale: 'The staging dataset is incomplete.',
-    ),
-    makeTestProjectRecommendation(
-      id: 'recommendation-2',
-      agentId: 'agent-1',
-      projectId: projectId,
-      title: 'Confirm the launch manifest',
-    ),
+  ProjectRecommendationEntity step(
+    String id,
+    String title, {
+    int position = 0,
+    ProjectRecommendationStatus status = ProjectRecommendationStatus.active,
+    String? createdTaskId,
+  }) => makeTestProjectRecommendation(
+    id: id,
+    agentId: 'agent-1',
+    projectId: projectId,
+    title: title,
+    position: position,
+    status: status,
+    createdTaskId: createdTaskId,
+    rationale: null,
+    priority: null,
+    createdAt: runCreatedAt,
+  );
+
+  final steps = [
+    step('s1', 'Confirm the escort'),
+    step('s2', 'Split the first wave', position: 1),
+    step('s3', 'Brief the elders', position: 2),
+    step('s4', 'Stage the krill', position: 3),
+    step('s5', 'Tag the pathfinders', position: 4),
   ];
-  final changeSet = makeTestChangeSet(
+  final proposals = makeTestChangeSet(
     id: 'set-1',
     agentId: 'agent-1',
     taskId: projectId,
-    items: [
-      const ChangeItem(
+    items: const [
+      ChangeItem(
         toolName: 'create_task',
         args: {'title': 'Pack fish'},
         humanSummary: 'Create task',
@@ -58,267 +74,550 @@ void main() {
 
   Widget subject({
     List<ProjectRecommendationEntity>? items,
+    DateTime? run,
     List<AgentDomainEntity> sets = const [],
-    Future<List<ProjectRecommendationEntity>> Function()? load,
+    bool enabled = true,
+    ValueChanged<String>? onOpenTask,
+    double width = 390,
+    bool withoutSnapshot = false,
+    bool legacyRun = false,
   }) => makeTestableWidgetWithScaffold(
-    const ProjectRecommendationsPanel(projectId: projectId),
+    SingleChildScrollView(
+      child: ProjectRecommendationsPanel(
+        projectId: projectId,
+        enabled: enabled,
+        onOpenTask: onOpenTask,
+      ),
+    ),
+    mediaQueryData: MediaQueryData(size: Size(width, 900)),
     overrides: [
       projectNextStepsProvider(projectId).overrideWith(
-        (ref) async => ProjectNextStepsSnapshot(
-          steps: await (load?.call() ?? Future.value(items ?? recommendations)),
-          runCreatedAt: null,
-        ),
+        (ref) => withoutSnapshot
+            ? Completer<ProjectNextStepsSnapshot>().future
+            : Future.value(
+                ProjectNextStepsSnapshot(
+                  steps: items ?? steps,
+                  runCreatedAt: legacyRun ? null : (run ?? runCreatedAt),
+                ),
+              ),
       ),
-      projectPendingChangeSetsProvider(
-        projectId,
-      ).overrideWith((ref) async => sets),
+      projectPendingChangeSetsProvider(projectId).overrideWith((ref) async {
+        pendingReads++;
+        return sets;
+      }),
       projectRecommendationServiceProvider.overrideWithValue(service),
       projectChangeSetConfirmationServiceProvider.overrideWithValue(
         confirmation,
       ),
-      agentUpdateStreamProvider(
-        'agent-1',
-      ).overrideWith((ref) => const Stream.empty()),
+      projectDetailNowProvider.overrideWithValue(() => now),
     ],
   );
 
-  testWidgets('shows actual text, shared row controls and one confirm-all', (
+  /// Drops the previous tree first: re-pumping a subject in place would keep
+  /// the old ProviderScope container and the panel's own state, and a test
+  /// could pass on data it never reloaded.
+  Future<void> pumpSubject(WidgetTester tester, Widget widget) async {
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpWidget(widget);
+    await tester.pump();
+    await tester.pump();
+  }
+
+  Future<void> settle(WidgetTester tester) async {
+    await tester.pump();
+    await tester.pump();
+  }
+
+  const updateError = "Couldn't update the recommendation. Please try again.";
+
+  testWidgets('renders the run in order with tags and counts only open steps', (
     tester,
   ) async {
-    await tester.pumpWidget(subject(sets: [changeSet]));
-    await tester.pumpAndSettle();
+    await pumpSubject(
+      tester,
+      subject(
+        width: 1000,
+        items: [
+          steps[0],
+          step(
+            's2',
+            'Split the first wave',
+            position: 1,
+            status: ProjectRecommendationStatus.dismissed,
+          ),
+          step(
+            's3',
+            'Brief the elders',
+            position: 2,
+            status: ProjectRecommendationStatus.resolved,
+            createdTaskId: 'task-3',
+          ),
+        ],
+        sets: [proposals],
+      ),
+    );
+
     expect(find.text('Recommended next steps'), findsOneWidget);
-    expect(find.text('Unblock launch QA'), findsOneWidget);
-    expect(find.text('The staging dataset is incomplete.'), findsOneWidget);
+    expect(find.text('1 pending'), findsNWidgets(2));
+    expect(find.text('Dismissed'), findsOneWidget);
+    expect(find.text('Added'), findsOneWidget);
+    expect(find.text('Open task'), findsOneWidget);
+    expect(
+      find.text('Undo'),
+      findsOneWidget,
+      reason: 'A dismissal stays undoable; a stored addition does not.',
+    );
+    expect(find.text('Proposed changes'), findsOneWidget);
     expect(find.text('Create task: Pack fish'), findsOneWidget);
-    expect(find.text('Confirm all'), findsOneWidget);
-    expect(find.byType(RowActions), findsNWidgets(3));
-  });
-
-  testWidgets('individual confirmation removes only that suggestion', (
-    tester,
-  ) async {
-    when(() => service.markResolved(any())).thenAnswer((_) async => true);
-    await tester.pumpWidget(subject());
-    await tester.pumpAndSettle();
-    await tester.tap(find.byTooltip('Confirm').first);
-    await tester.pumpAndSettle();
-    verify(() => service.markResolved('recommendation-1')).called(1);
-    verifyNever(() => service.markResolved('recommendation-2'));
-    expect(find.text('Unblock launch QA'), findsNothing);
-    expect(find.text('Confirm the launch manifest'), findsOneWidget);
-  });
-
-  testWidgets('individual dismissal preserves the other suggestion', (
-    tester,
-  ) async {
-    when(
-      () => service.dismissRecommendation(any()),
-    ).thenAnswer((_) async => true);
-    await tester.pumpWidget(subject());
-    await tester.pumpAndSettle();
-    await tester.tap(find.byTooltip('Reject').first);
-    await tester.pumpAndSettle();
-    verify(() => service.dismissRecommendation('recommendation-1')).called(1);
-    expect(find.text('Unblock launch QA'), findsNothing);
-    expect(find.text('Confirm the launch manifest'), findsOneWidget);
+    expect(
+      find.text('Add all as tasks'),
+      findsNothing,
+      reason: 'Bulk actions need more than one open step.',
+    );
+    final tops = [
+      'Confirm the escort',
+      'Split the first wave',
+      'Brief the elders',
+    ].map((title) => tester.getTopLeft(find.text(title)).dy).toList();
+    expect(tops, orderedEquals([...tops]..sort()));
   });
 
   testWidgets(
-    'create task consumes the suggestion without resolving siblings',
+    'Add task marks the row added, offers Undo for eight seconds and opens '
+    'the task',
     (tester) async {
-      when(() => service.createTask(any())).thenAnswer(
-        (_) async => const ToolExecutionResult(
+      final creation = Completer<ToolExecutionResult>();
+      when(() => service.createTask('s1')).thenAnswer((_) => creation.future);
+      final opened = <String>[];
+      await pumpSubject(
+        tester,
+        subject(items: steps.sublist(0, 2), onOpenTask: opened.add),
+      );
+
+      await tester.tap(find.text('Add task').first);
+      await tester.pump();
+      expect(find.text('Creating task…'), findsOneWidget);
+      expect(find.text('2 pending'), findsNothing);
+      expect(find.text('1 pending'), findsOneWidget);
+      creation.complete(
+        const ToolExecutionResult(
           success: true,
           output: '',
           mutatedEntityId: 'task-1',
         ),
       );
-      await tester.pumpWidget(subject());
-      await tester.pumpAndSettle();
-      await tester.tap(find.byTooltip('Add task').first);
-      await tester.pumpAndSettle();
-      verify(() => service.createTask('recommendation-1')).called(1);
-      verifyNever(() => service.markResolved(any()));
-      expect(find.text('Unblock launch QA'), findsNothing);
-      expect(find.text('Confirm the launch manifest'), findsOneWidget);
+      await settle(tester);
+
+      verify(() => service.createTask('s1')).called(1);
+      expect(find.text('Added'), findsOneWidget);
+      expect(find.text('Undo'), findsOneWidget);
+      expect(
+        find.text('Add task'),
+        findsOneWidget,
+        reason: 'The other step stays open.',
+      );
+      await tester.tap(find.text('Open task'));
+      expect(opened, ['task-1']);
+
+      await tester.pump(ProjectRecommendationsPanel.undoWindow);
+      await settle(tester);
+      expect(
+        find.text('Undo'),
+        findsNothing,
+        reason: 'The undo window closed.',
+      );
+      expect(find.text('Added'), findsOneWidget);
     },
   );
 
-  testWidgets('created task warnings consume the suggestion and stay visible', (
+  testWidgets('a failed Add task keeps the row with Retry and tries again', (
     tester,
   ) async {
-    when(() => service.createTask(any())).thenAnswer(
-      (_) async => const ToolExecutionResult(
-        success: true,
-        output: '',
-        mutatedEntityId: 'task-1',
-        errorMessage: 'Agent assignment unavailable',
+    var calls = 0;
+    when(() => service.createTask('s1')).thenAnswer((_) async {
+      calls++;
+      return ToolExecutionResult(
+        success: calls > 1,
+        output: calls > 1 ? '' : 'Recommendation is no longer active',
+        mutatedEntityId: calls > 1 ? 'task-1' : null,
+      );
+    });
+    await pumpSubject(tester, subject(items: steps.sublist(0, 1)));
+
+    await tester.tap(find.text('Add task'));
+    await settle(tester);
+    expect(find.text('Retry'), findsOneWidget);
+    expect(find.textContaining("Couldn't create the task."), findsOneWidget);
+    expect(find.text('Confirm the escort'), findsOneWidget);
+
+    await tester.tap(find.text('Retry'));
+    await settle(tester);
+    expect(calls, 2);
+    expect(find.text('Added'), findsOneWidget);
+    expect(find.text('Retry'), findsNothing);
+  });
+
+  testWidgets(
+    'a creation warning surfaces as a toast while the row reads Added',
+    (tester) async {
+      when(() => service.createTask('s1')).thenAnswer(
+        (_) async => const ToolExecutionResult(
+          success: true,
+          output: '',
+          mutatedEntityId: 'task-1',
+          errorMessage: 'Agent assignment unavailable',
+        ),
+      );
+      await pumpSubject(tester, subject(items: steps.sublist(0, 1)));
+
+      await tester.tap(find.text('Add task'));
+      await settle(tester);
+
+      expect(
+        find.textContaining('Agent assignment unavailable'),
+        findsOneWidget,
+      );
+      expect(find.text('Added'), findsOneWidget);
+    },
+  );
+
+  testWidgets('a task created without an id reads Done rather than Added', (
+    tester,
+  ) async {
+    when(() => service.createTask('s1')).thenAnswer(
+      (_) async => const ToolExecutionResult(success: true, output: ''),
+    );
+    await pumpSubject(tester, subject(items: steps.sublist(0, 1)));
+
+    await tester.tap(find.text('Add task'));
+    await settle(tester);
+
+    expect(find.text('Done'), findsOneWidget);
+    expect(find.text('Open task'), findsNothing);
+  });
+
+  testWidgets('Dismiss and Undo flip the row in place', (tester) async {
+    when(
+      () => service.dismissRecommendation('s1'),
+    ).thenAnswer((_) async => true);
+    when(
+      () => service.restoreRecommendation('s1'),
+    ).thenAnswer((_) async => true);
+    await pumpSubject(tester, subject(items: steps.sublist(0, 1)));
+
+    await tester.tap(find.text('Dismiss'));
+    await settle(tester);
+    verify(() => service.dismissRecommendation('s1')).called(1);
+    expect(find.text('Dismissed'), findsOneWidget);
+    expect(find.text('Confirm the escort'), findsOneWidget);
+
+    await tester.tap(find.text('Undo'));
+    await settle(tester);
+    verify(() => service.restoreRecommendation('s1')).called(1);
+    expect(find.text('Dismissed'), findsNothing);
+    expect(find.text('Add task'), findsOneWidget);
+  });
+
+  testWidgets('a refused Undo keeps the tag and says so', (tester) async {
+    when(
+      () => service.restoreRecommendation('s2'),
+    ).thenAnswer((_) async => false);
+    await pumpSubject(
+      tester,
+      subject(
+        items: [
+          steps[0],
+          step(
+            's2',
+            'Split the first wave',
+            position: 1,
+            status: ProjectRecommendationStatus.dismissed,
+          ),
+        ],
       ),
     );
-    await tester.pumpWidget(subject());
-    await tester.pumpAndSettle();
-    await tester.tap(find.byTooltip('Add task').first);
-    await tester.pumpAndSettle();
-    expect(find.text('Unblock launch QA'), findsNothing);
-    expect(find.textContaining('Agent assignment unavailable'), findsOneWidget);
+
+    await tester.tap(find.text('Undo'));
+    await settle(tester);
+
+    expect(find.text('Dismissed'), findsOneWidget);
+    expect(find.text(updateError), findsOneWidget);
+  });
+
+  testWidgets('a thrown dismissal is logged and reported without a crash', (
+    tester,
+  ) async {
+    when(
+      () => service.dismissRecommendation('s1'),
+    ).thenThrow(StateError('offline'));
+    await pumpSubject(tester, subject(items: steps.sublist(0, 1)));
+
+    await tester.tap(find.text('Dismiss'));
+    await settle(tester);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Add task'), findsOneWidget);
+    expect(find.text(updateError), findsOneWidget);
+  });
+
+  testWidgets('Add all and Dismiss all act on every open step in order', (
+    tester,
+  ) async {
+    final added = <String>[];
+    when(() => service.createTask(any())).thenAnswer((call) async {
+      added.add(call.positionalArguments.single as String);
+      return const ToolExecutionResult(
+        success: true,
+        output: '',
+        mutatedEntityId: 'task',
+      );
+    });
+    final dismissed = <String>[];
+    when(() => service.dismissRecommendation(any())).thenAnswer((call) async {
+      dismissed.add(call.positionalArguments.single as String);
+      return true;
+    });
+    await pumpSubject(
+      tester,
+      subject(
+        width: 1000,
+        items: [
+          steps[0],
+          steps[1],
+          step(
+            's3',
+            'Brief the elders',
+            position: 2,
+            status: ProjectRecommendationStatus.dismissed,
+          ),
+          steps[3],
+        ],
+      ),
+    );
+
+    await tester.tap(find.text('Add all as tasks'));
+    await settle(tester);
+    await settle(tester);
+    expect(added, ['s1', 's2', 's4']);
+    expect(find.text('Added'), findsNWidgets(3));
+    expect(find.text('Add all as tasks'), findsNothing);
+
+    await pumpSubject(
+      tester,
+      subject(width: 1000, items: steps.sublist(0, 2)),
+    );
+    await tester.tap(find.text('Dismiss all'));
+    await settle(tester);
+    await settle(tester);
+    expect(dismissed, ['s1', 's2']);
+    expect(find.text('Dismissed'), findsNWidgets(2));
+  });
+
+  testWidgets('a phone shows three rows until Show more', (tester) async {
+    await pumpSubject(tester, subject());
+
+    expect(find.text('Confirm the escort'), findsOneWidget);
+    expect(find.text('Brief the elders'), findsOneWidget);
+    expect(find.text('Stage the krill'), findsNothing);
+    expect(find.text('5 pending'), findsOneWidget);
+
+    await tester.tap(find.text('Show 2 more'));
+    await tester.pump();
+    expect(find.text('Stage the krill'), findsOneWidget);
+    expect(find.text('Tag the pathfinders'), findsOneWidget);
+    expect(find.textContaining('more'), findsNothing);
+
+    await pumpSubject(tester, subject(width: 1000));
+    expect(find.text('Tag the pathfinders'), findsOneWidget);
+    expect(find.textContaining('Show'), findsNothing);
+  });
+
+  testWidgets(
+    'a run decided before the page opened collapses to a summary with history',
+    (tester) async {
+      await pumpSubject(
+        tester,
+        subject(
+          run: now.subtract(const Duration(minutes: 40)),
+          items: [
+            step(
+              's1',
+              'Confirm the escort',
+              status: ProjectRecommendationStatus.resolved,
+              createdTaskId: 'task-1',
+            ),
+            step(
+              's2',
+              'Split the first wave',
+              position: 1,
+              status: ProjectRecommendationStatus.dismissed,
+            ),
+          ],
+        ),
+      );
+
+      expect(
+        find.text('Last run: 1 added, 1 dismissed · 40 min ago'),
+        findsOneWidget,
+      );
+      expect(find.text('Confirm the escort'), findsNothing);
+      expect(find.textContaining('pending'), findsNothing);
+
+      await tester.tap(find.text('Show'));
+      await tester.pump();
+      expect(find.text('Confirm the escort'), findsOneWidget);
+      expect(find.text('Split the first wave'), findsOneWidget);
+      expect(find.text('Hide'), findsOneWidget);
+    },
+  );
+
+  testWidgets('decisions made on the page keep their rows inline', (
+    tester,
+  ) async {
+    when(
+      () => service.dismissRecommendation(any()),
+    ).thenAnswer((_) async => true);
+    await pumpSubject(tester, subject(items: steps.sublist(0, 1)));
+
+    await tester.tap(find.text('Dismiss'));
+    await settle(tester);
+
+    expect(find.textContaining('Last run:'), findsNothing);
+    expect(find.text('Dismissed'), findsOneWidget);
+    expect(find.text('Confirm the escort'), findsOneWidget);
+  });
+
+  testWidgets('an empty run explains itself with when the agent last looked', (
+    tester,
+  ) async {
+    await pumpSubject(tester, subject(items: const []));
+    expect(
+      find.text('No open suggestions. Last looked 2 h ago.'),
+      findsOneWidget,
+    );
+
+    await pumpSubject(tester, subject(items: const [], legacyRun: true));
+    expect(find.text('No open suggestions.'), findsOneWidget);
+  });
+
+  testWidgets('without a snapshot and without proposals nothing renders', (
+    tester,
+  ) async {
+    await pumpSubject(tester, subject(withoutSnapshot: true));
+    expect(find.byType(ProjectRecommendationsPanel), findsOneWidget);
+    expect(find.text('Recommended next steps'), findsNothing);
+    expect(find.text('Proposed changes'), findsNothing);
+
+    await pumpSubject(
+      tester,
+      subject(withoutSnapshot: true, sets: [proposals]),
+    );
+    expect(find.text('Proposed changes'), findsOneWidget);
+    expect(find.text('Recommended next steps'), findsNothing);
+  });
+
+  testWidgets(
+    'proposals apply or reject through the confirmation service and keep '
+    'their tag',
+    (tester) async {
+      when(() => confirmation.confirmItem(any(), any())).thenAnswer(
+        (_) async => const ToolExecutionResult(success: true, output: ''),
+      );
+      await pumpSubject(tester, subject(items: const [], sets: [proposals]));
+      final readsBefore = pendingReads;
+
+      await tester.tap(find.byTooltip('Confirm'));
+      await settle(tester);
+
+      verify(() => confirmation.confirmItem(proposals, 0)).called(1);
+      expect(find.text('Confirmed'), findsOneWidget);
+      expect(find.text('Create task: Pack fish'), findsOneWidget);
+      expect(find.byTooltip('Confirm'), findsNothing);
+      expect(
+        pendingReads,
+        greaterThan(readsBefore),
+        reason: 'Only the proposal read is refreshed after a decision.',
+      );
+      expect(find.text('0 pending'), findsNothing);
+
+      when(
+        () => confirmation.rejectItem(any(), any()),
+      ).thenAnswer((_) async => true);
+      await pumpSubject(tester, subject(items: const [], sets: [proposals]));
+      await tester.tap(find.byTooltip('Reject'));
+      await settle(tester);
+      verify(() => confirmation.rejectItem(proposals, 0)).called(1);
+      expect(find.text('Dismissed'), findsOneWidget);
+    },
+  );
+
+  testWidgets('a failed proposal decision keeps the rail and reports it', (
+    tester,
+  ) async {
+    when(() => confirmation.confirmItem(any(), any())).thenAnswer(
+      (_) async => const ToolExecutionResult(success: false, output: 'no'),
+    );
+    await pumpSubject(tester, subject(items: const [], sets: [proposals]));
+
+    await tester.tap(find.byTooltip('Confirm'));
+    await settle(tester);
+
+    expect(find.byTooltip('Confirm'), findsOneWidget);
+    expect(find.text(updateError), findsOneWidget);
+  });
+
+  testWidgets('a disabled panel renders every control inert', (tester) async {
+    await pumpSubject(
+      tester,
+      subject(
+        width: 1000,
+        enabled: false,
+        items: [
+          steps[0],
+          steps[1],
+          step(
+            's3',
+            'Brief the elders',
+            position: 2,
+            status: ProjectRecommendationStatus.dismissed,
+          ),
+        ],
+        sets: [proposals],
+      ),
+    );
+
+    for (final button in tester.widgetList<DesignSystemButton>(
+      find.byType(DesignSystemButton),
+    )) {
+      expect(button.onPressed, isNull, reason: button.label);
+    }
+    expect(
+      find.text('Undo'),
+      findsNothing,
+      reason: 'Nothing is undoable while disabled.',
+    );
+    await tester.tap(find.byTooltip('Confirm'));
+    await tester.pump();
+    verifyNever(() => confirmation.confirmItem(any(), any()));
   });
 
   testWidgets(
     'disposing during a pending action completes without stale UI writes',
     (tester) async {
       final pending = Completer<bool>();
-      when(() => service.markResolved(any())).thenAnswer((_) => pending.future);
-      await tester.pumpWidget(subject());
-      await tester.pumpAndSettle();
-      await tester.tap(find.byTooltip('Confirm').first);
+      when(
+        () => service.dismissRecommendation('s1'),
+      ).thenAnswer((_) => pending.future);
+      await pumpSubject(tester, subject(items: steps.sublist(0, 1)));
+
+      await tester.tap(find.text('Dismiss'));
       await tester.pump();
       await tester.pumpWidget(const SizedBox.shrink());
       pending.complete(true);
       await tester.pump();
+
       expect(tester.takeException(), isNull);
-      verify(() => service.markResolved('recommendation-1')).called(1);
+      verify(() => service.dismissRecommendation('s1')).called(1);
     },
   );
-
-  testWidgets('confirm-all handles suggestions and proposals independently', (
-    tester,
-  ) async {
-    when(
-      () => service.markResolved('recommendation-1'),
-    ).thenAnswer((_) async => true);
-    when(
-      () => service.markResolved('recommendation-2'),
-    ).thenAnswer((_) async => false);
-    when(() => confirmation.confirmItem(any(), any())).thenAnswer(
-      (_) async => const ToolExecutionResult(success: true, output: ''),
-    );
-    await tester.pumpWidget(subject(sets: [changeSet]));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Confirm all'));
-    await tester.pumpAndSettle();
-    verify(() => service.markResolved('recommendation-1')).called(1);
-    verify(() => service.markResolved('recommendation-2')).called(1);
-    verify(() => confirmation.confirmItem(changeSet, 0)).called(1);
-    expect(find.text('Unblock launch QA'), findsNothing);
-    expect(find.text('Create task: Pack fish'), findsNothing);
-    expect(find.text('Confirm the launch manifest'), findsOneWidget);
-    expect(
-      find.text("Couldn't update the recommendation. Please try again."),
-      findsOneWidget,
-    );
-  });
-
-  testWidgets('all actions stay inert while creating a task', (tester) async {
-    final pending = Completer<ToolExecutionResult>();
-    when(() => service.createTask(any())).thenAnswer((_) => pending.future);
-    await tester.pumpWidget(subject());
-    await tester.pumpAndSettle();
-    await tester.tap(find.byTooltip('Add task').first);
-    await tester.pump();
-    expect(
-      tester
-          .widgetList<RowActions>(find.byType(RowActions))
-          .every((row) => row.busy),
-      isTrue,
-    );
-    expect(
-      tester
-          .widgetList<DesignSystemIconAction>(
-            find.byType(DesignSystemIconAction),
-          )
-          .every((row) => row.onPressed == null),
-      isTrue,
-    );
-    pending.complete(
-      const ToolExecutionResult(success: false, output: 'failed'),
-    );
-    await tester.pumpAndSettle();
-    expect(find.text('Unblock launch QA'), findsOneWidget);
-    expect(
-      find.text("Couldn't update the recommendation. Please try again."),
-      findsOneWidget,
-    );
-  });
-
-  testWidgets('throwing actions retain suggestions and surface an error', (
-    tester,
-  ) async {
-    when(() => service.markResolved(any())).thenThrow(StateError('failed'));
-    await tester.pumpWidget(subject());
-    await tester.pumpAndSettle();
-    await tester.tap(find.byTooltip('Confirm').first);
-    await tester.pumpAndSettle();
-    expect(find.text('Unblock launch QA'), findsOneWidget);
-    expect(
-      find.text("Couldn't update the recommendation. Please try again."),
-      findsOneWidget,
-    );
-  });
-
-  testWidgets('mutation-only list has individual reject and confirm controls', (
-    tester,
-  ) async {
-    when(
-      () => confirmation.rejectItem(any(), any()),
-    ).thenAnswer((_) async => true);
-    await tester.pumpWidget(subject(items: [], sets: [changeSet]));
-    await tester.pumpAndSettle();
-    expect(find.text('Proposed changes'), findsOneWidget);
-    await tester.tap(find.byTooltip('Reject'));
-    await tester.pumpAndSettle();
-    verify(() => confirmation.rejectItem(changeSet, 0)).called(1);
-    expect(find.text('Create task: Pack fish'), findsNothing);
-    expect(find.text('Proposed changes'), findsNothing);
-  });
-
-  testWidgets('retains a legacy proposal summary when its tool is unknown', (
-    tester,
-  ) async {
-    final legacy = changeSet.copyWith(
-      items: const [
-        ChangeItem(
-          toolName: 'legacy_project_action',
-          args: {},
-          humanSummary: 'Review the launch plan',
-        ),
-      ],
-    );
-    await tester.pumpWidget(subject(items: [], sets: [legacy]));
-    await tester.pumpAndSettle();
-    expect(find.text('Review the launch plan'), findsOneWidget);
-    expect(find.byTooltip('Confirm'), findsOneWidget);
-  });
-
-  testWidgets('repeated confirmation while pending dispatches only once', (
-    tester,
-  ) async {
-    final pending = Completer<bool>();
-    when(() => service.markResolved(any())).thenAnswer((_) => pending.future);
-    await tester.pumpWidget(subject());
-    await tester.pumpAndSettle();
-    final actions = tester.widget<RowActions>(find.byType(RowActions).first);
-    final first = actions.onConfirm();
-    await actions.onConfirm();
-    verify(() => service.markResolved('recommendation-1')).called(1);
-    pending.complete(true);
-    await first;
-    await tester.pumpAndSettle();
-    expect(find.text('Unblock launch QA'), findsNothing);
-    expect(find.text('Confirm the launch manifest'), findsOneWidget);
-  });
-
-  testWidgets('empty and initial error states have no action header', (
-    tester,
-  ) async {
-    await tester.pumpWidget(subject(items: []));
-    await tester.pumpAndSettle();
-    expect(find.text('Recommended next steps'), findsNothing);
-    await tester.pumpWidget(
-      subject(load: () async => throw StateError('failed')),
-    );
-    await tester.pumpAndSettle();
-    expect(find.text('Proposed changes'), findsNothing);
-    expect(find.text('Recommended next steps'), findsNothing);
-  });
 }


### PR DESCRIPTION
Second of three PRs implementing the design pass on the projects AI section (handover 2026-09-05; domain layer landed in #4138). This one is the band itself. Task grouping, sorting and the tasks header hardening follow in the third.

## What changes

The "Recommended next steps" band inside the project AI card is rebuilt around the design decisions:

- **Labelled actions, one meaning each.** Every open step offers **Add task** (creates a project-linked task and links the step to it) and **Dismiss**. The unlabelled check mark, the bare plus and "Confirm all" are gone; the check mark's double meaning (mark handled on a step, apply on a proposal) with it.
- **Decided steps stay in place.** A step keeps its row with an *Added* tag (linking to the task via `onOpenTask`), *Done* or *Dismissed*; the title of a dismissed step is struck through. Undo is offered for eight seconds after an addition and for as long as the run is current after a dismissal, backed by `restoreRecommendation`.
- **Failure is visible on the row.** A refused creation keeps the step with **Retry** and the failure copy instead of a toast and a vanished row.
- **Bulk actions with nameable results:** **Add all as tasks** and **Dismiss all**, shown when more than one step is open.
- **Proposals in their own band.** Status changes and agent-created tasks render under "Proposed changes" with the task agent's confirm/reject rail and resolved tag, so advice and mutations no longer share one ambiguous list.
- **Scales down.** Phones show three rows before "Show N more"; the action strip stacks under the text below 560 px so a title keeps the full row width.
- **Summary and empty states.** A run that was already fully decided when the page opened collapses to "Last run: 2 added, 1 dismissed · 40 min ago" with a history disclosure; an empty run reads "No open suggestions. Last looked 2 h ago."
- **No page flash.** The band no longer invalidates the agent update stream after every row. The service notification drives the snapshot re-read; per-row busy/failure state and an optimistic overlay cover the gap so a row never flickers back through "pending". A proposal decision refreshes only the proposal read. The card keeps the bands mounted while the page mutates and passes `enabled: false` instead of dropping them, so an in-flight decision keeps its row state.

New files: `next_steps/project_next_step_row.dart`, `project_proposal_row.dart`, `project_next_steps_summary.dart`, `project_next_steps_model.dart` (pure outcome/tally/cap/age logic). 23 new strings in all twelve catalogs; two unused tooltip keys removed.

Deliberate deviations from the prototype: Undo on an *applied* proposal is not offered (there is no undo for an applied mutation in the confirmation service); the added-step link opens the task instead of scrolling the task list; proposal rows keep the task page's solid row border rather than a dashed one.

## Validation

- Analyzer clean on `lib/features/projects`, `test/features/projects` and the touched agent layers; touched files formatted.
- Tests: model (examples + two Glados properties), step row, summary/empty, proposal row, panel (17 cases: order and tags, Add task with undo window, failure and retry, warning toast, done without id, dismiss/undo, refused undo, thrown dismissal, bulk in order, phone cap, collapsed summary, inline decisions, empty run, no snapshot, proposals confirm/reject, disabled panel, dispose mid-action), detail content, details page, agent summary card — all green.
- `make knowledge_check` and `make changelog_check` pass; `knowledge/features/projects.md` documents the bands, the row state machine and the no-invalidation rule.
- Screenshots below use the penguin demo world only.

## Before / after

Project Waddle, five steps and two proposals (desktop, light):

| Before | After |
|---|---|
| ![Desktop light before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-next-steps-band/a7bd357e54e877355992a3389812023e44d85b7d/before/ai_section_current_desktop_light.png) | ![Desktop light after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-next-steps-band/a7bd357e54e877355992a3389812023e44d85b7d/after/ai_section_current_desktop_light.png) |

Phone, light:

| Before | After |
|---|---|
| ![Phone light before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-next-steps-band/a7bd357e54e877355992a3389812023e44d85b7d/before/ai_section_current_mobile_light.png) | ![Phone light after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-next-steps-band/a7bd357e54e877355992a3389812023e44d85b7d/after/ai_section_current_mobile_light.png) |

<details><summary>Dark theme and the 40-task project</summary>

| Before | After |
|---|---|
| ![Desktop dark before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-next-steps-band/a7bd357e54e877355992a3389812023e44d85b7d/before/ai_section_current_desktop_dark.png) | ![Desktop dark after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-next-steps-band/a7bd357e54e877355992a3389812023e44d85b7d/after/ai_section_current_desktop_dark.png) |
| ![Phone dark before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-next-steps-band/a7bd357e54e877355992a3389812023e44d85b7d/before/ai_section_current_mobile_dark.png) | ![Phone dark after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-next-steps-band/a7bd357e54e877355992a3389812023e44d85b7d/after/ai_section_current_mobile_dark.png) |
| ![40 tasks desktop light before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-next-steps-band/a7bd357e54e877355992a3389812023e44d85b7d/before/ai_section_many_actions_desktop_light.png) | ![40 tasks desktop light after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-next-steps-band/a7bd357e54e877355992a3389812023e44d85b7d/after/ai_section_many_actions_desktop_light.png) |
| ![40 tasks desktop dark before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-next-steps-band/a7bd357e54e877355992a3389812023e44d85b7d/before/ai_section_many_actions_desktop_dark.png) | ![40 tasks desktop dark after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-next-steps-band/a7bd357e54e877355992a3389812023e44d85b7d/after/ai_section_many_actions_desktop_dark.png) |
| ![40 tasks phone light before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-next-steps-band/a7bd357e54e877355992a3389812023e44d85b7d/before/ai_section_many_actions_mobile_light.png) | ![40 tasks phone light after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-next-steps-band/a7bd357e54e877355992a3389812023e44d85b7d/after/ai_section_many_actions_mobile_light.png) |
| ![40 tasks phone dark before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-next-steps-band/a7bd357e54e877355992a3389812023e44d85b7d/before/ai_section_many_actions_mobile_dark.png) | ![40 tasks phone dark after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-next-steps-band/a7bd357e54e877355992a3389812023e44d85b7d/after/ai_section_many_actions_mobile_dark.png) |

</details>

The before images were captured at `0da3f7924` with the same fixtures; the band did not change between that commit and the base of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Project recommendations now appear as labelled next steps with **Add task** and **Dismiss** actions.
  - Added bulk actions, undo support, retry handling, task opening, and persistent outcome labels.
  - Proposed changes appear in a separate band with clearer decision states.
  - Mobile views show fewer steps with **Show more**; completed runs provide summaries and history.
  - Added localized text across supported languages.

- **Bug Fixes**
  - Deciding a recommendation no longer refreshes the entire project page.
  - Actions remain visible during updates while controls are safely disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->