### PR TITLE
perf: coalesce habit refreshes and project only daily winners

### DIFF
--- a/changelog.d/2026-09-05-habit-refresh-performance.md
+++ b/changelog.d/2026-09-05-habit-refresh-performance.md
@@ -1,0 +1,4 @@
+### Fixed
+- **Habit history refreshes do less work during sync.** Bursts of completion
+  updates now share database reads, older results cannot replace a newer range,
+  and long histories load their winning daily completions more efficiently.

--- a/docs/perf/2026-09-05-habit-refreshes.md
+++ b/docs/perf/2026-09-05-habit-refreshes.md
@@ -1,0 +1,85 @@
+# Habit completion refresh costs
+
+The completion stream used to start one range query per notification, then wait
+200 ms *after* fetching. A burst of 100 notifications therefore started 100
+queries. The controller now waits before fetching, shares one in-flight read,
+and keeps at most one trailing request. Regression tests verify 100 immediate
+notifications start one query; 21 overlapping explicit refresh/range requests
+start two sequential queries and all wait for the newest range. Notifications
+during initial loading are retained, and stale results cannot publish after a
+range change or provider invalidation.
+
+The SQL now ranks row IDs before joining winning journal rows to extract their
+display fields. This reduces JSON work and window-sort payload without adding an
+index or changing the winning-row contract. Local-day partitions, descending
+updated/created/end-date/ID tie-breakers, private/deleted filtering, recorded
+wall-clock timestamps, and result ordering are preserved. Database tests cover
+those timestamp and tie-breaker cases plus source/auto-completion attribution.
+
+## Synthetic experiment
+
+Linux ARM64, Python SQLite 3.45.1, in-memory database, 43,800 synthetic completion
+rows: 12 habits over 1,825 days, two revisions per day and approximately 2 KB of
+serialized payload. The schema below includes the existing browse index and
+config-flag lookup used by this query. Both versions run against the same
+connection, alternating six times; the first run is discarded. Results are
+asserted identical. These are isolated SQL timings, not end-to-end app latency
+or percentiles from the user logs. Other journal tables, disk contention, and
+Dart isolate transfer are outside this experiment.
+
+| Range | Winning rows | Before median | After median |
+|---|---:|---:|---:|
+| 30 days | 360 | 3.46 ms | 2.35 ms |
+| 365 days | 4,380 | 63.52 ms | 35.16 ms |
+| 1,825 days | 21,900 | 353.47 ms | 182.43 ms |
+
+`EXPLAIN QUERY PLAN` retains the indexed date-range scan and two temporary
+sorts. The new join looks up each winner by primary key. The improvement comes
+from sorting less data and projecting only winners, not removing those sorts.
+The independent controller change also avoids multiplying this cost for every
+notification. No machine-dependent timing threshold is imposed on unit tests.
+
+## Reproduce
+
+Run the following Python from the repository root at this change or later.
+It obtains the baseline query from commit `ab9427c6d` and the candidate from the
+current source. It uses only generated data and creates no database files.
+
+```python
+import sqlite3, json, time, statistics, pathlib, datetime, subprocess
+query_path='lib/database/database_data_queries.dart'
+def query(source):
+ return source.split('getHabitCompletionRecordsInRange(')[1].split("r\'\'\'",1)[1].split("\'\'\'",1)[0]
+queries={
+ 'before': query(subprocess.check_output(['git','show','ab9427c6d:'+query_path],text=True)),
+ 'after': query(pathlib.Path(query_path).read_text()),
+}
+db=sqlite3.connect(':memory:')
+db.executescript('CREATE TABLE journal(id TEXT PRIMARY KEY,type TEXT,private INTEGER,deleted INTEGER,date_from INTEGER,date_to INTEGER,updated_at INTEGER,created_at INTEGER,serialized TEXT); CREATE INDEX idx_journal_browse ON journal(deleted,type,date_from DESC); CREATE TABLE config_flags(name TEXT PRIMARY KEY,status INTEGER); INSERT INTO config_flags VALUES ("private",0);')
+start=datetime.datetime(2021,1,1)
+def rows():
+ for day in range(1825):
+  date=start+datetime.timedelta(days=day)
+  for habit in range(12):
+   for revision in range(2):
+    stamp=date+datetime.timedelta(hours=12,seconds=revision)
+    epoch=int(stamp.timestamp())
+    payload={'meta':{'dateFrom':stamp.isoformat()},'data':{'habitId':f'h{habit}', 'completionType':'success' if revision else 'fail','source':'manual','autoCompleteReason':None},'body':'synthetic journal payload '*80}
+    yield (f'{day}-{habit}-{revision}','HabitCompletionEntry',0,0,epoch,epoch,epoch,epoch,json.dumps(payload))
+db.executemany('INSERT INTO journal VALUES (?,?,?,?,?,?,?,?,?)',rows());db.commit()
+report={'sqlite':sqlite3.sqlite_version,'rows':43800,'habits':12,'historyDays':1825,'revisionsPerDay':2,'measurements':[]}
+for days in [30,365,1825]:
+ cutoff=int((start+datetime.timedelta(days=1825-days)).timestamp())
+ timings={name:[] for name in queries}
+ results={}
+ for iteration in range(6):
+  for name,sql in queries.items():
+   t=time.perf_counter();results[name]=db.execute(sql,(cutoff,)).fetchall()
+   timings[name].append((time.perf_counter()-t)*1000)
+ assert results['before']==results['after']
+ assert len(results['after'])==days*12
+ assert all(r[2]=='success' for r in results['after'])
+ report['measurements'].append({'rangeDays':days,'results':len(results['after']),
+  'medianMs':{name:statistics.median(values[1:]) for name,values in timings.items()}})
+print(json.dumps(report,indent=2))
+```

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -89,14 +89,15 @@ properties. It protects the tab maps, streak inputs, card strips, repository rea
 and direct `JournalDb` reads from **database row-order differences** when multiple
 writes share the same effective day.
 
