### PR TITLE
test: fix isolation failures exposed by shuffled CI

### DIFF
--- a/test/features/ai/ui/widgets/ai_error_display_test.dart
+++ b/test/features/ai/ui/widgets/ai_error_display_test.dart
@@ -42,7 +42,7 @@ void main() {
       tester.view
         ..physicalSize = const Size(1200, 800)
         ..devicePixelRatio = 1.0;
-      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.reset);
 
       await tester.pumpWidget(widget);
       await tester.pump();
@@ -441,6 +441,7 @@ void main() {
       ) async {
         tester.view.physicalSize = const Size(1200, 800);
         tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
         var retried = false;
         final error = InferenceError(
           message: 'Temporary error',

--- a/test/features/daily_os_next/ui/widgets/daily_os_date_strip_test.dart
+++ b/test/features/daily_os_next/ui/widgets/daily_os_date_strip_test.dart
@@ -1,3 +1,8 @@
+// The production width cache must start with the fonts this suite measures.
+// Other bundled suites can populate it before loading the app fonts.
+@Tags(['skip_very_good_optimization'])
+library;
+
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -7,9 +12,12 @@ import 'package:lotti/features/daily_os_next/ui/widgets/daily_os_date_strip.dart
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 
+import '../../../../test_utils/screenshot_harness.dart';
 import '../../../../widget_test_utils.dart';
 
 void main() {
+  setUpAll(loadAppFonts);
+
   final selected = DateTime(2026, 5, 27);
 
   Widget host({

--- a/test/features/journal/ui/widgets/entry_details/header/modern_action_items_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/header/modern_action_items_test.dart
@@ -111,7 +111,9 @@ void main() {
     // The production `ModernShareItem` calls `SharePlus.instance.share(...)`.
     fakeSharePlatform = _FakeSharePlatform();
     SharePlatform.instance = fakeSharePlatform;
+  });
 
+  setUp(() async {
     await setUpTestGetIt(
       additionalSetup: () {
         getIt
@@ -123,11 +125,12 @@ void main() {
   });
 
   tearDownAll(() async {
-    await tearDownTestGetIt();
     if (documentsDirectory.existsSync()) {
       documentsDirectory.deleteSync(recursive: true);
     }
   });
+
+  tearDown(tearDownTestGetIt);
 
   JournalEntry buildTextEntry({
     String id = 'entry-1',
@@ -1581,7 +1584,7 @@ void main() {
     late MockJournalDb mockJournalDbSrc;
     late MockUpdateNotifications mockUpdateNotificationsSrc;
 
-    setUpAll(() {
+    setUp(() {
       mockEditorStateServiceSrc = MockEditorStateService();
       mockPersistenceLogicSrc = MockPersistenceLogic();
       mockJournalDbSrc = MockJournalDb();
@@ -1597,10 +1600,6 @@ void main() {
         ..registerSingleton<PersistenceLogic>(mockPersistenceLogicSrc)
         ..registerSingleton<JournalDb>(mockJournalDbSrc)
         ..registerSingleton<UpdateNotifications>(mockUpdateNotificationsSrc);
-    });
-
-    tearDownAll(() async {
-      await getIt.reset();
     });
 
     JournalAudio buildAudioEntrySrc({String id = 'audio-1'}) {
@@ -2436,7 +2435,7 @@ void main() {
   });
 
   group('ModernCopyEntryTextItem - ', () {
-    setUpAll(() async {
+    setUp(() async {
       getIt.allowReassignment = true;
       getIt
         ..registerSingleton<JournalDb>(JournalDb(inMemoryDatabase: true))
@@ -2445,8 +2444,10 @@ void main() {
         ..registerSingleton<EditorStateService>(EditorStateService());
     });
 
-    tearDownAll(() async {
-      await getIt.reset();
+    tearDown(() async {
+      await getIt<JournalDb>().close();
+      await getIt<EditorDb>().close();
+      await getIt<UpdateNotifications>().dispose();
     });
 
     testWidgets('Copy as text triggers copy', (tester) async {

--- a/test/features/journal/ui/widgets/entry_details/header/switch_icon_widget_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/header/switch_icon_widget_test.dart
@@ -142,6 +142,10 @@ void main() {
           );
 
       // Test with value = false (should trigger heavy impact)
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, null);
+      });
       await tester.pumpWidget(
         makeTestableWidget(
           Material(

--- a/test/services/nav_service_test.dart
+++ b/test/services/nav_service_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/settings_db.dart';
-import 'package:lotti/features/sync/secure_storage.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/nav_service.dart';
@@ -13,6 +12,7 @@ import 'package:lotti/utils/consts.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../mocks/mocks.dart';
+import '../widget_test_utils.dart';
 
 enum _GeneratedNavPathKind {
   tasksRoot,
@@ -246,19 +246,12 @@ void main() {
     late SettingsDb settingsDb;
     late JournalDb mockJournalDb;
 
-    setUpAll(() async {
-      await getIt.reset();
-      final secureStorageMock = MockSecureStorage();
+    setUp(() async {
+      await setUpTestGetIt();
+      await getIt.unregister<JournalDb>();
+      await getIt.unregister<SettingsDb>();
       settingsDb = SettingsDb(inMemoryDatabase: true);
       mockJournalDb = mockJournalDbWithMeasurableTypes([]);
-
-      when(
-        () => secureStorageMock.readValue(lastRouteKey),
-      ).thenAnswer((_) async => '/settings');
-
-      when(
-        () => secureStorageMock.writeValue(lastRouteKey, any()),
-      ).thenAnswer((_) async {});
 
       when(() => mockJournalDb.watchConfigFlag(any())).thenAnswer((invocation) {
         final flagName = invocation.positionalArguments.first as String;
@@ -277,15 +270,15 @@ void main() {
       );
 
       getIt
-        ..registerSingleton<SecureStorage>(secureStorageMock)
         ..registerSingleton<JournalDb>(mockJournalDb)
         ..registerSingleton<SettingsDb>(settingsDb)
         ..registerSingleton<NavService>(navService);
     });
 
-    tearDownAll(() async {
+    tearDown(() async {
       await getIt<NavService>().dispose();
-      await getIt.reset();
+      await settingsDb.close();
+      await tearDownTestGetIt();
     });
 
     test('allowedTabDelegates refuses every route into a hidden tab', () async {
@@ -349,6 +342,9 @@ void main() {
 
     test('tap all tabs', () async {
       final navService = getIt<NavService>();
+      await navService.getIndexStream().firstWhere(
+        (_) => navService.beamerDelegates.length == 7,
+      );
 
       expect(navService.index, 0);
 
@@ -426,8 +422,11 @@ void main() {
       expect(navService.currentPath, '/habits');
     });
 
-    test('orders Daily OS directly after Tasks', () {
+    test('orders Daily OS directly after Tasks', () async {
       final navService = getIt<NavService>();
+      await navService.getIndexStream().firstWhere(
+        (_) => navService.beamerDelegates.length == 7,
+      );
 
       expect(
         navService.beamerDelegates,
@@ -704,14 +703,6 @@ void main() {
     });
 
     group('desktop task detail stack', () {
-      setUp(() {
-        // The NavService singleton is shared across tests. Clear the
-        // stack first so each test starts from a clean state and the
-        // idempotency guard in `resetDesktopTaskDetail` does not pick
-        // up state from a sibling test.
-        getIt<NavService>().resetDesktopTaskDetail(null);
-      });
-
       test('resetDesktopTaskDetail seeds the stack with one entry', () {
         final navService = getIt<NavService>()
           ..resetDesktopTaskDetail('task-a');
@@ -960,10 +951,6 @@ void main() {
     });
 
     group('resetDesktopTaskDetail selectedTaskId sync', () {
-      setUp(() {
-        getIt<NavService>().resetDesktopTaskDetail(null);
-      });
-
       test(
         'resetDesktopTaskDetail re-syncs desktopSelectedTaskId to stack.last '
         'when it had drifted',
@@ -1446,6 +1433,7 @@ void main() {
               subDomain: any<String>(named: 'subDomain'),
             ),
           ).thenReturn(null);
+          await getIt.unregister<DomainLogger>();
           getIt.registerSingleton<DomainLogger>(logger);
           addTearDown(() => getIt.unregister<DomainLogger>());
 


### PR DESCRIPTION
The shuffled validation run added in #4142 exposed test-order dependencies that normal ordering missed. This follow-up restores each test’s fixture state so the same assertions pass independently of the preceding tests.

- Create navigation services and settings databases per test; await flag initialization only in tests that need all optional tabs.
- Recreate journal action services per test, including nested groups, and close their real databases and notification streams.
- Restore both viewport metrics and remove the switch test’s platform-channel handler after use.
- Run date-strip geometry tests in their own isolate with app fonts loaded before the production width cache is populated. They remain included in CI.

Validation: 190 tests across the five changed files pass with ordering seed `92405`; targeted Dart MCP analysis is clean. Navigation and journal failures reproduced with the original fixtures. A temporary cross-suite probe reproduced viewport and haptic-handler leaks with fixes reverted and passed all 44 tests after restoring them. The temporary probe was removed. Full standard CI and all ten shuffled shards with seed `92405` passed, along with both property-test runs, performance budgets, Matrix integration, and Codecov patch/project checks.

Standard CI: https://github.com/matthiasn/lotti/actions/runs/33970687326
Shuffled replay: https://github.com/matthiasn/lotti/actions/runs/33970692219

Original shuffled run: https://github.com/matthiasn/lotti/actions/runs/33969810234

No application behavior changes or release-note fragment.
