### PR TITLE
fix(db): run the JournalDb upgrade in one transaction, rebuild config_flags (v48)

### DIFF
--- a/changelog.d/2026-09-05-atomic-database-upgrade.md
+++ b/changelog.d/2026-09-05-atomic-database-upgrade.md
@@ -1,0 +1,6 @@
+### Fixed
+- **An interrupted database upgrade could leave the journal half-migrated.**
+  If the app was killed while upgrading its database, the steps already
+  applied stayed while the version number did not advance, and the next
+  launch would try to apply them again. The whole upgrade now either
+  completes or rolls back to the version that was running.

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -81,7 +81,7 @@ migration work has to cover both, and embeddings are a third store again (below)
 
 | Database | File | Schema | Owns |
 |----------|------|--------|------|
-| `JournalDb` | `db.sqlite` | 47 | Journal entities, tasks, links, tags, config flags — the primary store |
+| `JournalDb` | `db.sqlite` | 48 | Journal entities, tasks, links, tags, config flags — the primary store |
 | `SyncDatabase` | `sync.sqlite` | 29 | Outbox, sequence log, host activity, inbound event queue, queue markers |
 | `AgentDatabase` | `agent.sqlite` | 19 | Agent state, reports, observations, change proposals, wake history |
 | `EditorDb` | `editor_drafts_db.sqlite` | 2 | Unsaved rich-text editor drafts |
@@ -224,13 +224,27 @@ histories. The journal strategy lives in `database_migration.dart` and
 
 1. `onUpgrade` takes a timestamped backup first — `backup/db.<ts>.sqlite` —
    unless the database is in-memory. A failed backup is logged, not fatal.
-2. Version steps run in order, adding tables, columns and partial indexes.
-   Current index definitions may reference columns absent in historical schemas:
-   the task priority index is created only after v29 adds priority columns, even
-   for a journal upgrading from before v25.
-3. Partial index DDL lives in top-level constants used by migrations. Callers
+2. **Every version step, and the index reconcile that ends them, runs in one
+   transaction.** Drift runs `onUpgrade` outside one, and SQLite's DDL is
+   transactional, so an interrupted upgrade rolls back to the version that
+   was running instead of leaving a half-applied schema at the old
+   `user_version` for the next launch to migrate again. That is why the
+   steps no longer probe for tables or columns before acting: on a database
+   that shipped, every column a step needs was added by an earlier step of
+   the same run, and a real schema bug should fail the upgrade loudly (the
+   history verifier catches it in development). The two probes that remain
+   are genuinely conditional on an install's history — `_ensureLabelTables`
+   for pre-release v26 installs and the v47 drop of the v20 `category_id`
+   column — and `_columnExists` propagates a failing PRAGMA rather than
+   reading it as "absent". Foreign-key enforcement is off during the upgrade
+   (it cannot change inside a transaction) and on from `beforeOpen` onward.
+3. Version steps run in order, adding tables, columns and partial indexes.
+   Current index definitions may reference columns absent in historical
+   schemas: the task priority index is created only after v29 adds priority
+   columns, even for a journal upgrading from before v25.
+4. Partial index DDL lives in top-level constants used by migrations. Callers
    can add `IF NOT EXISTS` with `replaceFirst` where needed.
-4. `beforeOpen` repairs the specific indexes named there; it does not rebuild
+5. `beforeOpen` repairs the specific indexes named there; it does not rebuild
    every index in the schema.
 
 Every migration test starts from a schema that shipped, seeded through

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -224,11 +224,15 @@ histories. The journal strategy lives in `database_migration.dart` and
 
 1. `onUpgrade` takes a timestamped backup first — `backup/db.<ts>.sqlite` —
    unless the database is in-memory. A failed backup is logged, not fatal.
-2. **Every version step, and the index reconcile that ends them, runs in one
-   transaction.** Drift runs `onUpgrade` outside one, and SQLite's DDL is
-   transactional, so an interrupted upgrade rolls back to the version that
-   was running instead of leaving a half-applied schema at the old
-   `user_version` for the next launch to migrate again. That is why the
+2. **Every version step, the index reconcile that ends them, and the
+   version stamp run in one transaction.** Drift runs `onUpgrade` outside
+   one and writes `user_version` only after `onUpgrade` and `beforeOpen`
+   have both completed, so the transaction stamps `PRAGMA user_version`
+   itself before committing (Drift's later write only repeats it). SQLite's
+   DDL is transactional, so an interrupted upgrade rolls back to the version
+   that was running instead of leaving a half-applied schema at the old
+   `user_version` for the next launch to migrate again, and a kill after the
+   commit cannot leave the new schema under the old stamp. That is why the
    steps no longer probe for tables before acting: on a database that
    shipped, every table a step needs exists, and a real schema bug should
    fail the upgrade loudly (the history verifier catches it in development).

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -229,15 +229,19 @@ histories. The journal strategy lives in `database_migration.dart` and
    transactional, so an interrupted upgrade rolls back to the version that
    was running instead of leaving a half-applied schema at the old
    `user_version` for the next launch to migrate again. That is why the
-   steps no longer probe for tables or columns before acting: on a database
-   that shipped, every column a step needs was added by an earlier step of
-   the same run, and a real schema bug should fail the upgrade loudly (the
-   history verifier catches it in development). The two probes that remain
-   are genuinely conditional on an install's history — `_ensureLabelTables`
-   for pre-release v26 installs and the v47 drop of the v20 `category_id`
-   column — and `_columnExists` propagates a failing PRAGMA rather than
-   reading it as "absent". Foreign-key enforcement is off during the upgrade
-   (it cannot change inside a transaction) and on from `beforeOpen` onward.
+   steps no longer probe for tables before acting: on a database that
+   shipped, every table a step needs exists, and a real schema bug should
+   fail the upgrade loudly (the history verifier catches it in development).
+   The probes that remain are conditional on an install's history:
+   `_ensureLabelTables` for pre-release v26 installs, the v47 drop of the
+   v20 `category_id` column, and `_addColumnUnlessPresent` around every
+   column-adding step before v48 — those steps shipped without the
+   transaction, so an install killed mid-step can already hold the column,
+   and a duplicate-column refusal inside the atomic upgrade would roll it
+   back on every launch. Steps from v48 on need no such check.
+   `_columnExists` propagates a failing PRAGMA rather than reading it as
+   "absent". Foreign-key enforcement is off during the upgrade (it cannot
+   change inside a transaction) and on from `beforeOpen` onward.
 3. Version steps run in order, adding tables, columns and partial indexes.
    Current index definitions may reference columns absent in historical
    schemas: the task priority index is created only after v29 adds priority

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -167,9 +167,11 @@ class JournalDb extends _$JournalDb
   @override
   int get schemaVersion => 48;
 
-  /// Whether [table] has a column named [column]. Used only where a step is
-  /// genuinely conditional on an install's history (the v20 `category_id`
-  /// column); a failing PRAGMA propagates rather than reading as "absent".
+  /// Whether [table] has a column named [column]. Used where a step is
+  /// conditional on an install's history: the v20 `category_id` column, and
+  /// the columns a pre-v48 upgrade may have added before it was interrupted
+  /// (see `_addColumnUnlessPresent`). A failing PRAGMA propagates rather
+  /// than reading as "absent".
   @override
   Future<bool> _columnExists(String table, String column) async {
     final rows = await customSelect('PRAGMA table_info($table)').get();

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -165,22 +165,15 @@ class JournalDb extends _$JournalDb
   final Directory? _documentsDirectory;
 
   @override
-  int get schemaVersion => 47;
+  int get schemaVersion => 48;
 
-  // Check whether a column exists in a given table to make migrations safer
+  /// Whether [table] has a column named [column]. Used only where a step is
+  /// genuinely conditional on an install's history (the v20 `category_id`
+  /// column); a failing PRAGMA propagates rather than reading as "absent".
   @override
   Future<bool> _columnExists(String table, String column) async {
-    try {
-      final rows = await customSelect('PRAGMA table_info($table)').get();
-      for (final row in rows) {
-        final name = row.read<String>('name');
-        if (name == column) return true;
-      }
-      return false;
-    } catch (_) {
-      // If PRAGMA fails for any reason, fall back to false so migration attempts add the column
-      return false;
-    }
+    final rows = await customSelect('PRAGMA table_info($table)').get();
+    return rows.any((row) => row.read<String>('name') == column);
   }
 
   @override
@@ -243,7 +236,6 @@ WHERE EXISTS (
     );
   }
 
-  @override
   Future<bool> _tableExists(String tableName) async {
     final result = await customSelect(
       'SELECT name FROM sqlite_master WHERE type = ? AND name = ?',

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -307,9 +307,11 @@ CREATE INDEX idx_dashboard_definitions_deleted_private_name ON dashboard_definit
   name COLLATE NOCASE ASC
 );
 
+-- `description` is a display string: no uniqueness on it, and `name` is
+-- unique through the primary key alone. Rebuilt into this shape in v48.
 CREATE TABLE config_flags (
-  name TEXT NOT NULL UNIQUE,
-  description TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL,
   status BOOLEAN NOT NULL DEFAULT FALSE,
   PRIMARY KEY (name)
 );

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -4578,7 +4578,7 @@ class ConfigFlags extends Table with TableInfo<ConfigFlags, ConfigFlag> {
     false,
     type: DriftSqlType.string,
     requiredDuringInsert: true,
-    $customConstraints: 'NOT NULL UNIQUE',
+    $customConstraints: 'NOT NULL',
   );
   static const VerificationMeta _descriptionMeta = const VerificationMeta(
     'description',
@@ -4589,7 +4589,7 @@ class ConfigFlags extends Table with TableInfo<ConfigFlags, ConfigFlag> {
     false,
     type: DriftSqlType.string,
     requiredDuringInsert: true,
-    $customConstraints: 'NOT NULL UNIQUE',
+    $customConstraints: 'NOT NULL',
   );
   static const VerificationMeta _statusMeta = const VerificationMeta('status');
   late final GeneratedColumn<bool> status = GeneratedColumn<bool>(

--- a/lib/database/database_migration.dart
+++ b/lib/database/database_migration.dart
@@ -66,7 +66,11 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
                 name: 'JournalDb',
                 message: 'Add category_id in journal table, with index',
               );
-              await m.addColumn(journal, journal.category);
+              await _addColumnUnlessPresent(
+                journal.actualTableName,
+                journal.category.name,
+                () => m.addColumn(journal, journal.category),
+              );
             }();
           }
 
@@ -76,7 +80,11 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
                 name: 'JournalDb',
                 message: 'Add hidden in linked_entries table',
               );
