### PR TITLE
perf(db): bound reservation scans and clarify executor timing

### DIFF
--- a/changelog.d/2026-09-05-sync-audit-performance.md
+++ b/changelog.d/2026-09-05-sync-audit-performance.md
@@ -1,0 +1,4 @@
+### Fixed
+- **Sync startup avoids scanning a device’s full sequence history.** Checking
+  pending local writes now reads only the matching counters, reducing database
+  work on profiles with a long sync history.

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -340,7 +340,7 @@ undercounts the gate badly:
 |-----------|-------|
 | `_queryWithPrivateFilter` | `journal_queries`, `definitions`, `project_queries`, `links_ratings` |
 | **`privateStatuses` passed as a parameter**, so the caller decides | `task_queries`, `task_query_builders`, `task_due_queries` |
-| **Raw SQL reading the flag directly** | `insights_queries` uses a `private_flag` CTE; `data_queries` uses a direct `config_flags` subquery in `getHabitCompletionsInRange` |
+| **Raw SQL reading the flag directly** | `insights_queries` uses a `private_flag` CTE; `data_queries` uses a direct `config_flags` subquery in `getHabitCompletionRecordsInRange` |
 
 Of the ten query-bearing mixins, **nine gate on private one of these ways**. The
 exception is `_JournalDbEntityOps`, which is maintenance and write operations

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -173,22 +173,42 @@ flowchart TD
 # Slow-query capture
 
 Every connection is wrapped in a `SlowQueryInterceptor` with a default
-threshold of **10 ms** — a fraction of the 16 ms frame budget, so anything it
-logs is already a meaningful slice of a frame. Writing is gated behind the
-logging domain in *Settings → Advanced → Logging Domains*, so the interceptor
-costs nothing until someone is investigating.
+threshold of **10 ms**. It times the awaited executor call even when logging
+is off; file writing and additional wall-clock metadata are gated behind
+*Settings → Advanced → Logging Domains*.
 
-**There is a second tier at 200 ms**, and it does more than log louder. A query
-crossing `superSlowThreshold` has its **`EXPLAIN QUERY PLAN` captured** (selects
-only) and is duplicated into a separate `super_slow_queries` file alongside the
-`slow_queries` one. So the 10 ms tier tells you *that* something is slow, while
-the 200 ms tier tells you *why* — start with the super-slow file, because it is
-the only one carrying a plan.
+The measured duration includes executor scheduling, isolate transport, waiting
+behind other work, and native SQLite execution. It is neither native SQL time
+nor UI-blocked time. The optional `TIMING` row records `scope=executorAwait`,
+`started`, `completed`, and `inFlightAtStart`. Both timestamps bracket the
+executor call, before query-plan capture. `inFlightAtStart` counts outstanding
+calls through that interceptor, including the new call; it is not the executor's
+queue depth. Correlated completion times can expose shared stalls without
+misattributing them to individual SQL statements. Wall-clock bounds can jump
+with clock changes; the duration still comes from a monotonic stopwatch.
+
+**The second tier is 200 ms.** A query crossing `superSlowThreshold` captures
+**`EXPLAIN QUERY PLAN`** (selects only) and is duplicated into the daily
+`super_slow_queries` file alongside `slow_queries`. The plan describes the SQL
+access path; it does not explain scheduler, lock, I/O, or suspend delays. The
+header timestamp is the later report time, which can include EXPLAIN latency.
+The two files contain overlapping events and must not be summed as independent
+work. Their percentiles describe only calls exceeding the logging threshold.
+
+The background factory's setup callbacks expose SQLite setup or isolate startup,
+not a per-call native timing hook. Exact queue/native attribution would need a
+worker-side executor measurement with a correlation identifier transported
+through the isolate protocol. The current metadata makes no such attribution.
 
 The threshold deliberately does not catch N+1 chains: each individual link sits
 under the bar. Counting round-trips in tests catches those chains;
 `JournalDb` coalesces adjacent entity lookups to reduce them. Deep-dive captures pass
 `Duration.zero` to surface every query.
+
+Own-host reservation and pending-burn audits select only `counter`, using the
+existing `idx_sync_sequence_log_host_status` index and sorting that sparse
+subset. This deliberately avoids SQLite choosing a host/counter history scan
+merely to satisfy ordering. The query has no new index or migration cost.
 
 # Migrations
 

--- a/lib/database/slow_query_logging.dart
+++ b/lib/database/slow_query_logging.dart
@@ -55,13 +55,28 @@ class SlowQueryLogEntry {
     this.isSuperSlow = false,
     this.queryPlan,
     this.callerStack,
+    this.startedAt,
+    this.completedAt,
+    this.inFlightAtStart,
   });
 
   final String databaseName;
   final String operation;
   final String statement;
   final List<Object?> arguments;
