### PR TITLE
perf(db): stream the purge and the search rebuild by rowid, drop the sleeps

### DIFF
--- a/changelog.d/2026-09-05-purge-and-search-rebuild-scale.md
+++ b/changelog.d/2026-09-05-purge-and-search-rebuild-scale.md
@@ -1,0 +1,6 @@
+### Changed
+- **Purging deleted entries and rebuilding search no longer slow down on a
+  large journal.** Both used to read the journal in a way that grew more
+  expensive with every page, and paused on purpose between steps to make
+  progress visible. They now walk the journal in fixed-size chunks and
+  report progress as they go.

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -540,6 +540,19 @@ either service** — `purgeDeleted` lives in
 `lib/database/database_entity_ops.dart` alongside the rest of `JournalDb`'s
 entity operations, which is where to look for it.
 
+Both whole-journal walks are **rowid keyset scans**, not `OFFSET` pages:
+`purgeDeletedFiles` reads soft-deleted rows 500 at a time with
+`WHERE deleted = 1 AND rowid > ?`, deleting each entity's media and JSON
+sidecar as it goes, and `recreateFts5` reads live rows the same way to feed
+the index (order is irrelevant to FTS). An `OFFSET` page re-scans every
+earlier row, which made a rebuild quadratic in the journal's size. Counts
+come from `COUNT(*)`, progress is reported after each table (purge) or each
+percent (rebuild), and nothing sleeps to make it visible. Neither walk takes
+a transaction: a row inserted or deleted concurrently is simply seen or not
+by the next chunk, which is correct for both — a new live entry gets indexed
+by the app's own write path, and a row deleted mid-purge has nothing left to
+purge.
+
 # Where to look
 
 | Concern | File |

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -773,13 +773,6 @@ emptyJournalSelection:
 SELECT * FROM journal
   WHERE 1 = 0;
 
-orderedJournal:
-SELECT * FROM journal
-  WHERE deleted = false
-  ORDER BY date_from DESC
-  LIMIT :limit
-  OFFSET :offset;
-
 orderedJournalInterval:
 SELECT * FROM journal
   WHERE deleted = false
@@ -1126,7 +1119,6 @@ SELECT journal.* FROM linked_entries
   AND journal.deleted = false
   AND journal.private IN :privateStatuses
   ORDER BY journal.date_from DESC;
-
 
 deleteLink:
 DELETE FROM linked_entries

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -6675,14 +6675,6 @@ abstract class _$JournalDb extends GeneratedDatabase {
     ).asyncMap(journal.mapFromRow);
   }
 
-  Selectable<JournalDbEntity> orderedJournal(int limit, int offset) {
-    return customSelect(
-      'SELECT * FROM journal WHERE deleted = FALSE ORDER BY date_from DESC LIMIT ?1 OFFSET ?2',
-      variables: [Variable<int>(limit), Variable<int>(offset)],
-      readsFrom: {journal},
-    ).asyncMap(journal.mapFromRow);
-  }
-
   Selectable<JournalDbEntity> orderedJournalInterval(
     DateTime start,
     DateTime end,

--- a/lib/database/database_entity_ops.dart
+++ b/lib/database/database_entity_ops.dart
@@ -226,42 +226,63 @@ mixin _JournalDbEntityOps
     return null;
   }
 
