### PR TITLE
fix: preserve habit reminder dates across rescheduling

### DIFF
--- a/changelog.d/2026-09-05-habit-reminder-date.md
+++ b/changelog.d/2026-09-05-habit-reminder-date.md
@@ -1,0 +1,6 @@
+### Fixed
+- **Completing a habit now keeps its reminder scheduled for tomorrow.** The
+  replacement reminder previously lost its date, causing a second reminder
+  today or leaving no reminder when the chosen time had passed. Saving a habit
+  after its reminder time now schedules tomorrow, including across daylight
+  saving changes and year boundaries.

--- a/knowledge/features/notifications.md
+++ b/knowledge/features/notifications.md
@@ -5,7 +5,7 @@ description: Durable app-level alerts stored outside the journal, converging acr
 resource: ../../lib/features/notifications
 tags: [notifications, sync, convergence]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-08-03T09:00:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-05T18:00:00Z }
 stale_after: 2027-03-01
 sources:
   - id: src
@@ -19,7 +19,7 @@ sources:
   - id: os-boundary
     resource: ../../lib/services/notification_service.dart
     title: NotificationService — the OS delivery boundary
-    last_modified: 2026-08-17
+    last_modified: 2026-09-05
   - id: scheduler
     resource: ../../lib/features/notifications/scheduler/notification_scheduler.dart
     title: NotificationScheduler — rows to OS alarms, and reconcile
@@ -241,6 +241,23 @@ the platform is not a reason to report it as unsaved.
 
 Cancelling is the one thing that stays ungated: removing an alert must keep
 working after notifications are switched off.
