### PR TITLE
fix(db): make the journal, link and definition write paths atomic and ordered

### DIFF
--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -226,6 +226,40 @@ composite prefixes, and the lone boolean `idx_linked_entries_hidden`. A new
 index needs a query that the planner demonstrably picks it for; the EXPLAIN
 tests under `test/database/` are where that is shown.
 
+# Write atomicity
+
+Three write paths do a check before they write, and each runs the check and
+the write in **one Drift transaction**. Drift serialises transactions on the
+write connection, so the second of two concurrent writes to the same row waits
+for the first and then sees its result — a pooled read snapshot cannot slip
+between the check and the write.
+
+- **`JournalDb.updateJournalEntity`** reads the stored row, compares vector
+  clocks, upserts, records or resolves the conflict row, and reconciles the
+  `labeled` table inside the transaction. Two concurrent writes of one id with
+  concurrent clocks therefore end with one applied and one recorded in
+  `conflicts`, never a silent overwrite. The JSON sidecar — the sync payload —
+  is written **after** commit, so it never describes a row that rolled back and
+  the writer lock is never held across file I/O. The sync inbound handler wraps
+  the same call together with the entity's embedded links in an outer
+  transaction; the inner one nests.
+- **`JournalDb.upsertEntryLink`** runs its equality pre-read, the
+  `(from_id, to_id, type)` duplicate check, the tombstone replacement and the
+  upsert the same way, so a local link creation racing the same link arriving by
+  sync is blocked as a duplicate instead of colliding on the UNIQUE constraint.
+  A failing pre-read propagates; it is not swallowed.
+- **Definition upserts** (`upsertEntityDefinition` and the five typed
+  variants) refuse a definition that is **strictly older** than the stored one.
+  Definitions replicate as whole documents and every local edit path refreshes
+  `updatedAt`, so "the later edit wins" — and this gate is where that rule is
+  enforced against a delayed sync event or a historical re-send. When both
+  sides carry a vector clock that orders them the clock decides; otherwise
+  `updatedAt` does, an exact tie applies the incoming copy, and the stored row
+  is read by id with no `deleted`/`private` filter so an older live copy cannot
+  resurrect a newer deletion. `PersistenceDefinitionOps` re-stamps a local edit
+  the gate rejected — a sync landed while the editor was open — and writes it
+  again, so a user's action always applies and wins on every peer.
+
 # From write to UI
 
 Journal writes announce themselves to the UI through

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -240,9 +240,12 @@ between the check and the write.
   concurrent clocks therefore end with one applied and one recorded in
   `conflicts`, never a silent overwrite. The JSON sidecar — the sync payload —
   is written **after** commit, so it never describes a row that rolled back and
-  the writer lock is never held across file I/O. The sync inbound handler wraps
-  the same call together with the entity's embedded links in an outer
-  transaction; the inner one nests.
+  the writer lock is never held across file I/O; sidecar writes for one entity
+  are published in commit order, so two accepted writes cannot leave the earlier
+  document on disk for the later row. The sync inbound handler wraps the same
+  call together with the entity's embedded links in an outer transaction; the
+  inner one nests. A sidecar write that fails after commit is not yet retried
+  durably — that repair is tracked separately.
 - **`JournalDb.upsertEntryLink`** runs its equality pre-read, the
   `(from_id, to_id, type)` duplicate check, the tombstone replacement and the
   upsert the same way, so a local link creation racing the same link arriving by
@@ -256,9 +259,13 @@ between the check and the write.
   sides carry a vector clock that orders them the clock decides; otherwise
   `updatedAt` does, an exact tie applies the incoming copy, and the stored row
   is read by id with no `deleted`/`private` filter so an older live copy cannot
-  resurrect a newer deletion. `PersistenceDefinitionOps` re-stamps a local edit
-  the gate rejected — a sync landed while the editor was open — and writes it
-  again, so a user's action always applies and wins on every peer.
+  resurrect a newer deletion. The gate returns 0 for a refused write, and both
+  callers honour it: the sync apply path neither reindexes nor announces a
+  refused definition, and `PersistenceDefinitionOps` rebuilds a refused local
+  edit from the stored stamp — a timestamp strictly above the stored one, the
+  stored vector clock carried over — and writes it again, so a user's action
+  applies and wins on every peer; an edit refused twice is reported as unsaved
+  and never announced or synced.
 
 # From write to UI
 

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -243,7 +243,9 @@ WHERE EXISTS (
   }
 
   @override