+  /// How many soft-deleted rows [purgeDeletedFiles] reads per round trip.
+  /// Keyed on rowid so the walk never re-reads what it has already visited,
+  /// and never holds every deleted entity's JSON in memory at once.
+  static const int _purgeChunk = 500;
+
+  /// Deletes the files — media and JSON sidecars — of every soft-deleted
+  /// journal entity, in rowid chunks of [_purgeChunk].
   Future<void> purgeDeletedFiles() async {
-    final deletedEntries = await (select(
-      journal,
-    )..where((tbl) => tbl.deleted.equals(true))).get();
-
-    for (final entry in deletedEntries) {
-      try {
-        final journalEntity = JournalEntity.fromJson(
-          jsonDecode(entry.serialized) as Map<String, dynamic>,
-        );
-
-        await journalEntity.maybeMap(
-          journalImage: (JournalImage image) async {
-            final fullPath = getFullImagePath(image);
-            await _deleteFileIfExists(fullPath);
-            await _deleteFileIfExists('$fullPath.json');
-          },
-          journalAudio: (JournalAudio audio) async {
-            final fullPath = await AudioUtils.getFullAudioPath(audio);
-            await _deleteFileIfExists(fullPath);
-            await _deleteFileIfExists('$fullPath.json');
-          },
-          orElse: () async {
-            // For all other entry types, just delete the JSON file
-            final docDir = getDocumentsDirectory();
-            await _deleteFileIfExists(entityPath(journalEntity, docDir));
-          },
-        );
-      } catch (e) {
-        // Log error but continue with other files
-        getIt<DomainLogger>().error(
-          LogDomain.database,
-          e,
-          subDomain: 'purgeDeletedFiles',
-        );
+    var lastRowId = 0;
+    while (true) {
+      final rows = await customSelect(
+        'SELECT rowid AS rid, serialized FROM journal '
+        'WHERE deleted = 1 AND rowid > ? ORDER BY rowid LIMIT ?',
+        variables: [
+          Variable.withInt(lastRowId),
+          Variable.withInt(_purgeChunk),
+        ],
+        readsFrom: {journal},
+      ).get();
+      if (rows.isEmpty) return;
+      for (final row in rows) {
+        lastRowId = row.read<int>('rid');
+        await _deleteFilesOf(row.read<String>('serialized'));
       }
+    }
+  }
+
+  Future<void> _deleteFilesOf(String serialized) async {
+    try {
+      final journalEntity = JournalEntity.fromJson(
+        jsonDecode(serialized) as Map<String, dynamic>,
+      );
+
+      await journalEntity.maybeMap(
+        journalImage: (JournalImage image) async {
+          final fullPath = getFullImagePath(image);
+          await _deleteFileIfExists(fullPath);
+          await _deleteFileIfExists('$fullPath.json');
+        },
+        journalAudio: (JournalAudio audio) async {
+          final fullPath = await AudioUtils.getFullAudioPath(audio);
+          await _deleteFileIfExists(fullPath);
+          await _deleteFileIfExists('$fullPath.json');
+        },
+        orElse: () async {
+          // For all other entry types, just delete the JSON file
+          final docDir = getDocumentsDirectory();
+          await _deleteFileIfExists(entityPath(journalEntity, docDir));
+        },
+      );
+    } catch (e) {
+      // Log error but continue with other files
+      getIt<DomainLogger>().error(
+        LogDomain.database,
+        e,
+        subDomain: 'purgeDeletedFiles',
+      );
     }
   }
 
@@ -275,10 +296,23 @@ mixin _JournalDbEntityOps
     }
   }
 