+
+  /// Awaited executor duration, including scheduling and isolate transport.
+  /// This is not a measurement of native SQLite execution alone.
   final Duration elapsed;
+
+  /// Wall-clock bounds captured around the executor await, before EXPLAIN.
+  /// Optional for manually constructed and logging-disabled entries.
+  final DateTime? startedAt;
+  final DateTime? completedAt;
+
+  /// Calls awaiting this interceptor's executor when this call started,
+  /// including this call. This is observed concurrency, not a queue length.
+  final int? inFlightAtStart;
 
   /// True when the query exceeded the interceptor's super-slow threshold and
   /// should be replicated to the dedicated super-slow log file.
@@ -101,6 +116,7 @@ class SlowQueryInterceptor extends QueryInterceptor {
   final String databaseName;
   final Duration threshold;
   final SlowQueryReporter reporter;
+  int _inFlight = 0;
 
   /// Queries whose elapsed time crosses this threshold also have their
   /// `EXPLAIN QUERY PLAN` captured (selects only) and are duplicated to the
@@ -125,7 +141,11 @@ class SlowQueryInterceptor extends QueryInterceptor {
           '[${entry.databaseName}] ${entry.operation} '
           '${elapsedMs.toStringAsFixed(3)}ms '
           'args=${entry.arguments.length} '
-          '${entry.formattedStatement}';
+          '${entry.formattedStatement}'
+          '${entry.startedAt == null ? '' : '\n  TIMING: scope=executorAwait '
+                    'started=${entry.startedAt!.toIso8601String()} '
+                    'completed=${entry.completedAt?.toIso8601String()} '
+                    'inFlightAtStart=${entry.inFlightAtStart}'}';
       _SlowQueryFileSink.instance.append(logFile, line);
 
       if (entry.isSuperSlow) {
@@ -218,11 +238,15 @@ class SlowQueryInterceptor extends QueryInterceptor {
         SlowQueryLoggingGate.markStatementSeenAndIsFirst(statement)) {
       callerStack = StackTrace.current;
     }
+    final startedAt = SlowQueryLoggingGate.isEnabled ? clock.now() : null;
+    final inFlightAtStart = ++_inFlight;
     final stopwatch = Stopwatch()..start();
     try {
       return await run();
     } finally {
       stopwatch.stop();
+      final completedAt = startedAt == null ? null : clock.now();
+      _inFlight--;
       final elapsed = stopwatch.elapsed;
       if (SlowQueryLoggingGate.isEnabled && elapsed >= threshold) {
         final isSuperSlow = elapsed >= superSlowThreshold;
@@ -250,6 +274,9 @@ class SlowQueryInterceptor extends QueryInterceptor {
             isSuperSlow: isSuperSlow,
             queryPlan: queryPlan,
             callerStack: callerStack,
+            startedAt: startedAt,
+            completedAt: completedAt,
+            inFlightAtStart: inFlightAtStart,
           ),
         );
       }

--- a/lib/database/sync_db_sequence.dart
+++ b/lib/database/sync_db_sequence.dart
@@ -136,18 +136,10 @@ mixin _SyncDbSequenceLog on _$SyncDatabase, _SyncDbSequenceWatermarks {
   /// convert to terminal unresolvable markers.
   Future<List<int>> reservedSequenceCountersForHost({
     required String hostId,
-  }) async {
-    final rows =
-        await (select(syncSequenceLog)
-              ..where(
-                (t) =>
-                    t.hostId.equals(hostId) &
-                    t.status.equals(SyncSequenceStatus.reserved.index),
-              )
-              ..orderBy([(t) => OrderingTerm(expression: t.counter)]))
-            .get();
-    return [for (final row in rows) row.counter];
-  }
+  }) => _sequenceCountersForHostWithStatus(
+    hostId: hostId,
+    status: SyncSequenceStatus.reserved,
+  );
 
   /// Mark a reservation as an authoritative local burn whose outbound
   /// unresolvable marker still needs to be durably enqueued. Unlike
@@ -221,6 +213,16 @@ mixin _SyncDbSequenceLog on _$SyncDatabase, _SyncDbSequenceWatermarks {
   /// unresolvable marker still needs a durable outbound enqueue.
   Future<List<int>> burnPendingSequenceCountersForHost({
     required String hostId,
+  }) => _sequenceCountersForHostWithStatus(
+    hostId: hostId,
+    status: SyncSequenceStatus.burnPending,
+  );
+
+  /// Both audit states are sparse. Prefer sorting that indexed subset over
+  /// scanning every historical counter just to obtain counter ordering.
+  Future<List<int>> _sequenceCountersForHostWithStatus({
+    required String hostId,
+    required SyncSequenceStatus status,
   }) async {
     final rows = await customSelect(
       '''
@@ -232,7 +234,7 @@ mixin _SyncDbSequenceLog on _$SyncDatabase, _SyncDbSequenceWatermarks {
       ''',
       variables: [
         Variable.withString(hostId),
-        Variable.withInt(SyncSequenceStatus.burnPending.index),
+        Variable.withInt(status.index),
       ],
       readsFrom: {syncSequenceLog},
     ).get();

--- a/test/database/slow_query_logging_test.dart
+++ b/test/database/slow_query_logging_test.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
 import 'dart:io';
+
+import 'package:clock/clock.dart';
 
 import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:flutter_test/flutter_test.dart';
@@ -468,6 +471,71 @@ void main() {
       });
     });
 
