### PR TITLE
fix(ai): recover transcription uploads and structured image requests

### DIFF
--- a/changelog.d/2026-09-05-ai-transcription-recovery.md
+++ b/changelog.d/2026-09-05-ai-transcription-recovery.md
@@ -1,0 +1,8 @@
+### Fixed
+- **Long recordings can be transcribed through Melious.** Recordings that
+  exceed its upload limit are sent as smaller temporary audio segments and
+  combined into one transcript, leaving the original recording unchanged.
+- **Mistral's default transcription model uses the correct API.** Existing
+  Voxtral Mini configurations now use its dedicated transcription endpoint.
+- **Melious image summaries retain their requested structure.** Collecting
+  usage and cost no longer drops the required summary tool selection.

--- a/knowledge/features/ai/attribution.md
+++ b/knowledge/features/ai/attribution.md
@@ -5,7 +5,7 @@ description: How every inference call becomes an auditable, costed record attach
 resource: ../../../lib/features/ai_consumption
 tags: [ai, attribution, consumption, cost, provenance]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-07-26T00:00:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-05T16:00:00Z }
 stale_after: 2026-10-19
 sources:
   - id: consumption
@@ -15,7 +15,7 @@ sources:
   - id: runner
     resource: ../../../lib/features/ai/services/skill_inference_runner.dart
     title: SkillInferenceRunner attribution sessions
-    last_modified: 2026-07-24
+    last_modified: 2026-09-05
 ---
 
 # The boundary
@@ -33,19 +33,35 @@ sequenceDiagram
   participant Journal as Journal/PersistenceLogic
   Runner->>Attr: begin(work type, actor, trigger, intended output)
   Runner->>Provider: inference request