+
+# Habit reminders retain their calendar date
+
+`scheduleHabitNotification` interprets the daily alert time in the resolved
+local zone. Completion requests the next calendar day; saving settings uses
+today if the alert time is still ahead, otherwise tomorrow. Calendar
+construction, rather than a 24-hour duration, preserves the intended day
+through daylight-saving changes and month/year boundaries. Subsecond clock
+values do not leak into the configured reminder time.
+
+`scheduleNotification` preserves that entire calendar date and wall-clock time
+when constructing the zoned alarm. Reusing today's date here would discard the
+completion caller's tomorrow: before the alert time it would ring again today,
+and after the alert time the plugin would reject the replacement after the
+previous alarm had been cancelled. This wall-clock contract differs from
+`scheduleNotificationAt`, which converts an absolute instant into the device
+zone. Both replace the prior alarm with the same notification ID.
 
 # Android needed settings before it needed anything else
 

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:lotti/classes/entity_definitions.dart';
@@ -510,13 +511,30 @@ class NotificationService {
     );
 
     if (alertAtTime != null) {
-      final notifyAt = DateTime.now()
-          .add(Duration(days: daysToAdd))
-          .copyWith(
-            hour: alertAtTime.hour,
-            minute: alertAtTime.minute,
-            second: alertAtTime.second,
-          );
+      final location = _resolveLocation(await getLocalTimezone());
+      final now = TZDateTime.from(clock.now(), location);
+      // Construct a calendar date: adding 24 hours can skip or repeat a day
+      // when daylight saving time changes.
+      var notifyAt = TZDateTime(
+        location,
+        now.year,
+        now.month,
+        now.day + daysToAdd,
+        alertAtTime.hour,
+        alertAtTime.minute,
+        alertAtTime.second,
+      );
+      if (!notifyAt.isAfter(now)) {
+        notifyAt = TZDateTime(
+          location,
+          now.year,
+          now.month,
+          now.day + 1,
+          alertAtTime.hour,
+          alertAtTime.minute,
+          alertAtTime.second,
+        );
+      }
 
       await getIt<NotificationService>().scheduleNotification(
         title: habitDefinition.name,
@@ -529,6 +547,8 @@ class NotificationService {
     }
   }
 
+  /// Schedules the requested calendar date and wall-clock time in the device
+  /// zone. Use [scheduleNotificationAt] when [notifyAt] represents an instant.
   Future<void> scheduleNotification({
     required String title,
     required String body,
@@ -545,14 +565,13 @@ class NotificationService {
 
     await _requestPermissions();
     await flutterLocalNotificationsPlugin.cancel(id: notificationId);
-    final now = DateTime.now();
     final location = _resolveLocation(await getLocalTimezone());
 
     final scheduledDate = TZDateTime(
       location,
-      now.year,
-      now.month,
-      now.day,
+      notifyAt.year,
+      notifyAt.month,
+      notifyAt.day,
       notifyAt.hour,
       notifyAt.minute,
       notifyAt.second,

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -837,107 +837,77 @@ void main() {
       setNotificationsEnabled(enabled: true);
     });
 
-    test('schedules today at the requested wall-clock time', () async {
-      final service = await buildService();
-
-      // The fixed clock does not control the scheduled date — production builds
-      // that from `DateTime.now()`. It only relaxes the plugin's
-      // `validateDateIsInTheFuture`, which otherwise throws whenever the suite
-      // runs later in the day than the time under test. That throw is real in
-      // production too: `scheduleNotification` with `repeat: false` and a
-      // time-of-day already past raises `ArgumentError`.
-      await withClock(Clock.fixed(DateTime.utc(2000)), () async {
-        await service.scheduleNotification(
-          title: 'Meditate',
-          body: 'Daily meditation',
-          notifyAt: DateTime(2024, 3, 15, 7, 45, 12),
-          notificationId: 42,
-          showOnMobile: false,
-          showOnDesktop: true,
+    for (final now in [
+      DateTime(2024, 12, 31, 6),
+      DateTime(2024, 12, 31, 20),
+    ]) {
+      test('preserves tomorrow after completion at ${now.hour}:00', () async {
+        final service = await buildService();
+        channel.calls.clear();
+        await withClock(Clock.fixed(now), () async {
+          await service.scheduleNotification(
+            title: 'Meditate',
+            body: 'Daily meditation',
+            notifyAt: DateTime(2025, 1, 1, 7, 45, 12),
+            notificationId: 42,
+            showOnMobile: false,
+            showOnDesktop: true,
+          );
+        });
+        final args = channel.argsOf('zonedSchedule');
+        expect(args['id'], 42);
+        expect(args['scheduledDateTime'], '2025-01-01T07:45:12');
+        expect(args['matchDateTimeComponents'], isNull);
+        expect(channel.methods, [
+          'requestPermissions',
+          'cancel',
+          'zonedSchedule',
+        ]);
+        expect(
+          channel.calls.firstWhere((call) => call.method == 'cancel').arguments,
+          42,
         );
       });
+    }
 
-      // The date component is "today"; only the time of day comes from
-      // notifyAt, which is what makes this the daily-habit entry point.
-      final args = channel.argsOf('zonedSchedule');
-      expect(args['id'], 42);
-      expect(args['scheduledDateTime'], endsWith('T07:45:12'));
-      expect(args['matchDateTimeComponents'], isNull);
-      expect(channel.countOf('cancel'), 1);
-    });
-
-    test('builds the wall clock in the device zone, not in UTC', () async {
-      // The reported failure, at the point where it actually costs the user a
-      // reminder. Unlike `scheduleNotificationAt`, this path composes an
-      // *instant out of wall-clock components* in the resolved location, so
-      // the location is not cosmetic: build 07:45 in UTC for a device in
-      // Berlin and the habit reminder arrives at 09:45.
-      //
-      // `local` stood in for the device zone whenever `getLocalTimezone()`
-      // could only produce an abbreviation — and on macOS it always could,
-      // because the tzdata version directory in the resolved /etc/localtime
-      // path defeated the IANA lookup. `configureLocalTimezone()` then failed
-      // the same way and left `local` at the package's UTC default, so the
-      // fallback silently became the bug.
-      // Mirrors `scheduleHabitNotification`'s own call: mobile on, desktop
-      // off. `_alertDetails` hands a platform the caller did not opt into null
-      // details, so a habit reminder only ever presents on iOS and Android —
-      // which is where this mistiming was actually felt.
-      _usePlatform(TargetPlatform.iOS);
-      tz.setLocalLocation(tz.getLocation('Europe/Berlin'));
-      final service = await buildService();
-
-      await withClock(Clock.fixed(DateTime.utc(2000)), () async {
-        await service.scheduleNotification(
-          title: 'Meditate',
-          body: 'Daily meditation',
-          notifyAt: DateTime(2024, 3, 15, 7, 45),
-          notificationId: 42,
-          showOnMobile: true,
-          showOnDesktop: false,
+    for (final date in [
+      DateTime(2024, 3, 31, 7, 45),
+      DateTime(2024, 10, 27, 7, 45),
+    ]) {
+      test('preserves device wall clock across DST on $date', () async {
+        _usePlatform(TargetPlatform.iOS);
+        final berlin = tz.getLocation('Europe/Berlin');
+        tz.setLocalLocation(berlin);
+        final service = await buildService();
+        await withClock(Clock.fixed(DateTime.utc(2024)), () async {
+          await service.scheduleNotification(
+            title: 'Meditate',
+            body: 'Daily meditation',
+            notifyAt: date,
+            notificationId: 42,
+            showOnMobile: true,
+            showOnDesktop: false,
+          );
+        });
+        final args = channel.argsOf('zonedSchedule');
+        final scheduled = DateTime.parse(
+          args['scheduledDateTimeISO8601']! as String,
         );
+        final expected = tz.TZDateTime(
+          berlin,
+          date.year,
+          date.month,
+          date.day,
+          7,
+          45,
+        );
+        expect(
+          scheduled.toUtc().millisecondsSinceEpoch,
+          expected.millisecondsSinceEpoch,
+        );
+        expect(args['scheduledDateTime'], endsWith('T07:45:00'));
       });
-
-      final args = channel.argsOf('zonedSchedule');
-      final scheduled = DateTime.parse(
-        args['scheduledDateTimeISO8601']! as String,
-      );
-      final today = DateTime.now();
-
-      expect(
-        args['scheduledDateTime'],
-        endsWith('T07:45:00'),
-        reason: 'the wall clock the user set is what they must see',
-      );
-      final berlin = tz.getLocation('Europe/Berlin');
-      final expected = tz.TZDateTime(
-        berlin,
-        today.year,
-        today.month,
-        today.day,
-        7,
-        45,
-      );
-
-      // Compared as instants: TZDateTime and DateTime never test equal to each
-      // other, so `expect(a, b)` on the objects would fail even when the two
-      // name the same moment.
-      expect(
-        scheduled.toUtc().millisecondsSinceEpoch,
-        expected.millisecondsSinceEpoch,
-        reason:
-            '07:45 in Berlin, not 07:45 in UTC — the gap is the whole '
-            'offset the device is in, which is exactly how late the reminder '
-            'used to arrive',
-      );
-      expect(
-        expected.toUtc().hour,
-        isNot(7),
-        reason:
-            'guards the guard: if Berlin ever sat at UTC+0 this test would '
-            'pass without distinguishing the two',
-      );
-    });
+    }
 
     test('repeat asks the OS to match on time of day', () async {
       final service = await buildService();
@@ -1161,7 +1131,12 @@ void main() {
         );
 
         final service = await buildService();
-        await service.scheduleHabitNotification(definition, daysToAdd: 2);
+        await withClock(
+          Clock.fixed(DateTime(2024, 12, 30, 23, 59, 59, 999)),
+          () async {
+            await service.scheduleHabitNotification(definition, daysToAdd: 2);
+          },
+        );
 
         final captured = verify(
           () => delegate.scheduleNotification(
@@ -1176,11 +1151,71 @@ void main() {
 
         final notifyAt = captured.single as DateTime;
         // The time-of-day is copied from alertAtTime regardless of "now".
-        expect(notifyAt.hour, 7);
-        expect(notifyAt.minute, 45);
-        expect(notifyAt.second, 12);
+        expect(notifyAt.toUtc(), DateTime.utc(2025, 1, 1, 7, 45, 12));
       },
     );
+
+    for (final scenario in [
+      (
+        now: DateTime.utc(2024, 3, 30, 22, 30),
+        days: 1,
+        expected: DateTime.utc(2024, 3, 31, 5, 45),
+      ),
+      (
+        now: DateTime.utc(2024, 10, 26, 22, 30),
+        days: 1,
+        expected: DateTime.utc(2024, 10, 28, 6, 45),
+      ),
+      (
+        now: DateTime.utc(2024, 12, 31, 19),
+        days: 0,
+        expected: DateTime.utc(2025, 1, 1, 6, 45),
+      ),
+      (
+        now: DateTime.utc(2024, 12, 31, 6, 45),
+        days: 0,
+        expected: DateTime.utc(2025, 1, 1, 6, 45),
+      ),
+      (
+        now: DateTime.utc(2024, 12, 31, 5),
+        days: 0,
+        expected: DateTime.utc(2024, 12, 31, 6, 45),
+      ),
+    ]) {
+      test(
+        'next habit reminder from ${scenario.now} plus ${scenario.days} calendar days',
+        () async {
+          tz.setLocalLocation(tz.getLocation('Europe/Berlin'));
+          final service = await buildService();
+          final definition = habit(
+            schedule: HabitSchedule.daily(
+              requiredCompletions: 1,
+              alertAtTime: DateTime(2024, 1, 1, 7, 45),
+            ),
+          );
+          await withClock(
+            Clock.fixed(scenario.now),
+            () => service.scheduleHabitNotification(
+              definition,
+              daysToAdd: scenario.days,
+            ),
+          );
+          final captured =
+              verify(
+                    () => delegate.scheduleNotification(
+                      title: 'Meditate',
+                      body: 'Daily meditation',
+                      showOnMobile: true,
+                      showOnDesktop: false,
+                      notifyAt: captureAny(named: 'notifyAt'),
+                      notificationId: 'habit-1'.hashCode,
+                    ),
+                  ).captured.single
+                  as DateTime;
+          expect(captured.toUtc(), scenario.expected);
+        },
+      );
+    }
 
     test('daily schedule without alertAtTime does not delegate', () async {
       final definition = habit(


### PR DESCRIPTION
Completing a daily habit requested tomorrow's reminder, but the notification service rebuilt it using today's date. Before the reminder time this scheduled another alert today; after that time the plugin rejected the replacement after cancelling the previous alert.

This preserves the full requested calendar date and device-local wall time. Habit scheduling now uses calendar days in the resolved timezone, so daylight-saving changes do not skip or repeat a day. Saving settings at or after the reminder time schedules tomorrow. The absolute-instant scheduling API retains its existing semantics.

Validation:
- 71 targeted notification service tests pass via Dart MCP, including exact platform-channel timestamps and replacement IDs.
- All 10 date/time regression cases fail with the original implementation restored.
- Dart MCP analyzer reports no errors; formatting, knowledge validation (including 525 Mermaid diagrams), and changelog checks pass.

Includes a user-facing release note and notification scheduling documentation. No user log content is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Habit reminders now remain scheduled for the intended calendar date when completing or saving a habit.
  * Reminders whose selected time has passed are scheduled for the following day instead of being lost or duplicated.
  * Reminder times now remain accurate across daylight-saving changes, month transitions, and year boundaries.

* **Documentation**
  * Updated notification documentation to describe calendar-date scheduling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->