### PR TITLE
fix(sync): recover missing payloads and preserve reserved counters

### DIFF
--- a/changelog.d/2026-09-05-sync-recovery.md
+++ b/changelog.d/2026-09-05-sync-recovery.md
@@ -1,0 +1,7 @@
+### Fixed
+- **Sync can recover missing journal upload files.** Entries still held in the
+  local database, including deletions, can be sent without repeatedly retrying
+  a missing file, provided they cover every queued version.
+- **Sync handles out-of-order labels and pending writes more reliably.** Missing
+  label definitions no longer fail background sync, and a pending local write
+  is not incorrectly reported to other devices as an unused sequence number.

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -103,6 +103,12 @@ Embeddings are the exception to "everything is Drift". Vector search uses
 because it provides on-device approximate nearest-neighbour search that SQLite
 does not.
 
+Label assignment tolerates SQLite constraint errors for duplicate assignments
+and label definitions that have not arrived through sync. The classifier uses
+the primary code's low byte, including extended codes transported through a
+background isolate. Other SQL errors propagate so reconciliation transactions
+roll back instead of committing a partial label set.
+
 # Opening a connection
 
 Every database goes through `openDbConnection()`, so they share one set of

--- a/knowledge/features/sync/send-path.md
+++ b/knowledge/features/sync/send-path.md
@@ -186,6 +186,13 @@ versions remain sendable. Journal and notification senders already snapshot
 their file bytes before upload and reconcile the envelope against that same
 snapshot; outbox bundles use a fresh UUID path and stamp the manifest upload id.
 
