### PR TITLE
perf: coalesce concurrent agent throttle clears

### DIFF
--- a/changelog.d/2026-09-05-coalesce-agent-throttle-clears.md
+++ b/changelog.d/2026-09-05-coalesce-agent-throttle-clears.md
@@ -1,0 +1,4 @@
+### Fixed
+- **Agent updates perform less redundant database work.** Overlapping requests
+  to clear the same cooldown now share a state read, while newly scheduled
+  cooldowns and stale deadlines left on disk remain correctly handled.

--- a/knowledge/features/agents/wake-orchestration.md
+++ b/knowledge/features/agents/wake-orchestration.md
@@ -5,7 +5,7 @@ description: How a local change becomes an agent wake — subscription matching,
 resource: ../../../lib/features/agents/wake
 tags: [agents, wake, scheduling, concurrency]
 status: stable
-generated: { by: codex/gpt-5, at: 2026-09-04T23:30:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-05T15:15:00Z }
 stale_after: 2026-10-12
 sources:
   - id: wake
@@ -179,6 +179,13 @@ Persisted throttle set/clear operations re-read and write the state inside the
 same repository transaction as other partial state writers. This keeps the
 device-local `nextWakeAt` mutation from restoring a consumed project marker or
 erasing activity that was persisted by the project monitor concurrently.
+Repeated clears for one agent share their pending transaction/read. Completion
+releases that sharing state, so a later clear still checks the database for
+unhydrated stale deadlines. Setting or hydrating a new deadline starts a new
+generation: its later clear cannot join an older operation, and an older
+completion cannot remove a newer pending clear. The existing deadline checks
+before and after the state read continue to protect re-armed cooldowns.
+Routine clear diagnostics use counted sampling rather than one line per call.
 
 A subscription can instead opt **out of the window entirely** with
 `AgentSubscription.drainImmediately`: matches enqueue and dispatch once the

