### PR TITLE
feat(projects): pinned task groups, remembered folds, desktop popover, focus the created task, swipe to decide, proposal Undo

### DIFF
--- a/changelog.d/2026-09-05-project-tasks-leftovers.md
+++ b/changelog.d/2026-09-05-project-tasks-leftovers.md
@@ -1,0 +1,11 @@
+### Added
+- **Project task groups stay in view and remember their folds.** A group's
+  header now stays pinned at the top while its tasks scroll past and hands
+  over to the next group's header. Which groups are folded is remembered per
+  project, together with the sort and group choice. On desktop the Sort and
+  group control opens as a popover next to the button; on a phone it stays a
+  sheet.
+- **A task created from a next step is easy to find.** The new task lights up
+  in the project's task list, and the step's "Added → title" link now scrolls
+  the list to it, unfolding its group if needed, instead of leaving the
+  project page.

--- a/changelog.d/2026-09-05-project-tasks-leftovers.md
+++ b/changelog.d/2026-09-05-project-tasks-leftovers.md
@@ -9,3 +9,9 @@
   in the project's task list, and the step's "Added → title" link now scrolls
   the list to it, unfolding its group if needed, instead of leaving the
   project page.
+- **Next steps decide by swipe, and proposals can be undone.** On a phone,
+  swiping a recommended step right adds it as a task and left dismisses it,
+  with the action named on the band the row reveals. Applying or rejecting
+  one of the agent's proposed changes now offers Undo for eight seconds: the
+  created task is removed or the previous status restored, and the proposal
+  is open again.

--- a/knowledge/features/design_system/component-contracts.md
+++ b/knowledge/features/design_system/component-contracts.md
@@ -155,6 +155,17 @@ ordinary outer row padding. The hover ink is painted by an inner Material and
 then clipped by the menu outline, so the final action reaches the rounded bottom
 edge instead of leaving an unhighlighted strip above the border.
 
+`DesignSystemPopoverAnchor` (`components/popovers/`) is the same anchored
+overlay — `MenuAnchor` beneath a caller-built trigger, dismissed by an outside
+tap or the trigger — but hosts a widget instead of menu rows, on
+`DesignSystemPopoverSurface`: the context menu's `background.level01` fill,
+`radii.s` corners and `DsShadows.floatingSurface`, at the menu's default width
+unless widened. It is how a desktop control opens in place what a phone opens
+as a sheet; the project task list's "Sort and group" panel is the adopter. The
+content decides when it is done — nothing inside closes the popover — so a
+picker that applies on tap stays open for the next pick. A scrollable inside
+it must not claim the page's primary scroll controller.
+
 `DesignSystemFloatingActionButton` is circular and icon-only by default and
 takes its `semanticLabel` for assistive technology. Passing a `label` extends
 it into a worded pill: same height, same token background and radius, growing

--- a/knowledge/features/design_system/component-contracts.md
+++ b/knowledge/features/design_system/component-contracts.md
@@ -166,6 +166,16 @@ content decides when it is done — nothing inside closes the popover — so a
 picker that applies on tap stays open for the next pick. A scrollable inside
 it must not claim the page's primary scroll controller.
 
+`DesignSystemSwipeActionBackground` (`components/lists/`) is the band a
+`Dismissible` reveals behind a row while it is dragged: a fill with the
+action's glyph and name at the edge the row moves away from, so a swipe always
+says what letting go will do. Callers pass fill and ink together, chosen once
+per surface — the habit row drags over its completion colours with
+high-emphasis text, a project next step over the AI card's accent wash with
+the accent ink. The pattern it serves never removes the row: `confirmDismiss`
+fires the action and returns `false`, and the row snaps back to show its
+new state.
+
 `DesignSystemFloatingActionButton` is circular and icon-only by default and
 takes its `semanticLabel` for assistive technology. Passing a `label` extends
 it into a worded pill: same height, same token background and radius, growing

--- a/knowledge/features/projects.md
+++ b/knowledge/features/projects.md
@@ -425,8 +425,9 @@ a task from "This week" to "Overdue". Within a group the sort key applies — ac
 (the same `compareTasksByActionability` the record provider uses for its
 rollups), created, due date, estimate, priority, recently updated or title —
 and every comparison breaks ties on title then id, so the result never depends
-on input order. Empty groups are omitted. Collapse state is keyed by the
-group's stable id and lives in the panel's state for the session.
+on input order. Empty groups are omitted. Which groups are folded is part of
+the options too (`collapsedGroups`, keyed by the group's stable id, `done`
+folded by default), so a fold is a change the host persists like any other.
 
 The choice is remembered per project by `ProjectTaskListOptionsController`
 (`projectTaskListOptionsProvider(projectId)`) under one `SettingsDb` key per
@@ -434,19 +435,43 @@ project, JSON-encoded and tolerant of unknown values; like the tasks-list
 density preference it loads once, holds state in memory and never lets an
 in-flight load clobber a fresh edit. Both database calls are fire-and-forget,
 so a failing read or write is logged under `LogDomain.settings` and swallowed:
-the read keeps the defaults, the write keeps the in-memory choice. The detail page watches it and opens the
-"Sort and group" sheet (`project_task_list_options_sheet.dart`), whose rows
-apply on tap through the controller. Read-only showcases pass no callback and
-show no control.
+the read keeps the defaults, the write keeps the in-memory choice. The detail
+page watches it and hands the panel the controller's `update` as its single
+`onOptionsChanged`: every pick in the "Sort and group" control and every fold
+flows through it. The panel decides how the control opens — on a screen at
+`kDesktopBreakpoint` or wider as a `DesignSystemPopoverAnchor` beside the sort
+button, otherwise as the shared single-page sheet
+(`project_task_list_options_sheet.dart`); both host the same
+`ProjectTaskListOptionsSheetContent`, whose rows apply on tap and leave the
+surface open for the next pick. Read-only showcases pass no callback, show no
+control, and keep folds in the panel's own state.
+
+Group headers are `SliverPinnedHeader`s inside a `MultiSliver` with
+`pushPinnedChildren` (the `sliver_tools` package): a group's header stays at
+the top of the viewport while its rows scroll past and is pushed out by the
+next group's header. The header paints the card surface opaquely so rows
+scroll beneath it. `DecoratedSliver` and `SliverMainAxisGroup` around the
+groups are unchanged, and folding a group only removes its list sliver, which
+`MultiSliver` handles without the geometry assertion the plain pinned
+persistent header used to trip.
+
+A `ProjectTaskFocus` (task id, request number, `scroll`) asks the panel to
+light one row up — the hover wash, held for `highlightDuration` — and, with
+`scroll` on, to bring it into view. The detail content owns the current focus
+and exposes `focusTask` to the agent band builder: the band's "Added → title"
+link calls it with scroll, a fresh creation calls it without, so the new task
+is marked where it is without pulling the page away from the band. Scrolling
+first unfolds the task's group through `onOptionsChanged`, then, because the
+list is lazy, jumps to the group's header (always built) and looks for the
+row on the following frames, stepping one viewport further each time until it
+exists or `maxScrollAttempts` run out; the row is then eased into view with
+`Scrollable.ensureVisible`.
 
 The header survives what used to break it: the title truncates before
 anything overflows, and in its compact form — below 480 pt of header width (a
 phone, or a desktop pane narrowed past what the full header needs) or at a
-text scale of 1.2× and above — the
-total estimate is dropped in favour of the per-group estimates and Add task
-turns into the glyph-only icon action. Group headers are ordinary rows rather than
-pinned slivers, the same trade-off the agents listing made to avoid the sliver
-geometry assertion when groups change.
+text scale of 1.2× and above — the total estimate is dropped in favour of the
+per-group estimates and Add task turns into the glyph-only icon action.
 
 # When the project agent actually wakes
 