+When a standalone journal sidecar is missing, the sender reads the canonical
+journal row, including deletion tombstones. That replacement must cover the
+queued vector clock and every merged covered clock before upload. Recovery
+serializes the row in memory and leaves the reclaimed sidecar absent. An absent
+row, an older or concurrent clock, or another filesystem error keeps the outbox
+item retryable; none acknowledges an unsent generation.
+
 # Item lifecycle
 
 ```mermaid

--- a/knowledge/features/sync/sequence-and-backfill.md
+++ b/knowledge/features/sync/sequence-and-backfill.md
@@ -114,6 +114,10 @@ Startup reconciliation retries `burnPending` rows by enqueueing the durable
 deliberately does **not** terminalize plain `reserved` rows: a crash may have
 left a real local payload behind before outbox logging ran, and burning it would
 destroy recoverable data.
+Backfill replies preserve the same distinction: an own-host `reserved` row is
+deferred without sending an unresolvable marker or starting a successful-reply
+cooldown. Once its payload binding succeeds, the next request can send it.
+
 
 Local persistence records the exact `(host, counter, entry, payload type)`
 binding immediately after its data commit. The outbox records it again as a

--- a/lib/database/database_definitions.dart
+++ b/lib/database/database_definitions.dart
@@ -20,10 +20,20 @@ mixin _JournalDbDefinitions on _$JournalDb, _JournalDbConfigFlags {
       // always tolerated; anything else now propagates so addLabeled's
       // transaction rolls back instead of committing a partial reconcile.
       // Drift can wrap SqliteException when running through an isolate, so
-      // match the printed form as well as the type.
+      // match the complete printed code as well as the type. Remote errors
+      // print extended codes (e.g. 787 for FOREIGN KEY); SQLite stores the
+      // primary result code in the low byte. Anchor at the exception header
+      // so SQL text or parameters cannot masquerade as a constraint error.
+      final resultCode = ex is SqliteException
+          ? ex.resultCode
+          : int.tryParse(
+              RegExp(
+                    r'^SqliteException\((\d+)\)',
+                  ).firstMatch(ex.toString())?.group(1) ??
+                  '',
+            );
       final isConstraintViolation =
-          (ex is SqliteException && ex.resultCode == 19) ||
-          ex.toString().contains('SqliteException(19');
+          resultCode != null && (resultCode & 0xff) == 19;
       if (!isConstraintViolation) rethrow;
       DevLogger.error(
         name: 'JournalDb',

--- a/lib/features/sync/backfill/backfill_response_handler.dart
+++ b/lib/features/sync/backfill/backfill_response_handler.dart
@@ -370,11 +370,20 @@ class BackfillResponseHandler {
     // DIFFERENT entity and its payload does not carry whatever the burnt
     // write would have mutated. Attributing that payload to the burnt
     // counter silently mis-maps state on the requester's side. For own-host
-    // misses we therefore send `unresolvable` immediately — our sequence
-    // log is authoritative for our own counters, so any miss is
-    // definitively a burn.
+    // misses outside an outstanding reservation, retain the legacy
+    // unresolvable response. A reserved row is not proof of a burn: the local
+    // write may still be in flight, or have committed before a crash prevented
+    // its sequence binding. Startup recovery preserves these rows too.
     final myHost = await _vectorClockService.getHost();
     final isOwnHost = myHost != null && hostId == myHost;
+
+    if (isOwnHost && logEntry?.status == SyncSequenceStatus.reserved.index) {
+      _trace(
+        'deferring own-host reservation until payload binding or release',
+        subDomain: 'backfill.reserved',
+      );
+      return false;
+    }
 
     if (logEntry != null && logEntry.entryId != null) {
       final payloadType = SyncSequencePayloadType.values.elementAt(
@@ -437,8 +446,8 @@ class BackfillResponseHandler {
         // so no write ever carried it. Covering by a later (necessarily
         // different) entity would misattribute unrelated state to this
         // counter on the requester's side — always wrong for own-host
-        // burns. Send unresolvable so the requester marks `status=5` and
-        // skips the covering lookup entirely.
+        // burns. The reserved case was deferred above. Send the authoritative
+        // unresolvable marker so peers mark it burned, without covering.
         _trace(
           'own-host miss → unresolvable (no covering attempted) '
           'hostId=$hostId counter=$counter payloadType=$payloadType',

--- a/lib/features/sync/matrix/matrix_payload_sender.dart
+++ b/lib/features/sync/matrix/matrix_payload_sender.dart
@@ -148,6 +148,40 @@ class MatrixPayloadSender {
     }
   }
 
+  /// Reads the sidecar snapshot, or reconstructs a missing file's payload from
+  /// the authoritative database without recreating it on disk. Only a version
+  /// covering every queued clock can replace that missing snapshot; otherwise
+  /// the outbox must retain the send for retry/recovery.
+  Future<Uint8List> _readJournalPayload(
+    SyncJournalEntity message,
+    String fullPath,
+  ) async {
+    try {
+      return await File(fullPath).readAsBytes();
+    } on PathNotFoundException {
+      final entities = await journalDb.journalEntityMapForIdsIncludingDeleted(
+        [message.id],
+      );
+      final entity = entities[message.id];
+      if (entity == null) rethrow;
+      final recoveredClock = entity.meta.vectorClock;
+      for (final queuedClock in [
+        message.vectorClock,
+        ...?message.coveredVectorClocks,
+      ]) {
+        if (queuedClock == null) continue;
+        if (recoveredClock == null ||
+            !{
+              VclockStatus.equal,
+              VclockStatus.a_gt_b,
+            }.contains(VectorClock.compare(recoveredClock, queuedClock))) {
+          throw StateError('Database payload does not cover queued version');
+        }
+      }
+      return Uint8List.fromList(utf8.encode(jsonEncode(entity.toJson())));
+    }
+  }
+
   Future<SyncJournalEntity?> sendJournalEntityPayload({
     required Room room,
     required SyncJournalEntity message,
@@ -159,7 +193,7 @@ class MatrixPayloadSender {
 
     late final Uint8List jsonBytes;
     try {
-      jsonBytes = await File(jsonFullPath).readAsBytes();
+      jsonBytes = await _readJournalPayload(message, jsonFullPath);
     } catch (error, stackTrace) {
       _trace(
         'EXCEPTION readJsonFile path=$jsonFullPath '

--- a/test/database/database_definitions_test.dart
+++ b/test/database/database_definitions_test.dart
@@ -592,6 +592,47 @@ void main() {
 
     group('insertLabel error handling -', () {
       test(
+        'background SQLite extended FK errors remain sync-tolerant',
+        () async {
+          final remoteDb = JournalDb(
+            overriddenFilename: 'remote-labels.sqlite',
+            readPool: 0,
+            documentsDirectoryProvider: () async => testDirectory,
+            tempDirectoryProvider: () async => testDirectory,
+          );
+          try {
+            final entry = buildJournalEntry(
+              id: 'remote-fk-entry',
+              timestamp: DateTime(2024, 12, 2, 9),
+              text: 'Synthetic sync entry',
+            );
+            await remoteDb.upsertJournalDbEntity(toDbEntity(entry));
+            DevLogger.clear();
+            await remoteDb.insertLabel(entry.meta.id, 'not-yet-synced');
+            expect(
+              await remoteDb.labeledForJournal(entry.meta.id).get(),
+              isEmpty,
+            );
+            expect(
+              DevLogger.capturedLogs.any(
+                (message) => message.contains('insertLabel failed'),
+              ),
+              isTrue,
+            );
+            // A remote SQL error must still propagate rather than being treated
+            // as an out-of-order label definition.
+            await remoteDb.customStatement('DROP TABLE labeled');
+            await expectLater(
+              remoteDb.insertLabel(entry.meta.id, 'not-yet-synced'),
+              throwsA(anything),
+            );
+          } finally {
+            await remoteDb.close();
+          }
+        },
+      );
+
+      test(
         'missing label definition (FK violation) is tolerated and logged',
         () async {
           final base = DateTime(2024, 12, 2, 9);

--- a/test/features/sync/backfill/backfill_response_handler_test.dart
+++ b/test/features/sync/backfill/backfill_response_handler_test.dart
@@ -1302,6 +1302,63 @@ void main() {
       },
     );
 
+    test('defers an own reserved counter until its payload is bound', () async {
+      const request = SyncBackfillRequest(
+        entries: [BackfillRequestEntry(hostId: aliceHostId, counter: 3)],
+        requesterId: requesterId,
+      );
+      _stubRequestLookup(
+        mockSequenceService,
+        mockOutboxService,
+        hostId: aliceHostId,
+        counter: 3,
+        logItem: _createLogItem(
+          aliceHostId,
+          3,
+          status: SyncSequenceStatus.reserved,
+        ),
+      );
+      await handler.handleBackfillRequest(request);
+      verifyNever(() => mockOutboxService.enqueueMessage(any()));
+      verifyNever(
+        () => mockSequenceService.markOwnCounterUnresolvable(
+          hostId: any(named: 'hostId'),
+          counter: any(named: 'counter'),
+          payloadType: any(named: 'payloadType'),
+        ),
+      );
+
+      // A later successful binding must be answerable immediately. Deferring
+      // the reservation must not start the successful-response cooldown.
+      _stubRequestLookup(
+        mockSequenceService,
+        mockOutboxService,
+        hostId: aliceHostId,
+        counter: 3,
+        logItem: _createLogItem(aliceHostId, 3, entryId: 'reserved-payload'),
+      );
+      when(
+        () => mockJournalDb.journalEntityById('reserved-payload'),
+      ).thenAnswer(
+        (_) async => _createJournalEntry(
+          'reserved-payload',
+          vectorClock: const VectorClock({aliceHostId: 3}),
+        ),
+      );
+      await handler.handleBackfillRequest(request);
+      verify(
+        () => mockOutboxService.enqueueMessage(
+          any(
+            that: isA<SyncJournalEntity>().having(
+              (message) => message.id,
+              'id',
+              'reserved-payload',
+            ),
+          ),
+        ),
+      ).called(1);
+    });
+
     test('sends unresolvable when own counter not in sequence log', () async {
       // Request for Alice's counter (our own) - we can't find it
       // Only we can answer for our own counters, so send unresolvable

--- a/test/features/sync/matrix/matrix_payload_sender_test.dart
+++ b/test/features/sync/matrix/matrix_payload_sender_test.dart
@@ -203,6 +203,173 @@ void main() {
     });
   });
 
+  group('sendJournalEntityPayload missing JSON recovery', () {
+    const message = SyncJournalEntity(
+      id: 'recovery-entry',
+      jsonPath: '/entries/recovery.json',
+      vectorClock: VectorClock({'hostA': 2}),
+      status: SyncEntryStatus.update,
+    );
+
+    JournalEntity entity({VectorClock? clock, bool deleted = false}) {
+      final date = DateTime.utc(2024, 3, 15);
+      return JournalEntity.journalEntry(
+        meta: Metadata(
+          id: message.id,
+          createdAt: date,
+          updatedAt: date,
+          dateFrom: date,
+          dateTo: date,
+          deletedAt: deleted ? date : null,
+          vectorClock: clock,
+        ),
+      );
+    }
+
+    void stubRecovery(JournalEntity? recovered) {
+      when(
+        () => journalDb.journalEntityMapForIdsIncludingDeleted([message.id]),
+      ).thenAnswer((_) async => {message.id: ?recovered});
+      when(
+        () => journalDb.getConfigFlag(resendAttachments),
+      ).thenAnswer((_) async => false);
+    }
+
+    for (final deleted in [false, true]) {
+      test(
+        'recovers missing JSON from DB including deleted=$deleted',
+        () async {
+          final recovered = entity(
+            clock: const VectorClock({'hostA': 3}),
+            deleted: deleted,
+          );
+          stubRecovery(recovered);
+          MatrixFile? uploaded;
+          when(
+            () => room.sendFileEvent(
+              any<MatrixFile>(),
+              extraContent: any<Map<String, dynamic>>(named: 'extraContent'),
+            ),
+          ).thenAnswer((invocation) async {
+            uploaded = invocation.positionalArguments.first as MatrixFile;
+            return 'recovered-upload';
+          });
+          final result = await payloadSender.sendJournalEntityPayload(
+            room: room,
+            message: message,
+          );
+          expect(result?.attachmentEventId, 'recovered-upload');
+          expect(result?.vectorClock, recovered.meta.vectorClock);
+          expect(result?.coveredVectorClocks, contains(message.vectorClock));
+          expect(
+            JournalEntity.fromJson(
+              jsonDecode(utf8.decode(gzip.decode(uploaded!.bytes)))
+                  as Map<String, dynamic>,
+            ),
+            recovered,
+          );
+          expect(
+            File('${documentsDirectory.path}${message.jsonPath}').existsSync(),
+            isFalse,
+            reason: 'Recovery must not recreate a reclaimed sidecar.',
+          );
+        },
+      );
+    }
+
+    for (final clock in <VectorClock?>[
+      null,
+      const VectorClock({'hostA': 1}),
+      const VectorClock({'hostA': 1, 'hostB': 3}),
+    ]) {
+      test(
+        'does not acknowledge a missing queued version from DB clock $clock',
+        () async {
+          stubRecovery(entity(clock: clock));
+          final result = await payloadSender.sendJournalEntityPayload(
+            room: room,
+            message: message,
+          );
+          expect(result, isNull);
+          verifyNever(
+            () => room.sendFileEvent(
+              any<MatrixFile>(),
+              extraContent: any<Map<String, dynamic>>(named: 'extraContent'),
+            ),
+          );
+          verify(
+            () => journalDb.journalEntityMapForIdsIncludingDeleted(
+              [message.id],
+            ),
+          ).called(1);
+        },
+      );
+    }
+
+    test('checks covered clocks as well as the queued version', () async {
+      stubRecovery(entity(clock: const VectorClock({'hostA': 3})));
+      final merged = message.copyWith(
+        coveredVectorClocks: const [
+          VectorClock({'hostB': 1}),
+        ],
+      );
+      expect(
+        await payloadSender.sendJournalEntityPayload(
+          room: room,
+          message: merged,
+        ),
+        isNull,
+      );
+      verifyNever(
+        () => room.sendFileEvent(
+          any<MatrixFile>(),
+          extraContent: any<Map<String, dynamic>>(named: 'extraContent'),
+        ),
+      );
+      verify(
+        () => journalDb.journalEntityMapForIdsIncludingDeleted([message.id]),
+      ).called(1);
+    });
+
+    test('keeps genuinely absent payloads retryable', () async {
+      stubRecovery(null);
+      expect(
+        await payloadSender.sendJournalEntityPayload(
+          room: room,
+          message: message,
+        ),
+        isNull,
+      );
+      verify(
+        () => journalDb.journalEntityMapForIdsIncludingDeleted(
+          [message.id],
+        ),
+      ).called(1);
+      verifyNever(
+        () => room.sendFileEvent(
+          any<MatrixFile>(),
+          extraContent: any<Map<String, dynamic>>(named: 'extraContent'),
+        ),
+      );
+    });
+
+    test('does not use DB fallback for other filesystem failures', () async {
+      Directory(
+        '${documentsDirectory.path}${message.jsonPath}',
+      ).createSync(recursive: true);
+      expect(
+        await payloadSender.sendJournalEntityPayload(
+          room: room,
+          message: message,
+        ),
+        isNull,
+      );
+      verifyNever(
+        () => journalDb.journalEntityMapForIdsIncludingDeleted(any()),
+      );
+    });
+  });
+
   group('sendJournalEntityPayload attachments', () {
     /// Writes an image entry's JSON payload and its 12-byte blob under the
     /// documents directory, and returns the relative paths of every file event


### PR DESCRIPTION
Standalone journal sends could repeatedly fail after their JSON sidecar disappeared, background-isolate label constraint errors escaped the intended sync tolerance, and backfill could declare an outstanding local reservation unused.

This change reconstructs missing standalone journal payloads from the database, including tombstones, only when the stored clock covers every queued version. It recognizes SQLite extended constraint codes and defers backfill replies for outstanding own-host reservations until a payload is bound or the reservation is explicitly released.

Validation:
- 118 targeted tests passed with randomized order.
- Regression tests fail with the production fixes reverted; a separate mutation proves that merged covered clocks are checked before uploading.
- Full-repository Dart MCP analyzer reports no errors, warnings, or infos.
- Knowledge validation passed, including all 525 Mermaid diagrams; changelog validation passed.

The existing reservation audit remains conservative: an audit record alone cannot prove that a counter is unused, so this change does not discard or burn historic reservations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sync can now recover missing journal upload files from local data, including deletion records, when the data covers all queued changes.
  * Missing journal files remain retryable when recovery data is unavailable, outdated, or incomplete.
  * Background sync now tolerates out-of-order label updates while continuing to report genuine database errors.
  * Pending local sequence reservations are deferred until their payload is available, preventing premature failure reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->