### PR TITLE
chore(db): keep only the newest three backups of each database

### DIFF
--- a/changelog.d/2026-09-05-backup-retention.md
+++ b/changelog.d/2026-09-05-backup-retention.md
@@ -1,0 +1,6 @@
+### Fixed
+- **Database safety copies piled up forever.** Every database upgrade and
+  every "purge deleted entries" run wrote a full copy of the database into the
+  app's backup folder, and nothing ever removed one, so the folder kept
+  growing for as long as the app was used. The app now keeps only the three
+  most recent copies of each database.

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -463,7 +463,10 @@ WAL instead, and the fallback is logged, so a reset is never blocked on a
 backup. It runs automatically before a **journal, sync or agent migration**
 (`backupBeforeMigration`, which logs a failure and continues rather than
 refusing to open the app) and on demand from
-*Settings → Advanced → Maintenance*.
+*Settings → Advanced → Maintenance*. Once a snapshot is complete, older
+snapshots of the same source beyond the three newest are deleted, WAL
+sidecar included, so `backup/` stays bounded at three files per store; a
+failed snapshot never costs an existing one.
 That helper is a **legacy per-database fallback**, not a supported profile
 backup. It copies only the main SQLite file, has no store identity, manifest,
 checksum, media coverage, encryption, coordinated quiescence, or restore path.

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -465,8 +465,11 @@ backup. It runs automatically before a **journal, sync or agent migration**
 refusing to open the app) and on demand from
 *Settings → Advanced → Maintenance*. Once a snapshot is complete, older
 snapshots of the same source beyond the three newest are deleted, WAL
-sidecar included, so `backup/` stays bounded at three files per store; a
-failed snapshot never costs an existing one.
+sidecar included, so `backup/` holds at most three snapshots per store (plus
+the `-wal` sidecar a raw-copy fallback keeps beside its snapshot); the
+snapshot just written is always among the three, even if the device clock
+has moved backwards since the previous one, and a failed snapshot never costs
+an existing one.
 That helper is a **legacy per-database fallback**, not a supported profile
 backup. It copies only the main SQLite file, has no store identity, manifest,
 checksum, media coverage, encryption, coordinated quiescence, or restore path.

--- a/lib/database/common.dart
+++ b/lib/database/common.dart
@@ -16,6 +16,15 @@ import 'package:sqlite3/sqlite3.dart';
 
 /// Constants for database backup operations
 const String _backupDirectoryName = 'backup';
+
+/// How many snapshots of one database [createDbBackup] keeps.
+///
+/// A backup is the safety copy for the migration or purge that just ran,
+/// not an archive: three covers the copy before this upgrade, the one
+/// before that, and a purge in between, while keeping `backup/` bounded.
+/// Before retention existed the directory only ever grew — three stores
+/// each adding a journal-sized file per upgrade.
+const int backupsKeptPerDatabase = 3;
 const String _backupFileExtension = '.sqlite';
 const String _backupTimestampFormat = 'yyyy-MM-dd_HH-mm-ss-S';
 
@@ -48,7 +57,11 @@ Future<File> getDatabaseFile(String dbFileName) async {
 ///
 /// Backups are named after their source: `backup/<stem>.<timestamp>.sqlite`,
 /// so `db.sqlite` becomes `backup/db.2025-10-17_14-30-45-123.sqlite` and
-/// `agent.sqlite` becomes `backup/agent.….sqlite`. Returns the backup file.
+/// `agent.sqlite` becomes `backup/agent.….sqlite`. Once the new snapshot is
+/// complete, older snapshots of the same source beyond
+/// [backupsKeptPerDatabase] are deleted (with the WAL sidecar a raw-copy
+/// fallback leaves), so a failed snapshot never costs an existing one.
+/// Returns the backup file.
 ///
 /// [documentsDirectoryProvider] names the directory the database lives in;
 /// it defaults to the active profile root, which is wrong for a database
@@ -105,7 +118,64 @@ Future<File> createDbBackup(
     await file.copy(target.path);
     await walStash?.rename('${target.path}-wal');
   }
+  await _pruneOlderBackups(backupDir, stem: stem, newest: target);
   return target;
+}
+
+final RegExp _backupTimestamp = RegExp(
+  r'^(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}-\d+)(?:-(\d+))?$',
+);
+
+/// Deletes every snapshot of [stem] in [backupDir] older than the
+/// [backupsKeptPerDatabase] newest, [newest] included. Ordering comes from
+/// the timestamp in the file name, so it matches the clock that named them
+/// rather than filesystem times.
+Future<void> _pruneOlderBackups(
+  Directory backupDir, {
+  required String stem,
+  required File newest,
+}) async {
+  final prefix = '$stem.';
+  final snapshots = <(String, int, File)>[];
+  for (final entity in backupDir.listSync()) {
+    if (entity is! File) continue;
+    final name = p.basename(entity.path);
+    if (!name.startsWith(prefix) || !name.endsWith(_backupFileExtension)) {
+      continue;
+    }
+    final match = _backupTimestamp.firstMatch(
+      name.substring(prefix.length, name.length - _backupFileExtension.length),
+    );
+    if (match == null) continue;
+    snapshots.add((
+      match.group(1)!,
+      int.tryParse(match.group(2) ?? '1') ?? 1,
+      entity,
+    ));
+  }
+  snapshots.sort((a, b) {
+    final byTime = b.$1.compareTo(a.$1);
+    return byTime != 0 ? byTime : b.$2.compareTo(a.$2);
+  });
+  final stale = snapshots.skip(backupsKeptPerDatabase);
+  var pruned = 0;
+  for (final (_, _, file) in stale) {
+    if (p.equals(file.path, newest.path)) continue;
+    await file.delete();
+    final wal = File('${file.path}-wal');
+    if (wal.existsSync()) {
+      await wal.delete();
+    }
+    pruned += 1;
+  }
+  if (pruned > 0) {
+    DevLogger.log(
+      name: 'Database',
+      message:
+          'Pruned $pruned older backup(s) of $stem, '
+          'keeping the $backupsKeptPerDatabase newest',
+    );
+  }
 }
 
 /// Two backups in one formatted instant (the same millisecond) must not