--- a/lib/features/agents/wake/wake_throttle_coordinator.dart
+++ b/lib/features/agents/wake/wake_throttle_coordinator.dart
@@ -31,6 +31,7 @@ class WakeThrottleCoordinator with AgentErrorLogging {
 
   final _throttleDeadlines = <String, DateTime>{};
   final _deferredDrainTimers = <String, Timer>{};
+  final _pendingClears = <String, Future<void>>{};
 
   void _log(String message, {String? subDomain}) {
     domainLogger?.log(LogDomain.agentRuntime, message, subDomain: subDomain);
@@ -71,6 +72,9 @@ class WakeThrottleCoordinator with AgentErrorLogging {
       return;
     }
     final deadline = customDeadline ?? now.add(throttleWindow);
+    // A new deadline starts a new generation: a later clear must run after
+    // its persistence, even if the previous generation is still clearing.
+    unawaited(_pendingClears.remove(agentId));
     _throttleDeadlines[agentId] = deadline;
 
     // Schedule the deferred drain FIRST (synchronous) so the timer is always
@@ -107,6 +111,9 @@ class WakeThrottleCoordinator with AgentErrorLogging {
   /// the past is ignored so a stale timestamp doesn't fire a drain immediately.
   void setDeadlineFromHydration(String agentId, DateTime deadline) {
     if (deadline.isBefore(clock.now())) return;
+    // A new deadline starts a new generation: a later clear must run after
+    // its persistence, even if the previous generation is still clearing.
+    unawaited(_pendingClears.remove(agentId));
     _throttleDeadlines[agentId] = deadline;
     _scheduleDeferredDrain(agentId, deadline);
   }
@@ -114,12 +121,16 @@ class WakeThrottleCoordinator with AgentErrorLogging {
   /// Cancels [agentId]'s cooldown: drops the in-memory deadline, cancels the
   /// deferred drain timer, and clears the persisted `nextWakeAt`. Used when a
   /// wake is forced (e.g. manual re-analysis) and the countdown is moot.
+  /// Concurrent clears share the persisted read until it completes. Even when
+  /// no deadline was hydrated, the first clear retires stale persisted state.
   void clearThrottle(String agentId) {
     _throttleDeadlines.remove(agentId);
     _deferredDrainTimers[agentId]?.cancel();
     _deferredDrainTimers.remove(agentId);
-    _log(
+    domainLogger?.logSampled(
+      LogDomain.agentRuntime,
       'throttle cleared for ${DomainLogger.sanitizeId(agentId)}',
+      sampleKey: 'throttle.clear',
       subDomain: 'throttle',
     );
     unawaited(_clearPersistedThrottle(agentId));
@@ -138,7 +149,22 @@ class WakeThrottleCoordinator with AgentErrorLogging {
   ///
   /// Writes directly to repository (bypassing AgentSyncService) because
   /// throttle state is per-device and should NOT be synced to other devices.
-  Future<void> _clearPersistedThrottle(String agentId) async {
+  Future<void> _clearPersistedThrottle(String agentId) {
+    final pending = _pendingClears[agentId];
+    if (pending != null) return pending;
+    final clear = _persistThrottleClear(agentId);
+    _pendingClears[agentId] = clear;
+    unawaited(
+      clear.whenComplete(() {
+        if (identical(_pendingClears[agentId], clear)) {
+          _pendingClears.remove(agentId);
+        }
+      }),
+    );
+    return clear;
+  }
+
+  Future<void> _persistThrottleClear(String agentId) async {
     try {
       if (_throttleDeadlines.containsKey(agentId)) return;
 

--- a/test/features/agents/wake/wake_throttle_coordinator_test.dart
+++ b/test/features/agents/wake/wake_throttle_coordinator_test.dart
@@ -436,6 +436,112 @@ void main() {
       });
     });
 
+    test('coalesces repeated clears while the same state read is pending', () {
+      fakeAsync((async) {
+        final read = Completer<AgentStateEntity?>();
+        when(
+          () => repository.getAgentState('agent-1'),
+        ).thenAnswer((_) => read.future);
+        final changed = <String>[];
+        final coordinator = createCoordinator(
+          onDrainRequested: () async {},
+          onPersistedStateChanged: changed.add,
+        );
+        addTearDown(coordinator.dispose);
+        for (var i = 0; i < 100; i++) {
+          coordinator.clearThrottle('agent-1');
+          async.flushMicrotasks();
+        }
+        verify(() => repository.getAgentState('agent-1')).called(1);
+        read.complete(
+          makeTestState(
+            agentId: 'agent-1',
+            nextWakeAt: DateTime(2026, 9, 5, 12),
+          ),
+        );
+        async.flushMicrotasks();
+        final saved =
+            verify(() => repository.upsertEntity(captureAny())).captured.single
+                as AgentStateEntity;
+        expect(saved.nextWakeAt, isNull);
+        expect(changed, ['agent-1']);
+
+        // Once the clear completed, a later request must re-read persisted
+        // state: it may have changed without in-memory hydration.
+        coordinator.clearThrottle('agent-1');
+        async.flushMicrotasks();
+        verify(() => repository.getAgentState('agent-1')).called(1);
+      });
+    });
+
+    test('old clear completion cannot evict a newer deadline clear', () {
+      fakeAsync((async) {
+        final reads = <Completer<AgentStateEntity?>>[];
+        when(() => repository.getAgentState('agent-1')).thenAnswer((_) {
+          final read = Completer<AgentStateEntity?>();
+          reads.add(read);
+          return read.future;
+        });
+        final coordinator = createCoordinator(onDrainRequested: () async {});
+        addTearDown(coordinator.dispose);
+        coordinator.clearThrottle('agent-1');
+        async.flushMicrotasks();
+        unawaited(coordinator.setDeadline('agent-1'));
+        async.flushMicrotasks();
+        coordinator.clearThrottle('agent-1');
+        async.flushMicrotasks();
+        expect(reads, hasLength(3));
+
+        reads[0].complete(makeTestState(agentId: 'agent-1'));
+        async.flushMicrotasks();
+        coordinator.clearThrottle('agent-1');
+        async.flushMicrotasks();
+        expect(reads, hasLength(3), reason: 'the newer clear is still pending');
+
+        reads[1].complete(makeTestState(agentId: 'agent-1'));
+        async.flushMicrotasks();
+        final deadlineWrite =
+            verify(() => repository.upsertEntity(captureAny())).captured.single
+                as AgentStateEntity;
+        expect(deadlineWrite.nextWakeAt, isNotNull);
+        reads[2].complete(deadlineWrite);
+        async.flushMicrotasks();
+        final clearWrite =
+            verify(() => repository.upsertEntity(captureAny())).captured.single
+                as AgentStateEntity;
+        expect(clearWrite.nextWakeAt, isNull);
+        expect(coordinator.deadlineFor('agent-1'), isNull);
+      });
+    });
+
+    test('repeated clear diagnostics retain counted summaries', () {
+      fakeAsync((async) {
+        final logging = MockLoggingService();
+        stubLoggingService(logging);
+        final logger = DomainLogger(loggingService: logging)
+          ..enabledDomains.add(LogDomain.agentRuntime);
+        final coordinator = createCoordinator(
+          onDrainRequested: () async {},
+          domainLogger: logger,
+        );
+        addTearDown(coordinator.dispose);
+        for (var i = 0; i < 101; i++) {
+          coordinator.clearThrottle('agent-1');
+        }
+        async.flushMicrotasks();
+        final messages = verify(
+          () => logging.captureEvent(
+            captureAny<dynamic>(),
+            domain: 'agentRuntime',
+            subDomain: 'throttle',
+          ),
+        ).captured.cast<String>();
+        expect(messages, hasLength(2));
+        expect(messages.first, contains('observed=1 suppressed=0 total=1'));
+        expect(messages.last, contains('observed=100 suppressed=99 total=101'));
+      });
+    });
+
     test('serializes persisted throttle set and clear mutations', () {
       final now = DateTime(2024, 3, 15, 10, 30);
       final transactionRepository = _TransactionCheckingAgentRepository();


### PR DESCRIPTION
Repeated cooldown clears could launch identical state transactions and emit one diagnostic line per request. Concurrent clears for one agent now share the pending read; a new or hydrated deadline starts a new generation so later clearing still runs after it. Requests after completion still check persisted state, including stale deadlines that were never hydrated. Clear diagnostics retain counted samples.

Validation: all 12 targeted tests (including property cases) pass with shuffled order, and the three new regressions fail with the fix reverted. The burst regression reduces 100 concurrent state reads to one; the race regression preserves a newer pending clear after the older completion, and diagnostics retain the count of 101 observations in two records. Dart MCP analysis, formatting, knowledge/Mermaid and changelog checks pass.
