### PR TITLE
test(db): verify every JournalDb migration against the schemas that shipped, reconcile indexes on upgrade

### DIFF
--- a/changelog.d/2026-09-05-obsolete-journal-indexes.md
+++ b/changelog.d/2026-09-05-obsolete-journal-indexes.md
@@ -1,0 +1,8 @@
+### Fixed
+- **Long-standing installs carried up to seventeen obsolete indexes on the
+  journal table.** Databases created before autumn 2025 kept every
+  single-column index the original schema had, even though later versions
+  stopped using them, and never gained the two date indexes newer installs
+  have. Every save paid to maintain the extras. The upgrade now brings the
+  indexes of an old database in line with a fresh install, and every future
+  upgrade re-checks them.

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -251,10 +251,13 @@ fails until you do. That test is what found the v24 drift below.
 
 **Indexes are reconciled from the declared schema on every upgrade.**
 `_reconcileIndexesWithSchema` ends `onUpgrade`: it drops explicit indexes on
-Drift-managed tables that `database.drift` no longer declares and creates
-declared ones that are missing. An index change is therefore an edit to
-`database.drift` plus a version bump, never a hand-written `CREATE INDEX`
-in a migration step. It exists because installs from before v25 (October
+Drift-managed tables that `database.drift` no longer declares, recreates
+declared ones whose stored definition differs (compared through
+`normaliseIndexDefinition`, which discards only case, whitespace, quoting
+and the default `COLLATE BINARY`/`ASC`), and creates declared ones that are
+missing. An index change — new, gone, or reshaped under the same name — is
+therefore an edit to `database.drift` plus a version bump, never a
+hand-written `CREATE INDEX` in a migration step. It exists because installs from before v25 (October
 2025) still carried up to seventeen single-column indexes the original schema
 created and later versions stopped declaring but never dropped, and lacked
 the two date indexes a fresh install has; v47 is the release that ran it for

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -81,7 +81,7 @@ migration work has to cover both, and embeddings are a third store again (below)
 
 | Database | File | Schema | Owns |
 |----------|------|--------|------|
-| `JournalDb` | `db.sqlite` | 46 | Journal entities, tasks, links, tags, config flags — the primary store |
+| `JournalDb` | `db.sqlite` | 47 | Journal entities, tasks, links, tags, config flags — the primary store |
 | `SyncDatabase` | `sync.sqlite` | 29 | Outbox, sequence log, host activity, inbound event queue, queue markers |
 | `AgentDatabase` | `agent.sqlite` | 19 | Agent state, reports, observations, change proposals, wake history |
 | `EditorDb` | `editor_drafts_db.sqlite` | 2 | Unsaved rich-text editor drafts |
@@ -237,6 +237,29 @@ Historical migration fixtures must describe the schema at their declared
 `user_version`, without future columns added merely to make current DDL pass.
 The v18 fixture in `test/database/database_test.dart` exercises the complete
 upgrade and verifies that its existing row survives with default priority.
+
+**The real historical schemas are committed.** `test/database/schemas/`
+holds `journal_v<N>.sql` for every journal version that ever shipped since
+v18: the DDL of `database.drift` at the last commit where N was current,
+extracted by `tool/db_schema/extract_journal_schema.dart` (Drift's own
+`schema dump` does not build with the drift_dev this repository can resolve).
+`test/database/journal_schema_history_test.dart` creates a database from each
+file, upgrades it, and diffs tables, columns and indexes against a fresh
+install — the check `SchemaVerifier` would run. Bumping `schemaVersion`
+means running the tool for the new version and committing the file; the test
+fails until you do. That test is what found the v24 drift below.
+
+**Indexes are reconciled from the declared schema on every upgrade.**
+`_reconcileIndexesWithSchema` ends `onUpgrade`: it drops explicit indexes on
+Drift-managed tables that `database.drift` no longer declares and creates
+declared ones that are missing. An index change is therefore an edit to
+`database.drift` plus a version bump, never a hand-written `CREATE INDEX`
+in a migration step. It exists because installs from before v25 (October
+2025) still carried up to seventeen single-column indexes the original schema
+created and later versions stopped declaring but never dropped, and lacked
+the two date indexes a fresh install has; v47 is the release that ran it for
+them. Tables Drift does not manage — `tag_entities` and `tagged`, left in
+place when tags were removed — are not touched.
 
 The indexes matter: `idx_journal_tasks_due_open` is keyed on the denormalized
 `due_at` column added in v41, which replaced an expression index over

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -165,7 +165,7 @@ class JournalDb extends _$JournalDb
   final Directory? _documentsDirectory;
 
   @override
-  int get schemaVersion => 46;
+  int get schemaVersion => 47;
 
   // Check whether a column exists in a given table to make migrations safer
   @override

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -173,6 +173,16 @@ WHERE type = 'Task'
   AND task = 1
   AND deleted = FALSE;
 
+-- Latest quantitative entry per subtype (health imports). Declared here so a
+-- fresh install and an upgraded one agree; `beforeOpen` also re-asserts it
+-- as a self-heal for a partially applied migration.
+CREATE INDEX idx_journal_quant_latest ON journal(
+  subtype COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'QuantitativeEntry'
+  AND deleted = FALSE;
+
 -- Partial covering index for the Insights time-analysis query (v43 in
 -- migrations). Only `date_from < :end` can be a seek bound — the
 -- `date_to > :start` overlap check is inherently residual — so the scan

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -5703,6 +5703,10 @@ abstract class _$JournalDb extends GeneratedDatabase {
     'idx_journal_tasks_priority_date',
     'CREATE INDEX idx_journal_tasks_priority_date ON journal (task_priority_rank COLLATE BINARY ASC, date_from COLLATE BINARY DESC, id COLLATE BINARY ASC) WHERE type = \'Task\' AND task = 1 AND deleted = FALSE',
   );
+  late final Index idxJournalQuantLatest = Index(
+    'idx_journal_quant_latest',
+    'CREATE INDEX idx_journal_quant_latest ON journal (subtype COLLATE BINARY ASC, date_from COLLATE BINARY DESC) WHERE type = \'QuantitativeEntry\' AND deleted = FALSE',
+  );
   late final Index idxJournalInsightsTime = Index(
     'idx_journal_insights_time',
     'CREATE INDEX idx_journal_insights_time ON journal (date_from COLLATE BINARY ASC, date_to COLLATE BINARY ASC, category COLLATE BINARY ASC, private COLLATE BINARY ASC, id COLLATE BINARY ASC) WHERE type = \'JournalEntry\' AND deleted = FALSE',
@@ -7428,6 +7432,7 @@ abstract class _$JournalDb extends GeneratedDatabase {
     idxJournalProjectTaskStatus,
     idxJournalTasksStatusPriorityDate,
     idxJournalTasksPriorityDate,
+    idxJournalQuantLatest,
     idxJournalInsightsTime,
     conflicts,
     idxConflictsStatusCreatedAt,

--- a/lib/database/database_migration.dart
+++ b/lib/database/database_migration.dart
@@ -447,16 +447,24 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
   }
 
   /// Brings the indexes of every Drift-managed table in line with the
-  /// declared schema: drops indexes the schema no longer declares, creates
-  /// declared ones that are missing.
+  /// declared schema: drops indexes the schema no longer declares, recreates
+  /// declared ones whose stored definition differs, creates declared ones
+  /// that are missing.
   ///
   /// Runs at the end of every upgrade. `database.drift` is the single
-  /// statement of which indexes exist, so an index change is an edit there
-  /// plus a version bump — no hand-written `CREATE`/`DROP INDEX` in the
+  /// statement of which indexes exist and what they look like, so an index
+  /// change — new, gone, or reshaped under the same name — is an edit there
+  /// plus a version bump, with no hand-written `CREATE`/`DROP INDEX` in the
   /// migration. It exists because the history did not work that way:
   /// installs from before v25 still carried every single-column index the
   /// original schema created and later versions stopped declaring but never
   /// dropped, up to seventeen on `journal`, each paid for on every write.
+  ///
+  /// Definitions are compared through [normaliseIndexDefinition], which
+  /// removes only spelling that does not change an index (case, whitespace,
+  /// quoting, the default `COLLATE BINARY` and `ASC`), so a `.drift`
+  /// declaration and the raw statement a past migration used compare equal
+  /// and nothing is rebuilt for cosmetics.
   ///
   /// Only explicitly created indexes on managed tables are touched;
   /// SQLite's own constraint indexes and any table Drift does not manage
@@ -471,12 +479,15 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
         index.entityName: index,
     };
     final existingRows = await customSelect(
-      "SELECT name, tbl_name FROM sqlite_master WHERE type = 'index' "
+      "SELECT name, tbl_name, sql FROM sqlite_master WHERE type = 'index' "
       'AND sql IS NOT NULL',
     ).get();
-    final existing = <String, String>{
+    final existing = <String, ({String table, String sql})>{
       for (final row in existingRows)
-        row.read<String>('name'): row.read<String>('tbl_name'),
+        row.read<String>('name'): (
+          table: row.read<String>('tbl_name'),
+          sql: row.read<String>('sql'),
+        ),
     };
     final existingTables = {
       for (final row in await customSelect(
@@ -485,39 +496,84 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
         row.read<String>('name'),
     };
 
+    final toCreate = <Index>[];
     for (final entry in existing.entries) {
       final name = entry.key;
-      final table = entry.value;
-      if (!managedTables.contains(table) || declared.containsKey(name)) {
+      final table = entry.value.table;
+      if (!managedTables.contains(table)) continue;
+      final index = declared[name];
+      if (index == null) {
+        DevLogger.log(
+          name: 'JournalDb',
+          message: 'Dropping undeclared index $name on $table',
+        );
+        await customStatement('DROP INDEX IF EXISTS "$name"');
         continue;
       }
-      DevLogger.log(
-        name: 'JournalDb',
-        message: 'Dropping undeclared index $name on $table',
-      );
-      await customStatement('DROP INDEX IF EXISTS "$name"');
+      final declaredSql = _declaredStatement(index);
+      if (declaredSql != null &&
+          normaliseIndexDefinition(entry.value.sql) !=
+              normaliseIndexDefinition(declaredSql)) {
+        DevLogger.log(
+          name: 'JournalDb',
+          message: 'Recreating index $name on $table: definition changed',
+        );
+        await customStatement('DROP INDEX IF EXISTS "$name"');
+        toCreate.add(index);
+      }
     }
 
     for (final index in declared.values) {
-      if (existing.containsKey(index.entityName)) continue;
+      if (existing.containsKey(index.entityName) && !toCreate.contains(index)) {
+        continue;
+      }
       final table = _indexedTable(index);
       if (table == null || !existingTables.contains(table)) continue;
-      DevLogger.log(
-        name: 'JournalDb',
-        message: 'Creating declared index ${index.entityName} on $table',
-      );
+      if (!toCreate.contains(index)) {
+        DevLogger.log(
+          name: 'JournalDb',
+          message: 'Creating declared index ${index.entityName} on $table',
+        );
+      }
       await m.createIndex(index);
     }
   }
 
+  static String? _declaredStatement(Index index) =>
+      index.createStatementsByDialect[SqlDialect.sqlite];
+
   /// The table an index is declared on, read from its `CREATE INDEX`
   /// statement; Drift's runtime [Index] does not carry the reference.
   static String? _indexedTable(Index index) {
-    final statement = index.createStatementsByDialect[SqlDialect.sqlite];
+    final statement = _declaredStatement(index);
     if (statement == null) return null;
     return RegExp(
       r'\bON\s+"?([A-Za-z0-9_]+)"?\s*\(',
       caseSensitive: false,
     ).firstMatch(statement)?.group(1);
   }
+}
+
+/// Reduces a `CREATE INDEX` statement to the spelling that determines what
+/// the index is, so two statements compare equal exactly when they would
+/// build the same index.
+///
+/// Removed: case, whitespace, double quotes, `IF NOT EXISTS`, spacing around
+/// parentheses, commas and `=`, and the defaults SQLite applies anyway —
+/// `COLLATE BINARY` and `ASC`. Kept: columns and their order, `DESC`,
+/// `UNIQUE`, expressions, and the partial `WHERE` clause.
+String normaliseIndexDefinition(String sql) {
+  return sql
+      .toLowerCase()
+      .replaceAll(RegExp(r'\s+'), ' ')
+      .replaceAll(' if not exists', '')
+      .replaceAll('"', '')
+      .replaceAll(RegExp(r'\s*\(\s*'), '(')
+      .replaceAll(RegExp(r'\s*\)\s*'), ')')
+      .replaceAll(RegExp(r'\s*,\s*'), ',')
+      .replaceAll(' collate binary', '')
+      .replaceAll(RegExp(r' asc\b'), '')
+      .replaceAll(RegExp(r'\s*=\s*'), '=')
+      .replaceAll(RegExp(r';\s*$'), '')
+      .trim();
 }

--- a/lib/database/database_migration.dart
+++ b/lib/database/database_migration.dart
@@ -441,7 +441,83 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
         }
 
         await _onUpgradeRecent(m, from);
+        await _reconcileIndexesWithSchema(m);
       },
     );
+  }
+
+  /// Brings the indexes of every Drift-managed table in line with the
+  /// declared schema: drops indexes the schema no longer declares, creates
+  /// declared ones that are missing.
+  ///
+  /// Runs at the end of every upgrade. `database.drift` is the single
+  /// statement of which indexes exist, so an index change is an edit there
+  /// plus a version bump — no hand-written `CREATE`/`DROP INDEX` in the
+  /// migration. It exists because the history did not work that way:
+  /// installs from before v25 still carried every single-column index the
+  /// original schema created and later versions stopped declaring but never
+  /// dropped, up to seventeen on `journal`, each paid for on every write.
+  ///
+  /// Only explicitly created indexes on managed tables are touched;
+  /// SQLite's own constraint indexes and any table Drift does not manage
+  /// (legacy tables left in place) are ignored. A declared index whose
+  /// table is absent — the case in minimal migration fixtures — is skipped.
+  Future<void> _reconcileIndexesWithSchema(Migrator m) async {
+    final managedTables = {
+      for (final table in allTables) table.actualTableName,
+    };
+    final declared = {
+      for (final index in allSchemaEntities.whereType<Index>())
+        index.entityName: index,
+    };
+    final existingRows = await customSelect(
+      "SELECT name, tbl_name FROM sqlite_master WHERE type = 'index' "
+      'AND sql IS NOT NULL',
+    ).get();
+    final existing = <String, String>{
+      for (final row in existingRows)
+        row.read<String>('name'): row.read<String>('tbl_name'),
+    };
+    final existingTables = {
+      for (final row in await customSelect(
+        "SELECT name FROM sqlite_master WHERE type = 'table'",
+      ).get())
+        row.read<String>('name'),
+    };
+
+    for (final entry in existing.entries) {
+      final name = entry.key;
+      final table = entry.value;
+      if (!managedTables.contains(table) || declared.containsKey(name)) {
+        continue;
+      }
+      DevLogger.log(
+        name: 'JournalDb',
+        message: 'Dropping undeclared index $name on $table',
+      );
+      await customStatement('DROP INDEX IF EXISTS "$name"');
+    }
+
+    for (final index in declared.values) {
+      if (existing.containsKey(index.entityName)) continue;
+      final table = _indexedTable(index);
+      if (table == null || !existingTables.contains(table)) continue;
+      DevLogger.log(
+        name: 'JournalDb',
+        message: 'Creating declared index ${index.entityName} on $table',
+      );
+      await m.createIndex(index);
+    }
+  }
+
+  /// The table an index is declared on, read from its `CREATE INDEX`
+  /// statement; Drift's runtime [Index] does not carry the reference.
+  static String? _indexedTable(Index index) {
+    final statement = index.createStatementsByDialect[SqlDialect.sqlite];
+    if (statement == null) return null;
+    return RegExp(
+      r'\bON\s+"?([A-Za-z0-9_]+)"?\s*\(',
+      caseSensitive: false,
+    ).firstMatch(statement)?.group(1);
   }
 }