-              await m.addColumn(linkedEntries, linkedEntries.hidden);
+              await _addColumnUnlessPresent(
+                linkedEntries.actualTableName,
+                linkedEntries.hidden.name,
+                () => m.addColumn(linkedEntries, linkedEntries.hidden),
+              );
             }();
           }
 
@@ -86,8 +94,16 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
                 name: 'JournalDb',
                 message: 'Add timestamps in linked_entries table, with index',
               );
-              await m.addColumn(linkedEntries, linkedEntries.createdAt);
-              await m.addColumn(linkedEntries, linkedEntries.updatedAt);
+              await _addColumnUnlessPresent(
+                linkedEntries.actualTableName,
+                linkedEntries.createdAt.name,
+                () => m.addColumn(linkedEntries, linkedEntries.createdAt),
+              );
+              await _addColumnUnlessPresent(
+                linkedEntries.actualTableName,
+                linkedEntries.updatedAt.name,
+                () => m.addColumn(linkedEntries, linkedEntries.updatedAt),
+              );
             }();
           }
 
@@ -162,8 +178,16 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
                 message: 'Adding task priority columns and updating index',
               );
 
-              await m.addColumn(journal, journal.taskPriority);
-              await m.addColumn(journal, journal.taskPriorityRank);
+              await _addColumnUnlessPresent(
+                journal.actualTableName,
+                journal.taskPriority.name,
+                () => m.addColumn(journal, journal.taskPriority),
+              );
+              await _addColumnUnlessPresent(
+                journal.actualTableName,
+                journal.taskPriorityRank.name,
+                () => m.addColumn(journal, journal.taskPriorityRank),
+              );
 
               // Backfill existing task rows to P2/2
               await customStatement(
@@ -300,7 +324,11 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
                 name: 'JournalDb',
                 message: 'Adding project_id column to journal table',
               );
-              await m.addColumn(journal, journal.projectId);
+              await _addColumnUnlessPresent(
+                journal.actualTableName,
+                journal.projectId.name,
+                () => m.addColumn(journal, journal.projectId),
+              );
               // Backfill project_id from the most-recent active ProjectLink.
               await customStatement(
                 "UPDATE journal SET project_id = ($_projectIdSubquery) WHERE type = 'Task'",

--- a/lib/database/database_migration.dart
+++ b/lib/database/database_migration.dart
@@ -4,8 +4,6 @@ part of 'database.dart';
 /// file for size. Kept as a mixin so it still overrides `_$JournalDb.migration`
 /// and can call the table/column probes that remain on the concrete database.
 mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
-  // _tableExists / _columnExists are inherited as contracts from
-  // _JournalDbMigrationRecent (this mixin's on-clause).
   Future<void> _ensureLabelTables(Migrator migrator);
   Future<void> _rebuildLabeledWithFkCascade();
   bool get inMemoryDatabase;
@@ -18,12 +16,8 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
       beforeOpen: (details) async {
         // PRAGMA is connection-local — must run on every connection.
         await customStatement('PRAGMA foreign_keys = ON');
-        if (await _tableExists('journal')) {
-          await customStatement(_createIdxJournalQuantLatestSql);
-        }
-        if (await _tableExists('conflicts')) {
-          await customStatement(_createIdxConflictsStatusCreatedSql);
-        }
+        await customStatement(_createIdxJournalQuantLatestSql);
+        await customStatement(_createIdxConflictsStatusCreatedSql);
       },
       onCreate: (Migrator m) async {
         return m.createAll();
@@ -43,258 +37,243 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
           );
         }
 
-        if (from < 19) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message: 'Creating category_definitions table and indices',
-            );
-            await m.createTable(categoryDefinitions);
-            await m.createIndex(idxCategoryDefinitionsName);
-            await m.createIndex(idxCategoryDefinitionsPrivate);
-          }();
-        }
+        // Every step, and the index reconcile that ends them, in one
+        // transaction. Drift runs onUpgrade outside one, and SQLite's DDL is
+        // transactional, so an interrupted upgrade — a crash, a kill mid
+        // rebuild — rolls back to the version that was running instead of
+        // leaving a half-applied schema at the old user_version that the
+        // next launch would try to migrate again. Foreign-key enforcement
+        // cannot change inside a transaction and is off on a fresh
+        // connection; it is switched on in beforeOpen once the upgrade has
+        // committed.
+        await customStatement('PRAGMA foreign_keys = OFF');
+        await transaction(() async {
+          if (from < 19) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message: 'Creating category_definitions table and indices',
+              );
+              await m.createTable(categoryDefinitions);
+              await m.createIndex(idxCategoryDefinitionsName);
+              await m.createIndex(idxCategoryDefinitionsPrivate);
+            }();
+          }
 
-        if (from < 21) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message: 'Add category_id in journal table, with index',
-            );
-            await m.addColumn(journal, journal.category);
-          }();
-        }
+          if (from < 21) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message: 'Add category_id in journal table, with index',
+              );
+              await m.addColumn(journal, journal.category);
+            }();
+          }
 
-        if (from < 22) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message: 'Add hidden in linked_entries table',
-            );
-            await m.addColumn(linkedEntries, linkedEntries.hidden);
-          }();
-        }
+          if (from < 22) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message: 'Add hidden in linked_entries table',
+              );
+              await m.addColumn(linkedEntries, linkedEntries.hidden);
+            }();
+          }
 
-        if (from < 23) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message: 'Add timestamps in linked_entries table, with index',
-            );
-            await m.addColumn(linkedEntries, linkedEntries.createdAt);
-            await m.addColumn(linkedEntries, linkedEntries.updatedAt);
-          }();
-        }
+          if (from < 23) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message: 'Add timestamps in linked_entries table, with index',
+              );
+              await m.addColumn(linkedEntries, linkedEntries.createdAt);
+              await m.addColumn(linkedEntries, linkedEntries.updatedAt);
+            }();
+          }
 
-        if (from < 24) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message: 'Adding composite indices',
-            );
-            await m.createIndex(idxLinkedEntriesFromIdHidden);
-            await m.createIndex(idxLinkedEntriesToIdHidden);
-          }();
-        }
+          if (from < 24) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message: 'Adding composite indices',
+              );
+              await m.createIndex(idxLinkedEntriesFromIdHidden);
+              await m.createIndex(idxLinkedEntriesToIdHidden);
+            }();
+          }
 
-        if (from < 25) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message: 'Adding composite indices',
-            );
-            await m.createIndex(idxJournalTab);
-            // The current task index references priority columns introduced
-            // in v29. That step below creates it after adding the columns;
-            // creating it here would fail on an actual pre-v25 database.
-            await m.createIndex(idxJournalTypeSubtype);
-          }();
-        }
+          if (from < 25) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message: 'Adding composite indices',
+              );
+              await m.createIndex(idxJournalTab);
+              // The current task index references priority columns introduced
+              // in v29. That step below creates it after adding the columns;
+              // creating it here would fail on an actual pre-v25 database.
+              await m.createIndex(idxJournalTypeSubtype);
+            }();
+          }
 
