### PR TITLE
chore(db): stamp database timestamps from clock.now() and evaluate outbox defaults per insert

### DIFF
--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -381,8 +381,9 @@ so affected screenshots do not disappear from existing journal entries.
 `JournalDb` migration and on demand from *Settings → Advanced → Maintenance*.
 Its timestamp comes from `package:clock`'s `clock.now()`, and so does every
 other instant the database layer stamps itself — the `updated_at` on a journal
-upsert, conflict rows, outbox leases and retries, sync watermarks, editor drafts
-and settings — so tests drive all of them with `withClock`. The one SQL-side
+upsert, conflict rows, outbox enqueue stamps, leases and retries, sync
+watermarks, editor drafts and settings — so tests drive all of them with
+`withClock`. The one SQL-side
 default, the outbox `created_at`/`updated_at` pair, is Drift's
 `currentDateAndTime`, which SQLite evaluates on each insert; a
 `Constant(DateTime.now())` default would bake the app-launch instant into the

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -5,13 +5,13 @@ description: The eleven Drift/SQLite databases, attachment storage, how connecti
 resource: ../../lib/database
 tags: [architecture, persistence, drift, sqlite, migrations]
 status: stable
-generated: { by: codex/gpt-6, at: 2026-09-05T12:00:00Z }
-stale_after: 2027-01-11
+generated: { by: claude-code/fable-5.1, at: 2026-09-05T14:00:00Z }
+stale_after: 2027-03-05
 sources:
   - id: sync-db
     resource: ../../lib/database/sync_db.dart
     title: SyncDatabase
-    last_modified: 2026-07-27
+    last_modified: 2026-09-05
   - id: agent-db
     resource: ../../lib/features/agents/database/agent_database.dart
     title: AgentDatabase
@@ -43,7 +43,7 @@ sources:
   - id: journal-db
     resource: ../../lib/database/database.dart
     title: JournalDb
-    last_modified: 2026-07-22
+    last_modified: 2026-09-05
   - id: journal-migration
     resource: ../../lib/database/database_migration.dart
     title: JournalDb migration strategy
@@ -379,8 +379,14 @@ so affected screenshots do not disappear from existing journal entries.
 `createDbBackup(fileName)` copies a database to
 `backup/db.<yyyy-MM-dd_HH-mm-ss-S>.sqlite`. It runs automatically before a
 `JournalDb` migration and on demand from *Settings → Advanced → Maintenance*.
-Timestamps come from `package:clock`'s `clock.now()`, so tests can drive them
-with `withClock`.
+Its timestamp comes from `package:clock`'s `clock.now()`, and so does every
+other instant the database layer stamps itself — the `updated_at` on a journal
+upsert, conflict rows, outbox leases and retries, sync watermarks, editor drafts
+and settings — so tests drive all of them with `withClock`. The one SQL-side
+default, the outbox `created_at`/`updated_at` pair, is Drift's
+`currentDateAndTime`, which SQLite evaluates on each insert; a
+`Constant(DateTime.now())` default would bake the app-launch instant into the
+`CREATE TABLE` statement instead.
 
 That helper is a **legacy per-database fallback**, not a supported profile
 backup. It copies only the main SQLite file, has no store identity, manifest,

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:collection/collection.dart';
 import 'package:drift/drift.dart';
 import 'package:enum_to_string/enum_to_string.dart';

--- a/lib/database/database_entity_ops.dart
+++ b/lib/database/database_entity_ops.dart
@@ -65,7 +65,7 @@ mixin _JournalDbEntityOps
           name: 'JournalDb',
           message: 'Conflicting vector clocks: $status',
         );
