### PR TITLE
chore(db): drop uncalled drift queries and redundant journal indexes

### DIFF
--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -5,8 +5,8 @@ description: The eleven Drift/SQLite databases, attachment storage, how connecti
 resource: ../../lib/database
 tags: [architecture, persistence, drift, sqlite, migrations]
 status: stable
-generated: { by: codex/gpt-6, at: 2026-09-05T12:00:00Z }
-stale_after: 2027-01-11
+generated: { by: claude-code/fable-5.1, at: 2026-09-05T14:00:00Z }
+stale_after: 2027-03-05
 sources:
   - id: sync-db
     resource: ../../lib/database/sync_db.dart
@@ -43,11 +43,11 @@ sources:
   - id: journal-db
     resource: ../../lib/database/database.dart
     title: JournalDb
-    last_modified: 2026-07-22
+    last_modified: 2026-09-05
   - id: journal-migration
     resource: ../../lib/database/database_migration.dart
     title: JournalDb migration strategy
-    last_modified: 2026-07-09
+    last_modified: 2026-09-05
   - id: image-path-migration
     resource: ../../lib/features/journal/service/image_path_migration_service.dart
     title: ImagePathMigrationService
@@ -81,7 +81,7 @@ migration work has to cover both, and embeddings are a third store again (below)
 
 | Database | File | Schema | Owns |
 |----------|------|--------|------|
-| `JournalDb` | `db.sqlite` | 45 | Journal entities, tasks, links, tags, config flags — the primary store |
+| `JournalDb` | `db.sqlite` | 46 | Journal entities, tasks, links, tags, config flags — the primary store |
 | `SyncDatabase` | `sync.sqlite` | 29 | Outbox, sequence log, host activity, inbound event queue, queue markers |
 | `AgentDatabase` | `agent.sqlite` | 19 | Agent state, reports, observations, change proposals, wake history |
 | `EditorDb` | `editor_drafts_db.sqlite` | 2 | Unsaved rich-text editor drafts |
@@ -216,6 +216,15 @@ The indexes matter: `idx_journal_tasks_due_open` is keyed on the denormalized
 `due_at` column added in v41, which replaced an expression index over
 `json_extract(serialized,'$.data.due')`. The column lets the planner stream
 `ORDER BY due_at ASC` straight from the index instead of parsing JSON per row.
+
+They also cost: every journal upsert rewrites the row, so each index is paid
+for on every write. v46 dropped nine that duplicated an index SQLite already
+had — the single-column DESC twins of the `date_from`/`date_to` indexes (an
+index is walked in either direction), the `idx_*_definitions_id` indexes on
+primary keys, the single-column `linked_entries` indexes shadowed by their
+composite prefixes, and the lone boolean `idx_linked_entries_hidden`. A new
+index needs a query that the planner demonstrably picks it for; the EXPLAIN
+tests under `test/database/` are where that is shown.
 
 # From write to UI
 

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -151,7 +151,7 @@ class JournalDb extends _$JournalDb
   final Directory? _documentsDirectory;
 
   @override
-  int get schemaVersion => 45;
+  int get schemaVersion => 46;
 
   // Check whether a column exists in a given table to make migrations safer
   @override
@@ -180,7 +180,6 @@ class JournalDb extends _$JournalDb
     final hasLabelDefinitions = await _tableExists('label_definitions');
     if (!hasLabelDefinitions) {
       await migrator.createTable(labelDefinitions);
-      await migrator.createIndex(idxLabelDefinitionsId);
       await migrator.createIndex(idxLabelDefinitionsName);
       await migrator.createIndex(idxLabelDefinitionsPrivate);
     }

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -35,10 +35,10 @@ CREATE TABLE journal (
   PRIMARY KEY (id)
 ) as JournalDbEntity;
 
+-- One index per date column: SQLite walks an index in either direction, so
+-- the DESC twins that used to sit next to these were pure write cost.
 CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
-CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC);
 CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
-CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC);
 
 CREATE INDEX idx_journal_day_audio ON journal(
   day_id COLLATE BINARY ASC,
@@ -57,10 +57,9 @@ WHERE type = 'JournalAudio'
   AND recording_session_id IS NOT NULL;
 
 CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
--- Supports the import-flag maintenance views: `countImportFlagEntries` filters
--- by `flag = 1`, while `entriesFlaggedImport` needs the same subset ordered by
--- newest entry first. The broad tab index leads with type/starred and cannot
--- serve either shape when no type filter is present.
+-- Supports the import-flag maintenance count: `countImportFlagEntries`
+-- filters by `flag = 1`. The broad tab index leads with type/starred and
+-- cannot serve that shape when no type filter is present.
 CREATE INDEX idx_journal_import_flag_date ON journal(
   flag COLLATE BINARY ASC,
   date_from COLLATE BINARY DESC,
@@ -228,7 +227,6 @@ CREATE TABLE habit_definitions (
   PRIMARY KEY (id)
 ) as HabitDefinitionDbEntity;
 
-CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
 CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
 CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
 CREATE INDEX idx_habit_definitions_deleted_private ON habit_definitions(
@@ -248,7 +246,6 @@ CREATE TABLE category_definitions (
   PRIMARY KEY (id)
 ) as CategoryDefinitionDbEntity;
 
-CREATE INDEX idx_category_definitions_id ON category_definitions (id);
 CREATE INDEX idx_category_definitions_name ON category_definitions (name);
 CREATE INDEX idx_category_definitions_private ON category_definitions (private);
 
@@ -264,7 +261,6 @@ CREATE TABLE label_definitions (
   PRIMARY KEY (id)
 ) as LabelDefinitionDbEntity;
 
-CREATE INDEX idx_label_definitions_id ON label_definitions (id);
 CREATE INDEX idx_label_definitions_name ON label_definitions (name);
 CREATE INDEX idx_label_definitions_private ON label_definitions (private);
 CREATE INDEX idx_label_definitions_deleted_private_name ON label_definitions(
@@ -293,7 +289,6 @@ CREATE TABLE dashboard_definitions (
   PRIMARY KEY (id)
 ) as DashboardDefinitionDbEntity;
 
-CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
 CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
 CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
 CREATE INDEX idx_dashboard_definitions_deleted_private_name ON dashboard_definitions(
@@ -335,10 +330,7 @@ CREATE TABLE linked_entries (
   UNIQUE(from_id, to_id, type)
 ) as LinkedDbEntry;
 
-CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
-CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
 CREATE INDEX idx_linked_entries_type ON linked_entries (type);
-CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
 
 CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
 -- Covering variant so `getBulkLinkedTimeSpans` can resolve `to_id`
@@ -386,11 +378,6 @@ WHERE type = 'RatingLink' AND COALESCE(hidden, FALSE) = FALSE;
 listConfigFlags:
 SELECT *
   FROM config_flags;
-
-configFlagByName:
-SELECT *
-  FROM config_flags
-  WHERE name = :name;
 
 filteredJournal:
 SELECT * FROM journal
@@ -453,29 +440,6 @@ SELECT * FROM journal
 
 filteredJournalByIds:
 SELECT * FROM journal
-  WHERE type IN :types
-  AND deleted = false
-  AND id IN :ids
-  AND starred IN :starredStatuses
-  AND private IN :privateStatuses
-  AND flag IN :flaggedStatuses
-  ORDER BY date_from DESC
-  LIMIT :limit
-  OFFSET :offset;
-
-filteredJournalIds:
-SELECT id FROM journal
-  WHERE type IN :types
-  AND deleted = false
-  AND starred IN :starredStatuses
-  AND private IN :privateStatuses
-  AND flag IN :flaggedStatuses
-  ORDER BY date_from DESC
-  LIMIT :limit
-  OFFSET :offset;
-
-filteredJournalIds2:
-SELECT id FROM journal
   WHERE type IN :types
   AND deleted = false
   AND id IN :ids
@@ -795,31 +759,6 @@ SELECT * FROM journal
   LIMIT :limit
   OFFSET :offset;
 
-filteredTaskIds:
-SELECT id FROM journal
-  WHERE type = 'Task'
-  AND deleted = false
-  AND private IN :privateStatuses
-  AND starred IN :starredStatuses
-  AND task = 1
-  AND task_status IN :taskStatuses
-  ORDER BY date_from DESC
-  LIMIT :limit
-  OFFSET :offset;
-
-filteredTaskIds2:
-SELECT id FROM journal
-  WHERE type = 'Task'
-  AND deleted = false
-  AND id IN :ids
-  AND private IN :privateStatuses
-  AND starred IN :starredStatuses
-  AND task = 1
-  AND task_status IN :taskStatuses
-  ORDER BY date_from DESC
-  LIMIT :limit
-  OFFSET :offset;
-
 emptyJournalSelection:
 SELECT * FROM journal
   WHERE 1 = 0;
@@ -839,20 +778,6 @@ SELECT * FROM journal
   ORDER BY updated_at ASC, id ASC
   LIMIT :limit
   OFFSET :offset;
-
-orderedAudioEntries:
-SELECT * FROM journal
-  WHERE type = 'JournalAudio'
-  AND deleted = false
-  ORDER BY date_from DESC
-  LIMIT :limit
-  OFFSET :offset;
-
-entriesFlaggedImport:
-SELECT * FROM journal
-  WHERE deleted = false AND flag = 1
-  ORDER BY date_from DESC
-  LIMIT :limit;
 
 conflictsByStatus:
 SELECT * FROM conflicts
@@ -968,14 +893,6 @@ SELECT COUNT(*) FROM journal
   AND task = 1
   AND private IN :privateStatuses
   AND task_status IN :taskStatuses;
-
-countTasksByCategory:
-SELECT COUNT(*) FROM journal
-  WHERE deleted = false
-  AND type = 'Task'
-  AND category = :categoryId
-  AND task = 1
-  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'));
 
 countTasksGroupedByCategory:
 SELECT category, COUNT(*) AS task_count FROM journal
@@ -1115,26 +1032,6 @@ DELETE FROM labeled
   WHERE journal_id = :journal_id
   AND label_id = :label_id;
 
-deleteLabeledForId:
-DELETE FROM labeled
-  WHERE journal_id = :journal_id;
-
-purgeDeletedDashboards:
-DELETE FROM dashboard_definitions
-  WHERE deleted = TRUE;
-
-purgeDeletedMeasurables:
-DELETE FROM measurable_types
-  WHERE deleted = TRUE;
-
-purgeDeletedLabelDefinitions:
-DELETE FROM label_definitions
-  WHERE deleted = TRUE;
-
-purgeDeletedJournalEntities:
-DELETE FROM journal
-  WHERE deleted = TRUE;
-
 linkedJournalEntities:
 SELECT journal.* FROM linked_entries
   INNER JOIN journal ON journal.id = linked_entries.to_id
@@ -1185,19 +1082,6 @@ entriesForIds:
 SELECT * FROM journal
   WHERE id IN :ids;
 
-journalEntitiesByIds:
-SELECT * FROM journal
-  WHERE deleted = false
-  AND id IN :ids
-  AND private IN :privateStatuses
-  ORDER BY date_from DESC;
-
-journalEntitiesByIdsAllPrivate:
-SELECT * FROM journal
-  WHERE deleted = false
-  AND id IN :ids
-  ORDER BY date_from DESC;
-
 journalEntitiesByIdsUnordered:
 SELECT * FROM journal
   WHERE deleted = false
@@ -1208,9 +1092,6 @@ journalEntitiesByIdsUnorderedAllPrivate:
 SELECT * FROM journal
   WHERE deleted = false
   AND id IN :ids;
-
-linkedJournalEntityIds:
-SELECT to_id FROM linked_entries WHERE from_id = :from_id AND hidden IN :hidden;
 
 parentLinkedEntityIds:
 SELECT from_id FROM linked_entries WHERE to_id = :to_id;

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -5639,17 +5639,9 @@ abstract class _$JournalDb extends GeneratedDatabase {
     'idx_journal_date_from_asc',
     'CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC)',
   );
-  late final Index idxJournalDateFromDesc = Index(
-    'idx_journal_date_from_desc',
-    'CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC)',
-  );
   late final Index idxJournalDateToAsc = Index(
     'idx_journal_date_to_asc',
     'CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC)',
-  );
-  late final Index idxJournalDateToDesc = Index(
-    'idx_journal_date_to_desc',
-    'CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC)',
   );
   late final Index idxJournalDayAudio = Index(
     'idx_journal_day_audio',
@@ -5722,10 +5714,6 @@ abstract class _$JournalDb extends GeneratedDatabase {
   );
   late final MeasurableTypes measurableTypes = MeasurableTypes(this);
   late final HabitDefinitions habitDefinitions = HabitDefinitions(this);
-  late final Index idxHabitDefinitionsId = Index(
-    'idx_habit_definitions_id',
-    'CREATE INDEX idx_habit_definitions_id ON habit_definitions (id)',
-  );
   late final Index idxHabitDefinitionsName = Index(
     'idx_habit_definitions_name',
     'CREATE INDEX idx_habit_definitions_name ON habit_definitions (name)',
@@ -5741,10 +5729,6 @@ abstract class _$JournalDb extends GeneratedDatabase {
   late final CategoryDefinitions categoryDefinitions = CategoryDefinitions(
     this,
   );
-  late final Index idxCategoryDefinitionsId = Index(
-    'idx_category_definitions_id',
-    'CREATE INDEX idx_category_definitions_id ON category_definitions (id)',
-  );
   late final Index idxCategoryDefinitionsName = Index(
     'idx_category_definitions_name',
     'CREATE INDEX idx_category_definitions_name ON category_definitions (name)',
@@ -5754,10 +5738,6 @@ abstract class _$JournalDb extends GeneratedDatabase {
     'CREATE INDEX idx_category_definitions_private ON category_definitions (private)',
   );
   late final LabelDefinitions labelDefinitions = LabelDefinitions(this);
-  late final Index idxLabelDefinitionsId = Index(
-    'idx_label_definitions_id',
-    'CREATE INDEX idx_label_definitions_id ON label_definitions (id)',
-  );
   late final Index idxLabelDefinitionsName = Index(
     'idx_label_definitions_name',
     'CREATE INDEX idx_label_definitions_name ON label_definitions (name)',
@@ -5776,10 +5756,6 @@ abstract class _$JournalDb extends GeneratedDatabase {
   );
   late final DashboardDefinitions dashboardDefinitions = DashboardDefinitions(
     this,
-  );
-  late final Index idxDashboardDefinitionsId = Index(
-    'idx_dashboard_definitions_id',
-    'CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id)',
   );
   late final Index idxDashboardDefinitionsName = Index(
     'idx_dashboard_definitions_name',
@@ -5804,21 +5780,9 @@ abstract class _$JournalDb extends GeneratedDatabase {
     'CREATE INDEX idx_labeled_label_id ON labeled (label_id)',
   );
   late final LinkedEntries linkedEntries = LinkedEntries(this);
-  late final Index idxLinkedEntriesFromId = Index(
-    'idx_linked_entries_from_id',
-    'CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id)',
-  );
-  late final Index idxLinkedEntriesToId = Index(
-    'idx_linked_entries_to_id',
-    'CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id)',
-  );
   late final Index idxLinkedEntriesType = Index(
     'idx_linked_entries_type',
     'CREATE INDEX idx_linked_entries_type ON linked_entries (type)',
-  );
-  late final Index idxLinkedEntriesHidden = Index(
-    'idx_linked_entries_hidden',
-    'CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden)',
   );
   late final Index idxLinkedEntriesFromIdHidden = Index(
     'idx_linked_entries_from_id_hidden',
@@ -5848,14 +5812,6 @@ abstract class _$JournalDb extends GeneratedDatabase {
     return customSelect(
       'SELECT * FROM config_flags',
       variables: [],
-      readsFrom: {configFlags},
-    ).asyncMap(configFlags.mapFromRow);
-  }
-
-  Selectable<ConfigFlag> configFlagByName(String name) {
-    return customSelect(
-      'SELECT * FROM config_flags WHERE name = ?1',
-      variables: [Variable<String>(name)],
       readsFrom: {configFlags},
     ).asyncMap(configFlags.mapFromRow);
   }
@@ -6084,90 +6040,6 @@ abstract class _$JournalDb extends GeneratedDatabase {
       ],
       readsFrom: {journal},
     ).asyncMap(journal.mapFromRow);
-  }
-
-  Selectable<String> filteredJournalIds(
-    List<String> types,
-    List<bool> starredStatuses,
-    List<bool> privateStatuses,
-    List<int> flaggedStatuses,
-    int limit,
-    int offset,
-  ) {
-    var $arrayStartIndex = 3;
-    final expandedtypes = $expandVar($arrayStartIndex, types.length);
-    $arrayStartIndex += types.length;
-    final expandedstarredStatuses = $expandVar(
-      $arrayStartIndex,
-      starredStatuses.length,
-    );
-    $arrayStartIndex += starredStatuses.length;
-    final expandedprivateStatuses = $expandVar(
-      $arrayStartIndex,
-      privateStatuses.length,
-    );
-    $arrayStartIndex += privateStatuses.length;
-    final expandedflaggedStatuses = $expandVar(
-      $arrayStartIndex,
-      flaggedStatuses.length,
-    );
-    $arrayStartIndex += flaggedStatuses.length;
-    return customSelect(
-      'SELECT id FROM journal WHERE type IN ($expandedtypes) AND deleted = FALSE AND starred IN ($expandedstarredStatuses) AND private IN ($expandedprivateStatuses) AND flag IN ($expandedflaggedStatuses) ORDER BY date_from DESC LIMIT ?1 OFFSET ?2',
-      variables: [
-        Variable<int>(limit),
-        Variable<int>(offset),
-        for (var $ in types) Variable<String>($),
-        for (var $ in starredStatuses) Variable<bool>($),
-        for (var $ in privateStatuses) Variable<bool>($),
-        for (var $ in flaggedStatuses) Variable<int>($),
-      ],
-      readsFrom: {journal},
-    ).map((QueryRow row) => row.read<String>('id'));
-  }
-
-  Selectable<String> filteredJournalIds2(
-    List<String> types,
-    List<String> ids,
-    List<bool> starredStatuses,
-    List<bool> privateStatuses,
-    List<int> flaggedStatuses,
-    int limit,
-    int offset,
-  ) {
-    var $arrayStartIndex = 3;
-    final expandedtypes = $expandVar($arrayStartIndex, types.length);
-    $arrayStartIndex += types.length;
-    final expandedids = $expandVar($arrayStartIndex, ids.length);
-    $arrayStartIndex += ids.length;
-    final expandedstarredStatuses = $expandVar(
-      $arrayStartIndex,
-      starredStatuses.length,
-    );
-    $arrayStartIndex += starredStatuses.length;
-    final expandedprivateStatuses = $expandVar(
-      $arrayStartIndex,
-      privateStatuses.length,
-    );
-    $arrayStartIndex += privateStatuses.length;
-    final expandedflaggedStatuses = $expandVar(
-      $arrayStartIndex,
-      flaggedStatuses.length,
-    );
-    $arrayStartIndex += flaggedStatuses.length;
-    return customSelect(
-      'SELECT id FROM journal WHERE type IN ($expandedtypes) AND deleted = FALSE AND id IN ($expandedids) AND starred IN ($expandedstarredStatuses) AND private IN ($expandedprivateStatuses) AND flag IN ($expandedflaggedStatuses) ORDER BY date_from DESC LIMIT ?1 OFFSET ?2',
-      variables: [
-        Variable<int>(limit),
-        Variable<int>(offset),
-        for (var $ in types) Variable<String>($),
-        for (var $ in ids) Variable<String>($),
-        for (var $ in starredStatuses) Variable<bool>($),
-        for (var $ in privateStatuses) Variable<bool>($),
-        for (var $ in flaggedStatuses) Variable<int>($),
-      ],
-      readsFrom: {journal},
-    ).map((QueryRow row) => row.read<String>('id'));
   }
 
   Selectable<JournalDbEntity> sortedCalenderEntriesInRange(
@@ -6791,82 +6663,6 @@ abstract class _$JournalDb extends GeneratedDatabase {
     ).asyncMap(journal.mapFromRow);
   }
 
-  Selectable<String> filteredTaskIds(
-    List<bool> privateStatuses,
-    List<bool> starredStatuses,
-    List<String?> taskStatuses,
-    int limit,
-    int offset,
-  ) {
-    var $arrayStartIndex = 3;
-    final expandedprivateStatuses = $expandVar(
-      $arrayStartIndex,
-      privateStatuses.length,
-    );
-    $arrayStartIndex += privateStatuses.length;
-    final expandedstarredStatuses = $expandVar(
-      $arrayStartIndex,
-      starredStatuses.length,
-    );
-    $arrayStartIndex += starredStatuses.length;
-    final expandedtaskStatuses = $expandVar(
-      $arrayStartIndex,
-      taskStatuses.length,
-    );
-    $arrayStartIndex += taskStatuses.length;
-    return customSelect(
-      'SELECT id FROM journal WHERE type = \'Task\' AND deleted = FALSE AND private IN ($expandedprivateStatuses) AND starred IN ($expandedstarredStatuses) AND task = 1 AND task_status IN ($expandedtaskStatuses) ORDER BY date_from DESC LIMIT ?1 OFFSET ?2',
-      variables: [
-        Variable<int>(limit),
-        Variable<int>(offset),
-        for (var $ in privateStatuses) Variable<bool>($),
-        for (var $ in starredStatuses) Variable<bool>($),
-        for (var $ in taskStatuses) Variable<String>($),
-      ],
-      readsFrom: {journal},
-    ).map((QueryRow row) => row.read<String>('id'));
-  }
-
-  Selectable<String> filteredTaskIds2(
-    List<String> ids,
-    List<bool> privateStatuses,
-    List<bool> starredStatuses,
-    List<String?> taskStatuses,
-    int limit,
-    int offset,
-  ) {
-    var $arrayStartIndex = 3;
-    final expandedids = $expandVar($arrayStartIndex, ids.length);
-    $arrayStartIndex += ids.length;
-    final expandedprivateStatuses = $expandVar(
-      $arrayStartIndex,
-      privateStatuses.length,
-    );
-    $arrayStartIndex += privateStatuses.length;
-    final expandedstarredStatuses = $expandVar(
-      $arrayStartIndex,
-      starredStatuses.length,
-    );
-    $arrayStartIndex += starredStatuses.length;
-    final expandedtaskStatuses = $expandVar(
-      $arrayStartIndex,
-      taskStatuses.length,
-    );
-    $arrayStartIndex += taskStatuses.length;
-    return customSelect(
-      'SELECT id FROM journal WHERE type = \'Task\' AND deleted = FALSE AND id IN ($expandedids) AND private IN ($expandedprivateStatuses) AND starred IN ($expandedstarredStatuses) AND task = 1 AND task_status IN ($expandedtaskStatuses) ORDER BY date_from DESC LIMIT ?1 OFFSET ?2',
-      variables: [
-        Variable<int>(limit),
-        Variable<int>(offset),
-        for (var $ in ids) Variable<String>($),
-        for (var $ in privateStatuses) Variable<bool>($),
-        for (var $ in starredStatuses) Variable<bool>($),
-        for (var $ in taskStatuses) Variable<String>($),
-      ],
-      readsFrom: {journal},
-    ).map((QueryRow row) => row.read<String>('id'));
-  }
-
   Selectable<JournalDbEntity> emptyJournalSelection() {
     return customSelect(
       'SELECT * FROM journal WHERE 1 = 0',
@@ -6897,22 +6693,6 @@ abstract class _$JournalDb extends GeneratedDatabase {
         Variable<int>(limit),
         Variable<int>(offset),
       ],
-      readsFrom: {journal},
-    ).asyncMap(journal.mapFromRow);
-  }
-
-  Selectable<JournalDbEntity> orderedAudioEntries(int limit, int offset) {
-    return customSelect(
-      'SELECT * FROM journal WHERE type = \'JournalAudio\' AND deleted = FALSE ORDER BY date_from DESC LIMIT ?1 OFFSET ?2',
-      variables: [Variable<int>(limit), Variable<int>(offset)],
-      readsFrom: {journal},
-    ).asyncMap(journal.mapFromRow);
-  }
-
-  Selectable<JournalDbEntity> entriesFlaggedImport(int limit) {
-    return customSelect(
-      'SELECT * FROM journal WHERE deleted = FALSE AND flag = 1 ORDER BY date_from DESC LIMIT ?1',
-      variables: [Variable<int>(limit)],
       readsFrom: {journal},
     ).asyncMap(journal.mapFromRow);
   }
@@ -7099,14 +6879,6 @@ abstract class _$JournalDb extends GeneratedDatabase {
         for (var $ in taskStatuses) Variable<String>($),
       ],
       readsFrom: {journal},
-    ).map((QueryRow row) => row.read<int>('_c0'));
-  }
-
-  Selectable<int> countTasksByCategory(String categoryId) {
-    return customSelect(
-      'SELECT COUNT(*) AS _c0 FROM journal WHERE deleted = FALSE AND type = \'Task\' AND category = ?1 AND task = 1 AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\'))',
-      variables: [Variable<String>(categoryId)],
-      readsFrom: {journal, configFlags},
     ).map((QueryRow row) => row.read<int>('_c0'));
   }
 
@@ -7334,51 +7106,6 @@ abstract class _$JournalDb extends GeneratedDatabase {
     );
   }
 
-  Future<int> deleteLabeledForId(String journalId) {
-    return customUpdate(
-      'DELETE FROM labeled WHERE journal_id = ?1',
-      variables: [Variable<String>(journalId)],
-      updates: {labeled},
-      updateKind: UpdateKind.delete,
-    );
-  }
-
-  Future<int> purgeDeletedDashboards() {
-    return customUpdate(
-      'DELETE FROM dashboard_definitions WHERE deleted = TRUE',
-      variables: [],
-      updates: {dashboardDefinitions},
-      updateKind: UpdateKind.delete,
-    );
-  }
-
-  Future<int> purgeDeletedMeasurables() {
-    return customUpdate(
-      'DELETE FROM measurable_types WHERE deleted = TRUE',
-      variables: [],
-      updates: {measurableTypes},
-      updateKind: UpdateKind.delete,
-    );
-  }
-
-  Future<int> purgeDeletedLabelDefinitions() {
-    return customUpdate(
-      'DELETE FROM label_definitions WHERE deleted = TRUE',
-      variables: [],
-      updates: {labelDefinitions},
-      updateKind: UpdateKind.delete,
-    );
-  }
-
-  Future<int> purgeDeletedJournalEntities() {
-    return customUpdate(
-      'DELETE FROM journal WHERE deleted = TRUE',
-      variables: [],
-      updates: {journal},
-      updateKind: UpdateKind.delete,
-    );
-  }
-
   Selectable<JournalDbEntity> linkedJournalEntities(
     String fromId,
     List<bool> privateStatuses,
@@ -7483,39 +7210,6 @@ abstract class _$JournalDb extends GeneratedDatabase {
     ).asyncMap(journal.mapFromRow);
   }
 
-  Selectable<JournalDbEntity> journalEntitiesByIds(
-    List<String> ids,
-    List<bool> privateStatuses,
-  ) {
-    var $arrayStartIndex = 1;
-    final expandedids = $expandVar($arrayStartIndex, ids.length);
-    $arrayStartIndex += ids.length;
-    final expandedprivateStatuses = $expandVar(
-      $arrayStartIndex,
-      privateStatuses.length,
-    );
-    $arrayStartIndex += privateStatuses.length;
-    return customSelect(
-      'SELECT * FROM journal WHERE deleted = FALSE AND id IN ($expandedids) AND private IN ($expandedprivateStatuses) ORDER BY date_from DESC',
-      variables: [
-        for (var $ in ids) Variable<String>($),
-        for (var $ in privateStatuses) Variable<bool>($),
-      ],
-      readsFrom: {journal},
-    ).asyncMap(journal.mapFromRow);
-  }
-
-  Selectable<JournalDbEntity> journalEntitiesByIdsAllPrivate(List<String> ids) {
-    var $arrayStartIndex = 1;
-    final expandedids = $expandVar($arrayStartIndex, ids.length);
-    $arrayStartIndex += ids.length;
-    return customSelect(
-      'SELECT * FROM journal WHERE deleted = FALSE AND id IN ($expandedids) ORDER BY date_from DESC',
-      variables: [for (var $ in ids) Variable<String>($)],
-      readsFrom: {journal},
-    ).asyncMap(journal.mapFromRow);
-  }
-
   Selectable<JournalDbEntity> journalEntitiesByIdsUnordered(
     List<String> ids,
     List<bool> privateStatuses,
@@ -7549,20 +7243,6 @@ abstract class _$JournalDb extends GeneratedDatabase {
       variables: [for (var $ in ids) Variable<String>($)],
       readsFrom: {journal},
     ).asyncMap(journal.mapFromRow);
-  }
-
-  Selectable<String> linkedJournalEntityIds(String fromId, List<bool?> hidden) {
-    var $arrayStartIndex = 2;
-    final expandedhidden = $expandVar($arrayStartIndex, hidden.length);
-    $arrayStartIndex += hidden.length;
-    return customSelect(
-      'SELECT to_id FROM linked_entries WHERE from_id = ?1 AND hidden IN ($expandedhidden)',
-      variables: [
-        Variable<String>(fromId),
-        for (var $ in hidden) Variable<bool>($),
-      ],
-      readsFrom: {linkedEntries},
-    ).map((QueryRow row) => row.read<String>('to_id'));
   }
 
   Selectable<String> parentLinkedEntityIds(String toId) {
@@ -7732,9 +7412,7 @@ abstract class _$JournalDb extends GeneratedDatabase {
   List<DatabaseSchemaEntity> get allSchemaEntities => [
     journal,
     idxJournalDateFromAsc,
-    idxJournalDateFromDesc,
     idxJournalDateToAsc,
-    idxJournalDateToDesc,
     idxJournalDayAudio,
     idxJournalRecordingSession,
     idxJournalTab,
@@ -7755,22 +7433,18 @@ abstract class _$JournalDb extends GeneratedDatabase {
     idxConflictsStatusCreatedAt,
     measurableTypes,
     habitDefinitions,
-    idxHabitDefinitionsId,
     idxHabitDefinitionsName,
     idxHabitDefinitionsPrivate,
     idxHabitDefinitionsDeletedPrivate,
     categoryDefinitions,
-    idxCategoryDefinitionsId,
     idxCategoryDefinitionsName,
     idxCategoryDefinitionsPrivate,
     labelDefinitions,
-    idxLabelDefinitionsId,
     idxLabelDefinitionsName,
     idxLabelDefinitionsPrivate,
     idxLabelDefinitionsDeletedPrivateName,
     idxLabelDefinitionsDeletedNameNocase,
     dashboardDefinitions,
-    idxDashboardDefinitionsId,
     idxDashboardDefinitionsName,
     idxDashboardDefinitionsPrivate,
     idxDashboardDefinitionsDeletedPrivateName,
@@ -7779,10 +7453,7 @@ abstract class _$JournalDb extends GeneratedDatabase {
     idxLabeledJournalId,
     idxLabeledLabelId,
     linkedEntries,
-    idxLinkedEntriesFromId,
-    idxLinkedEntriesToId,
     idxLinkedEntriesType,
-    idxLinkedEntriesHidden,
     idxLinkedEntriesFromIdHidden,
     idxLinkedEntriesFromIdHiddenToId,
     idxLinkedEntriesToIdHidden,

--- a/lib/database/database_migration.dart
+++ b/lib/database/database_migration.dart
@@ -57,7 +57,6 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
             );
             await m.createTable(categoryDefinitions);
             await m.createIndex(idxCategoryDefinitionsName);
-            await m.createIndex(idxCategoryDefinitionsId);
             await m.createIndex(idxCategoryDefinitionsPrivate);
           }();
         }
@@ -76,10 +75,9 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
           await () async {
             DevLogger.log(
               name: 'JournalDb',
-              message: 'Add hidden in linked_entries table, with index',
+              message: 'Add hidden in linked_entries table',
             );
             await m.addColumn(linkedEntries, linkedEntries.hidden);
-            await m.createIndex(idxLinkedEntriesHidden);
           }();
         }
 
@@ -126,7 +124,6 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
               message: 'Creating label_definitions and labeled tables',
             );
             await m.createTable(labelDefinitions);
-            await m.createIndex(idxLabelDefinitionsId);
             await m.createIndex(idxLabelDefinitionsName);
             await m.createIndex(idxLabelDefinitionsPrivate);
 

--- a/lib/database/database_migration_recent.dart
+++ b/lib/database/database_migration_recent.dart
@@ -268,5 +268,42 @@ WHERE type = 'JournalAudio' AND deleted = FALSE
         await customStatement('ANALYZE');
       }();
     }
+    if (from < 46) {
+      await () async {
+        DevLogger.log(
+          name: 'JournalDb',
+          message: 'Dropping redundant journal, definition and link indexes',
+        );
+        // Each of these duplicated an index SQLite already had, so every
+        // upsert paid to maintain it without any query being able to
+        // prefer it. Fresh installs no longer create them; `IF EXISTS`
+        // keeps the step safe on databases that never had them.
+        for (final name in _redundantIndexesDroppedInV46) {
+          await customStatement('DROP INDEX IF EXISTS $name');
+        }
+      }();
+    }
   }
 }
+
+/// Indexes dropped by the v46 step, with the index that already covers each:
+///
+/// * `idx_journal_date_from_desc`, `idx_journal_date_to_desc` — single-column
+///   DESC twins of the ASC indexes; SQLite walks an index in either direction.
+/// * the four `idx_*_definitions_id` indexes — the primary key on `id`
+///   already carries an automatic unique index.
+/// * `idx_linked_entries_from_id`, `idx_linked_entries_to_id` — leading
+///   prefixes of `(from_id, hidden, …)` and `(to_id, hidden)` /
+///   `(to_id, type)`.
+/// * `idx_linked_entries_hidden` — a lone boolean column.
+const List<String> _redundantIndexesDroppedInV46 = [
+  'idx_journal_date_from_desc',
+  'idx_journal_date_to_desc',
+  'idx_habit_definitions_id',
+  'idx_category_definitions_id',
+  'idx_label_definitions_id',
+  'idx_dashboard_definitions_id',
+  'idx_linked_entries_from_id',
+  'idx_linked_entries_to_id',
+  'idx_linked_entries_hidden',
+];

--- a/test/database/category_backfill_migration_test.dart
+++ b/test/database/category_backfill_migration_test.dart
@@ -138,7 +138,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 45);
+        expect(db.schemaVersion, 46);
 
         final rows = await db
             .customSelect('SELECT id, category FROM journal ORDER BY id')

--- a/test/database/database_migration_recent_test.dart
+++ b/test/database/database_migration_recent_test.dart
@@ -96,7 +96,7 @@ void main() {
     addTearDown(db.close);
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 45);
+    expect(version.read<int>('user_version'), 46);
     final rows = await db
         .customSelect(
           'SELECT id, day_id, recording_session_id FROM journal ORDER BY id',

--- a/test/database/definition_indexes_migration_test.dart
+++ b/test/database/definition_indexes_migration_test.dart
@@ -72,7 +72,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 45);
+      expect(db.schemaVersion, 46);
 
       final indexes = await db.customSelect('''
         SELECT name, sql FROM sqlite_master

--- a/test/database/due_at_migration_test.dart
+++ b/test/database/due_at_migration_test.dart
@@ -174,7 +174,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 45);
+      expect(db.schemaVersion, 46);
 
       final hasColumn = await db.columnExistsForTesting('journal', 'due_at');
       expect(hasColumn, isTrue);

--- a/test/database/linked_entries_index_migration_test.dart
+++ b/test/database/linked_entries_index_migration_test.dart
@@ -96,7 +96,7 @@ void main() {
       // Schema version advanced to the current schema
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 45);
+      expect(db.schemaVersion, 46);
 
       // The corrected index now references to_id in its column list
       final postMigrationIdx = await db.customSelect("""

--- a/test/database/priority_migration_test.dart
+++ b/test/database/priority_migration_test.dart
@@ -142,7 +142,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 45);
+        expect(db.schemaVersion, 46);
 
         // The non-partial composite `idx_journal_tasks_due_active` was
         // dropped in v41 — its only consumer (`getTasksSortedByDueDate`)
@@ -175,7 +175,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 45);
+      expect(db.schemaVersion, 46);
 
       final idx = await db.customSelect("""
         SELECT sql FROM sqlite_master
@@ -255,7 +255,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 45);
+        expect(db.schemaVersion, 46);
 
         final idx = await db.customSelect("""
         SELECT sql FROM sqlite_master
@@ -344,7 +344,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 45);
+        expect(db.schemaVersion, 46);
 
         final taskIdx = await db.customSelect("""
         SELECT sql FROM sqlite_master

--- a/test/database/redundant_indexes_v46_migration_test.dart
+++ b/test/database/redundant_indexes_v46_migration_test.dart
@@ -1,0 +1,228 @@
+// ignore_for_file: cascade_invocations
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart';
+
+/// The nine indexes v46 drops. Each duplicated an index SQLite already had:
+/// single-column DESC twins, primary-key indexes on the definition tables,
+/// prefix-shadowed single-column `linked_entries` indexes, and a boolean
+/// column index.
+const _redundant = <String>{
+  'idx_journal_date_from_desc',
+  'idx_journal_date_to_desc',
+  'idx_habit_definitions_id',
+  'idx_category_definitions_id',
+  'idx_label_definitions_id',
+  'idx_dashboard_definitions_id',
+  'idx_linked_entries_from_id',
+  'idx_linked_entries_to_id',
+  'idx_linked_entries_hidden',
+};
+
+/// A neighbour that must survive for every family the drop touches, so the
+/// step is proven to remove exactly the redundant shape and not the index
+/// that covers it.
+const _kept = <String>{
+  'idx_journal_date_from_asc',
+  'idx_journal_date_to_asc',
+  'idx_habit_definitions_name',
+  'idx_category_definitions_name',
+  'idx_label_definitions_name',
+  'idx_dashboard_definitions_name',
+  'idx_linked_entries_from_id_hidden',
+  'idx_linked_entries_to_id_hidden',
+  'idx_linked_entries_type',
+};
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Directory? testDirectory;
+  Directory? previousDirectory;
+
+  setUp(() {
+    if (getIt.isRegistered<Directory>()) {
+      previousDirectory = getIt<Directory>();
+      getIt.unregister<Directory>();
+    }
+    testDirectory = Directory.systemTemp.createTempSync('lotti_v46_mig_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (MethodCall methodCall) async {
+            if (methodCall.method == 'getApplicationDocumentsDirectory' ||
+                methodCall.method == 'getApplicationSupportDirectory' ||
+                methodCall.method == 'getTemporaryDirectory') {
+              return testDirectory!.path;
+            }
+            return null;
+          },
+        );
+    getIt.registerSingleton<Directory>(testDirectory!);
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    getIt.unregister<Directory>();
+    if (previousDirectory != null) {
+      getIt.registerSingleton<Directory>(previousDirectory!);
+    }
+    if (testDirectory != null && testDirectory!.existsSync()) {
+      testDirectory!.deleteSync(recursive: true);
+    }
+  });
+
+  /// A v45-shaped database reduced to the tables the dropped indexes sit on,
+  /// carrying every redundant index next to the index that covers it.
+  void createV45Schema(Database sqlite) {
+    sqlite.execute('''
+      CREATE TABLE journal (
+        id TEXT PRIMARY KEY,
+        serialized TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        date_from INTEGER NOT NULL,
+        date_to INTEGER NOT NULL,
+        deleted BOOLEAN NOT NULL DEFAULT FALSE,
+        type TEXT NOT NULL,
+        subtype TEXT
+      )
+    ''');
+    sqlite.execute(
+      'CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC)',
+    );
+    sqlite.execute(
+      'CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC)',
+    );
+    sqlite.execute(
+      'CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC)',
+    );
+    sqlite.execute(
+      'CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC)',
+    );
+
+    for (final table in [
+      'habit_definitions',
+      'category_definitions',
+      'label_definitions',
+      'dashboard_definitions',
+    ]) {
+      sqlite.execute('''
+        CREATE TABLE $table (
+          id TEXT NOT NULL,
+          name TEXT NOT NULL,
+          serialized TEXT NOT NULL,
+          PRIMARY KEY (id)
+        )
+      ''');
+      sqlite.execute('CREATE INDEX idx_${table}_id ON $table (id)');
+      sqlite.execute('CREATE INDEX idx_${table}_name ON $table (name)');
+    }
+
+    sqlite.execute('''
+      CREATE TABLE linked_entries (
+        id TEXT NOT NULL UNIQUE,
+        from_id TEXT NOT NULL,
+        to_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        serialized TEXT NOT NULL,
+        hidden BOOLEAN DEFAULT FALSE,
+        PRIMARY KEY (id),
+        UNIQUE(from_id, to_id, type)
+      )
+    ''');
+    sqlite.execute(
+      'CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id)',
+    );
+    sqlite.execute(
+      'CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id)',
+    );
+    sqlite.execute(
+      'CREATE INDEX idx_linked_entries_type ON linked_entries (type)',
+    );
+    sqlite.execute(
+      'CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden)',
+    );
+    sqlite.execute('''
+      CREATE INDEX idx_linked_entries_from_id_hidden
+        ON linked_entries (from_id, hidden)
+    ''');
+    sqlite.execute('''
+      CREATE INDEX idx_linked_entries_to_id_hidden
+        ON linked_entries (to_id, hidden)
+    ''');
+  }
+
+  Future<Set<String>> indexNames(JournalDb db) async {
+    final rows = await db
+        .customSelect("SELECT name FROM sqlite_master WHERE type = 'index'")
+        .get();
+    return rows.map((row) => row.read<String>('name')).toSet();
+  }
+
+  group('Redundant indexes v46 migration', () {
+    test('drops the nine redundant indexes and keeps their covering '
+        'neighbours', () async {
+      final dbFile = File(p.join(testDirectory!.path, 'test_v46.db'));
+      final sqlite = sqlite3.open(dbFile.path);
+      createV45Schema(sqlite);
+      sqlite.execute('PRAGMA user_version = 45');
+      sqlite.close();
+
+      final db = JournalDb(overriddenFilename: 'test_v46.db');
+      addTearDown(db.close);
+
+      final version = await db.customSelect('PRAGMA user_version').get();
+      expect(version.first.read<int>('user_version'), db.schemaVersion);
+      expect(db.schemaVersion, 46);
+
+      final names = await indexNames(db);
+      expect(names.intersection(_redundant), isEmpty);
+      expect(names.containsAll(_kept), isTrue, reason: '$names');
+    });
+
+    test('a database that never had them upgrades cleanly', () async {
+      final dbFile = File(p.join(testDirectory!.path, 'test_v46_bare.db'));
+      final sqlite = sqlite3.open(dbFile.path);
+      sqlite.execute('''
+        CREATE TABLE journal (
+          id TEXT PRIMARY KEY,
+          serialized TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          date_from INTEGER NOT NULL,
+          date_to INTEGER NOT NULL,
+          deleted BOOLEAN NOT NULL DEFAULT FALSE,
+          type TEXT NOT NULL,
+          subtype TEXT
+        )
+      ''');
+      sqlite.execute('PRAGMA user_version = 45');
+      sqlite.close();
+
+      final db = JournalDb(overriddenFilename: 'test_v46_bare.db');
+      addTearDown(db.close);
+
+      final version = await db.customSelect('PRAGMA user_version').get();
+      expect(version.first.read<int>('user_version'), 46);
+    });
+
+    test('a fresh database is created without them', () async {
+      final db = JournalDb(inMemoryDatabase: true);
+      addTearDown(db.close);
+
+      final names = await indexNames(db);
+      expect(names.intersection(_redundant), isEmpty);
+      expect(names.containsAll(_kept), isTrue, reason: '$names');
+    });
+  });
+}

--- a/test/database/task_indexes_v39_migration_test.dart
+++ b/test/database/task_indexes_v39_migration_test.dart
@@ -128,7 +128,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 45);
+        expect(db.schemaVersion, 46);
 
         // v41 swapped the expression-keyed shape for a column-keyed one.
         final sql = await indexSql(db, 'idx_journal_tasks_due_open');
@@ -291,7 +291,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 45);
+      expect(db.schemaVersion, 46);
 
       final sql = await indexSql(db, 'idx_journal_tasks_priority_date');
       expect(sql, contains('task_priority_rank COLLATE BINARY ASC'));


### PR DESCRIPTION
## Summary

Two more quick wins from a review of the persistence layer. No user-visible change; the journal write path gets cheaper and `database.g.dart` gets 329 lines shorter.

**Sixteen named queries with no caller.** `configFlagByName`, `countTasksByCategory`, `deleteLabeledForId`, `entriesFlaggedImport`, `filteredJournalIds`, `filteredJournalIds2`, `filteredTaskIds`, `filteredTaskIds2`, `journalEntitiesByIds`, `journalEntitiesByIdsAllPrivate`, `linkedJournalEntityIds`, `orderedAudioEntries`, `purgeDeletedDashboards`, `purgeDeletedJournalEntities`, `purgeDeletedLabelDefinitions`, `purgeDeletedMeasurables`. Verified with `rg` across `lib/`, `test/` and `integration_test/`: the only reference to each was its own definition (plus one index comment, updated).

**Nine indexes that duplicated an index SQLite already had**, so every upsert maintained them and no query could prefer them:

| Dropped | Already covered by |
|---|---|
| `idx_journal_date_from_desc`, `idx_journal_date_to_desc` | the ASC index on the same column; SQLite walks an index in either direction |
| `idx_habit_definitions_id`, `idx_category_definitions_id`, `idx_label_definitions_id`, `idx_dashboard_definitions_id` | the automatic unique index on the primary key |
| `idx_linked_entries_from_id` | `(from_id, hidden)` and `(from_id, hidden, to_id)` |
| `idx_linked_entries_to_id` | `(to_id, hidden)` and `(to_id, type)` |
| `idx_linked_entries_hidden` | nothing needs it: a lone boolean column |

They are removed from `database.drift` (fresh installs) and dropped by a new **v46** migration step with `DROP INDEX IF EXISTS`. The v19, v22 and v26 steps that used to create three of them no longer do, because v46 would drop them again on the same upgrade. `journal` goes from 20 indexes to 18 and `linked_entries` from 10 to 7. No `INDEXED BY` pin referenced any of the nine.

## Tests

- New `redundant_indexes_v46_migration_test.dart`: a v45-shaped file-backed database carrying all nine plus a covering neighbour for each family upgrades to 46 with the nine gone and the neighbours intact; a database that never had them upgrades cleanly; a fresh database is created without them. The first test fails with the drop loop neutralized.
- Existing migration tests updated for the version bump (`45` → `46` in the final-version assertions).
- Ran every migration test and the EXPLAIN-bearing query tests (`database_journal_queries`, `database_task_queries`, `database_insights_queries`, `database_entity_ops`, `database_links_ratings`, `database_definitions`, `database_test`, `database_config_flags`): all green. `make analyze` and `make knowledge_check` clean.

## Docs

`knowledge/architecture/persistence.md`: schema 46, and a paragraph on why the nine were dropped and what a new index has to demonstrate.

No changelog fragment: nothing a user would notice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the database to schema version 46.
  - Removed nine redundant database indexes, while preserving equivalent primary-key and covering indexes.
  - Existing databases now migrate safely to the updated schema.

- **Documentation**
  - Updated persistence architecture documentation to reflect the schema version and index changes.

- **Tests**
  - Added coverage for the schema migration, including removal of redundant indexes and preservation of required indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->