-# Completions are read as a three-field projection
+# Completions are read as a narrow projection
 
 Both the tab controller and the heatmap read completions through
 `JournalDb.getHabitCompletionRecordsInRange`, which returns
-`HabitCompletionRecord` — **`habitId`, `dateFrom`, `completionType`** — and not
+`HabitCompletionRecord` — **`habitId`, `dateFrom`, `completionType`, `source`,
+`autoCompleteReason`** — and not
 the `HabitCompletionEntry` entity.
 
-Those three fields are all any consumer ever touched. Carrying the whole entity
+These fields carry the outcome and its auto-completion attribution. Carrying the whole entity
 was the cost: the read averaged **636 ms** in the 2026-06/07 slow-query logs
 while the SQL itself measures ~29 ms on a comparable 10,000-row / 1,460-result
 set. The gap is ~20 columns per row — including the fat `serialized` JSON blob —
@@ -135,6 +136,43 @@ auto-completions are both ordinary `success` records and maintain the streak.
 **The controller filters to `habit.active == true` immediately.** Archived habits
 still exist in settings and storage, but the main tab derives only from active
 definitions.
+
+## Completion refresh lifecycle
+
+Completion notifications debounce the database query itself by 200 ms. Initial
+load, tab activation, explicit midnight refresh, and range changes refresh
+immediately. One read runs at a time; requests arriving during that read share
+one trailing read with the latest range. All callers wait for that drain, and a
+superseded result never replaces the displayed completion data. Definitions and
+filters can still recompute using the last successful data while a read runs.
+The update subscription starts before the first query so notifications during
+initial loading are retained. Disposal cancels the debounce timer and advances
+the generation; a late read cannot publish into a replacement computation.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Idle
+  Idle --> Debouncing: completion notification
+  Debouncing --> Debouncing: another notification resets timer
+  Debouncing --> Reading: 200 ms elapsed or explicit refresh
+  Idle --> Reading: initial load or explicit refresh
+  Reading --> ReadingAgain: refresh requested
+  ReadingAgain --> ReadingAgain: further requests coalesce
+  ReadingAgain --> Reading: read finishes, fetch latest range
+  Reading --> Idle: publish result or propagate error
+  ReadingAgain --> Idle: propagate error
+  Idle --> Disposed: dispose
+  Debouncing --> Disposed: cancel timer
+  Reading --> Disposed: discard late result
+  ReadingAgain --> Disposed: discard late result
+  Disposed --> [*]
+```
+
+The range query ranks IDs first, then joins the winning rows by primary key to
+project their five fields. Its local-day partition and write-recency tie-breakers
+are unchanged. This keeps wide serialized payloads out of the ranking sort and
+avoids extracting display fields for superseded rows. The synthetic benchmark
+and its reproduction are in [habit refresh costs](../../docs/perf/2026-09-05-habit-refreshes.md).
 
 # The editor lives on the habits page
 

--- a/knowledge/features/habits.md
+++ b/knowledge/features/habits.md
@@ -142,7 +142,9 @@ definitions.
 Completion notifications debounce the database query itself by 200 ms. Initial
 load, tab activation, explicit midnight refresh, and range changes refresh
 immediately. One read runs at a time; requests arriving during that read share
-one trailing read with the latest range. All callers wait for that drain, and a
+one trailing read with the latest range, even if the earlier attempt fails.
+Without a queued request, a failed read propagates its error and releases the
+drain for a later refresh. All callers wait for that drain, and a
 superseded result never replaces the displayed completion data. Definitions and
 filters can still recompute using the last successful data while a read runs.
 The update subscription starts before the first query so notifications during
@@ -160,7 +162,7 @@ stateDiagram-v2
   ReadingAgain --> ReadingAgain: further requests coalesce
   ReadingAgain --> Reading: read finishes, fetch latest range
   Reading --> Idle: publish result or propagate error
-  ReadingAgain --> Idle: propagate error
+  ReadingAgain --> Reading: failed read, fetch queued request
   Idle --> Disposed: dispose
   Debouncing --> Disposed: cancel timer
   Reading --> Disposed: discard late result

--- a/lib/database/database_data_queries.dart
+++ b/lib/database/database_data_queries.dart
@@ -32,7 +32,7 @@ mixin _JournalDbDataQueries on _$JournalDb, _JournalDbConfigFlags {
   }
 
   /// Latest habit completion per habit/day since [rangeStart], projected to
-  /// the three fields consumers actually read.
+  /// the five fields consumers actually read.
   ///
   /// Returns one winning row per habit/day under a last-write-wins contract,
   /// without ever putting the `serialized` payload on the wire.
@@ -58,21 +58,18 @@ mixin _JournalDbDataQueries on _$JournalDb, _JournalDbConfigFlags {
   /// Ranking is unaffected: `PARTITION BY`/`ORDER BY` still use the indexed
   /// column, exactly as before.
   ///
-  /// See `docs/perf/2026-08-01_slow-queries-investigation.md`.
+  /// Rank only row IDs first, then extract the display fields from winning
+  /// rows. This avoids carrying serialized payloads through the window sort
+  /// and parsing display fields for superseded completions.
+  ///
+  /// See `docs/perf/2026-09-05-habit-refreshes.md`.
   Future<List<HabitCompletionRecord>> getHabitCompletionRecordsInRange({
     required DateTime rangeStart,
   }) async {
     final rows = await customSelect(
       r'''
-        SELECT habit_id, recorded_at, completion_type, source, auto_reason
-        FROM (
-          SELECT
-            json_extract(serialized, '$.data.habitId') AS habit_id,
-            json_extract(serialized, '$.meta.dateFrom') AS recorded_at,
-            journal.date_from AS date_from,
-            json_extract(serialized, '$.data.completionType') AS completion_type,
-            json_extract(serialized, '$.data.source') AS source,
-            json_extract(serialized, '$.data.autoCompleteReason') AS auto_reason,
+        WITH ranked AS (
+          SELECT id,
             ROW_NUMBER() OVER (
               PARTITION BY
                 json_extract(serialized, '$.data.habitId'),
@@ -92,8 +89,16 @@ mixin _JournalDbDataQueries on _$JournalDb, _JournalDbConfigFlags {
             AND date_from >= ?
             AND deleted = FALSE
         )
+        SELECT
+          json_extract(j.serialized, '$.data.habitId') AS habit_id,
+          json_extract(j.serialized, '$.meta.dateFrom') AS recorded_at,
+          json_extract(j.serialized, '$.data.completionType') AS completion_type,
+          json_extract(j.serialized, '$.data.source') AS source,
+          json_extract(j.serialized, '$.data.autoCompleteReason') AS auto_reason
+        FROM ranked
+        JOIN journal AS j ON j.id = ranked.id
         WHERE rn = 1
-        ORDER BY date_from ASC, habit_id ASC
+        ORDER BY j.date_from ASC, habit_id ASC
       ''',
       variables: [Variable<DateTime>(rangeStart)],
       readsFrom: {journal, configFlags},

--- a/lib/features/habits/state/habits_controller.dart
+++ b/lib/features/habits/state/habits_controller.dart
@@ -44,6 +44,11 @@ class HabitsController extends Notifier<HabitsState> {
   StreamSubscription<Set<String>>? _updateSubscription;
   StreamSubscription<int>? _navIndexSubscription;
 
+  Timer? _refreshTimer;
+  Future<void>? _refreshFuture;
+  bool _refreshRequested = false;
+  int _generation = 0;
+
   List<HabitDefinition> _habitDefinitions = [];
   Map<String, HabitDefinition> _habitDefinitionsMap = {};
   List<HabitCompletionRecord> _habitCompletions = [];
@@ -68,6 +73,8 @@ class HabitsController extends Notifier<HabitsState> {
 
   @override
   HabitsState build() {
+    _refreshFuture = null;
+    _refreshRequested = false;
     _repository = ref.read(habitsRepositoryProvider);
     _now = ref.read(habitsNowProvider);
 
@@ -106,40 +113,73 @@ class HabitsController extends Notifier<HabitsState> {
     // runs as a microtask. The mounted-guard inside _startWatching
     // avoids touching disposed state if the provider is torn down
     // before the microtask drains.
-    Future.microtask(_startWatching);
+    final generation = _generation;
+    Future.microtask(() => _startWatching(generation));
     return HabitsState.initial(now: _now());
   }
 
   void _cleanup() {
+    _generation++;
+    _refreshTimer?.cancel();
     _definitionsSubscription?.cancel();
     _updateSubscription?.cancel();
     _navIndexSubscription?.cancel();
     EasyDebounce.cancel('clearInfoYmd');
   }
 
-  Future<void> _startWatching() async {
-    if (!ref.mounted) return;
-    await _fetchHabitCompletions();
-    if (!ref.mounted) return;
-    _determineHabitSuccessByDays();
-
-    _updateSubscription = _repository.updateStream.listen((affectedIds) async {
+  Future<void> _startWatching(int generation) async {
+    if (!ref.mounted || generation != _generation) return;
+    // Listen before the first read, so a write arriving during that read
+    // requests a trailing refresh instead of being lost.
+    _updateSubscription = _repository.updateStream.listen((affectedIds) {
       if (affectedIds.contains(habitCompletionNotification)) {
-        await _fetchHabitCompletions();
-        await Future<void>.delayed(const Duration(milliseconds: 200));
-        if (!ref.mounted) return;
-        _determineHabitSuccessByDays();
+        _refreshTimer?.cancel();
+        _refreshTimer = Timer(const Duration(milliseconds: 200), () {
+          _refreshTimer = null;
+          unawaited(refreshNow());
+        });
       }
     });
+    await refreshNow();
   }
 
-  Future<void> _fetchHabitCompletions() async {
-    final rangeStart = _now().dayAtMidnight.subtract(
-      Duration(days: state.timeSpanDays),
-    );
-    _habitCompletions = await _repository.getHabitCompletionsInRange(
-      rangeStart: rangeStart,
-    );
+  /// Serializes completion reads and collapses requests arriving during a read
+  /// into one trailing read with the latest range. All callers await that same
+  /// drain; an older result never overwrites the latest requested projection.
+  Future<void> _refreshCompletions() {
+    if (!ref.mounted) return Future<void>.value();
+    _refreshTimer?.cancel();
+    _refreshTimer = null;
+    _refreshRequested = true;
+    final existing = _refreshFuture;
+    if (existing != null) return existing;
+    final generation = _generation;
+    final completer = Completer<void>();
+    _refreshFuture = completer.future;
+    unawaited(() async {
+      try {
+        while (_refreshRequested && ref.mounted && generation == _generation) {
+          _refreshRequested = false;
+          final rangeStart = _now().dayAtMidnight.subtract(
+            Duration(days: state.timeSpanDays),
+          );
+          final completions = await _repository.getHabitCompletionsInRange(
+            rangeStart: rangeStart,
+          );
+          if (!ref.mounted || generation != _generation) break;
+          if (!_refreshRequested) {
+            _habitCompletions = completions;
+            _determineHabitSuccessByDays();
+          }
+        }
+        completer.complete();
+      } catch (error, stackTrace) {
+        completer.completeError(error, stackTrace);
+      } finally {
+        if (generation == _generation) _refreshFuture = null;
+      }
+    }());
+    return completer.future;
   }
 
   void _determineHabitSuccessByDays() {
@@ -328,9 +368,7 @@ class HabitsController extends Notifier<HabitsState> {
     _lastNavIndex = newIndex;
 
     if (isHabitsActive && (!wasActive || switchedTab)) {
-      await _fetchHabitCompletions();
-      if (!ref.mounted) return;
-      _determineHabitSuccessByDays();
+      await refreshNow();
     }
   }
 
@@ -340,10 +378,7 @@ class HabitsController extends Notifier<HabitsState> {
   /// database event): `showHabit` bucketing and the per-day maps are
   /// time-derived and would otherwise serve yesterday's split.
   Future<void> refreshNow() async {
-    if (!ref.mounted) return;
-    await _fetchHabitCompletions();
-    if (!ref.mounted) return;
-    _determineHabitSuccessByDays();
+    await _refreshCompletions();
   }
 
   /// Whether [navIndex] is a tab that renders habit rows from this
@@ -361,8 +396,7 @@ class HabitsController extends Notifier<HabitsState> {
       timeSpanDays: timeSpanDays,
       days: getHabitDays(timeSpanDays, now: _now()),
     );
-    await _fetchHabitCompletions();
-    _determineHabitSuccessByDays();
+    await refreshNow();
   }
 
   /// Sets the display filter for habits.

--- a/lib/features/habits/state/habits_controller.dart
+++ b/lib/features/habits/state/habits_controller.dart
@@ -163,9 +163,19 @@ class HabitsController extends Notifier<HabitsState> {
           final rangeStart = _now().dayAtMidnight.subtract(
             Duration(days: state.timeSpanDays),
           );
-          final completions = await _repository.getHabitCompletionsInRange(
-            rangeStart: rangeStart,
-          );
+          final List<HabitCompletionRecord> completions;
+          try {
+            completions = await _repository.getHabitCompletionsInRange(
+              rangeStart: rangeStart,
+            );
+          } catch (_) {
+            // A failed older attempt must not consume a newer request. Only
+            // retry when a caller actually queued another read in the meantime.
+            if (_refreshRequested && ref.mounted && generation == _generation) {
+              continue;
+            }
+            rethrow;
+          }
           if (!ref.mounted || generation != _generation) break;
           if (!_refreshRequested) {
             _habitCompletions = completions;

--- a/test/database/database_data_queries_test.dart
+++ b/test/database/database_data_queries_test.dart
@@ -279,6 +279,47 @@ void main() {
         },
       );
 
+      for (final tieBreaker in ['dateTo', 'id']) {
+        test(
+          'winning completion keeps $tieBreaker tie-breaking after ranking',
+          () async {
+            final day = DateTime(2024, 4, 16, 12);
+            final earlier =
+                buildHabitCompletionEntry(
+                      id: tieBreaker == 'id' ? 'a' : 'z',
+                      habitId: 'tie-habit',
+                      timestamp: day,
+                      completionType: HabitCompletionType.success,
+                    )
+                    as HabitCompletionEntry;
+            final winner = earlier.copyWith(
+              meta: earlier.meta.copyWith(
+                id: tieBreaker == 'id' ? 'z' : 'a',
+                dateTo: tieBreaker == 'dateTo'
+                    ? day.add(const Duration(hours: 1))
+                    : day,
+              ),
+              data: earlier.data.copyWith(
+                completionType: HabitCompletionType.fail,
+                source: HabitCompletionSource.auto,
+                autoCompleteReason: 'Synthetic winning write',
+              ),
+            );
+            await db!.upsertJournalDbEntity(toDbEntity(winner));
+            await db!.upsertJournalDbEntity(toDbEntity(earlier));
+            final result = await db!.getHabitCompletionRecordsInRange(
+              rangeStart: DateTime(2024, 4),
+            );
+            expect(result, hasLength(1));
+            expect(result.single.habitId, 'tie-habit');
+            expect(result.single.dateFrom, day);
+            expect(result.single.completionType, HabitCompletionType.fail);
+            expect(result.single.source, HabitCompletionSource.auto);
+            expect(result.single.autoCompleteReason, 'Synthetic winning write');
+          },
+        );
+      }
+
       test(
         'getHabitCompletionRecordsInRange decodes an unknown completion type '
         'as null rather than throwing',

--- a/test/features/habits/state/habits_controller_test.dart
+++ b/test/features/habits/state/habits_controller_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/habits/model/habit_completion_record.dart';
 import 'package:lotti/features/habits/repository/habits_repository.dart';
 import 'package:lotti/features/habits/state/habits_controller.dart';
 import 'package:lotti/features/habits/state/habits_state.dart';
@@ -496,6 +497,221 @@ void main() {
   });
 
   group('UpdateNotifications stream handling', () {
+    test('a completion burst debounces the query itself', () {
+      fakeAsync((async) {
+        container.read(habitsControllerProvider);
+        async.flushMicrotasks();
+        clearInteractions(mockRepository);
+        for (var i = 0; i < 100; i++) {
+          updateController.add({habitCompletionNotification});
+        }
+        async.flushMicrotasks();
+        verifyNever(
+          () => mockRepository.getHabitCompletionsInRange(
+            rangeStart: any(named: 'rangeStart'),
+          ),
+        );
+        async.elapse(const Duration(milliseconds: 200));
+        verify(
+          () => mockRepository.getHabitCompletionsInRange(
+            rangeStart: any(named: 'rangeStart'),
+          ),
+        ).called(1);
+      });
+    });
+
+    test(
+      'overlapping refreshes share one trailing read of the latest range',
+      () {
+        fakeAsync((async) {
+          final controller = container.read(habitsControllerProvider.notifier);
+          async.flushMicrotasks();
+          definitionsController.add([testHabit1]);
+          async.flushMicrotasks();
+          final pending = <Completer<List<HabitCompletionRecord>>>[];
+          final ranges = <DateTime>[];
+          when(
+            () => mockRepository.getHabitCompletionsInRange(
+              rangeStart: any(named: 'rangeStart'),
+            ),
+          ).thenAnswer((call) {
+            ranges.add(call.namedArguments[#rangeStart] as DateTime);
+            final next = Completer<List<HabitCompletionRecord>>();
+            pending.add(next);
+            return next.future;
+          });
+          var finished = 0;
+          controller.refreshNow().then((_) => finished++);
+          for (var i = 0; i < 20; i++) {
+            controller.setTimeSpan(30 + i).then((_) => finished++);
+          }
+          async.flushMicrotasks();
+          expect(pending, hasLength(1), reason: 'only one SQLite read may run');
+          pending.first.complete([
+            HabitCompletionRecord(
+              habitId: testHabit1.id,
+              dateFrom: controllerNow,
+              completionType: HabitCompletionType.success,
+            ),
+          ]);
+          async.flushMicrotasks();
+          expect(pending, hasLength(2));
+          expect(
+            ranges.last,
+            controllerNow.dayAtMidnight.subtract(const Duration(days: 49)),
+          );
+          expect(
+            finished,
+            0,
+            reason: 'callers wait until the latest request lands',
+          );
+          expect(
+            container.read(habitsControllerProvider).successfulToday,
+            isEmpty,
+            reason:
+                'an obsolete result must not publish during the trailing read',
+          );
+          pending.last.complete([
+            HabitCompletionRecord(
+              habitId: testHabit1.id,
+              dateFrom: controllerNow,
+              completionType: HabitCompletionType.fail,
+            ),
+          ]);
+          async.flushMicrotasks();
+          expect(finished, 21);
+          expect(
+            container
+                .read(habitsControllerProvider)
+                .failedByDay[controllerNow.ymd],
+            {testHabit1.id},
+          );
+          expect(container.read(habitsControllerProvider).timeSpanDays, 49);
+        });
+      },
+    );
+
+    test('a notification during the initial read is not lost', () {
+      fakeAsync((async) {
+        final pending = <Completer<List<HabitCompletionRecord>>>[];
+        when(
+          () => mockRepository.getHabitCompletionsInRange(
+            rangeStart: any(named: 'rangeStart'),
+          ),
+        ).thenAnswer((_) {
+          final next = Completer<List<HabitCompletionRecord>>();
+          pending.add(next);
+          return next.future;
+        });
+        container.read(habitsControllerProvider);
+        async.flushMicrotasks();
+        updateController.add({habitCompletionNotification});
+        async.elapse(const Duration(milliseconds: 200));
+        expect(pending, hasLength(1));
+        pending.first.complete([]);
+        async.flushMicrotasks();
+        expect(pending, hasLength(2));
+        pending.last.complete([]);
+        async.flushMicrotasks();
+      });
+    });
+
+    test('a failed read releases the drain for a later refresh', () {
+      fakeAsync((async) {
+        final controller = container.read(habitsControllerProvider.notifier);
+        async.flushMicrotasks();
+        final failure = StateError('database unavailable');
+        var attempts = 0;
+        when(
+          () => mockRepository.getHabitCompletionsInRange(
+            rangeStart: any(named: 'rangeStart'),
+          ),
+        ).thenAnswer((_) async {
+          if (attempts++ == 0) throw failure;
+          return [];
+        });
+        Object? caught;
+        controller.refreshNow().then<void>(
+          (_) {},
+          onError: (Object error) {
+            caught = error;
+          },
+        );
+        async.flushMicrotasks();
+        expect(caught, same(failure));
+        var recovered = false;
+        controller.refreshNow().then((_) => recovered = true);
+        async.flushMicrotasks();
+        expect(recovered, isTrue);
+        expect(attempts, 2);
+      });
+    });
+
+    test('an invalidated drain cannot overwrite its replacement', () {
+      fakeAsync((async) {
+        final controller = container.read(habitsControllerProvider.notifier);
+        async.flushMicrotasks();
+        final pending = <Completer<List<HabitCompletionRecord>>>[];
+        when(
+          () => mockRepository.getHabitCompletionsInRange(
+            rangeStart: any(named: 'rangeStart'),
+          ),
+        ).thenAnswer((_) {
+          final next = Completer<List<HabitCompletionRecord>>();
+          pending.add(next);
+          return next.future;
+        });
+        controller.refreshNow();
+        updateController.add({habitCompletionNotification});
+        async.flushMicrotasks();
+        container
+          ..invalidate(habitsControllerProvider)
+          ..read(habitsControllerProvider);
+        async.flushMicrotasks();
+        definitionsController.add([testHabit1]);
+        async.flushMicrotasks();
+        expect(pending, hasLength(2));
+        pending.last.complete([]);
+        async.flushMicrotasks();
+        pending.first.complete([
+          HabitCompletionRecord(
+            habitId: testHabit1.id,
+            dateFrom: controllerNow,
+            completionType: HabitCompletionType.success,
+          ),
+        ]);
+        async.flushMicrotasks();
+        expect(
+          container.read(habitsControllerProvider).successfulToday,
+          isEmpty,
+        );
+        expect(
+          async.pendingTimers,
+          isEmpty,
+          reason: 'invalidation cancels the queued notification debounce',
+        );
+      });
+    });
+
+    test(
+      'invalidation before startup does not duplicate the update listener',
+      () {
+        fakeAsync((async) {
+          container
+            ..read(habitsControllerProvider)
+            ..invalidate(habitsControllerProvider)
+            ..read(habitsControllerProvider);
+          async.flushMicrotasks();
+          verify(() => mockRepository.updateStream).called(1);
+          verify(
+            () => mockRepository.getHabitCompletionsInRange(
+              rangeStart: any(named: 'rangeStart'),
+            ),
+          ).called(1);
+        });
+      },
+    );
+
     test('refetches completions when habitCompletionNotification received', () {
       fakeAsync((async) {
         container.read(habitsControllerProvider);

--- a/test/features/habits/state/habits_controller_test.dart
+++ b/test/features/habits/state/habits_controller_test.dart
@@ -712,6 +712,42 @@ void main() {
       },
     );
 
+    test('a queued refresh survives failure of the in-flight read', () {
+      fakeAsync((async) {
+        final controller = container.read(habitsControllerProvider.notifier);
+        async.flushMicrotasks();
+        final first = Completer<List<HabitCompletionRecord>>();
+        var attempts = 0;
+        when(
+          () => mockRepository.getHabitCompletionsInRange(
+            rangeStart: any(named: 'rangeStart'),
+          ),
+        ).thenAnswer((_) {
+          attempts++;
+          return attempts == 1 ? first.future : Future.value([]);
+        });
+        final errors = <Object>[];
+        var completed = 0;
+        controller.refreshNow().then<void>(
+          (_) => completed++,
+          onError: errors.add,
+        );
+        controller.refreshNow().then<void>(
+          (_) => completed++,
+          onError: errors.add,
+        );
+        first.completeError(StateError('temporary read failure'));
+        async.flushMicrotasks();
+        expect(
+          attempts,
+          2,
+          reason: 'the queued request must still read after an earlier failure',
+        );
+        expect(errors, isEmpty);
+        expect(completed, 2);
+      });
+    });
+
     test('refetches completions when habitCompletionNotification received', () {
       fakeAsync((async) {
         container.read(habitsControllerProvider);


### PR DESCRIPTION
A burst of habit-completion notifications started a range query per event because the 200 ms delay happened after fetching. Notifications now debounce before querying, overlapping refreshes share one trailing read of the latest range, and stale reads cannot replace newer data. Listening before the initial query also prevents updates during startup from being lost.

The history query now ranks IDs and then projects only winning rows. On a synthetic 43,800-row, five-year history, alternating before/after SQL medians fell from 63.52 to 35.16 ms for a one-year range and 353.47 to 182.43 ms for the full history. The benchmark and reproduction are in `docs/perf/2026-09-05-habit-refreshes.md`; these are isolated SQLite timings, not app latency. Existing indexes, local-day ranking, write-recency tie-breakers, privacy/deletion filtering, and recorded wall-clock timestamps are preserved.

Validation: 48 targeted tests pass via Dart MCP; the analyzer is clean. Six controller regressions fail without their fixes, covering burst queries, overlapping ranges, initial-read notifications, stale generations, duplicate startup listeners, and queued refreshes after a read failure. Database tests cover winning-row tie-breakers and projection semantics. FVM formatting, `make knowledge_check`, and `make changelog_check` pass.