-        final now = DateTime.now();
+        final now = clock.now();
         await addConflict(
           Conflict(
             id: updated.meta.id,
@@ -92,7 +92,7 @@ mixin _JournalDbEntityOps
     JournalUpdateSkipReason? skipReason;
     var rowsWritten = 0;
     final dbEntity = toDbEntity(updated).copyWith(
-      updatedAt: DateTime.now(),
+      updatedAt: clock.now(),
     );
 
     final existingDbEntity = await entityById(dbEntity.id);

--- a/lib/database/editor_db.dart
+++ b/lib/database/editor_db.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:drift/drift.dart';
 import 'package:lotti/database/common.dart';
 import 'package:lotti/utils/file_utils.dart';
@@ -69,7 +70,7 @@ class EditorDb extends _$EditorDb {
   /// ```dart
   /// final id = await db.insertDraftState(
   ///   entryId: 'entry-123',
-  ///   lastSaved: DateTime.now(),
+  ///   lastSaved: clock.now(),
   ///   draftDeltaJson: '{"ops":[{"insert":"Hello"}]}',
   /// );
   /// ```
@@ -91,7 +92,7 @@ class EditorDb extends _$EditorDb {
       id: uuid.v1(),
       status: _draftStatusDraft,
       entryId: entryId,
-      createdAt: DateTime.now(),
+      createdAt: clock.now(),
       lastSaved: lastSaved,
       delta: draftDeltaJson,
     );

--- a/lib/database/settings_db.dart
+++ b/lib/database/settings_db.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:drift/drift.dart';
 import 'package:flutter/foundation.dart';
 import 'package:lotti/database/common.dart';
@@ -81,7 +82,7 @@ class SettingsDb extends _$SettingsDb {
     final settingsItem = SettingsItem(
       configKey: configKey,
       value: value,
-      updatedAt: DateTime.now(),
+      updatedAt: clock.now(),
     );
 
     final result = await into(settings).insertOnConflictUpdate(settingsItem);

--- a/lib/database/slow_query_logging.dart
+++ b/lib/database/slow_query_logging.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:drift/drift.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/services/dev_logger.dart';
@@ -115,12 +116,12 @@ class SlowQueryInterceptor extends QueryInterceptor {
     return (entry) {
       final elapsedMs =
           entry.elapsed.inMicroseconds / Duration.microsecondsPerMillisecond;
-      final date = DateFormat('yyyy-MM-dd').format(DateTime.now());
+      final date = DateFormat('yyyy-MM-dd').format(clock.now());
       final logFile = File(
         p.join(documentsDirectoryPath, 'logs', '$fileStem-$date.log'),
       );
       final line =
-          '${DateTime.now().toIso8601String()} '
+          '${clock.now().toIso8601String()} '
           '[${entry.databaseName}] ${entry.operation} '
           '${elapsedMs.toStringAsFixed(3)}ms '
           'args=${entry.arguments.length} '

--- a/lib/database/sync_db.dart
+++ b/lib/database/sync_db.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:drift/drift.dart';
 import 'package:lotti/database/common.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_payload_type.dart';

--- a/lib/database/sync_db.g.dart
+++ b/lib/database/sync_db.g.dart
@@ -31,7 +31,7 @@ class $OutboxTable extends Outbox with TableInfo<$OutboxTable, OutboxItem> {
     false,
     type: DriftSqlType.dateTime,
     requiredDuringInsert: false,
-    defaultValue: Constant(DateTime.now()),
+    defaultValue: currentDateAndTime,
   );
   static const VerificationMeta _updatedAtMeta = const VerificationMeta(
     'updatedAt',
@@ -43,7 +43,7 @@ class $OutboxTable extends Outbox with TableInfo<$OutboxTable, OutboxItem> {
     false,
     type: DriftSqlType.dateTime,
     requiredDuringInsert: false,
-    defaultValue: Constant(DateTime.now()),
+    defaultValue: currentDateAndTime,
   );
   static const VerificationMeta _statusMeta = const VerificationMeta('status');
   @override

--- a/lib/database/sync_db_backfill.dart
+++ b/lib/database/sync_db_backfill.dart
@@ -52,7 +52,7 @@ mixin _SyncDbBackfill on _$SyncDatabase {
     Duration? requestedMinAge,
     DateTime? now,
   }) {
-    final effectiveNow = now ?? DateTime.now();
+    final effectiveNow = now ?? clock.now();
     final cutoff = effectiveNow.subtract(minAge);
     final effectiveRequestedMinAge = requestedMinAge ?? minAge;
     final requestedCutoff = effectiveNow.subtract(effectiveRequestedMinAge);
@@ -94,7 +94,7 @@ mixin _SyncDbBackfill on _$SyncDatabase {
   ) async {
     if (entries.isEmpty) return;
 
-    final now = DateTime.now();
+    final now = clock.now();
     // Drift's default `dateTime()` column encodes values as Unix seconds
     // (see the `store_date_time_values_as_text` guide). Anything written
     // via raw `customStatement` bindings must match that encoding, or
@@ -225,7 +225,7 @@ mixin _SyncDbBackfill on _$SyncDatabase {
   ) async {
     if (entries.isEmpty) return;
 
-    final now = DateTime.now();
+    final now = clock.now();
     await batch((b) {
       for (final entry in entries) {
         b.update(
@@ -290,7 +290,7 @@ mixin _SyncDbBackfill on _$SyncDatabase {
     DateTime? now,
     int offset = 0,
   }) async {
-    final effectiveNow = now ?? DateTime.now();
+    final effectiveNow = now ?? clock.now();
     final minAgeCutoff = effectiveNow.subtract(minAge);
     final effectiveRequestedMinAge = requestedMinAge ?? minAge;
     final requestedCutoff = effectiveNow.subtract(effectiveRequestedMinAge);

--- a/lib/database/sync_db_lifecycle.dart
+++ b/lib/database/sync_db_lifecycle.dart
@@ -37,7 +37,7 @@ mixin _SyncDbSequenceLifecycle on _$SyncDatabase, _SyncDbSequenceWatermarks {
     int pageSize = 500,
   }) async {
     final unresolvable = SyncSequenceStatus.unresolvable.index;
-    final effectiveNow = now ?? DateTime.now();
+    final effectiveNow = now ?? clock.now();
     final cutoff = effectiveNow.subtract(grace);
 
     // `status IN (1, 2)` is inlined as a literal so the SQLite planner
@@ -112,7 +112,7 @@ mixin _SyncDbSequenceLifecycle on _$SyncDatabase, _SyncDbSequenceWatermarks {
     int pageSize = 500,
   }) async {
     final unresolvable = SyncSequenceStatus.unresolvable.index;
-    final effectiveNow = now ?? DateTime.now();
+    final effectiveNow = now ?? clock.now();
     final cutoff = effectiveNow.subtract(amnestyWindow);
 
     // Same `IN (1, 2)` literal trick as
@@ -222,7 +222,7 @@ mixin _SyncDbSequenceLifecycle on _$SyncDatabase, _SyncDbSequenceWatermarks {
         'WHERE status = ?',
         variables: [
           Variable.withInt(SyncSequenceStatus.missing.index),
-          Variable.withDateTime(DateTime.now()),
+          Variable.withDateTime(clock.now()),
           Variable.withInt(SyncSequenceStatus.unresolvable.index),
         ],
         updates: {syncSequenceLog},
@@ -249,7 +249,7 @@ mixin _SyncDbSequenceLifecycle on _$SyncDatabase, _SyncDbSequenceWatermarks {
         'WHERE status = ? AND entry_id IS NOT NULL',
         variables: [
           Variable.withInt(SyncSequenceStatus.missing.index),
-          Variable.withDateTime(DateTime.now()),
+          Variable.withDateTime(clock.now()),
           Variable.withInt(SyncSequenceStatus.unresolvable.index),
         ],
         updates: {syncSequenceLog},

--- a/lib/database/sync_db_onboarding.dart
+++ b/lib/database/sync_db_onboarding.dart
@@ -117,7 +117,7 @@ mixin _SyncDbOnboarding on _$SyncDatabase, _SyncDbSequenceWatermarks {
   Future<List<OnboardingSyncRoundItem>> activeInboundOnboardingSyncRounds({
     DateTime? now,
   }) {
-    final effectiveNow = now ?? DateTime.now();
+    final effectiveNow = now ?? clock.now();
     return (select(onboardingSyncRounds)
           ..where(
             (t) =>
@@ -136,7 +136,7 @@ mixin _SyncDbOnboarding on _$SyncDatabase, _SyncDbSequenceWatermarks {
     required String recipientHostId,
     DateTime? now,
   }) {
-    final effectiveNow = now ?? DateTime.now();
+    final effectiveNow = now ?? clock.now();
     return (select(onboardingSyncRounds)..where(
           (t) =>
               t.direction.equals('outbound') &
@@ -179,7 +179,7 @@ mixin _SyncDbOnboarding on _$SyncDatabase, _SyncDbSequenceWatermarks {
   }) async {
     final uniqueCounters = counters.toSet().toList()..sort();
     if (uniqueCounters.isEmpty) return;
-    final timestamp = now ?? DateTime.now();
+    final timestamp = now ?? clock.now();
     final timestampSeconds = timestamp.millisecondsSinceEpoch ~/ 1000;
 
     await transaction(() async {

--- a/lib/database/sync_db_outbox.dart
+++ b/lib/database/sync_db_outbox.dart
@@ -68,7 +68,7 @@ mixin _SyncDbOutbox on _$SyncDatabase {
     DateTime? now,
   }) async {
     if (maxSize <= 0) return const <OutboxItem>[];
-    final effectiveNow = now ?? DateTime.now();
+    final effectiveNow = now ?? clock.now();
     final reclaimWindow = effectiveNow.subtract(leaseDuration);
 
     return transaction(() async {
@@ -175,7 +175,7 @@ mixin _SyncDbOutbox on _$SyncDatabase {
     await (update(outbox)..where((t) => t.id.isIn(ids))).write(
       OutboxCompanion(
         status: Value(OutboxStatus.sent.index),
-        updatedAt: Value(now ?? DateTime.now()),
+        updatedAt: Value(now ?? clock.now()),
       ),
     );
   }

--- a/lib/database/sync_db_outbox_dedup.dart
+++ b/lib/database/sync_db_outbox_dedup.dart
@@ -133,7 +133,7 @@ mixin _SyncDbOutboxDedup on _$SyncDatabase {
           OutboxCompanion(
             message: Value(newMessage),
             subject: Value(newSubject),
-            updatedAt: Value(DateTime.now()),
+            updatedAt: Value(clock.now()),
             payloadSize: payloadSize != null
                 ? Value(payloadSize)
                 : const Value.absent(),

--- a/lib/database/sync_db_outbox_prune.dart
+++ b/lib/database/sync_db_outbox_prune.dart
@@ -30,7 +30,7 @@ mixin _SyncDbOutboxPrune on _$SyncDatabase {
     required Duration retention,
     DateTime? now,
   }) {
-    final effectiveNow = now ?? DateTime.now();
+    final effectiveNow = now ?? clock.now();
     final cutoff = effectiveNow.subtract(retention);
     return customUpdate(
       'DELETE FROM outbox '
@@ -76,7 +76,7 @@ mixin _SyncDbOutboxPrune on _$SyncDatabase {
     // `pageSize <= 0` so a misconfigured caller cannot stall the
     // writer.
     if (chunkSize <= 0) return 0;
-    final effectiveNow = now ?? DateTime.now();
+    final effectiveNow = now ?? clock.now();
     final cutoff = effectiveNow.subtract(retention);
     var total = 0;
     while (true) {

--- a/lib/database/sync_db_sequence.dart
+++ b/lib/database/sync_db_sequence.dart
@@ -35,7 +35,7 @@ mixin _SyncDbSequenceLog on _$SyncDatabase, _SyncDbSequenceWatermarks {
     SyncSequencePayloadType payloadType = SyncSequencePayloadType.journalEntity,
     DateTime? now,
   }) async {
-    final timestamp = now ?? DateTime.now();
+    final timestamp = now ?? clock.now();
     return transaction(() async {
       Future<bool> tryUpdateExisting() async {
         final updated =
@@ -104,7 +104,7 @@ mixin _SyncDbSequenceLog on _$SyncDatabase, _SyncDbSequenceWatermarks {
     required int counter,
     DateTime? now,
   }) async {
-    final timestamp = now ?? DateTime.now();
+    final timestamp = now ?? clock.now();
     return transaction(() async {
       final inserted = await into(syncSequenceLog).insert(
         SyncSequenceLogCompanion(
@@ -159,7 +159,7 @@ mixin _SyncDbSequenceLog on _$SyncDatabase, _SyncDbSequenceWatermarks {
     required int counter,
     DateTime? now,
   }) async {
-    final timestamp = now ?? DateTime.now();
+    final timestamp = now ?? clock.now();
     await transaction(() async {
       final existing = await getEntryByHostAndCounter(hostId, counter);
       if (existing == null) {
@@ -253,7 +253,7 @@ mixin _SyncDbSequenceLog on _$SyncDatabase, _SyncDbSequenceWatermarks {
               .write(
                 SyncSequenceLogCompanion(
                   status: Value(status.index),
-                  updatedAt: Value(DateTime.now()),
+                  updatedAt: Value(clock.now()),
                 ),
               );
       if (updated > 0) {
@@ -366,7 +366,7 @@ mixin _SyncDbSequenceLog on _$SyncDatabase, _SyncDbSequenceWatermarks {
     required Map<String, int> payloadCounters,
     DateTime? now,
   }) async {
-    final timestamp = now ?? DateTime.now();
+    final timestamp = now ?? clock.now();
     return transaction(() async {
       final rows =
           await (select(syncSequenceLog)..where(

--- a/lib/database/sync_db_tables.dart
+++ b/lib/database/sync_db_tables.dart
@@ -91,10 +91,10 @@ class Outbox extends Table {
   IntColumn get id => integer().autoIncrement()();
 
   DateTimeColumn get createdAt =>
-      dateTime().named('created_at').withDefault(Constant(DateTime.now()))();
+      dateTime().named('created_at').withDefault(currentDateAndTime)();
 
   DateTimeColumn get updatedAt =>
-      dateTime().named('updated_at').withDefault(Constant(DateTime.now()))();
+      dateTime().named('updated_at').withDefault(currentDateAndTime)();
 
   IntColumn get status =>
       integer().withDefault(Constant(OutboxStatus.pending.index))();

--- a/lib/database/sync_db_watermarks.dart
+++ b/lib/database/sync_db_watermarks.dart
@@ -52,7 +52,7 @@ mixin _SyncDbSequenceWatermarks on _$SyncDatabase {
       variables: [
         Variable.withString(hostId),
         Variable.withInt(lastCounter),
-        Variable.withInt(DateTime.now().millisecondsSinceEpoch ~/ 1000),
+        Variable.withInt(clock.now().millisecondsSinceEpoch ~/ 1000),
       ],
       updates: {syncSequenceLog},
     );

--- a/lib/features/agents/database/agent_repo_links.dart
+++ b/lib/features/agents/database/agent_repo_links.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:drift/drift.dart';
 import 'package:lotti/features/agents/database/agent_database.dart';
 import 'package:lotti/features/agents/database/agent_db_conversions.dart';
@@ -35,7 +36,7 @@ class AgentRepoLinks {
     }
 
     await _db.transaction(() async {
-      final now = DateTime.now();
+      final now = clock.now();
       // The SQL `deleted_at` / `updated_at` columns AND the
       // `serialized` JSON both need to carry the tombstone, otherwise
       // readers that decode the link from `serialized` (e.g. the

--- a/lib/features/ai/database/ai_config_db.dart
+++ b/lib/features/ai/database/ai_config_db.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:drift/drift.dart';
 import 'package:lotti/database/common.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
@@ -33,7 +34,7 @@ class AiConfigDb extends _$AiConfigDb {
   Future<int> saveConfig(AiConfig config) async {
     final existingConfig = await configById(config.id).getSingleOrNull();
 
-    final now = DateTime.now();
+    final now = clock.now();
 
     final dbEntity = AiConfigDbEntity(
       id: config.id,

--- a/lib/features/ai/database/sharded_embedding_store.dart
+++ b/lib/features/ai/database/sharded_embedding_store.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:clock/clock.dart';
 import 'package:lotti/features/ai/database/embedding_store.dart';
 import 'package:lotti/features/ai/database/objectbox_embedding_entity.dart';
 import 'package:lotti/features/ai/database/objectbox_embedding_store.dart';

--- a/lib/features/ai/database/sharded_embedding_store_migration.dart
+++ b/lib/features/ai/database/sharded_embedding_store_migration.dart
@@ -27,7 +27,7 @@ Future<void> migrateFromSingleEmbeddingStore({
     // No old store — write marker and return.
     await shardedBaseDir.create(recursive: true);
     await markerFile.writeAsString(
-      'Migrated at ${DateTime.now().toUtc().toIso8601String()}',
+      'Migrated at ${clock.now().toUtc().toIso8601String()}',
     );
     return;
   }
@@ -78,7 +78,7 @@ Future<void> migrateFromSingleEmbeddingStore({
 
     // Write marker only after successful migration.
     await markerFile.writeAsString(
-      'Migrated at ${DateTime.now().toUtc().toIso8601String()}',
+      'Migrated at ${clock.now().toUtc().toIso8601String()}',
     );
   } finally {
     oldOps.close();

--- a/lib/features/sync/outbox/outbox_repository.dart
+++ b/lib/features/sync/outbox/outbox_repository.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:drift/drift.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/sync/state/outbox_state_controller.dart';
@@ -153,7 +154,7 @@ class DatabaseOutboxRepository implements OutboxRepository {
       OutboxCompanion(
         id: Value(item.id),
         status: Value(OutboxStatus.sent.index),
-        updatedAt: Value(DateTime.now()),
+        updatedAt: Value(clock.now()),
       ),
     );
   }
@@ -181,7 +182,7 @@ class DatabaseOutboxRepository implements OutboxRepository {
         id: Value(item.id),
         status: Value(newStatus),
         retries: Value(retries),
-        updatedAt: Value(DateTime.now()),
+        updatedAt: Value(clock.now()),
       ),
     );
   }
@@ -189,7 +190,7 @@ class DatabaseOutboxRepository implements OutboxRepository {
   @override
   Future<void> markRetryBatch(List<OutboxItem> items) async {
     if (items.isEmpty) return;
-    final now = DateTime.now();
+    final now = clock.now();
     // One batched statement set rather than one round trip per row.
     //
     // A failed bundle retries up to `SyncTuning.outboxBundleMaxSize` (50) rows

--- a/lib/features/sync/outbox/outbox_service.dart
+++ b/lib/features/sync/outbox/outbox_service.dart
@@ -430,8 +430,8 @@ class MatrixOutboxService extends _OutboxServiceBase
       final commonFields = OutboxCompanion(
         status: Value(OutboxStatus.pending.index),
         message: Value(jsonString),
-        createdAt: Value(DateTime.now()),
-        updatedAt: Value(DateTime.now()),
+        createdAt: Value(clock.now()),
+        updatedAt: Value(clock.now()),
         payloadSize: Value(jsonByteLength),
         priority: Value(priority),
       );

--- a/lib/features/sync/ui/pages/outbox/outbox_monitor_page.dart
+++ b/lib/features/sync/ui/pages/outbox/outbox_monitor_page.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:drift/drift.dart' as drift;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -133,7 +134,7 @@ class _OutboxMonitorPageState extends State<OutboxMonitorPage> {
             id: drift.Value(item.id),
             status: drift.Value(OutboxStatus.pending.index),
             retries: drift.Value(item.retries + 1),
-            updatedAt: drift.Value(DateTime.now()),
+            updatedAt: drift.Value(clock.now()),
           ),
         );
       } catch (error, stackTrace) {

--- a/test/database/database_entity_ops_test.dart
+++ b/test/database/database_entity_ops_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:drift/drift.dart' show Variable;
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -616,6 +617,21 @@ void main() {
         expect(retrieved, isNotNull);
         expect(retrieved?.meta.id, entry.meta.id);
         expect(retrieved?.meta.dateFrom, isA<DateTime>());
+      });
+
+      test('updateJournalEntity stamps updated_at from clock.now()', () async {
+        // Drift stores DateTime columns as whole seconds, so a fixed instant
+        // with no sub-second part round-trips exactly.
+        final fixedNow = DateTime(2026, 9, 5, 10, 30);
+        final entry = createJournalEntry('Clock-driven write');
+
+        await withClock(
+          Clock.fixed(fixedNow),
+          () => db!.updateJournalEntity(entry),
+        );
+
+        final row = await db!.entityById(entry.meta.id);
+        expect(row?.updatedAt, fixedNow);
       });
 
       test(

--- a/test/database/sync_db_tables_test.dart
+++ b/test/database/sync_db_tables_test.dart
@@ -122,6 +122,33 @@ void main() {
       },
     );
 
+    test('outbox timestamp defaults are evaluated per insert', () async {
+      // `Constant(DateTime.now())` bakes the instant the table object was
+      // built into CREATE TABLE as a literal, so a row inserted without
+      // timestamps would carry the app-launch time. `currentDateAndTime`
+      // renders as a strftime expression SQLite evaluates on every insert.
+      final rows = await database
+          .customSelect(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' "
+            "AND name = 'outbox'",
+          )
+          .get();
+      final ddl = rows.single.read<String>('sql');
+
+      expect(
+        ddl,
+        isNot(
+          matches(
+            RegExp(r'(created_at|updated_at) INTEGER NOT NULL DEFAULT \d'),
+          ),
+        ),
+      );
+      expect(
+        RegExp(r"strftime\('%s', CURRENT_TIMESTAMP\)").allMatches(ddl),
+        hasLength(2),
+      );
+    });
+
     test('can insert and retrieve a QueueMarkers row', () async {
       const roomId = '!marker-room:example.org';
 

--- a/test/features/sync/outbox/outbox_repository_test.dart
+++ b/test/features/sync/outbox/outbox_repository_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:clock/clock.dart';
 import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -634,6 +635,29 @@ void main() {
           final capped = await realDb.getOutboxItemById(cappedId);
           expect(capped?.retries, 2);
           expect(capped?.status, OutboxStatus.error.index);
+        },
+      );
+
+      test(
+        'markRetry and markRetryBatch stamp updated_at from clock.now()',
+        () async {
+          // Drift stores DateTime columns as whole seconds, so a fixed
+          // instant with no sub-second part round-trips exactly.
+          final fixedNow = DateTime(2026, 9, 5, 10, 30);
+          final id1 = await insertRow(status: OutboxStatus.sending);
+          final id2 = await insertRow(status: OutboxStatus.sending);
+          final item1 = (await realDb.getOutboxItemById(id1))!;
+          final item2 = (await realDb.getOutboxItemById(id2))!;
+
+          await withClock(Clock.fixed(fixedNow), () async {
+            await realRepo.markRetry(item1);
+            await realRepo.markRetryBatch([item2]);
+          });
+
+          for (final id in [id1, id2]) {
+            final refreshed = await realDb.getOutboxItemById(id);
+            expect(refreshed?.updatedAt, fixedNow);
+          }
         },
       );
 


### PR DESCRIPTION
## Summary

Two quick wins from a review of the persistence layer. Neither changes runtime behaviour today; both close a gap that made the layer harder to test or would bite the next caller.

**Timestamps go through `clock.now()`.** Every instant the database layer stamped itself — the `updated_at` on a journal upsert, conflict rows, outbox leases and retries, sync watermarks, editor drafts, settings, agent links, AI config rows — came from `DateTime.now()`, which `withClock` cannot reach. `common.dart` already used `clock.now()` for backup names; this makes the rest of the layer consistent with it and with the repo's deterministic-dates testing rule. Outside `withClock`, `clock.now()` *is* `DateTime.now()`.

**Outbox `created_at`/`updated_at` defaults are evaluated per insert.** They were declared as `withDefault(Constant(DateTime.now()))`, which Drift evaluates once when the table object is built and bakes into `CREATE TABLE` as a literal. Every current insert sets both columns explicitly, so nothing is wrong on main, but the next companion that omits them would silently backdate rows to the app-launch time. `currentDateAndTime` renders as a `strftime` expression SQLite evaluates on each insert. Existing databases keep the literal default they were created with; the change only affects the DDL of newly created `sync.sqlite` files, and is harmless there for the same reason.

## Tests

- `updateJournalEntity stamps updated_at from clock.now()` — fixed clock, exact `updated_at` match. Fails on main with the real time.
- `outbox timestamp defaults are evaluated per insert` — asserts the `outbox` DDL carries two `strftime('%s', CURRENT_TIMESTAMP)` defaults and no literal-integer default. Fails on main.

Ran the test files for every touched source (`sync_db_*`, `editor_db`, `settings_db`, `slow_query_logging`, `database_entity_ops`, `agent_repo_links`, `ai_config_db_normalization`, `sharded_embedding_store`): all green. `make analyze` clean, `make knowledge_check` clean.

## Docs

`knowledge/architecture/persistence.md`: the backup paragraph now states that every layer-stamped timestamp comes from `clock.now()` and names the outbox default as the one SQL-side exception.

No changelog fragment: nothing a user would notice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected database and synchronization timestamps so they reflect the actual time each record is created or updated.
  * Improved outbox timestamp defaults so each inserted record receives its own current timestamp.

* **Documentation**
  * Clarified persistence timestamp behavior and testability details.

* **Tests**
  * Added coverage for timestamp handling and per-record outbox timestamp defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->