### PR TITLE
fix: stabilize goal provider refreshes

### DIFF
--- a/changelog.d/2026-09-05-goal-provider-lifecycle.md
+++ b/changelog.d/2026-09-05-goal-provider-lifecycle.md
@@ -1,0 +1,4 @@
+### Fixed
+- **Goals no longer leave callbacks running after navigation or refresh.**
+  Pending progress and banner reads stop when their view is disposed, avoiding
+  late provider errors and unnecessary deadline timers.

--- a/changelog.d/2026-09-05-goal-provider-lifecycle.md
+++ b/changelog.d/2026-09-05-goal-provider-lifecycle.md
@@ -2,3 +2,5 @@
 - **Goals no longer leave callbacks running after navigation or refresh.**
   Pending progress and banner reads stop when their view is disposed, avoiding
   late provider errors and unnecessary deadline timers.
+- Goal banners reuse the loaded goal list during banner-only refreshes,
+  reducing repeated database reads.

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -1114,6 +1114,10 @@ flowchart TD
   asynchronous read. Each computation stops before further provider access or
   timer registration when invalidated, including the interval before Riverpod
   replaces its ref. Existing deadline timers are cancelled on disposal.
+  Banners watch `activeGoalAgentsProvider.future` so the goal list and banner
+  share one identity query. Banner-only and per-agent refreshes retain that
+  identity result; global agent notifications invalidate it. App resume
+  explicitly refreshes the shared identities as well as banner deadlines.
   The data
   dimensions render under a Signals heading whose footnote states the
   deterministic freshness contract (live within seconds, bounded to what is

--- a/knowledge/features/goals.md
+++ b/knowledge/features/goals.md
@@ -1109,7 +1109,12 @@ flowchart TD
   completion service; category-time dimensions never trigger the suggestion
   because their days are observed by definition.
   The provider invalidates itself at the next local midnight so Today,
-  ages-out and window boundaries cannot remain stuck on yesterday. The data
+  ages-out and window boundaries cannot remain stuck on yesterday. Progress
+  projections and active-banner reads register disposal before their first
+  asynchronous read. Each computation stops before further provider access or
+  timer registration when invalidated, including the interval before Riverpod
+  replaces its ref. Existing deadline timers are cancelled on disposal.
+  The data
   dimensions render under a Signals heading whose footnote states the
   deterministic freshness contract (live within seconds, bounded to what is
   listed). A reliability tail is shown

--- a/lib/features/goals/state/goal_agent_providers.dart
+++ b/lib/features/goals/state/goal_agent_providers.dart
@@ -427,14 +427,15 @@ final FutureProvider<List<NudgeBannerEntry>> activeGoalNudgesProvider =
       var disposed = false;
       ref.onDispose(() => disposed = true);
       final lifecycleListener = AppLifecycleListener(
-        onResume: ref.invalidateSelf,
+        onResume: () {
+          // Resume refreshes identities as well as time-sensitive banners.
+          ref
+            ..invalidate(activeGoalAgentsProvider)
+            ..invalidateSelf();
+        },
       );
-      ref
-        ..onDispose(lifecycleListener.dispose)
-        ..watch(agentUpdateStreamProvider(agentNotification));
-      final agents = await ref
-          .watch(agentServiceProvider)
-          .listAgents(lifecycle: AgentLifecycle.active);
+      ref.onDispose(lifecycleListener.dispose);
+      final agents = await ref.watch(activeGoalAgentsProvider.future);
       if (disposed) return const [];
       final repository = ref.watch(agentRepositoryProvider);
       final entries = <NudgeBannerEntry>[];
@@ -448,7 +449,6 @@ final FutureProvider<List<NudgeBannerEntry>> activeGoalNudgesProvider =
       }
 
       for (final identity in agents) {
-        if (identity.kind != AgentKinds.goalAgent) continue;
         ref.watch(agentUpdateStreamProvider(identity.agentId));
         // A banner created under a superseded spec can sync in AFTER the
         // revision sweep ran — its own provenance is the fence (Phase A

--- a/lib/features/goals/state/goal_agent_providers.dart
+++ b/lib/features/goals/state/goal_agent_providers.dart
@@ -422,6 +422,10 @@ final FutureProvider<List<NudgeBannerEntry>> activeGoalNudgesProvider =
       final unifiedGoalsEnabled =
           ref.watch(configFlagProvider(enableUnifiedGoalsFlag)).value ?? false;
       if (!unifiedGoalsEnabled) return const [];
+      // onDispose also runs at invalidation, before Riverpod replaces the ref.
+      // Stop this generation immediately, even if an awaited read lands first.
+      var disposed = false;
+      ref.onDispose(() => disposed = true);
       final lifecycleListener = AppLifecycleListener(
         onResume: ref.invalidateSelf,
       );
@@ -431,6 +435,7 @@ final FutureProvider<List<NudgeBannerEntry>> activeGoalNudgesProvider =
       final agents = await ref
           .watch(agentServiceProvider)
           .listAgents(lifecycle: AgentLifecycle.active);
+      if (disposed) return const [];
       final repository = ref.watch(agentRepositoryProvider);
       final entries = <NudgeBannerEntry>[];
       final now = clock.now();
@@ -451,12 +456,14 @@ final FutureProvider<List<NudgeBannerEntry>> activeGoalNudgesProvider =
         final head = await repository.getEntity(
           goalSpecHeadId(identity.agentId),
         );
+        if (disposed) return const [];
         // The head must RESOLVE: a dangling pointer (partial sync) is
         // not a live spec, and a tagged banner validated against it
         // would render with no goal statement behind it.
         final headVersion = head is GoalSpecHeadEntity
             ? await repository.getEntity(head.versionId)
             : null;
+        if (disposed) return const [];
         final activeVersionId = headVersion is GoalSpecVersionEntity
             ? headVersion.id
             : null;
@@ -464,6 +471,7 @@ final FutureProvider<List<NudgeBannerEntry>> activeGoalNudgesProvider =
           identity.agentId,
           type: AgentEntityTypes.goalNudge,
         )).whereType<GoalNudgeEntity>();