-        if (from < 26) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message: 'Creating label_definitions and labeled tables',
-            );
-            await m.createTable(labelDefinitions);
-            await m.createIndex(idxLabelDefinitionsName);
-            await m.createIndex(idxLabelDefinitionsPrivate);
+          if (from < 26) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message: 'Creating label_definitions and labeled tables',
+              );
+              await m.createTable(labelDefinitions);
+              await m.createIndex(idxLabelDefinitionsName);
+              await m.createIndex(idxLabelDefinitionsPrivate);
 
-            await m.createTable(labeled);
-            await m.createIndex(idxLabeledJournalId);
-            await m.createIndex(idxLabeledLabelId);
-          }();
-        }
+              await m.createTable(labeled);
+              await m.createIndex(idxLabeledJournalId);
+              await m.createIndex(idxLabeledLabelId);
+            }();
+          }
 
-        if (from < 27) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message: 'Ensuring label tables exist for legacy v26 installs',
-            );
-            await _ensureLabelTables(m);
-          }();
-        }
+          if (from < 27) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message: 'Ensuring label tables exist for legacy v26 installs',
+              );
+              await _ensureLabelTables(m);
+            }();
+          }
 
-        // v28: Rebuild `labeled` with FK on label_id -> label_definitions(id) ON DELETE CASCADE
-        if (from < 28) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message:
-                  'Rebuilding labeled table to add FK with ON DELETE CASCADE',
-            );
-            await _rebuildLabeledWithFkCascade();
-          }();
-        }
+          // v28: Rebuild `labeled` with FK on label_id -> label_definitions(id) ON DELETE CASCADE
+          if (from < 28) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message:
+                    'Rebuilding labeled table to add FK with ON DELETE CASCADE',
+              );
+              await _rebuildLabeledWithFkCascade();
+            }();
+          }
 
-        // v29: Add task priority columns and update tasks index
-        if (from < 29) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message: 'Adding task priority columns and updating index',
-            );
+          // v29: Add task priority columns and update tasks index
+          if (from < 29) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message: 'Adding task priority columns and updating index',
+              );
 
-            // Add columns only if missing to avoid masking other errors
-            final hasTaskPriority = await _columnExists(
-              'journal',
-              'task_priority',
-            );
-            if (!hasTaskPriority) {
               await m.addColumn(journal, journal.taskPriority);
-            }
-
-            final hasTaskPriorityRank = await _columnExists(
-              'journal',
-              'task_priority_rank',
-            );
-            if (!hasTaskPriorityRank) {
               await m.addColumn(journal, journal.taskPriorityRank);
-            }
 
-            // Backfill existing task rows to P2/2
-            await customStatement(
-              "UPDATE journal SET task_priority = 'P2', task_priority_rank = 2 WHERE task = 1 AND (task_priority IS NULL OR task_priority = '')",
-            );
+              // Backfill existing task rows to P2/2
+              await customStatement(
+                "UPDATE journal SET task_priority = 'P2', task_priority_rank = 2 WHERE task = 1 AND (task_priority IS NULL OR task_priority = '')",
+              );
 
-            // Rebuild index to include priority rank
-            await customStatement('DROP INDEX IF EXISTS idx_journal_tasks');
-            await m.createIndex(idxJournalTasks);
-          }();
-        }
+              // Rebuild index to include priority rank
+              await customStatement('DROP INDEX IF EXISTS idx_journal_tasks');
+              await m.createIndex(idxJournalTasks);
+            }();
+          }
 
-        // v30: Fix copy-paste bug in idx_linked_entries_to_id_hidden
-        // which was indexing from_id instead of to_id
-        if (from < 30) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message: 'Fixing idx_linked_entries_to_id_hidden to index to_id',
-            );
-            await customStatement(
-              'DROP INDEX IF EXISTS idx_linked_entries_to_id_hidden',
-            );
-            await m.createIndex(idxLinkedEntriesToIdHidden);
-          }();
-        }
+          // v30: Fix copy-paste bug in idx_linked_entries_to_id_hidden
+          // which was indexing from_id instead of to_id
+          if (from < 30) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message:
+                    'Fixing idx_linked_entries_to_id_hidden to index to_id',
+              );
+              await customStatement(
+                'DROP INDEX IF EXISTS idx_linked_entries_to_id_hidden',
+              );
+              await m.createIndex(idxLinkedEntriesToIdHidden);
+            }();
+          }
 
-        // v33: Originally rebuilt the active task due-date index as a
-        // non-partial composite so it could be forced with INDEXED BY.
-        // The index itself is dropped in v41 (consumer rewritten to read
-        // the denormalized `due_at` column), so the v33 step is now just a
-        // no-op DROP — both for fresh installs that skip straight to v41
-        // and for legacy databases that already created the old index.
-        if (from < 33) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message: 'Dropping legacy active task due-date index',
-            );
-            await customStatement(
-              'DROP INDEX IF EXISTS idx_journal_tasks_due_active',
-            );
-          }();
-        }
+          // v33: Originally rebuilt the active task due-date index as a
+          // non-partial composite so it could be forced with INDEXED BY.
+          // The index itself is dropped in v41 (consumer rewritten to read
+          // the denormalized `due_at` column), so the v33 step is now just a
+          // no-op DROP — both for fresh installs that skip straight to v41
+          // and for legacy databases that already created the old index.
+          if (from < 33) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message: 'Dropping legacy active task due-date index',
+              );
+              await customStatement(
+                'DROP INDEX IF EXISTS idx_journal_tasks_due_active',
+              );
+            }();
+          }
 
-        // v34: Add composite indexes for definition list screens and the
-        // recency-ordered linksFromId() query.
-        if (from < 34) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message: 'Adding definition list and link recency indexes',
-            );
-            if (await _tableExists('habit_definitions')) {
+          // v34: Add composite indexes for definition list screens and the
+          // recency-ordered linksFromId() query.
+          if (from < 34) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message: 'Adding definition list and link recency indexes',
+              );
               await customStatement(
                 'DROP INDEX IF EXISTS idx_habit_definitions_deleted_private',
               );
               await m.createIndex(idxHabitDefinitionsDeletedPrivate);
-            }
-            if (await _tableExists('label_definitions')) {
               await customStatement(
                 'DROP INDEX IF EXISTS idx_label_definitions_deleted_private_name',
               );
               await m.createIndex(idxLabelDefinitionsDeletedPrivateName);
-            }
-            if (await _tableExists('dashboard_definitions')) {
               await customStatement(
                 'DROP INDEX IF EXISTS idx_dashboard_definitions_deleted_private_name',
               );
               await m.createIndex(idxDashboardDefinitionsDeletedPrivateName);
-            }
-            // tag_entities index migration removed — table is no longer
-            // managed by drift but left intact in existing databases.
-            if (await _tableExists('linked_entries')) {
+              // tag_entities index migration removed — table is no longer
+              // managed by drift but left intact in existing databases.
               await customStatement(
                 'DROP INDEX IF EXISTS idx_linked_entries_from_id_hidden_created_at_desc',
               );
               await m.createIndex(idxLinkedEntriesFromIdHiddenCreatedAtDesc);
-            }
-          }();
-        }
+            }();
+          }
 
-        // v35: Add a date-oriented task index for date-sorted task queries.
-        if (from < 35) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message: 'Adding date-oriented task index',
-            );
-            if (await _tableExists('journal')) {
+          // v35: Add a date-oriented task index for date-sorted task queries.
+          if (from < 35) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message: 'Adding date-oriented task index',
+              );
               await customStatement(
                 'DROP INDEX IF EXISTS idx_journal_tasks_date',
               );
               await m.createIndex(idxJournalTasksDate);
-            }
-          }();
-        }
+            }();
+          }
 
-        // v36: Add a browse-oriented journal index for common journal lists.
-        if (from < 36) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message: 'Adding browse-oriented journal index',
-            );
-            if (await _tableExists('journal')) {
+          // v36: Add a browse-oriented journal index for common journal lists.
+          if (from < 36) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message: 'Adding browse-oriented journal index',
+              );
               await customStatement('DROP INDEX IF EXISTS idx_journal_browse');
               await m.createIndex(idxJournalBrowse);
-            }
-          }();
-        }
+            }();
+          }
 
-        // v37: Rebuild task indexes as partial active-task indexes, add a
-        // priority-aware date index, and add a composite labeled lookup index.
-        if (from < 37) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message:
-                  'Rebuilding task indexes and adding labeled lookup index',
-            );
-            if (await _tableExists('journal')) {
+          // v37: Rebuild task indexes as partial active-task indexes, add a
+          // priority-aware date index, and add a composite labeled lookup index.
+          if (from < 37) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message:
+                    'Rebuilding task indexes and adding labeled lookup index',
+              );
               await customStatement('DROP INDEX IF EXISTS idx_journal_tasks');
               await customStatement(
                 'DROP INDEX IF EXISTS idx_journal_tasks_date',
@@ -305,100 +284,85 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
               await m.createIndex(idxJournalTasks);
               await m.createIndex(idxJournalTasksDate);
               await m.createIndex(idxJournalTasksDatePriority);
-            }
-            if (await _tableExists('labeled')) {
               // Remove redundant index — the UNIQUE(journal_id, label_id)
               // constraint already creates an equivalent implicit index.
               await customStatement(
                 'DROP INDEX IF EXISTS idx_labeled_journal_id_label_id',
               );
-            }
-          }();
-        }
+            }();
+          }
 
