### PR TITLE
chore(db): consistent VACUUM INTO backups for every migrating store, close before deleting database files

### DIFF
--- a/changelog.d/2026-09-05-consistent-database-backups.md
+++ b/changelog.d/2026-09-05-consistent-database-backups.md
@@ -1,0 +1,11 @@
+### Fixed
+- **Database backups could miss your latest changes.** The copy taken before
+  a database upgrade, and the one made when purging deleted entries, copied
+  the database file alone — while SQLite may still be holding the most recent
+  changes in its write-ahead log next to it. Backups are now taken as a
+  consistent snapshot that includes everything committed, and the sync and
+  agent databases get the same safety copy before their upgrades.
+- **Resetting the sync or editor database from Maintenance now takes effect
+  right away.** The reset used to remove the file underneath the running app,
+  which kept writing to the removed file until the next restart and could
+  replay stale sync state into the fresh database afterwards.

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -422,11 +422,16 @@ chosen by what the services holding a database can survive:
 
 - **Empty through the live connection** — `clearEditorDb`, `clearSyncDb`
   delete every row of every table (enumerated from `sqlite_master`, so the
-  raw-SQL `sync_sequence_watermarks` is included) and `VACUUM`. Every service
-  keeps a valid handle and the reset takes effect immediately. Unlinking the
-  file instead would leave those handles writing into a ghost inode until
-  restart and an orphaned `-wal` beside the file created on the next launch,
-  ready to be replayed into it.
+  raw-SQL `sync_sequence_watermarks` is included), `VACUUM`, and then call
+  `notifyUpdates` for those tables, because raw statements bypass Drift's
+  stream invalidation and the outbox count behind the sync badge would
+  otherwise keep its pre-reset value. Every service keeps a valid handle and
+  the reset takes effect immediately. `clearEditorDb` also calls
+  `EditorStateService.resetDrafts`, since drafts live in memory with a
+  debounced write and would otherwise be restored into an open editor or
+  written back moments later. Unlinking the file instead would leave those
+  handles writing into a ghost inode until restart and an orphaned `-wal`
+  beside the file created on the next launch, ready to be replayed into it.
 - **Close, then delete with companions** — `deleteAgentDb` backs up, closes
   the registered `AgentDatabase`, removes the file with `-wal`, `-shm` and
   `-journal`, and its caller quits the app, because every holder is now on a

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -385,19 +385,18 @@ paths, and failures are counted and reported without aborting the whole pass.
 The normal display resolver retains a read-only legacy fallback until repair,
 so affected screenshots do not disappear from existing journal entries.
 
-`createDbBackup(fileName)` copies a database to
-`backup/db.<yyyy-MM-dd_HH-mm-ss-S>.sqlite`. It runs automatically before a
-`JournalDb` migration and on demand from *Settings → Advanced → Maintenance*.
-Its timestamp comes from `package:clock`'s `clock.now()`, and so does every
-other instant the database layer stamps itself — the `updated_at` on a journal
-upsert, conflict rows, outbox enqueue stamps, leases and retries, sync
-watermarks, editor drafts and settings — so tests drive all of them with
-`withClock`. The one SQL-side
-default, the outbox `created_at`/`updated_at` pair, is Drift's
-`currentDateAndTime`, which SQLite evaluates on each insert; a
-`Constant(DateTime.now())` default would bake the app-launch instant into the
-`CREATE TABLE` statement instead.
-
+`createDbBackup(fileName)` snapshots a database to
+`backup/<stem>.<yyyy-MM-dd_HH-mm-ss-S>.sqlite` — `db.…` for the journal,
+`sync.…` and `agent.…` for the others — with `VACUUM INTO` on a private
+connection, run off the caller's isolate. The snapshot therefore holds every
+committed transaction, including those still in the WAL that a plain copy of
+the main file would miss, and arrives compacted. A file SQLite cannot open
+(the corrupt store a user is about to reset) is copied byte for byte with its
+WAL instead, and the fallback is logged, so a reset is never blocked on a
+backup. It runs automatically before a **journal, sync or agent migration**
+(`backupBeforeMigration`, which logs a failure and continues rather than
+refusing to open the app) and on demand from
+*Settings → Advanced → Maintenance*.
 That helper is a **legacy per-database fallback**, not a supported profile
 backup. It copies only the main SQLite file, has no store identity, manifest,
 checksum, media coverage, encryption, coordinated quiescence, or restore path.
@@ -418,13 +417,28 @@ and publish with one rename. It does not stop writers; lifecycle orchestration
 must satisfy that precondition. The full contract and remaining runtime layers
 are in [backup and restore](../features/backup-and-restore.md).
 
-`lib/database/maintenance.dart` owns physical database upkeep: whole-database
-deletion (`deleteAgentDb`, `deleteEditorDb`, `deleteSyncDb`), FTS rebuilding,
-and the `sent`-outbox purge. Historical re-send orchestration belongs to Sync
-and lives in `lib/features/sync/services/historical_sync_service.dart`; it uses
-database and repository row APIs without making queueing, retry, or Sync result
-types part of the database maintenance layer. **The deleted-entry purge is not
-in either service** — `purgeDeleted` lives in
+`lib/database/maintenance.dart` owns physical database upkeep. Two shapes,
+chosen by what the services holding a database can survive:
+
+- **Empty through the live connection** — `clearEditorDb`, `clearSyncDb`
+  delete every row of every table (enumerated from `sqlite_master`, so the
+  raw-SQL `sync_sequence_watermarks` is included) and `VACUUM`. Every service
+  keeps a valid handle and the reset takes effect immediately. Unlinking the
+  file instead would leave those handles writing into a ghost inode until
+  restart and an orphaned `-wal` beside the file created on the next launch,
+  ready to be replayed into it.
+- **Close, then delete with companions** — `deleteAgentDb` backs up, closes
+  the registered `AgentDatabase`, removes the file with `-wal`, `-shm` and
+  `-journal`, and its caller quits the app, because every holder is now on a
+  closed handle. `recreateFts5` does the same for the search index and then
+  registers a fresh instance.
+
+The `sent`-outbox purge lives here too. Historical re-send orchestration
+belongs to Sync and lives in
+`lib/features/sync/services/historical_sync_service.dart`; it uses database
+and repository row APIs without making queueing, retry, or Sync result types
+part of the database maintenance layer. **The deleted-entry purge is not in
+either service** — `purgeDeleted` lives in
 `lib/database/database_entity_ops.dart` alongside the rest of `JournalDb`'s
 entity operations, which is where to look for it.
 

--- a/lib/database/common.dart
+++ b/lib/database/common.dart
@@ -96,9 +96,7 @@ Future<File> createDbBackup(
           'VACUUM INTO failed for $fileName ($e); '
           'falling back to a raw copy of the main file and its WAL',
     );
-    if (target.existsSync()) {
-      await target.delete();
-    }
+    // File.copy replaces whatever a failed attempt left at the target.
     await file.copy(target.path);
     await walStash?.rename('${target.path}-wal');
   }

--- a/lib/database/common.dart
+++ b/lib/database/common.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:clock/clock.dart';
 import 'package:drift/drift.dart';
@@ -15,7 +16,6 @@ import 'package:sqlite3/sqlite3.dart';
 
 /// Constants for database backup operations
 const String _backupDirectoryName = 'backup';
-const String _backupFilePrefix = 'db.';
 const String _backupFileExtension = '.sqlite';
 const String _backupTimestampFormat = 'yyyy-MM-dd_HH-mm-ss-S';
 
@@ -33,31 +33,121 @@ Future<File> getDatabaseFile(String dbFileName) async {
   return File(p.join(dbFolder.path, dbFileName));
 }
 
-/// Creates a timestamped backup of the database file.
+/// Creates a timestamped, transactionally consistent backup of a database.
 ///
-/// Creates a backup directory if it doesn't exist and copies the database
-/// file with a timestamp in the filename. The backup format is:
-/// `db.yyyy-MM-dd_HH-mm-ss-S.sqlite`
+/// The snapshot is taken with `VACUUM INTO` on a private connection, so it
+/// holds every committed transaction — including those still sitting in the
+/// WAL, which a plain copy of the main file would miss — and arrives
+/// compacted. It runs on its own isolate because the sqlite3 bindings are
+/// synchronous and a large journal would otherwise stall the caller.
 ///
-/// Throws [FileSystemException] if the source file doesn't exist or
-/// if there are permission issues.
+/// When the source cannot be read as a database (the corrupt file a user is
+/// about to reset, for one) the main file and its WAL are copied byte for
+/// byte instead and a warning is logged, so a reset is never blocked on a
+/// backup of something SQLite cannot open.
 ///