--- a/lib/database/database_migration_recent.dart
+++ b/lib/database/database_migration_recent.dart
@@ -283,6 +283,24 @@ WHERE type = 'JournalAudio' AND deleted = FALSE
         }
       }();
     }
+    if (from < 47) {
+      await () async {
+        // v47 is the reconciliation release: the index reconcile that now
+        // ends every upgrade (see `_reconcileIndexesWithSchema`) needs an
+        // upgrade to run once on installs that predate v25. The only
+        // version-specific work is the `category_id` column that v20
+        // installs kept after v21 replaced it with `category`; its data was
+        // never read again (`category` is backfilled from the JSON in v43).
+        if (await _columnExists('journal', 'category_id')) {
+          DevLogger.log(
+            name: 'JournalDb',
+            message: 'Dropping the v20 journal.category_id column',
+          );
+          await customStatement('DROP INDEX IF EXISTS idx_journal_category_id');
+          await customStatement('ALTER TABLE journal DROP COLUMN category_id');
+        }
+      }();
+    }
   }
 }
 

--- a/test/database/category_backfill_migration_test.dart
+++ b/test/database/category_backfill_migration_test.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: cascade_invocations
 import 'dart:io';
 
 import 'package:flutter/services.dart';
@@ -7,6 +6,8 @@ import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqlite3/sqlite3.dart';
+
+import 'schema_fixtures.dart';
 
 /// Migration tests for v43 — `journal.category` backfill.
 ///
@@ -58,38 +59,6 @@ void main() {
     }
   });
 
-  /// Minimal v42-style schema: just the columns the v43 backfill reads.
-  void createV42Schema(Database sqlite) {
-    sqlite.execute('''
-      CREATE TABLE IF NOT EXISTS journal (
-        id TEXT PRIMARY KEY,
-        serialized TEXT NOT NULL,
-        created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL,
-        date_from INTEGER NOT NULL,
-        date_to INTEGER NOT NULL,
-        type TEXT NOT NULL,
-        subtype TEXT,
-        starred BOOLEAN DEFAULT FALSE,
-        private BOOLEAN DEFAULT FALSE,
-        deleted BOOLEAN DEFAULT FALSE,
-        task BOOLEAN DEFAULT FALSE,
-        task_status TEXT,
-        category TEXT NOT NULL DEFAULT '',
-        flag INTEGER DEFAULT 0,
-        schema_version INTEGER DEFAULT 0
-      )
-    ''');
-    sqlite.execute('''
-      CREATE TABLE IF NOT EXISTS config_flags (
-        name TEXT NOT NULL UNIQUE,
-        description TEXT NOT NULL UNIQUE,
-        status BOOLEAN NOT NULL DEFAULT FALSE,
-        PRIMARY KEY (name)
-      )
-    ''');
-  }
-
   void insertV42Entry(
     Database sqlite, {
     required String id,
@@ -115,7 +84,7 @@ void main() {
       () async {
         final dbFile = File(p.join(testDirectory!.path, 'test_v43.db'));
         final sqlite = sqlite3.open(dbFile.path);
-        createV42Schema(sqlite);
+        createJournalSchema(sqlite, 42);
         // Pre-migration column state, JSON truth in serialized:
         insertV42Entry(
           sqlite,
@@ -130,7 +99,6 @@ void main() {
           jsonCategoryId: 'cat-json-must-not-win',
         );
         insertV42Entry(sqlite, id: 'uncategorized', columnCategory: '');
-        sqlite.execute('PRAGMA user_version = 42');
         sqlite.close();
 
         final db = JournalDb(overriddenFilename: 'test_v43.db');
@@ -138,7 +106,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 46);
+        expect(db.schemaVersion, 47);
 
         final rows = await db
             .customSelect('SELECT id, category FROM journal ORDER BY id')

--- a/test/database/database_migration_recent_test.dart
+++ b/test/database/database_migration_recent_test.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as path;
 import 'package:sqlite3/sqlite3.dart';
 
 import '../widget_test_utils.dart';
+import 'schema_fixtures.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -49,54 +50,47 @@ void main() {
 
   test('v45 backfills and indexes Daily OS audio lookup identity', () async {
     final databaseFile = File(path.join(testDirectory.path, 'v45.db'));
-    sqlite3.open(databaseFile.path)
-      ..execute('''
-        CREATE TABLE journal (
-          id TEXT PRIMARY KEY,
-          serialized TEXT NOT NULL,
-          created_at INTEGER NOT NULL,
-          updated_at INTEGER NOT NULL,
-          date_from INTEGER NOT NULL,
-          date_to INTEGER NOT NULL,
-          deleted BOOLEAN NOT NULL DEFAULT FALSE,
-          type TEXT NOT NULL,
-          subtype TEXT
-        )
-      ''')
-      ..execute(
-        'INSERT INTO journal VALUES (?, ?, 0, 0, 0, 60, FALSE, ?, NULL)',
-        [
-          'audio-owner-a',
-          _serializedDayAudio(
-            dayId: 'dayplan-2026-07-18',
-            sessionId: 'duplicate-session',
-          ),
-          'JournalAudio',
-        ],
-      )
-      ..execute(
-        'INSERT INTO journal VALUES (?, ?, 0, 0, 60, 120, FALSE, ?, NULL)',
-        [
-          'audio-owner-b',
-          _serializedDayAudio(
-            dayId: 'dayplan-2026-07-18',
-            sessionId: 'duplicate-session',
-          ),
-          'JournalAudio',
-        ],
-      )
-      ..execute(
-        'INSERT INTO journal VALUES (?, ?, 0, 0, 0, 60, FALSE, ?, NULL)',
-        ['ordinary-entry', '{"data":{}}', 'JournalEntry'],
-      )
-      ..execute('PRAGMA user_version = 44')
+    final sqlite = sqlite3.open(databaseFile.path);
+    createJournalSchema(sqlite, 44);
+    const insert =
+        'INSERT INTO journal (id, serialized, created_at, updated_at, '
+        'date_from, date_to, deleted, type, subtype) '
+        'VALUES (?, ?, 0, 0, ?, ?, FALSE, ?, NULL)';
+    sqlite
+      ..execute(insert, [
+        'audio-owner-a',
+        _serializedDayAudio(
+          dayId: 'dayplan-2026-07-18',
+          sessionId: 'duplicate-session',
+        ),
+        0,
+        60,
+        'JournalAudio',
+      ])
+      ..execute(insert, [
+        'audio-owner-b',
+        _serializedDayAudio(
+          dayId: 'dayplan-2026-07-18',
+          sessionId: 'duplicate-session',
+        ),
+        60,
+        120,
+        'JournalAudio',
+      ])
+      ..execute(insert, [
+        'ordinary-entry',
+        '{"data":{}}',
+        0,
+        60,
+        'JournalEntry',
+      ])
       ..close();
 
     final db = JournalDb(overriddenFilename: 'v45.db');
     addTearDown(db.close);
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 46);
+    expect(version.read<int>('user_version'), 47);
     final rows = await db
         .customSelect(
           'SELECT id, day_id, recording_session_id FROM journal ORDER BY id',

--- a/test/database/database_migration_test.dart
+++ b/test/database/database_migration_test.dart
@@ -1,0 +1,171 @@
+// Tests for the migration strategy's index reconcile
+// (`lib/database/database_migration.dart`): the definition normaliser it
+// compares with, and the reconcile's behaviour on a real upgrade.
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Variable;
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/dev_logger.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart';
+
+import 'schema_fixtures.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('normaliseIndexDefinition', () {
+    test('ignores the spelling that does not change an index', () {
+      const declared = '''
+CREATE INDEX idx_journal_tasks_priority_date ON journal(
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE;''';
+      const asMigrationWroteIt =
+          'CREATE INDEX IF NOT EXISTS "idx_journal_tasks_priority_date" '
+          'ON journal ( task_priority_rank ASC, date_from DESC, id ) '
+          "where type='Task' and task=1 and deleted=false";
+      expect(
+        normaliseIndexDefinition(declared),
+        normaliseIndexDefinition(asMigrationWroteIt),
+      );
+    });
+
+    test('keeps what does change an index', () {
+      const base = 'CREATE INDEX i ON t(a, b DESC) WHERE x = 1';
+      for (final changed in const [
+        'CREATE INDEX i ON t(b DESC, a) WHERE x = 1', // column order
+        'CREATE INDEX i ON t(a, b) WHERE x = 1', // direction
+        'CREATE UNIQUE INDEX i ON t(a, b DESC) WHERE x = 1', // uniqueness
+        'CREATE INDEX i ON t(a, b DESC) WHERE x = 2', // predicate
+        'CREATE INDEX i ON t(a, b DESC)', // partial vs full
+        'CREATE INDEX i ON t(a, b DESC, c) WHERE x = 1', // extra column
+      ]) {
+        expect(
+          normaliseIndexDefinition(base),
+          isNot(normaliseIndexDefinition(changed)),
+          reason: changed,
+        );
+      }
+    });
+  });
+
+  group('index reconcile on upgrade', () {
+    late Directory testDirectory;
+    Directory? previousDirectory;
+
+    setUp(() {
+      if (getIt.isRegistered<Directory>()) {
+        previousDirectory = getIt<Directory>();
+        getIt.unregister<Directory>();
+      }
+      testDirectory = Directory.systemTemp.createTempSync('lotti_reconcile_');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            (MethodCall call) async => switch (call.method) {
+              'getApplicationDocumentsDirectory' ||
+              'getApplicationSupportDirectory' ||
+              'getTemporaryDirectory' => testDirectory.path,
+              _ => null,
+            },
+          );
+      getIt.registerSingleton<Directory>(testDirectory);
+      DevLogger.capturedLogs.clear();
+    });
+
+    tearDown(() async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            null,
+          );
+      getIt.unregister<Directory>();
+      if (previousDirectory != null) {
+        getIt.registerSingleton<Directory>(previousDirectory!);
+      }
+      if (testDirectory.existsSync()) {
+        testDirectory.deleteSync(recursive: true);
+      }
+    });
+
+    Future<String> indexSql(JournalDb db, String name) async {
+      final row = await db
+          .customSelect(
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?",
+            variables: [Variable.withString(name)],
+          )
+          .getSingle();
+      return row.read<String>('sql');
+    }
+
+    test(
+      'an index reshaped under the same name is rebuilt to the declared '
+      'definition',
+      () async {
+        final dbFile = File(p.join(testDirectory.path, 'reshaped.db'));
+        final sqlite = sqlite3.open(dbFile.path);
+        createJournalSchema(sqlite, 46);
+        // Same name, fewer columns: what an install would carry if a past
+        // migration had created this index in an older shape.
+        sqlite
+          ..execute('DROP INDEX idx_journal_tab')
+          ..execute('CREATE INDEX idx_journal_tab ON journal(type)')
+          ..close();
+
+        final db = JournalDb(overriddenFilename: 'reshaped.db');
+        addTearDown(db.close);
+        await db.customSelect('PRAGMA user_version').get();
+
+        final sql = await indexSql(db, 'idx_journal_tab');
+        expect(sql, contains('starred'));
+        expect(sql, contains('date_from COLLATE BINARY DESC'));
+        expect(
+          DevLogger.capturedLogs.any(
+            (line) => line.contains('Recreating index idx_journal_tab'),
+          ),
+          isTrue,
+          reason: DevLogger.capturedLogs.join('\n'),
+        );
+      },
+    );
+
+    test(
+      'an install whose indexes already match is not rebuilt for spelling',
+      () async {
+        final dbFile = File(p.join(testDirectory.path, 'matching.db'));
+        final sqlite = sqlite3.open(dbFile.path);
+        createJournalSchema(sqlite, 46);
+        sqlite.close();
+
+        final db = JournalDb(overriddenFilename: 'matching.db');
+        addTearDown(db.close);
+        await db.customSelect('PRAGMA user_version').get();
+
+        // v47 declares one new index; nothing that already existed is touched.
+        expect(
+          DevLogger.capturedLogs.where(
+            (line) =>
+                line.contains('Recreating index') ||
+                line.contains('Dropping undeclared index'),
+          ),
+          isEmpty,
+          reason: DevLogger.capturedLogs.join('\n'),
+        );
+        expect(
+          DevLogger.capturedLogs.where(
+            (line) => line.contains('Creating declared index'),
+          ),
+          hasLength(1),
+        );
+      },
+    );
+  });
+}