+    test(
+      'captures executor boundaries before deferred query-plan reporting',
+      () async {
+        SlowQueryLoggingGate.isEnabled = true;
+        final select = Completer<List<Map<String, Object?>>>();
+        final plan = Completer<List<Map<String, Object?>>>();
+        final planStarted = Completer<void>();
+        var now = DateTime.utc(2024, 1, 1, 10);
+        when(() => mockExecutor.runSelect('SELECT 1', any())).thenAnswer(
+          (_) => select.future,
+        );
+        when(
+          () => mockExecutor.runSelect('EXPLAIN QUERY PLAN SELECT 1', any()),
+        ).thenAnswer((_) {
+          planStarted.complete();
+          return plan.future;
+        });
+        interceptor = SlowQueryInterceptor(
+          databaseName: 'test_db',
+          threshold: Duration.zero,
+          superSlowThreshold: Duration.zero,
+          reporter: reportedEntries.add,
+        );
+        await withClock(Clock(() => now), () async {
+          final operation = interceptor.runSelect(mockExecutor, 'SELECT 1', []);
+          now = DateTime.utc(2024, 1, 1, 10, 0, 3);
+          select.complete([]);
+          await planStarted.future;
+          now = DateTime.utc(2024, 1, 1, 10, 0, 9);
+          plan.complete([]);
+          await operation;
+        });
+        final entry = reportedEntries.single;
+        expect(entry.startedAt, DateTime.utc(2024, 1, 1, 10));
+        expect(entry.completedAt, DateTime.utc(2024, 1, 1, 10, 0, 3));
+        expect(entry.inFlightAtStart, 1);
+      },
+    );
+
+    test(
+      'counts overlapping executor calls and releases failed calls',
+      () async {
+        SlowQueryLoggingGate.isEnabled = true;
+        final first = Completer<List<Map<String, Object?>>>();
+        when(
+          () => mockExecutor.runSelect('SELECT 1', any()),
+        ).thenAnswer((_) => first.future);
+        when(
+          () => mockExecutor.runSelect('SELECT 2', any()),
+        ).thenAnswer((_) async => []);
+        interceptor = createInterceptor();
+        final pending = interceptor.runSelect(mockExecutor, 'SELECT 1', []);
+        final failure = expectLater(pending, throwsStateError);
+        await interceptor.runSelect(mockExecutor, 'SELECT 2', []);
+        first.completeError(StateError('synthetic failure'));
+        await failure;
+        await interceptor.runSelect(mockExecutor, 'SELECT 2', []);
+        expect(reportedEntries.map((entry) => entry.inFlightAtStart), [
+          2,
+          1,
+          1,
+        ]);
+      },
+    );
+
     group('error propagation', () {
       test('propagates executor exception and still does not report when gate '
           'is disabled', () async {
@@ -816,6 +884,37 @@ void main() {
       // Line should end with newline
       expect(content, endsWith('\n'));
     });
+
+    test(
+      'writes executor timing bounds without claiming native SQL time',
+      () async {
+        final reporter = SlowQueryInterceptor.fileReporter(
+          documentsDirectoryPath: tempDir.path,
+        );
+        reporter(
+          SlowQueryLogEntry(
+            databaseName: 'test_db',
+            operation: 'select',
+            statement: 'SELECT 1',
+            arguments: const [],
+            elapsed: const Duration(seconds: 3),
+            startedAt: DateTime.utc(2024, 1, 1, 10),
+            completedAt: DateTime.utc(2024, 1, 1, 10, 0, 3),
+            inFlightAtStart: 4,
+          ),
+        );
+        await SlowQueryInterceptor.flushPendingFileWrites();
+        final content = Directory(
+          '${tempDir.path}/logs',
+        ).listSync().whereType<File>().single.readAsStringSync();
+        expect(
+          content,
+          contains(
+            'TIMING: scope=executorAwait started=2024-01-01T10:00:00.000Z completed=2024-01-01T10:00:03.000Z inFlightAtStart=4',
+          ),
+        );
+      },
+    );
 
     test('uses custom fileStem', () async {
       final reporter = SlowQueryInterceptor.fileReporter(

--- a/test/database/sync_db_sequence_test.dart
+++ b/test/database/sync_db_sequence_test.dart
@@ -4,10 +4,13 @@
 // `lib/database/sync_db_watermarks.dart`.
 // ignore_for_file: avoid_redundant_argument_values
 import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
 import 'package:glados/glados.dart';
+import 'package:lotti/database/slow_query_logging.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_payload_type.dart';
 
+import 'slow_query_logging_test_utils.dart';
 import 'sync_db_test_utils.dart';
 
 /// A generated scenario for the `getCountersForHostInRange` property: the set
@@ -433,6 +436,60 @@ void main() {
           reason:
               'the partial index is already ordered by host_id/counter, so '
               'the window should not need an external sort',
+        );
+      },
+    );
+
+    test(
+      'reservation audit reads only the indexed host/status subset',
+      () async {
+        final entries = <SlowQueryLogEntry>[];
+        final database = SyncDatabase.connect(
+          DatabaseConnection(
+            NativeDatabase.memory().interceptWith(
+              SlowQueryInterceptor(
+                databaseName: 'synthetic-sync',
+                threshold: Duration.zero,
+                superSlowThreshold: Duration.zero,
+                reporter: entries.add,
+              ),
+            ),
+          ),
+        );
+        addTearDown(database.close);
+        addTearDown(resetSlowQueryLoggingGate);
+        await database.customStatement('''
+        WITH RECURSIVE numbers(n) AS (
+          SELECT 1 UNION ALL SELECT n + 1 FROM numbers WHERE n < 10000
+        )
+        INSERT INTO sync_sequence_log
+          (host_id, counter, status, created_at, updated_at)
+        SELECT 'audit-host', n, CASE WHEN n IN (11, 9000) THEN 6 ELSE 0 END,
+               1704067200, 1704067200 FROM numbers
+      ''');
+        await database.recordReservedSequenceCounter(
+          hostId: 'another-host',
+          counter: 5,
+          now: DateTime.utc(2024),
+        );
+        await database.customStatement('ANALYZE');
+        entries.clear();
+        SlowQueryLoggingGate.isEnabled = true;
+        expect(
+          await database.reservedSequenceCountersForHost(hostId: 'audit-host'),
+          [11, 9000],
+        );
+        final query = entries.singleWhere(
+          (entry) => entry.operation == 'select',
+        );
+        expect(query.formattedStatement, startsWith('SELECT counter '));
+        expect(
+          query.queryPlan!.join(' '),
+          contains(
+            'idx_sync_sequence_log_host_status (host_id=? AND status=?)',
+          ),
+          reason:
+              'Do not scan all historical counters to avoid sorting two rows.',
         );
       },
     );


### PR DESCRIPTION
Reservation audits selected complete rows and could choose the host/counter index, scanning a device’s entire history to avoid sorting a tiny reservation set. They now share the pending-burn query’s explicit host/status index and select only counters, without adding an index or migration.

Slow-query records now include executor start/completion timestamps captured before EXPLAIN, plus the number of outstanding calls when each began. `scope=executorAwait` explicitly includes scheduling, transport and native execution; it does not claim a native/queue split. The persistence concept explains the measurement limits and duplicate slow/super-slow events.

Validation:
- 104 targeted tests pass with randomized order; full-repository Dart MCP analyzer reports no errors, warnings or infos.
- A 10,000-row production-query regression checks returned counters and the actual SQLite access plan. It fails with the old projection or with the index hint removed.
- Timing regressions fail when boundary capture, overlap counts or file metadata are removed; they cover delayed EXPLAIN and executor failure cleanup.
- Knowledge checks pass, including all 525 Mermaid diagrams; changelog validation passes.
- Synthetic in-memory SQLite benchmark: 320,000 rows across 8 hosts, 20 target reservations, ANALYZE, median of 30 reads. Full-row query: 14.09ms; projection alone: 14.23ms; existing host/status index with counter projection: 0.011ms. This is a synthetic query-cost comparison, not an estimate of the historical log stalls.