-  Stream<double> purgeDeleted({
-    bool backup = true,
-    Duration stepDelay = const Duration(milliseconds: 50),
-  }) async* {
+  Future<int> _countDeleted(TableInfo<Table, Object?> table) async {
+    final row = await customSelect(
+      'SELECT COUNT(*) AS c FROM ${table.actualTableName} WHERE deleted = 1',
+      readsFrom: {table},
+    ).getSingle();
+    return row.read<int>('c');
+  }
+
+  /// Removes every soft-deleted dashboard, measurable and journal row, after
+  /// deleting the journal rows' files, reporting progress as it goes.
+  ///
+  /// Counts come from `COUNT(*)`, not from loading the rows, and the file
+  /// walk streams in rowid chunks, so the purge costs the same memory on a
+  /// journal with a hundred deleted entries and one with a hundred thousand.
+  /// Progress is emitted after each table; nothing sleeps to make it
+  /// visible.
+  Stream<double> purgeDeleted({bool backup = true}) async* {
     if (backup) {
       await createDbBackup(journalDbFileName);
     }
@@ -286,50 +320,29 @@ mixin _JournalDbEntityOps
     // First delete the actual files
     await purgeDeletedFiles();
 
-    // Get counts for each type
-    final dashboardCount =
-        await (select(dashboardDefinitions)
-              ..where((tbl) => tbl.deleted.equals(true)))
-            .get()
-            .then((list) => list.length);
+    final dashboardCount = await _countDeleted(dashboardDefinitions);
+    final measurableCount = await _countDeleted(measurableTypes);
+    final journalCount = await _countDeleted(journal);
 
-    final measurableCount =
-        await (select(measurableTypes)
-              ..where((tbl) => tbl.deleted.equals(true)))
-            .get()
-            .then((list) => list.length);
-
-    final journalCount =
-        await (select(journal)..where((tbl) => tbl.deleted.equals(true)))
-            .get()
-            .then((list) => list.length);
-
-    final totalItems = dashboardCount + measurableCount + journalCount;
-
-    if (totalItems == 0) {
+    if (dashboardCount + measurableCount + journalCount == 0) {
       yield 1.0; // Already empty
       return;
     }
 
-    // Purge dashboards
     if (dashboardCount > 0) {
       await (delete(
         dashboardDefinitions,
       )..where((tbl) => tbl.deleted.equals(true))).go();
     }
     yield 0.33; // 33% complete after dashboards
-    await Future<void>.delayed(stepDelay);
 
-    // Purge measurables
     if (measurableCount > 0) {
       await (delete(
         measurableTypes,
       )..where((tbl) => tbl.deleted.equals(true))).go();
     }
     yield 0.66; // 66% complete after measurables
-    await Future<void>.delayed(stepDelay);
 
-    // Purge journal entries
     if (journalCount > 0) {
       await (delete(journal)..where((tbl) => tbl.deleted.equals(true))).go();
     }

--- a/lib/database/maintenance.dart
+++ b/lib/database/maintenance.dart
@@ -195,35 +195,37 @@ class Maintenance {
     final fts5Db = getIt<Fts5Db>();
 
     final entryCount = await _db.getJournalCount();
-    const pageSize = 500;
-    final pages = (entryCount / pageSize).ceil();
     var completed = 0;
     var lastReportedProgress = 0;
 
-    for (var page = 0; page <= pages; page++) {
-      final dbEntities = await _db
-          .orderedJournal(pageSize, page * pageSize)
+    // Walk the journal by rowid rather than OFFSET: an OFFSET page re-scans
+    // every row before it, which makes a full rebuild quadratic in the
+    // journal's size. The order does not matter to the index.
+    var lastRowId = 0;
+    while (true) {
+      final rows = await _db
+          .customSelect(
+            'SELECT rowid AS rid, * FROM journal '
+            'WHERE deleted = 0 AND rowid > ? ORDER BY rowid LIMIT ?',
+            variables: [
+              Variable.withInt(lastRowId),
+              Variable.withInt(_ftsRebuildChunk),
+            ],
+            readsFrom: {_db.journal},
+          )
           .get();
+      if (rows.isEmpty) break;
 
-      final entries = entityStreamMapper(dbEntities);
-
-      for (var i = 0; i < entries.length; i++) {
-        final entry = entries[i];
-        await fts5Db.insertText(entry);
+      for (final row in rows) {
+        lastRowId = row.read<int>('rid');
+        await fts5Db.insertText(fromDbEntity(_db.journal.map(row.data)));
         completed++;
 
-        // Calculate current progress percentage
-        final currentProgress = entryCount > 0 ? (completed / entryCount) : 0.0;
+        final currentProgress = entryCount > 0 ? completed / entryCount : 0.0;
         final currentPercentage = (currentProgress * 100).round();
-
-        // Only update if we've moved to a new percentage point
         if (currentPercentage > lastReportedProgress) {
           lastReportedProgress = currentPercentage;
           onProgress?.call(currentProgress);
-
-          // Add a small delay to make the progress visible
-          await Future<void>.delayed(const Duration(milliseconds: 10));
-
           getIt<DomainLogger>().log(
             LogDomain.database,
             'Progress: $currentPercentage%, $completed/$entryCount',
@@ -233,4 +235,7 @@ class Maintenance {
       }
     }
   }
+
+  /// Rows read per round trip while rebuilding the search index.
+  static const int _ftsRebuildChunk = 500;
 }

--- a/test/database/database_entity_ops_test.dart
+++ b/test/database/database_entity_ops_test.dart
@@ -554,9 +554,7 @@ void main() {
         final docDir = getIt<Directory>();
         await createPlaceholderDbFile(docDir);
 
-        final progress = await db!
-            .purgeDeleted(stepDelay: Duration.zero)
-            .toList();
+        final progress = await db!.purgeDeleted().toList();
         expect(progress, equals([1.0]));
 
         final backupDir = Directory('${docDir.path}/backup');
@@ -583,9 +581,7 @@ void main() {
           backupDir.deleteSync(recursive: true);
         }
 
-        final progress = await db!
-            .purgeDeleted(backup: false, stepDelay: Duration.zero)
-            .toList();
+        final progress = await db!.purgeDeleted(backup: false).toList();
         expect(progress, equals([1.0]));
         expect(backupDir.existsSync(), isFalse);
       });
@@ -596,9 +592,7 @@ void main() {
         await createPlaceholderDbFile(docDir);
         await seedDeletedDatabaseContent(db!, deletionTime);
 
-        await db!
-            .purgeDeleted(backup: false, stepDelay: Duration.zero)
-            .toList();
+        await db!.purgeDeleted(backup: false).toList();
 
         expect(await db!.select(db!.dashboardDefinitions).get(), isEmpty);
         expect(await db!.select(db!.measurableTypes).get(), isEmpty);
@@ -609,16 +603,43 @@ void main() {
         final deletionTime = DateTime(2024, 2, 2, 9);
         await seedDeletedDatabaseContent(db!, deletionTime);
 
-        final progress = await db!
-            .purgeDeleted(backup: false, stepDelay: Duration.zero)
-            .toList();
+        final progress = await db!.purgeDeleted(backup: false).toList();
         expect(progress, equals([0.33, 0.66, 1.0]));
       });
 
+      test(
+        'purges deleted entries and their files across chunk boundaries',
+        () async {
+          final docDir = getIt<Directory>();
+          final deletionTime = DateTime(2024, 2, 3, 10);
+          // More deleted rows than one chunk holds, so the rowid walk has
+          // to continue past its first page without skipping or repeating.
+          const total = 1203;
+          final paths = <String>[];
+          for (var i = 0; i < total; i++) {
+            final live = buildJournalEntry(
+              id: 'chunk-$i',
+              timestamp: deletionTime.add(Duration(seconds: i)),
+              text: 'deleted $i',
+            );
+            final entry = live.copyWith(
+              meta: live.meta.copyWith(deletedAt: deletionTime),
+            );
+            await db!.updateJournalEntity(entry);
+            paths.add(entityPath(entry, docDir));
+          }
+          expect(paths.where((p) => File(p).existsSync()), hasLength(total));
+
+          final progress = await db!.purgeDeleted(backup: false).toList();
+
+          expect(progress, equals([0.33, 0.66, 1.0]));
+          expect(await db!.select(db!.journal).get(), isEmpty);
+          expect(paths.where((p) => File(p).existsSync()), isEmpty);
+        },
+      );
+
       test('returns 1.0 immediately when nothing to purge', () async {
-        final progress = await db!
-            .purgeDeleted(backup: false, stepDelay: Duration.zero)
-            .toList();
+        final progress = await db!.purgeDeleted(backup: false).toList();
         expect(progress, equals([1.0]));
       });
     });

--- a/test/database/maintenance_test.dart
+++ b/test/database/maintenance_test.dart
@@ -504,11 +504,14 @@ void main() {
         await maintenance.recreateFts5();
 
         final newFtsDb = getIt<Fts5Db>();
-        final sampleMatches = await newFtsDb
-            .watchFullTextMatches('Bulk entry 519')
-            .first;
-
-        expect(sampleMatches, contains('bulk-519'));
+        // The first, the chunk boundary on both sides, and the last: a
+        // keyset walk that skipped or repeated a row would miss one of them.
+        for (final index in [0, 499, 500, 519]) {
+          final matches = await newFtsDb
+              .watchFullTextMatches('"Bulk entry $index"')
+              .first;
+          expect(matches, contains('bulk-$index'), reason: 'bulk-$index');
+        }
       });
 
       test('handles deletion errors gracefully and logs exception', () async {

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -814,7 +814,7 @@ void main() {
       expect(await getIt<JournalDb>().getWipCount(), 0);
 
       await getIt<JournalDb>()
-          .purgeDeleted(backup: false, stepDelay: Duration.zero)
+          .purgeDeleted(backup: false)
           .drain<void>();
     });
 
@@ -1132,7 +1132,7 @@ void main() {
       // Call purgeDeleted and collect all progress values
       final progressValues = <double>[];
       await getIt<JournalDb>()
-          .purgeDeleted(backup: false, stepDelay: Duration.zero)
+          .purgeDeleted(backup: false)
           .forEach(progressValues.add);
 
       // Verify the final progress is 1.0


### PR DESCRIPTION
## Summary

Finding 20 of the persistence-layer review.

**Purge.** `purgeDeleted` counted the deleted dashboards, measurables and journal rows by selecting every full row and taking `.length` (three times), `purgeDeletedFiles` loaded every deleted journal entity's JSON in one query to delete its files, and the stream slept between steps "to make progress visible". Counts now come from `COUNT(*)`, the file walk streams deleted rows in rowid chunks of 500, and progress is emitted after each table with no sleeps. The `stepDelay` parameter that only existed so tests could switch the sleep off is gone.

**Search rebuild.** `recreateFts5` paged the journal with `OFFSET`, which re-scans every earlier row for each page and makes a full rebuild quadratic in the journal's size, and slept ten milliseconds per percent of progress. It now walks live rows by rowid keyset (order is irrelevant to the index) and reports progress as it goes. The `orderedJournal` query it used is removed from `database.drift`.

Memory and time now scale with the chunk size rather than with the journal.

## Tests

- purge: 1203 deleted entries (more than two chunks) are purged with every sidecar removed and the same progress sequence as before; the existing purge tests drop the `stepDelay` argument.
- rebuild: the 520-entry test now asserts the first row, both sides of the chunk boundary (499, 500) and the last row are indexed, which a keyset walk that skipped or repeated a row would fail.
- `database_entity_ops`, `maintenance`, `database_journal_queries`: green. `make analyze` clean.

Changelog fragment added: users with large journals will notice both operations finishing faster.