-  Provider-->>Runner: response + usage/reported impact
-  Runner->>Attr: recordInteraction(digests + metadata)
-  Attr->>Sync: persist, then enqueue best effort
-  Runner->>Attr: prepareCompletion(output reference)
-  Runner->>Journal: persist carrier with attribution
-  Runner->>Attr: finalize local projection
+  alt complete response
+    Provider-->>Runner: response + usage/reported impact
+    Runner->>Attr: recordInteraction(digests + metadata)
+    Attr->>Sync: persist, then enqueue best effort
+    Runner->>Attr: prepareCompletion(output reference)
+    Runner->>Journal: persist carrier with attribution
+    Runner->>Attr: finalize local projection
+  else transcription fails after completed segments
+    Provider-->>Runner: error + incurred usage and impact
+    Runner->>Attr: recordInteraction(completed segments only)
+    Attr->>Sync: persist, then enqueue best effort
+    Runner->>Attr: prepareCompletion(failed)
+    Runner->>Attr: finalize failed local projection
+  end
 ```
 
 `SkillInferenceRunner` begins an in-memory attribution session **before**
 transcription, image analysis, prompt generation or image generation. Each
-provider call records usage, digests, and provider-reported cost/impact. The
+logical call records usage, digests, and provider-reported cost/impact. The
 completed output embeds the authoritative attribution, and only then is the local
 query projection updated.
+
+Segmented transcription aggregates its physical calls. If a later segment fails,
+`TranscriptionException` carries the completed segments' usage and impact; the
+runner records those incurred quantities once and finalizes a failed local
+attribution. No partial transcript carrier is written. Its output reference is
+an intended artifact, not evidence that an artifact exists. A canceled subscriber
+cannot receive this exception; cancellation accounting needs a separate caller
+lifecycle hook and is not captured by this failure path.
 
 # Carrier mapping is uniform
 

--- a/knowledge/features/ai/provider-routing.md
+++ b/knowledge/features/ai/provider-routing.md
@@ -5,7 +5,7 @@ description: The routing table behind CloudInferenceRepository, per-provider cat
 resource: ../../../lib/features/ai/repository/cloud_inference_repository.dart
 tags: [ai, providers, routing, audio, gemini, mlx]
 status: stable
-generated: { by: claude-code/opus-5, at: 2026-08-18T00:00:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-05T15:30:00Z }
 stale_after: 2026-10-19
 sources:
   - id: router
@@ -26,8 +26,12 @@ sources:
     last_modified: 2026-08-18
   - id: known-models-data
     resource: ../../../lib/features/ai/util/known_models_data.dart
-    title: The meliousModels catalog entries
-    last_modified: 2026-08-12
+    title: The curated provider catalogs
+    last_modified: 2026-09-05
+  - id: temporary-mp3
+    resource: ../../../lib/features/ai/util/temporary_mp3_encoder.dart
+    title: Temporary audio encoding and segment lifecycle
+    last_modified: 2026-09-05
 ---
 
 # One facade, two collaborators
@@ -116,6 +120,41 @@ Whisper-class ids (`whisper`, `transcribe`, `asr`, `stt`) route to
 and decode the returned `b64_json` bytes. Chat callers may opt into an
 OpenAI-compatible `reasoning_effort`; leaving it unset preserves the provider's
 model default.
+
+Melious's [transcription endpoint](https://melious.ai/docs/reference/audio)
+limits an uploaded file to 25 MB. Sources within that limit retain the original
+M4A upload. Larger sources are decoded once, then
+`encodeAudioBytesToTemporaryMp3Segments` prepares consecutive twenty-minute PCM
+ranges as independently playable 64 kbps MP3 files (about 9.6 MB each). Encoding
+uses bounded sample blocks, but the decoded WAV still occupies memory for the
+whole recording. No archived bytes are modified.
+
+```mermaid
+flowchart TD
+  Source[Archived audio bytes] --> Size{Within upload limit?}
+  Size -->|Yes| Original[Upload original M4A]
+  Size -->|No| Decode[Decode WAV once]
+  Decode --> Encode[Encode next temporary MP3 segment]
+  Encode --> Upload[Check size and upload segment]
+  Upload --> Clean[Delete temporary segment]
+  Clean --> More{More audio?}
+  More -->|Yes| Encode
+  More -->|No| Combine[Combine transcript and usage]
+  Upload -->|Failure or cancellation| Cleanup[Delete segment and stop]
+```
+
+Each segment is uploaded sequentially and deleted before the next is prepared.
+The caller receives one combined transcript only after every part succeeds;
+usage and additive environmental/billing quantities include every successful
+part. Cancellation aborts the active multipart request and stops further parts,
+including when a late successful response races cancellation. The request
+timeout covers both headers and response body. An unexpectedly oversized encoded
+part or unavailable decoder fails explicitly instead of sending an invalid
+upload. No automatic provider switch changes where private audio is sent.
+
+Buffered vision requests preserve the caller's forced tool choice as well as
+its tool schema. Collecting Melious impact data must not turn a required
+structured image summary into an automatic, optional tool call.
 
 **Reference-image generation is rejected explicitly** rather than silently
 ignored, because Melious currently documents only text-to-image generation.
@@ -265,9 +304,12 @@ deadline, conversion, cleanup, request errors and response normalization for bot
 providers. **Only the JSON audio part differs**: Melious uses the
 OpenAI-compatible `input_audio: {data, format: mp3}` object, while Mistral's
 native API expects `input_audio` to contain the base64 MP3 string directly.
-Mistral Transcribe 2 and other transcription-only variants stay on
-`/audio/transcriptions`, where diarization, timestamps and native `context_bias`
-are available.
+The `voxtral-mini-latest` alias now identifies Transcribe 2, so it uses
+`/audio/transcriptions` with diarization, timestamps and native `context_bias`.
+It is not a chat-audio alias. The fixed 25.07 Mini/Small models and
+`voxtral-small-latest` retain chat audio. This distinction follows the
+[Mistral transcription contract](https://docs.mistral.ai/studio/audio/speech_to_text/offline_transcription)
+and applies to existing stored model IDs without a profile migration.
 
 ## Platform decoders
 

--- a/knowledge/features/ai/provider-routing.md
+++ b/knowledge/features/ai/provider-routing.md
@@ -146,11 +146,17 @@ flowchart TD
 Each segment is uploaded sequentially and deleted before the next is prepared.
 The caller receives one combined transcript only after every part succeeds;
 usage and additive environmental/billing quantities include every successful
-part. Cancellation aborts the active multipart request and stops further parts,
+part. If a later part fails, the exception carries the already incurred usage
+and impact so the skill runner can record a failed attempt without saving a
+partial transcript. Cancellation aborts the active multipart request and stops further parts,
 including when a late successful response races cancellation. The request
 timeout covers both headers and response body. An unexpectedly oversized encoded
 part or unavailable decoder fails explicitly instead of sending an invalid
 upload. No automatic provider switch changes where private audio is sent.
+
+A subscriber that explicitly cancels cannot receive the terminal accounting
+exception. The runner currently has no cancellation-accounting hook, so charges
+incurred before such a cancellation are not persisted through this path.
 
 Buffered vision requests preserve the caller's forced tool choice as well as
 its tool schema. Collecting Melious impact data must not turn a required
@@ -306,7 +312,9 @@ OpenAI-compatible `input_audio: {data, format: mp3}` object, while Mistral's
 native API expects `input_audio` to contain the base64 MP3 string directly.
 The `voxtral-mini-latest` alias now identifies Transcribe 2, so it uses
 `/audio/transcriptions` with diarization, timestamps and native `context_bias`.
-It is not a chat-audio alias. The fixed 25.07 Mini/Small models and
+It is not a chat-audio alias. Dictionary phrases use repeated `context_bias`
+multipart text fields, matching the official SDK, rather than one comma-joined
+phrase; embedded commas and multi-word names remain intact. The fixed 25.07 Mini/Small models and
 `voxtral-small-latest` retain chat audio. This distinction follows the
 [Mistral transcription contract](https://docs.mistral.ai/studio/audio/speech_to_text/offline_transcription)
 and applies to existing stored model IDs without a profile migration.

--- a/lib/features/ai/model/ai_call_impact.dart
+++ b/lib/features/ai/model/ai_call_impact.dart
@@ -63,6 +63,29 @@ class MeliousCallImpact {
     return match.namedGroup('number') ?? match.namedGroup('string');
   }
 
+  /// Sums additive cost and environmental quantities across physical calls.
+  /// Descriptive metadata uses the first reported value; an exact provider
+  /// decimal is retained only when there is a single contributing call.
+  static MeliousCallImpact? combine(
+    MeliousCallImpact? a,
+    MeliousCallImpact? b,
+  ) {
+    if (a == null) return b;
+    if (b == null) return a;
+    double? sum(double? x, double? y) =>
+        x == null && y == null ? null : (x ?? 0) + (y ?? 0);
+    return MeliousCallImpact(
+      energyKwh: sum(a.energyKwh, b.energyKwh),
+      carbonGCo2: sum(a.carbonGCo2, b.carbonGCo2),
+      waterLiters: sum(a.waterLiters, b.waterLiters),
+      costCredits: sum(a.costCredits, b.costCredits),
+      renewablePercent: a.renewablePercent ?? b.renewablePercent,
+      pue: a.pue ?? b.pue,
+      dataCenter: a.dataCenter ?? b.dataCenter,
+      providerId: a.providerId ?? b.providerId,
+    );
+  }
+
   /// Energy in kilowatt-hours (`environment_impact.energy_kwh`).
   final double? energyKwh;
 

--- a/lib/features/ai/repository/completion_usage_parser.dart
+++ b/lib/features/ai/repository/completion_usage_parser.dart
@@ -73,3 +73,41 @@ int? _integerValue(Object? value) {
   if (value is String) return int.tryParse(value);
   return null;
 }
+
+/// Sums token usage across physical requests belonging to one logical call.
+CompletionUsage? combineCompletionUsage(
+  CompletionUsage? a,
+  CompletionUsage? b,
+) {
+  if (a == null) return b;
+  if (b == null) return a;
+  int? sum(int? x, int? y) =>
+      x == null && y == null ? null : (x ?? 0) + (y ?? 0);
+  final aDetails = a.completionTokensDetails;
+  final bDetails = b.completionTokensDetails;
+  final aPrompt = a.promptTokensDetails;
+  final bPrompt = b.promptTokensDetails;
+  return CompletionUsage(
+    promptTokens: sum(a.promptTokens, b.promptTokens),
+    completionTokens: sum(a.completionTokens, b.completionTokens),
+    totalTokens: sum(a.totalTokens, b.totalTokens),
+    completionTokensDetails: aDetails == null && bDetails == null
+        ? null
+        : CompletionTokensDetails(
+            reasoningTokens: sum(
+              aDetails?.reasoningTokens,
+              bDetails?.reasoningTokens,
+            ),
+            audioTokens: sum(aDetails?.audioTokens, bDetails?.audioTokens),
+          ),
+    // Carried for the same reason as the completion details: the
+    // consumption event reads `cachedTokens` off this, so dropping it would
+    // report null cached input on exactly the runs that retried.
+    promptTokensDetails: aPrompt == null && bPrompt == null
+        ? null
+        : PromptTokensDetails(
+            cachedTokens: sum(aPrompt?.cachedTokens, bPrompt?.cachedTokens),
+            audioTokens: sum(aPrompt?.audioTokens, bPrompt?.audioTokens),
+          ),
+  );
+}

--- a/lib/features/ai/repository/melious_inference_repository.dart
+++ b/lib/features/ai/repository/melious_inference_repository.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as developer;
+import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:clock/clock.dart';
 import 'package:http/http.dart' as http;
@@ -38,6 +40,7 @@ class MeliousInferenceRepository extends TranscriptionRepository {
     CloudInferenceRequestHelpers? helpers,
     MeliousChatCompletionStreamFactory? chatCompletionStreamFactory,
     AudioToTemporaryMp3Encoder? audioToTemporaryMp3Encoder,
+    Stream<File> Function(Uint8List)? audioSegmentEncoder,
     TemporaryAudioFileReader? temporaryFileReader,
     TemporaryAudioFileDeleter? temporaryFileDeleter,
     Clock? clockSource,
@@ -46,6 +49,8 @@ class MeliousInferenceRepository extends TranscriptionRepository {
            chatCompletionStreamFactory ?? _createChatCompletionStream,
        _audioToTemporaryMp3Encoder =
            audioToTemporaryMp3Encoder ?? encodeAudioBytesToTemporaryMp3,
+       _audioSegmentEncoder =
+           audioSegmentEncoder ?? encodeAudioBytesToTemporaryMp3Segments,
        _temporaryFileReader =
            temporaryFileReader ?? ((file) => file.readAsBytes()),
        _temporaryFileDeleter =
@@ -131,6 +136,11 @@ class MeliousInferenceRepository extends TranscriptionRepository {
 
   final CloudInferenceRequestHelpers _helpers;
   final MeliousChatCompletionStreamFactory _chatCompletionStreamFactory;
+
+  /// Provider-documented multipart file limit, in bytes.
+  static const maxTranscriptionUploadBytes = 25000000;
+
+  final Stream<File> Function(Uint8List) _audioSegmentEncoder;
   final AudioToTemporaryMp3Encoder _audioToTemporaryMp3Encoder;
   final TemporaryAudioFileReader _temporaryFileReader;
   final TemporaryAudioFileDeleter _temporaryFileDeleter;
@@ -441,6 +451,7 @@ class MeliousInferenceRepository extends TranscriptionRepository {
         temperature: temperature,
         maxCompletionTokens: maxCompletionTokens,
         tools: tools,
+        toolChoice: toolChoice,
         impactCollector: impactCollector,
       );
     }
@@ -655,6 +666,10 @@ class MeliousInferenceRepository extends TranscriptionRepository {
   /// Transcribes audio through Melious' OpenAI-compatible
   /// `/audio/transcriptions` endpoint.
   ///
+  /// Recordings above the upload limit use consecutive temporary MP3 parts.
+  /// Only the complete combined transcript is emitted; cancellation stops
+  /// subsequent parts and aborts the current upload. Source bytes are preserved.
+  ///
   /// [contextBiasTerms] are speech-dictionary words/phrases forwarded as the
   /// OpenAI-standard `prompt` form field to bias recognition toward names and
   /// domain vocabulary — honored by context-aware models such as Voxtral and
@@ -690,10 +705,141 @@ class MeliousInferenceRepository extends TranscriptionRepository {
       throw ArgumentError('API key cannot be empty');
     }
 
+    return _transcribeAudioUploads(
+      model: model,
+      audioBase64: audioBase64,
+      baseUrl: normalizedBaseUrl,
+      apiKey: normalizedApiKey,
+      responseFormat: responseFormat,
+      contextBiasTerms: contextBiasTerms,
+      timeout: timeout,
+      impactCollector: impactCollector,
+    );
+  }
+
+  Stream<CreateChatCompletionStreamResponse> _transcribeAudioUploads({
+    required String model,
+    required String audioBase64,
+    required String baseUrl,
+    required String apiKey,
+    required String responseFormat,
+    List<String>? contextBiasTerms,
+    Duration? timeout,
+    InferenceImpactCollector? impactCollector,
+  }) {
+    var canceled = false;
+    final abortTrigger = Completer<void>();
+    late final StreamController<CreateChatCompletionStreamResponse> controller;
+    Future<void> run() async {
+      try {
+        final bytes = base64Decode(audioBase64);
+        Future<CreateChatCompletionStreamResponse> upload(
+          Uint8List payload,
+          String filename,
+        ) async {
+          if (payload.length > maxTranscriptionUploadBytes) {
+            throw TranscriptionException(
+              'Prepared audio exceeds Melious’s 25 MB upload limit. Use a shorter recording or another transcription provider.',
+              provider: _providerName,
+              statusCode: 413,
+            );
+          }
+          return _transcribeAudioBytes(
+            model: model,
+            audioBytes: payload,
+            filename: filename,
+            normalizedBaseUrl: baseUrl,
+            normalizedApiKey: apiKey,
+            responseFormat: responseFormat,
+            contextBiasTerms: contextBiasTerms,
+            timeout: timeout,
+            impactCollector: impactCollector,
+            abortTrigger: abortTrigger.future,
+          ).first;
+        }
+
+        if (bytes.length <= maxTranscriptionUploadBytes) {
+          final result = await upload(bytes, 'audio.m4a');
+          if (!canceled) controller.add(result);
+        } else {
+          final texts = <String>[];
+          CompletionUsage? usage;
+          CreateChatCompletionStreamResponse? last;
+          await for (final file in _audioSegmentEncoder(bytes)) {
+            if (canceled) break;
+            final payload = await _temporaryFileReader(file);
+            if (canceled) break;
+            final result = await upload(payload, 'audio.mp3');
+            texts.add(result.choices?.first.delta?.content ?? '');
+            usage = combineCompletionUsage(usage, result.usage);
+            last = result;
+            if (canceled) break;
+          }
+          if (!canceled) {
+            if (last == null) {
+              throw const FormatException(
+                'Audio preparation produced no segments',
+              );
+            }
+            controller.add(
+              last.copyWith(
+                choices: [
+                  ChatCompletionStreamResponseChoice(
+                    delta: ChatCompletionStreamResponseDelta(
+                      content: texts.join('\n\n'),
+                    ),
+                    index: 0,
+                  ),
+                ],
+                usage: usage,
+              ),
+            );
+          }
+        }
+      } catch (error, stackTrace) {
+        if (!canceled) {
+          controller.addError(
+            error is TranscriptionException
+                ? error
+                : TranscriptionException(
+                    'Failed to prepare or transcribe audio. Try another transcription provider or a shorter recording.',
+                    provider: _providerName,
+                    originalError: error,
+                  ),
+            stackTrace,
+          );
+        }
+      } finally {
+        unawaited(controller.close());
+      }
+    }
+
+    controller = StreamController<CreateChatCompletionStreamResponse>(
+      onListen: () => unawaited(run()),
+      onCancel: () {
+        canceled = true;
+        if (!abortTrigger.isCompleted) abortTrigger.complete();
+      },
+    );
+    return controller.stream;
+  }
+
+  Stream<CreateChatCompletionStreamResponse> _transcribeAudioBytes({
+    required String model,
+    required Uint8List audioBytes,
+    required String filename,
+    required Future<void> abortTrigger,
+    required String normalizedBaseUrl,
+    required String normalizedApiKey,
+    required String responseFormat,
+    List<String>? contextBiasTerms,
+    Duration? timeout,
+    InferenceImpactCollector? impactCollector,
+  }) {
     return executeTranscription(
       providerName: _providerName,
       responseIdPrefix: 'melious-transcription-',
-      audioLengthForLog: audioBase64.length,
+      audioLengthForLog: audioBytes.length,
       timeout: timeout,
       onSuccessResponse: impactCollector == null
           ? null
@@ -705,24 +851,34 @@ class MeliousInferenceRepository extends TranscriptionRepository {
                       response.body,
                     ),
               );
-              if (impact.hasData) impactCollector.impact = impact;
+              if (impact.hasData) {
+                impactCollector.impact = MeliousCallImpact.combine(
+                  impactCollector.impact,
+                  impact,
+                );
+              }
             },
       sendRequest: (requestTimeout, timeoutErrorMessage) async {
         final uri = _buildEndpointUri(
           normalizedBaseUrl,
           'audio/transcriptions',
         );
-        final request = http.MultipartRequest('POST', uri)
-          ..headers['Authorization'] = 'Bearer $normalizedApiKey'
-          ..files.add(
-            http.MultipartFile.fromBytes(
-              'file',
-              base64Decode(audioBase64),
-              filename: 'audio.m4a',
-            ),
-          )
-          ..fields['model'] = model
-          ..fields['response_format'] = responseFormat;
+        final request =
+            http.AbortableMultipartRequest(
+                'POST',
+                uri,
+                abortTrigger: abortTrigger,
+              )
+              ..headers['Authorization'] = 'Bearer $normalizedApiKey'
+              ..files.add(
+                http.MultipartFile.fromBytes(
+                  'file',
+                  audioBytes,
+                  filename: filename,
+                ),
+              )
+              ..fields['model'] = model
+              ..fields['response_format'] = responseFormat;
 
         final biasTerms = contextBiasTerms
             ?.map((term) => term.trim())
@@ -733,8 +889,9 @@ class MeliousInferenceRepository extends TranscriptionRepository {
           request.fields['prompt'] = biasTerms.join(', ');
         }
 
-        final streamedResponse = await httpClient
+        return httpClient
             .send(request)
+            .then(http.Response.fromStream)
             .timeout(
               requestTimeout,
               onTimeout: () {
@@ -745,8 +902,6 @@ class MeliousInferenceRepository extends TranscriptionRepository {
                 );
               },
             );
-
-        return http.Response.fromStream(streamedResponse);
       },
     );
   }

--- a/lib/features/ai/repository/melious_inference_repository.dart
+++ b/lib/features/ai/repository/melious_inference_repository.dart
@@ -729,6 +729,9 @@ class MeliousInferenceRepository extends TranscriptionRepository {
   }) {
     var canceled = false;
     final abortTrigger = Completer<void>();
+    final incurredImpact = impactCollector ?? InferenceImpactCollector();
+    var completedSegments = 0;
+    CompletionUsage? usage;
     late final StreamController<CreateChatCompletionStreamResponse> controller;
     Future<void> run() async {
       try {
@@ -753,7 +756,7 @@ class MeliousInferenceRepository extends TranscriptionRepository {
             responseFormat: responseFormat,
             contextBiasTerms: contextBiasTerms,
             timeout: timeout,
-            impactCollector: impactCollector,
+            impactCollector: incurredImpact,
             abortTrigger: abortTrigger.future,
           ).first;
         }
@@ -763,13 +766,13 @@ class MeliousInferenceRepository extends TranscriptionRepository {
           if (!canceled) controller.add(result);
         } else {
           final texts = <String>[];
-          CompletionUsage? usage;
           CreateChatCompletionStreamResponse? last;
           await for (final file in _audioSegmentEncoder(bytes)) {
             if (canceled) break;
             final payload = await _temporaryFileReader(file);
             if (canceled) break;
             final result = await upload(payload, 'audio.mp3');
+            completedSegments++;
             texts.add(result.choices?.first.delta?.content ?? '');
             usage = combineCompletionUsage(usage, result.usage);
             last = result;
@@ -798,13 +801,24 @@ class MeliousInferenceRepository extends TranscriptionRepository {
         }
       } catch (error, stackTrace) {
         if (!canceled) {
+          final failure = error is TranscriptionException
+              ? error
+              : TranscriptionException(
+                  'Failed to prepare or transcribe audio. Try another transcription provider or a shorter recording.',
+                  provider: _providerName,
+                  originalError: error,
+                );
           controller.addError(
-            error is TranscriptionException
-                ? error
+            completedSegments == 0
+                ? failure
                 : TranscriptionException(
-                    'Failed to prepare or transcribe audio. Try another transcription provider or a shorter recording.',
-                    provider: _providerName,
-                    originalError: error,
+                    failure.message,
+                    provider: failure.provider,
+                    statusCode: failure.statusCode,
+                    originalError: failure.originalError ?? failure,
+                    completedSegments: completedSegments,
+                    partialUsage: usage,
+                    partialImpact: incurredImpact.impact,
                   ),
             stackTrace,
           );

--- a/lib/features/ai/repository/mistral_inference_repository.dart
+++ b/lib/features/ai/repository/mistral_inference_repository.dart
@@ -43,9 +43,9 @@ class MistralInferenceRepository {
 
   /// Whether [model] supports Mistral's instruction-following chat-audio API.
   ///
-  /// Mistral currently documents the `latest` aliases and the 25.07 Mini and
-  /// Small releases for `/chat/completions`. Transcribe 2, realtime, and TTS
-  /// variants use their dedicated audio endpoints instead.
+  /// The Mini `latest` alias points to Transcribe 2 and requires the
+  /// transcription endpoint. The 25.07 Mini/Small releases and Small's
+  /// `latest` alias support chat audio; realtime and TTS do not.
   static bool isMistralChatAudioModel(String model) {
     final normalized = model.trim().toLowerCase();
     if (!normalized.startsWith('voxtral-mini-') &&
@@ -57,7 +57,7 @@ class MistralInferenceRepository {
         normalized.contains('-tts-')) {
       return false;
     }
-    return normalized.endsWith('-latest') || normalized.endsWith('-2507');
+    return normalized == 'voxtral-small-latest' || normalized.endsWith('-2507');
   }
 
   /// Safely log exception to LoggingService if available

--- a/lib/features/ai/repository/mistral_transcription_repository.dart
+++ b/lib/features/ai/repository/mistral_transcription_repository.dart
@@ -45,8 +45,8 @@ class MistralTranscriptionRepository extends TranscriptionRepository {
   /// speaker labels (e.g., `[Speaker 1]`, `[Speaker 2]`).
   ///
   /// [contextBias] is a list of words/phrases (up to 100) that the model
-  /// should pay special attention to. Sent as comma-separated terms in the
-  /// `context_bias` multipart form field.
+  /// should pay special attention to. Each term is sent as a repeated
+  /// `context_bias` multipart text field, preserving phrase boundaries.
   Stream<CreateChatCompletionStreamResponse> transcribeAudio({
     required String model,
     required String audioBase64,
@@ -121,7 +121,11 @@ class MistralTranscriptionRepository extends TranscriptionRepository {
                 .take(100)
                 .toList();
             if (terms.isNotEmpty) {
-              request.fields['context_bias'] = terms.join(',');
+              request.files.addAll(
+                terms.map(
+                  (term) => http.MultipartFile.fromString('context_bias', term),
+                ),
+              );
             }
           }
 

--- a/lib/features/ai/repository/transcription_exception.dart
+++ b/lib/features/ai/repository/transcription_exception.dart
@@ -1,3 +1,6 @@
+import 'package:lotti/features/ai/model/ai_call_impact.dart';
+import 'package:openai_dart/openai_dart.dart';
+
 /// Exception thrown when audio transcription fails.
 ///
 /// Used by all transcription repositories (OpenAI, Mistral, Whisper).
@@ -8,6 +11,9 @@ class TranscriptionException implements Exception {
     this.provider,
     this.statusCode,
     this.originalError,
+    this.completedSegments = 0,
+    this.partialUsage,
+    this.partialImpact,
   });
 
   final String message;
@@ -20,6 +26,15 @@ class TranscriptionException implements Exception {
 
   /// The original exception that caused this error, if any.
   final Object? originalError;
+
+  /// Successfully completed segments before this attempt failed.
+  final int completedSegments;
+
+  /// Provider-reported usage already incurred by the completed segments.
+  final CompletionUsage? partialUsage;
+
+  /// Provider-reported billing and impact already incurred before failure.
+  final MeliousCallImpact? partialImpact;
 
   @override
   String toString() => 'TranscriptionException($provider): $message';

--- a/lib/features/ai/services/skill_inference_runner.dart
+++ b/lib/features/ai/services/skill_inference_runner.dart
@@ -22,6 +22,7 @@ import 'package:lotti/features/ai/model/resolved_profile.dart';
 import 'package:lotti/features/ai/repository/ai_consumption_mapping.dart';
 import 'package:lotti/features/ai/repository/ai_input_repository.dart';
 import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
+import 'package:lotti/features/ai/repository/completion_usage_parser.dart';
 import 'package:lotti/features/ai/repository/gemini_thinking_config.dart';
 import 'package:lotti/features/ai/repository/task_summary_resolver.dart';
 import 'package:lotti/features/ai/repository/tool_call_accumulator.dart';
@@ -1490,22 +1491,7 @@ class SkillInferenceRunner {
   static MeliousCallImpact? _mergeImpact(
     MeliousCallImpact? a,
     MeliousCallImpact? b,
-  ) {
-    if (a == null) return b;
-    if (b == null) return a;
-    double? sum(double? x, double? y) =>
-        x == null && y == null ? null : (x ?? 0) + (y ?? 0);
-    return MeliousCallImpact(
-      energyKwh: sum(a.energyKwh, b.energyKwh),
-      carbonGCo2: sum(a.carbonGCo2, b.carbonGCo2),
-      waterLiters: sum(a.waterLiters, b.waterLiters),
-      costCredits: sum(a.costCredits, b.costCredits),
-      renewablePercent: a.renewablePercent ?? b.renewablePercent,
-      pue: a.pue ?? b.pue,
-      dataCenter: a.dataCenter ?? b.dataCenter,
-      providerId: a.providerId ?? b.providerId,
-    );
-  }
+  ) => MeliousCallImpact.combine(a, b);
 
   /// Sums the token usage of two attempts at the same logical call.
   ///
@@ -1514,39 +1500,8 @@ class SkillInferenceRunner {
   /// needed prompting twice — exactly the model whose cost the user most needs
   /// to see. Null operands pass through so a provider that reports usage on
   /// only one attempt still contributes what it did report.
-  static CompletionUsage? _mergeUsage(CompletionUsage? a, CompletionUsage? b) {
-    if (a == null) return b;
-    if (b == null) return a;
-    int? sum(int? x, int? y) =>
-        x == null && y == null ? null : (x ?? 0) + (y ?? 0);
-    final aDetails = a.completionTokensDetails;
-    final bDetails = b.completionTokensDetails;
-    final aPrompt = a.promptTokensDetails;
-    final bPrompt = b.promptTokensDetails;
-    return CompletionUsage(
-      promptTokens: sum(a.promptTokens, b.promptTokens),
-      completionTokens: sum(a.completionTokens, b.completionTokens),
-      totalTokens: sum(a.totalTokens, b.totalTokens),
-      completionTokensDetails: aDetails == null && bDetails == null
-          ? null
-          : CompletionTokensDetails(
-              reasoningTokens: sum(
-                aDetails?.reasoningTokens,
-                bDetails?.reasoningTokens,
-              ),
-              audioTokens: sum(aDetails?.audioTokens, bDetails?.audioTokens),
-            ),
-      // Carried for the same reason as the completion details: the
-      // consumption event reads `cachedTokens` off this, so dropping it would
-      // report null cached input on exactly the runs that retried.
-      promptTokensDetails: aPrompt == null && bPrompt == null
-          ? null
-          : PromptTokensDetails(
-              cachedTokens: sum(aPrompt?.cachedTokens, bPrompt?.cachedTokens),
-              audioTokens: sum(aPrompt?.audioTokens, bPrompt?.audioTokens),
-            ),
-    );
-  }
+  static CompletionUsage? _mergeUsage(CompletionUsage? a, CompletionUsage? b) =>
+      combineCompletionUsage(a, b);
 
   /// Marks every parent task of [sourceEntryId] stale after an
   /// [AiResponseEntry] was linked beneath it.

--- a/lib/features/ai/services/skill_inference_runner.dart
+++ b/lib/features/ai/services/skill_inference_runner.dart
@@ -50,7 +50,7 @@ import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/utils/audio_utils.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:lotti/utils/image_utils.dart';
-import 'package:openai_dart/openai_dart.dart';
+import 'package:openai_dart/openai_dart.dart' hide Error;
 
 part 'skill_inference_runner_internals.dart';
 
@@ -254,7 +254,43 @@ class SkillInferenceRunner {
               );
 
         // 6. Collect streaming response.
-        final collected = await _collectStream(responseStream);
+        final collected = await _collectStream(responseStream)
+            .onError<TranscriptionException>((error, stackTrace) async {
+              if (error.completedSegments > 0) {
+                try {
+                  final failedAttribution = await _recordAttributedConsumption(
+                    attribution: attribution,
+                    entryId: audioEntryId,
+                    taskId: linkedTaskId,
+                    categoryId: entity.meta.categoryId,
+                    skillId: skill.id,
+                    provider: provider,
+                    modelId: modelId,
+                    responseType: skill.skillType.toResponseType,
+                    usage: error.partialUsage,
+                    impact: error.partialImpact,
+                    start: start,
+                    interactionKind: AiInteractionKind.audioTranscription,
+                    requestText:
+                        '${promptResult.systemMessage}\n${promptResult.userMessage}',
+                    responseText: '',
+                    status: AiWorkStatus.failed,
+                    errorCode: 'transcription_incomplete',
+                    errorSummary:
+                        'Transcription failed after completed audio segments.',
+                  );
+                  await _finalizeAttribution(failedAttribution);
+                } catch (accountingError, accountingStackTrace) {
+                  _loggingService.error(
+                    LogDomain.ai,
+                    accountingError,
+                    stackTrace: accountingStackTrace,
+                    subDomain: 'runTranscription.accounting',
+                  );
+                }
+              }
+              Error.throwWithStackTrace(error, stackTrace);
+            });
 
         // The Melious chat-audio adapter supplies provider-reported billing
         // and environmental impact through this collector; other providers
@@ -1645,6 +1681,9 @@ class SkillInferenceRunner {
     required AiInteractionKind interactionKind,
     required String requestText,
     required String responseText,
+    AiWorkStatus status = AiWorkStatus.succeeded,
+    String? errorCode,
+    String? errorSummary,
   }) async {
     if (attribution == null) {
       return null;
@@ -1678,6 +1717,9 @@ class SkillInferenceRunner {
     return getIt<AiAttributionService>().prepareCompletion(
       attributionId: attribution.id,
       outputs: attribution.intendedOutputs,
+      status: status,
+      errorCode: errorCode,
+      errorSummary: errorSummary,
     );
   }
 

--- a/lib/features/ai/util/known_models_data.dart
+++ b/lib/features/ai/util/known_models_data.dart
@@ -822,18 +822,17 @@ const List<KnownModel> mistralModels = [
         'Frontier-class multimodal reasoning model with 128k context. '
         'Supports function calling, vision, and document AI.',
   ),
-  // Instruction-following audio model — uses /v1/chat/completions with a
-  // temporary MP3 so the transcription prompt can include task context.
+  // Transcribe 2 alias — uses /v1/audio/transcriptions with diarization
+  // and speech dictionary context bias.
   KnownModel(
     providerModelId: 'voxtral-mini-latest',
-    name: 'Voxtral Mini',
-    inputModalities: [Modality.text, Modality.audio],
+    name: 'Voxtral Mini Transcribe 2',
+    inputModalities: [Modality.audio],
     outputModalities: [Modality.text],
     isReasoningModel: false,
     description:
-        'Instruction-following cloud audio model. Transcribes temporary MP3 '
-        'audio through chat completions so task instructions and speech '
-        'dictionary context are applied during recognition.',
+        'Cloud transcription with speaker diarization and timestamps. '
+        'Speech dictionary terms guide recognition through context bias.',
   ),
   // Real-time transcription model — uses WebSocket streaming endpoint
   KnownModel(

--- a/lib/features/ai/util/known_models_ftue.dart
+++ b/lib/features/ai/util/known_models_ftue.dart
@@ -180,7 +180,7 @@ KnownModel? findMistralKnownModel(String providerModelId) {
 /// Returns the three KnownModel configurations needed for Mistral FTUE.
 /// - Flash model (Mistral Small) for fast processing tasks
 /// - Reasoning model (Magistral Medium) for complex reasoning tasks
-/// - Instruction-following audio model (Voxtral Mini) for transcription
+/// - Dedicated transcription model (Voxtral Mini Transcribe 2) for transcription
 /// Note: Mistral does not have a native image generation model.
 ({
   KnownModel flash,

--- a/lib/features/ai/util/temporary_mp3_encoder.dart
+++ b/lib/features/ai/util/temporary_mp3_encoder.dart
@@ -105,7 +105,79 @@ Future<File> encodeWavBytesToTemporaryMp3(
     throw ArgumentError.value(bitRate, 'bitRate', 'must be positive');
   }
 
+  return _encodeWavSourceToTemporaryMp3(
+    _WavPcmSource.parse(wavBytes),
+    encoderFactory: encoderFactory,
+    temporaryDirectory: temporaryDirectory,
+    fileStem: fileStem,
+    bitRate: bitRate,
+  );
+}
+
+/// Prepares independently playable MP3 segments for bounded API uploads.
+///
+/// Decodes the source once and emits consecutive PCM ranges without dropping
+/// samples. At 64 kbps, the default twenty-minute segment is about 9.6 MB.
+/// Each file exists until the consumer advances or cancels the stream, then
+/// is deleted. The archived source is never changed.
+Stream<File> encodeAudioBytesToTemporaryMp3Segments(
+  Uint8List sourceBytes, {
+  M4aBytesToWavConverter? m4aToWavConverter,
+  Mp3FrameEncoderFactory? encoderFactory,
+  Directory? temporaryDirectory,
+  Duration segmentDuration = const Duration(minutes: 20),
+}) async* {
+  if (sourceBytes.isEmpty) {
+    throw const TemporaryMp3EncodingException('Audio data cannot be empty');
+  }
+  if (segmentDuration <= Duration.zero) {
+    throw ArgumentError.value(
+      segmentDuration,
+      'segmentDuration',
+      'must be positive',
+    );
+  }
+  final wavBytes = _isWavAudio(sourceBytes)
+      ? sourceBytes
+      : await (m4aToWavConverter ?? convertM4aBytesToTemporaryWav)(sourceBytes);
   final wav = _WavPcmSource.parse(wavBytes);
+  final framesPerSegment =
+      wav.sampleRate *
+      segmentDuration.inMicroseconds ~/
+      Duration.microsecondsPerSecond;
+  if (framesPerSegment == 0) {
+    throw ArgumentError.value(
+      segmentDuration,
+      'segmentDuration',
+      'must contain at least one audio frame',
+    );
+  }
+  for (var offset = 0; offset < wav.frameCount; offset += framesPerSegment) {
+    final file = await _encodeWavSourceToTemporaryMp3(
+      wav,
+      encoderFactory: encoderFactory,
+      temporaryDirectory: temporaryDirectory,
+      startFrame: offset,
+      endFrame: math.min(offset + framesPerSegment, wav.frameCount),
+    );
+    try {
+      yield file;
+    } finally {
+      if (file.existsSync()) file.deleteSync();
+    }
+  }
+}
+
+Future<File> _encodeWavSourceToTemporaryMp3(
+  _WavPcmSource wav, {
+  Mp3FrameEncoderFactory? encoderFactory,
+  Directory? temporaryDirectory,
+  String? fileStem,
+  int bitRate = 64,
+  int startFrame = 0,
+  int? endFrame,
+}) async {
+  final frameEnd = endFrame ?? wav.frameCount;
   final directory = temporaryDirectory ?? Directory.systemTemp;
   final stem = fileStem ?? 'lotti_voxtral_${const Uuid().v4()}';
   final outputFile = File(p.join(directory.path, '$stem.mp3'));
@@ -123,10 +195,10 @@ Future<File> encodeWavBytesToTemporaryMp3(
       bitRate: bitRate,
     );
 
-    for (var frameOffset = 0; frameOffset < wav.frameCount;) {
+    for (var frameOffset = startFrame; frameOffset < frameEnd;) {
       final frameLength = math.min(
         wav.sampleRate,
-        wav.frameCount - frameOffset,
+        frameEnd - frameOffset,
       );
       final leftChannel = wav.readChannel(
         channel: 0,

--- a/test/features/ai/repository/cloud_inference_generate_more_test.dart
+++ b/test/features/ai/repository/cloud_inference_generate_more_test.dart
@@ -134,7 +134,7 @@ void main() {
         final chunks = await mistralGenerateMore
             .generateWithAudio(
               prompt,
-              model: 'voxtral-mini-latest',
+              model: 'voxtral-small-latest',
               audioBase64: 'mistral-audio',
               baseUrl: mistralProvider.baseUrl,
               apiKey: mistralProvider.apiKey,
@@ -150,7 +150,7 @@ void main() {
           'mistral voxtral chat text',
         );
         final request = mistralRepository.chatAudioCalls.single;
-        expect(request.model, 'voxtral-mini-latest');
+        expect(request.model, 'voxtral-small-latest');
         expect(request.audioBase64, 'mistral-audio');
         expect(request.baseUrl, baseUrl);
         expect(request.apiKey, 'key');

--- a/test/features/ai/repository/cloud_inference_repository_test.dart
+++ b/test/features/ai/repository/cloud_inference_repository_test.dart
@@ -3550,9 +3550,19 @@ void main() {
           ).captured;
           expect(captured, hasLength(1));
           final request = captured.first as http.MultipartRequest;
+          final biasFields = request.files
+              .where((file) => file.field == 'context_bias')
+              .toList();
+          expect(biasFields, hasLength(3));
           expect(
-            request.fields['context_bias'],
-            equals('macOS,Flutter,Dart'),
+            biasFields.map((field) => field.filename),
+            everyElement(isNull),
+          );
+          expect(
+            await Future.wait(
+              biasFields.map((field) => field.finalize().bytesToString()),
+            ),
+            ['macOS', 'Flutter', 'Dart'],
           );
         },
       );

--- a/test/features/ai/repository/cloud_inference_repository_test.dart
+++ b/test/features/ai/repository/cloud_inference_repository_test.dart
@@ -3390,58 +3390,63 @@ void main() {
     });
 
     group('generateWithAudio with Mistral transcription models', () {
-      test(
-        'routes voxtral-mini-transcribe-2602 to Mistral transcription endpoint',
-        () async {
-          final mistralProvider = AiConfigInferenceProvider(
-            id: 'mistral-provider',
-            name: 'Mistral',
-            baseUrl: 'https://api.mistral.ai/v1',
-            apiKey: 'test-key',
-            createdAt: DateTime(2024),
-            inferenceProviderType: InferenceProviderType.mistral,
-          );
-
-          when(() => mockHttpClient.send(any())).thenAnswer((_) async {
-            return http.StreamedResponse(
-              Stream.value(
-                utf8.encode(jsonEncode({'text': 'Mistral transcribed text'})),
-              ),
-              200,
+      for (final model in [
+        'voxtral-mini-transcribe-2602',
+        'voxtral-mini-latest',
+      ]) {
+        test(
+          'routes $model to Mistral transcription endpoint',
+          () async {
+            final mistralProvider = AiConfigInferenceProvider(
+              id: 'mistral-provider',
+              name: 'Mistral',
+              baseUrl: 'https://api.mistral.ai/v1',
+              apiKey: 'test-key',
+              createdAt: DateTime(2024),
+              inferenceProviderType: InferenceProviderType.mistral,
             );
-          });
 
-          final stream = repository.generateWithAudio(
-            'Transcribe this audio',
-            model: 'voxtral-mini-transcribe-2602',
-            audioBase64: 'dGVzdC1hdWRpby1kYXRh',
-            baseUrl: 'https://api.mistral.ai/v1',
-            apiKey: 'test-key',
-            provider: mistralProvider,
-          );
+            when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+              return http.StreamedResponse(
+                Stream.value(
+                  utf8.encode(jsonEncode({'text': 'Mistral transcribed text'})),
+                ),
+                200,
+              );
+            });
 
-          final response = await stream.first;
+            final stream = repository.generateWithAudio(
+              'Transcribe this audio',
+              model: model,
+              audioBase64: 'dGVzdC1hdWRpby1kYXRh',
+              baseUrl: 'https://api.mistral.ai/v1',
+              apiKey: 'test-key',
+              provider: mistralProvider,
+            );
 
-          expect(
-            response.choices?.first.delta?.content,
-            equals('Mistral transcribed text'),
-          );
+            final response = await stream.first;
 
-          final captured = verify(
-            () => mockHttpClient.send(captureAny()),
-          ).captured;
-          expect(captured, hasLength(1));
-          final request = captured.first as http.MultipartRequest;
-          expect(
-            request.url.toString(),
-            equals('https://api.mistral.ai/v1/audio/transcriptions'),
-          );
-          expect(
-            request.fields['model'],
-            equals('voxtral-mini-transcribe-2602'),
-          );
-        },
-      );
+            expect(
+              response.choices?.first.delta?.content,
+              equals('Mistral transcribed text'),
+            );
+
+            final captured = verify(
+              () => mockHttpClient.send(captureAny()),
+            ).captured;
+            expect(captured, hasLength(1));
+            final request = captured.first as http.MultipartRequest;
+            expect(
+              request.url.toString(),
+              equals('https://api.mistral.ai/v1/audio/transcriptions'),
+            );
+            expect(
+              request.fields['model'],
+              equals(model),
+            );
+          },
+        );
+      }
 
       test(
         'routes voxtral-mini-2602 to Mistral transcription endpoint',

--- a/test/features/ai/repository/melious_inference_repository_test.dart
+++ b/test/features/ai/repository/melious_inference_repository_test.dart
@@ -1215,7 +1215,15 @@ void main() {
                   utf8.encode(
                     jsonEncode(
                       calls == 1
-                          ? {'text': 'First part'}
+                          ? {
+                              'text': 'First part',
+                              'usage': {
+                                'prompt_tokens': 10,
+                                'completion_tokens': 5,
+                                'total_tokens': 15,
+                              },
+                              'billing_cost': {'credits': 2},
+                            }
                           : {
                               'error': {'message': 'Unavailable'},
                             },
@@ -1238,11 +1246,23 @@ void main() {
                 )
                 .forEach(received.add),
             throwsA(
-              isA<TranscriptionException>().having(
-                (e) => e.statusCode,
-                'status',
-                503,
-              ),
+              isA<TranscriptionException>()
+                  .having(
+                    (e) => e.statusCode,
+                    'status',
+                    503,
+                  )
+                  .having((e) => e.completedSegments, 'completedSegments', 1)
+                  .having(
+                    (e) => e.partialUsage?.totalTokens,
+                    'partial tokens',
+                    15,
+                  )
+                  .having(
+                    (e) => e.partialImpact?.costCredits,
+                    'partial credits',
+                    2,
+                  ),
             ),
           );
           expect(received, isEmpty);

--- a/test/features/ai/repository/melious_inference_repository_test.dart
+++ b/test/features/ai/repository/melious_inference_repository_test.dart
@@ -12,6 +12,7 @@ import 'package:lotti/features/ai/model/ai_call_impact.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/repository/melious_inference_repository.dart';
 import 'package:lotti/features/ai/repository/transcription_exception.dart';
+import 'package:lotti/features/ai/skills/entry_summary_tool.dart';
 import 'package:lotti/features/ai/util/image_processing_utils.dart';
 import 'package:openai_dart/openai_dart.dart';
 
@@ -939,6 +940,319 @@ void main() {
         expect(request.files.single.filename, 'audio.m4a');
       },
     );
+
+    test('transcription timeout includes a stalled response body', () {
+      fakeAsync((async) {
+        final body = StreamController<List<int>>();
+        final repository = MeliousInferenceRepository(
+          httpClient: MockClient.streaming(
+            (_, _) async => http.StreamedResponse(body.stream, 200),
+          ),
+        );
+        Object? failure;
+        final subscription = repository
+            .transcribeAudio(
+              model: 'whisper-large-v3',
+              audioBase64: base64Encode([1]),
+              baseUrl: baseUrl,
+              apiKey: apiKey,
+              timeout: const Duration(seconds: 1),
+            )
+            .listen(
+              (_) => fail('A stalled body must not yield a transcript'),
+              onError: (Object error) => failure = error,
+            );
+        async
+          ..flushMicrotasks()
+          ..elapse(const Duration(seconds: 1));
+        expect(
+          failure,
+          isA<TranscriptionException>().having(
+            (e) => e.statusCode,
+            'status',
+            408,
+          ),
+        );
+        unawaited(subscription.cancel());
+        unawaited(body.close());
+        async.flushMicrotasks();
+        repository.close();
+      });
+    });
+
+    group('oversized transcription', () {
+      late Directory directory;
+      late String audio;
+      var prepared = 0;
+      var cleaned = 0;
+
+      setUpAll(() {
+        audio = base64Encode(
+          Uint8List(MeliousInferenceRepository.maxTranscriptionUploadBytes + 1),
+        );
+      });
+      setUp(() {
+        directory = Directory.systemTemp.createTempSync(
+          'lotti_audio_segments_',
+        );
+        prepared = 0;
+        cleaned = 0;
+      });
+      tearDown(() => directory.deleteSync(recursive: true));
+
+      Stream<File> segments(Uint8List bytes) async* {
+        expect(
+          bytes.length,
+          MeliousInferenceRepository.maxTranscriptionUploadBytes + 1,
+        );
+        for (var index = 1; index <= 3; index++) {
+          final file = File('${directory.path}/$index.mp3')
+            ..writeAsBytesSync([index]);
+          prepared++;
+          try {
+            yield file;
+          } finally {
+            file.deleteSync();
+            cleaned++;
+          }
+        }
+      }
+
+      test(
+        'uploads sequential MP3 parts and combines text, usage and impact',
+        () async {
+          var calls = 0;
+          final collector = InferenceImpactCollector();
+          final repository = MeliousInferenceRepository(
+            audioSegmentEncoder: segments,
+            httpClient: MockClient.streaming((request, _) async {
+              calls++;
+              expect(prepared, calls);
+              expect(cleaned, calls - 1);
+              final multipart = request as http.MultipartRequest;
+              expect(multipart.files.single.filename, 'audio.mp3');
+              expect(multipart.files.single.length, 1);
+              expect(multipart.fields['prompt'], 'Penguin');
+              return http.StreamedResponse(
+                Stream.value(
+                  utf8.encode(
+                    jsonEncode({
+                      'text': 'Part $calls',
+                      'usage': {
+                        'prompt_tokens': calls,
+                        'completion_tokens': 2,
+                        'total_tokens': calls + 2,
+                      },
+                      'billing_cost': {'credits': calls},
+                      'environment_impact': {'energy_kwh': calls},
+                    }),
+                  ),
+                ),
+                200,
+              );
+            }),
+          );
+          addTearDown(repository.close);
+          final result = await repository
+              .transcribeAudio(
+                model: 'whisper-large-v3',
+                audioBase64: audio,
+                baseUrl: baseUrl,
+                apiKey: apiKey,
+                contextBiasTerms: ['Penguin'],
+                impactCollector: collector,
+              )
+              .single;
+          expect(
+            result.choices?.single.delta?.content,
+            'Part 1\n\nPart 2\n\nPart 3',
+          );
+          expect(result.usage?.promptTokens, 6);
+          expect(result.usage?.completionTokens, 6);
+          expect(result.usage?.totalTokens, 12);
+          expect(collector.impact?.costCredits, 6);
+          expect(collector.impact?.energyKwh, 6);
+          expect(collector.impact?.costCreditsDecimal, isNull);
+          expect(calls, 3);
+          expect(cleaned, 3);
+          expect(directory.listSync(), isEmpty);
+        },
+      );
+
+      test('rejects an oversized encoded part before uploading it', () async {
+        var calls = 0;
+        final repository = MeliousInferenceRepository(
+          audioSegmentEncoder: segments,
+          temporaryFileReader: (_) async => Uint8List(
+            MeliousInferenceRepository.maxTranscriptionUploadBytes + 1,
+          ),
+          httpClient: MockClient.streaming((request, _) async {
+            calls++;
+            throw StateError('Oversized audio must not be uploaded');
+          }),
+        );
+        addTearDown(repository.close);
+        await expectLater(
+          repository
+              .transcribeAudio(
+                model: 'whisper-large-v3',
+                audioBase64: audio,
+                baseUrl: baseUrl,
+                apiKey: apiKey,
+              )
+              .toList(),
+          throwsA(
+            isA<TranscriptionException>().having(
+              (e) => e.statusCode,
+              'status',
+              413,
+            ),
+          ),
+        );
+        expect(calls, 0);
+        expect(prepared, 1);
+        expect(cleaned, 1);
+        expect(directory.listSync(), isEmpty);
+      });
+
+      for (final empty in [true, false]) {
+        test('audio preparation failure is typed (empty=$empty)', () async {
+          final repository = MeliousInferenceRepository(
+            audioSegmentEncoder: (_) => empty
+                ? const Stream<File>.empty()
+                : Stream<File>.error(
+                    const FormatException('Synthetic decoder failure'),
+                  ),
+            httpClient: MockClient.streaming(
+              (_, _) async => throw StateError('No upload is possible'),
+            ),
+          );
+          addTearDown(repository.close);
+          await expectLater(
+            repository
+                .transcribeAudio(
+                  model: 'whisper-large-v3',
+                  audioBase64: audio,
+                  baseUrl: baseUrl,
+                  apiKey: apiKey,
+                )
+                .toList(),
+            throwsA(
+              isA<TranscriptionException>().having(
+                (e) => e.originalError,
+                'cause',
+                isA<FormatException>(),
+              ),
+            ),
+          );
+        });
+      }
+
+      test('canceling aborts the upload and cleans its segment', () async {
+        final started = Completer<void>();
+        final finished = Completer<void>();
+        final response = Completer<http.StreamedResponse>();
+        final aborted = Completer<void>();
+        Stream<File> cancelableSegments(Uint8List bytes) async* {
+          try {
+            yield* segments(bytes);
+          } finally {
+            finished.complete();
+          }
+        }
+
+        final repository = MeliousInferenceRepository(
+          audioSegmentEncoder: cancelableSegments,
+          httpClient: MockClient.streaming((request, _) async {
+            if (!started.isCompleted) started.complete();
+            unawaited(
+              (request as http.AbortableMultipartRequest).abortTrigger!.then((
+                _,
+              ) {
+                if (!aborted.isCompleted) aborted.complete();
+              }),
+            );
+            return response.future;
+          }),
+        );
+        addTearDown(repository.close);
+        final results = <CreateChatCompletionStreamResponse>[];
+        final subscription = repository
+            .transcribeAudio(
+              model: 'whisper-large-v3',
+              audioBase64: audio,
+              baseUrl: baseUrl,
+              apiKey: apiKey,
+            )
+            .listen(results.add);
+        await started.future;
+        await subscription.cancel();
+        await aborted.future;
+        // A transport may win the cancellation race and return success.
+        response.complete(
+          http.StreamedResponse(
+            Stream.value(utf8.encode('{"text":"Late result"}')),
+            200,
+          ),
+        );
+        await finished.future;
+        expect(prepared, 1);
+        expect(cleaned, 1);
+        expect(results, isEmpty);
+        expect(directory.listSync(), isEmpty);
+      });
+
+      test(
+        'a failed part cleans files and never returns a partial transcript',
+        () async {
+          var calls = 0;
+          final repository = MeliousInferenceRepository(
+            audioSegmentEncoder: segments,
+            httpClient: MockClient.streaming((request, _) async {
+              calls++;
+              return http.StreamedResponse(
+                Stream.value(
+                  utf8.encode(
+                    jsonEncode(
+                      calls == 1
+                          ? {'text': 'First part'}
+                          : {
+                              'error': {'message': 'Unavailable'},
+                            },
+                    ),
+                  ),
+                ),
+                calls == 1 ? 200 : 503,
+              );
+            }),
+          );
+          addTearDown(repository.close);
+          final received = <CreateChatCompletionStreamResponse>[];
+          await expectLater(
+            repository
+                .transcribeAudio(
+                  model: 'whisper-large-v3',
+                  audioBase64: audio,
+                  baseUrl: baseUrl,
+                  apiKey: apiKey,
+                )
+                .forEach(received.add),
+            throwsA(
+              isA<TranscriptionException>().having(
+                (e) => e.statusCode,
+                'status',
+                503,
+              ),
+            ),
+          );
+          expect(received, isEmpty);
+          expect(calls, 2);
+          expect(prepared, 2);
+          expect(cleaned, 2);
+          expect(directory.listSync(), isEmpty);
+        },
+      );
+    });
 
     test(
       'transcribeAudio captures Melious billing and impact data',
@@ -2544,12 +2858,18 @@ void main() {
               baseUrl: baseUrl,
               apiKey: apiKey,
               images: const ['abc123'],
+              tools: [entrySummaryTool],
+              toolChoice: entrySummaryToolChoice,
               impactCollector: InferenceImpactCollector(),
             )
             .toList();
 
         final body = jsonDecode(captured.body) as Map<String, dynamic>;
         expect(body['stream'], false);
+        expect(body['tool_choice'], {
+          'type': 'function',
+          'function': {'name': entrySummaryToolName},
+        });
         expect(captured.body, contains('data:image/jpeg;base64,abc123'));
         expect(contentOf(chunks), 'vision reply');
       },

--- a/test/features/ai/repository/mistral_inference_repository_test.dart
+++ b/test/features/ai/repository/mistral_inference_repository_test.dart
@@ -89,7 +89,7 @@ void main() {
 
         final chunks = await chatRepository
             .transcribeChatAudio(
-              model: 'voxtral-mini-latest',
+              model: 'voxtral-small-latest',
               audioBase64: base64Encode([1, 2, 3]),
               baseUrl: 'https://api.mistral.ai/v1',
               apiKey: 'mistral-key',

--- a/test/features/ai/repository/mistral_inference_repository_test.dart
+++ b/test/features/ai/repository/mistral_inference_repository_test.dart
@@ -40,7 +40,7 @@ void main() {
   group('MistralInferenceRepository', () {
     group('chat audio', () {
       final modelCases = <String, bool>{
-        'voxtral-mini-latest': true,
+        'voxtral-mini-latest': false,
         'voxtral-small-latest': true,
         'voxtral-mini-2507': true,
         'voxtral-small-2507': true,

--- a/test/features/ai/repository/mistral_transcription_repository_test.dart
+++ b/test/features/ai/repository/mistral_transcription_repository_test.dart
@@ -16,11 +16,26 @@ import 'package:lotti/features/ai/state/consts.dart';
 ({
   http.Client client,
   http.MultipartRequest Function() multipart,
+  List<String> Function() contextBias,
 })
 _stubStreamingOk() {
   http.BaseRequest? captured;
-  final client = MockClient.streaming((request, _) async {
+  var biasTerms = <String>[];
+  final client = MockClient.streaming((request, body) async {
     captured = request;
+    final boundary = request.headers['content-type']!.split('boundary=').last;
+    final wire = await body.bytesToString();
+    biasTerms = wire
+        .split('--$boundary')
+        .where(
+          (part) =>
+              part.split('\r\n\r\n').first.contains('name="context_bias"'),
+        )
+        .map((part) {
+          final value = part.substring(part.indexOf('\r\n\r\n') + 4);
+          return value.substring(0, value.length - 2);
+        })
+        .toList();
     return http.StreamedResponse(
       Stream.value(utf8.encode(jsonEncode({'text': 'transcribed text'}))),
       200,
@@ -29,6 +44,7 @@ _stubStreamingOk() {
   return (
     client: client,
     multipart: () => captured! as http.MultipartRequest,
+    contextBias: () => biasTerms,
   );
 }
 
@@ -136,10 +152,13 @@ void main() {
         final multipart = stub.multipart();
         expect(multipart.fields['model'], equals(testModel));
         expect(
-          multipart.fields['context_bias'],
-          equals('macOS,Flutter,Kirkjubæjarklaustur'),
+          stub.contextBias(),
+          equals(['macOS', 'Flutter', 'Kirkjubæjarklaustur']),
         );
-        expect(multipart.files, hasLength(1));
+        expect(
+          multipart.files.where((file) => file.field == 'file'),
+          hasLength(1),
+        );
         expect(multipart.files.first.field, equals('file'));
         expect(multipart.files.first.filename, equals('audio.m4a'));
       });
@@ -189,11 +208,10 @@ void main() {
             if (expected.length == 100) break;
           }
 
-          final field = stub.multipart().fields['context_bias'];
+          final sent = stub.contextBias();
           if (expected.isEmpty) {
-            expect(field, isNull, reason: 'raw: $rawTerms');
+            expect(sent, isEmpty, reason: 'raw: $rawTerms');
           } else {
-            final sent = field!.split(',');
             expect(sent, expected, reason: 'raw: $rawTerms');
             expect(sent.length, lessThanOrEqualTo(100));
             expect(sent.toSet().length, sent.length, reason: 'no duplicates');
@@ -212,14 +230,13 @@ void main() {
               audioBase64: testAudioBase64,
               baseUrl: testBaseUrl,
               apiKey: testApiKey,
-              contextBias: ['Claude Code', 'macOS', 'Nano Banana Pro'],
+              contextBias: ['Claude Code', 'Penguin, Jr.', 'Nano Banana Pro'],
             )
             .toList();
 
-        final multipart = stub.multipart();
         expect(
-          multipart.fields['context_bias'],
-          equals('Claude Code,macOS,Nano Banana Pro'),
+          stub.contextBias(),
+          equals(['Claude Code', 'Penguin, Jr.', 'Nano Banana Pro']),
         );
       });
 
@@ -237,8 +254,7 @@ void main() {
             )
             .toList();
 
-        final multipart = stub.multipart();
-        final terms = multipart.fields['context_bias']!.split(',');
+        final terms = stub.contextBias();
         expect(
           terms.where((t) => t == 'Gemini Pro').length,
           equals(1),
@@ -260,8 +276,7 @@ void main() {
             )
             .toList();
 
-        final multipart = stub.multipart();
-        final terms = multipart.fields['context_bias']!.split(',');
+        final terms = stub.contextBias();
         expect(terms, hasLength(100));
         expect(terms.first, 'Term0');
         expect(terms.last, 'Term99');
@@ -280,8 +295,7 @@ void main() {
             )
             .toList();
 
-        final multipart = stub.multipart();
-        expect(multipart.fields.containsKey('context_bias'), isFalse);
+        expect(stub.contextBias(), isEmpty);
       });
 
       test('does not include context_bias field when empty', () async {
@@ -298,8 +312,7 @@ void main() {
             )
             .toList();
 
-        final multipart = stub.multipart();
-        expect(multipart.fields.containsKey('context_bias'), isFalse);
+        expect(stub.contextBias(), isEmpty);
       });
 
       test('throws TranscriptionException on HTTP error', () async {

--- a/test/features/ai/services/skill_inference_runner_test.dart
+++ b/test/features/ai/services/skill_inference_runner_test.dart
@@ -26,6 +26,7 @@ import 'package:lotti/features/ai/state/image_generation_error_controller.dart';
 import 'package:lotti/features/ai/state/inference_error_controller.dart';
 import 'package:lotti/features/ai/state/inference_status_controller.dart';
 import 'package:lotti/features/ai/util/image_processing_utils.dart';
+import 'package:lotti/features/ai_consumption/model/ai_attribution.dart';
 import 'package:lotti/features/ai_consumption/model/ai_consumption_enums.dart';
 import 'package:lotti/features/ai_consumption/model/ai_consumption_event.dart';
 import 'package:lotti/features/journal/service/image_path_migration_service.dart';
@@ -789,6 +790,87 @@ void main() {
         expect(updatedEntity.data.transcripts!.last.transcript, 'Hello World');
         expect(updatedEntity.data.transcripts!.last.model, 'whisper-1');
       });
+
+      for (final accountingFails in [false, true]) {
+        test(
+          'preserves transcription failure and incurred accounting (writeFails=$accountingFails)',
+          () async {
+            final attribution = _registerInteractionCapture();
+            if (accountingFails) {
+              when(
+                () => attribution.service.recordInteraction(
+                  attributionId: any(named: 'attributionId'),
+                  event: any(named: 'event'),
+                ),
+              ).thenThrow(StateError('Synthetic ledger failure'));
+            }
+            final entity = makeAudioEntity(categoryId: 'cat-audio');
+            await createStubAudioFile();
+            when(
+              () => mockAiInputRepo.getEntity('audio-1'),
+            ).thenAnswer((_) async => entity);
+            when(
+              () => mockPromptBuilderHelper.getSpeechDictionaryTerms(entity),
+            ).thenAnswer((_) async => []);
+            when(
+              () => mockTaskSummaryResolver.resolve(any()),
+            ).thenAnswer((_) async => null);
+            final failure = TranscriptionException(
+              'Upstream unavailable',
+              provider: 'Melious',
+              statusCode: 503,
+              completedSegments: 1,
+              partialUsage: const CompletionUsage(
+                promptTokens: 10,
+                completionTokens: 5,
+                totalTokens: 15,
+              ),
+              partialImpact: const MeliousCallImpact(
+                costCredits: 2,
+                energyKwh: 0.5,
+              ),
+            );
+            when(
+              () => mockCloudRepo.generateWithAudio(
+                any(),
+                model: any(named: 'model'),
+                audioBase64: any(named: 'audioBase64'),
+                baseUrl: any(named: 'baseUrl'),
+                apiKey: any(named: 'apiKey'),
+                provider: any(named: 'provider'),
+                systemMessage: any(named: 'systemMessage'),
+                speechDictionaryTerms: any(named: 'speechDictionaryTerms'),
+              ),
+            ).thenAnswer((_) => Stream.error(failure));
+            stubLoggingException();
+            Object? reported;
+            await runner.runTranscription(
+              audioEntryId: 'audio-1',
+              automationResult: makeTranscriptionResult(),
+              onError: (error) => reported = error,
+            );
+            final event = _capturedEvents(attribution).single;
+            expect(event.inputTokens, 10);
+            expect(event.outputTokens, 5);
+            expect(event.totalTokens, 15);
+            expect(event.credits, 2);
+            expect(event.energyKwh, 0.5);
+            if (accountingFails) {
+              verifyNever(() => attribution.service.finalize(any()));
+            } else {
+              final record =
+                  verify(
+                        () => attribution.service.finalize(captureAny()),
+                      ).captured.single
+                      as AiWorkAttribution;
+              expect(record.status, AiWorkStatus.failed);
+              expect(record.errorCode, 'transcription_incomplete');
+            }
+            expect(reported, same(failure));
+            verifyNever(() => mockJournalRepo.updateJournalEntity(any()));
+          },
+        );
+      }
 
       test(
         'records a consumption event with tokens from the response usage '

--- a/test/features/ai/util/temporary_mp3_encoder_test.dart
+++ b/test/features/ai/util/temporary_mp3_encoder_test.dart
@@ -126,6 +126,108 @@ void main() {
     expect(file.lengthSync(), lessThan(wavBytes.length ~/ 1000));
   });
 
+  test(
+    'segments preserve every PCM sample and clean files as consumed',
+    () async {
+      final samples = List.generate(20, (index) => index * 1000);
+      final encoders = <_RecordingMp3FrameEncoder>[];
+      final paths = <String>[];
+      await for (final file in encodeAudioBytesToTemporaryMp3Segments(
+        _pcm16Wav(sampleRate: 4, samples: samples),
+        temporaryDirectory: temporaryDirectory,
+        segmentDuration: const Duration(seconds: 2),
+        encoderFactory: _recordingEncoderFactory(encoders),
+      )) {
+        expect(paths.every((path) => !File(path).existsSync()), isTrue);
+        expect(file.readAsBytesSync().last, 0xFF);
+        paths.add(file.path);
+      }
+      expect(encoders, hasLength(3));
+      expect(
+        encoders.map(
+          (encoder) => encoder.leftChunks.expand((chunk) => chunk).length,
+        ),
+        [8, 8, 4],
+      );
+      expect(
+        encoders
+            .expand((encoder) => encoder.leftChunks)
+            .expand((chunk) => chunk),
+        samples.map((sample) => sample / 32768),
+      );
+      expect(encoders.every((encoder) => encoder.closed), isTrue);
+      expect(temporaryDirectory.listSync(), isEmpty);
+    },
+  );
+
+  test('canceling segment consumption cleans the current file', () async {
+    final encoders = <_RecordingMp3FrameEncoder>[];
+    await for (final file in encodeAudioBytesToTemporaryMp3Segments(
+      _pcm16Wav(sampleRate: 4, frameCount: 20),
+      temporaryDirectory: temporaryDirectory,
+      segmentDuration: const Duration(seconds: 2),
+      encoderFactory: _recordingEncoderFactory(encoders),
+    )) {
+      expect(file.existsSync(), isTrue);
+      break;
+    }
+    expect(encoders, hasLength(1));
+    expect(temporaryDirectory.listSync(), isEmpty);
+  });
+
+  for (final duration in [Duration.zero, const Duration(microseconds: 1)]) {
+    test(
+      'rejects a segment duration without complete frames: $duration',
+      () async {
+        await expectLater(
+          encodeAudioBytesToTemporaryMp3Segments(
+            _pcm16Wav(sampleRate: 4, frameCount: 8),
+            segmentDuration: duration,
+            temporaryDirectory: temporaryDirectory,
+          ).toList(),
+          throwsArgumentError,
+        );
+        expect(temporaryDirectory.listSync(), isEmpty);
+      },
+    );
+  }
+
+  test('rejects empty segmented audio before decoding', () async {
+    await expectLater(
+      encodeAudioBytesToTemporaryMp3Segments(Uint8List(0)).toList(),
+      throwsA(isA<TemporaryMp3EncodingException>()),
+    );
+  });
+
+  test(
+    'a later encoding failure removes all completed and partial segments',
+    () async {
+      final encoders = <_RecordingMp3FrameEncoder>[];
+      await expectLater(
+        encodeAudioBytesToTemporaryMp3Segments(
+          _pcm16Wav(sampleRate: 4, frameCount: 20),
+          temporaryDirectory: temporaryDirectory,
+          segmentDuration: const Duration(seconds: 2),
+          encoderFactory:
+              ({required sampleRate, required numChannels, required bitRate}) {
+                final encoder = _RecordingMp3FrameEncoder(
+                  sampleRate: sampleRate,
+                  numChannels: numChannels,
+                  bitRate: bitRate,
+                  failAtEncodeCall: encoders.isEmpty ? null : 1,
+                );
+                encoders.add(encoder);
+                return encoder;
+              },
+        ).drain<void>(),
+        throwsA(isA<TemporaryMp3EncodingException>()),
+      );
+      expect(encoders, hasLength(2));
+      expect(encoders.every((encoder) => encoder.closed), isTrue);
+      expect(temporaryDirectory.listSync(), isEmpty);
+    },
+  );
+
   test('removes a partial MP3 and closes LAME when encoding fails', () async {
     final wavBytes = _pcm16Wav(
       sampleRate: 2,

--- a/test/features/ai_chat/services/audio_transcription_service_test.dart
+++ b/test/features/ai_chat/services/audio_transcription_service_test.dart
@@ -933,7 +933,7 @@ void main() {
       },
     );
 
-    test('prefers Mistral chat audio over MLX Qwen when both exist', () async {
+    test('prefers Mistral transcription over MLX Qwen', () async {
       final aiRepo = isolatedRepo();
       await aiRepo.saveConfig(
         _provider(


### PR DESCRIPTION
Melious rejected oversized recordings with HTTP 413, Mistral's `voxtral-mini-latest` alias was sent to the chat endpoint, and buffered Melious image analysis dropped the requested summary tool choice.

- Route the existing Mistral alias to transcription and correct its catalog metadata, preserve dictionary phrases as repeated multipart fields, following [Mistral's current contract](https://docs.mistral.ai/studio/audio/speech_to_text/offline_transcription).
- Respect [Melious's 25 MB audio limit](https://melious.ai/docs/reference/audio): larger recordings use consecutive, independently playable 20-minute MP3 segments. Uploads run sequentially, preserve the archive, clean temporary files on every outcome, and emit one transcript only after all parts succeed. Cancellation aborts the upload and prevents subsequent parts; the timeout covers both headers and response body.
- Preserve forced image tool selection when collecting provider impact. Shared accounting helpers sum usage, cost, and environmental quantities across physical calls. A later segment failure records already incurred accounting once as a failed attempt without saving a partial transcript.

All targeted Dart MCP tests pass for the changed repositories, encoder, catalog, accounting helpers, and skill runner. Regression mutations fail for the Mistral route, segment bounds, oversized-upload routing, cancellation race, response-body timeout, and forced image tool selection. Dart MCP analysis reports no errors; formatting, knowledge validation, and changelog validation pass.

Validation uses synthetic audio and HTTP responses. The segment encoder still holds the decoded WAV in memory; it bounds encoded upload size rather than total decoding memory. Provider outages, exhausted credits, and missing locally installed MLX weights remain operational errors with existing recovery controls. Explicit caller cancellation currently has no accounting hook; completed-segment charges are captured on failure, but not after a canceled subscription.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Long audio recordings can now be transcribed by splitting them into temporary segments and combining the results without changing the original recording.
  - Mistral’s Voxtral Mini Transcribe model now uses the correct transcription service and preserves phrase-based context terms.
  - Image summaries retain their requested structure when usage and cost details are collected.
  - Failed transcriptions now preserve partial progress and usage information, with improved cancellation and cleanup behavior.

- **Documentation**
  - Updated AI provider and attribution documentation to describe segmented transcription, routing, failure handling, and accounting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->