-        // v38: Add denormalized project_id column to journal for efficient
-        // task-by-project filtering without a JOIN on linked_entries.
-        if (from < 38) {
-          await () async {
-            if (!await _tableExists('journal')) return;
-            DevLogger.log(
-              name: 'JournalDb',
-              message: 'Adding project_id column to journal table',
-            );
-            final hasProjectId = await _columnExists('journal', 'project_id');
-            if (!hasProjectId) {
+          // v38: Add denormalized project_id column to journal for efficient
+          // task-by-project filtering without a JOIN on linked_entries.
+          if (from < 38) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message: 'Adding project_id column to journal table',
+              );
               await m.addColumn(journal, journal.projectId);
-            }
-            // Backfill project_id from the most-recent active ProjectLink.
-            // Guarded by try-catch because minimal migration-test schemas may
-            // not include the linked_entries table.
-            try {
+              // Backfill project_id from the most-recent active ProjectLink.
               await customStatement(
                 "UPDATE journal SET project_id = ($_projectIdSubquery) WHERE type = 'Task'",
               );
-            } catch (_) {
-              // linked_entries does not exist in this DB — backfill skipped.
-            }
-            await customStatement(
-              'DROP INDEX IF EXISTS idx_journal_project_id',
-            );
-            await m.createIndex(idxJournalProjectId);
-          }();
-        }
+              await customStatement(
+                'DROP INDEX IF EXISTS idx_journal_project_id',
+              );
+              await m.createIndex(idxJournalProjectId);
+            }();
+          }
 
-        // v39: Add a partial expression index for the open-task due-date
-        // query (`_selectTasksDue`) so the ORDER BY streams from the index,
-        // and add idx_journal_task_status_private so `countInProgressTasks`
-        // and similar global task-status counts can use a narrow partial
-        // index instead of scanning the full task set.
-        //
-        // The due-open partial is created here in its original
-        // expression-keyed shape (`json_extract(serialized,'$.data.due')`)
-        // because the `due_at` column it would otherwise reference is not
-        // added until v41. The v41 step below drops this expression-keyed
-        // form and recreates the partial on the column.
-        if (from < 39) {
-          await () async {
-            if (!await _tableExists('journal')) return;
-            DevLogger.log(
-              name: 'JournalDb',
-              message:
-                  'Adding open-task due-date partial index and '
-                  'task_status/private count index',
-            );
-            await customStatement(
-              'DROP INDEX IF EXISTS idx_journal_tasks_due_open',
-            );
-            await customStatement(
-              'CREATE INDEX idx_journal_tasks_due_open '
-              r"ON journal(json_extract(serialized, '$.data.due') ASC) "
-              "WHERE type = 'Task' "
-              'AND task = 1 '
-              'AND deleted = FALSE '
-              "AND task_status NOT IN ('DONE', 'REJECTED')",
-            );
-            await customStatement(
-              'DROP INDEX IF EXISTS idx_journal_task_status_private',
-            );
-            await customStatement(_createIdxJournalTaskStatusPrivateSql);
-          }();
-        }
+          // v39: Add a partial expression index for the open-task due-date
+          // query (`_selectTasksDue`) so the ORDER BY streams from the index,
+          // and add idx_journal_task_status_private so `countInProgressTasks`
+          // and similar global task-status counts can use a narrow partial
+          // index instead of scanning the full task set.
+          //
+          // The due-open partial is created here in its original
+          // expression-keyed shape (`json_extract(serialized,'$.data.due')`)
+          // because the `due_at` column it would otherwise reference is not
+          // added until v41. The v41 step below drops this expression-keyed
+          // form and recreates the partial on the column.
+          if (from < 39) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message:
+                    'Adding open-task due-date partial index and '
+                    'task_status/private count index',
+              );
+              await customStatement(
+                'DROP INDEX IF EXISTS idx_journal_tasks_due_open',
+              );
+              await customStatement(
+                'CREATE INDEX idx_journal_tasks_due_open '
+                r"ON journal(json_extract(serialized, '$.data.due') ASC) "
+                "WHERE type = 'Task' "
+                'AND task = 1 '
+                'AND deleted = FALSE '
+                "AND task_status NOT IN ('DONE', 'REJECTED')",
+              );
+              await customStatement(
+                'DROP INDEX IF EXISTS idx_journal_task_status_private',
+              );
+              await customStatement(_createIdxJournalTaskStatusPrivateSql);
+            }();
+          }
 
-        // v40: Slow-query log surfaced four hotspots that all fall
-        // within the journal/linked_entries indexing surface. See
-        // `logs/slow_queries-2026-04-28.log` for the production
-        // traces this batch addresses.
-        if (from < 40) {
-          await () async {
-            DevLogger.log(
-              name: 'JournalDb',
-              message:
-                  'Adding linked_entries (to_id, type) composite + '
-                  'rating partial; journal (project_id, task_status) '
-                  'partial; backfilling task_priority_rank',
-            );
+          // v40: Slow-query log surfaced four hotspots that all fall
+          // within the journal/linked_entries indexing surface. See
+          // `logs/slow_queries-2026-04-28.log` for the production
+          // traces this batch addresses.
+          if (from < 40) {
+            await () async {
+              DevLogger.log(
+                name: 'JournalDb',
+                message:
+                    'Adding linked_entries (to_id, type) composite + '
+                    'rating partial; journal (project_id, task_status) '
+                    'partial; backfilling task_priority_rank',
+              );
 
-            if (await _tableExists('linked_entries')) {
               // Reverse-link `(to_id, type)` lookups (project rollups,
               // link expansion). The single-column `(to_id)` index
               // forced a per-row heap probe to evaluate `type`.
@@ -412,9 +376,7 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
                 'DROP INDEX IF EXISTS idx_linked_entries_rating_to_id',
               );
               await m.createIndex(idxLinkedEntriesRatingToId);
-            }
 
-            if (await _tableExists('journal')) {
               // Backfill any task rows that escaped the v29 fill so
               // the new ORDER BY clauses (which dropped the
               // `COALESCE(task_priority_rank, 2)` wrapper) match the
@@ -436,12 +398,12 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
                 'DROP INDEX IF EXISTS idx_journal_project_task_status',
               );
               await m.createIndex(idxJournalProjectTaskStatus);
-            }
-          }();
-        }
+            }();
+          }
 
-        await _onUpgradeRecent(m, from);
-        await _reconcileIndexesWithSchema(m);
+          await _onUpgradeRecent(m, from);
+          await _reconcileIndexesWithSchema(m);
+        });
       },
     );
   }

--- a/lib/database/database_migration.dart
+++ b/lib/database/database_migration.dart
@@ -37,15 +37,17 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
           );
         }
 
-        // Every step, and the index reconcile that ends them, in one
-        // transaction. Drift runs onUpgrade outside one, and SQLite's DDL is
-        // transactional, so an interrupted upgrade — a crash, a kill mid
-        // rebuild — rolls back to the version that was running instead of
-        // leaving a half-applied schema at the old user_version that the
-        // next launch would try to migrate again. Foreign-key enforcement
-        // cannot change inside a transaction and is off on a fresh
-        // connection; it is switched on in beforeOpen once the upgrade has
-        // committed.
+        // Every step, the index reconcile that ends them, and the version
+        // stamp, in one transaction. Drift runs onUpgrade outside one and
+        // writes user_version only after onUpgrade and beforeOpen have both
+        // completed; SQLite's DDL is transactional, so an interrupted
+        // upgrade — a crash, a kill mid rebuild — rolls back to the version
+        // that was running instead of leaving a half-applied schema at the
+        // old user_version that the next launch would try to migrate again,
+        // and a kill after the commit cannot leave the new schema under the
+        // old stamp either. Foreign-key enforcement cannot change inside a
+        // transaction and is off on a fresh connection; it is switched on in
+        // beforeOpen once the upgrade has committed.
         await customStatement('PRAGMA foreign_keys = OFF');
         await transaction(() async {
           if (from < 19) {
@@ -431,6 +433,9 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
 
           await _onUpgradeRecent(m, from);
           await _reconcileIndexesWithSchema(m);
+          // Drift repeats this write after beforeOpen; stamping here makes
+          // the schema and its version commit together.
+          await customStatement('PRAGMA user_version = $to');
         });
       },
     );

