### PR TITLE
test: isolate reminder scheduling from the host timezone

### DIFF
--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -118,10 +118,17 @@ class NotificationLocationResolver {
 }
 
 class NotificationService {
-  NotificationService({AppLocalizations Function()? messages})
-    : _messages = messages ?? deviceMessages {
+  NotificationService({
+    AppLocalizations Function()? messages,
+    Future<String> Function()? timezoneLookup,
+  }) : _messages = messages ?? deviceMessages,
+       _timezoneLookup = timezoneLookup ?? getLocalTimezone {
     initialized = _initializePlugin();
   }
+
+  /// Resolves the device IANA zone; injectable to exercise DST independently
+  /// of the host timezone.
+  final Future<String> Function() _timezoneLookup;
 
   int badgeCount = 0;
   final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
@@ -511,7 +518,7 @@ class NotificationService {
     );
 
     if (alertAtTime != null) {
-      final location = _resolveLocation(await getLocalTimezone());
+      final location = _resolveLocation(await _timezoneLookup());
       final now = TZDateTime.from(clock.now(), location);
       // Construct a calendar date: adding 24 hours can skip or repeat a day
       // when daylight saving time changes.
@@ -565,7 +572,7 @@ class NotificationService {
 
     await _requestPermissions();
     await flutterLocalNotificationsPlugin.cancel(id: notificationId);
-    final location = _resolveLocation(await getLocalTimezone());
+    final location = _resolveLocation(await _timezoneLookup());
 
     final scheduledDate = TZDateTime(
       location,
@@ -608,7 +615,7 @@ class NotificationService {
 
     await _requestPermissions();
     await flutterLocalNotificationsPlugin.cancel(id: notificationId);
-    final location = _resolveLocation(await getLocalTimezone());
+    final location = _resolveLocation(await _timezoneLookup());
     final scheduledDate = TZDateTime.from(notifyAt, location);
 
     await flutterLocalNotificationsPlugin.zonedSchedule(

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -178,7 +178,9 @@ void main() {
   /// Builds the service and waits for the constructor's fire-and-forget
   /// `initialize` to finish, so channel assertions are not racing it.
   Future<NotificationService> buildService() async {
-    final service = NotificationService();
+    final service = NotificationService(
+      timezoneLookup: () async => tz.local.name,
+    );
     await service.initialized;
     return service;
   }
@@ -869,6 +871,30 @@ void main() {
         );
       });
     }
+
+    test('uses the device lookup independently of the process zone', () async {
+      _usePlatform(TargetPlatform.iOS);
+      final service = NotificationService(
+        timezoneLookup: () async => 'Asia/Tokyo',
+      );
+      await service.initialized;
+      await withClock(
+        Clock.fixed(DateTime.utc(2024)),
+        () => service.scheduleNotification(
+          title: 'Meditate',
+          body: 'Daily meditation',
+          notifyAt: DateTime(2024, 3, 15, 7, 45),
+          notificationId: 42,
+          showOnMobile: true,
+          showOnDesktop: false,
+        ),
+      );
+      final args = channel.argsOf('zonedSchedule');
+      final scheduled = DateTime.parse(
+        args['scheduledDateTimeISO8601']! as String,
+      );
+      expect(scheduled.toUtc(), DateTime.utc(2024, 3, 14, 22, 45));
+    });
 
     for (final date in [
       DateTime(2024, 3, 31, 7, 45),


### PR DESCRIPTION
Reminder scheduling tests in #4147 selected a fixture timezone but still queried the host timezone before resolving notifications. Add an injectable device-zone lookup and use it consistently for habit, calendar-time, and instant scheduling so the tests exercise their selected zone on every machine.

The default remains the existing device lookup. A regression pins a Tokyo device zone independently of the process zone and asserts the exact UTC notification instant; it fails with the lookup calls reverted. All 72 notification-service tests pass, including a run launched with TZ=UTC, and scoped Dart MCP analysis reports no errors.