-/// Example:
-/// ```dart
-/// await createDbBackup('my_database.sqlite');
-/// // Creates: backup/db.2025-10-17_14-30-45-123.sqlite
-/// ```
-Future<void> createDbBackup(String fileName) async {
-  final file = await getDatabaseFile(fileName);
+/// Backups are named after their source: `backup/<stem>.<timestamp>.sqlite`,
+/// so `db.sqlite` becomes `backup/db.2025-10-17_14-30-45-123.sqlite` and
+/// `agent.sqlite` becomes `backup/agent.….sqlite`. Returns the backup file.
+///
+/// [documentsDirectoryProvider] names the directory the database lives in;
+/// it defaults to the active profile root, which is wrong for a database
+/// opened in another world, so a database backing itself up passes its own.
+///
+/// Throws [FileSystemException] if the source file does not exist.
+Future<File> createDbBackup(
+  String fileName, {
+  Future<Directory> Function()? documentsDirectoryProvider,
+}) async {
+  final directory = documentsDirectoryProvider == null
+      ? getDocumentsDirectory()
+      : await documentsDirectoryProvider();
+  final file = File(p.join(directory.path, fileName));
+  if (!file.existsSync()) {
+    throw FileSystemException('Database file does not exist', file.path);
+  }
   // clock.now() so tests can drive the backup timestamp deterministically
   // via withClock.
   final ts = DateFormat(_backupTimestampFormat).format(clock.now());
   final backupDir = await Directory(
     p.join(file.parent.path, _backupDirectoryName),
   ).create(recursive: true);
-  await file.copy(
-    p.join(backupDir.path, '$_backupFilePrefix$ts$_backupFileExtension'),
+  final stem = p.basenameWithoutExtension(fileName);
+  final target = File(
+    p.join(backupDir.path, '$stem.$ts$_backupFileExtension'),
   );
+
+  // Stash the WAL before touching the file: SQLite discards a `-wal` it
+  // finds beside a file it cannot read as a database, and that WAL is the
+  // most valuable thing a raw copy of a corrupt store can carry.
+  final wal = File('${file.path}-wal');
+  final walStash = wal.existsSync()
+      ? await wal.copy('${target.path}-wal.stash')
+      : null;
+  try {
+    final sourcePath = file.path;
+    final targetPath = target.path;
+    await Isolate.run(() => _vacuumInto(sourcePath, targetPath));
+    await walStash?.delete();
+  } on SqliteException catch (e) {
+    DevLogger.warning(
+      name: 'Database',
+      message:
+          'VACUUM INTO failed for $fileName ($e); '
+          'falling back to a raw copy of the main file and its WAL',
+    );
+    if (target.existsSync()) {
+      await target.delete();
+    }
+    await file.copy(target.path);
+    await walStash?.rename('${target.path}-wal');
+  }
+  return target;
+}
+
+/// Runs `VACUUM INTO` from a throwaway connection so the snapshot is taken
+/// under SQLite's own read transaction, independent of whatever the app's
+/// connection is doing (a migration in progress, for one).
+void _vacuumInto(String sourcePath, String targetPath) {
+  final database = sqlite3.open(sourcePath);
+  try {
+    database.execute('VACUUM INTO ?', [targetPath]);
+  } finally {
+    database.close();
+  }
+}
+
+/// Backs up [fileName] before a schema migration from [from] to [to].
+///
+/// A failed backup is logged, never fatal: refusing to migrate would leave
+/// the app unable to open at all, which is worse than migrating without a
+/// safety copy. Pass the database's actual file name — an overridden one
+/// included — so the copy is of the file being migrated.
+Future<void> backupBeforeMigration(
+  String fileName, {
+  required int from,
+  required int to,
+  Future<Directory> Function()? documentsDirectoryProvider,
+}) async {
+  try {
+    final backup = await createDbBackup(
+      fileName,
+      documentsDirectoryProvider: documentsDirectoryProvider,
+    );
+    DevLogger.log(
+      name: 'Database',
+      message:
+          'Backed up $fileName to ${backup.path} '
+          'before migrating v$from to v$to',
+    );
+  } catch (e, s) {
+    DevLogger.error(
+      name: 'Database',
+      message: 'Failed to back up $fileName before migrating v$from to v$to',
+      error: e,
+      stackTrace: s,
+    );
+  }
 }
 
 /// Configures WAL mode and recommended pragmas on a freshly opened database.

--- a/lib/database/common.dart
+++ b/lib/database/common.dart
@@ -73,9 +73,7 @@ Future<File> createDbBackup(
     p.join(file.parent.path, _backupDirectoryName),
   ).create(recursive: true);
   final stem = p.basenameWithoutExtension(fileName);
-  final target = File(
-    p.join(backupDir.path, '$stem.$ts$_backupFileExtension'),
-  );
+  final target = _unusedBackupTarget(backupDir, '$stem.$ts');
 
   // Stash the WAL before touching the file: SQLite discards a `-wal` it
   // finds beside a file it cannot read as a database, and that WAL is the
@@ -90,6 +88,13 @@ Future<File> createDbBackup(
     await Isolate.run(() => _vacuumInto(sourcePath, targetPath));
     await walStash?.delete();
   } on SqliteException catch (e) {
+    if (!_isUnreadableSource(e)) {
+      // Anything but "the source is not a readable database" — a busy
+      // lock, an unwritable target — is a failure of *this* backup, not a
+      // reason to hand back a raw copy that may not be consistent.
+      await walStash?.delete();
+      rethrow;
+    }
     DevLogger.warning(
       name: 'Database',
       message:
@@ -101,6 +106,31 @@ Future<File> createDbBackup(
     await walStash?.rename('${target.path}-wal');
   }
   return target;
+}
+
+/// Two backups in one formatted instant (the same millisecond) must not
+/// share a target: `VACUUM INTO` refuses an existing non-empty file, and the
+/// fallback would then overwrite the first backup. Suffix until free.
+File _unusedBackupTarget(Directory backupDir, String baseName) {
+  var candidate = File(
+    p.join(backupDir.path, '$baseName$_backupFileExtension'),
+  );
+  var attempt = 1;
+  while (candidate.existsSync()) {
+    attempt += 1;
+    candidate = File(
+      p.join(backupDir.path, '$baseName-$attempt$_backupFileExtension'),
+    );
+  }
+  return candidate;
+}
+
+/// `SQLITE_NOTADB` and `SQLITE_CORRUPT`: the source itself cannot be read as
+/// a database, which is the one case a raw copy is the best we can do.
+bool _isUnreadableSource(SqliteException e) {
+  const notADatabase = 26;
+  const corrupt = 11;
+  return e.resultCode == notADatabase || e.resultCode == corrupt;
 }
 
 /// Runs `VACUUM INTO` from a throwaway connection so the snapshot is taken

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -135,7 +135,9 @@ class JournalDb extends _$JournalDb
     Future<Directory> Function()? tempDirectoryProvider,
     this._loggingService,
     this._documentsDirectory,
-  }) : super(
+  }) : fileName = overriddenFilename ?? journalDbFileName,
+       _documentsDirectoryProvider = documentsDirectoryProvider,
+       super(
          openDbConnection(
            overriddenFilename ?? journalDbFileName,
            inMemoryDatabase: inMemoryDatabase,
@@ -148,6 +150,17 @@ class JournalDb extends _$JournalDb
 
   @override
   bool inMemoryDatabase = false;
+
+  /// The file this database lives in — the default `db.sqlite` or the
+  /// overridden name a test or a second world passed in. The pre-migration
+  /// backup copies this file, not the default one.
+  @override
+  final String fileName;
+
+  /// Where this database's file lives when it was opened outside the active
+  /// profile root; null means the registered root.
+  @override
+  final Future<Directory> Function()? _documentsDirectoryProvider;
   final DomainLogger? _loggingService;
   final Directory? _documentsDirectory;
 

--- a/lib/database/database_migration.dart
+++ b/lib/database/database_migration.dart
@@ -9,6 +9,8 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
   Future<void> _ensureLabelTables(Migrator migrator);
   Future<void> _rebuildLabeledWithFkCascade();
   bool get inMemoryDatabase;
+  String get fileName;
+  Future<Directory> Function()? get _documentsDirectoryProvider;
 
   @override
   MigrationStrategy get migration {
@@ -33,20 +35,12 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
         );
 
         if (!inMemoryDatabase) {
-          try {
-            await createDbBackup(journalDbFileName);
-            DevLogger.log(
-              name: 'JournalDb',
-              message: 'Database backup created before migration',
-            );
-          } catch (e, s) {
-            DevLogger.error(
-              name: 'JournalDb',
-              message: 'Failed to create backup before migration',
-              error: e,
-              stackTrace: s,
-            );
-          }
+          await backupBeforeMigration(
+            fileName,
+            from: from,
+            to: to,
+            documentsDirectoryProvider: _documentsDirectoryProvider,
+          );
         }
 
         if (from < 19) {

--- a/lib/database/maintenance.dart
+++ b/lib/database/maintenance.dart
@@ -27,30 +27,34 @@ class Maintenance {
   /// launch starts from an empty agent database and the backup.
   Future<void> deleteAgentDb() async {
     final file = await getDatabaseFile(agentDbFileName);
-    if (!file.existsSync()) {
+    if (file.existsSync()) {
+      await createDbBackup(agentDbFileName);
+    } else {
       getIt<DomainLogger>().log(
         LogDomain.database,
         'Database file $agentDbFileName does not exist',
         subDomain: 'deleteAgentDb',
       );
-      return;
     }
-    await createDbBackup(agentDbFileName);
     if (getIt.isRegistered<AgentDatabase>()) {
       await getIt<AgentDatabase>().close();
     }
+    // Companions are removed even when the main file is gone: a leftover
+    // `-wal` would be replayed into the database created on the next launch.
     _deleteWithCompanions(file);
   }
 
-  /// Empties the editor drafts database through its live connection and
-  /// drops the drafts the editor still holds in memory, cancelling their
-  /// pending debounced writes — otherwise a draft the user just discarded
-  /// would be restored into the editor, or written back moments later.
+  /// Drops the drafts the editor holds in memory, cancelling their pending
+  /// debounced writes, then empties the drafts database through its live
+  /// connection — otherwise a draft the user just discarded would be
+  /// restored into the editor, or written back moments later.
   Future<void> clearEditorDb() async {
-    await _emptyDatabase(getIt<EditorDb>(), subDomain: 'clearEditorDb');
+    // Drop the in-memory drafts first: a debounced write that fired while
+    // the rows were being deleted would land after them.
     if (getIt.isRegistered<EditorStateService>()) {
       getIt<EditorStateService>().resetDrafts();
     }
+    await _emptyDatabase(getIt<EditorDb>(), subDomain: 'clearEditorDb');
   }
 
   /// Empties the sync database — outbox, sequence log, host activity, inbound
@@ -156,19 +160,16 @@ class Maintenance {
   /// registered [Fts5Db] has been closed; [recreateFts5] does.
   Future<void> deleteFts5Db() async {
     final file = await getDatabaseFile(fts5DbFileName);
-    if (!file.existsSync()) {
-      getIt<DomainLogger>().log(
-        LogDomain.database,
-        'Database file $fts5DbFileName does not exist',
-        subDomain: 'deleteFts5Db',
-      );
-      return;
-    }
+    final existed = file.existsSync();
+    // Companions go regardless, so an orphaned `-wal` cannot be replayed
+    // into the index rebuilt next.
     _deleteWithCompanions(file);
     getIt<DomainLogger>().log(
       LogDomain.database,
-      'FTS5 database DELETED',
-      subDomain: 'recreateFts5',
+      existed
+          ? 'FTS5 database DELETED'
+          : 'Database file $fts5DbFileName does not exist',
+      subDomain: existed ? 'recreateFts5' : 'deleteFts5Db',
     );
   }
 

--- a/lib/database/maintenance.dart
+++ b/lib/database/maintenance.dart
@@ -11,6 +11,7 @@ import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/agents/database/agent_database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/domain_logging.dart';
+import 'package:lotti/services/editor_state_service.dart';
 
 class Maintenance {
   final JournalDb _db = getIt<JournalDb>();
@@ -41,9 +42,16 @@ class Maintenance {
     _deleteWithCompanions(file);
   }
 
-  /// Empties the editor drafts database through its live connection.
-  Future<void> clearEditorDb() =>
-      _emptyDatabase(getIt<EditorDb>(), subDomain: 'clearEditorDb');
+  /// Empties the editor drafts database through its live connection and
+  /// drops the drafts the editor still holds in memory, cancelling their
+  /// pending debounced writes — otherwise a draft the user just discarded
+  /// would be restored into the editor, or written back moments later.
+  Future<void> clearEditorDb() async {
+    await _emptyDatabase(getIt<EditorDb>(), subDomain: 'clearEditorDb');
+    if (getIt.isRegistered<EditorStateService>()) {
+      getIt<EditorStateService>().resetDrafts();
+    }
+  }
 
   /// Empties the sync database — outbox, sequence log, host activity, inbound
   /// queue, queue markers, onboarding rounds and watermarks — through its
@@ -71,15 +79,23 @@ class Maintenance {
           "AND name NOT LIKE 'sqlite_%'",
         )
         .get();
+    final names = [for (final row in tables) row.read<String>('name')];
     await db.transaction(() async {
-      for (final row in tables) {
-        await db.customStatement('DELETE FROM "${row.read<String>('name')}"');
+      for (final name in names) {
+        await db.customStatement('DELETE FROM "$name"');
       }
     });
     await db.customStatement('VACUUM');
+    // Raw statements bypass Drift's stream invalidation; tell every watched
+    // query (the outbox count behind the sync badge, for one) that its
+    // tables changed, or it would show the pre-reset value until the next
+    // ordinary write.
+    db.notifyUpdates({
+      for (final name in names) TableUpdate(name, kind: UpdateKind.delete),
+    });
     getIt<DomainLogger>().log(
       LogDomain.database,
-      'Emptied ${tables.length} table(s)',
+      'Emptied ${names.length} table(s)',
       subDomain: subDomain,
     );
   }

--- a/lib/database/maintenance.dart
+++ b/lib/database/maintenance.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:drift/drift.dart';
 import 'package:lotti/database/common.dart';
 import 'package:lotti/database/conversions.dart';
 import 'package:lotti/database/database.dart';
@@ -14,48 +15,83 @@ import 'package:lotti/services/domain_logging.dart';
 class Maintenance {
   final JournalDb _db = getIt<JournalDb>();
 
+  /// Backs up `agent.sqlite`, closes the registered [AgentDatabase], and
+  /// removes the file together with its WAL, shared-memory and rollback
+  /// journal companions.
+  ///
+  /// Closing first matters: an unlinked file stays open for every service
+  /// holding the handle, and a `-wal` left beside a freshly created file is
+  /// replayed into it on the next launch. Every holder is left with a closed
+  /// handle, which is why the caller quits the app right after — the next
+  /// launch starts from an empty agent database and the backup.
   Future<void> deleteAgentDb() async {
     final file = await getDatabaseFile(agentDbFileName);
-    if (file.existsSync()) {
-      await createDbBackup(agentDbFileName);
-      file.deleteSync();
-      // Delete WAL companion files created when SQLite WAL mode is enabled
-      final shmFile = File('${file.path}-shm');
-      final walFile = File('${file.path}-wal');
-      if (shmFile.existsSync()) shmFile.deleteSync();
-      if (walFile.existsSync()) walFile.deleteSync();
-    } else {
+    if (!file.existsSync()) {
       getIt<DomainLogger>().log(
         LogDomain.database,
         'Database file $agentDbFileName does not exist',
         subDomain: 'deleteAgentDb',
       );
+      return;
     }
+    await createDbBackup(agentDbFileName);
+    if (getIt.isRegistered<AgentDatabase>()) {
+      await getIt<AgentDatabase>().close();
+    }
+    _deleteWithCompanions(file);
   }
 
-  Future<void> deleteEditorDb() async {
-    final file = await getDatabaseFile(editorDbFileName);
-    if (file.existsSync()) {
-      file.deleteSync();
-    } else {
-      getIt<DomainLogger>().log(
-        LogDomain.database,
-        'Database file $editorDbFileName does not exist',
-        subDomain: 'deleteEditorDb',
-      );
-    }
+  /// Empties the editor drafts database through its live connection.
+  Future<void> clearEditorDb() =>
+      _emptyDatabase(getIt<EditorDb>(), subDomain: 'clearEditorDb');
+
+  /// Empties the sync database — outbox, sequence log, host activity, inbound
+  /// queue, queue markers, onboarding rounds and watermarks — through its
+  /// live connection.
+  Future<void> clearSyncDb() =>
+      _emptyDatabase(getIt<SyncDatabase>(), subDomain: 'clearSyncDb');
+
+  /// Deletes every row of every table in [db] and reclaims the space, on the
+  /// connection the app is using.
+  ///
+  /// Unlinking the file instead would leave every service holding the old
+  /// handle writing into a ghost inode until restart, and an orphaned `-wal`
+  /// beside the file created on the next launch. Emptying the tables keeps
+  /// every handle valid, takes effect immediately, and ends with the same
+  /// schema and no rows. Tables come from `sqlite_master`, not Drift's
+  /// `allTables`, because the sync watermarks are created by raw migration
+  /// SQL and would otherwise be skipped.
+  Future<void> _emptyDatabase(
+    GeneratedDatabase db, {
+    required String subDomain,
+  }) async {
+    final tables = await db
+        .customSelect(
+          "SELECT name FROM sqlite_master WHERE type = 'table' "
+          "AND name NOT LIKE 'sqlite_%'",
+        )
+        .get();
+    await db.transaction(() async {
+      for (final row in tables) {
+        await db.customStatement('DELETE FROM "${row.read<String>('name')}"');
+      }
+    });
+    await db.customStatement('VACUUM');
+    getIt<DomainLogger>().log(
+      LogDomain.database,
+      'Emptied ${tables.length} table(s)',
+      subDomain: subDomain,
+    );
   }
 
-  Future<void> deleteSyncDb() async {
-    final file = await getDatabaseFile(syncDbFileName);
-    if (file.existsSync()) {
-      file.deleteSync();
-    } else {
-      getIt<DomainLogger>().log(
-        LogDomain.database,
-        'Database file $syncDbFileName does not exist',
-        subDomain: 'deleteSyncDb',
-      );
+  /// Removes [file] and the `-wal`, `-shm` and `-journal` companions SQLite
+  /// keeps beside it. Call only on a closed database.
+  static void _deleteWithCompanions(File file) {
+    for (final suffix in const ['', '-wal', '-shm', '-journal']) {
+      final companion = File('${file.path}$suffix');
+      if (companion.existsSync()) {
+        companion.deleteSync();
+      }
     }
   }
 
@@ -100,30 +136,30 @@ class Maintenance {
     return deleted;
   }
 
+  /// Removes the FTS index file and its companions. Call only after the
+  /// registered [Fts5Db] has been closed; [recreateFts5] does.
   Future<void> deleteFts5Db() async {
     final file = await getDatabaseFile(fts5DbFileName);
-    var deleted = false;
-    if (file.existsSync()) {
-      file.deleteSync();
-      deleted = true;
-    } else {
+    if (!file.existsSync()) {
       getIt<DomainLogger>().log(
         LogDomain.database,
         'Database file $fts5DbFileName does not exist',
         subDomain: 'deleteFts5Db',
       );
+      return;
     }
-
-    if (deleted) {
-      getIt<DomainLogger>().log(
-        LogDomain.database,
-        'FTS5 database DELETED',
-        subDomain: 'recreateFts5',
-      );
-    }
+    _deleteWithCompanions(file);
+    getIt<DomainLogger>().log(
+      LogDomain.database,
+      'FTS5 database DELETED',
+      subDomain: 'recreateFts5',
+    );
   }
 
   Future<void> recreateFts5({void Function(double)? onProgress}) async {
+    // Close before unlinking: a file removed under an open connection keeps
+    // being written by that connection until restart.
+    await getIt<Fts5Db>().close();
     try {
       await deleteFts5Db();
     } catch (e, stackTrace) {
@@ -134,8 +170,6 @@ class Maintenance {
         subDomain: 'deleteFts5Db',
       );
     }
-
-    await getIt<Fts5Db>().close();
 
     getIt
       ..unregister<Fts5Db>()

--- a/lib/database/sync_db.dart
+++ b/lib/database/sync_db.dart
@@ -73,7 +73,9 @@ class SyncDatabase extends _$SyncDatabase
     bool background = true,
     Future<Directory> Function()? documentsDirectoryProvider,
     Future<Directory> Function()? tempDirectoryProvider,
-  }) : super(
+  }) : fileName = overriddenFilename ?? syncDbFileName,
+       _documentsDirectoryProvider = documentsDirectoryProvider,
+       super(
          openDbConnection(
            overriddenFilename ?? syncDbFileName,
            inMemoryDatabase: inMemoryDatabase,
@@ -85,9 +87,16 @@ class SyncDatabase extends _$SyncDatabase
 
   // Used by database tests to wrap instrumented Drift connections.
   // ignore: unused-code
-  SyncDatabase.connect(super.c) : super.connect();
+  SyncDatabase.connect(super.c)
+    : fileName = syncDbFileName,
+      _documentsDirectoryProvider = null,
+      super.connect();
 
   bool inMemoryDatabase = false;
+
+  /// The file this database lives in; the pre-migration backup copies it.
+  final String fileName;
+  final Future<Directory> Function()? _documentsDirectoryProvider;
 
   @override
   int get schemaVersion => 29;
@@ -104,6 +113,14 @@ class SyncDatabase extends _$SyncDatabase
         await customStatement(_createIdxOutboxActionableSubject);
       },
       onUpgrade: (Migrator m, int from, int to) async {
+        if (!inMemoryDatabase) {
+          await backupBeforeMigration(
+            fileName,
+            from: from,
+            to: to,
+            documentsDirectoryProvider: _documentsDirectoryProvider,
+          );
+        }
         if (from < 2) {
           // Creates tables with all current columns (including payload_type)
           await m.createTable(syncSequenceLog);

--- a/lib/features/agents/database/agent_database.dart
+++ b/lib/features/agents/database/agent_database.dart
@@ -20,7 +20,8 @@ class AgentDatabase extends _$AgentDatabase {
     int readPool = 2,
     Future<Directory> Function()? documentsDirectoryProvider,
     Future<Directory> Function()? tempDirectoryProvider,
-  }) : super(
+  }) : _documentsDirectoryProvider = documentsDirectoryProvider,
+       super(
          openDbConnection(
            agentDbFileName,
            inMemoryDatabase: inMemoryDatabase,
@@ -32,6 +33,7 @@ class AgentDatabase extends _$AgentDatabase {
        );
 
   final bool inMemoryDatabase;
+  final Future<Directory> Function()? _documentsDirectoryProvider;
 
   @override
   int get schemaVersion => 19;
@@ -144,6 +146,14 @@ class AgentDatabase extends _$AgentDatabase {
     return MigrationStrategy(
       onCreate: (m) => m.createAll(),
       onUpgrade: (m, from, to) async {
+        if (!inMemoryDatabase) {
+          await backupBeforeMigration(
+            agentDbFileName,
+            from: from,
+            to: to,
+            documentsDirectoryProvider: _documentsDirectoryProvider,
+          );
+        }
         if (from < 2) {
           await customStatement(
             'ALTER TABLE wake_run_log ADD COLUMN user_rating REAL',

--- a/lib/features/settings/ui/pages/advanced/maintenance_page.dart
+++ b/lib/features/settings/ui/pages/advanced/maintenance_page.dart
@@ -147,7 +147,7 @@ class _MaintenanceBodyState extends ConsumerState<MaintenanceBody>
                 confirmLabel: context.messages.maintenanceDeleteDatabaseConfirm,
               );
               if (confirmed && context.mounted) {
-                await maintenance.deleteEditorDb();
+                await maintenance.clearEditorDb();
               }
             },
           ),

--- a/lib/features/sync/ui/matrix_sync_maintenance_page.dart
+++ b/lib/features/sync/ui/matrix_sync_maintenance_page.dart
@@ -74,7 +74,7 @@ class _MatrixSyncMaintenanceBodyState extends State<MatrixSyncMaintenanceBody>
                 confirmLabel: context.messages.maintenanceDeleteDatabaseConfirm,
               );
               if (confirmed && context.mounted) {
-                await maintenance.deleteSyncDb();
+                await maintenance.clearSyncDb();
               }
             },
           ),

--- a/lib/services/editor_state_service.dart
+++ b/lib/services/editor_state_service.dart
@@ -153,5 +153,27 @@ class EditorStateService {
     unsavedStreamById[id]?.add(false);
   }
 
+  /// Forgets every draft held in memory without persisting any of it:
+  /// cancels each pending debounced write, clears deltas and selections, and
+  /// tells every open editor its entry is no longer unsaved.
+  ///
+  /// The database side is the caller's job — `Maintenance.clearEditorDb`
+  /// empties the drafts table and then calls this, so a draft the user just
+  /// discarded is neither restored into an open editor nor written back by a
+  /// debounce that was still pending. (A debounce that fires anyway finds no
+  /// delta and writes nothing.)
+  void resetDrafts() {
+    for (final id in editorStateById.keys.toList(growable: false)) {
+      EasyDebounce.cancel('persistDraftState-$id');
+    }
+    editorStateById.clear();
+    selectionById.clear();
+    for (final controller in unsavedStreamById.values) {
+      if (!controller.isClosed) {
+        controller.add(false);
+      }
+    }
+  }
+
   bool entryIsUnsaved(String id) => editorStateById.containsKey(id);
 }

--- a/test/database/common_test.dart
+++ b/test/database/common_test.dart
@@ -225,6 +225,67 @@ void main() {
     });
   });
 
+  group('backupBeforeMigration', () {
+    late Directory testDir;
+
+    setUp(() {
+      testDir = setupTestDirectory();
+      setupTestDirectoryWithGetIt(testDir);
+      DevLogger.capturedLogs.clear();
+    });
+
+    tearDown(() async {
+      await cleanupTestDirectoryWithGetIt(testDir);
+    });
+
+    test('writes the backup and logs where it went', () async {
+      final source = sqlite3.open(p.join(testDir.path, 'sync.sqlite'));
+      addTearDown(source.close);
+      source.execute('CREATE TABLE rows (id INTEGER PRIMARY KEY)');
+
+      await backupBeforeMigration('sync.sqlite', from: 3, to: 4);
+
+      final backups = Directory(
+        p.join(testDir.path, _backupDirectoryName),
+      ).listSync();
+      expect(backups, hasLength(1));
+      expect(
+        DevLogger.capturedLogs.any(
+          (line) =>
+              line.contains('Backed up sync.sqlite') &&
+              line.contains('before migrating v3 to v4'),
+        ),
+        isTrue,
+        reason: DevLogger.capturedLogs.join('\n'),
+      );
+    });
+
+    test(
+      'a failed backup is logged and never stops the migration',
+      () async {
+        // No such file: the backup throws, the migration must still run.
+        await expectLater(
+          backupBeforeMigration('missing.sqlite', from: 3, to: 4),
+          completes,
+        );
+
+        expect(
+          Directory(p.join(testDir.path, _backupDirectoryName)).existsSync(),
+          isFalse,
+        );
+        expect(
+          DevLogger.capturedLogs.any(
+            (line) => line.contains(
+              'Failed to back up missing.sqlite before migrating v3 to v4',
+            ),
+          ),
+          isTrue,
+          reason: DevLogger.capturedLogs.join('\n'),
+        );
+      },
+    );
+  });
+
   group('openDbConnection Tests', () {
     // Constructor smoke tests were removed: behavioral coverage for
     // openDbConnection (WAL mode, pragmas, directory creation) lives in

--- a/test/database/common_test.dart
+++ b/test/database/common_test.dart
@@ -10,6 +10,7 @@ import 'package:lotti/features/ai/database/ai_config_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/dev_logger.dart';
 import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart';
 
 // Test constants
 const String _testDirectoryPrefix = 'lotti_common_test_';
@@ -103,138 +104,124 @@ void main() {
       await cleanupTestDirectoryWithGetIt(testDir);
     });
 
-    test('creates backup directory if it does not exist', () async {
+    /// A real WAL-mode database with one row checkpointed into the main file
+    /// and, while the returned connection stays open, a second row that only
+    /// exists in the WAL.
+    Database seedWalDatabase(String fileName) {
+      final source = sqlite3.open(p.join(testDir.path, fileName));
+      addTearDown(source.close);
+      source
+        ..execute('PRAGMA journal_mode = WAL')
+        ..execute('CREATE TABLE rows (id INTEGER PRIMARY KEY, label TEXT)')
+        ..execute("INSERT INTO rows (label) VALUES ('checkpointed')")
+        ..execute('PRAGMA wal_checkpoint(TRUNCATE)')
+        ..execute("INSERT INTO rows (label) VALUES ('still in the wal')");
+      return source;
+    }
+
+    List<String> labelsIn(File backup) {
+      final copy = sqlite3.open(backup.path);
+      addTearDown(copy.close);
+      return copy
+          .select('SELECT label FROM rows ORDER BY id')
+          .map((row) => row['label'] as String)
+          .toList();
+    }
+
+    test('the backup holds commits that are still in the WAL', () async {
       const fileName = 'test_db.sqlite';
+      seedWalDatabase(fileName);
+      final wal = File(p.join(testDir.path, '$fileName-wal'));
+      expect(wal.lengthSync(), greaterThan(0), reason: 'row must be in WAL');
 
-      // Create source file
-      final sourceFile = File(p.join(testDir.path, fileName));
-      await sourceFile.writeAsString('test data');
+      final backup = await createDbBackup(fileName);
 
-      // Create backup
-      await createDbBackup(fileName);
-
-      // Verify backup directory exists
-      final backupDir = Directory(p.join(testDir.path, _backupDirectoryName));
-      expect(backupDir.existsSync(), isTrue);
+      // A plain copy of the main file would only carry 'checkpointed'.
+      expect(labelsIn(backup), ['checkpointed', 'still in the wal']);
+      expect(File('${backup.path}-wal').existsSync(), isFalse);
     });
 
-    test('creates backup with correct timestamp format', () async {
-      const fileName = 'test_db.sqlite';
+    test('backups are named after their source and the clock', () async {
+      seedWalDatabase('agent.sqlite');
 
-      // Create source file
-      final sourceFile = File(p.join(testDir.path, fileName));
-      await sourceFile.writeAsString('test data');
+      final backup = await withClock(
+        Clock.fixed(DateTime(2026, 9, 5, 10, 30, 15)),
+        () => createDbBackup('agent.sqlite'),
+      );
 
-      // Create backup
-      await createDbBackup(fileName);
-
-      // Check backup directory for files
-      final backupDir = Directory(p.join(testDir.path, _backupDirectoryName));
-      final backupFiles = backupDir.listSync();
-
-      expect(backupFiles.length, equals(1));
-      final backupFile = backupFiles.first as File;
-
-      // Verify timestamp format: db.yyyy-MM-dd_HH-mm-ss-S.sqlite
-      final backupFileName = p.basename(backupFile.path);
-      expect(backupFileName, startsWith('db.'));
-      expect(backupFileName, endsWith('.sqlite'));
+      expect(backup.parent.path, p.join(testDir.path, _backupDirectoryName));
       expect(
-        backupFileName,
-        matches(RegExp(r'db\.\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}-\d+\.sqlite')),
+        p.basename(backup.path),
+        matches(RegExp(r'^agent\.2026-09-05_10-30-15-\d+\.sqlite$')),
       );
     });
 
-    test('creates backup in correct location', () async {
+    test('successive backups never collide', () async {
       const fileName = 'test_db.sqlite';
+      seedWalDatabase(fileName);
 
-      // Create source file
-      final sourceFile = File(p.join(testDir.path, fileName));
-      await sourceFile.writeAsString('test data');
-
-      // Create backup
-      await createDbBackup(fileName);
-
-      // Verify backup location
-      final backupDir = Directory(p.join(testDir.path, _backupDirectoryName));
-      expect(backupDir.existsSync(), isTrue);
-
-      final backupFiles = backupDir.listSync();
-      expect(backupFiles.length, equals(1));
-    });
-
-    test('backup file contains same data as source', () async {
-      const fileName = 'test_db.sqlite';
-      const testData = 'This is test database content';
-
-      // Create source file with test data
-      final sourceFile = File(p.join(testDir.path, fileName));
-      await sourceFile.writeAsString(testData);
-
-      // Create backup
-      await createDbBackup(fileName);
-
-      // Read backup and verify content
-      final backupDir = Directory(p.join(testDir.path, _backupDirectoryName));
-      final backupFiles = backupDir.listSync();
-      final backupFile = backupFiles.first as File;
-      final backupContent = await backupFile.readAsString();
-
-      expect(backupContent, equals(testData));
-    });
-
-    test('handles non-existent source file gracefully', () async {
-      const fileName = 'nonexistent_db.sqlite';
-
-      // Try to create backup of non-existent file
-      expect(
+      final first = await withClock(
+        Clock.fixed(DateTime(2026, 9, 5, 10, 30, 15)),
         () => createDbBackup(fileName),
+      );
+      final second = await withClock(
+        Clock.fixed(DateTime(2026, 9, 5, 10, 30, 16)),
+        () => createDbBackup(fileName),
+      );
+
+      expect(first.path, isNot(second.path));
+      final backupDir = Directory(p.join(testDir.path, _backupDirectoryName));
+      expect(backupDir.listSync(), hasLength(2));
+    });
+
+    test('throws when the source file does not exist', () async {
+      await expectLater(
+        createDbBackup('missing.sqlite'),
         throwsA(isA<FileSystemException>()),
       );
+      expect(
+        Directory(p.join(testDir.path, _backupDirectoryName)).existsSync(),
+        isFalse,
+      );
     });
 
-    test('multiple backups create separate files', () async {
-      const fileName = 'test_db.sqlite';
+    test(
+      'a source SQLite cannot read is copied byte for byte with its WAL',
+      () async {
+        const fileName = 'broken.sqlite';
+        final garbage = List<int>.generate(_testBinaryDataSize, (i) => i);
+        final walGarbage = List<int>.generate(
+          _testBinaryDataSize,
+          (i) => 255 - i,
+        );
+        File(p.join(testDir.path, fileName)).writeAsBytesSync(garbage);
+        File(
+          p.join(testDir.path, '$fileName-wal'),
+        ).writeAsBytesSync(walGarbage);
 
-      // Create source file
-      final sourceFile = File(p.join(testDir.path, fileName));
-      await sourceFile.writeAsString('test data');
+        final backup = await createDbBackup(fileName);
 
-      // Drive the backup timestamps with fixed clocks so the filenames are
-      // guaranteed distinct — no wall-clock wait (fake-time policy).
-      await withClock(
-        Clock.fixed(DateTime(2024, 3, 15, 10, 30)),
-        () => createDbBackup(fileName),
+        expect(backup.readAsBytesSync(), garbage);
+        expect(File('${backup.path}-wal').readAsBytesSync(), walGarbage);
+      },
+    );
+
+    test('backs up from an explicit documents directory', () async {
+      final otherWorld = Directory(p.join(testDir.path, 'other-world'))
+        ..createSync();
+      final source = sqlite3.open(p.join(otherWorld.path, 'db.sqlite'));
+      addTearDown(source.close);
+      source
+        ..execute('CREATE TABLE rows (id INTEGER PRIMARY KEY, label TEXT)')
+        ..execute("INSERT INTO rows (label) VALUES ('elsewhere')");
+
+      final backup = await createDbBackup(
+        'db.sqlite',
+        documentsDirectoryProvider: () async => otherWorld,
       );
-      await withClock(
-        Clock.fixed(DateTime(2024, 3, 15, 10, 30, 1)),
-        () => createDbBackup(fileName),
-      );
 
-      // Verify that two distinct backup files were created
-      final backupDir = Directory(p.join(testDir.path, _backupDirectoryName));
-      final backupFiles = backupDir.listSync();
-      expect(backupFiles.length, equals(2));
-    });
-
-    test('backup preserves binary data', () async {
-      const fileName = 'test_db.sqlite';
-      final binaryData = List.generate(_testBinaryDataSize, (i) => i);
-
-      // Create source file with binary data
-      final sourceFile = File(p.join(testDir.path, fileName));
-      await sourceFile.writeAsBytes(binaryData);
-
-      // Create backup
-      await createDbBackup(fileName);
-
-      // Read backup and verify content
-      final backupDir = Directory(p.join(testDir.path, _backupDirectoryName));
-      final backupFiles = backupDir.listSync();
-      final backupFile = backupFiles.first as File;
-      final backupContent = await backupFile.readAsBytes();
-
-      expect(backupContent, equals(binaryData));
+      expect(p.isWithin(otherWorld.path, backup.path), isTrue);
+      expect(labelsIn(backup), ['elsewhere']);
     });
   });
 
@@ -524,28 +511,23 @@ void main() {
       expect(file.path, equals(testDir.path));
     });
 
-    test('backup handles empty source file', () async {
+    test('an empty source file backs up as a valid empty database', () async {
       const fileName = 'empty_db.sqlite';
-
-      // Create empty source file
+      // SQLite treats a zero-length file as an empty database, so the
+      // snapshot is a real (header-only) database rather than an empty file.
       final sourceFile = File(p.join(testDir.path, fileName));
       await sourceFile.writeAsString('');
 
-      // Create backup
-      await createDbBackup(fileName);
+      final backup = await createDbBackup(fileName);
 
-      // Verify backup was created
       final backupDir = Directory(p.join(testDir.path, _backupDirectoryName));
-      final backupFiles = backupDir.listSync();
-      expect(backupFiles.length, equals(1));
-
-      // Verify backup is also empty
-      final backupFile = backupFiles.first as File;
-      final content = await backupFile.readAsString();
-      expect(content, isEmpty);
+      expect(backupDir.listSync(), hasLength(1));
+      final snapshot = sqlite3.open(backup.path);
+      addTearDown(snapshot.close);
+      expect(snapshot.select('SELECT name FROM sqlite_master'), isEmpty);
     });
 
-    test('backup handles large file', () async {
+    test('a large source SQLite cannot read is copied in full', () async {
       const fileName = 'large_db.sqlite';
 
       // Create large source file (1MB)

--- a/test/database/common_test.dart
+++ b/test/database/common_test.dart
@@ -174,6 +174,59 @@ void main() {
       expect(backupDir.listSync(), hasLength(2));
     });
 
+    test('two backups in the same instant get distinct files', () async {
+      const fileName = 'test_db.sqlite';
+      seedWalDatabase(fileName);
+      final sameInstant = Clock.fixed(DateTime(2026, 9, 5, 10, 30, 15));
+
+      final first = await withClock(
+        sameInstant,
+        () => createDbBackup(fileName),
+      );
+      final second = await withClock(
+        sameInstant,
+        () => createDbBackup(fileName),
+      );
+
+      expect(first.path, isNot(second.path));
+      expect(p.basename(second.path), endsWith('-2.sqlite'));
+      // Both are real snapshots — the second did not overwrite the first.
+      expect(labelsIn(first), ['checkpointed', 'still in the wal']);
+      expect(labelsIn(second), ['checkpointed', 'still in the wal']);
+    });
+
+    test(
+      'a failure that is not an unreadable source propagates instead of '
+      'being papered over with a raw copy',
+      () async {
+        const fileName = 'test_db.sqlite';
+        seedWalDatabase(fileName);
+        // Occupy the exact target with a directory so VACUUM INTO cannot
+        // write there: the source is fine, the backup is what failed.
+        final backupDir = Directory(p.join(testDir.path, _backupDirectoryName))
+          ..createSync();
+        Directory(
+          p.join(backupDir.path, 'test_db.2026-09-05_10-30-15-000.sqlite'),
+        ).createSync();
+
+        await expectLater(
+          withClock(
+            Clock.fixed(DateTime(2026, 9, 5, 10, 30, 15)),
+            () => createDbBackup(fileName),
+          ),
+          throwsA(isA<SqliteException>()),
+        );
+
+        expect(
+          backupDir.listSync().whereType<File>().where(
+            (f) => f.path.endsWith('.sqlite'),
+          ),
+          isEmpty,
+          reason: 'no raw copy may stand in for a failed snapshot',
+        );
+      },
+    );
+
     test('throws when the source file does not exist', () async {
       await expectLater(
         createDbBackup('missing.sqlite'),

--- a/test/database/maintenance_test.dart
+++ b/test/database/maintenance_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:drift/drift.dart' show InsertMode, Value;
@@ -237,11 +238,22 @@ void main() {
 
           final editorState = MockEditorStateService();
           getIt.registerSingleton<EditorStateService>(editorState);
+          // Stand in for a debounced write still pending at reset time: it
+          // is queued when the in-memory drafts are dropped, so it must be
+          // deleted along with everything else rather than land afterwards.
+          when(editorState.resetDrafts).thenAnswer((_) {
+            unawaited(
+              editorDb.insertDraftState(
+                entryId: 'pending-at-reset',
+                lastSaved: DateTime(2026, 9, 5),
+                draftDeltaJson: '{"ops":[]}',
+              ),
+            );
+          });
 
           await maintenance.clearEditorDb();
 
           expect(await editorDb.select(editorDb.editorDrafts).get(), isEmpty);
-          // Drafts still held in memory (and their pending writes) go too.
           verify(editorState.resetDrafts).called(1);
           await editorDb.insertDraftState(
             entryId: 'entry-2',
@@ -343,6 +355,41 @@ void main() {
           expect(backupDir.existsSync(), isTrue);
           final backup = backupDir.listSync().single as File;
           expect(backup.readAsStringSync(), 'test-data');
+        },
+      );
+
+      test(
+        'deleteAgentDb removes orphaned companions when the main file is '
+        'already gone',
+        () async {
+          final dbFile = await getDatabaseFile(agentDbFileName);
+          File('${dbFile.path}-wal').createSync(recursive: true);
+          File('${dbFile.path}-shm').createSync();
+
+          await maintenance.deleteAgentDb();
+
+          expect(File('${dbFile.path}-wal').existsSync(), isFalse);
+          expect(File('${dbFile.path}-shm').existsSync(), isFalse);
+        },
+      );
+
+      test(
+        'deleteFts5Db removes orphaned companions when the main file is '
+        'already gone',
+        () async {
+          final dbFile = await getDatabaseFile(fts5DbFileName);
+          File('${dbFile.path}-wal').createSync(recursive: true);
+
+          await maintenance.deleteFts5Db();
+
+          expect(File('${dbFile.path}-wal').existsSync(), isFalse);
+          verify(
+            () => mockDomainLogger.log(
+              LogDomain.database,
+              'Database file $fts5DbFileName does not exist',
+              subDomain: 'deleteFts5Db',
+            ),
+          ).called(1);
         },
       );
 

--- a/test/database/maintenance_test.dart
+++ b/test/database/maintenance_test.dart
@@ -18,6 +18,7 @@ import 'package:lotti/features/sync/state/outbox_state_controller.dart'
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/domain_logging.dart';
+import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
@@ -234,9 +235,14 @@ void main() {
             hasLength(1),
           );
 
+          final editorState = MockEditorStateService();
+          getIt.registerSingleton<EditorStateService>(editorState);
+
           await maintenance.clearEditorDb();
 
           expect(await editorDb.select(editorDb.editorDrafts).get(), isEmpty);
+          // Drafts still held in memory (and their pending writes) go too.
+          verify(editorState.resetDrafts).called(1);
           await editorDb.insertDraftState(
             entryId: 'entry-2',
             lastSaved: DateTime(2026, 9, 5),
@@ -268,9 +274,18 @@ void main() {
             'INSERT INTO sync_sequence_watermarks '
             "(host_id, last_counter, updated_at) VALUES ('host-a', 3, 0)",
           );
+          // A live Drift stream, as behind the sync badge: it must learn
+          // about the reset although the rows go through raw statements.
+          final counts = <int>[];
+          final subscription = syncDb.watchOutboxCount().listen(counts.add);
+          addTearDown(subscription.cancel);
+          await pumpEventQueue();
+          expect(counts, [1]);
 
           await maintenance.clearSyncDb();
+          await pumpEventQueue();
 
+          expect(counts.last, 0);
           expect(await syncDb.select(syncDb.outbox).get(), isEmpty);
           final watermarks = await syncDb
               .customSelect(

--- a/test/database/maintenance_test.dart
+++ b/test/database/maintenance_test.dart
@@ -94,6 +94,24 @@ class _ThrowingMaintenance extends Maintenance {
   }
 }
 
+/// A file-backed agent database that records whether it was closed.
+class _ClosureTrackingAgentDb extends AgentDatabase {
+  _ClosureTrackingAgentDb(Directory directory)
+    : super(
+        background: false,
+        documentsDirectoryProvider: () async => directory,
+        tempDirectoryProvider: () async => directory,
+      );
+
+  bool closed = false;
+
+  @override
+  Future<void> close() {
+    closed = true;
+    return super.close();
+  }
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -198,91 +216,120 @@ void main() {
       await journalDb.close();
     });
 
-    group('database deletion helpers', () {
-      test('deleteEditorDb removes existing database file', () async {
-        final dbFile = await getDatabaseFile(editorDbFileName);
-        await dbFile.create(recursive: true);
-        expect(dbFile.existsSync(), isTrue);
-
-        await maintenance.deleteEditorDb();
-
-        expect(dbFile.existsSync(), isFalse);
-      });
-
-      test('deleteSyncDb removes existing database file', () async {
-        final dbFile = await getDatabaseFile(syncDbFileName);
-        await dbFile.create(recursive: true);
-        expect(dbFile.existsSync(), isTrue);
-
-        await maintenance.deleteSyncDb();
-
-        expect(dbFile.existsSync(), isFalse);
-      });
-
-      test('deleteFts5Db removes file and logs deletion event', () async {
-        final dbFile = await getDatabaseFile(fts5DbFileName);
-        await dbFile.create(recursive: true);
-        expect(dbFile.existsSync(), isTrue);
-
-        await maintenance.deleteFts5Db();
-
-        expect(dbFile.existsSync(), isFalse);
-
-        verify(
-          () => mockDomainLogger.log(
-            LogDomain.database,
-            'FTS5 database DELETED',
-            subDomain: 'recreateFts5',
-          ),
-        ).called(1);
-      });
-
+    group('database reset helpers', () {
       test(
-        'database deletion is idempotent when file does not exist',
+        'clearEditorDb empties the drafts through the live connection and '
+        'leaves it usable',
         () async {
-          final dbFile = await getDatabaseFile(editorDbFileName);
-          if (dbFile.existsSync()) {
-            await dbFile.delete();
-          }
+          final editorDb = EditorDb(inMemoryDatabase: true);
+          addTearDown(editorDb.close);
+          getIt.registerSingleton<EditorDb>(editorDb);
+          await editorDb.insertDraftState(
+            entryId: 'entry-1',
+            lastSaved: DateTime(2026, 9, 5),
+            draftDeltaJson: '{"ops":[]}',
+          );
+          expect(
+            await editorDb.select(editorDb.editorDrafts).get(),
+            hasLength(1),
+          );
 
-          await maintenance.deleteEditorDb();
+          await maintenance.clearEditorDb();
 
-          expect(dbFile.existsSync(), isFalse);
+          expect(await editorDb.select(editorDb.editorDrafts).get(), isEmpty);
+          await editorDb.insertDraftState(
+            entryId: 'entry-2',
+            lastSaved: DateTime(2026, 9, 5),
+            draftDeltaJson: '{"ops":[]}',
+          );
+          expect(
+            await editorDb.select(editorDb.editorDrafts).get(),
+            hasLength(1),
+          );
         },
       );
 
-      test('deleteAgentDb removes database and WAL companion files', () async {
-        final dbFile = await getDatabaseFile(agentDbFileName);
-        await dbFile.create(recursive: true);
-        final shmFile = File('${dbFile.path}-shm');
-        final walFile = File('${dbFile.path}-wal');
-        await shmFile.create();
-        await walFile.create();
-        expect(dbFile.existsSync(), isTrue);
-        expect(shmFile.existsSync(), isTrue);
-        expect(walFile.existsSync(), isTrue);
+      test(
+        'clearSyncDb empties every table, including ones created by raw '
+        'migration SQL',
+        () async {
+          final syncDb = SyncDatabase(inMemoryDatabase: true);
+          addTearDown(syncDb.close);
+          getIt.registerSingleton<SyncDatabase>(syncDb);
+          await syncDb.addOutboxItem(
+            OutboxCompanion(
+              subject: const Value('s'),
+              message: const Value('{}'),
+              createdAt: Value(DateTime(2026, 9, 5)),
+              updatedAt: Value(DateTime(2026, 9, 5)),
+            ),
+          );
+          await syncDb.customStatement(
+            'INSERT INTO sync_sequence_watermarks '
+            "(host_id, last_counter, updated_at) VALUES ('host-a', 3, 0)",
+          );
 
-        await maintenance.deleteAgentDb();
+          await maintenance.clearSyncDb();
 
-        expect(dbFile.existsSync(), isFalse);
-        expect(shmFile.existsSync(), isFalse);
-        expect(walFile.existsSync(), isFalse);
-      });
+          expect(await syncDb.select(syncDb.outbox).get(), isEmpty);
+          final watermarks = await syncDb
+              .customSelect(
+                'SELECT COUNT(*) AS c FROM sync_sequence_watermarks',
+              )
+              .getSingle();
+          expect(watermarks.read<int>('c'), 0);
+        },
+      );
 
-      test('deleteAgentDb creates backup before deletion', () async {
-        final dbFile = await getDatabaseFile(agentDbFileName);
-        await dbFile.create(recursive: true);
-        await dbFile.writeAsString('test-data');
+      test(
+        'deleteAgentDb backs up, closes the registered database and removes '
+        'the file with every companion',
+        () async {
+          final agentDb = _ClosureTrackingAgentDb(tempDir);
+          addTearDown(() async {
+            if (!agentDb.closed) await agentDb.close();
+          });
+          getIt.registerSingleton<AgentDatabase>(agentDb);
+          // Opening lazily creates the file and its WAL companions.
+          await agentDb.customSelect('SELECT 1').get();
+          final dbFile = await getDatabaseFile(agentDbFileName);
+          expect(dbFile.existsSync(), isTrue);
+          File('${dbFile.path}-journal').createSync();
 
-        await maintenance.deleteAgentDb();
+          await maintenance.deleteAgentDb();
 
-        expect(dbFile.existsSync(), isFalse);
+          expect(agentDb.closed, isTrue);
+          for (final suffix in const ['', '-wal', '-shm', '-journal']) {
+            expect(
+              File('${dbFile.path}$suffix').existsSync(),
+              isFalse,
+              reason: 'companion "$suffix" must be gone',
+            );
+          }
+          final backups = Directory(
+            '${tempDir.path}/backup',
+          ).listSync().map((entity) => entity.uri.pathSegments.last).toList();
+          expect(backups, hasLength(1));
+          expect(backups.single, startsWith('agent.'));
+        },
+      );
 
-        final backupDir = Directory('${tempDir.path}/backup');
-        expect(backupDir.existsSync(), isTrue);
-        final backupFiles = backupDir.listSync();
-        expect(backupFiles, isNotEmpty);
-      });
+      test(
+        'deleteAgentDb still backs up a file SQLite cannot read, as a raw copy',
+        () async {
+          final dbFile = await getDatabaseFile(agentDbFileName);
+          await dbFile.create(recursive: true);
+          await dbFile.writeAsString('test-data');
+
+          await maintenance.deleteAgentDb();
+
+          expect(dbFile.existsSync(), isFalse);
+          final backupDir = Directory('${tempDir.path}/backup');
+          expect(backupDir.existsSync(), isTrue);
+          final backup = backupDir.listSync().single as File;
+          expect(backup.readAsStringSync(), 'test-data');
+        },
+      );
 
       test('deleteAgentDb is idempotent when file does not exist', () async {
         final dbFile = await getDatabaseFile(agentDbFileName);
@@ -298,6 +345,26 @@ void main() {
             LogDomain.database,
             'Database file $agentDbFileName does not exist',
             subDomain: 'deleteAgentDb',
+          ),
+        ).called(1);
+      });
+
+      test('deleteFts5Db removes the file, its companions and logs', () async {
+        final dbFile = await getDatabaseFile(fts5DbFileName);
+        await dbFile.create(recursive: true);
+        File('${dbFile.path}-wal').createSync();
+        File('${dbFile.path}-shm').createSync();
+
+        await maintenance.deleteFts5Db();
+
+        expect(dbFile.existsSync(), isFalse);
+        expect(File('${dbFile.path}-wal').existsSync(), isFalse);
+        expect(File('${dbFile.path}-shm').existsSync(), isFalse);
+        verify(
+          () => mockDomainLogger.log(
+            LogDomain.database,
+            'FTS5 database DELETED',
+            subDomain: 'recreateFts5',
           ),
         ).called(1);
       });

--- a/test/database/sync_db_migration_test.dart
+++ b/test/database/sync_db_migration_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: avoid_redundant_argument_values, cascade_invocations
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -63,6 +64,46 @@ void main() {
   });
 
   group('SyncDatabase Migration Tests', () {
+    test(
+      'upgrading a file-backed database first writes a consistent backup '
+      'named after it',
+      () async {
+        final dbFile = File(
+          path.join(testDirectory!.path, 'test_sync_backup.db'),
+        );
+        final sqlite = sqlite3.open(dbFile.path);
+        _createOutboxV1(sqlite);
+        sqlite.execute('PRAGMA user_version = 1');
+        sqlite.close();
+
+        final db = SyncDatabase(overriddenFilename: 'test_sync_backup.db');
+        addTearDown(db.close);
+        // The migration runs on first use; the backup is taken inside it.
+        await withClock(
+          Clock.fixed(DateTime(2026, 9, 5, 10, 30, 15)),
+          () => db.customSelect('PRAGMA user_version').get(),
+        );
+
+        final backups = Directory(
+          path.join(testDirectory!.path, 'backup'),
+        ).listSync().whereType<File>().toList();
+        expect(backups, hasLength(1));
+        expect(
+          path.basename(backups.single.path),
+          matches(
+            RegExp(r'^test_sync_backup\.2026-09-05_10-30-15-\d+\.sqlite$'),
+          ),
+        );
+        // The backup is the pre-migration state, not the migrated one.
+        final snapshot = sqlite3.open(backups.single.path);
+        addTearDown(snapshot.close);
+        expect(
+          snapshot.select('PRAGMA user_version').single['user_version'],
+          1,
+        );
+      },
+    );
+
     test(
       'v2 migration creates sync_sequence_log and host_activity tables',
       () async {

--- a/test/features/agents/database/agent_database_test.dart
+++ b/test/features/agents/database/agent_database_test.dart
@@ -2,6 +2,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:drift/drift.dart' show QueryRow, Variable;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
@@ -15,6 +16,84 @@ import 'package:path/path.dart' as path;
 import 'package:sqlite3/sqlite3.dart' show SqliteException, sqlite3;
 
 import '../test_data/change_set_factories.dart';
+
+/// Seeds the schema an agent database had at v1, with one wake run.
+void _seedAgentV1(String dbFile) {
+  final rawDb = sqlite3.open(dbFile);
+
+  // Create v1 schema tables (minimal — only wake_run_log needed)
+  rawDb.execute('''
+  CREATE TABLE agent_entities (
+    id TEXT NOT NULL PRIMARY KEY,
+    agent_id TEXT NOT NULL,
+    type TEXT NOT NULL,
+    subtype TEXT,
+    thread_id TEXT,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    deleted_at DATETIME,
+    serialized TEXT NOT NULL,
+    schema_version INTEGER NOT NULL DEFAULT 1
+  )
+''');
+  rawDb.execute('''
+  CREATE TABLE agent_links (
+    id TEXT NOT NULL PRIMARY KEY,
+    from_id TEXT NOT NULL,
+    to_id TEXT NOT NULL,
+    type TEXT NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    deleted_at DATETIME,
+    serialized TEXT NOT NULL,
+    schema_version INTEGER NOT NULL DEFAULT 1,
+    UNIQUE(from_id, to_id, type)
+  )
+''');
+  rawDb.execute('''
+  CREATE TABLE wake_run_log (
+    run_key TEXT NOT NULL PRIMARY KEY,
+    agent_id TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    reason_id TEXT,
+    thread_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    logical_change_key TEXT,
+    created_at DATETIME NOT NULL,
+    started_at DATETIME,
+    completed_at DATETIME,
+    error_message TEXT,
+    template_id TEXT,
+    template_version_id TEXT
+  )
+''');
+  rawDb.execute('''
+  CREATE TABLE saga_log (
+    operation_id TEXT NOT NULL PRIMARY KEY,
+    agent_id TEXT NOT NULL,
+    run_key TEXT NOT NULL,
+    phase TEXT NOT NULL,
+    status TEXT NOT NULL,
+    tool_name TEXT NOT NULL,
+    last_error TEXT,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+  )
+''');
+
+  // Insert a test row to verify data survives migration
+  rawDb.execute('''
+  INSERT INTO wake_run_log
+    (run_key, agent_id, reason, thread_id, status, created_at)
+  VALUES
+    ('run-1', 'agent-1', 'scheduled', 'thread-1', 'completed',
+     '2026-02-20 10:00:00')
+''');
+
+  // Set schema version to 1
+  rawDb.execute('PRAGMA user_version = 1');
+  rawDb.close();
+}
 
 void main() {
   late Directory testDirectory;
@@ -346,84 +425,48 @@ void main() {
 
   group('AgentDatabase migration', () {
     test(
+      'upgrading a file-backed database first writes a consistent backup '
+      'named after it, in its own directory',
+      () async {
+        final dbFile = path.join(testDirectory.path, agentDbFileName);
+        _seedAgentV1(dbFile);
+
+        final db = AgentDatabase(
+          background: false,
+          documentsDirectoryProvider: () async => testDirectory,
+          tempDirectoryProvider: () async => testDirectory,
+        );
+        addTearDown(db.close);
+        // The migration runs on first use; the backup is taken inside it.
+        await withClock(
+          Clock.fixed(DateTime(2026, 9, 5, 10, 30, 15)),
+          () => db.customSelect('PRAGMA user_version').get(),
+        );
+
+        final backups = Directory(
+          path.join(testDirectory.path, 'backup'),
+        ).listSync().whereType<File>().toList();
+        expect(backups, hasLength(1));
+        expect(
+          path.basename(backups.single.path),
+          matches(RegExp(r'^agent\.2026-09-05_10-30-15-\d+\.sqlite$')),
+        );
+        // The backup is the pre-migration state, not the migrated one.
+        final snapshot = sqlite3.open(backups.single.path);
+        addTearDown(snapshot.close);
+        expect(
+          snapshot.select('PRAGMA user_version').single['user_version'],
+          1,
+        );
+      },
+    );
+
+    test(
       'v1 to v2 adds user_rating and rated_at columns to wake_run_log',
       () async {
         // Create a v1 database with the original schema (no rating columns)
         final dbFile = path.join(testDirectory.path, agentDbFileName);
-        final rawDb = sqlite3.open(dbFile);
-
-        // Create v1 schema tables (minimal — only wake_run_log needed)
-        rawDb.execute('''
-        CREATE TABLE agent_entities (
-          id TEXT NOT NULL PRIMARY KEY,
-          agent_id TEXT NOT NULL,
-          type TEXT NOT NULL,
-          subtype TEXT,
-          thread_id TEXT,
-          created_at DATETIME NOT NULL,
-          updated_at DATETIME NOT NULL,
-          deleted_at DATETIME,
-          serialized TEXT NOT NULL,
-          schema_version INTEGER NOT NULL DEFAULT 1
-        )
-      ''');
-        rawDb.execute('''
-        CREATE TABLE agent_links (
-          id TEXT NOT NULL PRIMARY KEY,
-          from_id TEXT NOT NULL,
-          to_id TEXT NOT NULL,
-          type TEXT NOT NULL,
-          created_at DATETIME NOT NULL,
-          updated_at DATETIME NOT NULL,
-          deleted_at DATETIME,
-          serialized TEXT NOT NULL,
-          schema_version INTEGER NOT NULL DEFAULT 1,
-          UNIQUE(from_id, to_id, type)
-        )
-      ''');
-        rawDb.execute('''
-        CREATE TABLE wake_run_log (
-          run_key TEXT NOT NULL PRIMARY KEY,
-          agent_id TEXT NOT NULL,
-          reason TEXT NOT NULL,
-          reason_id TEXT,
-          thread_id TEXT NOT NULL,
-          status TEXT NOT NULL,
-          logical_change_key TEXT,
-          created_at DATETIME NOT NULL,
-          started_at DATETIME,
-          completed_at DATETIME,
-          error_message TEXT,
-          template_id TEXT,
-          template_version_id TEXT
-        )
-      ''');
-        rawDb.execute('''
-        CREATE TABLE saga_log (
-          operation_id TEXT NOT NULL PRIMARY KEY,
-          agent_id TEXT NOT NULL,
-          run_key TEXT NOT NULL,
-          phase TEXT NOT NULL,
-          status TEXT NOT NULL,
-          tool_name TEXT NOT NULL,
-          last_error TEXT,
-          created_at DATETIME NOT NULL,
-          updated_at DATETIME NOT NULL
-        )
-      ''');
-
-        // Insert a test row to verify data survives migration
-        rawDb.execute('''
-        INSERT INTO wake_run_log
-          (run_key, agent_id, reason, thread_id, status, created_at)
-        VALUES
-          ('run-1', 'agent-1', 'scheduled', 'thread-1', 'completed',
-           '2026-02-20 10:00:00')
-      ''');
-
-        // Set schema version to 1
-        rawDb.execute('PRAGMA user_version = 1');
-        rawDb.close();
+        _seedAgentV1(dbFile);
 
         // Open with AgentDatabase to trigger v1→v2 migration
         final db = AgentDatabase(

--- a/test/features/settings/ui/pages/advanced/maintenance_page_test.dart
+++ b/test/features/settings/ui/pages/advanced/maintenance_page_test.dart
@@ -129,8 +129,8 @@ void main() {
       );
 
       final mockMaintenance = MockMaintenance();
-      when(mockMaintenance.deleteEditorDb).thenAnswer((_) async {});
-      when(mockMaintenance.deleteSyncDb).thenAnswer((_) async {});
+      when(mockMaintenance.clearEditorDb).thenAnswer((_) async {});
+      when(mockMaintenance.clearSyncDb).thenAnswer((_) async {});
       when(mockMaintenance.deleteAgentDb).thenAnswer((_) async {});
       when(
         mockImagePathMigrationService.migrateAll,
@@ -422,7 +422,7 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
 
-        verify(() => getIt<Maintenance>().deleteEditorDb()).called(1);
+        verify(() => getIt<Maintenance>().clearEditorDb()).called(1);
       },
     );
 
@@ -658,7 +658,7 @@ void main() {
       );
 
       final mockMaintenance = MockMaintenance();
-      when(mockMaintenance.deleteEditorDb).thenAnswer((_) async {});
+      when(mockMaintenance.clearEditorDb).thenAnswer((_) async {});
       when(mockMaintenance.deleteAgentDb).thenAnswer((_) async {});
 
       getIt

--- a/test/features/sync/ui/matrix_sync_maintenance_page_test.dart
+++ b/test/features/sync/ui/matrix_sync_maintenance_page_test.dart
@@ -46,7 +46,7 @@ void main() {
 
       mockMaintenance = MockMaintenance();
       mockHistoricalSyncService = MockHistoricalSyncService();
-      when(() => mockMaintenance.deleteSyncDb()).thenAnswer((_) async {});
+      when(() => mockMaintenance.clearSyncDb()).thenAnswer((_) async {});
       when(
         () => mockHistoricalSyncService.reSyncInterval(
           start: any(named: 'start'),
@@ -153,7 +153,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      verify(() => mockMaintenance.deleteSyncDb()).called(1);
+      verify(() => mockMaintenance.clearSyncDb()).called(1);
     });
 
     testWidgets('sync definitions card opens sync modal', (tester) async {
@@ -334,7 +334,7 @@ void main() {
           onProgress: any(named: 'onProgress'),
         ),
       ).thenAnswer((_) async => ReSyncResult.empty);
-      when(() => mockMaintenance.deleteSyncDb()).thenAnswer((_) async {});
+      when(() => mockMaintenance.clearSyncDb()).thenAnswer((_) async {});
 
       getIt
         ..registerSingleton<JournalDb>(mockJournalDb)

--- a/test/features/sync/ui/sync_manual_screenshots_test.dart
+++ b/test/features/sync/ui/sync_manual_screenshots_test.dart
@@ -791,7 +791,7 @@ void main() {
     when(
       verificationRunner.acceptEmojiVerification,
     ).thenAnswer((_) async {});
-    when(() => maintenance.deleteSyncDb()).thenAnswer((_) async {});
+    when(() => maintenance.clearSyncDb()).thenAnswer((_) async {});
     when(
       () => maintenance.purgeSentOutboxItems(
         retention: any(named: 'retention'),

--- a/test/services/editor_state_service_test.dart
+++ b/test/services/editor_state_service_test.dart
@@ -494,6 +494,61 @@ void main() {
       await expectation;
     });
 
+    test(
+      'resetDrafts forgets every draft, cancels pending writes and tells '
+      'open editors they are saved',
+      () {
+        fakeAsync((async) {
+          when(
+            () => mockEditorDb.getLatestDraft(
+              any(),
+              lastSaved: any(named: 'lastSaved'),
+            ),
+          ).thenAnswer((_) async => null);
+          final emitted = <bool>[];
+          editorStateService
+              .getUnsavedStream('entry-a', testEpochDateTime)
+              .listen(emitted.add);
+          editorStateService
+            ..saveTempState(
+              id: 'entry-a',
+              lastSaved: testEpochDateTime,
+              json: '{"ops":[{"insert":"a"}]}',
+            )
+            ..saveTempState(
+              id: 'entry-b',
+              lastSaved: testEpochDateTime,
+              json: '{"ops":[{"insert":"b"}]}',
+            )
+            ..saveSelection(
+              'entry-a',
+              const TextSelection.collapsed(offset: 1),
+            );
+          // The test environment debounces with zero delay, so stand in a
+          // write that is still pending, keyed the way the service keys it.
+          var pendingWriteFired = false;
+          EasyDebounce.debounce(
+            'persistDraftState-entry-a',
+            const Duration(seconds: 2),
+            () => pendingWriteFired = true,
+          );
+          async.flushMicrotasks();
+
+          editorStateService.resetDrafts();
+          async
+            ..flushMicrotasks()
+            ..elapse(const Duration(seconds: 3));
+
+          expect(editorStateService.getDelta('entry-a'), isNull);
+          expect(editorStateService.getDelta('entry-b'), isNull);
+          expect(editorStateService.getSelection('entry-a'), isNull);
+          expect(editorStateService.entryIsUnsaved('entry-b'), isFalse);
+          expect(pendingWriteFired, isFalse);
+          expect(emitted.last, isFalse);
+        });
+      },
+    );
+
     test('entryIsUnsaved returns true when entry has unsaved state', () {
       const entryId = 'test-entry-id';
 


### PR DESCRIPTION
## Summary

Findings 5 and 7 of the persistence-layer review.

**Backups are consistent snapshots, and every migrating store takes one.** `createDbBackup` copied `db.sqlite` with `File.copy` while every connection runs in WAL mode, so the copy taken before a migration (or before "purge deleted") could miss the latest commits still in `db.sqlite-wal`. The snapshot is now taken with `VACUUM INTO` on a private connection, run off the caller's isolate (the sqlite3 bindings are synchronous and a large journal would otherwise stall the UI). It holds every committed transaction and arrives compacted. Backups are named after their source (`backup/db.…`, `backup/sync.…`, `backup/agent.…`), and `SyncDatabase` (v29) and `AgentDatabase` (v19, whose migrations rewrite payloads) now take one before upgrading — only the journal did before. Each store backs up its own file, from its own directory: a database opened with a `documentsDirectoryProvider` (another world, a test) used to look for the default file in the active profile root.

A file SQLite cannot open (the corrupt store a user is about to reset) falls back to a raw copy of the main file plus a WAL that is stashed *before* the attempt, because SQLite discards a `-wal` it finds beside a file it cannot read. A reset is never blocked on a backup, and the fallback is logged.

**Maintenance no longer unlinks a database under its open connection.** `deleteEditorDb` and `deleteSyncDb` removed the file while the registered Drift singleton stayed open: every service kept writing into the unlinked inode until restart, and the leftover `-wal`/`-shm` sat beside the fresh file created on the next launch, ready to be replayed into it. They are now `clearEditorDb` and `clearSyncDb`, which delete every row of every table through the live connection (tables enumerated from `sqlite_master`, so the raw-SQL `sync_sequence_watermarks` is included) and `VACUUM`. Every handle stays valid and the reset takes effect immediately. `deleteAgentDb` backs up, **closes** the registered `AgentDatabase`, and removes the file with `-wal`, `-shm` and `-journal` (its caller already quits the app). `recreateFts5` now closes before it unlinks, and removes companions.

## Tests

- `createDbBackup`: the backup holds a row that only exists in the WAL (fails when the snapshot path is bypassed); named after source and clock; successive backups never collide; missing source throws; an unreadable source is copied byte for byte with its WAL; an explicit directory is honoured; an empty file becomes a valid empty database.
- `SyncDatabase` and `AgentDatabase`: upgrading a file-backed database writes a backup named after it whose `user_version` is the pre-migration one; the agent case uses a directory that is not the registered root.
- `Maintenance`: `clearEditorDb` empties and leaves the connection usable; `clearSyncDb` empties every table including the watermarks; `deleteAgentDb` closes the registered instance (tracked by a test double) and removes all four files, still backs up an unreadable file as a raw copy, and is idempotent; `deleteFts5Db` removes companions.
- The maintenance and sync maintenance page tests follow the rename.

`make analyze`, `make knowledge_check` and `make changelog_check` clean; the database, agent, maintenance page and sync page test files touched are green.

## Docs

`knowledge/architecture/persistence.md`: the backup paragraph (snapshot, naming, fallback, which stores) and the maintenance paragraph (empty through the live connection vs close-then-delete). Changelog fragment added: users will notice that backups include their latest changes and that the sync/editor reset takes effect immediately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database backups now capture consistent snapshots, including pending SQLite WAL data.
  * Backups are created automatically before database migrations.
  * Resetting editor or sync data from Maintenance now takes effect immediately without restarting.
  * Clearing editor data also resets unsaved drafts and selections.
  * Database cleanup now removes related SQLite companion files reliably.

* **Documentation**
  * Updated persistence documentation to describe backup behavior, naming, migration safeguards, and maintenance operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->