--- a/lib/database/database_migration_recent.dart
+++ b/lib/database/database_migration_recent.dart
@@ -3,7 +3,6 @@ part of 'database.dart';
 /// Most-recent schema-upgrade steps (v41+) for [JournalDb], split from
 /// [_JournalDbMigration] for file size and invoked from its onUpgrade.
 mixin _JournalDbMigrationRecent on _$JournalDb {
-  Future<bool> _tableExists(String tableName);
   Future<bool> _columnExists(String table, String column);
 
   Future<void> _onUpgradeRecent(Migrator m, int from) async {
@@ -22,7 +21,6 @@ mixin _JournalDbMigrationRecent on _$JournalDb {
     // planner choose its own access path.
     if (from < 41) {
       await () async {
-        if (!await _tableExists('journal')) return;
         DevLogger.log(
           name: 'JournalDb',
           message:
@@ -30,14 +28,10 @@ mixin _JournalDbMigrationRecent on _$JournalDb {
               'recreating tasks-due partial index',
         );
 
-        // 1. Add the nullable column. Idempotent via column-existence
-        //    check (mirrors the project_id / task_priority_rank
-        //    migration shape).
-        if (!await _columnExists('journal', 'due_at')) {
-          await customStatement(
-            'ALTER TABLE journal ADD COLUMN due_at DATETIME',
-          );
-        }
+        // 1. Add the nullable column.
+        await customStatement(
+          'ALTER TABLE journal ADD COLUMN due_at DATETIME',
+        );
 
         // 2. Backfill from JSON for every task with a non-null
         //    `data.due`, regardless of status. `getTasksSortedByDueDate`
@@ -91,34 +85,27 @@ mixin _JournalDbMigrationRecent on _$JournalDb {
         // planner stream the tasks list even when the user has
         // selected many categories, instead of falling back to
         // `idx_journal_browse + USE TEMP B-TREE FOR ORDER BY`.
-        // Guarded on `journal` because minimal migration-test
-        // schemas omit it.
-        if (await _tableExists('journal')) {
-          await customStatement(
-            'CREATE INDEX IF NOT EXISTS '
-            'idx_journal_tasks_status_priority_date ON journal('
-            '  task_status COLLATE BINARY ASC, '
-            '  task_priority_rank COLLATE BINARY ASC, '
-            '  date_from COLLATE BINARY DESC) '
-            "WHERE type = 'Task' "
-            'AND task = 1 '
-            'AND deleted = FALSE',
-          );
-        }
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS '
+          'idx_journal_tasks_status_priority_date ON journal('
+          '  task_status COLLATE BINARY ASC, '
+          '  task_priority_rank COLLATE BINARY ASC, '
+          '  date_from COLLATE BINARY DESC) '
+          "WHERE type = 'Task' "
+          'AND task = 1 '
+          'AND deleted = FALSE',
+        );
         // Covering variant of the existing (from_id, hidden) index
         // so `getBulkLinkedTimeSpans` resolves `to_id` from the
         // index and the planner stops reversing the join shape.
-        // Same table-existence guard as above.
-        if (await _tableExists('linked_entries')) {
-          await customStatement(
-            'CREATE INDEX IF NOT EXISTS '
-            'idx_linked_entries_from_id_hidden_to_id '
-            'ON linked_entries('
-            '  from_id COLLATE BINARY ASC, '
-            '  hidden COLLATE BINARY ASC, '
-            '  to_id COLLATE BINARY ASC)',
-          );
-        }
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS '
+          'idx_linked_entries_from_id_hidden_to_id '
+          'ON linked_entries('
+          '  from_id COLLATE BINARY ASC, '
+          '  hidden COLLATE BINARY ASC, '
+          '  to_id COLLATE BINARY ASC)',
+        );
         // One-shot ANALYZE so the planner picks up the new
         // indexes immediately. This runs ONCE per device on the
         // upgrade boot — same trade as any heavy migration step:
@@ -146,32 +133,30 @@ mixin _JournalDbMigrationRecent on _$JournalDb {
         // the column is TEXT and the JSON value is the raw UUID.
         // Guarded on `journal` because minimal migration-test schemas
         // omit it.
-        if (await _tableExists('journal')) {
-          await customStatement(
-            'UPDATE journal '
-            r"SET category = json_extract(serialized, '$.meta.categoryId') "
-            "WHERE category = '' "
-            r"AND json_extract(serialized, '$.meta.categoryId') IS NOT NULL",
-          );
-          // Partial covering index for the Insights time-analysis
-          // query: only `date_from < :end` can be a seek bound (the
-          // `date_to > :start` overlap check is inherently residual),
-          // so the scan walks every JournalEntry before :end. Covering
-          // (date_from, date_to, category, private, id) turns that
-          // walk into an index-only scan — no row fetches — keeping
-          // cold-fetch cost flat as lifetime history grows.
-          await customStatement(
-            'CREATE INDEX IF NOT EXISTS idx_journal_insights_time '
-            'ON journal('
-            '  date_from COLLATE BINARY ASC, '
-            '  date_to COLLATE BINARY ASC, '
-            '  category COLLATE BINARY ASC, '
-            '  private COLLATE BINARY ASC, '
-            '  id COLLATE BINARY ASC) '
-            "WHERE type = 'JournalEntry' AND deleted = FALSE",
-          );
-          await customStatement('ANALYZE');
-        }
+        await customStatement(
+          'UPDATE journal '
+          r"SET category = json_extract(serialized, '$.meta.categoryId') "
+          "WHERE category = '' "
+          r"AND json_extract(serialized, '$.meta.categoryId') IS NOT NULL",
+        );
+        // Partial covering index for the Insights time-analysis
+        // query: only `date_from < :end` can be a seek bound (the
+        // `date_to > :start` overlap check is inherently residual),
+        // so the scan walks every JournalEntry before :end. Covering
+        // (date_from, date_to, category, private, id) turns that
+        // walk into an index-only scan — no row fetches — keeping
+        // cold-fetch cost flat as lifetime history grows.
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_journal_insights_time '
+          'ON journal('
+          '  date_from COLLATE BINARY ASC, '
+          '  date_to COLLATE BINARY ASC, '
+          '  category COLLATE BINARY ASC, '
+          '  private COLLATE BINARY ASC, '
+          '  id COLLATE BINARY ASC) '
+          "WHERE type = 'JournalEntry' AND deleted = FALSE",
+        );
+        await customStatement('ANALYZE');
       }();
     }
     if (from < 44) {
@@ -182,53 +167,40 @@ mixin _JournalDbMigrationRecent on _$JournalDb {
               'Adding indexes for broad task-list, import-flag, and '
               'label-definition reads',
         );
-        if (await _tableExists('journal') &&
-            await _columnExists('journal', 'task_priority_rank')) {
-          await customStatement(
-            _createIdxJournalTasksPriorityDateSql.replaceFirst(
-              'CREATE INDEX ',
-              'CREATE INDEX IF NOT EXISTS ',
-            ),
-          );
-        }
-        if (await _tableExists('journal') &&
-            await _columnExists('journal', 'flag')) {
-          await customStatement(
-            _createIdxJournalImportFlagDateSql.replaceFirst(
-              'CREATE INDEX ',
-              'CREATE INDEX IF NOT EXISTS ',
-            ),
-          );
-        }
-        if (await _tableExists('label_definitions')) {
-          await customStatement(
-            'CREATE INDEX IF NOT EXISTS '
-            'idx_label_definitions_deleted_name_nocase '
-            'ON label_definitions('
-            '  deleted COLLATE BINARY ASC, '
-            '  name COLLATE NOCASE ASC)',
-          );
-        }
+        await customStatement(
+          _createIdxJournalTasksPriorityDateSql.replaceFirst(
+            'CREATE INDEX ',
+            'CREATE INDEX IF NOT EXISTS ',
+          ),
+        );
+        await customStatement(
+          _createIdxJournalImportFlagDateSql.replaceFirst(
+            'CREATE INDEX ',
+            'CREATE INDEX IF NOT EXISTS ',
+          ),
+        );
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS '
+          'idx_label_definitions_deleted_name_nocase '
+          'ON label_definitions('
+          '  deleted COLLATE BINARY ASC, '
+          '  name COLLATE NOCASE ASC)',
+        );
         await customStatement('ANALYZE');
       }();
     }
     if (from < 45) {
       await () async {
-        if (!await _tableExists('journal')) return;
         DevLogger.log(
           name: 'JournalDb',
           message:
               'Adding indexed Daily OS day and recording-session lookup '
               'columns',
         );
-        if (!await _columnExists('journal', 'day_id')) {
-          await customStatement('ALTER TABLE journal ADD COLUMN day_id TEXT');
-        }
-        if (!await _columnExists('journal', 'recording_session_id')) {
-          await customStatement(
-            'ALTER TABLE journal ADD COLUMN recording_session_id TEXT',
-          );
-        }
+        await customStatement('ALTER TABLE journal ADD COLUMN day_id TEXT');
+        await customStatement(
+          'ALTER TABLE journal ADD COLUMN recording_session_id TEXT',
+        );
         await customStatement(r'''
 UPDATE journal
 SET day_id = json_extract(serialized, '$.data.dayContext.dayId'),
@@ -299,6 +271,34 @@ WHERE type = 'JournalAudio' AND deleted = FALSE
           await customStatement('DROP INDEX IF EXISTS idx_journal_category_id');
           await customStatement('ALTER TABLE journal DROP COLUMN category_id');
         }
+      }();
+    }
+    if (from < 48) {
+      await () async {
+        // config_flags carried UNIQUE on `description` — a display string,
+        // which made rewording a flag a constraint concern and forbade two
+        // flags sharing one — and a UNIQUE on `name` that only duplicated
+        // the primary key. SQLite cannot drop a table constraint in place,
+        // so rebuild the table in the shape database.drift declares.
+        DevLogger.log(
+          name: 'JournalDb',
+          message: 'Rebuilding config_flags without the UNIQUE(description)',
+        );
+        await customStatement('''
+CREATE TABLE config_flags_v48 (
+  name TEXT NOT NULL,
+  description TEXT NOT NULL,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+)''');
+        await customStatement(
+          'INSERT INTO config_flags_v48 (name, description, status) '
+          'SELECT name, description, status FROM config_flags',
+        );
+        await customStatement('DROP TABLE config_flags');
+        await customStatement(
+          'ALTER TABLE config_flags_v48 RENAME TO config_flags',
+        );
       }();
     }
   }

--- a/lib/database/database_migration_recent.dart
+++ b/lib/database/database_migration_recent.dart
@@ -5,6 +5,34 @@ part of 'database.dart';
 mixin _JournalDbMigrationRecent on _$JournalDb {
   Future<bool> _columnExists(String table, String column);
 
+  /// Adds a column to [table] unless an interrupted upgrade already did.
+  ///
+  /// Every step before v48 shipped without a transaction around the upgrade,
+  /// so an install killed mid-step can hold the column while `user_version`
+  /// still names the previous version. `ALTER TABLE … ADD COLUMN` refuses a
+  /// duplicate, and inside the now-atomic upgrade that refusal would roll
+  /// the whole upgrade back on every launch; the pre-v48 column-adding steps
+  /// therefore skip a column that is already there. [add] issues the
+  /// statement: Drift's `Migrator.addColumn` where it derives the definition,
+  /// raw SQL where the declared type matters to the schema (`DATETIME`).
+  /// Steps from v48 on run atomically and need no such check.
+  Future<void> _addColumnUnlessPresent(
+    String table,
+    String column,
+    Future<void> Function() add,
+  ) async {
+    if (await _columnExists(table, column)) {
+      DevLogger.log(
+        name: 'JournalDb',
+        message:
+            'Column $table.$column already present from an interrupted '
+            'upgrade; skipping',
+      );
+      return;
+    }
+    await add();
+  }
+
   Future<void> _onUpgradeRecent(Migrator m, int from) async {
     // v41: Replace the `json_extract(serialized,'$.data.due')`
     // expression-keyed `idx_journal_tasks_due_open` with a partial
@@ -29,8 +57,11 @@ mixin _JournalDbMigrationRecent on _$JournalDb {
         );
 
         // 1. Add the nullable column.
-        await customStatement(
-          'ALTER TABLE journal ADD COLUMN due_at DATETIME',
+        await _addColumnUnlessPresent(
+          'journal',
+          'due_at',
+          () =>
+              customStatement('ALTER TABLE journal ADD COLUMN due_at DATETIME'),
         );
 
         // 2. Backfill from JSON for every task with a non-null
@@ -197,9 +228,17 @@ mixin _JournalDbMigrationRecent on _$JournalDb {
               'Adding indexed Daily OS day and recording-session lookup '
               'columns',
         );
-        await customStatement('ALTER TABLE journal ADD COLUMN day_id TEXT');
-        await customStatement(
-          'ALTER TABLE journal ADD COLUMN recording_session_id TEXT',
+        await _addColumnUnlessPresent(
+          'journal',
+          'day_id',
+          () => customStatement('ALTER TABLE journal ADD COLUMN day_id TEXT'),
+        );
+        await _addColumnUnlessPresent(
+          'journal',
+          'recording_session_id',
+          () => customStatement(
+            'ALTER TABLE journal ADD COLUMN recording_session_id TEXT',
+          ),
         );
         await customStatement(r'''
 UPDATE journal

--- a/test/database/category_backfill_migration_test.dart
+++ b/test/database/category_backfill_migration_test.dart
@@ -106,7 +106,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 47);
+        expect(db.schemaVersion, 48);
 
         final rows = await db
             .customSelect('SELECT id, category FROM journal ORDER BY id')

--- a/test/database/config_flags_migration_test.dart
+++ b/test/database/config_flags_migration_test.dart
@@ -1,0 +1,101 @@
+// The v48 config_flags rebuild (`lib/database/database_migration_recent.dart`).
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart';
+
+import 'schema_fixtures.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory testDirectory;
+  Directory? previousDirectory;
+
+  setUp(() {
+    if (getIt.isRegistered<Directory>()) {
+      previousDirectory = getIt<Directory>();
+      getIt.unregister<Directory>();
+    }
+    testDirectory = Directory.systemTemp.createTempSync('lotti_v48_flags_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (MethodCall call) async => switch (call.method) {
+            'getApplicationDocumentsDirectory' ||
+            'getApplicationSupportDirectory' ||
+            'getTemporaryDirectory' => testDirectory.path,
+            _ => null,
+          },
+        );
+    getIt.registerSingleton<Directory>(testDirectory);
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    getIt.unregister<Directory>();
+    if (previousDirectory != null) {
+      getIt.registerSingleton<Directory>(previousDirectory!);
+    }
+    if (testDirectory.existsSync()) {
+      testDirectory.deleteSync(recursive: true);
+    }
+  });
+
+  test(
+    'v48 keeps every flag and lets two flags share a description',
+    () async {
+      final dbFile = File(p.join(testDirectory.path, 'flags_v47.db'));
+      final sqlite = sqlite3.open(dbFile.path);
+      createJournalSchema(sqlite, 47);
+      sqlite
+        ..execute(
+          'INSERT INTO config_flags (name, description, status) '
+          "VALUES ('private', 'Show private entries', 1)",
+        )
+        ..execute(
+          'INSERT INTO config_flags (name, description, status) '
+          "VALUES ('enable_notifications', 'Enable notifications', 0)",
+        );
+      // What the old shape refused: a second flag with the same wording.
+      expect(
+        () => sqlite.execute(
+          'INSERT INTO config_flags (name, description, status) '
+          "VALUES ('other', 'Show private entries', 0)",
+        ),
+        throwsA(isA<SqliteException>()),
+      );
+      sqlite.close();
+
+      final db = JournalDb(overriddenFilename: 'flags_v47.db');
+      addTearDown(db.close);
+
+      final version = await db.customSelect('PRAGMA user_version').getSingle();
+      expect(version.read<int>('user_version'), 48);
+
+      final flags = await db.listConfigFlags().get();
+      expect(
+        {for (final flag in flags) flag.name: flag.status},
+        {'private': true, 'enable_notifications': false},
+      );
+
+      await db.upsertConfigFlag(
+        const ConfigFlag(
+          name: 'other',
+          description: 'Show private entries',
+          status: false,
+        ),
+      );
+      expect(await db.getConfigFlag('other'), isFalse);
+      expect(await db.listConfigFlags().get(), hasLength(3));
+    },
+  );
+}

--- a/test/database/database_migration_recent_test.dart
+++ b/test/database/database_migration_recent_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/dev_logger.dart';
 import 'package:path/path.dart' as path;
 import 'package:sqlite3/sqlite3.dart';
 
@@ -47,6 +48,41 @@ void main() {
       testDirectory.deleteSync(recursive: true);
     }
   });