--- a/knowledge/features/projects.md
+++ b/knowledge/features/projects.md
@@ -337,12 +337,27 @@ editor. The AI surface appears above the task list. `ProjectRecommendationsPanel
 renders two bands inside the card: the newest run's **recommended next steps**
 (`ProjectNextStepRow`, one per step) and the agent's **proposed changes**
 (`ProjectProposalRow`, reusing Task Details' `RowActions` rail). A step offers
-**Add task** and **Dismiss** as labelled controls; a decided step keeps its
-place with an *Added* (linking to the task), *Done* or *Dismissed* tag and an
-Undo — eight seconds for an addition, as long as the run is current for a
-dismissal. A failed creation keeps the row with Retry and the failure copy.
-Phones show three rows before "Show N more"; more than one open step adds
-**Add all as tasks** and **Dismiss all**.
+**Add task** and **Dismiss** as labelled controls, and on touch the same two
+by swipe — right adds, left dismisses, each named on the band the row reveals
+(`DesignSystemSwipeActionBackground`), and the row snaps back rather than
+leaving. A decided step keeps its place with an *Added* (its link focuses the
+task in the list below), *Done* or *Dismissed* tag and an Undo — eight
+seconds for an addition, as long as the run is current for a dismissal. A
+failed creation keeps the row with Retry and the failure copy. Phones show
+three rows before "Show N more"; more than one open step adds **Add all as
+tasks** and **Dismiss all**.
+
+Proposals go through `ProjectProposalService` (`projectProposalServiceProvider`,
+kept alive for the session): `confirm` and `reject` delegate to the change
+set confirmation service, and `confirm` remembers what the tool changed — the
+task a `create_task` created, the status an `update_project_status` replaced.
+A decided proposal keeps its *Confirmed* or *Dismissed* tag and, for the same
+eight seconds, an Undo while `canUndo` holds (always for a rejection; for a
+confirmation only while this session holds the memo). `undo` removes the
+created task or restores the previous status and drops its history entry,
+then calls `ChangeSetConfirmationService.reopenItem`, which records a
+`deferred` decision and puts the item back to `pending`; a failed revert
+leaves the item decided and the memo in place.
 
 The band never invalidates the agent's update stream. The service notifies
 after each write, `projectNextStepsProvider` re-reads, and the row changes

--- a/knowledge/features/projects.md
+++ b/knowledge/features/projects.md
@@ -353,11 +353,18 @@ set confirmation service, and `confirm` remembers what the tool changed — the
 task a `create_task` created, the status an `update_project_status` replaced.
 A decided proposal keeps its *Confirmed* or *Dismissed* tag and, for the same
 eight seconds, an Undo while `canUndo` holds (always for a rejection; for a
-confirmation only while this session holds the memo). `undo` removes the
-created task or restores the previous status and drops its history entry,
-then calls `ChangeSetConfirmationService.reopenItem`, which records a
-`deferred` decision and puts the item back to `pending`; a failed revert
-leaves the item decided and the memo in place.
+confirmation only while this session holds the memo). `undo` hands
+`ChangeSetConfirmationService.reopenItem` a revert closure: the record goes
+first — the item's newest user decision is rewritten in place as `deferred`
+(dated now, so it wins last-writer-wins and stops counting as feedback) and
+the item returns to `pending` — and only then does the revert remove the
+created task or restore the previous status and drop its history entry. The
+status restore is guarded: it happens only while the project still sits in
+the proposal's target status and the newest history entry is the status the
+memo remembers replacing; a status that moved on since is left alone. A
+refused or thrown revert makes `reopenItem` put the record back (verdict and
+item status) and return `false`, so the effect and the record always agree;
+the memo stays for another try.
 
 The band never invalidates the agent's update stream. The service notifies
 after each write, `projectNextStepsProvider` re-reads, and the row changes

--- a/lib/features/agents/model/agent_constants.dart
+++ b/lib/features/agents/model/agent_constants.dart
@@ -76,6 +76,7 @@ abstract final class AgentEntityTypes {
   static const attentionAward = 'attentionAward';
   static const standingAgreement = 'standingAgreement';
   static const agentState = 'agentState';
+  static const changeDecision = 'changeDecision';
   static const agentMessage = 'agentMessage';
   static const changeSet = 'changeSet';
   static const agentReport = 'agentReport';

--- a/lib/features/agents/service/change_set_confirmation_service.dart
+++ b/lib/features/agents/service/change_set_confirmation_service.dart
@@ -1,3 +1,6 @@
+import 'package:clock/clock.dart';
+import 'package:collection/collection.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
@@ -350,14 +353,28 @@ class ChangeSetConfirmationService {
   }
 
   /// Puts a decided item back to [ChangeItemStatus.pending] — the user's Undo
-  /// on a confirmed or rejected proposal — and records the reversal as a
-  /// [ChangeDecisionVerdict.deferred] decision, so the earlier verdict no
-  /// longer stands as feedback. Reverting whatever a confirmed tool did is
-  /// the caller's job; this only reopens the record.
+  /// on a confirmed or rejected proposal — and neutralises the verdict that
+  /// stood for it: the newest user decision for the item is rewritten in
+  /// place as [ChangeDecisionVerdict.deferred], dated now so the rewrite wins
+  /// last-writer-wins on other devices (feedback extraction reads verdicts
+  /// straight off the decisions, so a fresh neutral record next to the old
+  /// one would leave the undone verdict training the template). When no
+  /// decision can be found — decided on a device that has not synced it —
+  /// a fresh deferred decision is recorded instead.
+  ///
+  /// [revert] undoes whatever a confirmed tool did, and runs only once the
+  /// record says pending again, so a failed reopen never strands a reversed
+  /// effect behind a confirmed row. If the revert refuses or throws, the
+  /// record is put back the way it was — item status and verdict — and the
+  /// method returns `false`, leaving the effect and the record in agreement.
   ///
   /// Returns `false` when the item is out of range, still pending, or
   /// retracted by the agent (nothing of the user's to undo).
-  Future<bool> reopenItem(ChangeSetEntity changeSet, int itemIndex) async {
+  Future<bool> reopenItem(
+    ChangeSetEntity changeSet,
+    int itemIndex, {
+    Future<bool> Function()? revert,
+  }) async {
     final current = await _resolution.freshChangeSet(changeSet);
     if (itemIndex < 0 || itemIndex >= current.items.length) return false;
     final item = current.items[itemIndex];
@@ -378,21 +395,92 @@ class ChangeSetConfirmationService {
       'change set ${DomainLogger.sanitizeId(current.id)}',
       subDomain: _sub,
     );
-    await _resolution.persistDecision(
-      changeSet: current,
-      itemIndex: itemIndex,
-      toolName: item.toolName,
-      verdict: ChangeDecisionVerdict.deferred,
-      humanSummary: item.humanSummary,
-      args: item.args,
-    );
+    final standing = await _latestUserDecision(current, itemIndex);
+    final ChangeDecisionEntity decision;
+    if (standing == null) {
+      decision = await _resolution.persistDecision(
+        changeSet: current,
+        itemIndex: itemIndex,
+        toolName: item.toolName,
+        verdict: ChangeDecisionVerdict.deferred,
+        humanSummary: item.humanSummary,
+        args: item.args,
+      );
+    } else {
+      decision = standing.copyWith(
+        verdict: ChangeDecisionVerdict.deferred,
+        createdAt: clock.now(),
+      );
+      await _syncService.upsertEntity(decision);
+    }
     final reopened = await _resolution.updateChangeSetItemStatus(
       current,
       itemIndex,
       ChangeItemStatus.pending,
     );
-    return reopened != null;
+    if (reopened == null) return false;
+    if (revert == null) return true;
+
+    var reverted = false;
+    try {
+      reverted = await revert();
+    } catch (error, stackTrace) {
+      _domainLogger?.error(
+        LogDomain.agentWorkflow,
+        error,
+        stackTrace: stackTrace,
+        subDomain: _sub,
+        message: 'Revert threw while reopening item $itemIndex',
+      );
+    }
+    if (reverted) return true;
+
+    // The effect stands, so the record must say so again.
+    _domainLogger?.log(
+      LogDomain.agentWorkflow,
+      'Revert refused for item $itemIndex (${item.toolName}); restoring '
+      '${item.status.name}',
+      subDomain: _sub,
+    );
+    await _syncService.upsertEntity(
+      decision.copyWith(
+        verdict: item.status == ChangeItemStatus.confirmed
+            ? ChangeDecisionVerdict.confirmed
+            : ChangeDecisionVerdict.rejected,
+        createdAt: clock.now(),
+      ),
+    );
+    await _resolution.updateChangeSetItemStatus(
+      current,
+      itemIndex,
+      item.status,
+    );
+    return false;
   }
+
+  /// The newest decision a user recorded for the item at [itemIndex] of
+  /// [changeSet], or `null` when none is stored locally.
+  Future<ChangeDecisionEntity?> _latestUserDecision(
+    ChangeSetEntity changeSet,
+    int itemIndex,
+  ) async {
+    final entities = await _syncService.repository.getEntitiesByAgentId(
+      changeSet.agentId,
+      type: AgentEntityTypes.changeDecision,
+      limit: _decisionLookupLimit,
+    );
+    // Newest first.
+    return entities.whereType<ChangeDecisionEntity>().firstWhereOrNull(
+      (decision) =>
+          decision.changeSetId == changeSet.id &&
+          decision.itemIndex == itemIndex &&
+          decision.actor == DecisionActor.user,
+    );
+  }
+
+  /// How far back the newest-first decision read looks for an item's
+  /// standing verdict; a decided item's decision is always recent.
+  static const _decisionLookupLimit = 200;
 
   /// Rejects a single change item at [itemIndex] without dispatching
   /// any tool call.

--- a/lib/features/agents/service/change_set_confirmation_service.dart
+++ b/lib/features/agents/service/change_set_confirmation_service.dart
@@ -349,6 +349,51 @@ class ChangeSetConfirmationService {
         '$detail';
   }
 
+  /// Puts a decided item back to [ChangeItemStatus.pending] — the user's Undo
+  /// on a confirmed or rejected proposal — and records the reversal as a
+  /// [ChangeDecisionVerdict.deferred] decision, so the earlier verdict no
+  /// longer stands as feedback. Reverting whatever a confirmed tool did is
+  /// the caller's job; this only reopens the record.
+  ///
+  /// Returns `false` when the item is out of range, still pending, or
+  /// retracted by the agent (nothing of the user's to undo).
+  Future<bool> reopenItem(ChangeSetEntity changeSet, int itemIndex) async {
+    final current = await _resolution.freshChangeSet(changeSet);
+    if (itemIndex < 0 || itemIndex >= current.items.length) return false;
+    final item = current.items[itemIndex];
+    if (item.status != ChangeItemStatus.confirmed &&
+        item.status != ChangeItemStatus.rejected) {
+      _domainLogger?.log(
+        LogDomain.agentWorkflow,
+        'Skipping reopen for item $itemIndex (${item.toolName}) — '
+        '${item.status.name}',
+        subDomain: _sub,
+      );
+      return false;
+    }
+
+    _domainLogger?.log(
+      LogDomain.agentWorkflow,
+      'Reopening ${item.status.name} item $itemIndex (${item.toolName}) in '
+      'change set ${DomainLogger.sanitizeId(current.id)}',
+      subDomain: _sub,
+    );
+    await _resolution.persistDecision(
+      changeSet: current,
+      itemIndex: itemIndex,
+      toolName: item.toolName,
+      verdict: ChangeDecisionVerdict.deferred,
+      humanSummary: item.humanSummary,
+      args: item.args,
+    );
+    final reopened = await _resolution.updateChangeSetItemStatus(
+      current,
+      itemIndex,
+      ChangeItemStatus.pending,
+    );
+    return reopened != null;
+  }
+
   /// Rejects a single change item at [itemIndex] without dispatching
   /// any tool call.
   ///

--- a/lib/features/agents/service/project_proposal_service.dart
+++ b/lib/features/agents/service/project_proposal_service.dart
@@ -1,0 +1,134 @@
+import 'package:lotti/classes/project_data.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/service/change_set_confirmation_service.dart';
+import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
+import 'package:lotti/features/agents/tools/project_tool_definitions.dart';
+import 'package:lotti/features/projects/repository/project_repository.dart';
+import 'package:lotti/services/domain_logging.dart';
+
+/// Removes a task, returning `true` once it is gone.
+typedef ProjectTaskRemover = Future<bool> Function(String taskId);
+
+/// What a confirmed proposal changed, kept so it can be put back.
+class _AppliedProposal {
+  const _AppliedProposal({this.createdTaskId, this.previousStatus});
+
+  final String? createdTaskId;
+  final ProjectStatus? previousStatus;
+}
+
+/// Applies, rejects and undoes the project agent's proposed changes.
+///
+/// [confirm] and [reject] delegate to the change set confirmation service.
+/// A confirmed proposal's effect is remembered for this session — the task a
+/// `create_task` created, the status an `update_project_status` replaced —
+/// so [undo] can put the project back before it reopens the proposal.
+/// Rejections have no effect to revert, so their undo only reopens the
+/// item. Nothing here is invalidated by hand: the confirmation service
+/// persists through the agent sync service, whose update stream the pending
+/// read watches.
+class ProjectProposalService {
+  ProjectProposalService({
+    required this.confirmation,
+    required this.projectRepository,
+    required this.taskRemover,
+    this.domainLogger,
+  });
+
+  final ChangeSetConfirmationService confirmation;
+  final ProjectRepository projectRepository;
+  final ProjectTaskRemover taskRemover;
+  final DomainLogger? domainLogger;
+
+  final _applied = <String, _AppliedProposal>{};
+
+  static const _sub = 'ProjectProposal';
+
+  static String _key(ChangeSetEntity changeSet, int itemIndex) =>
+      '${changeSet.id}:$itemIndex';
+
+  /// Confirms the item at [itemIndex], remembering what it changed.
+  Future<ToolExecutionResult> confirm(
+    ChangeSetEntity changeSet,
+    int itemIndex,
+  ) async {
+    final item = changeSet.items[itemIndex];
+    ProjectStatus? previousStatus;
+    if (item.toolName == ProjectAgentToolNames.updateProjectStatus) {
+      final project = await projectRepository.getProjectById(
+        changeSet.taskId,
+      );
+      previousStatus = project?.data.status;
+    }
+    final result = await confirmation.confirmItem(changeSet, itemIndex);
+    if (result.success) {
+      _applied[_key(changeSet, itemIndex)] = _AppliedProposal(
+        createdTaskId: item.toolName == ProjectAgentToolNames.createTask
+            ? result.mutatedEntityId
+            : null,
+        previousStatus: previousStatus,
+      );
+    }
+    return result;
+  }
+
+  /// Rejects the item at [itemIndex] without applying anything.
+  Future<bool> reject(ChangeSetEntity changeSet, int itemIndex) =>
+      confirmation.rejectItem(changeSet, itemIndex);
+
+  /// Whether [undo] can still put the item at [itemIndex] back: always for a
+  /// rejection, and for a confirmation only while this session remembers
+  /// what it changed.
+  bool canUndo(ChangeSetEntity changeSet, int itemIndex) =>
+      switch (changeSet.items[itemIndex].status) {
+        ChangeItemStatus.rejected => true,
+        ChangeItemStatus.confirmed => _applied.containsKey(
+          _key(changeSet, itemIndex),
+        ),
+        _ => false,
+      };
+
+  /// Reverts what confirming the item at [itemIndex] did — the created task
+  /// is removed, the replaced status restored and its history entry dropped
+  /// — then reopens the item. Returns `false`, leaving the item decided,
+  /// when any step fails.
+  Future<bool> undo(ChangeSetEntity changeSet, int itemIndex) async {
+    final key = _key(changeSet, itemIndex);
+    final applied = _applied[key];
+    if (applied?.createdTaskId case final taskId?) {
+      if (!await taskRemover(taskId)) {
+        _log('Undo left task $taskId in place', changeSet);
+        return false;
+      }
+    }
+    if (applied?.previousStatus case final status?) {
+      final project = await projectRepository.getProjectById(
+        changeSet.taskId,
+      );
+      if (project == null) return false;
+      final history = [...project.data.statusHistory];
+      if (history.isNotEmpty && history.last == status) history.removeLast();
+      final restored = await projectRepository.updateProject(
+        project.copyWith(
+          data: project.data.copyWith(status: status, statusHistory: history),
+        ),
+      );
+      if (!restored) {
+        _log('Undo could not restore the project status', changeSet);
+        return false;
+      }
+    }
+    final reopened = await confirmation.reopenItem(changeSet, itemIndex);
+    if (reopened) _applied.remove(key);
+    return reopened;
+  }
+
+  void _log(String message, ChangeSetEntity changeSet) {
+    domainLogger?.log(
+      LogDomain.agentWorkflow,
+      '$message (change set ${DomainLogger.sanitizeId(changeSet.id)})',
+      subDomain: _sub,
+    );
+  }
+}

--- a/lib/features/agents/service/project_proposal_service.dart
+++ b/lib/features/agents/service/project_proposal_service.dart
@@ -1,9 +1,11 @@
+import 'package:clock/clock.dart';
 import 'package:lotti/classes/project_data.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/service/change_set_confirmation_service.dart';
 import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
 import 'package:lotti/features/agents/tools/project_tool_definitions.dart';
+import 'package:lotti/features/agents/workflow/project_tool_dispatcher.dart';
 import 'package:lotti/features/projects/repository/project_repository.dart';
 import 'package:lotti/services/domain_logging.dart';
 
@@ -89,39 +91,90 @@ class ProjectProposalService {
         _ => false,
       };
 
-  /// Reverts what confirming the item at [itemIndex] did — the created task
-  /// is removed, the replaced status restored and its history entry dropped
-  /// — then reopens the item. Returns `false`, leaving the item decided,
-  /// when any step fails.
+  /// Reopens the item at [itemIndex] and, once the record says pending
+  /// again, reverts what confirming it did: the created task is removed, or
+  /// the replaced status restored and its history entry dropped. A refused
+  /// revert puts the record back (see
+  /// [ChangeSetConfirmationService.reopenItem]) and returns `false`, leaving
+  /// the memo for another try.
   Future<bool> undo(ChangeSetEntity changeSet, int itemIndex) async {
     final key = _key(changeSet, itemIndex);
     final applied = _applied[key];
-    if (applied?.createdTaskId case final taskId?) {
+    final reopened = await confirmation.reopenItem(
+      changeSet,
+      itemIndex,
+      revert: applied == null
+          ? null
+          : () => _revert(applied, changeSet, itemIndex),
+    );
+    if (reopened) _applied.remove(key);
+    return reopened;
+  }
+
+  Future<bool> _revert(
+    _AppliedProposal applied,
+    ChangeSetEntity changeSet,
+    int itemIndex,
+  ) async {
+    if (applied.createdTaskId case final taskId?) {
       if (!await taskRemover(taskId)) {
         _log('Undo left task $taskId in place', changeSet);
         return false;
       }
     }
-    if (applied?.previousStatus case final status?) {
-      final project = await projectRepository.getProjectById(
-        changeSet.taskId,
-      );
-      if (project == null) return false;
-      final history = [...project.data.statusHistory];
-      if (history.isNotEmpty && history.last == status) history.removeLast();
-      final restored = await projectRepository.updateProject(
-        project.copyWith(
-          data: project.data.copyWith(status: status, statusHistory: history),
-        ),
-      );
-      if (!restored) {
-        _log('Undo could not restore the project status', changeSet);
-        return false;
-      }
+    if (applied.previousStatus case final previous?) {
+      return _restoreStatus(previous, changeSet, itemIndex);
     }
-    final reopened = await confirmation.reopenItem(changeSet, itemIndex);
-    if (reopened) _applied.remove(key);
-    return reopened;
+    return true;
+  }
+
+  /// Restores [previous] only when the project still looks the way the
+  /// confirmed tool left it: its status is the proposal's target and the
+  /// newest history entry is [previous]. A status that moved on since — sync,
+  /// another editor — is left alone, and the undo is refused rather than
+  /// overwriting it with stale data. A tool that found the project already
+  /// in its target status changed nothing, so there is nothing to restore.
+  Future<bool> _restoreStatus(
+    ProjectStatus previous,
+    ChangeSetEntity changeSet,
+    int itemIndex,
+  ) async {
+    final project = await projectRepository.getProjectById(changeSet.taskId);
+    if (project == null) {
+      _log('Undo found no project to restore', changeSet);
+      return false;
+    }
+    final data = project.data;
+    if (ProjectToolDispatcher.isSameSemanticStatus(data.status, previous)) {
+      return true;
+    }
+    final args = changeSet.items[itemIndex].args;
+    final target = switch (args['status']) {
+      final String raw => ProjectToolDispatcher.parseProjectStatus(
+        raw,
+        reason: args['reason'] as String?,
+        now: clock.now(),
+      ),
+      _ => null,
+    };
+    final history = [...data.statusHistory];
+    final untouched =
+        target != null &&
+        ProjectToolDispatcher.isSameSemanticStatus(data.status, target) &&
+        history.isNotEmpty &&
+        history.last == previous;
+    if (!untouched) {
+      _log('Undo left the project status alone: it moved since', changeSet);
+      return false;
+    }
+    history.removeLast();
+    final restored = await projectRepository.updateProject(
+      project.copyWith(
+        data: data.copyWith(status: previous, statusHistory: history),
+      ),
+    );
+    if (!restored) _log('Undo could not restore the project status', changeSet);
+    return restored;
   }
 
   void _log(String message, ChangeSetEntity changeSet) {

--- a/lib/features/agents/state/change_set_providers.dart
+++ b/lib/features/agents/state/change_set_providers.dart
@@ -5,6 +5,7 @@ import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/service/change_set_confirmation_service.dart';
 import 'package:lotti/features/agents/service/change_set_notification_service.dart';
+import 'package:lotti/features/agents/service/project_proposal_service.dart';
 import 'package:lotti/features/agents/service/project_recommendation_service.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/event_agent_providers.dart';
@@ -163,21 +164,33 @@ final projectRecommendationServiceProvider =
             domainLogger: ref.read(domainLoggerProvider),
             taskAgentService: ref.read(taskAgentServiceProvider),
           ).dispatch(tool, args, projectId),
-          // The repository delete logs and swallows a failed write, so its
-          // return value is not proof; the tombstone is. `journalEntityById`
-          // filters deleted rows, so a null read means the task is gone.
-          taskRemover: (taskId) async {
-            await ref
-                .read(journalRepositoryProvider)
-                .deleteJournalEntity(taskId);
-            final remaining = await ref
-                .read(journalDbProvider)
-                .journalEntityById(taskId);
-            return remaining == null;
-          },
+          taskRemover: projectTaskRemover(ref),
         );
       },
     );
+
+/// Soft-deletes a task and reports whether it is gone.
+///
+/// The repository delete logs and swallows a failed write, so its return
+/// value is not proof; the tombstone is. `journalEntityById` filters deleted
+/// rows, so a null read means the task is gone.
+ProjectTaskRemover projectTaskRemover(Ref ref) => (taskId) async {
+  await ref.read(journalRepositoryProvider).deleteJournalEntity(taskId);
+  final remaining = await ref.read(journalDbProvider).journalEntityById(taskId);
+  return remaining == null;
+};
+
+/// Decisions on the project agent's proposed changes, with Undo. Kept alive
+/// for the session so a confirmed proposal's effect stays undoable across
+/// rebuilds of the page that applied it.
+final projectProposalServiceProvider = Provider<ProjectProposalService>(
+  (ref) => ProjectProposalService(
+    confirmation: ref.watch(projectChangeSetConfirmationServiceProvider),
+    projectRepository: ref.watch(projectRepositoryProvider),
+    taskRemover: projectTaskRemover(ref),
+    domainLogger: ref.watch(domainLoggerProvider),
+  ),
+);
 
 /// The newest run's next steps for a project, in every status the detail
 /// band shows, plus when that run was published. Legacy pending batches are

--- a/lib/features/agents/workflow/project_tool_dispatcher.dart
+++ b/lib/features/agents/workflow/project_tool_dispatcher.dart
@@ -13,7 +13,6 @@ import 'package:lotti/features/projects/repository/project_repository.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/entities_cache_service.dart';
-import 'package:meta/meta.dart';
 import 'package:uuid/uuid.dart';
 
 /// Dispatches confirmed project-agent change-set items to project-domain
@@ -322,7 +321,6 @@ class ProjectToolDispatcher {
     }
   }
 
-  @visibleForTesting
   static ProjectStatus? parseProjectStatus(
     String rawStatus, {
     required String? reason,
@@ -368,7 +366,6 @@ class ProjectToolDispatcher {
     };
   }
 
-  @visibleForTesting
   static bool isSameSemanticStatus(
     ProjectStatus current,
     ProjectStatus next,

--- a/lib/features/design_system/components/context_menus/design_system_context_menu.dart
+++ b/lib/features/design_system/components/context_menus/design_system_context_menu.dart
@@ -54,6 +54,10 @@ class DesignSystemContextMenu extends StatelessWidget {
     super.key,
   });
 
+  /// The width every menu surface takes unless a caller asks otherwise;
+  /// shared with `DesignSystemPopoverAnchor` so popovers and menus line up.
+  static const double defaultWidth = _kMenuWidth;
+
   final List<DesignSystemContextMenuItem> items;
   final DesignSystemContextMenuSize size;
   final double width;

--- a/lib/features/design_system/components/lists/design_system_swipe_action_background.dart
+++ b/lib/features/design_system/components/lists/design_system_swipe_action_background.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+
+/// The band a [Dismissible] reveals behind a row while it is dragged: a fill
+/// with the action's glyph and name at the edge the row moves away from, so
+/// a swipe always says what letting go will do.
+///
+/// Callers pass the fill and the ink together so the pair is chosen once per
+/// surface — a habit row drags over the completion colours with high-emphasis
+/// text, an AI band row over its own accent wash with the accent ink.
+class DesignSystemSwipeActionBackground extends StatelessWidget {
+  const DesignSystemSwipeActionBackground({
+    required this.alignment,
+    required this.color,
+    required this.foregroundColor,
+    required this.icon,
+    required this.label,
+    super.key,
+  });
+
+  /// Where the glyph and label sit: the leading edge for a start-to-end
+  /// swipe, the trailing edge for the reverse.
+  final Alignment alignment;
+  final Color color;
+  final Color foregroundColor;
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return ColoredBox(
+      color: color,
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: tokens.spacing.step5),
+        child: Align(
+          alignment: alignment,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, color: foregroundColor, size: tokens.spacing.step6),
+              SizedBox(width: tokens.spacing.step2),
+              Text(
+                label,
+                style: tokens.typography.styles.body.bodyMedium.copyWith(
+                  color: foregroundColor,
+                  fontWeight: tokens.typography.weight.semiBold,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/design_system/components/popovers/design_system_popover_anchor.dart
+++ b/lib/features/design_system/components/popovers/design_system_popover_anchor.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/components/context_menus/design_system_context_menu.dart';
+import 'package:lotti/features/design_system/components/context_menus/design_system_context_menu_anchor.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+
+/// Opens arbitrary content in a dismiss-on-outside-tap popover beneath a
+/// caller-supplied trigger, on the context menu's floating surface.
+///
+/// `DesignSystemContextMenuAnchor` is the same overlay for a list of menu
+/// rows; this one hosts a widget instead — a settings panel, a picker — so a
+/// desktop control can open in place what a phone opens as a sheet. The
+/// content decides when it is done: nothing inside closes the popover, only
+/// an outside tap or the trigger itself.
+class DesignSystemPopoverAnchor extends StatefulWidget {
+  const DesignSystemPopoverAnchor({
+    required this.builder,
+    required this.child,
+    this.width = DesignSystemContextMenu.defaultWidth,
+    this.semanticsLabel,
+    super.key,
+  });
+
+  /// Builds the always-visible trigger.
+  final DesignSystemContextMenuTriggerBuilder builder;
+
+  /// The popover's content. It is built each time the popover opens, so it
+  /// always starts from the caller's current state.
+  final Widget child;
+
+  /// Width of the floating surface.
+  final double width;
+
+  /// Semantics label for the opened popover container.
+  final String? semanticsLabel;
+
+  @override
+  State<DesignSystemPopoverAnchor> createState() =>
+      _DesignSystemPopoverAnchorState();
+}
+
+class _DesignSystemPopoverAnchorState extends State<DesignSystemPopoverAnchor> {
+  final MenuController _controller = MenuController();
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return MenuAnchor(
+      controller: _controller,
+      alignmentOffset: Offset(0, tokens.spacing.step2),
+      // The panel itself is invisible — the surface below carries the
+      // background, radius and shadow, so a second background here would
+      // double up.
+      style: const MenuStyle(
+        backgroundColor: WidgetStatePropertyAll(Colors.transparent),
+        elevation: WidgetStatePropertyAll(0),
+        padding: WidgetStatePropertyAll(EdgeInsets.zero),
+        shape: WidgetStatePropertyAll(RoundedRectangleBorder()),
+        side: WidgetStatePropertyAll(BorderSide.none),
+      ),
+      menuChildren: [
+        DesignSystemPopoverSurface(
+          width: widget.width,
+          semanticsLabel: widget.semanticsLabel,
+          child: widget.child,
+        ),
+      ],
+      builder: (context, controller, child) {
+        void toggle() {
+          if (controller.isOpen) {
+            controller.close();
+          } else {
+            controller.open();
+          }
+        }
+
+        return widget.builder(
+          context,
+          toggle: toggle,
+          isOpen: controller.isOpen,
+        );
+      },
+    );
+  }
+}
+
+/// The floating surface a [DesignSystemPopoverAnchor] opens: the context
+/// menu's background, radius and shadow around [child].
+class DesignSystemPopoverSurface extends StatelessWidget {
+  const DesignSystemPopoverSurface({
+    required this.child,
+    this.width = DesignSystemContextMenu.defaultWidth,
+    this.semanticsLabel,
+    super.key,
+  });
+
+  final Widget child;
+  final double width;
+  final String? semanticsLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return Semantics(
+      container: true,
+      label: semanticsLabel,
+      child: Material(
+        color: Colors.transparent,
+        child: Container(
+          width: width,
+          decoration: BoxDecoration(
+            color: tokens.colors.background.level01,
+            borderRadius: BorderRadius.circular(tokens.radii.s),
+            boxShadow: DsShadows.floatingSurface,
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(tokens.radii.s),
+            child: Material(color: Colors.transparent, child: child),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/habits/ui/widgets/habit_action_row.dart
+++ b/lib/features/habits/ui/widgets/habit_action_row.dart
@@ -10,6 +10,7 @@ import 'package:lotti/features/design_system/components/celebration/celebration_
 import 'package:lotti/features/design_system/components/celebration/completion_burst.dart';
 import 'package:lotti/features/design_system/components/celebration/completion_glow.dart';
 import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_swipe_action_background.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/design_system/theme/ds_surface_elevation.dart';
@@ -341,15 +342,17 @@ class _HabitActionRowState extends ConsumerState<HabitActionRow>
                 DismissDirection.startToEnd: 0.4,
                 DismissDirection.endToStart: 0.4,
               },
-              background: _SwipeActionBackground(
+              background: DesignSystemSwipeActionBackground(
                 alignment: Alignment.centerLeft,
                 color: habitCompletionColor(HabitCompletionType.success),
+                foregroundColor: tokens.colors.text.highEmphasis,
                 icon: LottiIcons.confirmCircled,
                 label: messages.completeHabitSuccessButton,
               ),
-              secondaryBackground: _SwipeActionBackground(
+              secondaryBackground: DesignSystemSwipeActionBackground(
                 alignment: Alignment.centerRight,
                 color: habitCompletionColor(HabitCompletionType.fail),
+                foregroundColor: tokens.colors.text.highEmphasis,
                 icon: LottiIcons.closeCircled,
                 label: messages.completeHabitFailButton,
               ),
@@ -689,45 +692,3 @@ class _CompleteButton extends StatelessWidget {
 /// The coloured reveal behind a row while it is being swiped — an outcome
 /// colour with a leading/trailing icon and label so the gesture's effect is
 /// legible before the user commits to it.
-class _SwipeActionBackground extends StatelessWidget {
-  const _SwipeActionBackground({
-    required this.alignment,
-    required this.color,
-    required this.icon,
-    required this.label,
-  });
-
-  final Alignment alignment;
-  final Color color;
-  final IconData icon;
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    final onColor = tokens.colors.text.highEmphasis;
-    return ColoredBox(
-      color: color,
-      child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: tokens.spacing.step5),
-        child: Align(
-          alignment: alignment,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(icon, color: onColor, size: tokens.spacing.step6),
-              SizedBox(width: tokens.spacing.step2),
-              Text(
-                label,
-                style: tokens.typography.styles.body.bodyMedium.copyWith(
-                  color: onColor,
-                  fontWeight: tokens.typography.weight.semiBold,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}

--- a/lib/features/projects/README.md
+++ b/lib/features/projects/README.md
@@ -41,12 +41,13 @@ project agent is attached — a summary and health read that the agent maintains
 - **Keeps agent output actionable.** The AI report leads the task list with
   the agent's current next steps. Each step offers two labelled actions: **Add
   task** creates a project-linked task and links the step to it, **Dismiss**
-  sets it aside; both can be undone, and a decided step stays in place with its
-  tag instead of vanishing. The new task lights up in the list below, and the
-  step's "Added → title" link scrolls it into view. Bulk actions add or dismiss
-  every open step. The
+  sets it aside; on touch a swipe right or left does the same. Both can be
+  undone, and a decided step stays in place with its tag instead of vanishing.
+  The new task lights up in the list below, and the step's "Added → title"
+  link scrolls it into view. Bulk actions add or dismiss every open step. The
   agent's proposed changes (a status change, a task it wants to create) sit in
-  their own band under the steps. Each successful analysis replaces the list;
+  their own band under the steps; applying or rejecting one can be undone for
+  eight seconds, which puts the project back and reopens the proposal. Each successful analysis replaces the list;
   a run that was already fully decided collapses to a one-line summary with its
   history, and an empty run says when the agent last looked.
 

--- a/lib/features/projects/README.md
+++ b/lib/features/projects/README.md
@@ -13,7 +13,9 @@ project agent is attached — a summary and health read that the agent maintains
   task was created, newest first, folds finished tasks into a collapsed Done
   group, and offers a Sort and group control (status, priority, due window or
   no grouping; actionability, creation, due date, estimate, priority, last
-  update or title). The choice is remembered per project.
+  update or title) as a popover on desktop and a sheet on a phone. Group
+  headers stay pinned while their group scrolls past. The choice, and which
+  groups are folded, is remembered per project.
 - **Says where a project stands.** Six statuses: open, active, monitoring, on
   hold (with a required reason), completed, archived. "Monitoring" is for work
   that is not finished but has no time scheduled — checked on when something
@@ -40,7 +42,9 @@ project agent is attached — a summary and health read that the agent maintains
   the agent's current next steps. Each step offers two labelled actions: **Add
   task** creates a project-linked task and links the step to it, **Dismiss**
   sets it aside; both can be undone, and a decided step stays in place with its
-  tag instead of vanishing. Bulk actions add or dismiss every open step. The
+  tag instead of vanishing. The new task lights up in the list below, and the
+  step's "Added → title" link scrolls it into view. Bulk actions add or dismiss
+  every open step. The
   agent's proposed changes (a status change, a task it wants to create) sit in
   their own band under the steps. Each successful analysis replaces the list;
   a run that was already fully decided collapses to a one-line summary with its

--- a/lib/features/projects/ui/model/project_task_list_options.dart
+++ b/lib/features/projects/ui/model/project_task_list_options.dart
@@ -14,15 +14,17 @@ enum ProjectTaskSortBy {
   title,
 }
 
-/// The user's choice of grouping, ordering and whether done tasks stay in
-/// their groups or fold into one trailing "Done" group. Remembered per
-/// project; the defaults are what a project shows the first time.
+/// The user's choice of grouping, ordering, whether done tasks stay in
+/// their groups or fold into one trailing "Done" group, and which groups are
+/// folded shut. Remembered per project; the defaults are what a project
+/// shows the first time.
 @immutable
 class ProjectTaskListOptions {
   const ProjectTaskListOptions({
     this.groupBy = ProjectTaskGroupBy.creationMonth,
     this.sortBy = ProjectTaskSortBy.actionability,
     this.keepDoneInGroups = false,
+    this.collapsedGroups = defaultCollapsedGroups,
   });
 
   /// Tolerant of unknown or missing values: a preference written by a newer
@@ -30,6 +32,7 @@ class ProjectTaskListOptions {
   factory ProjectTaskListOptions.fromJson(Map<String, dynamic> json) {
     T pick<T extends Enum>(List<T> values, Object? raw, T fallback) =>
         values.firstWhere((v) => v.name == raw, orElse: () => fallback);
+    final collapsed = json['collapsedGroups'];
     return ProjectTaskListOptions(
       groupBy: pick(
         ProjectTaskGroupBy.values,
@@ -38,10 +41,17 @@ class ProjectTaskListOptions {
       ),
       sortBy: pick(ProjectTaskSortBy.values, json['sortBy'], defaults.sortBy),
       keepDoneInGroups: json['keepDoneInGroups'] == true,
+      collapsedGroups: collapsed is List
+          ? collapsed.whereType<String>().toSet()
+          : defaultCollapsedGroups,
     );
   }
 
   static const defaults = ProjectTaskListOptions();
+
+  /// The trailing "Done" group starts folded so a long project leads with
+  /// open work.
+  static const Set<String> defaultCollapsedGroups = {'done'};
 
   final ProjectTaskGroupBy groupBy;
   final ProjectTaskSortBy sortBy;
@@ -50,20 +60,37 @@ class ProjectTaskListOptions {
   /// `false` folds them into one collapsed trailing group so open work leads.
   final bool keepDoneInGroups;
 
+  /// The ids of the groups folded shut. Group ids are unique across every
+  /// grouping, so one set serves all of them.
+  final Set<String> collapsedGroups;
+
+  /// Whether the group with [groupId] is folded shut.
+  bool isCollapsed(String groupId) => collapsedGroups.contains(groupId);
+
+  /// These options with the group [groupId] folded the other way.
+  ProjectTaskListOptions toggleCollapsed(String groupId) => copyWith(
+    collapsedGroups: isCollapsed(groupId)
+        ? (collapsedGroups.toSet()..remove(groupId))
+        : {...collapsedGroups, groupId},
+  );
+
   ProjectTaskListOptions copyWith({
     ProjectTaskGroupBy? groupBy,
     ProjectTaskSortBy? sortBy,
     bool? keepDoneInGroups,
+    Set<String>? collapsedGroups,
   }) => ProjectTaskListOptions(
     groupBy: groupBy ?? this.groupBy,
     sortBy: sortBy ?? this.sortBy,
     keepDoneInGroups: keepDoneInGroups ?? this.keepDoneInGroups,
+    collapsedGroups: collapsedGroups ?? this.collapsedGroups,
   );
 
   Map<String, dynamic> toJson() => {
     'groupBy': groupBy.name,
     'sortBy': sortBy.name,
     'keepDoneInGroups': keepDoneInGroups,
+    'collapsedGroups': collapsedGroups.toList()..sort(),
   };
 
   @override
@@ -71,13 +98,20 @@ class ProjectTaskListOptions {
       other is ProjectTaskListOptions &&
       other.groupBy == groupBy &&
       other.sortBy == sortBy &&
-      other.keepDoneInGroups == keepDoneInGroups;
+      other.keepDoneInGroups == keepDoneInGroups &&
+      setEquals(other.collapsedGroups, collapsedGroups);
 
   @override
-  int get hashCode => Object.hash(groupBy, sortBy, keepDoneInGroups);
+  int get hashCode => Object.hash(
+    groupBy,
+    sortBy,
+    keepDoneInGroups,
+    Object.hashAllUnordered(collapsedGroups),
+  );
 
   @override
   String toString() =>
       'ProjectTaskListOptions(${groupBy.name}, ${sortBy.name}, '
-      'keepDoneInGroups: $keepDoneInGroups)';
+      'keepDoneInGroups: $keepDoneInGroups, '
+      'collapsed: ${collapsedGroups.toList()..sort()})';
 }

--- a/lib/features/projects/ui/pages/project_details_page.dart
+++ b/lib/features/projects/ui/pages/project_details_page.dart
@@ -24,7 +24,6 @@ import 'package:lotti/features/projects/ui/widgets/project_mobile_detail_content
 import 'package:lotti/features/projects/ui/widgets/project_recommendations_panel.dart';
 import 'package:lotti/features/projects/ui/widgets/project_status_attributes.dart';
 import 'package:lotti/features/projects/ui/widgets/project_status_picker.dart';
-import 'package:lotti/features/projects/ui/widgets/project_task_list_options_sheet.dart';
 import 'package:lotti/features/projects/ui/widgets/showcase/showcase_palette.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/logic/create/create_entry.dart';
@@ -169,11 +168,14 @@ class ProjectDetailsPage extends ConsumerWidget {
               agentIdentity: identity,
               agentActionsBuilder: identity == null
                   ? null
-                  : ({required enabled}) => ProjectRecommendationsPanel(
-                      projectId: projectId,
-                      enabled: enabled,
-                      onOpenTask: (taskId) => beamToNamed('/tasks/$taskId'),
-                    ),
+                  : ({required enabled, required focusTask}) =>
+                        ProjectRecommendationsPanel(
+                          projectId: projectId,
+                          enabled: enabled,
+                          onOpenTask: focusTask,
+                          onTaskCreated: (taskId) =>
+                              focusTask(taskId, scroll: false),
+                        ),
               hasProjectAgent: identity != null || agentAsync.isLoading,
               isRefreshingReport: isRefreshingReport,
               isSaving: detailState.isSaving,
@@ -183,16 +185,9 @@ class ProjectDetailsPage extends ConsumerWidget {
               taskListOptions: ref.watch(
                 projectTaskListOptionsProvider(projectId),
               ),
-              onTaskListOptionsChanged: (options) =>
-                  showProjectTaskListOptionsSheet(
-                    context: context,
-                    options: options,
-                    onChanged: ref
-                        .read(
-                          projectTaskListOptionsProvider(projectId).notifier,
-                        )
-                        .update,
-                  ),
+              onTaskListOptionsChanged: ref
+                  .read(projectTaskListOptionsProvider(projectId).notifier)
+                  .update,
             ),
           ),
         );

--- a/lib/features/projects/ui/widgets/next_steps/project_next_step_row.dart
+++ b/lib/features/projects/ui/widgets/next_steps/project_next_step_row.dart
@@ -4,6 +4,7 @@ import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/tools/project_tool_definitions.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_inline_action.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_swipe_action_background.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_showcase_chips.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -128,7 +129,7 @@ class ProjectNextStepRow extends StatelessWidget {
           )
         : null;
 
-    return DecoratedBox(
+    final card = DecoratedBox(
       decoration: BoxDecoration(
         color: _decided ? ai.subtleWash : ai.row,
         borderRadius: BorderRadius.circular(tokens.radii.s),
@@ -170,6 +171,51 @@ class ProjectNextStepRow extends StatelessWidget {
             );
           },
         ),
+      ),
+    );
+
+    // On touch a pending row also decides by swipe — right to add the task,
+    // left to dismiss — with the action named on the band it reveals. The
+    // row snaps back rather than leaving: it stays in place with its tag.
+    final swipeable =
+        enabled &&
+        state == ProjectNextStepRowState.pending &&
+        (onAddTask != null || onDismiss != null);
+    if (!swipeable) return card;
+    final messages = context.messages;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(tokens.radii.s),
+      child: Dismissible(
+        key: ValueKey('project-next-step-swipe-${step.id}'),
+        direction: onAddTask == null
+            ? DismissDirection.endToStart
+            : onDismiss == null
+            ? DismissDirection.startToEnd
+            : DismissDirection.horizontal,
+        dismissThresholds: const {
+          DismissDirection.startToEnd: 0.4,
+          DismissDirection.endToStart: 0.4,
+        },
+        background: DesignSystemSwipeActionBackground(
+          alignment: Alignment.centerLeft,
+          color: ai.accentSoft,
+          foregroundColor: ai.accent,
+          icon: LottiIcons.add,
+          label: messages.projectActionAddTask,
+        ),
+        secondaryBackground: DesignSystemSwipeActionBackground(
+          alignment: Alignment.centerRight,
+          color: ai.subtleWashStrong,
+          foregroundColor: ai.metaText,
+          icon: LottiIcons.close,
+          label: messages.projectNextStepDismiss,
+        ),
+        confirmDismiss: (direction) async {
+          (direction == DismissDirection.startToEnd ? onAddTask : onDismiss)
+              ?.call();
+          return false;
+        },
+        child: card,
       ),
     );
   }

--- a/lib/features/projects/ui/widgets/next_steps/project_proposal_row.dart
+++ b/lib/features/projects/ui/widgets/next_steps/project_proposal_row.dart
@@ -4,6 +4,7 @@ import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_widgets_part.dart';
 import 'package:lotti/features/agents/ui/localized_change_summary.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_inline_action.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 
@@ -22,6 +23,8 @@ class ProjectProposalRow extends StatelessWidget {
     required this.onConfirm,
     required this.onReject,
     this.enabled = true,
+    this.canUndo = false,
+    this.onUndo,
     super.key,
   });
 
@@ -36,6 +39,10 @@ class ProjectProposalRow extends StatelessWidget {
 
   /// `false` keeps the rail visible but inert.
   final bool enabled;
+
+  /// Whether a decided row still offers Undo; [onUndo] puts it back.
+  final bool canUndo;
+  final VoidCallback? onUndo;
 
   ChangeItem get item => changeSet.items[itemIndex];
 
@@ -73,9 +80,20 @@ class ProjectProposalRow extends StatelessWidget {
               ),
             ),
             SizedBox(width: tokens.spacing.step3),
-            if (decided)
-              ResolvedTag(status: item.status)
-            else
+            if (decided) ...[
+              ResolvedTag(status: item.status),
+              if (canUndo) ...[
+                SizedBox(width: tokens.spacing.step3),
+                IntrinsicWidth(
+                  child: DesignSystemInlineAction(
+                    onTap: enabled ? onUndo : null,
+                    semanticsLabel: context.messages.designSystemUndoLabel,
+                    label: context.messages.designSystemUndoLabel,
+                    leadingIcon: LottiIcons.undo,
+                  ),
+                ),
+              ],
+            ] else
               RowActions(
                 busy: busy,
                 enabled: enabled,

--- a/lib/features/projects/ui/widgets/project_mobile_detail_content.dart
+++ b/lib/features/projects/ui/widgets/project_mobile_detail_content.dart
@@ -82,14 +82,22 @@ class ProjectMobileDetailContent extends StatefulWidget {
   /// Builds the agent's action bands for the AI card. `enabled` is false
   /// while this surface runs a mutation of its own, so the bands stay
   /// mounted (no decision state is lost) but every control is disabled.
-  final Widget Function({required bool enabled})? agentActionsBuilder;
+  /// `focusTask` lets a band point at a task in the list below — the one an
+  /// added step created — and have the list scroll to it and light it up.
+  final Widget Function({
+    required bool enabled,
+    required ProjectTaskFocusRequest focusTask,
+  })?
+  agentActionsBuilder;
   final bool hasProjectAgent;
   final bool isRefreshingReport;
   final bool isSaving;
   final ValueChanged<TaskSummary>? onTaskTap;
 
-  /// How the task list groups and orders itself; the host remembers it per
-  /// project. Without [onTaskListOptionsChanged] the list shows no control.
+  /// How the task list groups, orders and folds itself; the host remembers
+  /// it per project and receives every change through
+  /// [onTaskListOptionsChanged]. Without the callback the list shows no
+  /// control and keeps its folds to itself.
   final ProjectTaskListOptions taskListOptions;
   final ValueChanged<ProjectTaskListOptions>? onTaskListOptionsChanged;
 
@@ -102,6 +110,18 @@ class _ProjectMobileDetailContentState
     extends State<ProjectMobileDetailContent> {
   late final ScrollController _scrollController = ScrollController();
   bool _isAddingTask = false;
+  ProjectTaskFocus? _taskFocus;
+
+  void _focusTask(String taskId, {bool scroll = true}) {
+    setState(() {
+      _taskFocus = ProjectTaskFocus(
+        taskId: taskId,
+        request: (_taskFocus?.request ?? 0) + 1,
+        scroll: scroll,
+      );
+    });
+  }
+
   bool _isDeleting = false;
   bool _isAssigningAgent = false;
 
@@ -289,6 +309,7 @@ class _ProjectMobileDetailContentState
                                     : () => widget.onTaskTap!(firstBlockedTask),
                                 actions: widget.agentActionsBuilder?.call(
                                   enabled: !isMutating,
+                                  focusTask: _focusTask,
                                 ),
                                 isRefreshing: widget.isRefreshingReport,
                               ),
@@ -301,6 +322,7 @@ class _ProjectMobileDetailContentState
                               now: widget.currentTime,
                               options: widget.taskListOptions,
                               onOptionsChanged: widget.onTaskListOptionsChanged,
+                              focus: _taskFocus,
                               onTaskTap: isMutating ? null : widget.onTaskTap,
                               onAddTask: widget.onAddTask == null
                                   ? null

--- a/lib/features/projects/ui/widgets/project_recommendations_panel.dart
+++ b/lib/features/projects/ui/widgets/project_recommendations_panel.dart
@@ -37,6 +37,7 @@ class ProjectRecommendationsPanel extends ConsumerStatefulWidget {
     required this.projectId,
     this.enabled = true,
     this.onOpenTask,
+    this.onTaskCreated,
     super.key,
   });
 
@@ -52,8 +53,13 @@ class ProjectRecommendationsPanel extends ConsumerStatefulWidget {
   /// own; the bands stay mounted so no decision state is lost.
   final bool enabled;
 
-  /// Opens the task an added step created.
+  /// Called with the task id when the "Added → title" link is tapped; the
+  /// page brings that task into view in the list below.
   final ValueChanged<String>? onOpenTask;
+
+  /// Called with the task id right after a step created it, so the page can
+  /// mark the new row in the list without moving the band.
+  final ValueChanged<String>? onTaskCreated;
 
   @override
   ConsumerState<ProjectRecommendationsPanel> createState() =>
@@ -162,7 +168,10 @@ class _ProjectRecommendationsPanelState
         _optimistic[step.id] = taskId == null
             ? ProjectNextStepRowState.done
             : ProjectNextStepRowState.added;
-        if (taskId != null) _createdTasks[step.id] = taskId;
+        if (taskId != null) {
+          _createdTasks[step.id] = taskId;
+          widget.onTaskCreated?.call(taskId);
+        }
         _armUndo(step.id);
         if (result.errorMessage case final warning?) {
           context.showToast(

--- a/lib/features/projects/ui/widgets/project_recommendations_panel.dart
+++ b/lib/features/projects/ui/widgets/project_recommendations_panel.dart
@@ -290,10 +290,10 @@ class _ProjectRecommendationsPanelState
     setState(() => _busyProposals.add(key));
     var succeeded = false;
     try {
-      final service = ref.read(projectChangeSetConfirmationServiceProvider);
+      final service = ref.read(projectProposalServiceProvider);
       succeeded = confirm
-          ? (await service.confirmItem(set, index)).success
-          : await service.rejectItem(set, index);
+          ? (await service.confirm(set, index)).success
+          : await service.reject(set, index);
     } catch (error, stackTrace) {
       _log('Failed to apply a project proposal', error, stackTrace);
     }
@@ -308,10 +308,50 @@ class _ProjectRecommendationsPanelState
               : ChangeItemStatus.rejected,
         );
         _decidedProposals[key] = (set.copyWith(items: items), index);
+        _armUndo(key);
       }
     });
     // Only the proposal read moves; the agent's update stream is left alone
     // so the report, health and footer never reload for a row decision.
+    ref.invalidate(projectPendingChangeSetsProvider(widget.projectId));
+    if (!succeeded) {
+      context.showToast(
+        tone: DesignSystemToastTone.error,
+        title: context.messages.projectRecommendationUpdateError,
+      );
+    }
+  }
+
+  /// A decided proposal offers Undo for the same window as an added step,
+  /// and only while the service can still put its effect back.
+  bool _canUndoProposal(ChangeSetEntity set, int index) {
+    if (!widget.enabled) return false;
+    final key = _proposalKey(set, index);
+    if (!(_undoDeadlines[key]?.isAfter(_now) ?? false)) return false;
+    return ref.read(projectProposalServiceProvider).canUndo(set, index);
+  }
+
+  Future<void> _undoProposal(ChangeSetEntity set, int index) async {
+    final key = _proposalKey(set, index);
+    if (_busyProposals.contains(key)) return;
+    setState(() => _busyProposals.add(key));
+    var succeeded = false;
+    try {
+      succeeded = await ref
+          .read(projectProposalServiceProvider)
+          .undo(set, index);
+    } catch (error, stackTrace) {
+      _log('Failed to undo a project proposal', error, stackTrace);
+    }
+    if (!mounted) return;
+    setState(() {
+      _busyProposals.remove(key);
+      if (succeeded) {
+        _decidedProposals.remove(key);
+        _undoTimers.remove(key)?.cancel();
+        _undoDeadlines.remove(key);
+      }
+    });
     ref.invalidate(projectPendingChangeSetsProvider(widget.projectId));
     if (!succeeded) {
       context.showToast(
@@ -402,6 +442,8 @@ class _ProjectRecommendationsPanelState
                               _decideProposal(set, index, confirm: true),
                           onReject: () =>
                               _decideProposal(set, index, confirm: false),
+                          canUndo: _canUndoProposal(set, index),
+                          onUndo: () => _undoProposal(set, index),
                         ),
                       ),
                   ],

--- a/lib/features/projects/ui/widgets/project_task_list_options_sheet.dart
+++ b/lib/features/projects/ui/widgets/project_task_list_options_sheet.dart
@@ -84,7 +84,10 @@ class _ProjectTaskListOptionsSheetContentState
   @override
   Widget build(BuildContext context) {
     final messages = context.messages;
+    // Never the page's primary scrollable: inside the desktop popover the
+    // page's own scroll view already holds the primary controller.
     return SingleChildScrollView(
+      primary: false,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/features/projects/ui/widgets/project_tasks_panel.dart
+++ b/lib/features/projects/ui/widgets/project_tasks_panel.dart
@@ -1,37 +1,81 @@
 import 'dart:async';
 
 import 'package:clock/clock.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_icon_action.dart';
+import 'package:lotti/features/design_system/components/popovers/design_system_popover_anchor.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/projects/ui/model/project_list_detail_models.dart';
 import 'package:lotti/features/projects/ui/model/project_task_groups.dart';
 import 'package:lotti/features/projects/ui/model/project_task_list_options.dart';
+import 'package:lotti/features/projects/ui/widgets/project_task_list_options_sheet.dart';
 import 'package:lotti/features/projects/ui/widgets/shared_widgets.dart';
 import 'package:lotti/features/projects/ui/widgets/showcase/showcase_palette.dart';
 import 'package:lotti/features/projects/ui/widgets/showcase/showcase_status_helpers.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:sliver_tools/sliver_tools.dart';
+
+/// Asks the task list to focus [taskId]: scroll to it and light it up, or
+/// with `scroll: false` only light it up where it is.
+typedef ProjectTaskFocusRequest = void Function(String taskId, {bool scroll});
+
+/// A request to bring one task's row into view and light it up.
+///
+/// Each request carries a fresh [request] number so asking for the same task
+/// twice scrolls twice. With [scroll] off the row is only highlighted where
+/// it is — the way a task just created from a next step is marked without
+/// pulling the page away from the band that created it.
+@immutable
+class ProjectTaskFocus {
+  const ProjectTaskFocus({
+    required this.taskId,
+    required this.request,
+    this.scroll = true,
+  });
+
+  final String taskId;
+  final int request;
+  final bool scroll;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ProjectTaskFocus &&
+      other.taskId == taskId &&
+      other.request == request &&
+      other.scroll == scroll;
+
+  @override
+  int get hashCode => Object.hash(taskId, request, scroll);
+}
 
 /// The project's task list as a sliver: a header with the count, the total
-/// estimate and the actions, then the tasks in collapsible groups.
+/// estimate and the actions, then the tasks in collapsible groups whose
+/// headers stay pinned while their group scrolls past.
 ///
-/// Grouping and order come from [options] (creation month, newest first, by
-/// default); [onOptionsChanged] wires the header's "Sort and group" control
-/// and is omitted by read-only showcases. Finished tasks fold into one
-/// trailing group that starts collapsed. Due-window groups re-evaluate at
-/// local midnight while the panel stays mounted. The header survives a narrow pane, a phone
-/// and large text: the title truncates before anything overflows, and in the
-/// compact form (below [compactWidth], or at large text) the total estimate is
-/// dropped and Add task turns icon-only.
+/// Grouping, order and which groups are folded come from [options] (creation
+/// month, newest first, Done folded, by default); [onOptionsChanged] receives
+/// every change — a pick in the "Sort and group" control, a group folded or
+/// unfolded — and is omitted by read-only showcases, which then show no
+/// control and keep folds to themselves. The control opens as a popover on a
+/// desktop-wide screen and as the shared sheet elsewhere. Finished tasks fold
+/// into one trailing group. Due-window groups re-evaluate at local midnight
+/// while the panel stays mounted. [focus] scrolls to and highlights one task
+/// on request. The header survives a narrow pane, a phone and large text:
+/// the title truncates before anything overflows, and in the compact form
+/// (below [compactWidth], or at large text) the total estimate is dropped and
+/// Add task turns icon-only.
 class ProjectTasksSliverPanel extends StatefulWidget {
   const ProjectTasksSliverPanel({
     required this.record,
     required this.now,
     this.options = ProjectTaskListOptions.defaults,
     this.onOptionsChanged,
+    this.focus,
     this.onTaskTap,
     this.onAddTask,
     this.isAddTaskEnabled = true,
@@ -50,12 +94,20 @@ class ProjectTasksSliverPanel extends StatefulWidget {
   /// From this text scale on the header takes its compact form at any width.
   static const double largeTextScale = 1.2;
 
+  /// How long a focused row stays lit.
+  static const Duration highlightDuration = Duration(seconds: 3);
+
+  /// How many frames a scroll request keeps looking for a row that the lazy
+  /// list has not built yet, stepping a viewport further each time.
+  static const int maxScrollAttempts = 12;
+
   final ProjectRecord record;
 
   /// Reference time for the due-window groups.
   final DateTime now;
   final ProjectTaskListOptions options;
   final ValueChanged<ProjectTaskListOptions>? onOptionsChanged;
+  final ProjectTaskFocus? focus;
   final ValueChanged<TaskSummary>? onTaskTap;
   final VoidCallback? onAddTask;
   final bool isAddTaskEnabled;
@@ -67,8 +119,15 @@ class ProjectTasksSliverPanel extends StatefulWidget {
 }
 
 class _ProjectTasksSliverPanelState extends State<ProjectTasksSliverPanel> {
-  /// Group ids the user folded; the trailing Done group starts folded.
-  final _collapsed = <String>{const ProjectTaskDoneKey().id};
+  /// Folds made while the host offers no [ProjectTasksSliverPanel.onOptionsChanged]
+  /// live here; otherwise the host's options are the only truth.
+  ProjectTaskListOptions? _localOptions;
+
+  ProjectTaskListOptions get _options => _localOptions ?? widget.options;
+
+  String? _highlightedTaskId;
+  Timer? _highlightTimer;
+  int _scrollAttempts = 0;
 
   /// The reference time for due windows: the host's [ProjectTasksSliverPanel.now]
   /// until local midnight passes while the panel stays mounted, then the
@@ -81,6 +140,7 @@ class _ProjectTasksSliverPanelState extends State<ProjectTasksSliverPanel> {
   void initState() {
     super.initState();
     _armDayTimer();
+    if (widget.focus case final focus?) _focus(focus);
   }
 
   @override
@@ -91,12 +151,103 @@ class _ProjectTasksSliverPanelState extends State<ProjectTasksSliverPanel> {
         oldWidget.options.groupBy != widget.options.groupBy) {
       _armDayTimer();
     }
+    if (oldWidget.options != widget.options) _localOptions = null;
+    if (widget.focus case final focus? when focus != oldWidget.focus) {
+      _focus(focus);
+    }
   }
 
   @override
   void dispose() {
     _dayTimer?.cancel();
+    _highlightTimer?.cancel();
     super.dispose();
+  }
+
+  List<ProjectTaskGroup> _groups() => groupProjectTasks(
+    widget.record.highlightedTaskSummaries,
+    options: _options,
+    now: _now,
+  );
+
+  void _focus(ProjectTaskFocus focus) {
+    _highlightTimer?.cancel();
+    _highlightedTaskId = focus.taskId;
+    _highlightTimer = Timer(ProjectTasksSliverPanel.highlightDuration, () {
+      if (!mounted) return;
+      setState(() => _highlightedTaskId = null);
+    });
+    if (!focus.scroll) return;
+    final group = _groups().firstWhereOrNull(
+      (ProjectTaskGroup group) => group.tasks.any(
+        (TaskSummary summary) => summary.task.meta.id == focus.taskId,
+      ),
+    );
+    if (group == null) return;
+    if (_options.isCollapsed(group.key.id)) {
+      _setOptions(_options.toggleCollapsed(group.key.id));
+    }
+    _scrollAttempts = 0;
+    _scrollToRow(focus.taskId, group.key.id);
+  }
+
+  /// Brings the row for [taskId] into view once the lazy list has built it.
+  ///
+  /// Group headers are always built, so the first attempt jumps to the
+  /// group's header, which builds the rows after it; each later attempt steps
+  /// one viewport further until the row exists or the attempts run out.
+  void _scrollToRow(String taskId, String groupId) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final row = _findContext(ValueKey('project-task-row-$taskId'));
+      if (row != null) {
+        Scrollable.ensureVisible(
+          row,
+          alignment: 0.2,
+          duration: MotionDurations.medium2,
+          curve: MotionCurves.standard,
+        );
+        return;
+      }
+      if (_scrollAttempts++ >= ProjectTasksSliverPanel.maxScrollAttempts) {
+        return;
+      }
+      if (_scrollAttempts == 1) {
+        final header = _findContext(ValueKey('project-task-group-$groupId'));
+        if (header != null) Scrollable.ensureVisible(header);
+      } else if (Scrollable.maybeOf(context)?.position case final position?) {
+        position.jumpTo(
+          (position.pixels + position.viewportDimension).clamp(
+            position.minScrollExtent,
+            position.maxScrollExtent,
+          ),
+        );
+      }
+      _scrollToRow(taskId, groupId);
+    });
+  }
+
+  BuildContext? _findContext(Key key) {
+    BuildContext? found;
+    void visit(Element element) {
+      if (found != null) return;
+      if (element.widget.key == key) {
+        found = element;
+        return;
+      }
+      element.visitChildElements(visit);
+    }
+
+    context.visitChildElements(visit);
+    return found;
+  }
+
+  void _setOptions(ProjectTaskListOptions next) {
+    if (widget.onOptionsChanged case final apply?) {
+      apply(next);
+    } else {
+      setState(() => _localOptions = next);
+    }
   }
 
   /// Only due windows depend on the date, so only that grouping keeps a
@@ -116,21 +267,14 @@ class _ProjectTasksSliverPanelState extends State<ProjectTasksSliverPanel> {
     );
   }
 
-  void _toggle(ProjectTaskGroup group) {
-    setState(() {
-      if (!_collapsed.remove(group.key.id)) _collapsed.add(group.key.id);
-    });
-  }
+  void _toggle(ProjectTaskGroup group) =>
+      _setOptions(_options.toggleCollapsed(group.key.id));
 
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final border = ShowcasePalette.border(context);
-    final groups = groupProjectTasks(
-      widget.record.highlightedTaskSummaries,
-      options: widget.options,
-      now: _now,
-    );
+    final groups = _groups();
 
     Widget divider() => Divider(
       height: BorderWidths.hairline,
@@ -156,9 +300,8 @@ class _ProjectTasksSliverPanelState extends State<ProjectTasksSliverPanel> {
               ),
               child: _ProjectTasksPanelHeader(
                 record: widget.record,
-                onOptions: widget.onOptionsChanged == null
-                    ? null
-                    : () => widget.onOptionsChanged!(widget.options),
+                options: _options,
+                onOptionsChanged: widget.onOptionsChanged,
                 onAddTask: widget.onAddTask,
                 isAddTaskEnabled: widget.isAddTaskEnabled,
                 isAddingTask: widget.isAddingTask,
@@ -166,58 +309,69 @@ class _ProjectTasksSliverPanelState extends State<ProjectTasksSliverPanel> {
             ),
           ),
           SliverToBoxAdapter(child: divider()),
-          for (final (groupIndex, group) in groups.indexed) ...[
-            if (group.hasHeader)
-              SliverToBoxAdapter(
-                child: _ProjectTaskGroupHeader(
-                  key: ValueKey('project-task-group-${group.key.id}'),
-                  group: group,
-                  expanded: !_collapsed.contains(group.key.id),
-                  onToggle: () => _toggle(group),
-                ),
-              )
-            else if (group.tasks.isNotEmpty)
-              SliverToBoxAdapter(child: SizedBox(height: tokens.spacing.step2)),
-            if (!_collapsed.contains(group.key.id))
-              SliverList.builder(
-                itemCount: group.tasks.length,
-                // Rows carry the task id so a row's element (and its hover
-                // state) follows the task when a sort or grouping change
-                // reorders the group, instead of staying with the index.
-                findChildIndexCallback: (key) {
-                  final index = group.tasks.indexWhere(
-                    (summary) => projectTaskRowKey(summary) == key,
-                  );
-                  return index < 0 ? null : index;
-                },
-                itemBuilder: (context, index) {
-                  final summary = group.tasks[index];
-                  final last = index == group.tasks.length - 1;
-                  return Column(
-                    key: projectTaskRowKey(summary),
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      TaskSummaryRow(
-                        summary: summary,
-                        topInset: tokens.spacing.step2,
-                        bottomInset: last ? 0 : tokens.spacing.step2,
-                        onTap: widget.onTaskTap,
-                      ),
-                      if (!last) ...[
-                        SizedBox(height: tokens.spacing.step2),
-                        divider(),
-                        SizedBox(height: tokens.spacing.step2),
-                      ] else if (groupIndex < groups.length - 1) ...[
-                        SizedBox(height: tokens.spacing.step2),
-                        divider(),
-                      ],
-                    ],
-                  );
-                },
-              )
-            else if (groupIndex < groups.length - 1)
-              SliverToBoxAdapter(child: divider()),
-          ],
+          for (final (groupIndex, group) in groups.indexed)
+            MultiSliver(
+              // A group's header stays pinned while its rows scroll past and
+              // is pushed out by the next group's header.
+              pushPinnedChildren: true,
+              children: [
+                if (group.hasHeader)
+                  SliverPinnedHeader(
+                    child: _ProjectTaskGroupHeader(
+                      key: ValueKey('project-task-group-${group.key.id}'),
+                      group: group,
+                      expanded: !_options.isCollapsed(group.key.id),
+                      onToggle: () => _toggle(group),
+                    ),
+                  )
+                else if (group.tasks.isNotEmpty)
+                  SliverToBoxAdapter(
+                    child: SizedBox(height: tokens.spacing.step2),
+                  ),
+                if (!_options.isCollapsed(group.key.id))
+                  SliverList.builder(
+                    itemCount: group.tasks.length,
+                    // Rows carry the task id so a row's element (and its
+                    // hover state) follows the task when a sort or grouping
+                    // change reorders the group, instead of staying with the
+                    // index.
+                    findChildIndexCallback: (key) {
+                      final index = group.tasks.indexWhere(
+                        (summary) => projectTaskRowKey(summary) == key,
+                      );
+                      return index < 0 ? null : index;
+                    },
+                    itemBuilder: (context, index) {
+                      final summary = group.tasks[index];
+                      final last = index == group.tasks.length - 1;
+                      return Column(
+                        key: projectTaskRowKey(summary),
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          TaskSummaryRow(
+                            summary: summary,
+                            topInset: tokens.spacing.step2,
+                            bottomInset: last ? 0 : tokens.spacing.step2,
+                            highlighted:
+                                summary.task.meta.id == _highlightedTaskId,
+                            onTap: widget.onTaskTap,
+                          ),
+                          if (!last) ...[
+                            SizedBox(height: tokens.spacing.step2),
+                            divider(),
+                            SizedBox(height: tokens.spacing.step2),
+                          ] else if (groupIndex < groups.length - 1) ...[
+                            SizedBox(height: tokens.spacing.step2),
+                            divider(),
+                          ],
+                        ],
+                      );
+                    },
+                  )
+                else if (groupIndex < groups.length - 1)
+                  SliverToBoxAdapter(child: divider()),
+              ],
+            ),
         ],
       ),
     );
@@ -227,14 +381,16 @@ class _ProjectTasksSliverPanelState extends State<ProjectTasksSliverPanel> {
 class _ProjectTasksPanelHeader extends StatelessWidget {
   const _ProjectTasksPanelHeader({
     required this.record,
-    this.onOptions,
+    required this.options,
+    this.onOptionsChanged,
     this.onAddTask,
     this.isAddTaskEnabled = true,
     this.isAddingTask = false,
   });
 
   final ProjectRecord record;
-  final VoidCallback? onOptions;
+  final ProjectTaskListOptions options;
+  final ValueChanged<ProjectTaskListOptions>? onOptionsChanged;
   final VoidCallback? onAddTask;
   final bool isAddTaskEnabled;
   final bool isAddingTask;
@@ -302,12 +458,31 @@ class _ProjectTasksPanelHeader extends StatelessWidget {
               ),
             ],
             const Spacer(),
-            if (onOptions != null)
-              DesignSystemIconAction(
-                icon: LottiIcons.sort,
-                tooltip: messages.projectTasksSortAndGroup,
-                onPressed: onOptions,
-              ),
+            if (onOptionsChanged case final onChanged?)
+              if (MediaQuery.sizeOf(context).width >= kDesktopBreakpoint)
+                DesignSystemPopoverAnchor(
+                  semanticsLabel: messages.projectTasksSortAndGroup,
+                  builder: (context, {required toggle, required isOpen}) =>
+                      DesignSystemIconAction(
+                        icon: LottiIcons.sort,
+                        tooltip: messages.projectTasksSortAndGroup,
+                        onPressed: toggle,
+                      ),
+                  child: ProjectTaskListOptionsSheetContent(
+                    options: options,
+                    onChanged: onChanged,
+                  ),
+                )
+              else
+                DesignSystemIconAction(
+                  icon: LottiIcons.sort,
+                  tooltip: messages.projectTasksSortAndGroup,
+                  onPressed: () => showProjectTaskListOptionsSheet(
+                    context: context,
+                    options: options,
+                    onChanged: onChanged,
+                  ),
+                ),
             if (onAddTask != null) ...[
               SizedBox(width: tokens.spacing.step2),
               if (compact)
@@ -389,6 +564,8 @@ class _ProjectTaskGroupHeader extends StatelessWidget {
           onTap: onToggle,
           child: Container(
             decoration: BoxDecoration(
+              // Opaque: the header stays pinned while rows scroll beneath it.
+              color: ShowcasePalette.surface(context),
               border: Border(
                 bottom: BorderSide(color: ShowcasePalette.border(context)),
               ),
@@ -445,11 +622,15 @@ Key projectTaskRowKey(TaskSummary summary) =>
     ValueKey('project-task-row-${summary.task.meta.id}');
 
 /// A row displaying a single task's title, estimated duration, and status.
+///
+/// [highlighted] paints the hover wash without a pointer, for the row the
+/// list was just asked to bring into view.
 class TaskSummaryRow extends StatelessWidget {
   const TaskSummaryRow({
     required this.summary,
     this.topInset = 0,
     this.bottomInset = 0,
+    this.highlighted = false,
     this.onTap,
     super.key,
   });
@@ -457,6 +638,7 @@ class TaskSummaryRow extends StatelessWidget {
   final TaskSummary summary;
   final double topInset;
   final double bottomInset;
+  final bool highlighted;
   final ValueChanged<TaskSummary>? onTap;
 
   @override
@@ -465,6 +647,7 @@ class TaskSummaryRow extends StatelessWidget {
       summary: summary,
       topInset: topInset,
       bottomInset: bottomInset,
+      highlighted: highlighted,
       onTap: onTap,
     );
   }
@@ -475,12 +658,14 @@ class _TaskSummaryRowSurface extends StatefulWidget {
     required this.summary,
     required this.topInset,
     required this.bottomInset,
+    required this.highlighted,
     this.onTap,
   });
 
   final TaskSummary summary;
   final double topInset;
   final double bottomInset;
+  final bool highlighted;
   final ValueChanged<TaskSummary>? onTap;
 
   @override
@@ -495,7 +680,7 @@ class _TaskSummaryRowSurfaceState extends State<_TaskSummaryRowSurface> {
     final oneLiner = widget.summary.oneLiner;
 
     final tokens = context.designTokens;
-    final backgroundColor = _hovered
+    final backgroundColor = _hovered || widget.highlighted
         ? ShowcasePalette.hoverFill(context)
         : null;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2753,7 +2753,7 @@ packages:
     source: sdk
     version: "0.0.0"
   sliver_tools:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: sliver_tools
       sha256: eae28220badfb9d0559207badcbbc9ad5331aac829a88cb0964d330d2a4636a6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -125,6 +125,7 @@ dependencies:
   rxdart: ^0.28.0
   share_plus: ^12.0.0
   shared_preferences: ^2.3.2
+  sliver_tools: ^0.2.12
   sqflite_common_ffi: ^2.3.3
   sqlite3: ^3.5.1
   super_clipboard: ^0.9.1

--- a/test/features/agents/service/change_set_confirmation_service_test.dart
+++ b/test/features/agents/service/change_set_confirmation_service_test.dart
@@ -1217,6 +1217,99 @@ void main() {
       });
     });
 
+    group('reopenItem', () {
+      test(
+        'puts a confirmed item back to pending under a deferred decision',
+        () async {
+          final changeSet = makeChangeSetWith(
+            items: [
+              const ChangeItem(
+                toolName: 'update_task_estimate',
+                args: {'minutes': 120},
+                humanSummary: 'Set estimate to 2 hours',
+                status: ChangeItemStatus.confirmed,
+              ),
+              const ChangeItem(
+                toolName: 'set_task_title',
+                args: {'title': 'New Title'},
+                humanSummary: 'Set title to "New Title"',
+                status: ChangeItemStatus.rejected,
+              ),
+            ],
+          );
+
+          await withClock(testClock, () async {
+            expect(await service.reopenItem(changeSet, 0), isTrue);
+
+            verifyNever(
+              () => mockToolDispatcher.dispatch(any(), any(), any()),
+            );
+            final captured = verify(
+              () => mockSyncService.upsertEntity(captureAny()),
+            ).captured;
+            expect(captured, hasLength(2));
+
+            final decision = captured[0] as ChangeDecisionEntity;
+            expect(decision.verdict, ChangeDecisionVerdict.deferred);
+            expect(decision.actor, DecisionActor.user);
+            expect(decision.itemIndex, 0);
+            expect(decision.args, {'minutes': 120});
+
+            final reopened = captured[1] as ChangeSetEntity;
+            expect(reopened.items[0].status, ChangeItemStatus.pending);
+            expect(reopened.items[1].status, ChangeItemStatus.rejected);
+            expect(reopened.status, ChangeSetStatus.partiallyResolved);
+            expect(reopened.resolvedAt, isNull);
+          });
+        },
+      );
+
+      test('reopens a rejected item too', () async {
+        final changeSet = makeChangeSetWith(
+          items: [
+            const ChangeItem(
+              toolName: 'set_task_title',
+              args: {'title': 'New Title'},
+              humanSummary: 'Set title',
+              status: ChangeItemStatus.rejected,
+            ),
+          ],
+        );
+
+        expect(await service.reopenItem(changeSet, 0), isTrue);
+        final captured = verify(
+          () => mockSyncService.upsertEntity(captureAny()),
+        ).captured;
+        final reopened = captured.last as ChangeSetEntity;
+        expect(reopened.items[0].status, ChangeItemStatus.pending);
+        expect(reopened.status, ChangeSetStatus.pending);
+      });
+
+      test('refuses a pending or retracted item and a bad index', () async {
+        final changeSet = makeChangeSetWith(
+          items: [
+            const ChangeItem(
+              toolName: 'set_task_title',
+              args: {'title': 'A'},
+              humanSummary: 'Pending',
+            ),
+            const ChangeItem(
+              toolName: 'set_task_title',
+              args: {'title': 'B'},
+              humanSummary: 'Retracted',
+              status: ChangeItemStatus.retracted,
+            ),
+          ],
+        );
+
+        expect(await service.reopenItem(changeSet, 0), isFalse);
+        expect(await service.reopenItem(changeSet, 1), isFalse);
+        expect(await service.reopenItem(changeSet, 2), isFalse);
+        expect(await service.reopenItem(changeSet, -1), isFalse);
+        verifyNever(() => mockSyncService.upsertEntity(any()));
+      });
+    });
+
     group('rejectItem', () {
       test('persists rejected decision without tool dispatch', () async {
         final changeSet = makeChangeSetWith();

--- a/test/features/agents/service/change_set_confirmation_service_test.dart
+++ b/test/features/agents/service/change_set_confirmation_service_test.dart
@@ -8,6 +8,7 @@ import 'package:lotti/features/agents/service/change_set_confirmation_service.da
 import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
 import 'package:lotti/features/agents/tools/agent_tool_registry.dart';
 import 'package:lotti/features/agents/tools/running_timer_update_handler.dart';
+import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -1218,25 +1219,90 @@ void main() {
     });
 
     group('reopenItem', () {
+      ChangeSetEntity decidedSet() => makeChangeSetWith(
+        items: [
+          const ChangeItem(
+            toolName: 'update_task_estimate',
+            args: {'minutes': 120},
+            humanSummary: 'Set estimate to 2 hours',
+            status: ChangeItemStatus.confirmed,
+          ),
+          const ChangeItem(
+            toolName: 'set_task_title',
+            args: {'title': 'New Title'},
+            humanSummary: 'Set title to "New Title"',
+            status: ChangeItemStatus.rejected,
+          ),
+        ],
+      );
+
+      ChangeDecisionEntity decisionFor(
+        ChangeSetEntity changeSet,
+        int itemIndex, {
+        required ChangeDecisionVerdict verdict,
+        DecisionActor actor = DecisionActor.user,
+        String id = 'decision-1',
+        DateTime? createdAt,
+      }) =>
+          AgentDomainEntity.changeDecision(
+                id: id,
+                agentId: changeSet.agentId,
+                changeSetId: changeSet.id,
+                itemIndex: itemIndex,
+                toolName: changeSet.items[itemIndex].toolName,
+                verdict: verdict,
+                actor: actor,
+                taskId: changeSet.taskId,
+                createdAt: createdAt ?? DateTime(2026, 9, 5, 9),
+                vectorClock: const VectorClock({}),
+              )
+              as ChangeDecisionEntity;
+
+      void stubDecisions(List<AgentDomainEntity> decisions) {
+        when(
+          () => mockRepository.getEntitiesByAgentId(
+            any(),
+            type: any(named: 'type'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async => decisions);
+      }
+
       test(
-        'puts a confirmed item back to pending under a deferred decision',
+        'rewrites the standing decision as deferred and reopens the item',
         () async {
-          final changeSet = makeChangeSetWith(
-            items: [
-              const ChangeItem(
-                toolName: 'update_task_estimate',
-                args: {'minutes': 120},
-                humanSummary: 'Set estimate to 2 hours',
-                status: ChangeItemStatus.confirmed,
-              ),
-              const ChangeItem(
-                toolName: 'set_task_title',
-                args: {'title': 'New Title'},
-                humanSummary: 'Set title to "New Title"',
-                status: ChangeItemStatus.rejected,
-              ),
-            ],
-          );
+          final changeSet = decidedSet();
+          // Newest first, as the repository returns them: a stale retry row,
+          // an agent retraction and another item's decision must all lose to
+          // the newest user decision for this item.
+          stubDecisions([
+            decisionFor(
+              changeSet,
+              1,
+              verdict: ChangeDecisionVerdict.rejected,
+              id: 'other-item',
+            ),
+            decisionFor(
+              changeSet,
+              0,
+              verdict: ChangeDecisionVerdict.retracted,
+              actor: DecisionActor.agent,
+              id: 'agent-row',
+            ),
+            decisionFor(
+              changeSet,
+              0,
+              verdict: ChangeDecisionVerdict.confirmed,
+              id: 'standing',
+            ),
+            decisionFor(
+              changeSet,
+              0,
+              verdict: ChangeDecisionVerdict.rejected,
+              id: 'older',
+              createdAt: DateTime(2026, 9, 4),
+            ),
+          ]);
 
           await withClock(testClock, () async {
             expect(await service.reopenItem(changeSet, 0), isTrue);
@@ -1250,10 +1316,9 @@ void main() {
             expect(captured, hasLength(2));
 
             final decision = captured[0] as ChangeDecisionEntity;
+            expect(decision.id, 'standing', reason: 'rewritten in place');
             expect(decision.verdict, ChangeDecisionVerdict.deferred);
-            expect(decision.actor, DecisionActor.user);
-            expect(decision.itemIndex, 0);
-            expect(decision.args, {'minutes': 120});
+            expect(decision.createdAt, testClock.now(), reason: 'LWW wins');
 
             final reopened = captured[1] as ChangeSetEntity;
             expect(reopened.items[0].status, ChangeItemStatus.pending);
@@ -1264,25 +1329,104 @@ void main() {
         },
       );
 
-      test('reopens a rejected item too', () async {
-        final changeSet = makeChangeSetWith(
-          items: [
-            const ChangeItem(
-              toolName: 'set_task_title',
-              args: {'title': 'New Title'},
-              humanSummary: 'Set title',
-              status: ChangeItemStatus.rejected,
-            ),
-          ],
+      test('records a fresh deferred decision when none is stored', () async {
+        final changeSet = decidedSet();
+        stubDecisions(const []);
+
+        await withClock(testClock, () async {
+          expect(await service.reopenItem(changeSet, 1), isTrue);
+          final captured = verify(
+            () => mockSyncService.upsertEntity(captureAny()),
+          ).captured;
+          expect(captured, hasLength(2));
+          final decision = captured[0] as ChangeDecisionEntity;
+          expect(decision.verdict, ChangeDecisionVerdict.deferred);
+          expect(decision.actor, DecisionActor.user);
+          expect(decision.itemIndex, 1);
+          expect(decision.args, {'title': 'New Title'});
+          final reopened = captured[1] as ChangeSetEntity;
+          expect(reopened.items[1].status, ChangeItemStatus.pending);
+        });
+      });
+
+      test('runs the revert only once the record is pending again', () async {
+        final changeSet = decidedSet();
+        stubDecisions([
+          decisionFor(changeSet, 0, verdict: ChangeDecisionVerdict.confirmed),
+        ]);
+        var upsertsBeforeRevert = -1;
+        var reverts = 0;
+
+        final result = await service.reopenItem(
+          changeSet,
+          0,
+          revert: () async {
+            reverts++;
+            upsertsBeforeRevert = verify(
+              () => mockSyncService.upsertEntity(captureAny()),
+            ).captured.length;
+            return true;
+          },
         );
 
-        expect(await service.reopenItem(changeSet, 0), isTrue);
+        expect(result, isTrue);
+        expect(reverts, 1);
+        expect(
+          upsertsBeforeRevert,
+          2,
+          reason: 'decision and item were written before the revert ran',
+        );
+        verifyNever(() => mockSyncService.upsertEntity(any()));
+      });
+
+      for (final (label, revert) in [
+        ('refuses', () async => false),
+        ('throws', () async => throw StateError('offline')),
+      ]) {
+        test('puts the record back when the revert $label', () async {
+          final changeSet = decidedSet();
+          stubDecisions([
+            decisionFor(changeSet, 0, verdict: ChangeDecisionVerdict.confirmed),
+          ]);
+
+          await withClock(testClock, () async {
+            expect(
+              await service.reopenItem(changeSet, 0, revert: revert),
+              isFalse,
+            );
+          });
+
+          final captured = verify(
+            () => mockSyncService.upsertEntity(captureAny()),
+          ).captured;
+          expect(captured, hasLength(4));
+          final restoredDecision = captured[2] as ChangeDecisionEntity;
+          expect(restoredDecision.id, 'decision-1');
+          expect(restoredDecision.verdict, ChangeDecisionVerdict.confirmed);
+          final restoredSet = captured[3] as ChangeSetEntity;
+          expect(restoredSet.items[0].status, ChangeItemStatus.confirmed);
+        });
+      }
+
+      test('a refused revert on a rejection restores the rejection', () async {
+        final changeSet = decidedSet();
+        stubDecisions(const []);
+
+        expect(
+          await service.reopenItem(changeSet, 1, revert: () async => false),
+          isFalse,
+        );
         final captured = verify(
           () => mockSyncService.upsertEntity(captureAny()),
         ).captured;
-        final reopened = captured.last as ChangeSetEntity;
-        expect(reopened.items[0].status, ChangeItemStatus.pending);
-        expect(reopened.status, ChangeSetStatus.pending);
+        final fresh = captured[0] as ChangeDecisionEntity;
+        final restored = captured[2] as ChangeDecisionEntity;
+        expect(restored.id, fresh.id, reason: 'the fresh record is reused');
+        expect(restored.verdict, ChangeDecisionVerdict.rejected);
+        expect(
+          (captured[3] as ChangeSetEntity).items[1].status,
+          ChangeItemStatus.rejected,
+        );
       });
 
       test('refuses a pending or retracted item and a bad index', () async {
@@ -1301,11 +1445,22 @@ void main() {
             ),
           ],
         );
+        var reverts = 0;
 
-        expect(await service.reopenItem(changeSet, 0), isFalse);
-        expect(await service.reopenItem(changeSet, 1), isFalse);
-        expect(await service.reopenItem(changeSet, 2), isFalse);
-        expect(await service.reopenItem(changeSet, -1), isFalse);
+        for (final index in [0, 1, 2, -1]) {
+          expect(
+            await service.reopenItem(
+              changeSet,
+              index,
+              revert: () async {
+                reverts++;
+                return true;
+              },
+            ),
+            isFalse,
+          );
+        }
+        expect(reverts, 0);
         verifyNever(() => mockSyncService.upsertEntity(any()));
       });
     });

--- a/test/features/agents/service/project_proposal_service_test.dart
+++ b/test/features/agents/service/project_proposal_service_test.dart
@@ -1,0 +1,255 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/project_data.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/agents/service/project_proposal_service.dart';
+import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
+import '../../projects/test_utils.dart';
+import '../test_utils.dart';
+
+void main() {
+  const projectId = 'project-1';
+  late MockChangeSetConfirmationService confirmation;
+  late MockProjectRepository repository;
+  late MockDomainLogger logger;
+  late List<String> removed;
+  late bool removerSucceeds;
+  late ProjectProposalService service;
+
+  final open = ProjectStatus.open(
+    id: 'status-open',
+    createdAt: DateTime(2026, 9),
+    utcOffset: 0,
+  );
+  final monitoring = ProjectStatus.monitoring(
+    id: 'status-monitoring',
+    createdAt: DateTime(2026, 9, 5),
+    utcOffset: 0,
+  );
+
+  ChangeSetEntity setWith(ChangeItem item) => makeTestChangeSet(
+    id: 'set-1',
+    agentId: 'agent-1',
+    taskId: projectId,
+    items: [item],
+  );
+  const createTask = ChangeItem(
+    toolName: 'create_task',
+    args: {'title': 'Pack fish'},
+    humanSummary: 'Create task',
+  );
+  const setStatus = ChangeItem(
+    toolName: 'update_project_status',
+    args: {'status': 'monitoring'},
+    humanSummary: 'Set status',
+  );
+  ChangeSetEntity decided(ChangeItem item, ChangeItemStatus status) =>
+      setWith(item.copyWith(status: status));
+
+  setUpAll(registerAllFallbackValues);
+  setUp(() {
+    confirmation = MockChangeSetConfirmationService();
+    repository = MockProjectRepository();
+    logger = MockDomainLogger();
+    removed = [];
+    removerSucceeds = true;
+    service = ProjectProposalService(
+      confirmation: confirmation,
+      projectRepository: repository,
+      taskRemover: (taskId) async {
+        removed.add(taskId);
+        return removerSucceeds;
+      },
+      domainLogger: logger,
+    );
+    when(() => confirmation.reopenItem(any(), any())).thenAnswer(
+      (_) async => true,
+    );
+    when(() => repository.updateProject(any())).thenAnswer((_) async => true);
+  });
+
+  test('reject delegates to the confirmation service', () async {
+    when(
+      () => confirmation.rejectItem(any(), any()),
+    ).thenAnswer((_) async => true);
+    final set = setWith(createTask);
+
+    expect(await service.reject(set, 0), isTrue);
+    verify(() => confirmation.rejectItem(set, 0)).called(1);
+  });
+
+  test(
+    'a rejection is always undoable; a confirmation only once remembered',
+    () async {
+      expect(
+        service.canUndo(decided(createTask, ChangeItemStatus.rejected), 0),
+        isTrue,
+      );
+      expect(
+        service.canUndo(decided(createTask, ChangeItemStatus.confirmed), 0),
+        isFalse,
+        reason: 'nothing remembered: the effect cannot be put back',
+      );
+      expect(service.canUndo(setWith(createTask), 0), isFalse);
+      expect(
+        service.canUndo(decided(createTask, ChangeItemStatus.retracted), 0),
+        isFalse,
+      );
+
+      when(() => confirmation.confirmItem(any(), any())).thenAnswer(
+        (_) async => const ToolExecutionResult(
+          success: true,
+          output: '',
+          mutatedEntityId: 'task-9',
+        ),
+      );
+      final set = setWith(createTask);
+      expect((await service.confirm(set, 0)).success, isTrue);
+      expect(
+        service.canUndo(decided(createTask, ChangeItemStatus.confirmed), 0),
+        isTrue,
+      );
+    },
+  );
+
+  test('a failed confirmation remembers nothing', () async {
+    when(() => confirmation.confirmItem(any(), any())).thenAnswer(
+      (_) async => const ToolExecutionResult(success: false, output: 'no'),
+    );
+    expect((await service.confirm(setWith(createTask), 0)).success, isFalse);
+    expect(
+      service.canUndo(decided(createTask, ChangeItemStatus.confirmed), 0),
+      isFalse,
+    );
+  });
+
+  test('undoing a created task removes it, then reopens the item', () async {
+    when(() => confirmation.confirmItem(any(), any())).thenAnswer(
+      (_) async => const ToolExecutionResult(
+        success: true,
+        output: '',
+        mutatedEntityId: 'task-9',
+      ),
+    );
+    final set = setWith(createTask);
+    await service.confirm(set, 0);
+    final applied = decided(createTask, ChangeItemStatus.confirmed);
+
+    expect(await service.undo(applied, 0), isTrue);
+    expect(removed, ['task-9']);
+    verify(() => confirmation.reopenItem(applied, 0)).called(1);
+    verifyNever(() => repository.getProjectById(any()));
+    expect(
+      service.canUndo(applied, 0),
+      isFalse,
+      reason: 'the memo is spent',
+    );
+  });
+
+  test('undoing a status change restores the status and its history', () async {
+    final before = makeTestProject(id: projectId, status: open);
+    when(
+      () => repository.getProjectById(projectId),
+    ).thenAnswer((_) async => before);
+    when(() => confirmation.confirmItem(any(), any())).thenAnswer(
+      (_) async => const ToolExecutionResult(
+        success: true,
+        output: '',
+        mutatedEntityId: projectId,
+      ),
+    );
+    final set = setWith(setStatus);
+    await service.confirm(set, 0);
+
+    // The tool moved the project on and appended the old status to history.
+    final after = before.copyWith(
+      data: before.data.copyWith(
+        status: monitoring,
+        statusHistory: [open],
+      ),
+    );
+    when(
+      () => repository.getProjectById(projectId),
+    ).thenAnswer((_) async => after);
+
+    expect(
+      await service.undo(decided(setStatus, ChangeItemStatus.confirmed), 0),
+      isTrue,
+    );
+    final restored =
+        verify(() => repository.updateProject(captureAny())).captured.single
+            as ProjectEntry;
+    expect(restored.data.status, open);
+    expect(restored.data.statusHistory, isEmpty);
+    expect(removed, isEmpty);
+  });
+
+  test('undoing a rejection only reopens the item', () async {
+    final rejected = decided(setStatus, ChangeItemStatus.rejected);
+
+    expect(await service.undo(rejected, 0), isTrue);
+    verify(() => confirmation.reopenItem(rejected, 0)).called(1);
+    verifyNever(() => repository.updateProject(any()));
+    expect(removed, isEmpty);
+  });
+
+  test(
+    'a task that will not go, or a project that will not save, stops the undo',
+    () async {
+      when(() => confirmation.confirmItem(any(), any())).thenAnswer(
+        (_) async => const ToolExecutionResult(
+          success: true,
+          output: '',
+          mutatedEntityId: 'task-9',
+        ),
+      );
+      await service.confirm(setWith(createTask), 0);
+      removerSucceeds = false;
+      final applied = decided(createTask, ChangeItemStatus.confirmed);
+      expect(await service.undo(applied, 0), isFalse);
+      verifyNever(() => confirmation.reopenItem(any(), any()));
+      expect(service.canUndo(applied, 0), isTrue, reason: 'still undoable');
+
+      final before = makeTestProject(id: projectId, status: open);
+      when(
+        () => repository.getProjectById(projectId),
+      ).thenAnswer((_) async => before);
+      await service.confirm(setWith(setStatus), 0);
+      when(
+        () => repository.updateProject(any()),
+      ).thenAnswer((_) async => false);
+      final status = decided(setStatus, ChangeItemStatus.confirmed);
+      expect(await service.undo(status, 0), isFalse);
+      verifyNever(() => confirmation.reopenItem(any(), any()));
+
+      when(
+        () => repository.getProjectById(projectId),
+      ).thenAnswer((_) async => null);
+      expect(await service.undo(status, 0), isFalse, reason: 'project gone');
+    },
+  );
+
+  test('a refused reopen keeps the memo for another try', () async {
+    when(() => confirmation.reopenItem(any(), any())).thenAnswer(
+      (_) async => false,
+    );
+    when(() => confirmation.confirmItem(any(), any())).thenAnswer(
+      (_) async => const ToolExecutionResult(
+        success: true,
+        output: '',
+        mutatedEntityId: 'task-9',
+      ),
+    );
+    await service.confirm(setWith(createTask), 0);
+    final applied = decided(createTask, ChangeItemStatus.confirmed);
+
+    expect(await service.undo(applied, 0), isFalse);
+    expect(service.canUndo(applied, 0), isTrue);
+  });
+}

--- a/test/features/agents/service/project_proposal_service_test.dart
+++ b/test/features/agents/service/project_proposal_service_test.dart
@@ -1,11 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/project_data.dart';
+import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/service/project_proposal_service.dart';
 import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
@@ -68,9 +70,20 @@ void main() {
       },
       domainLogger: logger,
     );
-    when(() => confirmation.reopenItem(any(), any())).thenAnswer(
-      (_) async => true,
-    );
+    // The real reopen runs the revert once the record is pending again and
+    // reports its outcome; the mock does the same so the tests exercise the
+    // revert through the same seam.
+    when(
+      () => confirmation.reopenItem(
+        any(),
+        any(),
+        revert: any(named: 'revert'),
+      ),
+    ).thenAnswer((invocation) async {
+      final revert =
+          invocation.namedArguments[#revert] as Future<bool> Function()?;
+      return revert == null || await revert();
+    });
     when(() => repository.updateProject(any())).thenAnswer((_) async => true);
   });
 
@@ -143,7 +156,13 @@ void main() {
 
     expect(await service.undo(applied, 0), isTrue);
     expect(removed, ['task-9']);
-    verify(() => confirmation.reopenItem(applied, 0)).called(1);
+    verify(
+      () => confirmation.reopenItem(
+        applied,
+        0,
+        revert: any(named: 'revert', that: isNotNull),
+      ),
+    ).called(1);
     verifyNever(() => repository.getProjectById(any()));
     expect(
       service.canUndo(applied, 0),
@@ -194,7 +213,13 @@ void main() {
     final rejected = decided(setStatus, ChangeItemStatus.rejected);
 
     expect(await service.undo(rejected, 0), isTrue);
-    verify(() => confirmation.reopenItem(rejected, 0)).called(1);
+    verify(
+      () => confirmation.reopenItem(
+        rejected,
+        0,
+        revert: any(named: 'revert', that: isNull),
+      ),
+    ).called(1);
     verifyNever(() => repository.updateProject(any()));
     expect(removed, isEmpty);
   });
@@ -213,20 +238,40 @@ void main() {
       removerSucceeds = false;
       final applied = decided(createTask, ChangeItemStatus.confirmed);
       expect(await service.undo(applied, 0), isFalse);
-      verifyNever(() => confirmation.reopenItem(any(), any()));
       expect(service.canUndo(applied, 0), isTrue, reason: 'still undoable');
+      verify(
+        () => logger.log(
+          LogDomain.agentWorkflow,
+          any<String>(that: contains('task-9')),
+          subDomain: 'ProjectProposal',
+          level: any<InsightLevel>(named: 'level'),
+        ),
+      ).called(1);
 
       final before = makeTestProject(id: projectId, status: open);
       when(
         () => repository.getProjectById(projectId),
       ).thenAnswer((_) async => before);
       await service.confirm(setWith(setStatus), 0);
+      final moved = before.copyWith(
+        data: before.data.copyWith(status: monitoring, statusHistory: [open]),
+      );
+      when(
+        () => repository.getProjectById(projectId),
+      ).thenAnswer((_) async => moved);
       when(
         () => repository.updateProject(any()),
       ).thenAnswer((_) async => false);
       final status = decided(setStatus, ChangeItemStatus.confirmed);
       expect(await service.undo(status, 0), isFalse);
-      verifyNever(() => confirmation.reopenItem(any(), any()));
+      verify(
+        () => logger.log(
+          LogDomain.agentWorkflow,
+          any<String>(that: contains('status')),
+          subDomain: 'ProjectProposal',
+          level: any<InsightLevel>(named: 'level'),
+        ),
+      ).called(1);
 
       when(
         () => repository.getProjectById(projectId),
@@ -235,10 +280,105 @@ void main() {
     },
   );
 
-  test('a refused reopen keeps the memo for another try', () async {
-    when(() => confirmation.reopenItem(any(), any())).thenAnswer(
-      (_) async => false,
+  test('a status that moved on since the confirmation is left alone', () async {
+    final before = makeTestProject(id: projectId, status: open);
+    when(
+      () => repository.getProjectById(projectId),
+    ).thenAnswer((_) async => before);
+    when(() => confirmation.confirmItem(any(), any())).thenAnswer(
+      (_) async => const ToolExecutionResult(
+        success: true,
+        output: '',
+        mutatedEntityId: projectId,
+      ),
     );
+    await service.confirm(setWith(setStatus), 0);
+    final applied = decided(setStatus, ChangeItemStatus.confirmed);
+    final active = ProjectStatus.active(
+      id: 'status-active',
+      createdAt: DateTime(2026, 9, 6),
+      utcOffset: 0,
+    );
+
+    // Another editor moved the project on after the tool set Monitoring.
+    when(() => repository.getProjectById(projectId)).thenAnswer(
+      (_) async => before.copyWith(
+        data: before.data.copyWith(
+          status: active,
+          statusHistory: [open, monitoring],
+        ),
+      ),
+    );
+    expect(await service.undo(applied, 0), isFalse);
+    verifyNever(() => repository.updateProject(any()));
+
+    // The tool's own write raced a sync: the status is right but the
+    // history does not end in what this session remembers replacing.
+    when(() => repository.getProjectById(projectId)).thenAnswer(
+      (_) async => before.copyWith(
+        data: before.data.copyWith(
+          status: monitoring,
+          statusHistory: [active],
+        ),
+      ),
+    );
+    expect(await service.undo(applied, 0), isFalse);
+    verifyNever(() => repository.updateProject(any()));
+    expect(service.canUndo(applied, 0), isTrue);
+  });
+
+  test('a status the tool did not need to change is not restored', () async {
+    final already = makeTestProject(id: projectId, status: monitoring);
+    when(
+      () => repository.getProjectById(projectId),
+    ).thenAnswer((_) async => already);
+    when(() => confirmation.confirmItem(any(), any())).thenAnswer(
+      (_) async => const ToolExecutionResult(success: true, output: ''),
+    );
+    await service.confirm(setWith(setStatus), 0);
+
+    expect(
+      await service.undo(decided(setStatus, ChangeItemStatus.confirmed), 0),
+      isTrue,
+    );
+    verifyNever(() => repository.updateProject(any()));
+  });
+
+  test('a proposal without a parsable target status is not restored', () async {
+    final before = makeTestProject(id: projectId, status: open);
+    when(
+      () => repository.getProjectById(projectId),
+    ).thenAnswer((_) async => before);
+    when(() => confirmation.confirmItem(any(), any())).thenAnswer(
+      (_) async => const ToolExecutionResult(success: true, output: ''),
+    );
+    const odd = ChangeItem(
+      toolName: 'update_project_status',
+      args: {'status': 42},
+      humanSummary: 'Set status',
+    );
+    await service.confirm(setWith(odd), 0);
+    when(() => repository.getProjectById(projectId)).thenAnswer(
+      (_) async => before.copyWith(
+        data: before.data.copyWith(status: monitoring, statusHistory: [open]),
+      ),
+    );
+
+    expect(
+      await service.undo(decided(odd, ChangeItemStatus.confirmed), 0),
+      isFalse,
+    );
+    verifyNever(() => repository.updateProject(any()));
+  });
+
+  test('a refused reopen keeps the memo for another try', () async {
+    when(
+      () => confirmation.reopenItem(
+        any(),
+        any(),
+        revert: any(named: 'revert'),
+      ),
+    ).thenAnswer((_) async => false);
     when(() => confirmation.confirmItem(any(), any())).thenAnswer(
       (_) async => const ToolExecutionResult(
         success: true,

--- a/test/features/agents/state/change_set_providers_test.dart
+++ b/test/features/agents/state/change_set_providers_test.dart
@@ -8,6 +8,7 @@ import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/service/change_set_confirmation_service.dart';
+import 'package:lotti/features/agents/service/project_proposal_service.dart';
 import 'package:lotti/features/agents/service/project_recommendation_service.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/change_set_providers.dart';
@@ -271,6 +272,74 @@ void main() {
         expect(result.pending.map((step) => step.id), contains('pr-older'));
       },
     );
+  });
+
+  group('projectProposalServiceProvider', () {
+    ProviderContainer build({
+      MockJournalRepository? journal,
+      MockJournalDb? journalDb,
+    }) {
+      final container = ProviderContainer(
+        overrides: [
+          journalDbProvider.overrideWithValue(journalDb ?? MockJournalDb()),
+          journalRepositoryProvider.overrideWithValue(
+            journal ?? MockJournalRepository(),
+          ),
+          projectRepositoryProvider.overrideWithValue(MockProjectRepository()),
+          projectChangeSetConfirmationServiceProvider.overrideWithValue(
+            MockChangeSetConfirmationService(),
+          ),
+          domainLoggerProvider.overrideWithValue(MockDomainLogger()),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test('wires the project confirmation service and repository', () {
+      final container = build();
+
+      final service = container.read(projectProposalServiceProvider);
+
+      expect(service, isA<ProjectProposalService>());
+      expect(
+        service.confirmation,
+        same(container.read(projectChangeSetConfirmationServiceProvider)),
+      );
+      expect(
+        service.projectRepository,
+        same(container.read(projectRepositoryProvider)),
+      );
+      expect(
+        container.read(projectProposalServiceProvider),
+        same(service),
+        reason: 'kept alive, so undo memos survive page rebuilds',
+      );
+    });
+
+    for (final gone in [true, false]) {
+      test(
+        'removes a task through the journal and reports '
+        '${gone ? 'success once the tombstone reads back' : 'failure while the task still reads'}',
+        () async {
+          final journal = MockJournalRepository();
+          final journalDb = MockJournalDb();
+          when(
+            () => journal.deleteJournalEntity('task-1'),
+          ).thenAnswer((_) async => true);
+          when(
+            () => journalDb.journalEntityById('task-1'),
+          ).thenAnswer((_) async => gone ? null : makeTestTask(id: 'task-1'));
+          final container = build(journal: journal, journalDb: journalDb);
+
+          final service = container.read(projectProposalServiceProvider);
+
+          expect(await service.taskRemover('task-1'), gone);
+          verify(() => journal.deleteJournalEntity('task-1')).called(1);
+          verify(() => journalDb.journalEntityById('task-1')).called(1);
+        },
+      );
+    }
   });
 
   group('projectRecommendationServiceProvider', () {

--- a/test/features/design_system/components/lists/design_system_swipe_action_background_test.dart
+++ b/test/features/design_system/components/lists/design_system_swipe_action_background_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_swipe_action_background.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  testWidgets('names the action in the given ink on the given fill', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      makeTestableWidget2(
+        const SizedBox(
+          width: 400,
+          height: 80,
+          child: DesignSystemSwipeActionBackground(
+            alignment: Alignment.centerRight,
+            color: Color(0xFF123456),
+            foregroundColor: Color(0xFFABCDEF),
+            icon: Icons.close,
+            label: 'Dismiss',
+          ),
+        ),
+      ),
+    );
+
+    final fill = find.descendant(
+      of: find.byType(DesignSystemSwipeActionBackground),
+      matching: find.byType(ColoredBox),
+    );
+    expect(tester.widget<ColoredBox>(fill).color, const Color(0xFF123456));
+    expect(
+      tester.widget<Icon>(find.byIcon(Icons.close)).color,
+      const Color(0xFFABCDEF),
+    );
+    final label = tester.widget<Text>(find.text('Dismiss'));
+    expect(label.style?.color, const Color(0xFFABCDEF));
+    expect(
+      tester.getCenter(find.text('Dismiss')).dx,
+      greaterThan(200),
+      reason: 'sits at the trailing edge for an end-to-start swipe',
+    );
+  });
+}

--- a/test/features/design_system/components/popovers/design_system_popover_anchor_test.dart
+++ b/test/features/design_system/components/popovers/design_system_popover_anchor_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/context_menus/design_system_context_menu.dart';
+import 'package:lotti/features/design_system/components/popovers/design_system_popover_anchor.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  group('DesignSystemPopoverAnchor', () {
+    Widget subject({double? width, Widget? child}) => Align(
+      alignment: Alignment.topLeft,
+      child: DesignSystemPopoverAnchor(
+        semanticsLabel: 'Options',
+        width: width ?? DesignSystemContextMenu.defaultWidth,
+        builder: (context, {required toggle, required isOpen}) => TextButton(
+          onPressed: toggle,
+          child: Text(isOpen ? 'Close' : 'Open'),
+        ),
+        child: child ?? const Text('Content'),
+      ),
+    );
+
+    testWidgets('the trigger toggles the content on its surface', (
+      tester,
+    ) async {
+      await tester.pumpWidget(makeTestableWidgetWithScaffold(subject()));
+
+      expect(find.text('Content'), findsNothing);
+      expect(find.byType(DesignSystemPopoverSurface), findsNothing);
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      expect(find.text('Content'), findsOneWidget);
+      expect(find.text('Close'), findsOneWidget, reason: 'isOpen reported');
+      expect(
+        tester.getSize(find.byType(DesignSystemPopoverSurface)).width,
+        DesignSystemContextMenu.defaultWidth,
+      );
+      expect(
+        tester.getSemantics(find.byType(DesignSystemPopoverSurface)).label,
+        startsWith('Options'),
+      );
+
+      await tester.tap(find.text('Close'));
+      await tester.pumpAndSettle();
+      expect(find.text('Content'), findsNothing);
+      expect(find.text('Open'), findsOneWidget);
+    });
+
+    testWidgets('content interaction leaves it open; outside tap closes', (
+      tester,
+    ) async {
+      var presses = 0;
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          subject(
+            child: TextButton(
+              onPressed: () => presses++,
+              child: const Text('Inside'),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Inside'));
+      await tester.pumpAndSettle();
+      expect(presses, 1);
+      expect(
+        find.text('Inside'),
+        findsOneWidget,
+        reason: 'The content decides when it is done, not the popover.',
+      );
+
+      await tester.tapAt(const Offset(700, 500));
+      await tester.pumpAndSettle();
+      expect(find.text('Inside'), findsNothing);
+    });
+
+    testWidgets('a caller can widen the surface', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(subject(width: 420)),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      expect(
+        tester.getSize(find.byType(DesignSystemPopoverSurface)).width,
+        420,
+      );
+    });
+  });
+}

--- a/test/features/projects/ui/model/project_task_list_options_test.dart
+++ b/test/features/projects/ui/model/project_task_list_options_test.dart
@@ -9,6 +9,25 @@ void main() {
       expect(options.groupBy, ProjectTaskGroupBy.creationMonth);
       expect(options.sortBy, ProjectTaskSortBy.actionability);
       expect(options.keepDoneInGroups, isFalse);
+      expect(options.collapsedGroups, {'done'});
+      expect(options.isCollapsed('done'), isTrue);
+      expect(options.isCollapsed('2026-09'), isFalse);
+    },
+  );
+
+  test(
+    'toggleCollapsed folds and unfolds one group without touching others',
+    () {
+      const options = ProjectTaskListOptions.defaults;
+
+      final folded = options.toggleCollapsed('2026-09');
+      expect(folded.collapsedGroups, {'done', '2026-09'});
+      expect(folded.isCollapsed('2026-09'), isTrue);
+      expect(options.collapsedGroups, {'done'}, reason: 'immutable');
+
+      final unfolded = folded.toggleCollapsed('done');
+      expect(unfolded.collapsedGroups, {'2026-09'});
+      expect(unfolded.toggleCollapsed('2026-09').collapsedGroups, isEmpty);
     },
   );
 
@@ -17,13 +36,27 @@ void main() {
       groupBy: ProjectTaskGroupBy.dueWindow,
       sortBy: ProjectTaskSortBy.title,
       keepDoneInGroups: true,
+      collapsedGroups: {'later', 'none'},
     );
 
-    final restored = ProjectTaskListOptions.fromJson(options.toJson());
+    final json = options.toJson();
+    expect(json['collapsedGroups'], ['later', 'none'], reason: 'sorted');
+    final restored = ProjectTaskListOptions.fromJson(json);
 
     expect(restored, options);
     expect(restored.hashCode, options.hashCode);
     expect(restored, isNot(options.copyWith(keepDoneInGroups: false)));
+    expect(restored, isNot(options.copyWith(collapsedGroups: const {'later'})));
+    expect(
+      restored,
+      const ProjectTaskListOptions(
+        groupBy: ProjectTaskGroupBy.dueWindow,
+        sortBy: ProjectTaskSortBy.title,
+        keepDoneInGroups: true,
+        collapsedGroups: {'none', 'later'},
+      ),
+      reason: 'set order does not matter',
+    );
     expect(
       options.copyWith(groupBy: ProjectTaskGroupBy.none).groupBy,
       ProjectTaskGroupBy.none,
@@ -44,12 +77,27 @@ void main() {
       ProjectTaskListOptions.fromJson(const <String, dynamic>{}),
       ProjectTaskListOptions.defaults,
     );
+    expect(
+      ProjectTaskListOptions.fromJson(const {
+        'collapsedGroups': 'done',
+      }).collapsedGroups,
+      {'done'},
+      reason: 'a non-list falls back to the default fold',
+    );
+    expect(
+      ProjectTaskListOptions.fromJson(const {
+        'collapsedGroups': ['2026-08', 7, null],
+      }).collapsedGroups,
+      {'2026-08'},
+      reason: 'non-string entries are dropped, and an explicit list wins',
+    );
   });
 
   test('describes itself for logs', () {
     expect(
       ProjectTaskListOptions.defaults.toString(),
-      'ProjectTaskListOptions(creationMonth, actionability, keepDoneInGroups: false)',
+      'ProjectTaskListOptions(creationMonth, actionability, '
+      'keepDoneInGroups: false, collapsed: [done])',
     );
   });
 }

--- a/test/features/projects/ui/pages/project_details_page_test.dart
+++ b/test/features/projects/ui/pages/project_details_page_test.dart
@@ -1178,20 +1178,33 @@ void main() {
           );
           expect(content.onRefreshReport, isNotNull);
           expect(content.onCancelScheduledReportWake, isNotNull);
-          final panel = content.agentActionsBuilder!(enabled: true);
+          final focused = <String>[];
+          void focusTask(String taskId, {bool scroll = true}) =>
+              focused.add('$taskId scroll=$scroll');
+          final panel = content.agentActionsBuilder!(
+            enabled: true,
+            focusTask: focusTask,
+          );
           expect(panel, isA<ProjectRecommendationsPanel>());
           expect((panel as ProjectRecommendationsPanel).enabled, isTrue);
           expect(
-            (content.agentActionsBuilder!(enabled: false)
+            (content.agentActionsBuilder!(
+                      enabled: false,
+                      focusTask: focusTask,
+                    )
                     as ProjectRecommendationsPanel)
                 .enabled,
             isFalse,
           );
+          // "Added → title" brings the task into view in the list below
+          // instead of leaving the page; a fresh creation only marks it.
           final opened = <String>[];
           beamToNamedOverride = opened.add;
           addTearDown(() => beamToNamedOverride = null);
           panel.onOpenTask!('task-42');
-          expect(opened, ['/tasks/task-42']);
+          panel.onTaskCreated!('task-7');
+          expect(focused, ['task-42 scroll=true', 'task-7 scroll=false']);
+          expect(opened, isEmpty);
 
           // Invoking the wired callbacks must dispatch to the project
           // agent service for the resolved agent ID, with the cancel path

--- a/test/features/projects/ui/widgets/next_steps/project_next_step_row_test.dart
+++ b/test/features/projects/ui/widgets/next_steps/project_next_step_row_test.dart
@@ -54,6 +54,87 @@ void main() {
     expect(find.text('Creating task…'), findsNothing);
   });
 
+  testWidgets('a pending step decides by swipe and stays in place', (
+    tester,
+  ) async {
+    var added = 0;
+    var dismissed = 0;
+    await tester.pumpWidget(
+      subject(
+        ProjectNextStepRow(
+          step: step,
+          state: ProjectNextStepRowState.pending,
+          onAddTask: () => added++,
+          onDismiss: () => dismissed++,
+        ),
+      ),
+    );
+    final swipe = find.byKey(const ValueKey('project-next-step-swipe-step-1'));
+    expect(swipe, findsOneWidget);
+
+    await tester.drag(swipe, const Offset(400, 0));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(added, 1);
+    expect(dismissed, 0);
+    expect(find.text(title), findsOneWidget, reason: 'snaps back');
+
+    await tester.drag(swipe, const Offset(-400, 0));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(dismissed, 1);
+    expect(added, 1);
+    expect(find.text(title), findsOneWidget);
+  });
+
+  testWidgets('only a pending, enabled step with an action swipes', (
+    tester,
+  ) async {
+    Widget row({
+      ProjectNextStepRowState state = ProjectNextStepRowState.pending,
+      bool enabled = true,
+      VoidCallback? onAddTask,
+      VoidCallback? onDismiss,
+    }) => subject(
+      ProjectNextStepRow(
+        step: step,
+        state: state,
+        enabled: enabled,
+        onAddTask: onAddTask,
+        onDismiss: onDismiss,
+      ),
+    );
+    void noop() {}
+
+    await tester.pumpWidget(row(state: ProjectNextStepRowState.added));
+    expect(find.byType(Dismissible), findsNothing);
+
+    await tester.pumpWidget(row(enabled: false, onAddTask: noop));
+    expect(find.byType(Dismissible), findsNothing);
+
+    await tester.pumpWidget(row());
+    expect(find.byType(Dismissible), findsNothing, reason: 'no action wired');
+
+    await tester.pumpWidget(row(onDismiss: noop));
+    expect(
+      tester.widget<Dismissible>(find.byType(Dismissible)).direction,
+      DismissDirection.endToStart,
+      reason: 'only Dismiss is wired',
+    );
+
+    await tester.pumpWidget(row(onAddTask: noop));
+    expect(
+      tester.widget<Dismissible>(find.byType(Dismissible)).direction,
+      DismissDirection.startToEnd,
+    );
+
+    await tester.pumpWidget(row(onAddTask: noop, onDismiss: noop));
+    expect(
+      tester.widget<Dismissible>(find.byType(Dismissible)).direction,
+      DismissDirection.horizontal,
+    );
+  });
+
   testWidgets('a disabled row keeps its controls visible but inert', (
     tester,
   ) async {

--- a/test/features/projects/ui/widgets/project_mobile_detail_content_test.dart
+++ b/test/features/projects/ui/widgets/project_mobile_detail_content_test.dart
@@ -22,6 +22,7 @@ import 'package:lotti/features/projects/ui/model/project_list_detail_models.dart
 import 'package:lotti/features/projects/ui/model/project_task_list_options.dart';
 import 'package:lotti/features/projects/ui/widgets/project_agent_summary_card.dart';
 import 'package:lotti/features/projects/ui/widgets/project_mobile_detail_content.dart';
+import 'package:lotti/features/projects/ui/widgets/project_task_list_options_sheet.dart';
 import 'package:lotti/features/projects/ui/widgets/project_tasks_panel.dart';
 import 'package:lotti/features/projects/ui/widgets/shared_widgets.dart';
 import 'package:lotti/features/tasks/ui/header/desktop_task_header.dart';
@@ -75,7 +76,7 @@ void main() {
           ProjectMobileDetailContent(
             record: makeTestProjectRecord(),
             currentTime: DateTime(2026, 3, 28, 1, 18),
-            agentActionsBuilder: ({required enabled}) =>
+            agentActionsBuilder: ({required enabled, required focusTask}) =>
                 const Text('Agent decisions'),
           ),
           size: const Size(430, 1400),
@@ -200,14 +201,14 @@ void main() {
       const options = ProjectTaskListOptions(
         groupBy: ProjectTaskGroupBy.status,
       );
-      ProjectTaskListOptions? requested;
+      ProjectTaskListOptions? changed;
       await tester.pumpWidget(
         wrap(
           ProjectMobileDetailContent(
             record: makeTestProjectRecord(),
             currentTime: DateTime(2026, 3, 28, 1, 18),
             taskListOptions: options,
-            onTaskListOptionsChanged: (value) => requested = value,
+            onTaskListOptionsChanged: (value) => changed = value,
           ),
           size: const Size(430, 1200),
         ),
@@ -215,7 +216,11 @@ void main() {
       await tester.pump();
 
       await tester.tap(find.byTooltip('Sort and group'));
-      expect(requested, options);
+      await tester.pumpAndSettle();
+      expect(find.byType(ProjectTaskListOptionsSheetContent), findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('project-tasks-group-none')));
+      await tester.pump();
+      expect(changed, options.copyWith(groupBy: ProjectTaskGroupBy.none));
 
       await tester.pumpWidget(
         wrap(
@@ -230,6 +235,41 @@ void main() {
       expect(find.byTooltip('Sort and group'), findsNothing);
     });
 
+    testWidgets('an agent band can light up a task in the list', (
+      tester,
+    ) async {
+      final record = makeTestProjectRecord(
+        highlightedTaskSummaries: [
+          makeTestTaskSummary(
+            task: makeTestTask(id: 'lit', title: 'Refill the krill'),
+          ),
+        ],
+      );
+      await tester.pumpWidget(
+        wrap(
+          ProjectMobileDetailContent(
+            record: record,
+            currentTime: DateTime(2026, 3, 28, 1, 18),
+            agentActionsBuilder: ({required enabled, required focusTask}) =>
+                TextButton(
+                  onPressed: () => focusTask('lit', scroll: false),
+                  child: const Text('Mark it'),
+                ),
+          ),
+          size: const Size(430, 1400),
+        ),
+      );
+      await tester.pump();
+      final wash = find.byKey(
+        const ValueKey('task-summary-row-background-lit'),
+      );
+      expect(wash, findsNothing);
+
+      await tester.tap(find.text('Mark it'));
+      await tester.pump();
+      expect(wash, findsOneWidget);
+    });
+
     testWidgets(
       'keeps agent actions mounted but disabled while a mutation runs',
       (
@@ -238,7 +278,7 @@ void main() {
         Widget subject({required bool isSaving}) => ProjectMobileDetailContent(
           record: makeTestProjectRecord(),
           currentTime: DateTime(2026, 3, 28, 1, 18),
-          agentActionsBuilder: ({required enabled}) =>
+          agentActionsBuilder: ({required enabled, required focusTask}) =>
               Text(enabled ? 'Agent decisions' : 'Agent decisions (disabled)'),
           isSaving: isSaving,
         );

--- a/test/features/projects/ui/widgets/project_recommendations_panel_test.dart
+++ b/test/features/projects/ui/widgets/project_recommendations_panel_test.dart
@@ -24,13 +24,14 @@ void main() {
   final now = DateTime(2026, 9, 5, 12);
   final runCreatedAt = now.subtract(const Duration(hours: 2));
   late MockProjectRecommendationService service;
-  late MockChangeSetConfirmationService confirmation;
+  late MockProjectProposalService proposalService;
   late int pendingReads;
 
   setUpAll(registerAllFallbackValues);
   setUp(() {
     service = MockProjectRecommendationService();
-    confirmation = MockChangeSetConfirmationService();
+    proposalService = MockProjectProposalService();
+    when(() => proposalService.canUndo(any(), any())).thenReturn(true);
     pendingReads = 0;
   });
 
@@ -109,9 +110,7 @@ void main() {
         return sets;
       }),
       projectRecommendationServiceProvider.overrideWithValue(service),
-      projectChangeSetConfirmationServiceProvider.overrideWithValue(
-        confirmation,
-      ),
+      projectProposalServiceProvider.overrideWithValue(proposalService),
       projectDetailNowProvider.overrideWithValue(() => now),
     ],
   );
@@ -550,7 +549,7 @@ void main() {
     'proposals apply or reject through the confirmation service and keep '
     'their tag',
     (tester) async {
-      when(() => confirmation.confirmItem(any(), any())).thenAnswer(
+      when(() => proposalService.confirm(any(), any())).thenAnswer(
         (_) async => const ToolExecutionResult(success: true, output: ''),
       );
       await pumpSubject(tester, subject(items: const [], sets: [proposals]));
@@ -559,7 +558,7 @@ void main() {
       await tester.tap(find.byTooltip('Confirm'));
       await settle(tester);
 
-      verify(() => confirmation.confirmItem(proposals, 0)).called(1);
+      verify(() => proposalService.confirm(proposals, 0)).called(1);
       expect(find.text('Confirmed'), findsOneWidget);
       expect(find.text('Create task: Pack fish'), findsOneWidget);
       expect(find.byTooltip('Confirm'), findsNothing);
@@ -571,20 +570,108 @@ void main() {
       expect(find.text('0 pending'), findsNothing);
 
       when(
-        () => confirmation.rejectItem(any(), any()),
+        () => proposalService.reject(any(), any()),
       ).thenAnswer((_) async => true);
       await pumpSubject(tester, subject(items: const [], sets: [proposals]));
       await tester.tap(find.byTooltip('Reject'));
       await settle(tester);
-      verify(() => confirmation.rejectItem(proposals, 0)).called(1);
+      verify(() => proposalService.reject(proposals, 0)).called(1);
       expect(find.text('Dismissed'), findsOneWidget);
     },
   );
 
+  testWidgets('a decided proposal offers Undo for eight seconds', (
+    tester,
+  ) async {
+    when(() => proposalService.confirm(any(), any())).thenAnswer(
+      (_) async => const ToolExecutionResult(success: true, output: ''),
+    );
+    when(() => proposalService.undo(any(), any())).thenAnswer(
+      (_) async => true,
+    );
+    await pumpSubject(tester, subject(items: const [], sets: [proposals]));
+
+    await tester.tap(find.byTooltip('Confirm'));
+    await settle(tester);
+    expect(find.text('Confirmed'), findsOneWidget);
+    expect(find.text('Undo'), findsOneWidget);
+    final readsBefore = pendingReads;
+
+    await tester.tap(find.text('Undo'));
+    await settle(tester);
+    verify(() => proposalService.undo(any(), 0)).called(1);
+    expect(find.text('Confirmed'), findsNothing);
+    expect(
+      find.byTooltip('Confirm'),
+      findsOneWidget,
+      reason: 'The proposal is pending again.',
+    );
+    expect(pendingReads, greaterThan(readsBefore));
+
+    // The window closes on its own.
+    await tester.tap(find.byTooltip('Confirm'));
+    await settle(tester);
+    expect(find.text('Undo'), findsOneWidget);
+    await tester.pump(ProjectRecommendationsPanel.undoWindow);
+    await tester.pump();
+    expect(find.text('Undo'), findsNothing);
+    expect(find.text('Confirmed'), findsOneWidget);
+  });
+
+  testWidgets('a refused or unavailable proposal Undo keeps the tag', (
+    tester,
+  ) async {
+    when(() => proposalService.confirm(any(), any())).thenAnswer(
+      (_) async => const ToolExecutionResult(success: true, output: ''),
+    );
+    when(() => proposalService.undo(any(), any())).thenAnswer(
+      (_) async => false,
+    );
+    await pumpSubject(tester, subject(items: const [], sets: [proposals]));
+    await tester.tap(find.byTooltip('Confirm'));
+    await settle(tester);
+
+    await tester.tap(find.text('Undo'));
+    await settle(tester);
+    expect(find.text('Confirmed'), findsOneWidget);
+    expect(find.text('Undo'), findsOneWidget);
+    expect(find.text(updateError), findsOneWidget);
+
+    when(() => proposalService.canUndo(any(), any())).thenReturn(false);
+    await pumpSubject(tester, subject(items: const [], sets: [proposals]));
+    await tester.tap(find.byTooltip('Confirm'));
+    await settle(tester);
+    expect(find.text('Confirmed'), findsOneWidget);
+    expect(
+      find.text('Undo'),
+      findsNothing,
+      reason: 'The service cannot put this one back.',
+    );
+  });
+
+  testWidgets('a proposal Undo that throws is reported, not swallowed', (
+    tester,
+  ) async {
+    when(() => proposalService.confirm(any(), any())).thenAnswer(
+      (_) async => const ToolExecutionResult(success: true, output: ''),
+    );
+    when(
+      () => proposalService.undo(any(), any()),
+    ).thenThrow(StateError('offline'));
+    await pumpSubject(tester, subject(items: const [], sets: [proposals]));
+    await tester.tap(find.byTooltip('Confirm'));
+    await settle(tester);
+
+    await tester.tap(find.text('Undo'));
+    await settle(tester);
+    expect(find.text('Confirmed'), findsOneWidget);
+    expect(find.text(updateError), findsOneWidget);
+  });
+
   testWidgets('a failed proposal decision keeps the rail and reports it', (
     tester,
   ) async {
-    when(() => confirmation.confirmItem(any(), any())).thenAnswer(
+    when(() => proposalService.confirm(any(), any())).thenAnswer(
       (_) async => const ToolExecutionResult(success: false, output: 'no'),
     );
     await pumpSubject(tester, subject(items: const [], sets: [proposals]));
@@ -633,7 +720,7 @@ void main() {
     );
     await tester.tap(find.byTooltip('Confirm'));
     await tester.pump();
-    verifyNever(() => confirmation.confirmItem(any(), any()));
+    verifyNever(() => proposalService.confirm(any(), any()));
   });
 
   testWidgets('bulk work disables the other rows until it finishes', (
@@ -770,7 +857,7 @@ void main() {
   ) async {
     when(() => service.createTask('s1')).thenThrow(StateError('offline'));
     when(
-      () => confirmation.confirmItem(any(), any()),
+      () => proposalService.confirm(any(), any()),
     ).thenThrow(StateError('offline'));
     await pumpSubject(
       tester,

--- a/test/features/projects/ui/widgets/project_recommendations_panel_test.dart
+++ b/test/features/projects/ui/widgets/project_recommendations_panel_test.dart
@@ -79,6 +79,7 @@ void main() {
     List<AgentDomainEntity> sets = const [],
     bool enabled = true,
     ValueChanged<String>? onOpenTask,
+    ValueChanged<String>? onTaskCreated,
     double width = 390,
     bool withoutSnapshot = false,
     bool legacyRun = false,
@@ -88,6 +89,7 @@ void main() {
         projectId: projectId,
         enabled: enabled,
         onOpenTask: onOpenTask,
+        onTaskCreated: onTaskCreated,
       ),
     ),
     mediaQueryData: MediaQueryData(size: Size(width, 900)),
@@ -256,6 +258,33 @@ void main() {
     expect(calls, 2);
     expect(find.text('Added'), findsOneWidget);
     expect(find.text('Retry'), findsNothing);
+  });
+
+  testWidgets('reports a created task to the host, but never a failed one', (
+    tester,
+  ) async {
+    final created = <String>[];
+    var calls = 0;
+    when(() => service.createTask('s1')).thenAnswer((_) async {
+      calls++;
+      return ToolExecutionResult(
+        success: calls > 1,
+        output: calls > 1 ? '' : 'Recommendation is no longer active',
+        mutatedEntityId: calls > 1 ? 'task-1' : null,
+      );
+    });
+    await pumpSubject(
+      tester,
+      subject(items: steps.sublist(0, 1), onTaskCreated: created.add),
+    );
+
+    await tester.tap(find.text('Add task'));
+    await settle(tester);
+    expect(created, isEmpty);
+
+    await tester.tap(find.text('Retry'));
+    await settle(tester);
+    expect(created, ['task-1']);
   });
 
   testWidgets(

--- a/test/features/projects/ui/widgets/project_tasks_panel_test.dart
+++ b/test/features/projects/ui/widgets/project_tasks_panel_test.dart
@@ -5,11 +5,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_icon_action.dart';
+import 'package:lotti/features/design_system/components/popovers/design_system_popover_anchor.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/projects/ui/model/project_list_detail_models.dart';
 import 'package:lotti/features/projects/ui/model/project_task_groups.dart';
 import 'package:lotti/features/projects/ui/model/project_task_list_options.dart';
+import 'package:lotti/features/projects/ui/widgets/project_task_list_options_sheet.dart';
 import 'package:lotti/features/projects/ui/widgets/project_tasks_panel.dart';
 
 import '../../../../widget_test_utils.dart';
@@ -284,6 +286,7 @@ void main() {
     Widget wrapSliver(
       Widget sliver, {
       double width = 400,
+      double? screenWidth,
       double textScale = 1,
     }) {
       return makeTestableWidget2(
@@ -299,7 +302,7 @@ void main() {
           ),
         ),
         mediaQueryData: MediaQueryData(
-          size: Size(width, 900),
+          size: Size(screenWidth ?? width, 900),
           textScaler: TextScaler.linear(textScale),
         ),
       );
@@ -498,9 +501,51 @@ void main() {
       expect(find.textContaining('2026'), findsNothing);
     });
 
-    testWidgets('the sort-and-group control reports the current options', (
+    testWidgets('folds report through onOptionsChanged and read back', (
       tester,
     ) async {
+      final reported = <ProjectTaskListOptions>[];
+      await tester.pumpWidget(
+        wrapSliver(
+          ProjectTasksSliverPanel(
+            record: record,
+            now: now,
+            onOptionsChanged: reported.add,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('Done'));
+      await tester.pump();
+      expect(reported.single.collapsedGroups, isEmpty);
+      expect(
+        find.text('Ship it'),
+        findsNothing,
+        reason: 'The host owns the fold; nothing moves until it re-renders.',
+      );
+
+      await tester.pumpWidget(
+        wrapSliver(
+          ProjectTasksSliverPanel(
+            record: record,
+            now: now,
+            options: reported.single,
+            onOptionsChanged: reported.add,
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(find.text('Ship it'), findsOneWidget);
+
+      await tester.tap(find.text('September 2026'));
+      await tester.pump();
+      expect(reported.last.collapsedGroups, {
+        const ProjectTaskMonthKey(2026, 9).id,
+      });
+    });
+
+    testWidgets('the control opens the sheet on a phone', (tester) async {
       const options = ProjectTaskListOptions(
         groupBy: ProjectTaskGroupBy.status,
         sortBy: ProjectTaskSortBy.title,
@@ -519,7 +564,13 @@ void main() {
       await tester.pump();
 
       await tester.tap(find.byTooltip('Sort and group'));
-      expect(reported, options);
+      await tester.pumpAndSettle();
+      expect(find.byType(ProjectTaskListOptionsSheetContent), findsOneWidget);
+      expect(find.byType(DesignSystemPopoverSurface), findsNothing);
+
+      await tester.tap(find.byKey(const ValueKey('project-tasks-group-none')));
+      await tester.pump();
+      expect(reported, options.copyWith(groupBy: ProjectTaskGroupBy.none));
 
       await tester.pumpWidget(
         wrapSliver(ProjectTasksSliverPanel(record: record, now: now)),
@@ -530,6 +581,233 @@ void main() {
         findsNothing,
         reason: 'A read-only showcase wires no control.',
       );
+    });
+
+    testWidgets('the control opens a popover on a desktop-wide screen', (
+      tester,
+    ) async {
+      ProjectTaskListOptions? reported;
+      await tester.pumpWidget(
+        wrapSliver(
+          ProjectTasksSliverPanel(
+            record: record,
+            now: now,
+            onOptionsChanged: (value) => reported = value,
+          ),
+          width: 900,
+          screenWidth: 1200,
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.byTooltip('Sort and group'));
+      await tester.pump();
+      expect(find.byType(DesignSystemPopoverSurface), findsOneWidget);
+      expect(find.byType(ProjectTaskListOptionsSheetContent), findsOneWidget);
+
+      final titleRow = find.byKey(const ValueKey('project-tasks-sort-title'));
+      await tester.ensureVisible(titleRow);
+      await tester.pump();
+      await tester.tap(titleRow);
+      await tester.pump();
+      expect(reported?.sortBy, ProjectTaskSortBy.title);
+      expect(
+        find.byType(DesignSystemPopoverSurface),
+        findsOneWidget,
+        reason: 'A pick applies at once and leaves the popover open.',
+      );
+
+      await tester.tapAt(const Offset(5, 5));
+      await tester.pump();
+      expect(find.byType(DesignSystemPopoverSurface), findsNothing);
+    });
+
+    testWidgets(
+      'group headers pin while their rows scroll and push each other',
+      (
+        tester,
+      ) async {
+        final many = makeTestProjectRecord(
+          highlightedTaskSummaries: [
+            for (var i = 0; i < 12; i++)
+              summary('s$i', 'September task $i', createdAt: DateTime(2026, 9)),
+            for (var i = 0; i < 12; i++)
+              summary('a$i', 'August task $i', createdAt: DateTime(2026, 8)),
+          ],
+        );
+        await tester.pumpWidget(
+          wrapSliver(ProjectTasksSliverPanel(record: many, now: now)),
+        );
+        await tester.pump();
+        final viewportTop = tester.getRect(find.byType(CustomScrollView)).top;
+        expect(
+          tester.getRect(find.text('September 2026')).top,
+          greaterThan(viewportTop),
+        );
+
+        await tester.drag(find.byType(CustomScrollView), const Offset(0, -400));
+        await tester.pump();
+        expect(
+          tester.getRect(find.text('September 2026')).top,
+          closeTo(viewportTop + 14, 6),
+          reason: 'The header of the group being scrolled stays pinned.',
+        );
+        expect(
+          find.text('Project Tasks'),
+          findsNothing,
+          reason: 'The card header scrolls away.',
+        );
+
+        await tester.drag(find.byType(CustomScrollView), const Offset(0, -900));
+        await tester.pump();
+        expect(
+          tester.getRect(find.text('August 2026')).top,
+          closeTo(viewportTop + 14, 6),
+          reason: 'The next group header takes the pinned slot.',
+        );
+        expect(
+          find.text('September 2026'),
+          findsNothing,
+          reason: 'Pushed out.',
+        );
+      },
+    );
+
+    testWidgets('a highlighted row paints the wash without a pointer', (
+      tester,
+    ) async {
+      final one = summary('h', 'Hot row', createdAt: DateTime(2026, 9));
+      await tester.pumpWidget(
+        wrapSliver(
+          ProjectTasksSliverPanel(
+            record: makeTestProjectRecord(highlightedTaskSummaries: [one]),
+            now: now,
+            focus: const ProjectTaskFocus(
+              taskId: 'h',
+              request: 1,
+              scroll: false,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      final wash = find.byKey(const ValueKey('task-summary-row-background-h'));
+      expect(wash, findsOneWidget);
+
+      await tester.pump(ProjectTasksSliverPanel.highlightDuration);
+      expect(wash, findsNothing, reason: 'The highlight fades on its own.');
+    });
+
+    testWidgets('focus scrolls a deep row into view, unfolding its group', (
+      tester,
+    ) async {
+      final many = makeTestProjectRecord(
+        highlightedTaskSummaries: [
+          for (var i = 0; i < 40; i++)
+            summary('s$i', 'September task $i', createdAt: DateTime(2026, 9)),
+          summary('done', 'Shipped', createdAt: DateTime(2026, 8), done: true),
+        ],
+      );
+      final reported = <ProjectTaskListOptions>[];
+      Widget subject({
+        ProjectTaskFocus? focus,
+        ProjectTaskListOptions? options,
+      }) => wrapSliver(
+        ProjectTasksSliverPanel(
+          record: many,
+          now: now,
+          focus: focus,
+          options: options ?? ProjectTaskListOptions.defaults,
+          onOptionsChanged: reported.add,
+        ),
+      );
+      await tester.pumpWidget(subject());
+      await tester.pump();
+      expect(find.text('September task 39'), findsNothing, reason: 'lazy');
+
+      await tester.pumpWidget(
+        subject(focus: const ProjectTaskFocus(taskId: 's39', request: 1)),
+      );
+      for (var i = 0; i < ProjectTasksSliverPanel.maxScrollAttempts; i++) {
+        await tester.pump();
+      }
+      await tester.pump(MotionDurations.medium2);
+      final viewport = tester.getRect(find.byType(CustomScrollView));
+      final row = tester.getRect(find.text('September task 39'));
+      expect(row.top, greaterThanOrEqualTo(viewport.top));
+      expect(row.bottom, lessThanOrEqualTo(viewport.bottom));
+      expect(
+        find.byKey(const ValueKey('task-summary-row-background-s39')),
+        findsOneWidget,
+      );
+      expect(reported, isEmpty, reason: 'September was never folded.');
+
+      // A task in the folded Done group: the fold opens through the host.
+      await tester.pumpWidget(
+        subject(focus: const ProjectTaskFocus(taskId: 'done', request: 2)),
+      );
+      await tester.pump();
+      expect(reported.single.isCollapsed('done'), isFalse);
+      await tester.pumpWidget(
+        subject(
+          focus: const ProjectTaskFocus(taskId: 'done', request: 2),
+          options: reported.single,
+        ),
+      );
+      for (var i = 0; i < ProjectTasksSliverPanel.maxScrollAttempts; i++) {
+        await tester.pump();
+      }
+      await tester.pump(MotionDurations.medium2);
+      final shipped = tester.getRect(find.text('Shipped'));
+      expect(shipped.top, greaterThanOrEqualTo(viewport.top));
+      expect(shipped.bottom, lessThanOrEqualTo(viewport.bottom));
+    });
+
+    testWidgets('focus on an ungrouped list steps through the viewport', (
+      tester,
+    ) async {
+      final many = makeTestProjectRecord(
+        highlightedTaskSummaries: [
+          for (var i = 0; i < 40; i++)
+            summary('t$i', 'Task $i', createdAt: DateTime(2026, 9)),
+        ],
+      );
+      await tester.pumpWidget(
+        wrapSliver(
+          ProjectTasksSliverPanel(
+            record: many,
+            now: now,
+            options: const ProjectTaskListOptions(
+              groupBy: ProjectTaskGroupBy.none,
+              sortBy: ProjectTaskSortBy.title,
+            ),
+            focus: const ProjectTaskFocus(taskId: 't9', request: 1),
+          ),
+        ),
+      );
+      for (var i = 0; i < ProjectTasksSliverPanel.maxScrollAttempts; i++) {
+        await tester.pump();
+      }
+      await tester.pump(MotionDurations.medium2);
+      final viewport = tester.getRect(find.byType(CustomScrollView));
+      final row = tester.getRect(find.text('Task 9'));
+      expect(row.top, greaterThanOrEqualTo(viewport.top));
+      expect(row.bottom, lessThanOrEqualTo(viewport.bottom));
+    });
+
+    test('ProjectTaskFocus compares by task, request and mode', () {
+      const a = ProjectTaskFocus(taskId: 't', request: 1);
+      expect(a, const ProjectTaskFocus(taskId: 't', request: 1));
+      expect(
+        a.hashCode,
+        const ProjectTaskFocus(taskId: 't', request: 1).hashCode,
+      );
+      expect(a, isNot(const ProjectTaskFocus(taskId: 't', request: 2)));
+      expect(
+        a,
+        isNot(const ProjectTaskFocus(taskId: 't', request: 1, scroll: false)),
+      );
+      expect(a, isNot(const ProjectTaskFocus(taskId: 'u', request: 1)));
     });
 
     testWidgets('Add task is labelled when wide and a glyph when compact', (

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -41,6 +41,7 @@ import 'package:lotti/features/agents/service/feedback_extraction_service.dart';
 import 'package:lotti/features/agents/service/improver_agent_service.dart';
 import 'package:lotti/features/agents/service/project_activity_monitor.dart';
 import 'package:lotti/features/agents/service/project_agent_service.dart';
+import 'package:lotti/features/agents/service/project_proposal_service.dart';
 import 'package:lotti/features/agents/service/project_recommendation_service.dart';
 import 'package:lotti/features/agents/service/soul_document_service.dart';
 import 'package:lotti/features/agents/service/subject_agent_lookup.dart';
@@ -1369,6 +1370,9 @@ class MockTemplateEvolutionWorkflow extends Mock
 
 class MockChangeSetConfirmationService extends Mock
     implements ChangeSetConfirmationService {}
+
+class MockProjectProposalService extends Mock
+    implements ProjectProposalService {}
 
 class MockFeedbackExtractionService extends Mock
     implements FeedbackExtractionService {}


### PR DESCRIPTION
Closes the gap between the 2026-09-05 design pass on the projects AI section and what #4138, #4139 and #4140 shipped. Tracked under Beads lotti3-7w1.2 (epic lotti3-7w1).

## Task list

- **Pinned group headers.** Each group is a `MultiSliver` with `pushPinnedChildren` around a `SliverPinnedHeader` (new dependency `sliver_tools`): the header of the group being scrolled stays at the top of the viewport and is pushed out by the next group's header. The header paints the card surface opaquely so rows scroll beneath it.
- **Folds are remembered.** Which groups are collapsed is part of `ProjectTaskListOptions` (`collapsedGroups`, Done folded by default) and persists per project with the sort and group choice through the same controller. Showcases without a callback keep folds locally.
- **Popover on desktop, sheet on a phone.** The Sort and group control opens as a `DesignSystemPopoverAnchor` (new design-system component: the context menu's anchored overlay and surface, hosting arbitrary content) on a desktop-wide screen, and as the shared sheet elsewhere. Both host the same rows, which apply on tap and leave the surface open for the next pick.
- **"Added → title" focuses the task in the list.** A `ProjectTaskFocus` scrolls the list to the created task (unfolding its group, stepping through the lazy list until the row exists) and lights it up with the hover wash for three seconds; a fresh creation only lights it up so the band does not move under the user.

## AI band

- **Swipe to decide.** A pending next step swipes right to add the task and left to dismiss, with the action named on the band the row reveals (`DesignSystemSwipeActionBackground`, extracted from the habit row, which now uses it too). The row snaps back and shows its tag.
- **Undo on a proposal.** `ProjectProposalService` (kept alive per session) wraps the project change set confirmation service: `confirm` remembers the task a `create_task` created or the status an `update_project_status` replaced; `undo` removes the task or restores the status and its history entry, then calls the new `ChangeSetConfirmationService.reopenItem`, which records a `deferred` decision and puts the item back to pending. A decided proposal keeps its tag and offers Undo for eight seconds while the service can still put it back.

## Not in this PR

- Dashed borders on proposal rows: the design system has no dashed border primitive, and dash and gap lengths would be new visual values, so this waits for a decision.
- Real-device German and largest-text captures remain the owner's.

## Validation

- Analyzer clean on the whole repository; `make knowledge_check` and `make changelog_check` pass.
- New tests: options model (folds), tasks panel (fold persistence, popover vs sheet, pinned headers pushing each other, highlight, focus through a lazy list and a folded group), popover anchor, detail content (focus plumbing), details page (band wiring), band (created-task callback, proposal Undo incl. refusal, timeout and throw), proposal service, `reopenItem`, swipe background, step row swipe, change-set providers. Every touched source file is fully covered locally.
- Screenshots use the penguin demo world only; before images were captured at the base commit `9a26fb103`.

## Before / after

Pinned group header while scrolling (desktop light):

| Before | After |
|---|---|
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/before/tasks_pinned_header_desktop_light.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/after/tasks_pinned_header_desktop_light.png) |

Sort and group on desktop (light):

| Before | After |
|---|---|
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/before/tasks_sort_control_desktop_light.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/after/tasks_sort_control_desktop_light.png) |

A confirmed proposal (phone light):

| Before | After |
|---|---|
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/before/ai_proposal_decided_mobile_light.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/after/ai_proposal_decided_mobile_light.png) |

A next step mid-swipe (phone light):

| Before | After |
|---|---|
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/before/ai_step_swipe_mobile_light.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/after/ai_step_swipe_mobile_light.png) |

<details><summary>Dark theme and phone pinned header</summary>

| Before | After |
|---|---|
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/before/tasks_pinned_header_desktop_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/after/tasks_pinned_header_desktop_dark.png) |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/before/tasks_pinned_header_mobile_light.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/after/tasks_pinned_header_mobile_light.png) |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/before/tasks_pinned_header_mobile_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/after/tasks_pinned_header_mobile_dark.png) |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/before/tasks_sort_control_desktop_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/after/tasks_sort_control_desktop_dark.png) |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/before/ai_proposal_decided_desktop_light.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/after/ai_proposal_decided_desktop_light.png) |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/before/ai_proposal_decided_desktop_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/after/ai_proposal_decided_desktop_dark.png) |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/before/ai_proposal_decided_mobile_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/after/ai_proposal_decided_mobile_dark.png) |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/before/ai_step_swipe_mobile_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/projects-handover-leftovers/294de9131815b0e83039a0bf065c863248b00295/after/ai_step_swipe_mobile_dark.png) |

</details>