--- a/lib/database/common.dart
+++ b/lib/database/common.dart
@@ -126,10 +126,13 @@ final RegExp _backupTimestamp = RegExp(
   r'^(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}-\d+)(?:-(\d+))?$',
 );
 
-/// Deletes every snapshot of [stem] in [backupDir] older than the
-/// [backupsKeptPerDatabase] newest, [newest] included. Ordering comes from
-/// the timestamp in the file name, so it matches the clock that named them
-/// rather than filesystem times.
+/// Keeps [newest] plus the [backupsKeptPerDatabase] − 1 most recent other
+/// snapshots of [stem] in [backupDir] and deletes the rest. [newest] is
+/// kept by identity, not by rank: if the device clock has moved backwards
+/// since the previous snapshot, the file just written sorts *below* older
+/// ones, and ranking alone would keep four copies. Ordering of the others
+/// comes from the timestamp in the file name, so it matches the clock that
+/// named them rather than filesystem times.
 Future<void> _pruneOlderBackups(
   Directory backupDir, {
   required String stem,
@@ -153,14 +156,15 @@ Future<void> _pruneOlderBackups(
       entity,
     ));
   }
-  snapshots.sort((a, b) {
-    final byTime = b.$1.compareTo(a.$1);
-    return byTime != 0 ? byTime : b.$2.compareTo(a.$2);
-  });
-  final stale = snapshots.skip(backupsKeptPerDatabase);
+  snapshots
+    ..removeWhere((snapshot) => p.equals(snapshot.$3.path, newest.path))
+    ..sort((a, b) {
+      final byTime = b.$1.compareTo(a.$1);
+      return byTime != 0 ? byTime : b.$2.compareTo(a.$2);
+    });
+  final stale = snapshots.skip(backupsKeptPerDatabase - 1);
   var pruned = 0;
   for (final (_, _, file) in stale) {
-    if (p.equals(file.path, newest.path)) continue;
     await file.delete();
     final wal = File('${file.path}-wal');
     if (wal.existsSync()) {

--- a/test/database/common_test.dart
+++ b/test/database/common_test.dart
@@ -227,6 +227,91 @@ void main() {
       },
     );
 
+    test(
+      'keeps only the newest snapshots of a database and takes a pruned '
+      "raw copy's WAL with it",
+      () async {
+        const fileName = 'test_db.sqlite';
+        seedWalDatabase(fileName);
+        final backupDir = Directory(p.join(testDir.path, _backupDirectoryName))
+          ..createSync();
+        // A legacy raw-copy snapshot from before VACUUM INTO, with its WAL:
+        // it sorts oldest and must be the first to go, sidecar included.
+        File(
+          p.join(backupDir.path, 'test_db.2026-01-01_00-00-00-000.sqlite'),
+        ).writeAsStringSync('old');
+        File(
+          p.join(backupDir.path, 'test_db.2026-01-01_00-00-00-000.sqlite-wal'),
+        ).writeAsStringSync('old wal');
+
+        final kept = <String>[];
+        for (final second in [10, 11, 12]) {
+          final backup = await withClock(
+            Clock.fixed(DateTime(2026, 9, 5, 10, 30, second)),
+            () => createDbBackup(fileName),
+          );
+          kept.add(p.basename(backup.path));
+        }
+
+        final remaining =
+            backupDir
+                .listSync()
+                .map((entity) => p.basename(entity.path))
+                .toList()
+              ..sort();
+        expect(remaining, kept..sort());
+        expect(remaining, hasLength(backupsKeptPerDatabase));
+      },
+    );
+
+    test('prunes each database separately', () async {
+      seedWalDatabase('db.sqlite');
+      seedWalDatabase('agent.sqlite');
+      for (final second in [10, 11, 12, 13]) {
+        await withClock(
+          Clock.fixed(DateTime(2026, 9, 5, 10, 30, second)),
+          () => createDbBackup('db.sqlite'),
+        );
+      }
+      await withClock(
+        Clock.fixed(DateTime(2026, 9, 5, 10, 30, 10)),
+        () => createDbBackup('agent.sqlite'),
+      );
+
+      final names = Directory(
+        p.join(testDir.path, _backupDirectoryName),
+      ).listSync().map((entity) => p.basename(entity.path)).toList();
+      expect(names.where((n) => n.startsWith('db.')), hasLength(3));
+      expect(
+        names.where((n) => n.startsWith('db.')),
+        isNot(contains('db.2026-09-05_10-30-10-000.sqlite')),
+      );
+      expect(names.where((n) => n.startsWith('agent.')), hasLength(1));
+    });
+
+    test('a failed snapshot leaves the existing backups untouched', () async {
+      const fileName = 'test_db.sqlite';
+      seedWalDatabase(fileName);
+      final earlier = await withClock(
+        Clock.fixed(DateTime(2026, 9, 5, 10, 30, 10)),
+        () => createDbBackup(fileName),
+      );
+      final backupDir = Directory(p.join(testDir.path, _backupDirectoryName));
+      Directory(
+        p.join(backupDir.path, 'test_db.2026-09-05_10-30-15-000.sqlite'),
+      ).createSync();
+
+      await expectLater(
+        withClock(
+          Clock.fixed(DateTime(2026, 9, 5, 10, 30, 15)),
+          () => createDbBackup(fileName),
+        ),
+        throwsA(isA<SqliteException>()),
+      );
+
+      expect(earlier.existsSync(), isTrue);
+    });
+
     test('throws when the source file does not exist', () async {
       await expectLater(
         createDbBackup('missing.sqlite'),

--- a/test/database/common_test.dart
+++ b/test/database/common_test.dart
@@ -264,6 +264,38 @@ void main() {
       },
     );
 
+    test(
+      'a snapshot taken after the clock moved backwards still counts as the '
+      'newest, so three copies remain',
+      () async {
+        const fileName = 'test_db.sqlite';
+        seedWalDatabase(fileName);
+        for (final second in [10, 11, 12]) {
+          await withClock(
+            Clock.fixed(DateTime(2026, 9, 5, 10, 30, second)),
+            () => createDbBackup(fileName),
+          );
+        }
+
+        // The device clock was corrected backwards: the new file sorts
+        // below all three existing ones.
+        final latest = await withClock(
+          Clock.fixed(DateTime(2026, 9, 5, 10, 30, 5)),
+          () => createDbBackup(fileName),
+        );
+
+        final remaining = Directory(
+          p.join(testDir.path, _backupDirectoryName),
+        ).listSync().map((entity) => p.basename(entity.path)).toList()..sort();
+        expect(remaining, hasLength(backupsKeptPerDatabase));
+        expect(remaining, contains(p.basename(latest.path)));
+        expect(
+          remaining,
+          isNot(contains('test_db.2026-09-05_10-30-10-000.sqlite')),
+        );
+      },
+    );
+
     test('prunes each database separately', () async {
       seedWalDatabase('db.sqlite');
       seedWalDatabase('agent.sqlite');


### PR DESCRIPTION
## Summary

Finding 6 of the persistence-layer review. `backup/` was never pruned: every journal, sync and agent migration (three stores since #4158) and every "purge deleted entries" run added a full snapshot, and the profile backup catalog deliberately excludes the directory, so it grew for as long as the app was used — a journal-sized file per upgrade per store.

`createDbBackup` now deletes older snapshots of the same source beyond the three newest once the new snapshot is complete, taking the `-wal` sidecar a raw-copy fallback leaves. Ordering comes from the timestamp in the file name (the clock that named them), with the collision suffix as tie-break, not from filesystem times. Pruning runs only after a successful snapshot, so a failed one never costs an existing copy. Legacy `db.<ts>.sqlite` files from before source-named backups fall under the journal stem and are pruned the same way. Three is a safety-copy policy, not an archive: the copy before this upgrade, the one before that, and a purge in between.

## Tests

- four snapshots of one database leave the three newest, and a pruned raw copy's WAL goes with it (fails without pruning)
- each database is pruned separately
- a failed snapshot leaves existing backups untouched

`make analyze`, `make knowledge_check`, `make changelog_check` clean.

## Docs

Concept: the backup paragraph states the retention rule. Changelog fragment added; users will see the backup folder stop growing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database maintenance backups now retain only the three most recent copies per database.
  * Older backup files and associated WAL sidecars are automatically removed.
  * The newest snapshot is retained even if the device clock moves backward.
  * Existing backups remain unchanged if creating a new snapshot fails.

* **Documentation**
  * Updated backup documentation to describe retention behavior, clock changes, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->