### PR TITLE
fix(sync): prevent media repair work after disposal

### DIFF
--- a/changelog.d/2026-09-05-media-repair-disposal.md
+++ b/changelog.d/2026-09-05-media-repair-disposal.md
@@ -1,0 +1,4 @@
+### Fixed
+- **Stopping sync also stops pending media repair.** A delayed device lookup
+  or failed upload-queue operation can no longer restart media requests after
+  sync has been shut down.

--- a/knowledge/features/sync/send-path.md
+++ b/knowledge/features/sync/send-path.md
@@ -153,6 +153,19 @@ burst of misses becomes one request, a batch cap so a backlog drains across
 successive requests, an attempt cap so a blob no peer holds is eventually
 abandoned, and a tracking cap so the pending set cannot grow without limit.
 
+Media repair disposal cancels its debounce and clears pending ids and attempt
+counts. A host lookup completing after disposal cannot enqueue a request; a
+pending enqueue failure cannot restore cleared state or arm another retry.
+Failures while the service remains active still restore the batch and its
+attempt budget for the normal debounced retry.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Active
+  Active --> Disposed: dispose cancels debounce and clears state
+  Disposed --> [*]
+```
+
 # The CAS claim is load-bearing
 
 `claimNextBatch` is a per-row compare-and-set from `pending` to `sending`. That

--- a/knowledge/features/sync/send-path.md
+++ b/knowledge/features/sync/send-path.md
@@ -5,17 +5,17 @@ description: Outbox staging, the CAS claim that makes merges safe, dequeue-time 
 resource: ../../../lib/features/sync/outbox
 tags: [sync, outbox, bundling, retries]
 status: stable
-generated: { by: codex/gpt-5, at: 2026-08-06T00:30:48+02:00 }
+generated: { by: codex/gpt-6, at: 2026-09-05T15:44:17+00:00 }
 stale_after: 2026-11-02
 sources:
   - id: outbox
     resource: ../../../lib/features/sync/outbox
     title: Outbox service, processor, repository
-    last_modified: 2026-08-05
+    last_modified: 2026-09-05
   - id: payload-sender
     resource: ../../../lib/features/sync/matrix/matrix_payload_sender.dart
     title: MatrixPayloadSender — wire encoding
-    last_modified: 2026-08-06
+    last_modified: 2026-09-05
   - id: agent-payload-sender
     resource: ../../../lib/features/sync/matrix/matrix_payload_sender_notifications.dart
     title: Agent and notification payload encoding
@@ -23,15 +23,15 @@ sources:
   - id: media-repair
     resource: ../../../lib/features/sync/media
     title: Media self-healing — request and response
-    last_modified: 2026-07-28
+    last_modified: 2026-09-05
   - id: attachment-policy
     resource: ../../../lib/features/sync/model/sync_attachment_policy.dart
     title: shouldSendJournalAttachments — the media-send decision
-    last_modified: 2026-07-27
+    last_modified: 2026-07-28
   - id: tuning
     resource: ../../../lib/features/sync/tuning.dart
     title: SyncTuning
-    last_modified: 2026-05-30
+    last_modified: 2026-08-02
 ---
 
 # Staging

--- a/lib/features/sync/media/media_repair_service.dart
+++ b/lib/features/sync/media/media_repair_service.dart
@@ -76,6 +76,10 @@ class MediaRepairService {
   /// Entry ids currently waiting for their next request — test seam.
   Set<String> get debugPending => Set.unmodifiable(_pending);
 
+  /// Number of retained attempt counters — lifecycle test seam.
+  @visibleForTesting
+  int get debugAttemptedEntryCount => _attempts.length;
+
   /// Cancels the debounce and sends the currently pending batch.
   ///
   /// Integration tests use this seam after observing the expected missing
@@ -127,11 +131,13 @@ class MediaRepairService {
   /// Sends the pending ids as one request, up to the batch cap. Surplus ids
   /// stay pending and a fresh debounce window is armed for them, so a large
   /// backlog drains in successive requests instead of one oversized envelope.
+  /// Disposal during an await must not send or restore cleared retry state.
   Future<void> _flush() async {
     if (_disposed || _pending.isEmpty) return;
 
     final batch = _pending.take(_maxBatchSize).toList();
     final requesterId = await _vectorClock.getHost();
+    if (_disposed) return;
     if (requesterId == null) {
       // No host id yet (first run, before the vector clock is initialised).
       // Keep the ids pending and try again on the next miss rather than
@@ -160,6 +166,7 @@ class MediaRepairService {
         subDomain: 'mediaRepair.send',
       );
     } catch (error, stackTrace) {
+      if (_disposed) return;
       // Put the batch back so a transient enqueue failure does not burn the
       // entries' attempt budget for nothing.
       _pending.addAll(batch);

--- a/test/features/sync/media/media_repair_service_test.dart
+++ b/test/features/sync/media/media_repair_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/sync/media/media_repair_service.dart';
@@ -90,21 +92,21 @@ void main() {
     });
   });
 
-  test('flushes pending misses without waiting for the debounce', () async {
-    final service = buildService();
-    addTearDown(service.dispose);
-
-    service
-      ..reportMissing(entryId: 'image-1', relativePath: '/images/1')
-      ..reportMissing(entryId: 'audio-1', relativePath: '/audio/1');
-
-    expect(requests, isEmpty);
-
-    await service.flushPendingForTesting();
-
-    expect(requests, hasLength(1));
-    expect(requests.single.entryIds, ['image-1', 'audio-1']);
-    expect(service.debugPending, isEmpty);
+  test('flushes pending misses without waiting for the debounce', () {
+    fakeAsync((async) {
+      final service = buildService();
+      addTearDown(service.dispose);
+      service
+        ..reportMissing(entryId: 'image-1', relativePath: '/images/1')
+        ..reportMissing(entryId: 'audio-1', relativePath: '/audio/1');
+      expect(requests, isEmpty);
+      unawaited(service.flushPendingForTesting());
+      async.flushMicrotasks();
+      expect(requests, hasLength(1));
+      expect(requests.single.entryIds, ['image-1', 'audio-1']);
+      expect(service.debugPending, isEmpty);
+      expect(async.pendingTimers, isEmpty);
+    });
   });
 
   test('splits a backlog across successive requests at the batch cap', () {
@@ -212,6 +214,43 @@ void main() {
 
       async.elapse(debounce * 2);
       expect(requests, isEmpty);
+    });
+  });
+
+  test('dispose during host lookup prevents sending and restoring state', () {
+    fakeAsync((async) {
+      final host = Completer<String?>();
+      when(() => vectorClockService.getHost()).thenAnswer((_) => host.future);
+      final service = buildService()
+        ..reportMissing(entryId: 'entry-1', relativePath: '/images/1');
+      async.elapse(debounce);
+      service.dispose();
+      host.complete('host-a');
+      async.flushMicrotasks();
+      expect(requests, isEmpty);
+      expect(service.debugPending, isEmpty);
+      expect(service.debugAttemptedEntryCount, 0);
+      expect(async.pendingTimers, isEmpty);
+    });
+  });
+
+  test('enqueue failure after dispose cannot restore retries or timers', () {
+    fakeAsync((async) {
+      final enqueue = Completer<void>();
+      when(
+        () => outboxService.enqueueMessage(any()),
+      ).thenAnswer((_) => enqueue.future);
+      final service = buildService()
+        ..reportMissing(entryId: 'entry-1', relativePath: '/images/1');
+      async.elapse(debounce);
+      expect(service.debugAttemptedEntryCount, 1);
+      service.dispose();
+      enqueue.completeError(StateError('synthetic outbox shutdown'));
+      async.flushMicrotasks();
+      expect(service.debugPending, isEmpty);
+      expect(service.debugAttemptedEntryCount, 0);
+      expect(async.pendingTimers, isEmpty);
+      verify(() => outboxService.enqueueMessage(any())).called(1);
     });
   });
 


### PR DESCRIPTION
Media repair could enqueue a request after disposal if its host lookup completed late. A pending outbox failure could also restore cleared pending IDs and attempt counters and start another retry timer.

Guard both continuations against disposal while retaining normal retry restoration for an active service. Add deterministic lifecycle regressions and convert the existing immediate-flush test to fake time.

Validation:
- 10 targeted tests pass with randomized order, including both new regressions failing before the fix.
- Dart MCP analyzer reports no errors, warnings, or infos.
- Knowledge checks pass with all 526 Mermaid diagrams; changelog validation passes.

This fixes a reproduced shutdown race; it is not claimed to be the proven cause of the historical shutdown timeout in the reviewed logs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Stopping synchronization now reliably cancels pending media repair operations.
  - Delayed device lookups and failed upload-queue operations can no longer restart media requests after sync has stopped.
  - Pending repair retries and timers are cleared when media repair is disposed.

- **Documentation**
  - Added documentation describing media repair disposal behavior and retry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->