-  Future<void> _persistEntityJson(JournalEntity updated) =>
+  @protected
+  @visibleForTesting
+  Future<void> persistEntityJson(JournalEntity updated) =>
       saveJournalEntityJson(
         updated,
         documentsDirectory: _documentsDirectory,

--- a/lib/database/database_definitions.dart
+++ b/lib/database/database_definitions.dart
@@ -161,31 +161,59 @@ mixin _JournalDbDefinitions on _$JournalDb, _JournalDbConfigFlags {
 
   Future<int> upsertMeasurableDataType(
     MeasurableDataType entityDefinition,
-  ) async {
-    return into(
-      measurableTypes,
-    ).insertOnConflictUpdate(measurableDbEntity(entityDefinition));
+  ) {
+    return _upsertDefinitionIfNotOlder(
+      entityDefinition,
+      readExistingSerialized: () => _serializedById(
+        measurableTypes,
+        entityDefinition.id,
+      ),
+      write: () => into(
+        measurableTypes,
+      ).insertOnConflictUpdate(measurableDbEntity(entityDefinition)),
+    );
   }
 
-  Future<int> upsertHabitDefinition(HabitDefinition habitDefinition) async {
-    return into(
-      habitDefinitions,
-    ).insertOnConflictUpdate(habitDefinitionDbEntity(habitDefinition));
+  Future<int> upsertHabitDefinition(HabitDefinition habitDefinition) {
+    return _upsertDefinitionIfNotOlder(
+      habitDefinition,
+      readExistingSerialized: () => _serializedById(
+        habitDefinitions,
+        habitDefinition.id,
+      ),
+      write: () => into(
+        habitDefinitions,
+      ).insertOnConflictUpdate(habitDefinitionDbEntity(habitDefinition)),
+    );
   }
 
   Future<int> upsertDashboardDefinition(
     DashboardDefinition dashboardDefinition,
-  ) async {
-    return into(dashboardDefinitions).insertOnConflictUpdate(
-      dashboardDefinitionDbEntity(dashboardDefinition),
+  ) {
+    return _upsertDefinitionIfNotOlder(
+      dashboardDefinition,
+      readExistingSerialized: () => _serializedById(
+        dashboardDefinitions,
+        dashboardDefinition.id,
+      ),
+      write: () => into(dashboardDefinitions).insertOnConflictUpdate(
+        dashboardDefinitionDbEntity(dashboardDefinition),
+      ),
     );
   }
 
   Future<int> upsertCategoryDefinition(
     CategoryDefinition categoryDefinition,
-  ) async {
-    return into(categoryDefinitions).insertOnConflictUpdate(
-      categoryDefinitionDbEntity(categoryDefinition),
+  ) {
+    return _upsertDefinitionIfNotOlder(
+      categoryDefinition,
+      readExistingSerialized: () => _serializedById(
+        categoryDefinitions,
+        categoryDefinition.id,
+      ),
+      write: () => into(categoryDefinitions).insertOnConflictUpdate(
+        categoryDefinitionDbEntity(categoryDefinition),
+      ),
     );
   }
 
@@ -204,9 +232,99 @@ mixin _JournalDbDefinitions on _$JournalDb, _JournalDbConfigFlags {
 
   Future<int> upsertLabelDefinition(
     LabelDefinition labelDefinition,
+  ) {
+    return _upsertDefinitionIfNotOlder(
+      labelDefinition,
+      readExistingSerialized: () => _serializedById(
+        labelDefinitions,
+        labelDefinition.id,
+      ),
+      write: () => into(
+        labelDefinitions,
+      ).insertOnConflictUpdate(labelDefinitionDbEntity(labelDefinition)),
+    );
+  }
+
+  /// The stored JSON document for [id] in [table], or null when absent.
+  ///
+  /// Reads by primary key with no `deleted`/`private` filter: the recency
+  /// gate must see a deleted-but-newer row, or an older live copy arriving
+  /// late would resurrect it.
+  Future<String?> _serializedById<T extends Table, R>(
+    TableInfo<T, R> table,
+    String id,
   ) async {
-    return into(
-      labelDefinitions,
-    ).insertOnConflictUpdate(labelDefinitionDbEntity(labelDefinition));
+    final row = await customSelect(
+      'SELECT serialized FROM ${table.actualTableName} WHERE id = ?',
+      variables: [Variable.withString(id)],
+      readsFrom: {table},
+    ).getSingleOrNull();
+    return row?.read<String>('serialized');
+  }
+
+  /// Writes [incoming] unless the stored definition is strictly newer.
+  ///
+  /// Definitions replicate as whole documents and the local edit paths
+  /// refresh `updatedAt` so that "the later edit wins" on sync. This is
+  /// where that rule is enforced: an older definition arriving late — a
+  /// delayed sync event, a historical re-send — must not overwrite a newer
+  /// local one, and an older live copy must not resurrect a newer deletion.
+  /// When both sides carry a vector clock that orders them, the clock
+  /// decides; otherwise `updatedAt` does, and an exact tie applies
+  /// [incoming] so a local re-save never silently disappears.
+  ///
+  /// Only `updatedAt` and `vectorClock` of the stored document are decoded,
+  /// never the whole document, which for legacy dashboards may not parse.
+  /// Read and write share one transaction so the decision cannot interleave
+  /// with another writer. Returns the write's result, or 0 when skipped.
+  Future<int> _upsertDefinitionIfNotOlder(
+    EntityDefinition incoming, {
+    required Future<String?> Function() readExistingSerialized,
+    required Future<int> Function() write,
+  }) {
+    return transaction(() async {
+      final existingSerialized = await readExistingSerialized();
+      if (existingSerialized != null) {
+        final existing =
+            json.decode(existingSerialized) as Map<String, dynamic>;
+        if (_definitionIsOlder(incoming, than: existing)) {
+          DevLogger.log(
+            name: 'JournalDb',
+            message:
+                'Skipping older definition ${incoming.id}: '
+                'incoming ${incoming.updatedAt.toIso8601String()} '
+                'vs stored ${existing['updatedAt']}',
+          );
+          return 0;
+        }
+      }
+      return write();
+    });
+  }
+
+  static bool _definitionIsOlder(
+    EntityDefinition incoming, {
+    required Map<String, dynamic> than,
+  }) {
+    final incomingClock = incoming.vectorClock;
+    final existingClockJson = than['vectorClock'];
+    if (incomingClock != null && existingClockJson is Map<String, dynamic>) {
+      switch (VectorClock.compare(
+        VectorClock.fromJson(existingClockJson),
+        incomingClock,
+      )) {
+        case VclockStatus.a_gt_b:
+          return true;
+        case VclockStatus.b_gt_a:
+          return false;
+        case VclockStatus.equal:
+        case VclockStatus.concurrent:
+          break;
+      }
+    }
+    final existingUpdatedAt = than['updatedAt'];
+    if (existingUpdatedAt is! String) return false;
+    final stored = DateTime.tryParse(existingUpdatedAt);
+    return stored != null && incoming.updatedAt.isBefore(stored);
   }
 }

--- a/lib/database/database_definitions.dart
+++ b/lib/database/database_definitions.dart
@@ -302,17 +302,44 @@ mixin _JournalDbDefinitions on _$JournalDb, _JournalDbConfigFlags {
     });
   }
 
+  /// The `updatedAt` and `vectorClock` of the stored copy of [definition],
+  /// or null when no row exists. Reads by id with no `deleted`/`private`
+  /// filter — the same view the recency gate uses — so a caller whose write
+  /// was refused can build a copy that is genuinely newer than what is
+  /// stored.
+  Future<DefinitionStamp?> definitionStamp(EntityDefinition definition) async {
+    final table = definition.map<TableInfo<Table, Object?>>(
+      measurableDataType: (_) => measurableTypes,
+      habit: (_) => habitDefinitions,
+      dashboard: (_) => dashboardDefinitions,
+      categoryDefinition: (_) => categoryDefinitions,
+      labelDefinition: (_) => labelDefinitions,
+    );
+    final serialized = await _serializedById(table, definition.id);
+    if (serialized == null) return null;
+    return _stampOf(json.decode(serialized) as Map<String, dynamic>);
+  }
+
+  static DefinitionStamp _stampOf(Map<String, dynamic> stored) {
+    final updatedAt = stored['updatedAt'];
+    final vectorClock = stored['vectorClock'];
+    return (
+      updatedAt: updatedAt is String ? DateTime.tryParse(updatedAt) : null,
+      vectorClock: vectorClock is Map<String, dynamic>
+          ? VectorClock.fromJson(vectorClock)
+          : null,
+    );
+  }
+
   static bool _definitionIsOlder(
     EntityDefinition incoming, {
     required Map<String, dynamic> than,
   }) {
+    final stored = _stampOf(than);
     final incomingClock = incoming.vectorClock;
-    final existingClockJson = than['vectorClock'];
-    if (incomingClock != null && existingClockJson is Map<String, dynamic>) {
-      switch (VectorClock.compare(
-        VectorClock.fromJson(existingClockJson),
-        incomingClock,
-      )) {
+    final storedClock = stored.vectorClock;
+    if (incomingClock != null && storedClock != null) {
+      switch (VectorClock.compare(storedClock, incomingClock)) {
         case VclockStatus.a_gt_b:
           return true;
         case VclockStatus.b_gt_a:
@@ -322,9 +349,13 @@ mixin _JournalDbDefinitions on _$JournalDb, _JournalDbConfigFlags {
           break;
       }
     }
-    final existingUpdatedAt = than['updatedAt'];
-    if (existingUpdatedAt is! String) return false;
-    final stored = DateTime.tryParse(existingUpdatedAt);
-    return stored != null && incoming.updatedAt.isBefore(stored);
+    final storedUpdatedAt = stored.updatedAt;
+    return storedUpdatedAt != null &&
+        incoming.updatedAt.isBefore(storedUpdatedAt);
   }
 }
+
+/// What the recency gate compares: the stored document's `updatedAt` (null
+/// only for a document that has none, which no writer produces) and its
+/// `vectorClock`.
+typedef DefinitionStamp = ({DateTime? updatedAt, VectorClock? vectorClock});

--- a/lib/database/database_entity_ops.dart
+++ b/lib/database/database_entity_ops.dart
@@ -16,8 +16,20 @@ mixin _JournalDbEntityOps
 
   /// Writes the canonical JSON file for [updated], honoring the
   /// documents-directory override injected via the [JournalDb]
-  /// constructor.
-  Future<void> _persistEntityJson(JournalEntity updated);
+  /// constructor. Protected so a test double can delay or fail one write
+  /// and exercise [_publishSidecar]'s ordering.
+  @protected
+  @visibleForTesting
+  Future<void> persistEntityJson(JournalEntity updated);
+
+  // Per-entity ordering for sidecar writes. The transaction hands out a
+  // ticket per applied write; sidecar writes for one id run one after the
+  // other, and a ticket older than the newest one already on disk is
+  // skipped — so two accepted writes of the same entity can never leave
+  // the earlier document as the sync payload for the later row.
+  final Map<String, int> _sidecarIssued = <String, int>{};
+  final Map<String, int> _sidecarWritten = <String, int>{};
+  final Map<String, Future<void>> _sidecarChain = <String, Future<void>>{};
 
   /// Reports [error] to the domain logger, if one is available.
   void _captureException(
@@ -97,7 +109,8 @@ mixin _JournalDbEntityOps
   /// The JSON sidecar is written **after** the transaction commits: it is
   /// the sync payload, so it must never describe a row that rolled back,
   /// and writing it inside the transaction would hold the journal writer
-  /// lock across file I/O.
+  /// lock across file I/O. Sidecar writes for one entity are published in
+  /// commit order (see [_publishSidecar]).
   Future<JournalUpdateResult> updateJournalEntity(
     JournalEntity updated, {
     bool overrideComparison = false,
@@ -107,6 +120,7 @@ mixin _JournalDbEntityOps
       updatedAt: clock.now(),
     );
 
+    var ticket = 0;
     final result = await transaction(() async {
       var applied = false;
       JournalUpdateSkipReason? skipReason;
@@ -160,6 +174,8 @@ mixin _JournalDbEntityOps
 
       if (applied) {
         await addLabeled(updated);
+        ticket = (_sidecarIssued[dbEntity.id] ?? 0) + 1;
+        _sidecarIssued[dbEntity.id] = ticket;
         return JournalUpdateResult.applied(rowsWritten: rowsWritten);
       }
 
@@ -169,9 +185,37 @@ mixin _JournalDbEntityOps
     });
 
     if (result.applied) {
-      await _persistEntityJson(updated);
+      await _publishSidecar(updated, ticket);
     }
     return result;
+  }
+
+  /// Writes the sidecar for [entity] after the sidecar writes queued before
+  /// it for the same id, and only if no newer [ticket] has been written yet.
+  ///
+  /// A failed write does not poison the chain: the next writer for the id
+  /// still runs, and the failure surfaces to this caller.
+  Future<void> _publishSidecar(JournalEntity entity, int ticket) {
+    final id = entity.meta.id;
+    final previous = _sidecarChain[id] ?? Future<void>.value();
+    late final Future<void> current;
+    current = previous
+        .catchError((Object _) {})
+        .then((_) async {
+          if ((_sidecarWritten[id] ?? 0) >= ticket) return;
+          await persistEntityJson(entity);
+          _sidecarWritten[id] = ticket;
+        })
+        .whenComplete(() {
+          if (!identical(_sidecarChain[id], current)) return;
+          _sidecarChain.remove(id);
+          if (_sidecarWritten[id] == _sidecarIssued[id]) {
+            _sidecarIssued.remove(id);
+            _sidecarWritten.remove(id);
+          }
+        });
+    _sidecarChain[id] = current;
+    return current;
   }
 
   Future<Conflict?> conflictById(String id) async {

--- a/lib/database/database_entity_ops.dart
+++ b/lib/database/database_entity_ops.dart
@@ -83,73 +83,95 @@ mixin _JournalDbEntityOps
     return VclockStatus.b_gt_a;
   }
 
+  /// Applies [updated] to the journal after a vector-clock comparison with
+  /// the stored row.
+  ///
+  /// The read of the existing row, the comparison, the upsert, the conflict
+  /// bookkeeping and the `labeled` reconciliation run in **one transaction**:
+  /// Drift serialises transactions on the write connection, so a concurrent
+  /// write to the same id — a local edit racing an inbound sync, or two
+  /// pooled readers seeing different snapshots — cannot slip between the
+  /// check and the write. A caller that already holds a transaction (the
+  /// sync inbound handler) simply nests this one.
+  ///
+  /// The JSON sidecar is written **after** the transaction commits: it is
+  /// the sync payload, so it must never describe a row that rolled back,
+  /// and writing it inside the transaction would hold the journal writer
+  /// lock across file I/O.
   Future<JournalUpdateResult> updateJournalEntity(
     JournalEntity updated, {
     bool overrideComparison = false,
     bool overwrite = true,
   }) async {
-    var applied = false;
-    JournalUpdateSkipReason? skipReason;
-    var rowsWritten = 0;
     final dbEntity = toDbEntity(updated).copyWith(
       updatedAt: clock.now(),
     );
 
-    final existingDbEntity = await entityById(dbEntity.id);
+    final result = await transaction(() async {
+      var applied = false;
+      JournalUpdateSkipReason? skipReason;
+      var rowsWritten = 0;
 
-    if (existingDbEntity != null && !overwrite) {
-      skipReason = JournalUpdateSkipReason.overwritePrevented;
-    } else if (existingDbEntity != null) {
-      final existing = fromDbEntity(existingDbEntity);
-      VclockStatus? status;
-      try {
-        status = await detectConflict(existing, updated);
-      } catch (error, stackTrace) {
-        _captureException(
-          error,
-          subDomain: 'detectConflict',
-          stackTrace: stackTrace,
-        );
-        skipReason = JournalUpdateSkipReason.conflict;
-      }
+      final existingDbEntity = await entityById(dbEntity.id);
 
-      final canApply =
-          status == VclockStatus.b_gt_a ||
-          (overrideComparison && status != null);
+      if (existingDbEntity != null && !overwrite) {
+        skipReason = JournalUpdateSkipReason.overwritePrevented;
+      } else if (existingDbEntity != null) {
+        final existing = fromDbEntity(existingDbEntity);
+        VclockStatus? status;
+        try {
+          status = await detectConflict(existing, updated);
+        } catch (error, stackTrace) {
+          _captureException(
+            error,
+            subDomain: 'detectConflict',
+            stackTrace: stackTrace,
+          );
+          skipReason = JournalUpdateSkipReason.conflict;
+        }
 
-      if (canApply) {
+        final canApply =
+            status == VclockStatus.b_gt_a ||
+            (overrideComparison && status != null);
+
+        if (canApply) {
+          rowsWritten = await upsertJournalDbEntity(dbEntity);
+          applied = true;
+          final existingConflict = await conflictById(dbEntity.id);
+
+          if (existingConflict != null) {
+            await resolveConflict(existingConflict);
+          }
+        } else if (status != null) {
+          _captureEvent(
+            EnumToString.convertToString(status),
+            subDomain: 'Conflict status',
+          );
+          skipReason = status == VclockStatus.concurrent
+              ? JournalUpdateSkipReason.conflict
+              : JournalUpdateSkipReason.olderOrEqual;
+        } else {
+          skipReason ??= JournalUpdateSkipReason.conflict;
+        }
+      } else {
         rowsWritten = await upsertJournalDbEntity(dbEntity);
         applied = true;
-        final existingConflict = await conflictById(dbEntity.id);
-
-        if (existingConflict != null) {
-          await resolveConflict(existingConflict);
-        }
-      } else if (status != null) {
-        _captureEvent(
-          EnumToString.convertToString(status),
-          subDomain: 'Conflict status',
-        );
-        skipReason = status == VclockStatus.concurrent
-            ? JournalUpdateSkipReason.conflict
-            : JournalUpdateSkipReason.olderOrEqual;
-      } else {
-        skipReason ??= JournalUpdateSkipReason.conflict;
       }
-    } else {
-      rowsWritten = await upsertJournalDbEntity(dbEntity);
-      applied = true;
-    }
 
-    if (applied) {
+      if (applied) {
+        await addLabeled(updated);
+        return JournalUpdateResult.applied(rowsWritten: rowsWritten);
+      }
+
+      return JournalUpdateResult.skipped(
+        reason: skipReason ?? JournalUpdateSkipReason.olderOrEqual,
+      );
+    });
+
+    if (result.applied) {
       await _persistEntityJson(updated);
-      await addLabeled(updated);
-      return JournalUpdateResult.applied(rowsWritten: rowsWritten);
     }
-
-    return JournalUpdateResult.skipped(
-      reason: skipReason ?? JournalUpdateSkipReason.olderOrEqual,
-    );
+    return result;
   }
 
   Future<Conflict?> conflictById(String id) async {

--- a/lib/database/database_links_ratings.dart
+++ b/lib/database/database_links_ratings.dart
@@ -310,23 +310,27 @@ mixin _JournalDbLinksRatings
     return entryLinkFromLinkedDbEntry(res);
   }
 
+  /// Inserts or updates [link], refusing self-links and active duplicates.
+  ///
+  /// The equality pre-read, the `(from_id, to_id, type)` duplicate check,
+  /// the tombstone replacement and the upsert run in one transaction, so two
+  /// concurrent creations of the same link — a local one racing the same
+  /// link arriving by sync — cannot both pass the duplicate check and then
+  /// collide on the UNIQUE constraint. A failing read propagates; it is a
+  /// database error, not a reason to write blind.
   Future<int> upsertEntryLink(EntryLink link) async {
-    if (link.fromId != link.toId) {
-      try {
-        // Equality precheck: if an entry with the same id exists and the
-        // serialized payload is identical, skip the UPSERT to avoid a no-op
-        // UPDATE and downstream log noise.
-        final existing = await (select(
-          linkedEntries,
-        )..where((t) => t.id.equals(link.id))).getSingleOrNull();
-        if (existing != null) {
-          final incomingSerialized = jsonEncode(link);
-          if (existing.serialized == incomingSerialized) {
-            return 0; // no change needed
-          }
-        }
-      } catch (_) {
-        // Best-effort precheck only; fall through to UPSERT on failure.
+    if (link.fromId == link.toId) {
+      return 0;
+    }
+    return transaction(() async {
+      // Equality precheck: if an entry with the same id exists and the
+      // serialized payload is identical, skip the UPSERT to avoid a no-op
+      // UPDATE and downstream log noise.
+      final existing = await (select(
+        linkedEntries,
+      )..where((t) => t.id.equals(link.id))).getSingleOrNull();
+      if (existing != null && existing.serialized == jsonEncode(link)) {
+        return 0; // no change needed
       }
 
       // Guard against secondary UNIQUE(from_id, to_id, type) constraint.
@@ -366,9 +370,7 @@ mixin _JournalDbLinksRatings
       }
 
       return res;
-    } else {
-      return 0;
-    }
+    });
   }
 }
 

--- a/lib/features/sync/matrix/sync_event_processor_apply.dart
+++ b/lib/features/sync/matrix/sync_event_processor_apply.dart
@@ -51,7 +51,21 @@ extension SyncEventProcessorApply on SyncEventProcessor {
         final previousMeasurable = measurable != null && fts5Db != null
             ? await journalDb.getMeasurableDataTypeById(measurable.id)
             : null;
-        await journalDb.upsertEntityDefinition(entityDefinition);
+        final linesAffected = await journalDb.upsertEntityDefinition(
+          entityDefinition,
+        );
+        if (linesAffected == 0) {
+          // The journal kept a newer copy. Nothing changed locally, so there
+          // is nothing to reindex or announce — reindexing from this stale
+          // copy would rewrite search rows with labels the app no longer
+          // shows.
+          _loggingService.log(
+            LogDomain.sync,
+            'Skipped older definition ${entityDefinition.id}',
+            subDomain: 'processor.apply.entityDefinition.skipped',
+          );
+          return null;
+        }
         if (measurable != null &&
             fts5Db != null &&
             measurementDefinitionAffectsFts(previousMeasurable, measurable)) {

--- a/lib/logic/persistence_definition_ops.dart
+++ b/lib/logic/persistence_definition_ops.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/fts5_db.dart';
@@ -18,13 +19,14 @@ class PersistenceDefinitionOps extends PersistenceCollaboratorBase {
   PersistenceDefinitionOps(super.logic);
 
   Future<int> upsertEntityDefinitionImpl(
-    EntityDefinition entityDefinition,
+    EntityDefinition definition,
   ) async {
-    final previousMeasurable = entityDefinition is MeasurableDataType
-        ? await journalDb.getMeasurableDataTypeById(entityDefinition.id)
+    final previousMeasurable = definition is MeasurableDataType
+        ? await journalDb.getMeasurableDataTypeById(definition.id)
         : null;
-    final linesAffected = await journalDb.upsertEntityDefinition(
-      entityDefinition,
+    final (entityDefinition, linesAffected) = await _writeLocalEdit(
+      definition,
+      journalDb.upsertEntityDefinition,
     );
     final typeNotification = switch (entityDefinition) {
       CategoryDefinition() => categoriesNotification,
@@ -50,6 +52,34 @@ class PersistenceDefinitionOps extends PersistenceCollaboratorBase {
     return linesAffected;
   }
 
+  /// Writes a local definition edit so that it always applies and wins.
+  ///
+  /// `JournalDb` refuses a definition that is older than the stored one —
+  /// the guard that keeps a late sync arrival from overwriting a newer edit.
+  /// A local edit can trip the same guard when a sync landed while the
+  /// editor was open and the caller did not refresh `updatedAt` (deletes
+  /// from the settings pages, for one). A user's action must still apply,
+  /// and must win on every peer, so it is stamped as the latest edit and
+  /// written again. Returns the definition that was actually stored, which
+  /// is also what gets notified and synced.
+  Future<(EntityDefinition, int)> _writeLocalEdit(
+    EntityDefinition definition,
+    Future<int> Function(EntityDefinition definition) write,
+  ) async {
+    final linesAffected = await write(definition);
+    if (linesAffected != 0) {
+      return (definition, linesAffected);
+    }
+    final restamped = definition.copyWith(updatedAt: clock.now());
+    final restampedLines = await write(restamped);
+    loggingService.log(
+      LogDomain.persistence,
+      'Re-stamped stale local definition edit ${definition.id}',
+      subDomain: 'upsertEntityDefinition.restamp',
+    );
+    return (restamped, restampedLines);
+  }
+
   Future<void> _reindexMeasurements(MeasurableDataType dataType) async {
     try {
       final entries = await journalDb.getMeasurementsByType(
@@ -72,9 +102,12 @@ class PersistenceDefinitionOps extends PersistenceCollaboratorBase {
   }
 
   Future<int> upsertDashboardDefinitionImpl(
-    DashboardDefinition dashboard,
+    DashboardDefinition definition,
   ) async {
-    final linesAffected = await journalDb.upsertDashboardDefinition(dashboard);
+    final (dashboard, linesAffected) = await _writeLocalEdit(
+      definition,
+      (d) => journalDb.upsertDashboardDefinition(d as DashboardDefinition),
+    );
     updateNotifications.notify({dashboard.id, dashboardsNotification});
     await outboxService.enqueueMessage(
       SyncMessage.entityDefinition(

--- a/lib/logic/persistence_definition_ops.dart
+++ b/lib/logic/persistence_definition_ops.dart
@@ -24,10 +24,12 @@ class PersistenceDefinitionOps extends PersistenceCollaboratorBase {
     final previousMeasurable = definition is MeasurableDataType
         ? await journalDb.getMeasurableDataTypeById(definition.id)
         : null;
-    final (entityDefinition, linesAffected) = await _writeLocalEdit(
+    final written = await _writeLocalEdit(
       definition,
       journalDb.upsertEntityDefinition,
     );
+    if (written == null) return 0;
+    final (entityDefinition, linesAffected) = written;
     final typeNotification = switch (entityDefinition) {
       CategoryDefinition() => categoriesNotification,
       HabitDefinition() => habitsNotification,
@@ -52,17 +54,23 @@ class PersistenceDefinitionOps extends PersistenceCollaboratorBase {
     return linesAffected;
   }
 
-  /// Writes a local definition edit so that it always applies and wins.
+  /// Writes a local definition edit so that it applies and wins on sync.
   ///
-  /// `JournalDb` refuses a definition that is older than the stored one —
-  /// the guard that keeps a late sync arrival from overwriting a newer edit.
-  /// A local edit can trip the same guard when a sync landed while the
-  /// editor was open and the caller did not refresh `updatedAt` (deletes
-  /// from the settings pages, for one). A user's action must still apply,
-  /// and must win on every peer, so it is stamped as the latest edit and
-  /// written again. Returns the definition that was actually stored, which
-  /// is also what gets notified and synced.
-  Future<(EntityDefinition, int)> _writeLocalEdit(
+  /// `JournalDb` refuses a definition older than the stored one — the guard
+  /// that keeps a late sync arrival from overwriting a newer edit. A local
+  /// edit trips the same guard when a sync landed while the editor was open
+  /// and the caller did not refresh `updatedAt` (deletes from the settings
+  /// pages, for one). A user's action must still apply, so the edit is
+  /// rebuilt from the stored stamp: its timestamp goes strictly above the
+  /// stored one — even when the peer's clock runs ahead of ours — and it
+  /// carries the stored vector clock, so an ordered clock cannot outrank it
+  /// (equal clocks defer to `updatedAt`). That copy applies here and wins on
+  /// every peer holding the same stored version.
+  ///
+  /// Returns the definition that was actually stored with the write's row
+  /// count, or null when even the rebuilt copy was refused — then nothing
+  /// was saved, and the caller must neither announce nor sync it.
+  Future<(EntityDefinition, int)?> _writeLocalEdit(
     EntityDefinition definition,
     Future<int> Function(EntityDefinition definition) write,
   ) async {
@@ -70,8 +78,27 @@ class PersistenceDefinitionOps extends PersistenceCollaboratorBase {
     if (linesAffected != 0) {
       return (definition, linesAffected);
     }
-    final restamped = definition.copyWith(updatedAt: clock.now());
+
+    final stored = await journalDb.definitionStamp(definition);
+    final now = clock.now();
+    final floor = stored?.updatedAt;
+    final restamped = definition.copyWith(
+      updatedAt: floor == null || now.isAfter(floor)
+          ? now
+          : floor.add(const Duration(milliseconds: 1)),
+      vectorClock: stored?.vectorClock ?? definition.vectorClock,
+    );
     final restampedLines = await write(restamped);
+    if (restampedLines == 0) {
+      loggingService.error(
+        LogDomain.persistence,
+        StateError(
+          'Local definition edit ${definition.id} refused twice; not saved',
+        ),
+        subDomain: 'upsertEntityDefinition.restamp',
+      );
+      return null;
+    }
     loggingService.log(
       LogDomain.persistence,
       'Re-stamped stale local definition edit ${definition.id}',
@@ -104,10 +131,12 @@ class PersistenceDefinitionOps extends PersistenceCollaboratorBase {
   Future<int> upsertDashboardDefinitionImpl(
     DashboardDefinition definition,
   ) async {
-    final (dashboard, linesAffected) = await _writeLocalEdit(
+    final written = await _writeLocalEdit(
       definition,
       (d) => journalDb.upsertDashboardDefinition(d as DashboardDefinition),
     );
+    if (written == null) return 0;
+    final (dashboard, linesAffected) = written;
     updateNotifications.notify({dashboard.id, dashboardsNotification});
     await outboxService.enqueueMessage(
       SyncMessage.entityDefinition(

--- a/test/database/database_definitions_test.dart
+++ b/test/database/database_definitions_test.dart
@@ -435,6 +435,26 @@ void main() {
         );
       });
 
+      test(
+        'definitionStamp exposes the stored timestamp and clock, deleted '
+        'rows included, and null when nothing is stored',
+        () async {
+          expect(await db!.definitionStamp(categoryMindfulness), isNull);
+
+          await db!.upsertEntityDefinition(
+            categoryMindfulness.copyWith(
+              updatedAt: base,
+              deletedAt: base,
+              vectorClock: const VectorClock({'a': 2}),
+            ),
+          );
+
+          final stamp = await db!.definitionStamp(categoryMindfulness);
+          expect(stamp?.updatedAt, base);
+          expect(stamp?.vectorClock?.vclock, {'a': 2});
+        },
+      );
+
       test('the gate covers every definition table', () async {
         final older = base.subtract(const Duration(minutes: 1));
 

--- a/test/database/database_definitions_test.dart
+++ b/test/database/database_definitions_test.dart
@@ -8,6 +8,7 @@ import 'package:lotti/classes/task.dart';
 import 'package:lotti/database/conversions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/journal_db/config_flags.dart';
+import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/dev_logger.dart';
 import 'package:lotti/utils/consts.dart';
@@ -284,6 +285,209 @@ void main() {
           ).name,
           'Entity Habit',
         );
+      });
+    });
+
+    group('Recency gate -', () {
+      final base = DateTime(2026, 9, 5, 10);
+
+      Future<String?> storedCategoryName(String id) async {
+        final row = await (db!.select(
+          db!.categoryDefinitions,
+        )..where((t) => t.id.equals(id))).getSingleOrNull();
+        return row == null ? null : fromCategoryDefinitionDbEntity(row).name;
+      }
+
+      test('an older incoming definition is skipped', () async {
+        final stored = categoryMindfulness.copyWith(
+          name: 'Stored',
+          updatedAt: base,
+        );
+        expect(await db!.upsertEntityDefinition(stored), isNot(0));
+
+        final lateArrival = categoryMindfulness.copyWith(
+          name: 'Late arrival',
+          updatedAt: base.subtract(const Duration(minutes: 1)),
+        );
+        expect(await db!.upsertEntityDefinition(lateArrival), 0);
+
+        expect(await storedCategoryName(categoryMindfulness.id), 'Stored');
+      });
+
+      test('a newer incoming definition replaces the stored one', () async {
+        await db!.upsertEntityDefinition(
+          categoryMindfulness.copyWith(name: 'Stored', updatedAt: base),
+        );
+
+        final newer = categoryMindfulness.copyWith(
+          name: 'Newer',
+          updatedAt: base.add(const Duration(minutes: 1)),
+        );
+        expect(await db!.upsertEntityDefinition(newer), isNot(0));
+
+        expect(await storedCategoryName(categoryMindfulness.id), 'Newer');
+      });
+
+      test(
+        'an equal updatedAt still applies, so a local re-save that did not '
+        'touch the timestamp is never dropped',
+        () async {
+          await db!.upsertEntityDefinition(
+            categoryMindfulness.copyWith(name: 'Stored', updatedAt: base),
+          );
+
+          final resave = categoryMindfulness.copyWith(
+            name: 'Re-saved',
+            updatedAt: base,
+          );
+          expect(await db!.upsertEntityDefinition(resave), isNot(0));
+
+          expect(await storedCategoryName(categoryMindfulness.id), 'Re-saved');
+        },
+      );
+
+      test(
+        'an older deleted definition cannot resurrect a newer deletion',
+        () async {
+          await db!.upsertEntityDefinition(
+            categoryMindfulness.copyWith(
+              name: 'Deleted',
+              updatedAt: base,
+              deletedAt: base,
+            ),
+          );
+
+          final resurrect = categoryMindfulness.copyWith(
+            name: 'Back from the dead',
+            updatedAt: base.subtract(const Duration(hours: 1)),
+          );
+          expect(await db!.upsertEntityDefinition(resurrect), 0);
+
+          final row = await (db!.select(
+            db!.categoryDefinitions,
+          )..where((t) => t.id.equals(categoryMindfulness.id))).getSingle();
+          expect(row.deleted, isTrue);
+        },
+      );
+
+      test(
+        'ordered vector clocks decide before updatedAt does',
+        () async {
+          await db!.upsertEntityDefinition(
+            categoryMindfulness.copyWith(
+              name: 'Stored',
+              updatedAt: base,
+              vectorClock: const VectorClock({'a': 2}),
+            ),
+          );
+
+          // Causally newer but with an older wall clock: the clock wins.
+          final causallyNewer = categoryMindfulness.copyWith(
+            name: 'Causally newer',
+            updatedAt: base.subtract(const Duration(hours: 1)),
+            vectorClock: const VectorClock({'a': 3}),
+          );
+          expect(await db!.upsertEntityDefinition(causallyNewer), isNot(0));
+          expect(
+            await storedCategoryName(categoryMindfulness.id),
+            'Causally newer',
+          );
+
+          // Causally older but with a newer wall clock: still skipped.
+          final causallyOlder = categoryMindfulness.copyWith(
+            name: 'Causally older',
+            updatedAt: base.add(const Duration(hours: 1)),
+            vectorClock: const VectorClock({'a': 1}),
+          );
+          expect(await db!.upsertEntityDefinition(causallyOlder), 0);
+          expect(
+            await storedCategoryName(categoryMindfulness.id),
+            'Causally newer',
+          );
+        },
+      );
+
+      test('concurrent vector clocks fall back to updatedAt', () async {
+        await db!.upsertEntityDefinition(
+          categoryMindfulness.copyWith(
+            name: 'Stored',
+            updatedAt: base,
+            vectorClock: const VectorClock({'a': 1}),
+          ),
+        );
+
+        final olderConcurrent = categoryMindfulness.copyWith(
+          name: 'Older concurrent',
+          updatedAt: base.subtract(const Duration(minutes: 1)),
+          vectorClock: const VectorClock({'b': 1}),
+        );
+        expect(await db!.upsertEntityDefinition(olderConcurrent), 0);
+
+        final newerConcurrent = categoryMindfulness.copyWith(
+          name: 'Newer concurrent',
+          updatedAt: base.add(const Duration(minutes: 1)),
+          vectorClock: const VectorClock({'b': 1}),
+        );
+        expect(await db!.upsertEntityDefinition(newerConcurrent), isNot(0));
+        expect(
+          await storedCategoryName(categoryMindfulness.id),
+          'Newer concurrent',
+        );
+      });
+
+      test('the gate covers every definition table', () async {
+        final older = base.subtract(const Duration(minutes: 1));
+
+        await db!.upsertHabitDefinition(
+          habitFlossing.copyWith(name: 'Stored habit', updatedAt: base),
+        );
+        expect(
+          await db!.upsertHabitDefinition(
+            habitFlossing.copyWith(name: 'Late habit', updatedAt: older),
+          ),
+          0,
+        );
+        final habitRow = await (db!.select(
+          db!.habitDefinitions,
+        )..where((t) => t.id.equals(habitFlossing.id))).getSingle();
+        expect(fromHabitDefinitionDbEntity(habitRow).name, 'Stored habit');
+
+        await db!.upsertLabelDefinition(
+          testLabelDefinition1.copyWith(name: 'Stored label', updatedAt: base),
+        );
+        expect(
+          await db!.upsertLabelDefinition(
+            testLabelDefinition1.copyWith(
+              name: 'Late label',
+              updatedAt: older,
+            ),
+          ),
+          0,
+        );
+        final labelRow = await (db!.select(
+          db!.labelDefinitions,
+        )..where((t) => t.id.equals(testLabelDefinition1.id))).getSingle();
+        expect(fromLabelDefinitionDbEntity(labelRow).name, 'Stored label');
+
+        await db!.upsertMeasurableDataType(
+          measurableWater.copyWith(
+            displayName: 'Stored water',
+            updatedAt: base,
+          ),
+        );
+        expect(
+          await db!.upsertMeasurableDataType(
+            measurableWater.copyWith(
+              displayName: 'Late water',
+              updatedAt: older,
+            ),
+          ),
+          0,
+        );
+        final measurableRow = await (db!.select(
+          db!.measurableTypes,
+        )..where((t) => t.id.equals(measurableWater.id))).getSingle();
+        expect(measurableDataType(measurableRow).displayName, 'Stored water');
       });
     });
 

--- a/test/database/database_entity_ops_test.dart
+++ b/test/database/database_entity_ops_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -23,6 +24,23 @@ import 'package:mocktail/mocktail.dart';
 
 import '../mocks/mocks.dart';
 import 'test_utils.dart';
+
+/// Holds the first sidecar write until released so a later write for the
+/// same entity can overtake it on disk.
+class _SlowFirstSidecarJournalDb extends JournalDb {
+  _SlowFirstSidecarJournalDb() : super(inMemoryDatabase: true);
+
+  final Completer<void> releaseFirst = Completer<void>();
+  int sidecarWrites = 0;
+
+  @override
+  Future<void> persistEntityJson(JournalEntity updated) async {
+    if (++sidecarWrites == 1) {
+      await releaseFirst.future;
+    }
+    await super.persistEntityJson(updated);
+  }
+}
 
 enum _ConflictClockRelation {
   equal,
@@ -743,6 +761,41 @@ void main() {
           final conflict = await db!.conflictById(id);
           expect(conflict, isNotNull);
           expect(conflict!.status, ConflictStatus.unresolved.index);
+        },
+      );
+
+      test(
+        'sidecars for one entity land in commit order even when the earlier '
+        'write finishes last',
+        () async {
+          final slowDb = _SlowFirstSidecarJournalDb();
+          addTearDown(slowDb.close);
+          await initConfigFlags(slowDb, inMemoryDatabase: true);
+          const id = 'ordered-sidecar';
+          final first = createJournalEntryWithVclock(
+            const VectorClock({'a': 1}),
+            id: id,
+          );
+          final second = createJournalEntryWithVclock(
+            const VectorClock({'a': 2}),
+            id: id,
+          );
+
+          final firstWrite = slowDb.updateJournalEntity(first);
+          final secondWrite = slowDb.updateJournalEntity(second);
+          // Both rows commit; the first sidecar write is parked. Without
+          // per-entity ordering the second sidecar lands now and the first
+          // overwrites it once released, leaving the older document as the
+          // sync payload for the newer row.
+          await pumpEventQueue();
+          slowDb.releaseFirst.complete();
+          await Future.wait([firstWrite, secondWrite]);
+
+          final sidecar = File(entityPath(second, testDirectory));
+          final onDisk = JournalEntity.fromJson(
+            jsonDecode(sidecar.readAsStringSync()) as Map<String, dynamic>,
+          );
+          expect(onDisk.meta.vectorClock?.vclock, {'a': 2});
         },
       );
 

--- a/test/database/database_entity_ops_test.dart
+++ b/test/database/database_entity_ops_test.dart
@@ -712,6 +712,63 @@ void main() {
       );
     });
 
+    group('Write-path atomicity -', () {
+      test(
+        'concurrent writes of the same id are serialised: the second sees '
+        'the first and records a conflict instead of overwriting it',
+        () async {
+          const id = 'race-entry';
+          final first = createJournalEntryWithVclock(
+            const VectorClock({'a': 1}),
+            id: id,
+          );
+          final second = createJournalEntryWithVclock(
+            const VectorClock({'b': 1}),
+            id: id,
+          );
+
+          // Both calls are issued before either has read the row. Without a
+          // transaction around read + write, both reads return "no row", both
+          // writes apply, and the concurrent clocks are never noticed.
+          final results = await Future.wait([
+            db!.updateJournalEntity(first),
+            db!.updateJournalEntity(second),
+          ]);
+
+          expect(results.where((r) => r.applied), hasLength(1));
+          expect(
+            results.map((r) => r.skipReason),
+            contains(JournalUpdateSkipReason.conflict),
+          );
+          final conflict = await db!.conflictById(id);
+          expect(conflict, isNotNull);
+          expect(conflict!.status, ConflictStatus.unresolved.index);
+        },
+      );
+
+      test('the JSON sidecar is written only for an applied write', () async {
+        final existing = createJournalEntryWithVclock(
+          const VectorClock({'a': 2}),
+          id: 'sidecar-entry',
+        );
+        await db!.updateJournalEntity(existing);
+        final sidecar = File(entityPath(existing, testDirectory));
+        expect(sidecar.existsSync(), isTrue);
+        final before = sidecar.lastModifiedSync();
+        final beforeContent = sidecar.readAsStringSync();
+
+        final older = createJournalEntryWithVclock(
+          const VectorClock({'a': 1}),
+          id: 'sidecar-entry',
+        );
+        final result = await db!.updateJournalEntity(older);
+
+        expect(result.applied, isFalse);
+        expect(sidecar.lastModifiedSync(), before);
+        expect(sidecar.readAsStringSync(), beforeContent);
+      });
+    });
+
     group('Conflict Handling -', () {
       test(
         'addConflict upserts: writing the same conflict id twice keeps a '

--- a/test/database/database_links_ratings_test.dart
+++ b/test/database/database_links_ratings_test.dart
@@ -649,7 +649,7 @@ void main() {
         expect(newLookup.single.toId, 'updated');
       });
 
-      test('upsertEntryLink handles precheck errors gracefully', () async {
+      test('a failing pre-read propagates instead of writing blind', () async {
         final specialDb = _PrecheckThrowingJournalDb();
         addTearDown(() async {
           await specialDb.close();
@@ -663,11 +663,40 @@ void main() {
           timestamp: DateTime(2024, 8, 9),
         );
 
-        final result = await specialDb.upsertEntryLink(link);
-        expect(result, 1);
-        final stored = await specialDb.linksForEntryIds({'dst'});
-        expect(stored, hasLength(1));
+        await expectLater(specialDb.upsertEntryLink(link), throwsStateError);
+        expect(await specialDb.linksForEntryIds({'dst'}), isEmpty);
       });
+
+      test(
+        'concurrent inserts of one (from, to, type) with different ids are '
+        'serialised: one wins, the other is blocked rather than thrown',
+        () async {
+          final base = DateTime(2024, 8, 9);
+          final a = buildEntryLink(
+            id: 'race-a',
+            fromId: 'race-from',
+            toId: 'race-to',
+            timestamp: base,
+          );
+          final b = buildEntryLink(
+            id: 'race-b',
+            fromId: 'race-from',
+            toId: 'race-to',
+            timestamp: base,
+          );
+
+          // Without a transaction both duplicate checks see no row, both
+          // insert, and the second collides on UNIQUE(from_id, to_id, type).
+          final results = await Future.wait([
+            db!.upsertEntryLink(a),
+            db!.upsertEntryLink(b),
+          ]);
+
+          expect(results.where((r) => r != 0), hasLength(1));
+          expect(results, contains(0));
+          expect(await db!.linksForEntryIds({'race-to'}), hasLength(1));
+        },
+      );
     });
 
     group('typedLinksForTaskIds -', () {

--- a/test/features/sync/matrix/sync_event_processor_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_test.dart
@@ -611,6 +611,53 @@ void main() {
     verify(() => fts5Db.reindexMeasurements(renamed, entries)).called(1);
   });
 
+  test(
+    'a definition the journal refuses as older is neither reindexed nor '
+    'announced',
+    () async {
+      final fts5Db = MockFts5Db();
+      final renamed = measurableHydration.copyWith(
+        choices: [
+          for (final choice in measurableHydration.choices!)
+            if (choice.id == hydrationClear.id)
+              choice.copyWith(title: 'Transparent')
+            else
+              choice,
+        ],
+      );
+      processor = SyncEventProcessor(
+        loggingService: loggingService,
+        updateNotifications: updateNotifications,
+        aiConfigRepository: aiConfigRepository,
+        savedTaskFiltersRepository: savedTaskFiltersRepository,
+        settingsDb: settingsDb,
+        journalEntityLoader: journalEntityLoader,
+        fts5Db: fts5Db,
+      );
+      when(
+        () => journalDb.getMeasurableDataTypeById(renamed.id),
+      ).thenAnswer((_) async => measurableHydration);
+      when(
+        () => journalDb.upsertEntityDefinition(any()),
+      ).thenAnswer((_) async => 0);
+      final message = SyncMessage.entityDefinition(
+        entityDefinition: renamed,
+        status: SyncEntryStatus.update,
+      );
+      when(() => event.text).thenReturn(encodeMessage(message));
+
+      await processor.process(event: event, journalDb: journalDb);
+
+      verifyNever(() => fts5Db.reindexMeasurements(any(), any()));
+      verifyNever(
+        () => updateNotifications.notify(
+          any(),
+          fromSync: any(named: 'fromSync'),
+        ),
+      );
+    },
+  );
+
   test('processes ai config messages', () async {
     final message = SyncMessage.aiConfig(
       aiConfig: fallbackAiConfig,

--- a/test/logic/persistence_definition_ops_test.dart
+++ b/test/logic/persistence_definition_ops_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/features/notifications/scheduler/notification_scheduler.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
+import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_definition_ops.dart';
 import 'package:lotti/services/db_notification.dart';
@@ -166,6 +167,9 @@ void main() {
         when(
           () => mocks.journalDb.upsertEntityDefinition(any()),
         ).thenAnswer((_) async => answers.removeAt(0));
+        when(
+          () => mocks.journalDb.definitionStamp(any()),
+        ).thenAnswer((_) async => null);
 
         final affected = await withClock(
           Clock.fixed(fixedNow),
@@ -201,12 +205,81 @@ void main() {
       ).called(1);
     });
 
+    test(
+      'the retry is built from the stored stamp: above its timestamp even '
+      'when that runs ahead of our clock, and carrying its vector clock',
+      () async {
+        final storedAt = DateTime(2026, 9, 5, 14);
+        final fixedNow = DateTime(2026, 9, 5, 12);
+        final stale = categoryMindfulness.copyWith(
+          updatedAt: DateTime(2026, 9, 5, 10),
+          vectorClock: const VectorClock({'a': 1}),
+        );
+        final answers = <int>[0, 1];
+        when(
+          () => mocks.journalDb.upsertEntityDefinition(any()),
+        ).thenAnswer((_) async => answers.removeAt(0));
+        when(() => mocks.journalDb.definitionStamp(any())).thenAnswer(
+          (_) async => (
+            updatedAt: storedAt,
+            vectorClock: const VectorClock({'a': 2}),
+          ),
+        );
+
+        final affected = await withClock(
+          Clock.fixed(fixedNow),
+          () => ops.upsertEntityDefinitionImpl(stale),
+        );
+
+        expect(affected, 1);
+        final written = verify(
+          () => mocks.journalDb.upsertEntityDefinition(captureAny()),
+        ).captured.cast<EntityDefinition>().toList();
+        expect(written, hasLength(2));
+        expect(
+          written.last.updatedAt,
+          storedAt.add(const Duration(milliseconds: 1)),
+        );
+        expect(written.last.vectorClock?.vclock, {'a': 2});
+        final message =
+            verify(
+                  () => outboxService.enqueueMessage(captureAny()),
+                ).captured.single
+                as SyncEntityDefinition;
+        expect(message.entityDefinition, written.last);
+      },
+    );
+
+    test(
+      'an edit refused twice is reported as unsaved and is neither '
+      'announced, reindexed nor synced',
+      () async {
+        when(
+          () => mocks.journalDb.upsertEntityDefinition(any()),
+        ).thenAnswer((_) async => 0);
+        when(() => mocks.journalDb.definitionStamp(any())).thenAnswer(
+          (_) async => (updatedAt: DateTime(2026, 9, 5, 14), vectorClock: null),
+        );
+
+        final affected = await ops.upsertEntityDefinitionImpl(
+          categoryMindfulness,
+        );
+
+        expect(affected, 0);
+        verifyNever(() => mocks.updateNotifications.notify(any()));
+        verifyNever(() => outboxService.enqueueMessage(any()));
+      },
+    );
+
     test('a stale dashboard edit is re-stamped the same way', () async {
       final fixedNow = DateTime(2026, 9, 5, 12);
       final answers = <int>[0, 1];
       when(
         () => mocks.journalDb.upsertDashboardDefinition(any()),
       ).thenAnswer((_) async => answers.removeAt(0));
+      when(
+        () => mocks.journalDb.definitionStamp(any()),
+      ).thenAnswer((_) async => null);
 
       final affected = await withClock(
         Clock.fixed(fixedNow),

--- a/test/logic/persistence_definition_ops_test.dart
+++ b/test/logic/persistence_definition_ops_test.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
@@ -151,6 +152,75 @@ void main() {
       );
     },
   );
+
+  group('stale local edits -', () {
+    test(
+      'an edit the database skips as older is re-stamped and written again, '
+      'and the re-stamped copy is what syncs',
+      () async {
+        final stale = categoryMindfulness.copyWith(
+          updatedAt: DateTime(2026, 9, 5, 10),
+        );
+        final fixedNow = DateTime(2026, 9, 5, 12);
+        final answers = <int>[0, 1];
+        when(
+          () => mocks.journalDb.upsertEntityDefinition(any()),
+        ).thenAnswer((_) async => answers.removeAt(0));
+
+        final affected = await withClock(
+          Clock.fixed(fixedNow),
+          () => ops.upsertEntityDefinitionImpl(stale),
+        );
+
+        expect(affected, 1);
+        final written = verify(
+          () => mocks.journalDb.upsertEntityDefinition(captureAny()),
+        ).captured.cast<EntityDefinition>().toList();
+        expect(written, hasLength(2));
+        expect(written.first, stale);
+        expect(written.last.updatedAt, fixedNow);
+        expect(written.last.id, stale.id);
+        final message =
+            verify(
+                  () => outboxService.enqueueMessage(captureAny()),
+                ).captured.single
+                as SyncEntityDefinition;
+        expect(message.entityDefinition.updatedAt, fixedNow);
+      },
+    );
+
+    test('an edit the database applies is written exactly once', () async {
+      when(
+        () => mocks.journalDb.upsertEntityDefinition(any()),
+      ).thenAnswer((_) async => 1);
+
+      await ops.upsertEntityDefinitionImpl(categoryMindfulness);
+
+      verify(
+        () => mocks.journalDb.upsertEntityDefinition(categoryMindfulness),
+      ).called(1);
+    });
+
+    test('a stale dashboard edit is re-stamped the same way', () async {
+      final fixedNow = DateTime(2026, 9, 5, 12);
+      final answers = <int>[0, 1];
+      when(
+        () => mocks.journalDb.upsertDashboardDefinition(any()),
+      ).thenAnswer((_) async => answers.removeAt(0));
+
+      final affected = await withClock(
+        Clock.fixed(fixedNow),
+        () => ops.upsertDashboardDefinitionImpl(dashboard),
+      );
+
+      expect(affected, 1);
+      final written = verify(
+        () => mocks.journalDb.upsertDashboardDefinition(captureAny()),
+      ).captured.cast<DashboardDefinition>().toList();
+      expect(written, hasLength(2));
+      expect(written.last.updatedAt, fixedNow);
+    });
+  });
 
   test(
     'upsertDashboardDefinitionImpl notifies and enqueues a sync update',


### PR DESCRIPTION
## Summary

Findings 1–3 of the persistence-layer review, which share one transaction shape.

**`updateJournalEntity` is one transaction.** It read the stored row, compared vector clocks, upserted, resolved conflicts and reconciled `labeled` as separate statements. On the local path nothing wrapped them (the sync inbound handler already wraps its call), so a local edit racing an inbound sync of the same id could both pass the check and both write, and with `readPool: 4` the pre-write read could be served from a stale snapshot. Drift serialises transactions on the write connection, so the second writer now waits, sees the first row, and records a conflict instead of silently overwriting. The JSON sidecar — the sync payload — is written **after** commit, so it never describes a row that rolled back and the writer lock is never held across file I/O. The sync handler's outer transaction simply nests.

**`upsertEntryLink` is one transaction.** Same shape: an equality pre-read, a `(from_id, to_id, type)` duplicate check, a tombstone delete, the insert. Two concurrent creations of the same link (local plus sync) could both pass the check and collide on the UNIQUE constraint. The `catch (_)` around the pre-read is gone: a failing read is a database error, not a reason to write blind.

**Definition upserts are gated on recency.** `upsertEntityDefinition` and the five typed upserts were blind `insertOnConflictUpdate` calls, although every definition carries `updatedAt` (which every local edit path refreshes "so the change wins the last-writer-wins merge on sync", per `CategoriesRepository`) and a `vectorClock`. Nothing enforced that on the receiving side, so a definition arriving late by sync, or re-sent by a historical resync, overwrote a newer local one, and an older live copy could resurrect a newer deletion. Now: when both sides carry a vector clock that orders them, the clock decides; otherwise `updatedAt` does; an exact tie applies the incoming copy so a local re-save is never dropped; and the stored row is read by id with no `deleted`/`private` filter (the `.drift` getters filter deleted rows, which is exactly the resurrection hole). Only `updatedAt` and `vectorClock` of the stored JSON are decoded, never the whole document, so a legacy dashboard that no longer parses cannot block the write.

Some local edit paths (the measurables page, habit delete) do not refresh `updatedAt`. If a sync landed while such an editor was open, the gate would reject the user's action. `PersistenceDefinitionOps` therefore re-stamps a rejected local edit with `clock.now()` and writes it again, and the re-stamped copy is what gets notified and synced. That preserves today's "local action always applies" behaviour while making it win on every peer.

## Tests

Each of these fails with the corresponding fix reverted (verified by stashing the three database files):

- concurrent `updateJournalEntity` calls for one id with concurrent clocks → exactly one applied, a conflict row recorded (previously both applied, no conflict)
- the sidecar is untouched when a write is skipped
- concurrent `upsertEntryLink` for one `(from, to, type)` with different ids → one wins, the other returns 0 (previously a UNIQUE violation)
- a failing pre-read propagates and nothing is written (replaces the test that asserted the error was swallowed)
- recency gate: older skipped, newer applied, tie applied, older cannot resurrect a newer deletion, ordered vector clocks beat `updatedAt`, concurrent clocks fall back to `updatedAt`, gate covers habits, labels and measurables too
- `PersistenceDefinitionOps`: a rejected local edit is re-stamped and written again, the re-stamped copy syncs; an accepted edit is written once; dashboards take the same path

Also ran every sync and logic test that uses a real `JournalDb` (323 tests, including the inbound journal handler that nests its transaction around this call): green. `make analyze` and `make knowledge_check` clean.

## Docs

`knowledge/architecture/persistence.md` gains a "Write atomicity" section describing the three guarantees.

No changelog fragment: the visible effect is the absence of a rare silent overwrite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented older or conflicting updates from overwriting newer data.
  * Improved handling of concurrent writes, duplicate links, deletions, and conflict recording.
  * Ensured failed database reads stop link updates instead of allowing unintended writes.
  * Preserved sidecar data when an update is rejected.
  * Automatically refreshed timestamps for stale local edits so they can be saved and synchronized correctly.

* **Documentation**
  * Added documentation describing transactional write guarantees and concurrency behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->