--- a/test/database/definition_indexes_migration_test.dart
+++ b/test/database/definition_indexes_migration_test.dart
@@ -72,7 +72,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 46);
+      expect(db.schemaVersion, 47);
 
       final indexes = await db.customSelect('''
         SELECT name, sql FROM sqlite_master

--- a/test/database/due_at_migration_test.dart
+++ b/test/database/due_at_migration_test.dart
@@ -174,7 +174,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 46);
+      expect(db.schemaVersion, 47);
 
       final hasColumn = await db.columnExistsForTesting('journal', 'due_at');
       expect(hasColumn, isTrue);

--- a/test/database/journal_schema_history_test.dart
+++ b/test/database/journal_schema_history_test.dart
@@ -9,12 +9,14 @@
 // hand-written approximation — the check drift_dev's `SchemaVerifier` would
 // run if its CLI built in this repository.
 //
-// The comparison is structural (tables, columns, indexes), normalised for
-// the cosmetic differences between `createAll()` and `ALTER TABLE` /
-// `CREATE INDEX` statements: column order, declared type spelling within
-// one affinity, and boolean default spelling. Anything else — a column,
-// default, constraint or index that a fresh install has and a migrated
-// database does not, or the reverse — fails the test with a readable diff.
+// The comparison is structural — tables, columns, foreign keys, the
+// implicit indexes behind table-level UNIQUE and PRIMARY KEY constraints,
+// and explicit indexes — normalised for the cosmetic differences between
+// `createAll()` and `ALTER TABLE` / `CREATE INDEX` statements: column
+// order, declared type spelling within one affinity, and boolean default
+// spelling. Anything else — a column, default, constraint or index that a
+// fresh install has and a migrated database does not, or the reverse —
+// fails the test with a readable diff.
 import 'dart:io';
 
 import 'package:flutter/foundation.dart' show immutable;
@@ -194,6 +196,23 @@ List<String> _diff({required _Schema fresh, required _Schema migrated}) {
     }
   }
 
+  for (final table in fresh.constraints.keys) {
+    final expected = fresh.constraints[table]!;
+    final actual = migrated.constraints[table];
+    if (actual == null) continue; // the missing table is reported above
+    for (final constraint in expected.difference(actual)) {
+      differences.add(
+        'constraint on $table: $constraint missing after migration',
+      );
+    }
+    for (final constraint in actual.difference(expected)) {
+      differences.add(
+        'constraint on $table: $constraint present after migration, not in a '
+        'fresh install',
+      );
+    }
+  }
+
   for (final index in fresh.indexes.keys) {
     final expected = fresh.indexes[index]!;
     final actual = migrated.indexes[index];
@@ -216,13 +235,20 @@ List<String> _diff({required _Schema fresh, required _Schema migrated}) {
   return differences;
 }
 
-/// A structural snapshot of a database: every user table with its columns,
+/// A structural snapshot of a database: every user table with its columns
+/// and constraints (foreign keys, and the implicit indexes behind table-level
+/// UNIQUE and PRIMARY KEY clauses, which `PRAGMA table_info` does not show),
 /// and every explicitly created index with its normalised definition.
 class _Schema {
-  const _Schema({required this.tables, required this.indexes});
+  const _Schema({
+    required this.tables,
+    required this.constraints,
+    required this.indexes,
+  });
 
   static Future<_Schema> of(JournalDb db) async {
     final tables = <String, Map<String, _Column>>{};
+    final constraints = <String, Set<String>>{};
     final tableRows = await db
         .customSelect(
           "SELECT name FROM sqlite_master WHERE type = 'table' "
@@ -244,6 +270,7 @@ class _Schema {
         );
       }
       tables[table] = columns;
+      constraints[table] = await _constraintsOf(db, table);
     }
 
     final indexes = <String, _Index>{};
@@ -259,10 +286,38 @@ class _Schema {
         definition: _normaliseIndexSql(row.read<String>('sql')),
       );
     }
-    return _Schema(tables: tables, indexes: indexes);
+    return _Schema(tables: tables, constraints: constraints, indexes: indexes);
+  }
+
+  /// Foreign keys as `fk(col->table.col, delete:x, update:y)` and constraint
+  /// indexes as `unique(a,b)` / `pk(a,b)`, so a missing cascade or a dropped
+  /// UNIQUE clause shows up by name.
+  static Future<Set<String>> _constraintsOf(JournalDb db, String table) async {
+    final result = <String>{};
+    for (final fk
+        in await db.customSelect('PRAGMA foreign_key_list("$table")').get()) {
+      result.add(
+        'fk(${fk.read<String>('from')}->${fk.read<String>('table')}.'
+        '${fk.read<String>('to')}, delete:${fk.read<String>('on_delete')}, '
+        'update:${fk.read<String>('on_update')})',
+      );
+    }
+    for (final index
+        in await db.customSelect('PRAGMA index_list("$table")').get()) {
+      final origin = index.read<String>('origin');
+      if (origin == 'c') continue; // explicit CREATE INDEX, compared by name
+      final name = index.read<String>('name');
+      final columns =
+          (await db.customSelect('PRAGMA index_info("$name")').get())
+              .map((row) => row.readNullable<String>('name') ?? '<expr>')
+              .join(',');
+      result.add('$origin($columns)');
+    }
+    return result;
   }
 
   final Map<String, Map<String, _Column>> tables;
+  final Map<String, Set<String>> constraints;
   final Map<String, _Index> indexes;
 }
 

--- a/test/database/journal_schema_history_test.dart
+++ b/test/database/journal_schema_history_test.dart
@@ -1,0 +1,368 @@
+// Migrates every committed historical JournalDb schema to the current
+// version and diffs the result against a fresh install.
+//
+// `test/database/schemas/journal_v<N>.sql` is the fresh-install schema at
+// version N, lifted from `lib/database/database.drift` at the last commit
+// where that version was current (see `tool/db_schema/`). A device that
+// installed at N and upgrades today starts from exactly that, so this is the
+// migration ladder tested against what actually shipped rather than a
+// hand-written approximation — the check drift_dev's `SchemaVerifier` would
+// run if its CLI built in this repository.
+//
+// The comparison is structural (tables, columns, indexes), normalised for
+// the cosmetic differences between `createAll()` and `ALTER TABLE` /
+// `CREATE INDEX` statements: column order, declared type spelling within
+// one affinity, and boolean default spelling. Anything else — a column,
+// default, constraint or index that a fresh install has and a migrated
+// database does not, or the reverse — fails the test with a readable diff.
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show immutable;
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart';
+
+import '../../tool/db_schema/drift_ddl.dart';
+import 'schema_fixtures.dart';
+
+/// Tables an upgraded database may still carry that a fresh install never
+/// creates. Each entry needs a reason; an unexplained extra table is a
+/// finding, not a tolerance.
+const _legacyTablesLeftInPlace = <String, String>{
+  'tag_entities':
+      'tags were removed from the schema in v25; the table was left in '
+      'place on existing installs rather than dropping user data',
+  'tagged':
+      'the tag assignment table from the same removal, kept for the same '
+      'reason',
+};
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory testDirectory;
+  Directory? previousDirectory;
+
+  setUp(() {
+    if (getIt.isRegistered<Directory>()) {
+      previousDirectory = getIt<Directory>();
+      getIt.unregister<Directory>();
+    }
+    testDirectory = Directory.systemTemp.createTempSync('lotti_schema_hist_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (MethodCall call) async => switch (call.method) {
+            'getApplicationDocumentsDirectory' ||
+            'getApplicationSupportDirectory' ||
+            'getTemporaryDirectory' => testDirectory.path,
+            _ => null,
+          },
+        );
+    getIt.registerSingleton<Directory>(testDirectory);
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    getIt.unregister<Directory>();
+    if (previousDirectory != null) {
+      getIt.registerSingleton<Directory>(previousDirectory!);
+    }
+    if (testDirectory.existsSync()) {
+      testDirectory.deleteSync(recursive: true);
+    }
+  });
+
+  final schemaFiles = committedJournalSchemas();
+
+  test('at least one historical schema is committed', () {
+    expect(schemaFiles, isNotEmpty);
+  });
+
+  test(
+    'the committed schema for the current version matches database.drift',
+    () async {
+      // The maintenance hook: bumping `schemaVersion` without committing the
+      // schema being left behind, or editing `database.drift` without
+      // re-extracting the current one, fails here.
+      final db = JournalDb(inMemoryDatabase: true);
+      addTearDown(db.close);
+      final current = journalSchemaFile(db.schemaVersion);
+      expect(
+        current.existsSync(),
+        isTrue,
+        reason:
+            'run: dart run tool/db_schema/extract_journal_schema.dart '
+            '--version ${db.schemaVersion} --ref HEAD',
+      );
+      expect(
+        extractDriftDdl(current.readAsStringSync()),
+        extractDriftDdl(
+          File('lib/database/database.drift').readAsStringSync(),
+        ),
+      );
+    },
+  );
+
+  group('a database installed at', () {
+    for (final entry in schemaFiles.entries) {
+      final version = entry.key;
+      test(
+        'v$version migrates to a schema identical to a fresh install',
+        () async {
+          final dbFile = File(
+            p.join(testDirectory.path, 'journal_v$version.db'),
+          );
+          final sqlite = sqlite3.open(dbFile.path);
+          createJournalSchema(sqlite, version);
+          sqlite.close();
+
+          final migrated = JournalDb(
+            overriddenFilename: 'journal_v$version.db',
+          );
+          addTearDown(migrated.close);
+          final fresh = JournalDb(inMemoryDatabase: true);
+          addTearDown(fresh.close);
+
+          final versionRow = await migrated
+              .customSelect('PRAGMA user_version')
+              .getSingle();
+          expect(versionRow.read<int>('user_version'), migrated.schemaVersion);
+
+          final differences = _diff(
+            fresh: await _Schema.of(fresh),
+            migrated: await _Schema.of(migrated),
+          );
+          expect(
+            differences,
+            isEmpty,
+            reason:
+                'migrated v$version differs from a fresh install:\n'
+                '${differences.join('\n')}',
+          );
+        },
+      );
+    }
+  });
+}
+
+List<String> _diff({required _Schema fresh, required _Schema migrated}) {
+  final differences = <String>[];
+
+  for (final table in fresh.tables.keys) {
+    if (!migrated.tables.containsKey(table)) {
+      differences.add('table $table: missing after migration');
+    }
+  }
+  for (final table in migrated.tables.keys) {
+    if (fresh.tables.containsKey(table)) continue;
+    if (_legacyTablesLeftInPlace.containsKey(table)) continue;
+    differences.add(
+      'table $table: present after migration, not in a fresh install',
+    );
+  }
+
+  for (final table in fresh.tables.keys) {
+    final freshColumns = fresh.tables[table]!;
+    final migratedColumns = migrated.tables[table];
+    if (migratedColumns == null) continue;
+    for (final column in freshColumns.keys) {
+      final expected = freshColumns[column]!;
+      final actual = migratedColumns[column];
+      if (actual == null) {
+        differences.add('column $table.$column: missing after migration');
+      } else if (actual != expected) {
+        differences.add(
+          'column $table.$column: fresh $expected, migrated $actual',
+        );
+      }
+    }
+    for (final column in migratedColumns.keys) {
+      if (!freshColumns.containsKey(column)) {
+        differences.add(
+          'column $table.$column: present after migration, not in a fresh '
+          'install',
+        );
+      }
+    }
+  }
+
+  for (final index in fresh.indexes.keys) {
+    final expected = fresh.indexes[index]!;
+    final actual = migrated.indexes[index];
+    if (actual == null) {
+      differences.add('index $index: missing after migration');
+    } else if (actual != expected) {
+      differences.add('index $index: fresh $expected, migrated $actual');
+    }
+  }
+  for (final index in migrated.indexes.keys) {
+    if (fresh.indexes.containsKey(index)) continue;
+    final table = migrated.indexes[index]!.table;
+    if (_legacyTablesLeftInPlace.containsKey(table)) continue;
+    differences.add(
+      'index $index on $table: present after migration, not in a fresh '
+      'install',
+    );
+  }
+
+  return differences;
+}
+
+/// A structural snapshot of a database: every user table with its columns,
+/// and every explicitly created index with its normalised definition.
+class _Schema {
+  const _Schema({required this.tables, required this.indexes});
+
+  static Future<_Schema> of(JournalDb db) async {
+    final tables = <String, Map<String, _Column>>{};
+    final tableRows = await db
+        .customSelect(
+          "SELECT name FROM sqlite_master WHERE type = 'table' "
+          "AND name NOT LIKE 'sqlite_%' ORDER BY name",
+        )
+        .get();
+    for (final row in tableRows) {
+      final table = row.read<String>('name');
+      final columns = <String, _Column>{};
+      for (final info
+          in await db.customSelect('PRAGMA table_info("$table")').get()) {
+        columns[info.read<String>('name')] = _Column(
+          affinity: _affinity(info.read<String>('type')),
+          notNull: info.read<int>('notnull') == 1,
+          defaultValue: _normaliseDefault(
+            info.readNullable<String>('dflt_value'),
+          ),
+          primaryKey: info.read<int>('pk') > 0,
+        );
+      }
+      tables[table] = columns;
+    }
+
+    final indexes = <String, _Index>{};
+    final indexRows = await db
+        .customSelect(
+          "SELECT name, tbl_name, sql FROM sqlite_master WHERE type = 'index' "
+          'AND sql IS NOT NULL ORDER BY name',
+        )
+        .get();
+    for (final row in indexRows) {
+      indexes[row.read<String>('name')] = _Index(
+        table: row.read<String>('tbl_name'),
+        definition: _normaliseIndexSql(row.read<String>('sql')),
+      );
+    }
+    return _Schema(tables: tables, indexes: indexes);
+  }
+
+  final Map<String, Map<String, _Column>> tables;
+  final Map<String, _Index> indexes;
+}
+
+@immutable
+class _Column {
+  const _Column({
+    required this.affinity,
+    required this.notNull,
+    required this.defaultValue,
+    required this.primaryKey,
+  });
+
+  final String affinity;
+  final bool notNull;
+  final String? defaultValue;
+  final bool primaryKey;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _Column &&
+      other.affinity == affinity &&
+      other.notNull == notNull &&
+      other.defaultValue == defaultValue &&
+      other.primaryKey == primaryKey;
+
+  @override
+  int get hashCode => Object.hash(affinity, notNull, defaultValue, primaryKey);
+
+  @override
+  String toString() =>
+      '$affinity${notNull ? ' NOT NULL' : ''}'
+      '${defaultValue == null ? '' : ' DEFAULT $defaultValue'}'
+      '${primaryKey ? ' PRIMARY KEY' : ''}';
+}
+
+@immutable
+class _Index {
+  const _Index({required this.table, required this.definition});
+
+  final String table;
+  final String definition;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _Index && other.table == table && other.definition == definition;
+
+  @override
+  int get hashCode => Object.hash(table, definition);
+
+  @override
+  String toString() => definition;
+}
+
+/// SQLite type affinity of a declared type, so `BOOLEAN`, `INTEGER` and
+/// `DATETIME` (all INTEGER affinity, and all used interchangeably between
+/// `.drift` DDL and Drift's generated `ALTER TABLE`) compare equal.
+String _affinity(String declared) {
+  final upper = declared.toUpperCase();
+  if (upper.contains('INT') ||
+      upper.contains('BOOL') ||
+      upper.contains('DATE')) {
+    return 'INTEGER';
+  }
+  if (upper.contains('CHAR') ||
+      upper.contains('CLOB') ||
+      upper.contains('TEXT')) {
+    return 'TEXT';
+  }
+  if (upper.contains('BLOB') || upper.isEmpty) return 'BLOB';
+  if (upper.contains('REAL') ||
+      upper.contains('FLOA') ||
+      upper.contains('DOUB')) {
+    return 'REAL';
+  }
+  return 'NUMERIC';
+}
+
+String? _normaliseDefault(String? raw) {
+  if (raw == null) return null;
+  final value = raw.trim().toLowerCase();
+  if (value == 'false') return '0';
+  if (value == 'true') return '1';
+  if (value == "''") return "''";
+  return value;
+}
+
+/// Lower-cases, collapses whitespace, and strips the tokens that vary
+/// between the `.drift` DDL and the raw `CREATE INDEX` strings in the
+/// migration steps without changing what the index is.
+String _normaliseIndexSql(String sql) {
+  return sql
+      .toLowerCase()
+      .replaceAll(RegExp(r'\s+'), ' ')
+      .replaceAll(' if not exists', '')
+      .replaceAll('"', '')
+      .replaceAll(RegExp(r'\s*\(\s*'), '(')
+      .replaceAll(RegExp(r'\s*\)\s*'), ')')
+      .replaceAll(RegExp(r'\s*,\s*'), ',')
+      .replaceAll(' collate binary', '')
+      .replaceAll(' asc', '')
+      .replaceAll(RegExp(r'\s*=\s*'), '=')
+      .trim();
+}

--- a/test/database/labels_migration_test.dart
+++ b/test/database/labels_migration_test.dart
@@ -13,6 +13,7 @@ import 'package:path/path.dart' as path;
 import 'package:sqlite3/sqlite3.dart';
 
 import 'migration_test_helper.dart';
+import 'schema_fixtures.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -64,27 +65,8 @@ void main() {
       final dbFile = File(path.join(testDirectory!.path, 'test_v26.db'));
       final sqlite = sqlite3.open(dbFile.path);
 
-      // First create basic schema at v25 (without label tables)
-      createJournalTable(sqlite, version: 25);
-
-      createLegacyTagEntitiesTable(sqlite);
-
-      sqlite.execute('''
-        CREATE TABLE IF NOT EXISTS category_definitions (
-          id TEXT PRIMARY KEY,
-          serialized TEXT NOT NULL,
-          created_at INTEGER NOT NULL,
-          updated_at INTEGER NOT NULL,
-          deleted BOOLEAN DEFAULT FALSE,
-          private BOOLEAN DEFAULT FALSE,
-          schema_version INTEGER DEFAULT 0
-        )
-      ''');
-
-      createLinkedEntriesTableWithBuggyIndex(sqlite);
-
-      // Set schema version to 25
-      sqlite.execute('PRAGMA user_version = 25');
+      // The real v25 schema, as it shipped: no label tables yet.
+      createJournalSchema(sqlite, 25);
 
       // Close raw connection
       sqlite.close();

--- a/test/database/linked_entries_index_migration_test.dart
+++ b/test/database/linked_entries_index_migration_test.dart
@@ -96,7 +96,7 @@ void main() {
       // Schema version advanced to the current schema
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 46);
+      expect(db.schemaVersion, 47);
 
       // The corrected index now references to_id in its column list
       final postMigrationIdx = await db.customSelect("""

--- a/test/database/priority_migration_test.dart
+++ b/test/database/priority_migration_test.dart
@@ -142,7 +142,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 46);
+        expect(db.schemaVersion, 47);
 
         // The non-partial composite `idx_journal_tasks_due_active` was
         // dropped in v41 — its only consumer (`getTasksSortedByDueDate`)
@@ -175,7 +175,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 46);
+      expect(db.schemaVersion, 47);
 
       final idx = await db.customSelect("""
         SELECT sql FROM sqlite_master
@@ -255,7 +255,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 46);
+        expect(db.schemaVersion, 47);
 
         final idx = await db.customSelect("""
         SELECT sql FROM sqlite_master
@@ -344,7 +344,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 46);
+        expect(db.schemaVersion, 47);
 
         final taskIdx = await db.customSelect("""
         SELECT sql FROM sqlite_master

--- a/test/database/redundant_indexes_v46_migration_test.dart
+++ b/test/database/redundant_indexes_v46_migration_test.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: cascade_invocations
 import 'dart:io';
 
 import 'package:flutter/services.dart';
@@ -7,6 +6,8 @@ import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqlite3/sqlite3.dart';
+
+import 'schema_fixtures.dart';
 
 /// The nine indexes v46 drops. Each duplicated an index SQLite already had:
 /// single-column DESC twins, primary-key indexes on the definition tables,
@@ -81,87 +82,6 @@ void main() {
     }
   });
 
-  /// A v45-shaped database reduced to the tables the dropped indexes sit on,
-  /// carrying every redundant index next to the index that covers it.
-  void createV45Schema(Database sqlite) {
-    sqlite.execute('''
-      CREATE TABLE journal (
-        id TEXT PRIMARY KEY,
-        serialized TEXT NOT NULL,
-        created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL,
-        date_from INTEGER NOT NULL,
-        date_to INTEGER NOT NULL,
-        deleted BOOLEAN NOT NULL DEFAULT FALSE,
-        type TEXT NOT NULL,
-        subtype TEXT
-      )
-    ''');
-    sqlite.execute(
-      'CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC)',
-    );
-    sqlite.execute(
-      'CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC)',
-    );
-    sqlite.execute(
-      'CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC)',
-    );
-    sqlite.execute(
-      'CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC)',
-    );
-
-    for (final table in [
-      'habit_definitions',
-      'category_definitions',
-      'label_definitions',
-      'dashboard_definitions',
-    ]) {
-      sqlite.execute('''
-        CREATE TABLE $table (
-          id TEXT NOT NULL,
-          name TEXT NOT NULL,
-          serialized TEXT NOT NULL,
-          PRIMARY KEY (id)
-        )
-      ''');
-      sqlite.execute('CREATE INDEX idx_${table}_id ON $table (id)');
-      sqlite.execute('CREATE INDEX idx_${table}_name ON $table (name)');
-    }
-
-    sqlite.execute('''
-      CREATE TABLE linked_entries (
-        id TEXT NOT NULL UNIQUE,
-        from_id TEXT NOT NULL,
-        to_id TEXT NOT NULL,
-        type TEXT NOT NULL,
-        serialized TEXT NOT NULL,
-        hidden BOOLEAN DEFAULT FALSE,
-        PRIMARY KEY (id),
-        UNIQUE(from_id, to_id, type)
-      )
-    ''');
-    sqlite.execute(
-      'CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id)',
-    );
-    sqlite.execute(
-      'CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id)',
-    );
-    sqlite.execute(
-      'CREATE INDEX idx_linked_entries_type ON linked_entries (type)',
-    );
-    sqlite.execute(
-      'CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden)',
-    );
-    sqlite.execute('''
-      CREATE INDEX idx_linked_entries_from_id_hidden
-        ON linked_entries (from_id, hidden)
-    ''');
-    sqlite.execute('''
-      CREATE INDEX idx_linked_entries_to_id_hidden
-        ON linked_entries (to_id, hidden)
-    ''');
-  }
-
   Future<Set<String>> indexNames(JournalDb db) async {
     final rows = await db
         .customSelect("SELECT name FROM sqlite_master WHERE type = 'index'")
@@ -174,8 +94,8 @@ void main() {
         'neighbours', () async {
       final dbFile = File(p.join(testDirectory!.path, 'test_v46.db'));
       final sqlite = sqlite3.open(dbFile.path);
-      createV45Schema(sqlite);
-      sqlite.execute('PRAGMA user_version = 45');
+      // The real v45 schema, which declared every one of the nine.
+      createJournalSchema(sqlite, 45);
       sqlite.close();
 
       final db = JournalDb(overriddenFilename: 'test_v46.db');
@@ -183,7 +103,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 46);
+      expect(db.schemaVersion, 47);
 
       final names = await indexNames(db);
       expect(names.intersection(_redundant), isEmpty);
@@ -193,27 +113,16 @@ void main() {
     test('a database that never had them upgrades cleanly', () async {
       final dbFile = File(p.join(testDirectory!.path, 'test_v46_bare.db'));
       final sqlite = sqlite3.open(dbFile.path);
-      sqlite.execute('''
-        CREATE TABLE journal (
-          id TEXT PRIMARY KEY,
-          serialized TEXT NOT NULL,
-          created_at INTEGER NOT NULL,
-          updated_at INTEGER NOT NULL,
-          date_from INTEGER NOT NULL,
-          date_to INTEGER NOT NULL,
-          deleted BOOLEAN NOT NULL DEFAULT FALSE,
-          type TEXT NOT NULL,
-          subtype TEXT
-        )
-      ''');
-      sqlite.execute('PRAGMA user_version = 45');
+      // v46 is the first schema without them.
+      createJournalSchema(sqlite, 46);
       sqlite.close();
 
       final db = JournalDb(overriddenFilename: 'test_v46_bare.db');
       addTearDown(db.close);
 
       final version = await db.customSelect('PRAGMA user_version').get();
-      expect(version.first.read<int>('user_version'), 46);
+      expect(version.first.read<int>('user_version'), 47);
+      expect((await indexNames(db)).intersection(_redundant), isEmpty);
     });
 
     test('a fresh database is created without them', () async {

--- a/test/database/schema_fixtures.dart
+++ b/test/database/schema_fixtures.dart
@@ -1,0 +1,56 @@
+/// Seeds a raw SQLite database with the fresh-install `JournalDb` schema of
+/// a past version, as it actually shipped.
+///
+/// The schemas live in `test/database/schemas/journal_v<N>.sql`, extracted
+/// from `lib/database/database.drift` in git history by
+/// `tool/db_schema/extract_journal_schema.dart`. A migration test that
+/// starts from one of these starts from what a real device installed at
+/// that version has — every column, every index — so the migration ladder
+/// (and the index reconcile that ends it) runs against the real thing
+/// rather than a hand-written subset that happens to have the columns the
+/// step under test touches.
+library;
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart';
+
+import '../../tool/db_schema/drift_ddl.dart';
+
+const journalSchemaDirectory = 'test/database/schemas';
+
+/// The committed schema file for journal [version].
+File journalSchemaFile(int version) =>
+    File(p.join(journalSchemaDirectory, 'journal_v$version.sql'));
+
+/// Every committed journal schema, keyed by version, ascending.
+Map<int, File> committedJournalSchemas() {
+  final pattern = RegExp(r'^journal_v(\d+)\.sql$');
+  final files = <int, File>{};
+  for (final entity in Directory(journalSchemaDirectory).listSync()) {
+    if (entity is! File) continue;
+    final match = pattern.firstMatch(p.basename(entity.path));
+    if (match == null) continue;
+    files[int.parse(match.group(1)!)] = entity;
+  }
+  return Map.fromEntries(
+    files.entries.toList()..sort((a, b) => a.key.compareTo(b.key)),
+  );
+}
+
+/// Creates every table and index of journal schema [version] in [sqlite]
+/// and stamps `PRAGMA user_version` with it, so opening the file with
+/// `JournalDb` runs the migration from exactly that version.
+void createJournalSchema(Database sqlite, int version) {
+  final file = journalSchemaFile(version);
+  if (!file.existsSync()) {
+    throw StateError(
+      'No committed schema for journal v$version; run '
+      'dart run tool/db_schema/extract_journal_schema.dart '
+      '--version $version --ref <commit where that version was current>',
+    );
+  }
+  extractDriftDdl(file.readAsStringSync()).forEach(sqlite.execute);
+  sqlite.execute('PRAGMA user_version = $version');
+}

--- a/test/database/schemas/journal_v18.sql
+++ b/test/database/schemas/journal_v18.sql
@@ -1,0 +1,179 @@
+-- JournalDb fresh-install schema at schemaVersion 18.
+-- Extracted from lib/database/database.drift at 79bf3b7c0
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_created_at ON journal (created_at);
+
+CREATE INDEX idx_journal_updated_at ON journal (updated_at);
+
+CREATE INDEX idx_journal_date_from ON journal (date_from);
+
+CREATE INDEX idx_journal_date_to ON journal (date_to);
+
+CREATE INDEX idx_journal_deleted ON journal (deleted);
+
+CREATE INDEX idx_journal_starred ON journal (starred);
+
+CREATE INDEX idx_journal_private ON journal (private);
+
+CREATE INDEX idx_journal_task ON journal (task);
+
+CREATE INDEX idx_journal_task_status ON journal (task_status);
+
+CREATE INDEX idx_journal_flag ON journal (flag);
+
+CREATE INDEX idx_journal_type ON journal (type);
+
+CREATE INDEX idx_journal_subtype ON journal (subtype);
+
+CREATE INDEX idx_journal_geohash_string ON journal (geohash_string);
+
+CREATE INDEX idx_journal_geohash_int ON journal (geohash_int);
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE tag_entities (
+  id TEXT NOT NULL UNIQUE,
+  tag TEXT NOT NULL,
+  type TEXT NOT NULL,
+  inactive BOOLEAN DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(tag, type)
+);
+
+CREATE INDEX idx_tag_entities_id ON tag_entities (id);
+
+CREATE INDEX idx_tag_entities_tag ON tag_entities (tag);
+
+CREATE INDEX idx_tag_entities_type ON tag_entities (type);
+
+CREATE INDEX idx_tag_entities_private ON tag_entities (private);
+
+CREATE INDEX idx_tag_entities_inactive ON tag_entities (inactive);
+
+CREATE TABLE tagged (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  tag_entity_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(tag_entity_id) REFERENCES tag_entities(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, tag_entity_id)
+);
+
+CREATE INDEX idx_tagged_journal_id ON tagged (journal_id);
+
+CREATE INDEX idx_tagged_tag_entity_id ON tagged (tag_entity_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+/* Queries;
+

--- a/test/database/schemas/journal_v19.sql
+++ b/test/database/schemas/journal_v19.sql
@@ -1,0 +1,197 @@
+-- JournalDb fresh-install schema at schemaVersion 19.
+-- Extracted from lib/database/database.drift at d4a9a1f5a
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_created_at ON journal (created_at);
+
+CREATE INDEX idx_journal_updated_at ON journal (updated_at);
+
+CREATE INDEX idx_journal_date_from ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to ON journal (date_to);
+
+CREATE INDEX idx_journal_deleted ON journal (deleted);
+
+CREATE INDEX idx_journal_starred ON journal (starred);
+
+CREATE INDEX idx_journal_private ON journal (private);
+
+CREATE INDEX idx_journal_task ON journal (task);
+
+CREATE INDEX idx_journal_task_status ON journal (task_status);
+
+CREATE INDEX idx_journal_flag ON journal (flag);
+
+CREATE INDEX idx_journal_type ON journal (type);
+
+CREATE INDEX idx_journal_subtype ON journal (subtype);
+
+CREATE INDEX idx_journal_geohash_string ON journal (geohash_string);
+
+CREATE INDEX idx_journal_geohash_int ON journal (geohash_int);
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE tag_entities (
+  id TEXT NOT NULL UNIQUE,
+  tag TEXT NOT NULL,
+  type TEXT NOT NULL,
+  inactive BOOLEAN DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(tag, type)
+);
+
+CREATE INDEX idx_tag_entities_id ON tag_entities (id);
+
+CREATE INDEX idx_tag_entities_tag ON tag_entities (tag);
+
+CREATE INDEX idx_tag_entities_type ON tag_entities (type);
+
+CREATE INDEX idx_tag_entities_private ON tag_entities (private);
+
+CREATE INDEX idx_tag_entities_inactive ON tag_entities (inactive);
+
+CREATE TABLE tagged (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  tag_entity_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(tag_entity_id) REFERENCES tag_entities(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, tag_entity_id)
+);
+
+CREATE INDEX idx_tagged_journal_id ON tagged (journal_id);
+
+CREATE INDEX idx_tagged_tag_entity_id ON tagged (tag_entity_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+/* Queries;
+

--- a/test/database/schemas/journal_v20.sql
+++ b/test/database/schemas/journal_v20.sql
@@ -1,0 +1,200 @@
+-- JournalDb fresh-install schema at schemaVersion 20.
+-- Extracted from lib/database/database.drift at 848b6fbab
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category_id TEXT,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_created_at ON journal (created_at);
+
+CREATE INDEX idx_journal_updated_at ON journal (updated_at);
+
+CREATE INDEX idx_journal_date_from ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to ON journal (date_to);
+
+CREATE INDEX idx_journal_deleted ON journal (deleted);
+
+CREATE INDEX idx_journal_starred ON journal (starred);
+
+CREATE INDEX idx_journal_private ON journal (private);
+
+CREATE INDEX idx_journal_task ON journal (task);
+
+CREATE INDEX idx_journal_task_status ON journal (task_status);
+
+CREATE INDEX idx_journal_flag ON journal (flag);
+
+CREATE INDEX idx_journal_type ON journal (type);
+
+CREATE INDEX idx_journal_subtype ON journal (subtype);
+
+CREATE INDEX idx_journal_geohash_string ON journal (geohash_string);
+
+CREATE INDEX idx_journal_geohash_int ON journal (geohash_int);
+
+CREATE INDEX idx_journal_category_id ON journal (category_id);
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE tag_entities (
+  id TEXT NOT NULL UNIQUE,
+  tag TEXT NOT NULL,
+  type TEXT NOT NULL,
+  inactive BOOLEAN DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(tag, type)
+);
+
+CREATE INDEX idx_tag_entities_id ON tag_entities (id);
+
+CREATE INDEX idx_tag_entities_tag ON tag_entities (tag);
+
+CREATE INDEX idx_tag_entities_type ON tag_entities (type);
+
+CREATE INDEX idx_tag_entities_private ON tag_entities (private);
+
+CREATE INDEX idx_tag_entities_inactive ON tag_entities (inactive);
+
+CREATE TABLE tagged (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  tag_entity_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(tag_entity_id) REFERENCES tag_entities(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, tag_entity_id)
+);
+
+CREATE INDEX idx_tagged_journal_id ON tagged (journal_id);
+
+CREATE INDEX idx_tagged_tag_entity_id ON tagged (tag_entity_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+/* Queries;
+

--- a/test/database/schemas/journal_v21.sql
+++ b/test/database/schemas/journal_v21.sql
@@ -1,0 +1,200 @@
+-- JournalDb fresh-install schema at schemaVersion 21.
+-- Extracted from lib/database/database.drift at b4bf4ec63
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_created_at ON journal (created_at);
+
+CREATE INDEX idx_journal_updated_at ON journal (updated_at);
+
+CREATE INDEX idx_journal_date_from ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to ON journal (date_to);
+
+CREATE INDEX idx_journal_deleted ON journal (deleted);
+
+CREATE INDEX idx_journal_starred ON journal (starred);
+
+CREATE INDEX idx_journal_private ON journal (private);
+
+CREATE INDEX idx_journal_task ON journal (task);
+
+CREATE INDEX idx_journal_task_status ON journal (task_status);
+
+CREATE INDEX idx_journal_flag ON journal (flag);
+
+CREATE INDEX idx_journal_type ON journal (type);
+
+CREATE INDEX idx_journal_subtype ON journal (subtype);
+
+CREATE INDEX idx_journal_geohash_string ON journal (geohash_string);
+
+CREATE INDEX idx_journal_geohash_int ON journal (geohash_int);
+
+CREATE INDEX idx_journal_category ON journal (category);
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE tag_entities (
+  id TEXT NOT NULL UNIQUE,
+  tag TEXT NOT NULL,
+  type TEXT NOT NULL,
+  inactive BOOLEAN DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(tag, type)
+);
+
+CREATE INDEX idx_tag_entities_id ON tag_entities (id);
+
+CREATE INDEX idx_tag_entities_tag ON tag_entities (tag);
+
+CREATE INDEX idx_tag_entities_type ON tag_entities (type);
+
+CREATE INDEX idx_tag_entities_private ON tag_entities (private);
+
+CREATE INDEX idx_tag_entities_inactive ON tag_entities (inactive);
+
+CREATE TABLE tagged (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  tag_entity_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(tag_entity_id) REFERENCES tag_entities(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, tag_entity_id)
+);
+
+CREATE INDEX idx_tagged_journal_id ON tagged (journal_id);
+
+CREATE INDEX idx_tagged_tag_entity_id ON tagged (tag_entity_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+/* Queries;
+

--- a/test/database/schemas/journal_v23.sql
+++ b/test/database/schemas/journal_v23.sql
@@ -1,0 +1,205 @@
+-- JournalDb fresh-install schema at schemaVersion 23.
+-- Extracted from lib/database/database.drift at 8f0e1d6a2
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_created_at ON journal (created_at);
+
+CREATE INDEX idx_journal_updated_at ON journal (updated_at);
+
+CREATE INDEX idx_journal_date_from ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to ON journal (date_to);
+
+CREATE INDEX idx_journal_deleted ON journal (deleted);
+
+CREATE INDEX idx_journal_starred ON journal (starred);
+
+CREATE INDEX idx_journal_private ON journal (private);
+
+CREATE INDEX idx_journal_task ON journal (task);
+
+CREATE INDEX idx_journal_task_status ON journal (task_status);
+
+CREATE INDEX idx_journal_flag ON journal (flag);
+
+CREATE INDEX idx_journal_type ON journal (type);
+
+CREATE INDEX idx_journal_subtype ON journal (subtype);
+
+CREATE INDEX idx_journal_geohash_string ON journal (geohash_string);
+
+CREATE INDEX idx_journal_geohash_int ON journal (geohash_int);
+
+CREATE INDEX idx_journal_category ON journal (category);
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE tag_entities (
+  id TEXT NOT NULL UNIQUE,
+  tag TEXT NOT NULL,
+  type TEXT NOT NULL,
+  inactive BOOLEAN DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(tag, type)
+);
+
+CREATE INDEX idx_tag_entities_id ON tag_entities (id);
+
+CREATE INDEX idx_tag_entities_tag ON tag_entities (tag);
+
+CREATE INDEX idx_tag_entities_type ON tag_entities (type);
+
+CREATE INDEX idx_tag_entities_private ON tag_entities (private);
+
+CREATE INDEX idx_tag_entities_inactive ON tag_entities (inactive);
+
+CREATE TABLE tagged (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  tag_entity_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(tag_entity_id) REFERENCES tag_entities(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, tag_entity_id)
+);
+
+CREATE INDEX idx_tagged_journal_id ON tagged (journal_id);
+
+CREATE INDEX idx_tagged_tag_entity_id ON tagged (tag_entity_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
+
+/* Queries;
+

--- a/test/database/schemas/journal_v24.sql
+++ b/test/database/schemas/journal_v24.sql
@@ -1,0 +1,219 @@
+-- JournalDb fresh-install schema at schemaVersion 24.
+-- Extracted from lib/database/database.drift at 3bc19f6e3
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_created_at ON journal (created_at);
+
+CREATE INDEX idx_journal_updated_at ON journal (updated_at);
+
+CREATE INDEX idx_journal_date_from ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to ON journal (date_to);
+
+CREATE INDEX idx_journal_deleted ON journal (deleted);
+
+CREATE INDEX idx_journal_starred ON journal (starred);
+
+CREATE INDEX idx_journal_private ON journal (private);
+
+CREATE INDEX idx_journal_task ON journal (task);
+
+CREATE INDEX idx_journal_task_status ON journal (task_status);
+
+CREATE INDEX idx_journal_flag ON journal (flag);
+
+CREATE INDEX idx_journal_type ON journal (type);
+
+CREATE INDEX idx_journal_subtype ON journal (subtype);
+
+CREATE INDEX idx_journal_geohash_string ON journal (geohash_string);
+
+CREATE INDEX idx_journal_geohash_int ON journal (geohash_int);
+
+CREATE INDEX idx_journal_category ON journal (category);
+
+CREATE INDEX idx_journal_composite ON journal(type COLLATE BINARY ASC, private COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, deleted COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_habit_completions ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, deleted COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY ASC, date_from COLLATE BINARY DESC, date_to COLLATE BINARY ASC, date_to COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_habit_completions2 ON journal(type COLLATE BINARY ASC, deleted COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY ASC, date_from COLLATE BINARY DESC, created_at COLLATE BINARY ASC);
+
+CREATE INDEX idx_journal_linked ON journal(id COLLATE BINARY ASC, private COLLATE BINARY ASC, deleted COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_filtered_tasks ON journal(type COLLATE BINARY ASC, private COLLATE BINARY ASC, starred COLLATE BINARY ASC, private COLLATE BINARY ASC, deleted COLLATE BINARY ASC, task COLLATE BINARY ASC, task_status COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE tag_entities (
+  id TEXT NOT NULL UNIQUE,
+  tag TEXT NOT NULL,
+  type TEXT NOT NULL,
+  inactive BOOLEAN DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(tag, type)
+);
+
+CREATE INDEX idx_tag_entities_id ON tag_entities (id);
+
+CREATE INDEX idx_tag_entities_tag ON tag_entities (tag);
+
+CREATE INDEX idx_tag_entities_type ON tag_entities (type);
+
+CREATE INDEX idx_tag_entities_private ON tag_entities (private);
+
+CREATE INDEX idx_tag_entities_inactive ON tag_entities (inactive);
+
+CREATE TABLE tagged (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  tag_entity_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(tag_entity_id) REFERENCES tag_entities(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, tag_entity_id)
+);
+
+CREATE INDEX idx_tagged_journal_id ON tagged (journal_id);
+
+CREATE INDEX idx_tagged_tag_entity_id ON tagged (tag_entity_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+/* Queries;
+

--- a/test/database/schemas/journal_v25.sql
+++ b/test/database/schemas/journal_v25.sql
@@ -1,0 +1,193 @@
+-- JournalDb fresh-install schema at schemaVersion 25.
+-- Extracted from lib/database/database.drift at 68e5b7a28
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
+
+CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
+
+CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC);
+
+CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_tasks ON journal(type COLLATE BINARY ASC, task_status COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_type_subtype ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE tag_entities (
+  id TEXT NOT NULL UNIQUE,
+  tag TEXT NOT NULL,
+  type TEXT NOT NULL,
+  inactive BOOLEAN DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(tag, type)
+);
+
+CREATE INDEX idx_tag_entities_id ON tag_entities (id);
+
+CREATE INDEX idx_tag_entities_tag ON tag_entities (tag);
+
+CREATE INDEX idx_tag_entities_type ON tag_entities (type);
+
+CREATE INDEX idx_tag_entities_private ON tag_entities (private);
+
+CREATE INDEX idx_tag_entities_inactive ON tag_entities (inactive);
+
+CREATE TABLE tagged (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  tag_entity_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(tag_entity_id) REFERENCES tag_entities(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, tag_entity_id)
+);
+
+CREATE INDEX idx_tagged_journal_id ON tagged (journal_id);
+
+CREATE INDEX idx_tagged_tag_entity_id ON tagged (tag_entity_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+/* Queries;
+

--- a/test/database/schemas/journal_v28.sql
+++ b/test/database/schemas/journal_v28.sql
@@ -1,0 +1,225 @@
+-- JournalDb fresh-install schema at schemaVersion 28.
+-- Extracted from lib/database/database.drift at e67e35ae3
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
+
+CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
+
+CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC);
+
+CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_tasks ON journal(type COLLATE BINARY ASC, task_status COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_type_subtype ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE label_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  color TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_label_definitions_id ON label_definitions (id);
+
+CREATE INDEX idx_label_definitions_name ON label_definitions (name);
+
+CREATE INDEX idx_label_definitions_private ON label_definitions (private);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE tag_entities (
+  id TEXT NOT NULL UNIQUE,
+  tag TEXT NOT NULL,
+  type TEXT NOT NULL,
+  inactive BOOLEAN DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(tag, type)
+);
+
+CREATE INDEX idx_tag_entities_id ON tag_entities (id);
+
+CREATE INDEX idx_tag_entities_tag ON tag_entities (tag);
+
+CREATE INDEX idx_tag_entities_type ON tag_entities (type);
+
+CREATE INDEX idx_tag_entities_private ON tag_entities (private);
+
+CREATE INDEX idx_tag_entities_inactive ON tag_entities (inactive);
+
+CREATE TABLE tagged (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  tag_entity_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(tag_entity_id) REFERENCES tag_entities(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, tag_entity_id)
+);
+
+CREATE INDEX idx_tagged_journal_id ON tagged (journal_id);
+
+CREATE INDEX idx_tagged_tag_entity_id ON tagged (tag_entity_id);
+
+CREATE TABLE labeled (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  label_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(label_id) REFERENCES label_definitions(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, label_id)
+);
+
+CREATE INDEX idx_labeled_journal_id ON labeled (journal_id);
+
+CREATE INDEX idx_labeled_label_id ON labeled (label_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+/* Queries;
+

--- a/test/database/schemas/journal_v29.sql
+++ b/test/database/schemas/journal_v29.sql
@@ -1,0 +1,233 @@
+-- JournalDb fresh-install schema at schemaVersion 29.
+-- Extracted from lib/database/database.drift at 153cf50f0
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  task_priority TEXT,
+  task_priority_rank INTEGER,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
+
+CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
+
+CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC);
+
+CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_tasks ON journal(
+  type COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  category COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_journal_type_subtype ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE label_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  color TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_label_definitions_id ON label_definitions (id);
+
+CREATE INDEX idx_label_definitions_name ON label_definitions (name);
+
+CREATE INDEX idx_label_definitions_private ON label_definitions (private);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE tag_entities (
+  id TEXT NOT NULL UNIQUE,
+  tag TEXT NOT NULL,
+  type TEXT NOT NULL,
+  inactive BOOLEAN DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(tag, type)
+);
+
+CREATE INDEX idx_tag_entities_id ON tag_entities (id);
+
+CREATE INDEX idx_tag_entities_tag ON tag_entities (tag);
+
+CREATE INDEX idx_tag_entities_type ON tag_entities (type);
+
+CREATE INDEX idx_tag_entities_private ON tag_entities (private);
+
+CREATE INDEX idx_tag_entities_inactive ON tag_entities (inactive);
+
+CREATE TABLE tagged (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  tag_entity_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(tag_entity_id) REFERENCES tag_entities(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, tag_entity_id)
+);
+
+CREATE INDEX idx_tagged_journal_id ON tagged (journal_id);
+
+CREATE INDEX idx_tagged_tag_entity_id ON tagged (tag_entity_id);
+
+CREATE TABLE labeled (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  label_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(label_id) REFERENCES label_definitions(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, label_id)
+);
+
+CREATE INDEX idx_labeled_journal_id ON labeled (journal_id);
+
+CREATE INDEX idx_labeled_label_id ON labeled (label_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+/* Queries;
+

--- a/test/database/schemas/journal_v30.sql
+++ b/test/database/schemas/journal_v30.sql
@@ -1,0 +1,233 @@
+-- JournalDb fresh-install schema at schemaVersion 30.
+-- Extracted from lib/database/database.drift at 123d210d9
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  task_priority TEXT,
+  task_priority_rank INTEGER,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
+
+CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
+
+CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC);
+
+CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_tasks ON journal(
+  type COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  category COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_journal_type_subtype ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE label_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  color TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_label_definitions_id ON label_definitions (id);
+
+CREATE INDEX idx_label_definitions_name ON label_definitions (name);
+
+CREATE INDEX idx_label_definitions_private ON label_definitions (private);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE tag_entities (
+  id TEXT NOT NULL UNIQUE,
+  tag TEXT NOT NULL,
+  type TEXT NOT NULL,
+  inactive BOOLEAN DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(tag, type)
+);
+
+CREATE INDEX idx_tag_entities_id ON tag_entities (id);
+
+CREATE INDEX idx_tag_entities_tag ON tag_entities (tag);
+
+CREATE INDEX idx_tag_entities_type ON tag_entities (type);
+
+CREATE INDEX idx_tag_entities_private ON tag_entities (private);
+
+CREATE INDEX idx_tag_entities_inactive ON tag_entities (inactive);
+
+CREATE TABLE tagged (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  tag_entity_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(tag_entity_id) REFERENCES tag_entities(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, tag_entity_id)
+);
+
+CREATE INDEX idx_tagged_journal_id ON tagged (journal_id);
+
+CREATE INDEX idx_tagged_tag_entity_id ON tagged (tag_entity_id);
+
+CREATE TABLE labeled (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  label_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(label_id) REFERENCES label_definitions(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, label_id)
+);
+
+CREATE INDEX idx_labeled_journal_id ON labeled (journal_id);
+
+CREATE INDEX idx_labeled_label_id ON labeled (label_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(to_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+/* Queries;
+

--- a/test/database/schemas/journal_v37.sql
+++ b/test/database/schemas/journal_v37.sql
@@ -1,0 +1,297 @@
+-- JournalDb fresh-install schema at schemaVersion 37.
+-- Extracted from lib/database/database.drift at b58b3b062
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  task_priority TEXT,
+  task_priority_rank INTEGER,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
+
+CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
+
+CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC);
+
+CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_browse ON journal(
+  deleted COLLATE BINARY ASC,
+  type COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_journal_tasks ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date_priority ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_type_subtype ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_tasks_due_active ON journal(
+  type COLLATE BINARY ASC,
+  deleted COLLATE BINARY ASC,
+  json_extract(serialized, '$.data.due') ASC
+);
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE INDEX idx_habit_definitions_deleted_private ON habit_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE label_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  color TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_label_definitions_id ON label_definitions (id);
+
+CREATE INDEX idx_label_definitions_name ON label_definitions (name);
+
+CREATE INDEX idx_label_definitions_private ON label_definitions (private);
+
+CREATE INDEX idx_label_definitions_deleted_private_name ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE INDEX idx_dashboard_definitions_deleted_private_name ON dashboard_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE tag_entities (
+  id TEXT NOT NULL UNIQUE,
+  tag TEXT NOT NULL,
+  type TEXT NOT NULL,
+  inactive BOOLEAN DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(tag, type)
+);
+
+CREATE INDEX idx_tag_entities_id ON tag_entities (id);
+
+CREATE INDEX idx_tag_entities_tag ON tag_entities (tag);
+
+CREATE INDEX idx_tag_entities_type ON tag_entities (type);
+
+CREATE INDEX idx_tag_entities_private ON tag_entities (private);
+
+CREATE INDEX idx_tag_entities_inactive ON tag_entities (inactive);
+
+CREATE INDEX idx_tag_entities_deleted_private_tag ON tag_entities(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  tag COLLATE NOCASE ASC
+);
+
+CREATE TABLE tagged (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  tag_entity_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(tag_entity_id) REFERENCES tag_entities(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, tag_entity_id)
+);
+
+CREATE INDEX idx_tagged_journal_id ON tagged (journal_id);
+
+CREATE INDEX idx_tagged_tag_entity_id ON tagged (tag_entity_id);
+
+CREATE TABLE labeled (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  label_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(label_id) REFERENCES label_definitions(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, label_id)
+);
+
+CREATE INDEX idx_labeled_journal_id ON labeled (journal_id);
+
+CREATE INDEX idx_labeled_label_id ON labeled (label_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(to_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_created_at_desc ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  created_at COLLATE BINARY DESC
+);
+
+/* Queries;
+

--- a/test/database/schemas/journal_v38.sql
+++ b/test/database/schemas/journal_v38.sql
@@ -1,0 +1,260 @@
+-- JournalDb fresh-install schema at schemaVersion 38.
+-- Extracted from lib/database/database.drift at 8e2d85719
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  task_priority TEXT,
+  task_priority_rank INTEGER,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  project_id TEXT,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
+
+CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
+
+CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC);
+
+CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_browse ON journal(
+  deleted COLLATE BINARY ASC,
+  type COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_journal_tasks ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date_priority ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_type_subtype ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_tasks_due_active ON journal(
+  type COLLATE BINARY ASC,
+  deleted COLLATE BINARY ASC,
+  json_extract(serialized, '$.data.due') ASC
+);
+
+CREATE INDEX idx_journal_project_id ON journal(project_id)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE INDEX idx_habit_definitions_deleted_private ON habit_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE label_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  color TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_label_definitions_id ON label_definitions (id);
+
+CREATE INDEX idx_label_definitions_name ON label_definitions (name);
+
+CREATE INDEX idx_label_definitions_private ON label_definitions (private);
+
+CREATE INDEX idx_label_definitions_deleted_private_name ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE INDEX idx_dashboard_definitions_deleted_private_name ON dashboard_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE labeled (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  label_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(label_id) REFERENCES label_definitions(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, label_id)
+);
+
+CREATE INDEX idx_labeled_journal_id ON labeled (journal_id);
+
+CREATE INDEX idx_labeled_label_id ON labeled (label_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(to_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_created_at_desc ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  created_at COLLATE BINARY DESC
+);
+
+/* Queries;
+

--- a/test/database/schemas/journal_v39.sql
+++ b/test/database/schemas/journal_v39.sql
@@ -1,0 +1,274 @@
+-- JournalDb fresh-install schema at schemaVersion 39.
+-- Extracted from lib/database/database.drift at 4dc7dac5a
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  task_priority TEXT,
+  task_priority_rank INTEGER,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  project_id TEXT,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
+
+CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
+
+CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC);
+
+CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_browse ON journal(
+  deleted COLLATE BINARY ASC,
+  type COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_journal_tasks ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date_priority ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_type_subtype ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_tasks_due_active ON journal(
+  type COLLATE BINARY ASC,
+  deleted COLLATE BINARY ASC,
+  json_extract(serialized, '$.data.due') ASC
+);
+
+CREATE INDEX idx_journal_tasks_due_open ON journal(
+  json_extract(serialized, '$.data.due') ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND task_status NOT IN ('DONE', 'REJECTED');
+
+CREATE INDEX idx_journal_task_status_private ON journal(
+  task_status COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+)
+WHERE type = 'Task' AND task = 1 AND deleted = FALSE;
+
+CREATE INDEX idx_journal_project_id ON journal(project_id)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE INDEX idx_habit_definitions_deleted_private ON habit_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE label_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  color TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_label_definitions_id ON label_definitions (id);
+
+CREATE INDEX idx_label_definitions_name ON label_definitions (name);
+
+CREATE INDEX idx_label_definitions_private ON label_definitions (private);
+
+CREATE INDEX idx_label_definitions_deleted_private_name ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE INDEX idx_dashboard_definitions_deleted_private_name ON dashboard_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE labeled (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  label_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(label_id) REFERENCES label_definitions(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, label_id)
+);
+
+CREATE INDEX idx_labeled_journal_id ON labeled (journal_id);
+
+CREATE INDEX idx_labeled_label_id ON labeled (label_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(to_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_created_at_desc ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  created_at COLLATE BINARY DESC
+);
+
+/* Queries;
+

--- a/test/database/schemas/journal_v40.sql
+++ b/test/database/schemas/journal_v40.sql
@@ -1,0 +1,294 @@
+-- JournalDb fresh-install schema at schemaVersion 40.
+-- Extracted from lib/database/database.drift at 4ff5099c4
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  task_priority TEXT,
+  task_priority_rank INTEGER,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  project_id TEXT,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
+
+CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
+
+CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC);
+
+CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_browse ON journal(
+  deleted COLLATE BINARY ASC,
+  type COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_journal_tasks ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date_priority ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_type_subtype ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_tasks_due_active ON journal(
+  type COLLATE BINARY ASC,
+  deleted COLLATE BINARY ASC,
+  json_extract(serialized, '$.data.due') ASC
+);
+
+CREATE INDEX idx_journal_tasks_due_open ON journal(
+  json_extract(serialized, '$.data.due') ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND task_status NOT IN ('DONE', 'REJECTED');
+
+CREATE INDEX idx_journal_task_status_private ON journal(
+  task_status COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+)
+WHERE type = 'Task' AND task = 1 AND deleted = FALSE;
+
+CREATE INDEX idx_journal_project_id ON journal(project_id)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE INDEX idx_journal_project_task_status ON journal(
+  project_id COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE INDEX idx_habit_definitions_deleted_private ON habit_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE label_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  color TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_label_definitions_id ON label_definitions (id);
+
+CREATE INDEX idx_label_definitions_name ON label_definitions (name);
+
+CREATE INDEX idx_label_definitions_private ON label_definitions (private);
+
+CREATE INDEX idx_label_definitions_deleted_private_name ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE INDEX idx_dashboard_definitions_deleted_private_name ON dashboard_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE labeled (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  label_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(label_id) REFERENCES label_definitions(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, label_id)
+);
+
+CREATE INDEX idx_labeled_journal_id ON labeled (journal_id);
+
+CREATE INDEX idx_labeled_label_id ON labeled (label_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(to_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_created_at_desc ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  created_at COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_linked_entries_to_id_type ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  type COLLATE BINARY ASC
+);
+
+CREATE INDEX idx_linked_entries_rating_to_id ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  from_id COLLATE BINARY ASC
+)
+WHERE type = 'RatingLink' AND COALESCE(hidden, FALSE) = FALSE;
+
+/* Queries;
+

--- a/test/database/schemas/journal_v41.sql
+++ b/test/database/schemas/journal_v41.sql
@@ -1,0 +1,291 @@
+-- JournalDb fresh-install schema at schemaVersion 41.
+-- Extracted from lib/database/database.drift at 2104d41bc
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  task_priority TEXT,
+  task_priority_rank INTEGER,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  project_id TEXT,
+  
+  
+  
+  
+  due_at DATETIME,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
+
+CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
+
+CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC);
+
+CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_browse ON journal(
+  deleted COLLATE BINARY ASC,
+  type COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_journal_tasks ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date_priority ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_type_subtype ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_tasks_due_open ON journal(due_at ASC)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND task_status NOT IN ('DONE', 'REJECTED');
+
+CREATE INDEX idx_journal_task_status_private ON journal(
+  task_status COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+)
+WHERE type = 'Task' AND task = 1 AND deleted = FALSE;
+
+CREATE INDEX idx_journal_project_id ON journal(project_id)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE INDEX idx_journal_project_task_status ON journal(
+  project_id COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE INDEX idx_habit_definitions_deleted_private ON habit_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE label_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  color TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_label_definitions_id ON label_definitions (id);
+
+CREATE INDEX idx_label_definitions_name ON label_definitions (name);
+
+CREATE INDEX idx_label_definitions_private ON label_definitions (private);
+
+CREATE INDEX idx_label_definitions_deleted_private_name ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE INDEX idx_dashboard_definitions_deleted_private_name ON dashboard_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE labeled (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  label_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(label_id) REFERENCES label_definitions(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, label_id)
+);
+
+CREATE INDEX idx_labeled_journal_id ON labeled (journal_id);
+
+CREATE INDEX idx_labeled_label_id ON labeled (label_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(to_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_created_at_desc ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  created_at COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_linked_entries_to_id_type ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  type COLLATE BINARY ASC
+);
+
+CREATE INDEX idx_linked_entries_rating_to_id ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  from_id COLLATE BINARY ASC
+)
+WHERE type = 'RatingLink' AND COALESCE(hidden, FALSE) = FALSE;
+
+/* Queries;
+

--- a/test/database/schemas/journal_v42.sql
+++ b/test/database/schemas/journal_v42.sql
@@ -1,0 +1,306 @@
+-- JournalDb fresh-install schema at schemaVersion 42.
+-- Extracted from lib/database/database.drift at 909ab1b39
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  task_priority TEXT,
+  task_priority_rank INTEGER,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  project_id TEXT,
+  
+  
+  
+  
+  due_at DATETIME,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
+
+CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
+
+CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC);
+
+CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_browse ON journal(
+  deleted COLLATE BINARY ASC,
+  type COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_journal_tasks ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date_priority ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_type_subtype ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_tasks_due_open ON journal(due_at ASC)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND task_status NOT IN ('DONE', 'REJECTED');
+
+CREATE INDEX idx_journal_task_status_private ON journal(
+  task_status COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+)
+WHERE type = 'Task' AND task = 1 AND deleted = FALSE;
+
+CREATE INDEX idx_journal_project_id ON journal(project_id)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE INDEX idx_journal_project_task_status ON journal(
+  project_id COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE INDEX idx_journal_tasks_status_priority_date ON journal(
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE;
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE INDEX idx_habit_definitions_deleted_private ON habit_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE label_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  color TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_label_definitions_id ON label_definitions (id);
+
+CREATE INDEX idx_label_definitions_name ON label_definitions (name);
+
+CREATE INDEX idx_label_definitions_private ON label_definitions (private);
+
+CREATE INDEX idx_label_definitions_deleted_private_name ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE INDEX idx_dashboard_definitions_deleted_private_name ON dashboard_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE labeled (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  label_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(label_id) REFERENCES label_definitions(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, label_id)
+);
+
+CREATE INDEX idx_labeled_journal_id ON labeled (journal_id);
+
+CREATE INDEX idx_labeled_label_id ON labeled (label_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_to_id ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  to_id COLLATE BINARY ASC
+);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(to_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_created_at_desc ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  created_at COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_linked_entries_to_id_type ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  type COLLATE BINARY ASC
+);
+
+CREATE INDEX idx_linked_entries_rating_to_id ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  from_id COLLATE BINARY ASC
+)
+WHERE type = 'RatingLink' AND COALESCE(hidden, FALSE) = FALSE;
+
+/* Queries;
+

--- a/test/database/schemas/journal_v43.sql
+++ b/test/database/schemas/journal_v43.sql
@@ -1,0 +1,316 @@
+-- JournalDb fresh-install schema at schemaVersion 43.
+-- Extracted from lib/database/database.drift at 81f30b25f
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  task_priority TEXT,
+  task_priority_rank INTEGER,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  project_id TEXT,
+  
+  
+  
+  
+  due_at DATETIME,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
+
+CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
+
+CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC);
+
+CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_browse ON journal(
+  deleted COLLATE BINARY ASC,
+  type COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_journal_tasks ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date_priority ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_type_subtype ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_tasks_due_open ON journal(due_at ASC)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND task_status NOT IN ('DONE', 'REJECTED');
+
+CREATE INDEX idx_journal_task_status_private ON journal(
+  task_status COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+)
+WHERE type = 'Task' AND task = 1 AND deleted = FALSE;
+
+CREATE INDEX idx_journal_project_id ON journal(project_id)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE INDEX idx_journal_project_task_status ON journal(
+  project_id COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE INDEX idx_journal_tasks_status_priority_date ON journal(
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE;
+
+CREATE INDEX idx_journal_insights_time ON journal(
+  date_from COLLATE BINARY ASC,
+  date_to COLLATE BINARY ASC,
+  category COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'JournalEntry'
+  AND deleted = FALSE;
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE INDEX idx_habit_definitions_deleted_private ON habit_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE label_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  color TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_label_definitions_id ON label_definitions (id);
+
+CREATE INDEX idx_label_definitions_name ON label_definitions (name);
+
+CREATE INDEX idx_label_definitions_private ON label_definitions (private);
+
+CREATE INDEX idx_label_definitions_deleted_private_name ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE INDEX idx_dashboard_definitions_deleted_private_name ON dashboard_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE labeled (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  label_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(label_id) REFERENCES label_definitions(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, label_id)
+);
+
+CREATE INDEX idx_labeled_journal_id ON labeled (journal_id);
+
+CREATE INDEX idx_labeled_label_id ON labeled (label_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_to_id ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  to_id COLLATE BINARY ASC
+);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(to_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_created_at_desc ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  created_at COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_linked_entries_to_id_type ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  type COLLATE BINARY ASC
+);
+
+CREATE INDEX idx_linked_entries_rating_to_id ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  from_id COLLATE BINARY ASC
+)
+WHERE type = 'RatingLink' AND COALESCE(hidden, FALSE) = FALSE;
+
+/* Queries;
+

--- a/test/database/schemas/journal_v44.sql
+++ b/test/database/schemas/journal_v44.sql
@@ -1,0 +1,340 @@
+-- JournalDb fresh-install schema at schemaVersion 44.
+-- Extracted from lib/database/database.drift at 3a98b9823
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  task_priority TEXT,
+  task_priority_rank INTEGER,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  project_id TEXT,
+  
+  
+  
+  
+  due_at DATETIME,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
+
+CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
+
+CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC);
+
+CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_import_flag_date ON journal(
+  flag COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE deleted = FALSE;
+
+CREATE INDEX idx_journal_browse ON journal(
+  deleted COLLATE BINARY ASC,
+  type COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_journal_tasks ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date_priority ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_type_subtype ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_tasks_due_open ON journal(due_at ASC)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND task_status NOT IN ('DONE', 'REJECTED');
+
+CREATE INDEX idx_journal_task_status_private ON journal(
+  task_status COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+)
+WHERE type = 'Task' AND task = 1 AND deleted = FALSE;
+
+CREATE INDEX idx_journal_project_id ON journal(project_id)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE INDEX idx_journal_project_task_status ON journal(
+  project_id COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE INDEX idx_journal_tasks_status_priority_date ON journal(
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE;
+
+CREATE INDEX idx_journal_tasks_priority_date ON journal(
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE;
+
+CREATE INDEX idx_journal_insights_time ON journal(
+  date_from COLLATE BINARY ASC,
+  date_to COLLATE BINARY ASC,
+  category COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'JournalEntry'
+  AND deleted = FALSE;
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_conflicts_status_created_at
+ON conflicts(status ASC, created_at DESC);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE INDEX idx_habit_definitions_deleted_private ON habit_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE label_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  color TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_label_definitions_id ON label_definitions (id);
+
+CREATE INDEX idx_label_definitions_name ON label_definitions (name);
+
+CREATE INDEX idx_label_definitions_private ON label_definitions (private);
+
+CREATE INDEX idx_label_definitions_deleted_private_name ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE INDEX idx_label_definitions_deleted_name_nocase ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE INDEX idx_dashboard_definitions_deleted_private_name ON dashboard_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE labeled (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  label_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(label_id) REFERENCES label_definitions(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, label_id)
+);
+
+CREATE INDEX idx_labeled_journal_id ON labeled (journal_id);
+
+CREATE INDEX idx_labeled_label_id ON labeled (label_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_to_id ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  to_id COLLATE BINARY ASC
+);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(to_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_created_at_desc ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  created_at COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_linked_entries_to_id_type ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  type COLLATE BINARY ASC
+);
+
+CREATE INDEX idx_linked_entries_rating_to_id ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  from_id COLLATE BINARY ASC
+)
+WHERE type = 'RatingLink' AND COALESCE(hidden, FALSE) = FALSE;
+
+/* Queries;
+

--- a/test/database/schemas/journal_v45.sql
+++ b/test/database/schemas/journal_v45.sql
@@ -1,0 +1,360 @@
+-- JournalDb fresh-install schema at schemaVersion 45.
+-- Extracted from lib/database/database.drift at 8ea2ebb83
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  task_priority TEXT,
+  task_priority_rank INTEGER,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  project_id TEXT,
+  
+  
+  day_id TEXT,
+  recording_session_id TEXT,
+  
+  
+  
+  
+  due_at DATETIME,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
+
+CREATE INDEX idx_journal_date_from_desc ON journal (date_from DESC);
+
+CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
+
+CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC);
+
+CREATE INDEX idx_journal_day_audio ON journal(
+  day_id COLLATE BINARY ASC,
+  date_from COLLATE BINARY ASC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'JournalAudio'
+  AND deleted = FALSE
+  AND day_id IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_journal_recording_session ON journal(
+  recording_session_id COLLATE BINARY ASC
+)
+WHERE type = 'JournalAudio'
+  AND deleted = FALSE
+  AND recording_session_id IS NOT NULL;
+
+CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_import_flag_date ON journal(
+  flag COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE deleted = FALSE;
+
+CREATE INDEX idx_journal_browse ON journal(
+  deleted COLLATE BINARY ASC,
+  type COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_journal_tasks ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date_priority ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_type_subtype ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_tasks_due_open ON journal(due_at ASC)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND task_status NOT IN ('DONE', 'REJECTED');
+
+CREATE INDEX idx_journal_task_status_private ON journal(
+  task_status COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+)
+WHERE type = 'Task' AND task = 1 AND deleted = FALSE;
+
+CREATE INDEX idx_journal_project_id ON journal(project_id)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE INDEX idx_journal_project_task_status ON journal(
+  project_id COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE INDEX idx_journal_tasks_status_priority_date ON journal(
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE;
+
+CREATE INDEX idx_journal_tasks_priority_date ON journal(
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE;
+
+CREATE INDEX idx_journal_insights_time ON journal(
+  date_from COLLATE BINARY ASC,
+  date_to COLLATE BINARY ASC,
+  category COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'JournalEntry'
+  AND deleted = FALSE;
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_conflicts_status_created_at
+ON conflicts(status ASC, created_at DESC);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE INDEX idx_habit_definitions_deleted_private ON habit_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_id ON category_definitions (id);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE label_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  color TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_label_definitions_id ON label_definitions (id);
+
+CREATE INDEX idx_label_definitions_name ON label_definitions (name);
+
+CREATE INDEX idx_label_definitions_private ON label_definitions (private);
+
+CREATE INDEX idx_label_definitions_deleted_private_name ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE INDEX idx_label_definitions_deleted_name_nocase ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE INDEX idx_dashboard_definitions_deleted_private_name ON dashboard_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE labeled (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  label_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(label_id) REFERENCES label_definitions(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, label_id)
+);
+
+CREATE INDEX idx_labeled_journal_id ON labeled (journal_id);
+
+CREATE INDEX idx_labeled_label_id ON labeled (label_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_to_id ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  to_id COLLATE BINARY ASC
+);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(to_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_created_at_desc ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  created_at COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_linked_entries_to_id_type ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  type COLLATE BINARY ASC
+);
+
+CREATE INDEX idx_linked_entries_rating_to_id ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  from_id COLLATE BINARY ASC
+)
+WHERE type = 'RatingLink' AND COALESCE(hidden, FALSE) = FALSE;
+
+/* Queries;
+

--- a/test/database/schemas/journal_v46.sql
+++ b/test/database/schemas/journal_v46.sql
@@ -1,0 +1,342 @@
+-- JournalDb fresh-install schema at schemaVersion 46.
+-- Extracted from lib/database/database.drift at b38c9aefa
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  task_priority TEXT,
+  task_priority_rank INTEGER,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  project_id TEXT,
+  
+  
+  day_id TEXT,
+  recording_session_id TEXT,
+  
+  
+  
+  
+  due_at DATETIME,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
+
+CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
+
+CREATE INDEX idx_journal_day_audio ON journal(
+  day_id COLLATE BINARY ASC,
+  date_from COLLATE BINARY ASC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'JournalAudio'
+  AND deleted = FALSE
+  AND day_id IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_journal_recording_session ON journal(
+  recording_session_id COLLATE BINARY ASC
+)
+WHERE type = 'JournalAudio'
+  AND deleted = FALSE
+  AND recording_session_id IS NOT NULL;
+
+CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_import_flag_date ON journal(
+  flag COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE deleted = FALSE;
+
+CREATE INDEX idx_journal_browse ON journal(
+  deleted COLLATE BINARY ASC,
+  type COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_journal_tasks ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date_priority ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_type_subtype ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_tasks_due_open ON journal(due_at ASC)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND task_status NOT IN ('DONE', 'REJECTED');
+
+CREATE INDEX idx_journal_task_status_private ON journal(
+  task_status COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+)
+WHERE type = 'Task' AND task = 1 AND deleted = FALSE;
+
+CREATE INDEX idx_journal_project_id ON journal(project_id)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE INDEX idx_journal_project_task_status ON journal(
+  project_id COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE INDEX idx_journal_tasks_status_priority_date ON journal(
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE;
+
+CREATE INDEX idx_journal_tasks_priority_date ON journal(
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE;
+
+CREATE INDEX idx_journal_insights_time ON journal(
+  date_from COLLATE BINARY ASC,
+  date_to COLLATE BINARY ASC,
+  category COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'JournalEntry'
+  AND deleted = FALSE;
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_conflicts_status_created_at
+ON conflicts(status ASC, created_at DESC);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE INDEX idx_habit_definitions_deleted_private ON habit_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE label_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  color TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_label_definitions_name ON label_definitions (name);
+
+CREATE INDEX idx_label_definitions_private ON label_definitions (private);
+
+CREATE INDEX idx_label_definitions_deleted_private_name ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE INDEX idx_label_definitions_deleted_name_nocase ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE INDEX idx_dashboard_definitions_deleted_private_name ON dashboard_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE labeled (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  label_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(label_id) REFERENCES label_definitions(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, label_id)
+);
+
+CREATE INDEX idx_labeled_journal_id ON labeled (journal_id);
+
+CREATE INDEX idx_labeled_label_id ON labeled (label_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_to_id ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  to_id COLLATE BINARY ASC
+);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(to_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_created_at_desc ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  created_at COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_linked_entries_to_id_type ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  type COLLATE BINARY ASC
+);
+
+CREATE INDEX idx_linked_entries_rating_to_id ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  from_id COLLATE BINARY ASC
+)
+WHERE type = 'RatingLink' AND COALESCE(hidden, FALSE) = FALSE;
+
+/* Queries;
+

--- a/test/database/schemas/journal_v47.sql
+++ b/test/database/schemas/journal_v47.sql
@@ -1,0 +1,349 @@
+-- JournalDb fresh-install schema at schemaVersion 47.
+-- Extracted from lib/database/database.drift at bd2a6dfd8
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  task_priority TEXT,
+  task_priority_rank INTEGER,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  project_id TEXT,
+  
+  
+  day_id TEXT,
+  recording_session_id TEXT,
+  
+  
+  
+  
+  due_at DATETIME,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
+
+CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
+
+CREATE INDEX idx_journal_day_audio ON journal(
+  day_id COLLATE BINARY ASC,
+  date_from COLLATE BINARY ASC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'JournalAudio'
+  AND deleted = FALSE
+  AND day_id IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_journal_recording_session ON journal(
+  recording_session_id COLLATE BINARY ASC
+)
+WHERE type = 'JournalAudio'
+  AND deleted = FALSE
+  AND recording_session_id IS NOT NULL;
+
+CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_import_flag_date ON journal(
+  flag COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE deleted = FALSE;
+
+CREATE INDEX idx_journal_browse ON journal(
+  deleted COLLATE BINARY ASC,
+  type COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_journal_tasks ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date_priority ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_type_subtype ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_tasks_due_open ON journal(due_at ASC)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND task_status NOT IN ('DONE', 'REJECTED');
+
+CREATE INDEX idx_journal_task_status_private ON journal(
+  task_status COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+)
+WHERE type = 'Task' AND task = 1 AND deleted = FALSE;
+
+CREATE INDEX idx_journal_project_id ON journal(project_id)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE INDEX idx_journal_project_task_status ON journal(
+  project_id COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE INDEX idx_journal_tasks_status_priority_date ON journal(
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE;
+
+CREATE INDEX idx_journal_tasks_priority_date ON journal(
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE;
+
+CREATE INDEX idx_journal_quant_latest ON journal(
+  subtype COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'QuantitativeEntry'
+  AND deleted = FALSE;
+
+CREATE INDEX idx_journal_insights_time ON journal(
+  date_from COLLATE BINARY ASC,
+  date_to COLLATE BINARY ASC,
+  category COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'JournalEntry'
+  AND deleted = FALSE;
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_conflicts_status_created_at
+ON conflicts(status ASC, created_at DESC);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE INDEX idx_habit_definitions_deleted_private ON habit_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE label_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  color TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_label_definitions_name ON label_definitions (name);
+
+CREATE INDEX idx_label_definitions_private ON label_definitions (private);
+
+CREATE INDEX idx_label_definitions_deleted_private_name ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE INDEX idx_label_definitions_deleted_name_nocase ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE INDEX idx_dashboard_definitions_deleted_private_name ON dashboard_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL UNIQUE,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE labeled (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  label_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(label_id) REFERENCES label_definitions(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, label_id)
+);
+
+CREATE INDEX idx_labeled_journal_id ON labeled (journal_id);
+
+CREATE INDEX idx_labeled_label_id ON labeled (label_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_to_id ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  to_id COLLATE BINARY ASC
+);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(to_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_created_at_desc ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  created_at COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_linked_entries_to_id_type ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  type COLLATE BINARY ASC
+);
+
+CREATE INDEX idx_linked_entries_rating_to_id ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  from_id COLLATE BINARY ASC
+)
+WHERE type = 'RatingLink' AND COALESCE(hidden, FALSE) = FALSE;
+
+/* Queries;
+

--- a/test/database/task_indexes_v39_migration_test.dart
+++ b/test/database/task_indexes_v39_migration_test.dart
@@ -9,6 +9,8 @@ import 'package:lotti/get_it.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqlite3/sqlite3.dart';
 
+import 'schema_fixtures.dart';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -128,7 +130,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 46);
+        expect(db.schemaVersion, 47);
 
         // v41 swapped the expression-keyed shape for a column-keyed one.
         final sql = await indexSql(db, 'idx_journal_tasks_due_open');
@@ -280,8 +282,7 @@ void main() {
         p.join(testDirectory!.path, 'test_v44_task_priority_date.db'),
       );
       final sqlite = sqlite3.open(dbFile.path);
-      createV38Schema(sqlite);
-      sqlite.execute('PRAGMA user_version = 43');
+      createJournalSchema(sqlite, 43);
       sqlite.close();
 
       final db = JournalDb(
@@ -291,7 +292,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 46);
+      expect(db.schemaVersion, 47);
 
       final sql = await indexSql(db, 'idx_journal_tasks_priority_date');
       expect(sql, contains('task_priority_rank COLLATE BINARY ASC'));

--- a/test/tool/db_schema/drift_ddl_test.dart
+++ b/test/tool/db_schema/drift_ddl_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../tool/db_schema/drift_ddl.dart';
+
+void main() {
+  group('extractDriftDdl', () {
+    const source = '''
+-- A leading comment.
+CREATE TABLE journal (
+  id TEXT NOT NULL, -- trailing comment
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (id)
+) as JournalDbEntity;
+
+/* A block
+   comment. */
+CREATE INDEX idx_journal_deleted ON journal (deleted)
+WHERE deleted = FALSE;
+
+CREATE TABLE plain (
+  id TEXT NOT NULL
+);
+
+listEntries:
+SELECT * FROM journal;
+
+CREATE TABLE not_schema (id TEXT);
+''';
+
+    test(
+      'keeps every DDL statement, in order, terminated with a semicolon',
+      () {
+        final statements = extractDriftDdl(source);
+        expect(statements, hasLength(3));
+        expect(statements[0], startsWith('CREATE TABLE journal ('));
+        expect(statements[1], startsWith('CREATE INDEX idx_journal_deleted'));
+        expect(statements[2], 'CREATE TABLE plain (\n  id TEXT NOT NULL\n);');
+        expect(statements.every((s) => s.endsWith(';')), isTrue);
+      },
+    );
+
+    test('strips the Drift data-class suffix raw SQLite rejects', () {
+      final table = extractDriftDdl(source).first;
+      expect(table, isNot(contains('as JournalDbEntity')));
+      expect(table, endsWith('PRIMARY KEY (id)\n);'));
+    });
+
+    test('drops line and block comments', () {
+      final joined = extractDriftDdl(source).join('\n');
+      expect(joined, isNot(contains('comment')));
+      expect(joined, isNot(contains('/*')));
+    });
+
+    test('stops at the first named query', () {
+      final joined = extractDriftDdl(source).join('\n');
+      expect(joined, isNot(contains('listEntries')));
+      expect(joined, isNot(contains('not_schema')));
+    });
+
+    test('ignores whitespace-only fragments', () {
+      expect(extractDriftDdl('\n\n;;\n  ;\n'), isEmpty);
+    });
+  });
+
+  group('renderSchemaFile', () {
+    test('writes a header naming version and origin, then the statements', () {
+      final rendered = renderSchemaFile(
+        statements: const [
+          'CREATE TABLE a (id TEXT);',
+          'CREATE INDEX i ON a (id);',
+        ],
+        version: 46,
+        gitRef: 'b38c9aefa',
+      );
+      expect(
+        rendered,
+        startsWith('-- JournalDb fresh-install schema at schemaVersion 46.'),
+      );
+      expect(rendered, contains('at b38c9aefa'));
+      expect(rendered, contains('Do not edit.'));
+      // The rendered file round-trips through the extractor unchanged.
+      expect(extractDriftDdl(rendered), [
+        'CREATE TABLE a (id TEXT);',
+        'CREATE INDEX i ON a (id);',
+      ]);
+    });
+  });
+}

--- a/tool/db_schema/drift_ddl.dart
+++ b/tool/db_schema/drift_ddl.dart
@@ -1,0 +1,67 @@
+/// Extracts plain SQLite DDL from a `.drift` schema file.
+///
+/// A `.drift` file is the fresh-install truth for a Drift database whose
+/// `onCreate` is `createAll()`: every `CREATE TABLE` / `CREATE INDEX` in it,
+/// in order, is what a new install gets. The file at any past commit is
+/// therefore the schema a device installed at that version started from —
+/// which is what a migration test has to begin with, rather than a
+/// hand-written approximation.
+///
+/// Drift's own tooling (`drift_dev schema dump`) would do this from the
+/// Dart side, but the version that resolves in this repository does not
+/// build, so the DDL is lifted from the file directly. The only
+/// Drift-specific syntax in the DDL region is the `) as DataClassName;`
+/// suffix, which raw SQLite rejects and which is removed here.
+library;
+
+/// Returns the DDL statements of [driftSource], one per entry, each ending
+/// with `;`, with comments and Drift data-class suffixes removed.
+///
+/// Everything from the first named query (`name:` on its own line) onward is
+/// dropped: named queries are Dart-side accessors, not schema.
+List<String> extractDriftDdl(String driftSource) {
+  final ddlRegion = StringBuffer();
+  for (final line in driftSource.split('\n')) {
+    if (_namedQueryStart.hasMatch(line)) break;
+    final withoutComment = line.replaceFirst(_lineComment, '');
+    ddlRegion.writeln(withoutComment);
+  }
+
+  final withoutBlockComments = ddlRegion.toString().replaceAll(
+    _blockComment,
+    '',
+  );
+
+  final statements = <String>[];
+  for (final raw in withoutBlockComments.split(';')) {
+    final statement = raw.replaceFirst(_dataClassSuffix, ')').trim();
+    if (statement.isEmpty) continue;
+    statements.add('$statement;');
+  }
+  return statements;
+}
+
+/// Renders [statements] as the canonical text of a committed schema file:
+/// a header naming the origin, then one statement per block.
+String renderSchemaFile({
+  required List<String> statements,
+  required int version,
+  required String gitRef,
+}) {
+  final buffer = StringBuffer()
+    ..writeln('-- JournalDb fresh-install schema at schemaVersion $version.')
+    ..writeln('-- Extracted from lib/database/database.drift at $gitRef')
+    ..writeln('-- by tool/db_schema/extract_journal_schema.dart. Do not edit.')
+    ..writeln();
+  for (final statement in statements) {
+    buffer
+      ..writeln(statement)
+      ..writeln();
+  }
+  return buffer.toString();
+}
+
+final RegExp _namedQueryStart = RegExp(r'^[A-Za-z0-9_]+:\s*$');
+final RegExp _lineComment = RegExp(r'--.*$');
+final RegExp _blockComment = RegExp(r'/\*.*?\*/', dotAll: true);
+final RegExp _dataClassSuffix = RegExp(r'\)\s+as\s+[A-Za-z0-9_]+\s*$');

--- a/tool/db_schema/extract_journal_schema.dart
+++ b/tool/db_schema/extract_journal_schema.dart
@@ -1,0 +1,97 @@
+/// Writes the JournalDb fresh-install schema at a past version as plain DDL.
+///
+/// Usage:
+///
+/// ```sh
+/// dart run tool/db_schema/extract_journal_schema.dart --version 45 --ref <sha>
+/// ```
+///
+/// The `--ref` must be a commit at which `lib/database/database.dart` declared
+/// `schemaVersion => <version>` — the last such commit before the next
+/// version was introduced gives the schema as it shipped — or the literal
+/// `WORKTREE` to read the uncommitted files, which is how the file for a
+/// version being introduced is produced before its commit exists. The tool
+/// checks the declared version before writing, so a schema file can never
+/// carry the wrong version number.
+///
+/// Output goes to `test/database/schemas/journal_v<version>.sql`, which
+/// `test/database/journal_schema_history_test.dart` migrates to the current
+/// version and diffs against a fresh install. When `schemaVersion` is bumped,
+/// run this for the version being left behind (`--ref HEAD` before the bump
+/// commit, or the bump commit's parent afterwards) and commit the file.
+library;
+
+import 'dart:io';
+
+import 'drift_ddl.dart';
+
+const _driftPath = 'lib/database/database.drift';
+const _databasePath = 'lib/database/database.dart';
+const _outputDirectory = 'test/database/schemas';
+
+void main(List<String> args) {
+  final version = _argument(args, '--version');
+  final ref = _argument(args, '--ref');
+  if (version == null || ref == null) {
+    stderr.writeln(
+      'usage: dart run tool/db_schema/extract_journal_schema.dart '
+      '--version <n> --ref <git ref>',
+    );
+    exitCode = 64;
+    return;
+  }
+
+  final declared = RegExp(
+    r'int get schemaVersion => (\d+);',
+  ).firstMatch(_read(ref, _databasePath))?.group(1);
+  if (declared != version) {
+    stderr.writeln(
+      'Refusing to write: $ref declares schemaVersion $declared, '
+      'not $version.',
+    );
+    exitCode = 65;
+    return;
+  }
+
+  final statements = extractDriftDdl(_read(ref, _driftPath));
+  final resolved = ref == worktreeRef
+      ? 'the working tree'
+      : Process.runSync('git', [
+          'rev-parse',
+          '--short',
+          ref,
+        ]).stdout.toString().trim();
+  final output = File('$_outputDirectory/journal_v$version.sql')
+    ..parent.createSync(recursive: true)
+    ..writeAsStringSync(
+      renderSchemaFile(
+        statements: statements,
+        version: int.parse(version),
+        gitRef: resolved,
+      ),
+    );
+  stdout.writeln(
+    'Wrote ${output.path}: ${statements.length} statements from $resolved',
+  );
+}
+
+String? _argument(List<String> args, String name) {
+  final index = args.indexOf(name);
+  if (index < 0 || index + 1 >= args.length) return null;
+  return args[index + 1];
+}
+
+/// The `--ref` value that reads the uncommitted working tree.
+const worktreeRef = 'WORKTREE';
+
+String _read(String ref, String path) =>
+    ref == worktreeRef ? File(path).readAsStringSync() : _gitShow(ref, path);
+
+String _gitShow(String ref, String path) {
+  final result = Process.runSync('git', ['show', '$ref:$path']);
+  if (result.exitCode != 0) {
+    stderr.writeln(result.stderr);
+    throw StateError('git show $ref:$path failed');
+  }
+  return result.stdout.toString();
+}


### PR DESCRIPTION
## Summary

Finding 9 of the persistence-layer review (with a piece of 8), and the first thing it turned up.

**The real historical schemas are now committed and tested against.** `drift_dev schema dump` / `SchemaVerifier` is the standard tool, but the only drift_dev this repository can resolve (2.34.0, capped by the objectbox generator's analyzer pin) does not build against drift 2.34.4. The equivalent is done from git instead: for every journal schema version that ever shipped since v18, `tool/db_schema/extract_journal_schema.dart` lifts the DDL of `lib/database/database.drift` at the last commit where that version was current — the fresh-install schema a device installed at that version started from — into `test/database/schemas/journal_v<N>.sql` (20 versions, about 200 KB of plain DDL). `journal_schema_history_test.dart` creates a database from each, upgrades it, and diffs tables, columns and indexes against a fresh install, normalised only for column order, type spelling within one affinity and boolean default spelling. It also asserts that the file for the current version matches the working `.drift`, so bumping `schemaVersion` fails until the new file is committed (`--ref WORKTREE` produces it before the commit exists).

**What it found.** Installs created before v25 (October 2025) still carried every single-column index the original schema created and later versions stopped declaring but never dropped — `idx_journal_created_at`, `_updated_at`, `_deleted`, `_starred`, `_private`, `_flag`, `_type`, `_subtype`, `_task`, `_task_status`, `_date_from`, `_date_to`, `_geohash_string`, `_geohash_int`, `_category`, plus `_composite`, `_filtered_tasks`, `_habit_completions(2)`, `_linked` on v23/v24 — up to seventeen on `journal`, each maintained on every write for years. They also lacked `idx_journal_date_from_asc` / `_date_to_asc`, which only a fresh install ever got. v20 installs kept a dead `category_id` column and its index.

**The durable fix.** Every upgrade now ends with `_reconcileIndexesWithSchema`: it drops explicit indexes on Drift-managed tables that `database.drift` no longer declares and creates declared ones that are missing (skipping tables the fixture lacks, and never touching the legacy `tag_entities`/`tagged` tables Drift does not manage). From here on an index change is an edit to `database.drift` plus a version bump, never a hand-written `CREATE INDEX` in a migration step, and the verifier proves migrated equals fresh for every starting version. v47 exists to run it once on old installs and drops the v20 column. `idx_journal_quant_latest`, previously created only by the `beforeOpen` self-heal, is now declared in the schema so a fresh install and an upgraded one agree.

**Fixtures.** The reconcile exposed the hand-written migration fixtures for what they are: approximations that lack columns the declared indexes need (`due_at`, `day_id`, `starred`, `task_priority_rank`, `name`). The five tests it broke now seed from the real schemas through `schema_fixtures.dart`; the remaining ones, deleting `migration_test_helper.dart`, and removing the `_tableExists`/`_columnExists` guards from the migration code (finding 8) follow in a separate PR to keep this one reviewable.

## Tests

- 23 verifier cases (v18–v47 and the current-file check), all green; with the reconcile disabled, every pre-v25 case fails with the index list above.
- Extractor unit tests; every migration test file and `database_test.dart` green after the v47 bump.
- `make analyze`, `make knowledge_check`, `make changelog_check` clean.

## Docs

`knowledge/architecture/persistence.md`: the committed schema history, the verifier, and the index reconcile. Changelog fragment: old installs will notice faster saves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved upgrades for older installations by aligning database indexes with fresh installations.
  - Removed obsolete journal database structures during upgrades.
  - Added automatic reconciliation that restores missing indexes and recreates outdated managed indexes.

- **Performance**
  - Improved retrieval of the latest quantitative journal entries.

- **Documentation**
  - Updated database schema documentation and migration history for schema version 47.
  - Added historical schema coverage for upgrade validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->