### PR TITLE
fix: buffer domain logs and omit routine identity details

### DIFF
--- a/changelog.d/2026-09-05-buffer-domain-logs.md
+++ b/changelog.d/2026-09-05-buffer-domain-logs.md
@@ -2,5 +2,8 @@
 - **Diagnostic logging causes fewer disk writes.** Domain logs now share the
   buffered writer and shutdown flush used by other logs, while errors still
   request an immediate flush. Routine logging bursts have a bounded queue with
-  counted summaries for omitted records. Sync and recording logs also omit account
-  identities, device names and absolute recording paths.
+  counted summaries for omitted records. Sync and recording logs also omit
+  account identities, device names and absolute recording paths.
+- **Delayed log writes stay with their original profile.** Switching profiles
+  while disk writes are blocked no longer sends older buffered records into
+  the newly selected profile.

--- a/changelog.d/2026-09-05-buffer-domain-logs.md
+++ b/changelog.d/2026-09-05-buffer-domain-logs.md
@@ -1,0 +1,5 @@
+### Fixed
+- **Diagnostic logging causes fewer disk writes.** Domain logs now share the
+  buffered writer and shutdown flush used by other logs, while errors still
+  request an immediate flush. Routine sync and recording logs also omit account
+  identities, device names and absolute recording paths.

--- a/changelog.d/2026-09-05-buffer-domain-logs.md
+++ b/changelog.d/2026-09-05-buffer-domain-logs.md
@@ -1,5 +1,6 @@
 ### Fixed
 - **Diagnostic logging causes fewer disk writes.** Domain logs now share the
   buffered writer and shutdown flush used by other logs, while errors still
-  request an immediate flush. Routine sync and recording logs also omit account
+  request an immediate flush. Routine logging bursts have a bounded queue with
+  counted summaries for omitted records. Sync and recording logs also omit account
   identities, device names and absolute recording paths.

--- a/knowledge/architecture/bootstrap-and-di.md
+++ b/knowledge/architecture/bootstrap-and-di.md
@@ -5,9 +5,13 @@ description: How the app starts, which singletons GetIt owns, and why registrati
 resource: ../../lib/get_it.dart
 tags: [architecture, startup, dependency-injection, get-it, riverpod]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-08-06T15:25:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-05T16:05:00Z }
 stale_after: 2027-01-11
 sources:
+  - id: app-bootstrap
+    resource: ../../lib/app_bootstrap.dart
+    title: Per-generation service registration
+    last_modified: 2026-09-05
   - id: main
     resource: ../../lib/main.dart
     title: main() entry point
@@ -33,7 +37,7 @@ arbitrary.
 
 | Container | Holds | Lifetime |
 |-----------|-------|----------|
-| **GetIt** (`getIt`) | Process-wide services and database handles that exist before any widget does: `JournalDb`, `MatrixService`, `OutboxService`, `LoggingService`, `PersistenceLogic`. | Registered during startup, disposed at process exit. |
+| **GetIt** (`getIt`) | Profile services and database handles constructed before their widget tree: `JournalDb`, `MatrixService`, `OutboxService`, `LoggingService`, `PersistenceLogic`. | Registered per service generation, disposed on profile switch or process shutdown. |
 | **Riverpod** (`ProviderScope`) | Everything scoped to the widget tree: controllers, repositories built on top of GetIt services, UI state. | Created on first watch, disposed with its scope. |
 
 The rule that falls out of this: **Riverpod providers may resolve GetIt