+        if (disposed) return const [];
         for (final nudge in nudges) {
           final origin = nudge.provenance['specVersionId'];
           if (nudge.deletedAt != null ||

--- a/lib/features/goals/state/goal_progress_view.dart
+++ b/lib/features/goals/state/goal_progress_view.dart
@@ -1032,7 +1032,14 @@ Future<GoalProgressView?> _progressView(
   String agentId,
   int? historyDays,
 ) async {
+  // Invalidation runs onDispose before the scheduled rebuild replaces Ref.
+  // Guard the computation itself, including that interval between generations.
+  var disposed = false;
+  ref.onDispose(() => disposed = true);
   final health = await ref.watch(goalAgentHealthProvider(agentId).future);
+  // A dependency may complete after navigation or a reload disposed this
+  // computation. Never register a timer or read another provider in that case.
+  if (disposed) return null;
   final spec = health.spec;
   if (spec == null) return null;
   final reference = clock.now();
@@ -1057,6 +1064,7 @@ Future<GoalProgressView?> _progressView(
         shortTermDays: math.max(43, (historyDays ?? 0) + 7),
       );
 
+  if (disposed) return null;
   final habitIds = <String>{};
   void collect(GoalCriterion criterion) {
     switch (criterion) {
@@ -1124,6 +1132,7 @@ Future<GoalProgressView?> _progressView(
     final definition = await db.getLabelDefinitionById(labelId);
     if (definition != null) labelNames[labelId] = definition.name;
   }
+  if (disposed) return null;
   final captureDecisions = measurableIds.isEmpty
       ? const <String, GoalMeasurableCaptureDecision>{}
       : await ref.watch(

--- a/lib/features/goals/state/goal_progress_view.dart
+++ b/lib/features/goals/state/goal_progress_view.dart
@@ -1138,6 +1138,7 @@ Future<GoalProgressView?> _progressView(
       : await ref.watch(
           goalMeasurableCaptureDecisionsProvider(agentId).future,
         );
+  if (disposed) return null;
   final agentRecordedMeasurementIds = {
     for (final decision in captureDecisions.values)
       if (decision.recorded) ...decision.entryIds,

--- a/test/features/goals/state/goal_agent_providers_test.dart
+++ b/test/features/goals/state/goal_agent_providers_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:clock/clock.dart';
 import 'package:fake_async/fake_async.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/goal_criterion.dart';
@@ -35,6 +36,7 @@ import 'package:lotti/features/nudges/state/nudge_banner_providers.dart';
 import 'package:lotti/features/nudges/ui/nudge_banner_dock.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/providers/service_providers.dart' show journalDbProvider;
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:mocktail/mocktail.dart';
@@ -1650,6 +1652,95 @@ void main() {
     expect(health.spec?.version, 2);
   });
 
+  test(
+    'banner and goal list share identities across banner-only refreshes',
+    () {
+      fakeAsync((async) {
+        when(
+          () => updateNotifications.updateStream,
+        ).thenAnswer((_) => syncStream.stream);
+        when(
+          () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+        ).thenAnswer((_) async => [goalIdentity('goal-a')]);
+        final agentsSub = container.listen(activeGoalAgentsProvider, (_, _) {});
+        final bannerSub = container.listen(activeGoalNudgesProvider, (_, _) {});
+        async.elapse(const Duration(milliseconds: 1));
+        expect(
+          container
+              .read(activeGoalAgentsProvider)
+              .requireValue
+              .map((a) => a.agentId),
+          ['goal-a'],
+        );
+        verify(
+          () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+        ).called(1);
+        container.invalidate(activeGoalNudgesProvider);
+        async.elapse(Duration.zero);
+        syncStream.add({'goal-a'});
+        async.elapse(const Duration(milliseconds: 1));
+        verifyNever(
+          () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+        );
+        when(
+          () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+        ).thenAnswer((_) async => [goalIdentity('goal-b')]);
+        syncStream.add({agentNotification});
+        async.elapse(const Duration(milliseconds: 1));
+        verify(
+          () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+        ).called(1);
+        expect(
+          container
+              .read(activeGoalAgentsProvider)
+              .requireValue
+              .map((a) => a.agentId),
+          ['goal-b'],
+        );
+        verify(() => repository.getEntity(goalSpecHeadId('goal-b'))).called(1);
+        bannerSub.close();
+        agentsSub.close();
+      }, initialTime: DateTime(2026, 9, 5, 12));
+    },
+  );
+
+  testWidgets('resume refreshes the shared identities used by banners', (
+    tester,
+  ) async {
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    when(
+      () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+    ).thenAnswer((_) async => [goalIdentity('goal-a')]);
+    final agentsSub = container.listen(activeGoalAgentsProvider, (_, _) {});
+    final bannerSub = container.listen(activeGoalNudgesProvider, (_, _) {});
+    addTearDown(agentsSub.close);
+    addTearDown(bannerSub.close);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1));
+    verify(
+      () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+    ).called(1);
+    when(
+      () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+    ).thenAnswer((_) async => [goalIdentity('goal-b')]);
+    tester.binding
+      ..handleAppLifecycleStateChanged(AppLifecycleState.inactive)
+      ..handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1));
+    verify(
+      () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+    ).called(1);
+    expect(
+      container
+          .read(activeGoalAgentsProvider)
+          .requireValue
+          .map((a) => a.agentId),
+      ['goal-b'],
+    );
+    verify(() => repository.getEntity(goalSpecHeadId('goal-b'))).called(1);
+  });
+
   for (final fullyDispose in [false, true]) {
     for (final pendingStage in ['agents', 'head', 'version', 'nudges']) {
       test(
@@ -1675,6 +1766,10 @@ void main() {
             ).thenAnswer((_) => nudges.future);
             final flag = container.listen(
               configFlagProvider(enableUnifiedGoalsFlag),
+              (_, _) {},
+            );
+            final agentsSubscription = container.listen(
+              activeGoalAgentsProvider,
               (_, _) {},
             );
             final probe = FutureProviderProbe(activeGoalNudgesProvider);
@@ -1745,6 +1840,7 @@ void main() {
                 ),
               );
             }
+            agentsSubscription.close();
             flag.close();
           }, initialTime: DateTime(2026, 9, 5, 12));
         },

--- a/test/features/goals/state/goal_agent_providers_test.dart
+++ b/test/features/goals/state/goal_agent_providers_test.dart
@@ -40,6 +40,7 @@ import 'package:lotti/utils/consts.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
+import '../../../helpers/future_provider_probe.dart';
 import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
 
@@ -1648,6 +1649,108 @@ void main() {
     expect(health.attainment, 0.9);
     expect(health.spec?.version, 2);
   });