+
+  test(
+    'an install a pre-v48 app left mid-v45 finishes the step instead of '
+    'failing on the column it already added',
+    () async {
+      final dbFile = File(path.join(testDirectory.path, 'half_v45.db'));
+      final sqlite = sqlite3.open(dbFile.path);
+      createJournalSchema(sqlite, 44);
+      // Killed after the first ADD COLUMN, before the second and before
+      // user_version advanced: what a release without the upgrade
+      // transaction could leave behind.
+      sqlite
+        ..execute('ALTER TABLE journal ADD COLUMN day_id TEXT')
+        ..close();
+      DevLogger.capturedLogs.clear();
+
+      final db = JournalDb(overriddenFilename: 'half_v45.db');
+      addTearDown(db.close);
+      final version = await db.customSelect('PRAGMA user_version').getSingle();
+      expect(version.read<int>('user_version'), 48);
+
+      final columns =
+          (await db.customSelect('PRAGMA table_info(journal)').get())
+              .map((row) => row.read<String>('name'))
+              .toSet();
+      expect(columns, containsAll(['day_id', 'recording_session_id']));
+      expect(
+        DevLogger.capturedLogs.where(
+          (line) => line.contains('already present from an interrupted'),
+        ),
+        hasLength(1),
+        reason: DevLogger.capturedLogs.join('\n'),
+      );
+    },
+  );
 
   test('v45 backfills and indexes Daily OS audio lookup identity', () async {
     final databaseFile = File(path.join(testDirectory.path, 'v45.db'));

--- a/test/database/database_migration_recent_test.dart
+++ b/test/database/database_migration_recent_test.dart
@@ -90,7 +90,7 @@ void main() {
     addTearDown(db.close);
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 47);
+    expect(version.read<int>('user_version'), 48);
     final rows = await db
         .customSelect(
           'SELECT id, day_id, recording_session_id FROM journal ORDER BY id',

--- a/test/database/database_migration_test.dart
+++ b/test/database/database_migration_test.dart
@@ -138,6 +138,48 @@ WHERE type = 'Task'
     );
 
     test(
+      'a step that fails rolls back everything the upgrade did before it',
+      () async {
+        final dbFile = File(p.join(testDirectory.path, 'atomic.db'));
+        final sqlite = sqlite3.open(dbFile.path);
+        createJournalSchema(sqlite, 46);
+        // A v20-era column with its index, plus a second index on the same
+        // column that the v47 step does not know about: the step drops the
+        // index it expects and then fails to drop the column, which SQLite
+        // refuses while another index still references it.
+        sqlite
+          ..execute('ALTER TABLE journal ADD COLUMN category_id TEXT')
+          ..execute(
+            'CREATE INDEX idx_journal_category_id ON journal(category_id)',
+          )
+          ..execute('CREATE INDEX idx_blocker ON journal(category_id)')
+          ..close();
+
+        final db = JournalDb(overriddenFilename: 'atomic.db');
+        await expectLater(
+          db.customSelect('PRAGMA user_version').get(),
+          throwsA(isA<Object>()),
+        );
+        await db.close();
+
+        // Without one transaction around the upgrade, the first DROP INDEX
+        // would have survived the failure that followed it.
+        final raw = sqlite3.open(dbFile.path);
+        addTearDown(raw.close);
+        final indexes = raw
+            .select(
+              "SELECT name FROM sqlite_master WHERE type = 'index' "
+              "AND tbl_name = 'journal'",
+            )
+            .map((row) => row['name'] as String)
+            .toSet();
+        expect(indexes, contains('idx_journal_category_id'));
+        expect(indexes, contains('idx_blocker'));
+        expect(raw.select('PRAGMA user_version').single['user_version'], 46);
+      },
+    );
+
+    test(
       'an install whose indexes already match is not rebuilt for spelling',
       () async {
         final dbFile = File(p.join(testDirectory.path, 'matching.db'));

--- a/test/database/database_migration_test.dart
+++ b/test/database/database_migration_test.dart
@@ -14,6 +14,28 @@ import 'package:sqlite3/sqlite3.dart';
 
 import 'schema_fixtures.dart';
 
+/// Reads the version stamp from inside the upgrade transaction, after the
+/// steps and before the commit: what the file would carry if the process
+/// died right after that commit, before Drift's own stamp.
+class _StampProbingDb extends JournalDb {
+  _StampProbingDb({required super.overriddenFilename});
+
+  int? versionInsideTransaction;
+
+  @override
+  Future<T> transaction<T>(
+    Future<T> Function() action, {
+    bool requireNew = false,
+  }) {
+    return super.transaction(() async {
+      final result = await action();
+      final row = await customSelect('PRAGMA user_version').getSingle();
+      versionInsideTransaction = row.read<int>('user_version');
+      return result;
+    }, requireNew: requireNew);
+  }
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -176,6 +198,25 @@ WHERE type = 'Task'
         expect(indexes, contains('idx_journal_category_id'));
         expect(indexes, contains('idx_blocker'));
         expect(raw.select('PRAGMA user_version').single['user_version'], 46);
+      },
+    );
+
+    test(
+      'the version stamp commits with the schema, not after it',
+      () async {
+        final dbFile = File(p.join(testDirectory.path, 'stamped.db'));
+        final sqlite = sqlite3.open(dbFile.path);
+        createJournalSchema(sqlite, 46);
+        sqlite.close();
+
+        final db = _StampProbingDb(overriddenFilename: 'stamped.db');
+        addTearDown(db.close);
+        await db.customSelect('PRAGMA user_version').get();
+
+        // Drift stamps the version only after onUpgrade and beforeOpen have
+        // both completed; a kill in between would otherwise leave the new
+        // schema under the old stamp for the next launch to re-migrate.
+        expect(db.versionInsideTransaction, db.schemaVersion);
       },
     );
 

--- a/test/database/definition_indexes_migration_test.dart
+++ b/test/database/definition_indexes_migration_test.dart
@@ -73,7 +73,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 47);
+      expect(db.schemaVersion, 48);
 
       final indexes = await db.customSelect('''
         SELECT name, sql FROM sqlite_master

--- a/test/database/due_at_migration_test.dart
+++ b/test/database/due_at_migration_test.dart
@@ -122,7 +122,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 47);
+      expect(db.schemaVersion, 48);
 
       final hasColumn = await db.columnExistsForTesting('journal', 'due_at');
       expect(hasColumn, isTrue);

--- a/test/database/linked_entries_index_migration_test.dart
+++ b/test/database/linked_entries_index_migration_test.dart
@@ -95,7 +95,7 @@ void main() {
       // Schema version advanced to the current schema
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 47);
+      expect(db.schemaVersion, 48);
 
       // The corrected index now references to_id in its column list
       final postMigrationIdx = await db.customSelect("""

--- a/test/database/priority_migration_test.dart
+++ b/test/database/priority_migration_test.dart
@@ -128,7 +128,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 47);
+        expect(db.schemaVersion, 48);
 
         // The non-partial composite `idx_journal_tasks_due_active` was
         // dropped in v41 — its only consumer (`getTasksSortedByDueDate`)
@@ -160,7 +160,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 47);
+      expect(db.schemaVersion, 48);
 
       final idx = await db.customSelect("""
         SELECT sql FROM sqlite_master
@@ -238,7 +238,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 47);
+        expect(db.schemaVersion, 48);
 
         final idx = await db.customSelect("""
         SELECT sql FROM sqlite_master
@@ -325,7 +325,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 47);
+        expect(db.schemaVersion, 48);
 
         final taskIdx = await db.customSelect("""
         SELECT sql FROM sqlite_master

--- a/test/database/redundant_indexes_v46_migration_test.dart
+++ b/test/database/redundant_indexes_v46_migration_test.dart
@@ -103,7 +103,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 47);
+      expect(db.schemaVersion, 48);
 
       final names = await indexNames(db);
       expect(names.intersection(_redundant), isEmpty);
@@ -121,7 +121,7 @@ void main() {
       addTearDown(db.close);
 
       final version = await db.customSelect('PRAGMA user_version').get();
-      expect(version.first.read<int>('user_version'), 47);
+      expect(version.first.read<int>('user_version'), 48);
       expect((await indexNames(db)).intersection(_redundant), isEmpty);
     });
 

--- a/test/database/schemas/journal_v48.sql
+++ b/test/database/schemas/journal_v48.sql
@@ -1,0 +1,349 @@
+-- JournalDb fresh-install schema at schemaVersion 48.
+-- Extracted from lib/database/database.drift at the working tree
+-- by tool/db_schema/extract_journal_schema.dart. Do not edit.
+
+CREATE TABLE journal (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  date_from DATETIME NOT NULL,
+  date_to DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  starred BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  task BOOLEAN NOT NULL DEFAULT FALSE,
+  task_status TEXT,
+  task_priority TEXT,
+  task_priority_rank INTEGER,
+  flag INTEGER NOT NULL DEFAULT 0,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  plain_text TEXT,
+  latitude REAL,
+  longitude REAL,
+  geohash_string TEXT,
+  geohash_int INTEGER,
+  category TEXT NOT NULL DEFAULT '',
+  project_id TEXT,
+  
+  
+  day_id TEXT,
+  recording_session_id TEXT,
+  
+  
+  
+  
+  due_at DATETIME,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_journal_date_from_asc ON journal (date_from ASC);
+
+CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
+
+CREATE INDEX idx_journal_day_audio ON journal(
+  day_id COLLATE BINARY ASC,
+  date_from COLLATE BINARY ASC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'JournalAudio'
+  AND deleted = FALSE
+  AND day_id IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_journal_recording_session ON journal(
+  recording_session_id COLLATE BINARY ASC
+)
+WHERE type = 'JournalAudio'
+  AND deleted = FALSE
+  AND recording_session_id IS NOT NULL;
+
+CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_import_flag_date ON journal(
+  flag COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE deleted = FALSE;
+
+CREATE INDEX idx_journal_browse ON journal(
+  deleted COLLATE BINARY ASC,
+  type COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_journal_tasks ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_tasks_date_priority ON journal(
+  category COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC,
+  task_priority COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND deleted = FALSE
+  AND task = 1;
+
+CREATE INDEX idx_journal_type_subtype ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
+CREATE INDEX idx_journal_tasks_due_open ON journal(due_at ASC)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND task_status NOT IN ('DONE', 'REJECTED');
+
+CREATE INDEX idx_journal_task_status_private ON journal(
+  task_status COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+)
+WHERE type = 'Task' AND task = 1 AND deleted = FALSE;
+
+CREATE INDEX idx_journal_project_id ON journal(project_id)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE INDEX idx_journal_project_task_status ON journal(
+  project_id COLLATE BINARY ASC,
+  task_status COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE
+  AND project_id IS NOT NULL;
+
+CREATE INDEX idx_journal_tasks_status_priority_date ON journal(
+  task_status COLLATE BINARY ASC,
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE;
+
+CREATE INDEX idx_journal_tasks_priority_date ON journal(
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE;
+
+CREATE INDEX idx_journal_quant_latest ON journal(
+  subtype COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC
+)
+WHERE type = 'QuantitativeEntry'
+  AND deleted = FALSE;
+
+CREATE INDEX idx_journal_insights_time ON journal(
+  date_from COLLATE BINARY ASC,
+  date_to COLLATE BINARY ASC,
+  category COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'JournalEntry'
+  AND deleted = FALSE;
+
+CREATE TABLE conflicts (
+  id TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  serialized TEXT NOT NULL,
+  schema_version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_conflicts_status_created_at
+ON conflicts(status ASC, created_at DESC);
+
+CREATE TABLE measurable_types (
+  id TEXT NOT NULL,
+  unique_name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  status INTEGER NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE habit_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+
+CREATE INDEX idx_habit_definitions_deleted_private ON habit_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC
+);
+
+CREATE TABLE category_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_category_definitions_name ON category_definitions (name);
+
+CREATE INDEX idx_category_definitions_private ON category_definitions (private);
+
+CREATE TABLE label_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL UNIQUE,
+  color TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_label_definitions_name ON label_definitions (name);
+
+CREATE INDEX idx_label_definitions_private ON label_definitions (private);
+
+CREATE INDEX idx_label_definitions_deleted_private_name ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE INDEX idx_label_definitions_deleted_name_nocase ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE dashboard_definitions (
+  id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  last_reviewed DATETIME NOT NULL,
+  deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  private BOOLEAN NOT NULL DEFAULT FALSE,
+  serialized TEXT NOT NULL,
+  active BOOLEAN NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+
+CREATE INDEX idx_dashboard_definitions_deleted_private_name ON dashboard_definitions(
+  deleted COLLATE BINARY ASC,
+  private COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
+
+CREATE TABLE config_flags (
+  name TEXT NOT NULL,
+  description TEXT NOT NULL,
+  status BOOLEAN NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (name)
+);
+
+CREATE TABLE labeled (
+  id TEXT NOT NULL UNIQUE,
+  journal_id TEXT NOT NULL,
+  label_id TEXT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY(journal_id) REFERENCES journal(id) ON DELETE CASCADE,
+  FOREIGN KEY(label_id) REFERENCES label_definitions(id) ON DELETE CASCADE,
+  UNIQUE(journal_id, label_id)
+);
+
+CREATE INDEX idx_labeled_journal_id ON labeled (journal_id);
+
+CREATE INDEX idx_labeled_label_id ON labeled (label_id);
+
+CREATE TABLE linked_entries (
+  id TEXT NOT NULL UNIQUE,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  serialized TEXT NOT NULL,
+  hidden BOOLEAN DEFAULT FALSE,
+  created_at DATETIME,
+  updated_at DATETIME,
+  PRIMARY KEY (id),
+  UNIQUE(from_id, to_id, type)
+);
+
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_to_id ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  to_id COLLATE BINARY ASC
+);
+
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(to_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+
+CREATE INDEX idx_linked_entries_from_id_hidden_created_at_desc ON linked_entries(
+  from_id COLLATE BINARY ASC,
+  hidden COLLATE BINARY ASC,
+  created_at COLLATE BINARY DESC
+);
+
+CREATE INDEX idx_linked_entries_to_id_type ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  type COLLATE BINARY ASC
+);
+
+CREATE INDEX idx_linked_entries_rating_to_id ON linked_entries(
+  to_id COLLATE BINARY ASC,
+  from_id COLLATE BINARY ASC
+)
+WHERE type = 'RatingLink' AND COALESCE(hidden, FALSE) = FALSE;
+
+/* Queries;
+

--- a/test/database/task_indexes_v39_migration_test.dart
+++ b/test/database/task_indexes_v39_migration_test.dart
@@ -80,7 +80,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 47);
+        expect(db.schemaVersion, 48);
 
         // v41 swapped the expression-keyed shape for a column-keyed one.
         final sql = await indexSql(db, 'idx_journal_tasks_due_open');
@@ -238,7 +238,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 47);
+      expect(db.schemaVersion, 48);
 
       final sql = await indexSql(db, 'idx_journal_tasks_priority_date');
       expect(sql, contains('task_priority_rank COLLATE BINARY ASC'));


### PR DESCRIPTION
Persistence review findings 8 and 15 (Beads lotti3-nicl).

## Atomic upgrade (finding 8)

Drift runs `onUpgrade` outside a transaction and stamps `user_version` only after `onUpgrade` and `beforeOpen` have both completed. A crash or kill mid-upgrade left the steps already applied in place while `user_version` stayed at the old number, so the next launch re-ran the whole ladder against a half-migrated schema. `onUpgrade` now runs every version step, the closing index reconcile and the `PRAGMA user_version` stamp inside one `transaction()`, so schema and version commit together (Drift's later stamp only repeats it). Foreign-key enforcement is switched off before it (SQLite cannot change it inside a transaction) and on again from `beforeOpen`, the pattern Drift's migration docs prescribe. The backup still happens before the transaction; there is no `VACUUM` in the ladder.

With the upgrade atomic, the `_tableExists` probes that only served hand-built test fixtures (`if (!await _tableExists('journal')) return;`, the v38 `try { backfill } catch (_) {}`, the `beforeOpen` guards) are removed from the ladder: every table a step needs exists on a database that shipped. `_columnExists` propagates a failing PRAGMA instead of reading it as "absent". The probes that remain are conditional on real install history: `_ensureLabelTables` for pre-release v26 installs, the v47 drop of the v20 `category_id` column, and `_addColumnUnlessPresent` around every column-adding statement in the v21–v45 steps. Those steps shipped without the transaction, so an install killed mid-step can already hold the column, and a duplicate-column refusal inside the atomic upgrade would roll it back on every launch. Steps from v48 on run atomically and need no such check.

## `config_flags` v48 (finding 15)

`config_flags` carried `UNIQUE` on `description` — a display string, which made rewording a flag a constraint concern and forbade two flags sharing one — and a `UNIQUE` on `name` that only duplicated the primary key. SQLite cannot drop a table constraint in place, so v48 rebuilds the table (create `config_flags_v48`, `INSERT … SELECT`, drop, rename) inside the same transaction. `database.drift` declares the new shape; `journal_v48.sql` is extracted from the working tree, as the extractor documents for a version being introduced.

## Tests

- **Atomicity**: a v46 database with `category_id`, its index, and a second index on the same column. The v47 step drops the index it knows and then fails to drop the column. The failed open must leave `idx_journal_category_id` present and `user_version` at 46. Verified to fail with the transaction removed.
- **v48**: a v47 database with two flags (and a demonstration that the old shape refused a shared description) upgrades to 48 keeping every flag and accepting a third flag with an existing description.
- **Stamp inside the transaction**: a `JournalDb` subclass reads `user_version` after the steps and before the commit and expects the target version. Reads the old version with the in-transaction stamp removed.
- **Interrupted-upgrade recovery**: a v44 database that already carries `day_id` (a pre-v48 app killed mid-v45) reaches 48 with `recording_session_id` added. Fails with a duplicate-column error when the check is disabled.
- All 31 committed schemas (v18–v48) still migrate to a schema identical to a fresh install; the per-topic migration tests pass on the real ladder without guards.

Concept `knowledge/architecture/persistence.md` documents the transaction and why the guards are gone. Changelog fragment for the interrupted-upgrade fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Database upgrades now complete atomically: interrupted or failed upgrades roll back instead of leaving the database partially migrated.
  - Upgrade validation now provides more predictable behavior when recovering from interrupted migrations.

- **Improvements**
  - Configuration flags can now share descriptions while retaining unique names.
  - Updated the database schema to version 48 with improved indexes and migration handling for existing installations.

- **Documentation**
  - Updated persistence documentation to describe the revised upgrade and rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