@@ -74,10 +78,12 @@ ProviderScope(
 # Startup sequence
 
 The bootstrap is split along the profile-switch boundary
-(`lib/app_bootstrap.dart`): `registerProcessLogging()` and
-`initPlatformOnce()` run exactly once per process, while
-`resolveActiveProfile()` + `bootstrapProfileServices()` run once per service
-generation — on cold boot and again after every in-app profile switch.
+(`lib/app_bootstrap.dart`): `initPlatformOnce()` runs exactly once per process.
+`registerProcessLogging()`, `resolveActiveProfile()`, and
+`bootstrapProfileServices()` run once per service generation — on cold boot
+and again after every in-app profile switch. Each generation has its own
+logging pair; destination binding is described in
+[logging and diagnostics](logging-and-diagnostics.md).
 
 ```mermaid
 flowchart TD

--- a/knowledge/architecture/logging-and-diagnostics.md
+++ b/knowledge/architecture/logging-and-diagnostics.md
@@ -65,13 +65,15 @@ there is no separate registry to keep in step.
 flowchart TD
   Log["DomainLogger.log(domain, ...)"] --> Enabled{"domain flag enabled?"}
   Enabled -->|no| Drop["dropped"]
-  Enabled -->|non-sync| General["general app log for the day"]
+  Enabled -->|yes| RoutineRoute{"domain routes to the sync file?"}
+  RoutineRoute -->|yes| SyncLog["sync-YYYY-MM-DD.log"]
+  RoutineRoute -->|no| General["general app log for the day"]
+  RoutineRoute -->|no| DomainLog["&lt;domain&gt;-YYYY-MM-DD.log"]
   Err["DomainLogger.error(...)"] --> General2["general app log + error-YYYY-MM-DD.log<br/>full text, force-flushed"]
   Err --> Safe["error-safe-YYYY-MM-DD.log<br/>no raw error, no stack trace<br/>message kept verbatim"]
-  Enabled -->|yes| PerDomain
   Err --> PerDomain{"domain routes to the sync file?"}
-  PerDomain -->|yes| SyncLog["sync-YYYY-MM-DD.log"]
-  PerDomain -->|no| DomainLog["&lt;domain&gt;-YYYY-MM-DD.log"]
+  PerDomain -->|yes| SyncLog
+  PerDomain -->|no| DomainLog
 ```
 
 **An error reaches two to four files**, depending on its domain: the general log,
@@ -134,8 +136,11 @@ startup, so a toggle takes effect immediately rather than at next launch.
 `LoggingService` owns the shared file sink for general, sync, per-domain and
 safe-error files. Routine lines are buffered per file stem and flushed on a
 **500 ms** timer or after **40 lines**. Domain logging no longer creates a
-synchronous, force-flushed disk write for every event. Error lines bypass the
-timer and request a durable flush; per-file drains serialize appends and
+synchronous, force-flushed disk write for every event. Queued routine payloads
+are capped at 1,048,576 UTF-16 code units per file, including batches waiting
+behind active disk I/O. Excess routine records are omitted with a counted
+summary, and the budget is released after each write completes or fails.
+Error records bypass this limit and the timer and request a durable flush; per-file drains serialize appends and
 `LoggingService.flush()` waits for every destination during orderly shutdown.
 
 Files are named `<stem>-<yyyy-MM-dd>.log`, using the date at write time. In the

--- a/knowledge/architecture/logging-and-diagnostics.md
+++ b/knowledge/architecture/logging-and-diagnostics.md
@@ -76,7 +76,7 @@ flowchart TD
   PerDomain -->|no| DomainLog
 ```
 
-**An error reaches two to four files**, depending on its domain: the general log,
+**A production `DomainLogger.error` call targets four files**: the general log,
 the full `error-<date>.log` mirror, the PII-safe `error-safe-<date>.log`, and then
 either the shared `sync-<date>.log` or its own `<domain>-<date>.log`.
 
@@ -122,14 +122,15 @@ its pending count before removing the state. This preserves both the diagnostic
 context and evidence of a rebuild loop without allowing one framework
 exception to generate an unbounded error file.
 
-**`sync` is the one domain that routes to its own file.** It is off by default
-and far noisier than everything else — a catch-up can produce thousands of lines
-in a second — so it goes to `sync-<date>.log` where it can be read in isolation
-without burying the rest.
+**Routine `sync` events omit the general log.** Sync is off by default;
+a catch-up can produce thousands of lines in a second. Those events go to
+`sync-<date>.log` without burying the rest of the app's general telemetry.
 
 Flags are toggled in *Settings → Advanced → Logging Domains* and stored as
-config flags in `JournalDb`. `LoggingService.listenToConfigFlag()` subscribes at
-startup, so a toggle takes effect immediately rather than at next launch.
+config flags in `JournalDb`. `domainLoggerProvider` listens to each domain flag
+and updates the shared logger in place without restarting the agent runtime.
+`LoggingService.listenToConfigFlag()` separately tracks the general logging and
+slow-query flags, so these gates also update without a restart.
 
 # File writing is batched
 

--- a/knowledge/architecture/logging-and-diagnostics.md
+++ b/knowledge/architecture/logging-and-diagnostics.md
@@ -5,7 +5,7 @@ description: Twenty-four opt-in logging domains, where their lines land, and why
 resource: ../../lib/services/logging_domains.dart
 tags: [architecture, logging, diagnostics, observability]
 status: stable
-generated: { by: codex/gpt-5, at: 2026-08-01T16:29:35Z }
+generated: { by: codex/gpt-6, at: 2026-09-05T14:55:00Z }
 stale_after: 2027-01-11
 sources:
   - id: log-domains
@@ -15,11 +15,11 @@ sources:
   - id: logging-service
     resource: ../../lib/services/logging_service.dart
     title: LoggingService
-    last_modified: 2026-07-12
+    last_modified: 2026-09-05
   - id: domain-logging
     resource: ../../lib/services/domain_logging.dart
     title: DomainLogger
-    last_modified: 2026-08-01
+    last_modified: 2026-09-05
   - id: framework-errors
     resource: ../../lib/main.dart
     title: Flutter framework error handler
@@ -65,7 +65,7 @@ there is no separate registry to keep in step.
 flowchart TD
   Log["DomainLogger.log(domain, ...)"] --> Enabled{"domain flag enabled?"}
   Enabled -->|no| Drop["dropped"]
-  Enabled -->|yes| General["general app log for the day"]
+  Enabled -->|non-sync| General["general app log for the day"]
   Err["DomainLogger.error(...)"] --> General2["general app log + error-YYYY-MM-DD.log<br/>full text, force-flushed"]
   Err --> Safe["error-safe-YYYY-MM-DD.log<br/>no raw error, no stack trace<br/>message kept verbatim"]
   Enabled -->|yes| PerDomain
@@ -131,10 +131,22 @@ startup, so a toggle takes effect immediately rather than at next launch.
 
 # File writing is batched
 
-Log lines are buffered per file stem and flushed on a **500 ms** timer rather
-than written synchronously. Files are named `<stem>-<yyyy-MM-dd>.log`, so a day
-is one file and rotation is implicit. In the test environment file writing is
-skipped entirely — tests assert on the logger, not on disk.
+`LoggingService` owns the shared file sink for general, sync, per-domain and
+safe-error files. Routine lines are buffered per file stem and flushed on a
+**500 ms** timer or after **40 lines**. Domain logging no longer creates a
+synchronous, force-flushed disk write for every event. Error lines bypass the
+timer and request a durable flush; per-file drains serialize appends and
+`LoggingService.flush()` waits for every destination during orderly shutdown.
+
+Files are named `<stem>-<yyyy-MM-dd>.log`, using the date at write time. In the
+test environment `DomainLogger` skips its additional file destinations;
+`LoggingService` uses a synchronous sink for deterministic legacy file tests.
+File-sink integration tests exercise production buffering explicitly.
+
+Routine Matrix initialization logs readiness without account IDs, device IDs
+or device names. Recorder start/delete telemetry omits absolute paths while
+retaining recording configuration for diagnosis. Full exception diagnostics
+remain available locally under the error policy above.
 
 # Slow queries
 

--- a/knowledge/architecture/logging-and-diagnostics.md
+++ b/knowledge/architecture/logging-and-diagnostics.md
@@ -139,10 +139,22 @@ safe-error files. Routine lines are buffered per file stem and flushed on a
 **500 ms** timer or after **40 lines**. Domain logging no longer creates a
 synchronous, force-flushed disk write for every event. Queued routine payloads
 are capped at 1,048,576 UTF-16 code units per file, including batches waiting
-behind active disk I/O. Excess routine records are omitted with a counted
-summary, and the budget is released after each write completes or fails.
-Error records bypass this limit and the timer and request a durable flush; per-file drains serialize appends and
-`LoggingService.flush()` waits for every destination during orderly shutdown.
+behind active disk I/O. Excess routine records remain an aggregate counter
+behind at most one queued or in-flight summary per destination. The summary
+reads that counter when its write starts, so prolonged disk stalls cannot
+accumulate a separate summary for every timer window. Drops arriving during
+that write produce at most one successor summary. The payload budget is
+released after each write completes or fails.
+Error records bypass this limit and the timer and request a durable flush;
+per-file drains serialize appends. `LoggingService.flush()` waits until every
+destination is stable and empty, including successor summaries created while
+an earlier write finishes during orderly shutdown.
+
+Each logger lazily binds to the first registered documents directory observed
+at record admission. Bootstrap can construct it before that registration;
+unbound early records retry resolution when their drain runs. A profile switch
+creates a fresh logging pair, while queued and buffered writes in the outgoing
+instance retain its original destination even if its final flush times out.
 
 Files are named `<stem>-<yyyy-MM-dd>.log`, using the date at write time. In the
 test environment `DomainLogger` skips its additional file destinations;

--- a/lib/app_bootstrap.dart
+++ b/lib/app_bootstrap.dart
@@ -46,17 +46,15 @@ import 'package:window_manager/window_manager.dart';
 
 /// The bootstrap is split along the profile-switch boundary:
 ///
-/// - [registerProcessLogging] and [initPlatformOnce] run exactly once per
-///   process. They own state that must survive a profile switch (log sinks
-///   flush per-write against the active root; native inits are not
-///   re-runnable).
-/// - [resolveActiveProfile] and [bootstrapProfileServices] run once per
-///   service generation: on cold boot and again after every profile switch,
-///   re-pointing the entire documents/database layer at the active world.
+/// - [initPlatformOnce] runs once per process for native initialization that
+///   cannot safely be repeated during a profile switch.
+/// - [registerProcessLogging], [resolveActiveProfile], and
+///   [bootstrapProfileServices] run once per service generation: on cold boot
+///   and again after every profile switch, rebuilding logging and profile stores.
 
-/// Registers the process-lifetime logging pair. LoggingService resolves its
-/// log directory per write via the registered `Directory`, so a single
-/// instance follows the active profile across switches.
+/// Registers the logging pair for the next service generation. The profile
+/// directory is registered later; the sink binds lazily when a root becomes
+/// available and keeps that destination for any delayed writes after teardown.
 void registerProcessLogging() {
   final loggingService = LoggingService();
   getIt
@@ -171,7 +169,7 @@ class AppLifecycleHolder {
 /// Per-generation service bootstrap: registers the world-scoped singletons
 /// for the active profile and runs the full [registerSingletons] sequence
 /// against its root. Runs on cold boot and after every profile switch;
-/// expects getIt to contain only the process-lifetime registrations.
+/// expects the generation's logging pair to be registered already.
 Future<ProfileContext> bootstrapProfileServices(
   ProfileBootInfo info, {
   required AppLifecycleHolder lifecycleHolder,

--- a/lib/features/speech/repository/audio_recorder_repository.dart
+++ b/lib/features/speech/repository/audio_recorder_repository.dart
@@ -168,7 +168,7 @@ class AudioRecorderRepository {
 
       _loggingService.log(
         LogDomain.speech,
-        'Starting audio recording: path=$filePath, sampleRate=$sampleRate, autoGain=$autoGain, isLinux=${Platform.isLinux}, isFlatpak=${PortalService.shouldUsePortal}',
+        'Starting audio recording: sampleRate=$sampleRate, autoGain=$autoGain, isLinux=${Platform.isLinux}, isFlatpak=${PortalService.shouldUsePortal}',
         subDomain: AudioRecorderConstants.startRecordingSubdomain,
       );
 
@@ -236,7 +236,7 @@ class AudioRecorderRepository {
         await file.delete();
         _loggingService.log(
           LogDomain.speech,
-          'Deleted cancelled recording: $filePath',
+          'Deleted cancelled recording',
           subDomain: AudioRecorderConstants.deleteRecordingSubdomain,
         );
       }

--- a/lib/features/sync/matrix/matrix_service.dart
+++ b/lib/features/sync/matrix/matrix_service.dart
@@ -317,8 +317,7 @@ class MatrixService {
 
     _loggingService.log(
       LogDomain.sync,
-      'MatrixService initialized - deviceId: ${client.deviceID}, '
-      'deviceName: ${client.deviceName}, userId: ${client.userID}',
+      'MatrixService initialized',
       subDomain: 'init',
     );
   }

--- a/lib/services/domain_logging.dart
+++ b/lib/services/domain_logging.dart
@@ -1,12 +1,9 @@
 import 'dart:collection';
-import 'dart:io';
 
 import 'package:clock/clock.dart';
-import 'package:intl/intl.dart';
 import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/services/logging_domains.dart';
 import 'package:lotti/services/logging_service.dart';
-import 'package:lotti/utils/file_utils.dart';
 import 'package:lotti/utils/platform.dart';
 
 export 'package:lotti/services/logging_domains.dart';
@@ -35,7 +32,6 @@ class DomainLogger {
   DomainLogger({required this._loggingService});
 
   final LoggingService _loggingService;
-  static final _dateFmt = DateFormat('yyyy-MM-dd');
 
   static const int _sampleStateCapacity = 256;
   final LinkedHashMap<String, _LogSampleState> _sampleStates =
@@ -256,6 +252,7 @@ class DomainLogger {
       fileStem: domain,
       line: '${_now()} [$level]$sd: $message',
       stackTrace: stackTrace,
+      forceFlush: level == 'ERROR',
     );
   }
 
@@ -274,39 +271,25 @@ class DomainLogger {
       fileStem: fileStem,
       line: '${_now()} [$level] $domain$sd: $message',
       stackTrace: stackTrace,
+      forceFlush: level == 'ERROR',
     );
   }
 
   String _now() => clock.now().toIso8601String();
 
-  /// Best-effort synchronous append. File-sink errors are swallowed so logging
-  /// never interferes with app flows. Skipped entirely in test environments.
+  /// Uses the shared buffered sink so shutdown drains every destination.
   void _writeLine({
     required String fileStem,
     required String line,
     StackTrace? stackTrace,
+    bool forceFlush = false,
   }) {
     if (isTestEnv) return;
-    try {
-      final dir = getDocumentsDirectory();
-      final logDir = Directory('${dir.path}/logs');
-      if (!logDir.existsSync()) {
-        logDir.createSync(recursive: true);
-      }
-      final date = _dateFmt.format(DateTime.now());
-      final file = File('${logDir.path}/$fileStem-$date.log');
-      final buffer = StringBuffer(line)..writeln();
-      if (stackTrace != null) {
-        buffer.writeln(stackTrace);
-      }
-      file.writeAsStringSync(
-        buffer.toString(),
-        mode: FileMode.append,
-        flush: true,
-      );
-    } catch (_) {
-      // Swallow file-sink errors.
-    }
+    _loggingService.captureFileLine(
+      fileStem,
+      stackTrace == null ? line : '$line\n$stackTrace',
+      forceFlush: forceFlush,
+    );
   }
 
   // ── PII scrubbing helpers ───────────────────────────────────────────────

--- a/lib/services/logging_service.dart
+++ b/lib/services/logging_service.dart
@@ -136,6 +136,21 @@ class LoggingService {
     await _slowQueryFlagSubscription?.cancel();
   }
 
+  /// Appends an already formatted domain or safe-error line to the shared sink.
+  ///
+  /// DomainLogger owns the domain gate. Errors bypass that gate and request an
+  /// immediate durable write; routine lines use the same batching as app logs.
+  /// All destinations participate in [flush] during orderly shutdown.
+  void captureFileLine(
+    String fileStem,
+    String line, {
+    bool forceFlush = false,
+  }) {
+    final future = _appendToNamedFile(fileStem, line, forceFlush: forceFlush);
+    _pendingWrites.add(future);
+    unawaited(future.whenComplete(() => _pendingWrites.remove(future)));
+  }
+
   // --- Text file sink -----------------------------------------------------
   Future<void> _appendToNamedFile(
     String fileStem,

--- a/lib/services/logging_service.dart
+++ b/lib/services/logging_service.dart
@@ -19,6 +19,9 @@ class LoggingService {
   final _dateFmt = DateFormat('yyyy-MM-dd');
   static const Duration _fileFlushInterval = Duration(milliseconds: 500);
   static const int _fileFlushLineThreshold = 40;
+  // Includes pending lines and payloads queued behind an active disk write.
+  // Error records bypass this routine-telemetry limit to retain diagnostics.
+  static const int _maxQueuedFileCharacters = 1024 * 1024;
   static const String _generalLogStem = 'lotti';
   static const String _syncLogStem = 'sync';
 
@@ -33,6 +36,8 @@ class LoggingService {
   final Map<String, List<String>> _pendingFileLinesByStem =
       <String, List<String>>{};
   final Map<String, Timer> _fileFlushTimers = <String, Timer>{};
+  final _queuedFileCharacters = <String, int>{};
+  final _droppedFileLines = <String, int>{};
 
   /// Seam for scheduling the buffered-flush timer. Defaults to the real
   /// [Timer] constructor; tests override it so the 500 ms flush path can be
@@ -165,7 +170,20 @@ class LoggingService {
     final pendingLines = _pendingFileLinesByStem.putIfAbsent(
       fileStem,
       () => <String>[],
-    )..add(line);
+    );
+    final queuedCharacters = _queuedFileCharacters[fileStem] ?? 0;
+    final lineCharacters = line.length + 1;
+    if (!forceFlush &&
+        queuedCharacters + lineCharacters > _maxQueuedFileCharacters) {
+      _droppedFileLines.update(
+        fileStem,
+        (count) => count + 1,
+        ifAbsent: () => 1,
+      );
+    } else {
+      pendingLines.add(line);
+      _queuedFileCharacters[fileStem] = queuedCharacters + lineCharacters;
+    }
     final shouldFlushNow =
         forceFlush || pendingLines.length >= _fileFlushLineThreshold;
 
@@ -205,12 +223,23 @@ class LoggingService {
     bool forceFlush = false,
   }) async {
     final pendingLines = _pendingFileLinesByStem[fileStem];
-    if (pendingLines == null || pendingLines.isEmpty) {
+    final dropped = _droppedFileLines.remove(fileStem) ?? 0;
+    if ((pendingLines == null || pendingLines.isEmpty) && dropped == 0) {
       return;
     }
 
-    final lines = List<String>.from(pendingLines);
-    pendingLines.clear();
+    final lines = List<String>.of(pendingLines ?? const <String>[]);
+    final queuedCharacters = lines.fold<int>(
+      0,
+      (count, line) => count + line.length + 1,
+    );
+    pendingLines?.clear();
+    if (dropped > 0) {
+      lines.add(
+        '${DateTime.now().toIso8601String()} [WARN] logging: '
+        'routine buffer capacity exceeded dropped=$dropped',
+      );
+    }
 
     final currentDrain = _fileDrains[fileStem] ?? Future<void>.value();
     final nextDrain = currentDrain.then((_) async {
@@ -228,6 +257,14 @@ class LoggingService {
         );
       } catch (_) {
         // Swallow file-sink errors so logging never interferes with app flows.
+      } finally {
+        final remaining =
+            (_queuedFileCharacters[fileStem] ?? 0) - queuedCharacters;
+        if (remaining == 0) {
+          _queuedFileCharacters.remove(fileStem);
+        } else {
+          _queuedFileCharacters[fileStem] = remaining;
+        }
       }
     });
     _fileDrains[fileStem] = nextDrain;

--- a/lib/services/logging_service.dart
+++ b/lib/services/logging_service.dart
@@ -17,6 +17,10 @@ class LoggingService {
   bool _enableLogging = !isTestEnv;
   bool _enableSlowQueryLogging = false;
   final _dateFmt = DateFormat('yyyy-MM-dd');
+  Directory? _documentsDirectory;
+
+  Directory _resolveDocumentsDirectory() =>
+      _documentsDirectory ??= getDocumentsDirectory();
   static const Duration _fileFlushInterval = Duration(milliseconds: 500);
   static const int _fileFlushLineThreshold = 40;
   // Includes pending lines and payloads queued behind an active disk write.
@@ -38,6 +42,9 @@ class LoggingService {
   final Map<String, Timer> _fileFlushTimers = <String, Timer>{};
   final _queuedFileCharacters = <String, int>{};
   final _droppedFileLines = <String, int>{};
+  // One queued/in-flight loss summary per destination, regardless of how many
+  // timer windows overflow while disk I/O is blocked.
+  final _queuedDropSummaries = <String>{};
 
   /// Seam for scheduling the buffered-flush timer. Defaults to the real
   /// [Timer] constructor; tests override it so the 500 ms flush path can be
@@ -162,6 +169,15 @@ class LoggingService {
     String line, {
     bool forceFlush = false,
   }) async {
+    // Bootstrap constructs logging before registering the profile directory.
+    // Bind once it is available, at admission rather than delayed disk I/O,
+    // so a timed-out old drain cannot follow GetIt into a new profile.
+    try {
+      _resolveDocumentsDirectory();
+    } catch (_) {
+      // Early bootstrap records may precede registration. The drain retries
+      // resolution, preserving the existing best-effort startup behavior.
+    }
     if (isTestEnv) {
       _appendToNamedFileSync(fileStem, line);
       return;
@@ -204,7 +220,7 @@ class LoggingService {
 
   void _appendToNamedFileSync(String fileStem, String line) {
     try {
-      final dir = getDocumentsDirectory();
+      final dir = _resolveDocumentsDirectory();
       final logDir = Directory(p.join(dir.path, 'logs'));
       final fileName = '$fileStem-${_dateFmt.format(DateTime.now())}.log';
       final file = File(p.join(logDir.path, fileName));
@@ -223,8 +239,10 @@ class LoggingService {
     bool forceFlush = false,
   }) async {
     final pendingLines = _pendingFileLinesByStem[fileStem];
-    final dropped = _droppedFileLines.remove(fileStem) ?? 0;
-    if ((pendingLines == null || pendingLines.isEmpty) && dropped == 0) {
+    final includeDropSummary =
+        (_droppedFileLines[fileStem] ?? 0) > 0 &&
+        _queuedDropSummaries.add(fileStem);
+    if ((pendingLines == null || pendingLines.isEmpty) && !includeDropSummary) {
       return;
     }
 
@@ -234,17 +252,21 @@ class LoggingService {
       (count, line) => count + line.length + 1,
     );
     pendingLines?.clear();
-    if (dropped > 0) {
-      lines.add(
-        '${DateTime.now().toIso8601String()} [WARN] logging: '
-        'routine buffer capacity exceeded dropped=$dropped',
-      );
-    }
-
     final currentDrain = _fileDrains[fileStem] ?? Future<void>.value();
     final nextDrain = currentDrain.then((_) async {
       try {
-        final dir = getDocumentsDirectory();
+        // Read the counter only when this drain reaches the disk, so repeated
+        // overflow windows share one marker instead of retaining many strings.
+        final dropped = includeDropSummary
+            ? (_droppedFileLines.remove(fileStem) ?? 0)
+            : 0;
+        if (dropped > 0) {
+          lines.add(
+            '${DateTime.now().toIso8601String()} [WARN] logging: '
+            'routine buffer capacity exceeded dropped=$dropped',
+          );
+        }
+        final dir = _resolveDocumentsDirectory();
         final logDir = Directory(p.join(dir.path, 'logs'));
         final fileName = '$fileStem-${_dateFmt.format(DateTime.now())}.log';
         final file = File(p.join(logDir.path, fileName));
@@ -265,6 +287,14 @@ class LoggingService {
         } else {
           _queuedFileCharacters[fileStem] = remaining;
         }
+        if (includeDropSummary) {
+          _queuedDropSummaries.remove(fileStem);
+          if ((_droppedFileLines[fileStem] ?? 0) > 0) {
+            // Overflow can arrive while the summary itself is being written.
+            // Queue one successor without awaiting our own drain chain.
+            unawaited(_flushPendingLines(fileStem, forceFlush: forceFlush));
+          }
+        }
       }
     });
     _fileDrains[fileStem] = nextDrain;
@@ -278,20 +308,29 @@ class LoggingService {
   /// timer are not lost when `_exit(0)` terminates the process before the
   /// timer fires.
   Future<void> flush() async {
-    // Await all tracked unawaited writes (captureEvent / captureException).
-    // Snapshot first since whenComplete callbacks remove items during iteration.
-    await Future.wait(List<Future<void>>.of(_pendingWrites));
-    // Cancel any pending timer-based flushes and drain remaining lines.
-    for (final entry in _fileFlushTimers.entries.toList()) {
-      entry.value.cancel();
+    while (true) {
+      // Callbacks can enqueue a final loss summary as a blocked write drains.
+      // Keep taking snapshots until every destination is stable and empty.
+      await Future.wait(List<Future<void>>.of(_pendingWrites));
+      for (final timer in _fileFlushTimers.values.toList()) {
+        timer.cancel();
+      }
+      _fileFlushTimers.clear();
+      for (final stem in _pendingFileLinesByStem.keys.toList()) {
+        await _flushPendingLines(stem, forceFlush: true);
+      }
+      final drains = Map<String, Future<void>>.of(_fileDrains);
+      await Future.wait(drains.values);
+      if (_pendingWrites.isEmpty &&
+          _pendingFileLinesByStem.values.every((lines) => lines.isEmpty) &&
+          _droppedFileLines.isEmpty &&
+          _queuedDropSummaries.isEmpty &&
+          _fileDrains.entries.every(
+            (entry) => identical(drains[entry.key], entry.value),
+          )) {
+        break;
+      }
     }
-    _fileFlushTimers.clear();
-    for (final stem in _pendingFileLinesByStem.keys.toList()) {
-      await _flushPendingLines(stem, forceFlush: true);
-    }
-    // A timer callback may already have moved its lines into an active drain.
-    // Wait for those writes as well so shutdown cannot return before disk IO.
-    await Future.wait(List<Future<void>>.of(_fileDrains.values));
     await SlowQueryInterceptor.flushPendingFileWrites();
   }
 

--- a/test/features/speech/repository/audio_recorder_repository_test.dart
+++ b/test/features/speech/repository/audio_recorder_repository_test.dart
@@ -347,7 +347,12 @@ void main() {
         verify(
           () => mockDomainLogger.log(
             LogDomain.speech,
-            any<String>(that: contains('Deleted cancelled recording')),
+            any<String>(
+              that: allOf(
+                contains('Deleted cancelled recording'),
+                isNot(contains(tempDir.path)),
+              ),
+            ),
             subDomain: AudioRecorderConstants.deleteRecordingSubdomain,
           ),
         ).called(1);
@@ -480,14 +485,16 @@ void main() {
             path: any(named: 'path'),
           ),
         ).called(1);
-        // log is called twice: "Starting..." then "Audio recording started successfully"
-        verify(
+        final messages = verify(
           () => mockDomainLogger.log(
             LogDomain.speech,
-            any<String>(),
+            captureAny<String>(),
             subDomain: AudioRecorderConstants.startRecordingSubdomain,
           ),
-        ).called(2);
+        ).captured.cast<String>();
+        expect(messages, hasLength(2));
+        expect(messages.first, contains('sampleRate='));
+        expect(messages.join(), isNot(contains(tempDir.path)));
       },
     );
 

--- a/test/features/sync/matrix/matrix_service_test.dart
+++ b/test/features/sync/matrix/matrix_service_test.dart
@@ -433,7 +433,7 @@ void main() {
 
     // Covers lines 301-306: init() logs the initialized banner after wiring
     // the sync engine, config load, connect, and queue pipeline start.
-    test('init logs initialized banner with device and user ids', () async {
+    test('init logs readiness without account or device identity', () async {
       when(
         () => syncEngine.initialize(
           onLogin: any(named: 'onLogin'),
@@ -460,8 +460,10 @@ void main() {
           LogDomain.sync,
           any(
             that: allOf(
-              contains('DEVICE1'),
-              contains('@me:server'),
+              contains('MatrixService initialized'),
+              isNot(contains('DEVICE1')),
+              isNot(contains('@me:server')),
+              isNot(contains('Lotti')),
             ),
           ),
           subDomain: 'init',

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' as io;
 
 import 'package:beamer/beamer.dart';
 import 'package:device_info_plus/device_info_plus.dart';
@@ -1580,3 +1581,7 @@ class MockOrtSession extends Mock implements OrtSession {}
 class MockOnnxRuntime extends Mock implements OnnxRuntime {}
 
 class MockSupertonicTtsSession extends Mock implements SupertonicTtsSession {}
+
+class MockIoFile extends Mock implements io.File {}
+
+class MockIoDirectory extends Mock implements io.Directory {}

--- a/test/services/domain_logging_test.dart
+++ b/test/services/domain_logging_test.dart
@@ -6,11 +6,13 @@ import 'package:glados/glados.dart' as glados;
 import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/domain_logging.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/platform.dart' as platform_utils;
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 
 import '../mocks/mocks.dart';
+import '../widget_test_utils.dart';
 
 class _GeneratedId {
   const _GeneratedId({
@@ -362,7 +364,7 @@ void main() {
   // ---------------------------------------------------------------------------
   group('DomainLogger file sink (non-test-env)', () {
     late Directory tempDocs;
-    late MockLoggingService mockLoggingService;
+    late LoggingService loggingService;
     late DomainLogger logger;
 
     File? findLogFile(String prefix) {
@@ -386,35 +388,52 @@ void main() {
         }
       });
 
-      await getIt.reset();
-      getIt.registerSingleton<Directory>(tempDocs);
-
-      mockLoggingService = MockLoggingService();
-      stubLoggingService(mockLoggingService);
-      logger = DomainLogger(loggingService: mockLoggingService);
+      await setUpTestGetIt(
+        additionalSetup: () => getIt.registerSingleton<Directory>(tempDocs),
+      );
+      loggingService = getIt<LoggingService>();
+      logger = getIt<DomainLogger>();
     });
 
     tearDown(() async {
-      await getIt.reset();
+      await loggingService.flush();
+      await tearDownTestGetIt();
     });
 
-    test('log writes message to domain log file when domain is enabled', () {
+    test('routine domain lines wait for the shared shutdown flush', () async {
       logger.enabledDomains.add(LogDomain.agentRuntime);
-
-      logger.log(LogDomain.agentRuntime, 'file sink message');
-
-      final logFile = findLogFile('agentRuntime-');
-      expect(
-        logFile,
-        isNotNull,
-        reason: 'Domain log file should have been created',
-      );
-      final content = logFile!.readAsStringSync();
-      expect(content, contains('[INFO]'));
-      expect(content, contains('file sink message'));
+      logger
+        ..log(LogDomain.agentRuntime, 'first buffered event')
+        ..log(LogDomain.agentRuntime, 'second buffered event');
+      expect(findLogFile('agentRuntime-'), isNull);
+      await loggingService.flush();
+      final lines = findLogFile('agentRuntime-')!.readAsLinesSync();
+      expect(lines, hasLength(2));
+      expect(lines[0], contains('first buffered event'));
+      expect(lines[1], contains('second buffered event'));
     });
 
-    test('log writes subDomain and custom level to domain log file', () {
+    test(
+      'log writes message to domain log file when domain is enabled',
+      () async {
+        logger.enabledDomains.add(LogDomain.agentRuntime);
+
+        logger.log(LogDomain.agentRuntime, 'file sink message');
+
+        await loggingService.flush();
+        final logFile = findLogFile('agentRuntime-');
+        expect(
+          logFile,
+          isNotNull,
+          reason: 'Domain log file should have been created',
+        );
+        final content = logFile!.readAsStringSync();
+        expect(content, contains('[INFO]'));
+        expect(content, contains('file sink message'));
+      },
+    );
+
+    test('log writes subDomain and custom level to domain log file', () async {
       logger.enabledDomains.add(LogDomain.agentWorkflow);
 
       logger.log(
@@ -424,6 +443,7 @@ void main() {
         level: InsightLevel.warn,
       );
 
+      await loggingService.flush();
       final logFile = findLogFile('agentWorkflow-');
       expect(
         logFile,
@@ -436,7 +456,7 @@ void main() {
       expect(content, contains('sub-domain log'));
     });
 
-    test('error writes full description to domain log file', () {
+    test('error writes full description to domain log file', () async {
       final exception = Exception('disk full');
       logger.error(
         LogDomain.agentRuntime,
@@ -444,6 +464,7 @@ void main() {
         message: 'write failed',
       );
 
+      await loggingService.flush();
       final domainFile = findLogFile('agentRuntime-');
       expect(
         domainFile,
@@ -456,7 +477,7 @@ void main() {
       expect(content, contains('disk full'));
     });
 
-    test('error appends stackTrace lines to domain log file', () {
+    test('error appends stackTrace lines to domain log file', () async {
       final stackTrace = StackTrace.fromString(
         '#0  fake_frame (package:lotti/fake.dart:1:1)',
       );
@@ -466,6 +487,7 @@ void main() {
         stackTrace: stackTrace,
       );
 
+      await loggingService.flush();
       final logFile = findLogFile('agentRuntime-');
       expect(logFile, isNotNull);
       final content = logFile!.readAsStringSync();
@@ -473,7 +495,7 @@ void main() {
       expect(content, contains('fake_frame'));
     });
 
-    test('error keeps diagnostics out of the PII-safe log file', () {
+    test('error keeps diagnostics out of the PII-safe log file', () async {
       final exception = Exception('secret user content');
       logger.errorWithDiagnostics(
         LogDomain.agentRuntime,
@@ -482,6 +504,7 @@ void main() {
         diagnostics: 'widget: private journal title',
       );
 
+      await loggingService.flush();
       final safeFile = findLogFile('error-safe-');
       expect(
         safeFile,
@@ -504,25 +527,28 @@ void main() {
       );
     });
 
-    test('error for sync domain skips domain log file but writes safe log', () {
+    test('sync error is written once alongside its safe mirror', () async {
       logger.error(
         LogDomain.sync,
         'sync error',
       );
 
-      // sync domain routes to the shared sync file, not a domain log file
+      await loggingService.flush();
       final domainFile = findLogFile('sync-');
-      // There is no per-domain file written for sync (routesToSyncFile == true)
       // The PII-safe log should still be created.
       final safeFile = findLogFile('error-safe-');
       expect(safeFile, isNotNull, reason: 'PII-safe error log always written');
       final safeContent = safeFile!.readAsStringSync();
       expect(safeContent, contains('sync'));
-      // domain log file should not exist (no _appendToDomainFile call for sync)
-      expect(domainFile, isNull, reason: 'sync domain skips per-domain file');
+      expect(
+        domainFile!.readAsLinesSync().where(
+          (line) => line.contains('sync error'),
+        ),
+        hasLength(1),
+      );
     });
 
-    test('_writeLine swallows file-sink errors gracefully', () {
+    test('_writeLine swallows file-sink errors gracefully', () async {
       // Point getIt at a path that cannot be created (a file used as dir).
       File(p.join(tempDocs.path, 'logs')).createSync();
 

--- a/test/services/logging_service_test.dart
+++ b/test/services/logging_service_test.dart
@@ -765,6 +765,67 @@ void main() {
     File? findSyncLog() => _findLogFile(bufferedTempDocs, prefix: 'sync-');
 
     test(
+      'bounds queued routine payloads and retains errors under pressure',
+      () async {
+        final payload = 'x' * 10000;
+        for (var i = 0; i < 200; i++) {
+          bufferedLogging.captureFileLine('bounded', 'record-$i $payload');
+        }
+        bufferedLogging.captureFileLine(
+          'bounded',
+          'important failure',
+          forceFlush: true,
+        );
+        await bufferedLogging.flush();
+        final lines = _findLogFile(
+          bufferedTempDocs,
+          prefix: 'bounded-',
+        )!.readAsLinesSync();
+        final records = lines
+            .where((line) => line.startsWith('record-'))
+            .toList();
+        expect(records.length, greaterThanOrEqualTo(40));
+        expect(records.length, lessThan(200));
+        expect(records.first, 'record-0 $payload');
+        expect(lines, contains('important failure'));
+        expect(lines, contains(contains('dropped=${200 - records.length}')));
+
+        // Pressure has drained; future routine records must be admitted again.
+        bufferedLogging.captureFileLine('bounded', 'after drain');
+        await bufferedLogging.flush();
+        expect(
+          _findLogFile(
+            bufferedTempDocs,
+            prefix: 'bounded-',
+          )!.readAsLinesSync().last,
+          'after drain',
+        );
+      },
+    );
+
+    test(
+      'oversized routine line reports loss but oversized error survives',
+      () async {
+        final payload = 'x' * (2 * 1024 * 1024);
+        bufferedLogging.captureFileLine('oversized', payload);
+        await bufferedLogging.flush();
+        final file = _findLogFile(bufferedTempDocs, prefix: 'oversized-')!;
+        expect(file.lengthSync(), lessThan(1000));
+        expect(file.readAsLinesSync(), hasLength(1));
+        expect(file.readAsStringSync(), contains('dropped=1'));
+        expect(file.readAsStringSync(), isNot(contains(payload)));
+
+        bufferedLogging.captureFileLine('oversized', payload, forceFlush: true);
+        await bufferedLogging.flush();
+        expect(
+          file.readAsLinesSync().last == payload,
+          isTrue,
+          reason: 'the complete oversized error must survive the routine limit',
+        );
+      },
+    );
+
+    test(
       'single buffered line is flushed when the 500 ms flush timer fires',
       () async {
         // A lone, non-force info event neither hits the line threshold nor

--- a/test/services/logging_service_test.dart
+++ b/test/services/logging_service_test.dart
@@ -764,6 +764,192 @@ void main() {
     File? findGeneralLog() => _findLogFile(bufferedTempDocs);
     File? findSyncLog() => _findLogFile(bufferedTempDocs, prefix: 'sync-');
 
+    ({
+      MockIoFile file,
+      MockIoDirectory directory,
+      List<String> writes,
+      List<Completer<File>> gates,
+    })
+    blockedSink() {
+      final file = MockIoFile();
+      final directory = MockIoDirectory();
+      when(
+        () => directory.path,
+      ).thenReturn(p.join(bufferedTempDocs.path, 'logs'));
+      final writes = <String>[];
+      final gates = <Completer<File>>[];
+      when(
+        () => directory.create(recursive: true),
+      ).thenAnswer((_) async => directory);
+      when(
+        () => file.writeAsString(
+          any(),
+          mode: FileMode.append,
+          flush: any(named: 'flush'),
+        ),
+      ).thenAnswer((invocation) {
+        writes.add(invocation.positionalArguments.single as String);
+        return writes.length <= gates.length
+            ? gates[writes.length - 1].future
+            : Future.value(file);
+      });
+      return (file: file, directory: directory, writes: writes, gates: gates);
+    }
+
+    test(
+      'coalesces prolonged overflow behind a blocked sink and retains errors',
+      () {
+        final sink = blockedSink();
+        IOOverrides.runZoned(
+          () => fakeAsync((async) {
+            sink.gates.addAll(List.generate(3, (_) => Completer<File>()));
+            sink.gates[1].complete(sink.file);
+            sink.gates[2].complete(sink.file);
+            bufferedLogging.captureFileLine('blocked', 'initial');
+            async.elapse(const Duration(milliseconds: 500));
+            expect(sink.writes, ['initial\n']);
+            final oversized = 'x' * (2 * 1024 * 1024);
+            for (var i = 0; i < 100; i++) {
+              bufferedLogging.captureFileLine('blocked', oversized);
+              async.elapse(const Duration(milliseconds: 500));
+            }
+            bufferedLogging.captureFileLine(
+              'blocked',
+              'critical failure',
+              forceFlush: true,
+            );
+            var flushed = false;
+            unawaited(bufferedLogging.flush().then((_) => flushed = true));
+            async.flushMicrotasks();
+            expect(flushed, isFalse);
+            sink.gates.first.complete(sink.file);
+            async.flushMicrotasks();
+            expect(flushed, isTrue);
+            expect(
+              sink.writes,
+              hasLength(3),
+              reason:
+                  'one initial write, one aggregate loss summary, one retained error',
+            );
+            expect(sink.writes[1], contains('dropped=100'));
+            expect(sink.writes.last, 'critical failure\n');
+            expect(async.pendingTimers, isEmpty);
+          }),
+          createFile: (_) => sink.file,
+          createDirectory: (_) => sink.directory,
+        );
+      },
+    );
+
+    test('shutdown awaits overflow arriving during a loss-summary write', () {
+      final sink = blockedSink();
+      IOOverrides.runZoned(
+        () => fakeAsync((async) {
+          sink.gates.addAll(List.generate(3, (_) => Completer<File>()));
+          bufferedLogging.captureFileLine('blocked', 'initial');
+          async.elapse(const Duration(milliseconds: 500));
+          final oversized = 'x' * (2 * 1024 * 1024);
+          bufferedLogging.captureFileLine('blocked', oversized);
+          async.elapse(const Duration(milliseconds: 500));
+          sink.gates.first.complete(sink.file);
+          async.flushMicrotasks();
+          expect(sink.writes, hasLength(2));
+          expect(sink.writes[1], contains('dropped=1'));
+          for (var i = 0; i < 5; i++) {
+            bufferedLogging.captureFileLine('blocked', oversized);
+            async.elapse(const Duration(milliseconds: 500));
+          }
+          var flushed = false;
+          unawaited(bufferedLogging.flush().then((_) => flushed = true));
+          async.flushMicrotasks();
+          sink.gates[1].complete(sink.file);
+          async.flushMicrotasks();
+          expect(sink.writes, hasLength(3));
+          expect(sink.writes[2], contains('dropped=5'));
+          expect(
+            flushed,
+            isFalse,
+            reason: 'the follow-up loss write still owns disk IO',
+          );
+          sink.gates[2].complete(sink.file);
+          async.flushMicrotasks();
+          expect(flushed, isTrue);
+          expect(sink.writes, hasLength(3));
+          expect(async.pendingTimers, isEmpty);
+        }),
+        createFile: (_) => sink.file,
+        createDirectory: (_) => sink.directory,
+      );
+    });
+
+    test('old queued and buffered batches keep their originating profile', () {
+      final nextProfile = Directory(
+        p.join(bufferedTempDocs.path, 'next-profile'),
+      );
+      final sink = blockedSink();
+      final openedPaths = <String>[];
+      var directoryPath = '';
+      when(() => sink.directory.path).thenAnswer((_) => directoryPath);
+      IOOverrides.runZoned(
+        () => fakeAsync((async) {
+          sink.gates.addAll(List.generate(3, (_) => Completer<File>()));
+          sink.gates[1].complete(sink.file);
+          sink.gates[2].complete(sink.file);
+          unawaited(Future<void>.sync(() => getIt.unregister<Directory>()));
+          async.flushMicrotasks();
+          // Logging is constructed and can receive an early record before
+          // bootstrap has registered the profile directory.
+          final oldLogging = LoggingService();
+          oldLogging.captureFileLine('profile', 'initial old record');
+          getIt.registerSingleton<Directory>(bufferedTempDocs);
+          async.elapse(const Duration(milliseconds: 500));
+          oldLogging.captureFileLine(
+            'profile',
+            'queued old record',
+            forceFlush: true,
+          );
+          oldLogging.captureFileLine('profile', 'buffered old record');
+          getIt.pushNewScope(
+            init: (scope) => scope.registerSingleton<Directory>(nextProfile),
+          );
+          addTearDown(getIt.popScope);
+          var oldFlushed = false;
+          unawaited(oldLogging.flush().then((_) => oldFlushed = true));
+          async.flushMicrotasks();
+          expect(oldFlushed, isFalse);
+          sink.gates.first.complete(sink.file);
+          async.flushMicrotasks();
+          expect(oldFlushed, isTrue);
+          final nextLogging = LoggingService();
+          nextLogging.captureFileLine('profile', 'new profile record');
+          var newFlushed = false;
+          unawaited(nextLogging.flush().then((_) => newFlushed = true));
+          async.flushMicrotasks();
+          expect(newFlushed, isTrue);
+          expect(sink.writes, [
+            'initial old record\n',
+            'queued old record\n',
+            'buffered old record\n',
+            'new profile record\n',
+          ]);
+          expect(
+            openedPaths.take(3).map(p.dirname),
+            everyElement(p.join(bufferedTempDocs.path, 'logs')),
+          );
+          expect(p.dirname(openedPaths.last), p.join(nextProfile.path, 'logs'));
+          expect(async.pendingTimers, isEmpty);
+        }),
+        createFile: (path) {
+          openedPaths.add(path);
+          return sink.file;
+        },
+        createDirectory: (path) {
+          directoryPath = path;
+          return sink.directory;
+        },
+      );
+    });
+
     test(
       'bounds queued routine payloads and retains errors under pressure',
       () async {


### PR DESCRIPTION
Domain logging wrote every routine event synchronously with a forced disk flush, bypassing the buffered writer. Domain and safe-error files now share the sink, batch routine writes, force-flush errors, and participate in orderly shutdown flushing. A per-file routine payload budget includes batches waiting for disk I/O; overflow coalesces into one queued loss-summary marker, and error records bypass the limit. Shutdown also awaits summaries generated while an earlier write completes.

Each logging-service generation lazily binds its profile directory when it becomes available. Delayed old-profile writes therefore retain their original destination across profile switches, including batches waiting behind blocked disk I/O. Routine Matrix initialization and recorder start/delete messages omit account/device identity and absolute recording paths.

Validation: targeted recorder, Matrix, domain logger and logging-service tests pass, including 66 service tests with shuffled ordering. Regression tests fail with their fixes reverted, including prolonged overflow, drops during summary writes, shutdown waiting and cross-profile destination isolation. Tests also cover ordered writes, pressure recovery, oversized errors, full-versus-safe diagnostics and one sync error copy. Scoped Dart MCP analysis reports no errors; formatting, 525 Mermaid diagrams, knowledge and changelog validation pass.