+
+  for (final fullyDispose in [false, true]) {
+    for (final pendingStage in ['agents', 'head', 'version', 'nudges']) {
+      test(
+        'disposed goal banners stop after pending $pendingStage lookup (fully disposed: $fullyDispose)',
+        () {
+          fakeAsync((async) {
+            final agents = Completer<List<AgentIdentityEntity>>();
+            final head = Completer<AgentDomainEntity?>();
+            final version = Completer<AgentDomainEntity?>();
+            final nudges = Completer<List<AgentDomainEntity>>();
+            when(
+              () => agentService.listAgents(lifecycle: AgentLifecycle.active),
+            ).thenAnswer((_) => agents.future);
+            when(
+              () => repository.getEntity(any()),
+            ).thenAnswer((_) => head.future);
+            when(
+              () => repository.getEntity('goal-a:spec-v1'),
+            ).thenAnswer((_) => version.future);
+            when(
+              () =>
+                  repository.getEntitiesByAgentId('goal-a', type: 'goalNudge'),
+            ).thenAnswer((_) => nudges.future);
+            final flag = container.listen(
+              configFlagProvider(enableUnifiedGoalsFlag),
+              (_, _) {},
+            );
+            final probe = FutureProviderProbe(activeGoalNudgesProvider);
+            final sub = container.listen(probe.provider, (_, _) {});
+            async.elapse(const Duration(milliseconds: 1));
+            if (pendingStage != 'agents') {
+              agents.complete([goalIdentity('goal-a')]);
+              async.flushMicrotasks();
+            }
+            if (pendingStage == 'version' || pendingStage == 'nudges') {
+              head.complete(
+                AgentDomainEntity.goalSpecHead(
+                  id: goalSpecHeadId('goal-a'),
+                  agentId: 'goal-a',
+                  versionId: 'goal-a:spec-v1',
+                  updatedAt: DateTime(2026),
+                  vectorClock: null,
+                ),
+              );
+              async.flushMicrotasks();
+            }
+            if (pendingStage == 'nudges') {
+              version.complete(null);
+              async.flushMicrotasks();
+            }
+            sub.close();
+            probe.results.clear();
+            container.invalidate(probe.provider);
+            if (fullyDispose) async.elapse(Duration.zero);
+            if (!agents.isCompleted) agents.complete([goalIdentity('goal-a')]);
+            if (!head.isCompleted) head.complete(null);
+            if (!version.isCompleted) version.complete(null);
+            nudges.complete([
+              AgentDomainEntity.goalNudge(
+                id: 'pending-banner',
+                agentId: 'goal-a',
+                status: NudgeStatus.active,
+                brief: const NudgeBrief(
+                  headline: 'A reminder',
+                  tone: NudgeTone.nudge,
+                  animation: NudgeBannerAnimation.steady,
+                ),
+                briefDigest: 'digest',
+                createdAt: DateTime(2026),
+                updatedAt: DateTime(2026),
+                vectorClock: null,
+                staleAt: clock.now().add(const Duration(hours: 1)),
+              ),
+            ]);
+            async
+              ..flushMicrotasks()
+              ..elapse(Duration.zero);
+            expect(probe.errors, isEmpty);
+            expect(probe.results, [isEmpty]);
+            expect(
+              async.pendingTimers,
+              isEmpty,
+              reason: 'a disposed banner must not leave a deadline callback',
+            );
+            if (pendingStage == 'agents') {
+              verifyNever(() => repository.getEntity(any()));
+            }
+            if (pendingStage == 'head' || pendingStage == 'version') {
+              verifyNever(
+                () => repository.getEntitiesByAgentId(
+                  'goal-a',
+                  type: 'goalNudge',
+                ),
+              );
+            }
+            flag.close();
+          }, initialTime: DateTime(2026, 9, 5, 12));
+        },
+      );
+    }
+  }
 
   test('a rendered banner is re-evaluated at its staleness deadline, with '
       'no agent notification needed', () {

--- a/test/features/goals/state/goal_progress_view_test.dart
+++ b/test/features/goals/state/goal_progress_view_test.dart
@@ -1,10 +1,14 @@
+import 'dart:async';
+
 import 'package:clock/clock.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/goal_criterion.dart';
 import 'package:lotti/classes/goal_enums.dart';
 import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/goals/evaluation/goal_signal_window.dart';
 import 'package:lotti/features/goals/model/goal_health_data_types.dart';
@@ -16,6 +20,7 @@ import 'package:lotti/widgets/day_indicators/day_mark.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
+import '../../../helpers/future_provider_probe.dart';
 import '../../../mocks/mocks.dart';
 import '../../../test_data/test_data.dart';
 
@@ -26,6 +31,111 @@ void main() {
   DateTime day(int offset) => GoalWindow.dayUtc(
     today.subtract(Duration(days: offset)),
   );
+
+  for (final fullyDispose in [false, true]) {
+    for (final span in [false, true]) {
+      for (final stage in ['health', 'signals', 'definitions']) {
+        test(
+          'disposed progress stops after pending $stage (span: $span, fully disposed: $fullyDispose)',
+          () {
+            fakeAsync((async) {
+              final pending = Completer<GoalAgentHealth>();
+              final signals = Completer<List<JournalEntity>>();
+              final definition = Completer<HabitDefinition?>();
+              final db = MockJournalDb();
+              when(
+                () => db.getHabitCompletionsByHabitId(
+                  habitId: any(named: 'habitId'),
+                  rangeStart: any(named: 'rangeStart'),
+                  rangeEnd: any(named: 'rangeEnd'),
+                ),
+              ).thenAnswer((_) => signals.future);
+              when(
+                () => db.getHabitById('floss'),
+              ).thenAnswer((_) => definition.future);
+              final container = ProviderContainer(
+                overrides: [
+                  journalDbProvider.overrideWithValue(db),
+                  goalAgentHealthProvider(
+                    'goal-1',
+                  ).overrideWith((ref) => pending.future),
+                ],
+              );
+              final provider = span
+                  ? goalAgentProgressViewForSpanProvider((
+                      agentId: 'goal-1',
+                      historyDays: 14,
+                    ))
+                  : goalAgentProgressViewProvider('goal-1');
+              final healthSubscription = container.listen(
+                goalAgentHealthProvider('goal-1'),
+                (_, _) {},
+              );
+              final probe = FutureProviderProbe(provider);
+              final subscription = container.listen(probe.provider, (_, _) {});
+              async.flushMicrotasks();
+              final health = (
+                trackStatus: null,
+                attainment: null,
+                reportOneLiner: null,
+                pendingProposals: 0,
+                direction: null,
+                deficit: null,
+                buffer: null,
+                spec:
+                    AgentDomainEntity.goalSpecVersion(
+                          id: 'goal-1:spec-v1',
+                          agentId: 'goal-1',
+                          version: 1,
+                          status: GoalSpecVersionStatus.active,
+                          authoredBy: 'user',
+                          title: 'Floss',
+                          statement: 'Floss consistently',
+                          criteria: const GoalCriterion.habit(
+                            criterionId: 'floss',
+                            habitId: 'floss',
+                            window: GoalWindow.rollingDays(count: 7),
+                            targetCount: 2,
+                          ),
+                          createdAt: DateTime(2026),
+                          vectorClock: null,
+                        )
+                        as GoalSpecVersionEntity,
+              );
+              if (stage != 'health') {
+                pending.complete(health);
+                async.flushMicrotasks();
+              }
+              if (stage == 'definitions') {
+                signals.complete([]);
+                async.flushMicrotasks();
+              }
+              subscription.close();
+              probe.results.clear();
+              container.invalidate(probe.provider);
+              if (fullyDispose) async.elapse(Duration.zero);
+              if (!pending.isCompleted) pending.complete(health);
+              if (!signals.isCompleted) signals.complete([]);
+              definition.complete(null);
+              async
+                ..flushMicrotasks()
+                ..elapse(Duration.zero);
+              expect(probe.errors, isEmpty);
+              expect(probe.results, [isNull]);
+              expect(
+                async.pendingTimers,
+                isEmpty,
+                reason:
+                    'a disposed projection must not arm a midnight callback',
+              );
+              healthSubscription.close();
+              container.dispose();
+            }, initialTime: DateTime(2026, 9, 5, 12));
+          },
+        );
+      }
+    }
+  }
 
   test('without an evaluator figure, successesInWindow folds only the days '
       'inside the authored window — never the rendered history', () {

--- a/test/features/goals/state/goal_progress_view_test.dart
+++ b/test/features/goals/state/goal_progress_view_test.dart
@@ -34,7 +34,7 @@ void main() {
 
   for (final fullyDispose in [false, true]) {
     for (final span in [false, true]) {
-      for (final stage in ['health', 'signals', 'definitions']) {
+      for (final stage in ['health', 'signals', 'definitions', 'captures']) {
         test(
           'disposed progress stops after pending $stage (span: $span, fully disposed: $fullyDispose)',
           () {
@@ -42,7 +42,19 @@ void main() {
               final pending = Completer<GoalAgentHealth>();
               final signals = Completer<List<JournalEntity>>();
               final definition = Completer<HabitDefinition?>();
+              final captures =
+                  Completer<Map<String, GoalMeasurableCaptureDecision>>();
               final db = MockJournalDb();
+              when(
+                () => db.getMeasurementsByType(
+                  type: any(named: 'type'),
+                  rangeStart: any(named: 'rangeStart'),
+                  rangeEnd: any(named: 'rangeEnd'),
+                ),
+              ).thenAnswer((_) async => []);
+              when(
+                () => db.getMeasurableDataTypeById('water'),
+              ).thenAnswer((_) async => null);
               when(
                 () => db.getHabitCompletionsByHabitId(
                   habitId: any(named: 'habitId'),
@@ -56,6 +68,9 @@ void main() {
               final container = ProviderContainer(
                 overrides: [
                   journalDbProvider.overrideWithValue(db),
+                  goalMeasurableCaptureDecisionsProvider(
+                    'goal-1',
+                  ).overrideWith((ref) => captures.future),
                   goalAgentHealthProvider(
                     'goal-1',
                   ).overrideWith((ref) => pending.future),
@@ -69,6 +84,10 @@ void main() {
                   : goalAgentProgressViewProvider('goal-1');
               final healthSubscription = container.listen(
                 goalAgentHealthProvider('goal-1'),
+                (_, _) {},
+              );
+              final capturesSubscription = container.listen(
+                goalMeasurableCaptureDecisionsProvider('goal-1'),
                 (_, _) {},
               );
               final probe = FutureProviderProbe(provider);
@@ -91,12 +110,20 @@ void main() {
                           authoredBy: 'user',
                           title: 'Floss',
                           statement: 'Floss consistently',
-                          criteria: const GoalCriterion.habit(
-                            criterionId: 'floss',
-                            habitId: 'floss',
-                            window: GoalWindow.rollingDays(count: 7),
-                            targetCount: 2,
-                          ),
+                          criteria: stage == 'captures'
+                              ? const GoalCriterion.measurable(
+                                  criterionId: 'water',
+                                  dataTypeId: 'water',
+                                  window: GoalWindow.rollingDays(count: 7),
+                                  aggregation: GoalAggregation.sum,
+                                  target: 2,
+                                )
+                              : const GoalCriterion.habit(
+                                  criterionId: 'floss',
+                                  habitId: 'floss',
+                                  window: GoalWindow.rollingDays(count: 7),
+                                  targetCount: 2,
+                                ),
                           createdAt: DateTime(2026),
                           vectorClock: null,
                         )
@@ -117,6 +144,7 @@ void main() {
               if (!pending.isCompleted) pending.complete(health);
               if (!signals.isCompleted) signals.complete([]);
               definition.complete(null);
+              captures.complete({});
               async
                 ..flushMicrotasks()
                 ..elapse(Duration.zero);
@@ -128,6 +156,7 @@ void main() {
                 reason:
                     'a disposed projection must not arm a midnight callback',
               );
+              capturesSubscription.close();
               healthSubscription.close();
               container.dispose();
             }, initialTime: DateTime(2026, 9, 5, 12));

--- a/test/helpers/future_provider_probe.dart
+++ b/test/helpers/future_provider_probe.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Observes the raw computation, including errors Riverpod discards after
+/// disposal. Use with real container lifecycle changes and controlled futures
+/// to avoid a vacuous "no provider error" assertion after invalidation.
+class FutureProviderProbe<T> {
+  FutureProviderProbe(FutureProvider<T> original) {
+    provider = FutureProvider.autoDispose((ref) async {
+      try {
+        // The public provider future stops observing a disposed computation.
+        // This test-only seam keeps observing its actual async work instead.
+        // ignore: invalid_use_of_internal_member
+        final result = await original.create(ref);
+        results.add(result);
+        return result;
+      } catch (error) {
+        errors.add(error);
+        rethrow;
+      }
+    });
+  }
+
+  late final FutureProvider<T> provider;
+  final results = <T>[];
+  final errors = <Object>[];
+}


### PR DESCRIPTION
Goal progress and banner computations could resume after navigation or invalidation and touch disposed providers or create deadline timers. Each computation now registers disposal before awaiting dependencies and stops before further provider access or timer creation, including the interval between invalidation and Riverpod replacing its ref.

Banners also share the active-goal identity provider with the goal list. Banner-only and per-agent updates reuse those identities; global identity notifications and app resume refresh them. This removes duplicate lifecycle queries while preserving banner deadline updates and resume freshness.

Regression coverage observes the raw computation, since Riverpod can suppress late errors from disposed providers. All 24 lifecycle cases fail with their guards reverted. Two additional tests cover shared reads, banner-only invalidation, identity notifications, and resume refreshes; both fail when the relevant fix is removed. All 93 targeted tests pass.

Validation: Dart MCP targeted tests and analyzer, scoped FVM formatting, `make knowledge_check`, and `make changelog_check`.
