### PR TITLE
fix: serialize sync metrics refreshes

### DIFF
--- a/changelog.d/2026-09-05-sync-metrics-refresh.md
+++ b/changelog.d/2026-09-05-sync-metrics-refresh.md
@@ -1,0 +1,4 @@
+### Fixed
+- **Sync diagnostics avoid overlapping refreshes.** Opening the metrics panel
+  or pressing refresh during a slow load now shares the running request and
+  follows manual actions with one fresh update.

--- a/docs/perf/2026-09-05-sync-query-followup.md
+++ b/docs/perf/2026-09-05-sync-query-followup.md
@@ -1,0 +1,126 @@
+# Sync query follow-up
+
+The remaining outbox and inbound-queue queries already have appropriate indexes.
+The September log clusters do not establish that those SQL statements themselves
+took seconds. This investigation found a separate source of avoidable demand:
+the Matrix metrics panel guarded periodic polls, but its initial and manual
+refreshes bypassed that guard. A held initial request admitted another periodic
+request; three manual refreshes during a held poll admitted three more requests.
+The panel now serializes all its metric loads, skips overlapping periodic ticks,
+and preserves one trailing manual refresh. Finishing retry/rescan after the panel
+is disposed cannot invalidate its providers or start another metrics load.
+
+## Experiment
+
+Run from the repository root:
+
+```sh
+python3 tool/benchmarks/sync_queue_queries.py > /tmp/sync-queue-benchmark.json
+```
+
+The [script](../../tool/benchmarks/sync_queue_queries.py) uses the exact
+[fresh-install schema snapshot](fixtures/sync-v29.sql) from
+`SyncDatabase(inMemoryDatabase: true)` at `d9a4f2a99`, schema 29. The snapshot was
+exported through a temporary Dart MCP test using:
+
+```dart
+final rows = await db.customSelect(
+  'SELECT sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY type DESC, name',
+).get();
+```
+
+The export omits only SQLite's automatic `sqlite_sequence` table declaration;
+AUTOINCREMENT creates it. This is a fixed experiment fixture, not a maintained
+migration schema. The script executes the production query shapes at that commit,
+plus explicitly labeled comparison candidates. It does not read the app's files.
+
+Measurements: Linux ARM64 VM, Python's SQLite 3.45.1 (not Flutter's bundled SQLite),
+file-backed WAL databases, synchronous=NORMAL, one connection, warm reads, 21 timed
+runs per statement after an untimed read. Each dataset is measured before and
+after ANALYZE. Synthetic JSON payloads are approximately 1 KB. The history column
+means that many sent outbox rows and that many applied inbound rows; the active
+column means that many pending/sending outbox rows and that many inbound
+active/abandoned rows. Outbox active rows split equally pending/sending, inbound
+rows split equally enqueued/leased/retrying/abandoned, with three producers.
+The small corpus has one room marker; aged corpora have 1,000.
+
+Every timed read must equal its untimed result. Independent checks assert active
+and applied counts and the exact IDs/order returned by the priority-first
+pending batch. VM steps are measured separately with SQLite's progress handler;
+its instrumentation overhead is excluded from timings. These are isolated
+statement measurements, not app latency, production percentiles, or a reproduction
+of the multi-second shared stalls. Warm caches, one connection, OS/filesystem,
+SQLite version, and payload distribution limit generalization. Inserts are timed
+inside a savepoint and exclude commit/fsync; they do not rule out storage latency.
+
+## Results and decisions
+
+Rounded median milliseconds after ANALYZE (the JSON report also has p95, before
+ANALYZE results, query plans, and VM instruction counts):
+
+| Retained rows | Active rows | Pending batch, limit 20 | Actionable count | Queue marker | Inbound depth | Applied count |
+|---:|---:|---:|---:|---:|---:|---:|
+| 0 | 100 | 0.030 | 0.004 | 0.003 | 0.020 | 0.002 |
+| 100000 | 0 | 0.002 | 0.002 | 0.003 | 0.003 | 4.059 |
+| 100000 | 100 | 0.029 | 0.004 | 0.003 | 0.020 | 4.049 |
+| 100000 | 10000 | 0.031 | 0.186 | 0.003 | 0.757 | 4.110 |
+| 100000 | 100000 | 0.031 | 2.697 | 0.003 | 9.312 | 4.132 |
+
+- **Pending outbox, shape 6:** the status/priority/creation index satisfies
+  filtering and ordering. A full 20-row result costs 330 VM steps regardless of
+  the tested retained history or backlog size; there is no temporary sort.
+  Keep the existing query and index.
+  The claim transaction's companion query also checks expired sending leases.
+  A 20-row expired result remains bounded (371 steps), but 50,000 unexpired
+  sending rows take 250,012 steps and about 41 ms to establish there is no
+  expired row. This is a synthetic stress boundary, not a backlog inferred
+  from the logs: queued pending rows are not outstanding sending leases.
+  Normal batches limit sending concurrency; the priority-first reclaim policy
+  intentionally uses the existing ordering index. No new index is proposed
+  without evidence of a substantial unexpired-sending population in practice.
+- **Actionable count, shape 9:** the existing partial index scans the actionable
+  subset, not the sent ledger. Its cost is linear in the number still queued
+  (311 steps at 100 rows; 300,011 at 100,000). Removing the index hint changes to
+  the existing covering status index and has similar step counts; microsecond
+  differences at smaller backlogs do not justify a change. Large simultaneous
+  backlogs still make repeated exact counts material.
+- **Room marker, shape 11:** a primary-key seek costs 17 VM steps at both one and
+  1,000 rooms. Another index would not address the observed shared waits.
+- **Inbound aggregate, shape 12:** the existing status/producer/enqueued covering
+  index needs no heap reads or temporary grouping sort. The current depth path
+  already excludes applied history. With 100,000 retained rows and only 100
+  active/abandoned rows it performs 1,445 steps; including applied history in
+  the older aggregate would perform 1,201,501. Full `stats()` deliberately counts
+  the applied ledger separately, costing 400,011 steps for 100,000 rows. Keep
+  the bounded depth path and reduce duplicate full-statistics demand.
+- **Outbox insert, shape 25:** statement medians inside the synthetic transaction
+  were roughly 0.003 ms. All current indexes were present. No new insert-specific
+  SQL change is supported; transaction, commit, scheduling, and storage behavior
+  need separate diagnostics.
+- **Pending existence candidate:** replacing a one-row full fetch with EXISTS
+  reduced roughly 0.004 ms to 0.002 ms for this payload. This does not justify an
+  extra accessor in this change. Much larger inline payloads would be a different
+  workload and have not been validated by this experiment.
+
+## Refresh amplification audit
+
+The outbox badge and service use Drift's watched actionable count; sends can
+invalidate it when rows change status even when the total count is unchanged.
+Those reads still count only the active subset. The runner already debounces
+its DB-driven nudges, and the query log alone cannot identify redundant emissions
+or prove an unbounded refresh loop. No cache or invalidation shortcut was added.
+
+The inbound depth emitter already shares an in-flight aggregate and retains one
+rerun; transaction holds collapse batch mutations into one post-transaction
+emission. The full metrics panel additionally reads the applied count. Its
+five-second periodic guard did not cover initial loads or manual actions, which
+is the reproduced amplification fixed here. Regressions use held futures and
+fake widget time to assert query counts, the delivered latest metrics, retained
+manual work after a null service response, and disposal safety. They fail with
+the scheduling/disposal fixes reverted. The service catches normal metric
+collection failures and returns null or retained queue values; the panel does
+not introduce an automatic retry loop for backend failures.
+
+The shared historical sync stalls remain unexplained by this benchmark. The
+executor/transaction diagnostics investigation is separate; these measurements
+support avoiding speculative indexes on already-bounded lookup paths.

--- a/docs/perf/fixtures/sync-v29.sql
+++ b/docs/perf/fixtures/sync-v29.sql
@@ -1,0 +1,38 @@
+-- SyncDatabase fresh-create schema 29 at d9a4f2a99.
+-- Exported from sqlite_master through the app database constructor.
+-- sqlite_sequence is automatically created by AUTOINCREMENT, so omitted.
+CREATE TABLE "host_activity" ("host_id" TEXT NOT NULL, "last_seen_at" INTEGER NOT NULL, PRIMARY KEY ("host_id"));
+CREATE TABLE "inbound_event_queue" ("queue_id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, "event_id" TEXT NOT NULL UNIQUE, "room_id" TEXT NOT NULL, "origin_ts" INTEGER NOT NULL, "producer" TEXT NOT NULL, "raw_json" TEXT NOT NULL, "enqueued_at" INTEGER NOT NULL, "attempts" INTEGER NOT NULL DEFAULT 0, "next_due_at" INTEGER NOT NULL DEFAULT 0, "lease_until" INTEGER NOT NULL DEFAULT 0, "status" TEXT NOT NULL DEFAULT 'enqueued', "committed_at" INTEGER NULL, "abandoned_at" INTEGER NULL, "last_error_reason" TEXT NULL, "resurrection_count" INTEGER NOT NULL DEFAULT 0, "json_path" TEXT NULL);
+CREATE TABLE "onboarding_sync_rounds" ("round_id" TEXT NOT NULL, "direction" TEXT NOT NULL, "state" TEXT NOT NULL, "sender_host_id" TEXT NOT NULL, "sender_user_id" TEXT NULL, "sender_device_id" TEXT NULL, "recipient_host_id" TEXT NULL, "recipient_user_id" TEXT NOT NULL, "recipient_device_id" TEXT NOT NULL, "coverage_upper_bounds_json" TEXT NOT NULL, "started_at" INTEGER NOT NULL, "updated_at" INTEGER NOT NULL, "expires_at" INTEGER NOT NULL, PRIMARY KEY ("round_id"));
+CREATE TABLE "outbox" ("id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, "created_at" INTEGER NOT NULL DEFAULT (CAST(strftime('%s', CURRENT_TIMESTAMP) AS INTEGER)), "updated_at" INTEGER NOT NULL DEFAULT (CAST(strftime('%s', CURRENT_TIMESTAMP) AS INTEGER)), "status" INTEGER NOT NULL DEFAULT 0, "retries" INTEGER NOT NULL DEFAULT 0, "message" TEXT NOT NULL, "subject" TEXT NOT NULL, "file_path" TEXT NULL, "outbox_entry_id" TEXT NULL, "payload_size" INTEGER NULL, "priority" INTEGER NOT NULL DEFAULT 2);
+CREATE TABLE "queue_markers" ("room_id" TEXT NOT NULL, "last_applied_event_id" TEXT NULL, "last_applied_ts" INTEGER NOT NULL DEFAULT 0, "last_applied_commit_seq" INTEGER NOT NULL DEFAULT 0, "resume_floor_ts" INTEGER NULL, PRIMARY KEY ("room_id"));
+CREATE TABLE "sync_sequence_log" ("host_id" TEXT NOT NULL, "counter" INTEGER NOT NULL, "entry_id" TEXT NULL, "payload_type" INTEGER NOT NULL DEFAULT 0, "originating_host_id" TEXT NULL, "status" INTEGER NOT NULL DEFAULT 0, "created_at" INTEGER NOT NULL, "updated_at" INTEGER NOT NULL, "request_count" INTEGER NOT NULL DEFAULT 0, "last_requested_at" INTEGER NULL, "json_path" TEXT NULL, PRIMARY KEY ("host_id", "counter"));
+CREATE TABLE sync_sequence_watermarks (
+  host_id TEXT PRIMARY KEY NOT NULL,
+  last_counter INTEGER NOT NULL DEFAULT 0,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX idx_inbound_event_queue_abandoned_path ON inbound_event_queue (json_path) WHERE status = 'abandoned';
+CREATE INDEX idx_inbound_event_queue_abandoned_reason ON inbound_event_queue (last_error_reason) WHERE status = 'abandoned';
+CREATE INDEX idx_inbound_event_queue_abandoned_reason_resurrection ON inbound_event_queue (last_error_reason, resurrection_count) WHERE status = 'abandoned';
+CREATE INDEX idx_inbound_event_queue_active_ready_at ON inbound_event_queue (next_due_at, lease_until) WHERE status IN ('enqueued', 'retrying', 'leased');
+CREATE INDEX idx_inbound_event_queue_active_room_ts ON inbound_event_queue (room_id, origin_ts) WHERE status IN ('enqueued', 'leased', 'retrying');
+CREATE INDEX idx_inbound_event_queue_active_status_room ON inbound_event_queue (status, room_id) WHERE status IN ('enqueued', 'leased', 'retrying');
+CREATE INDEX idx_inbound_event_queue_ready ON inbound_event_queue (next_due_at, origin_ts, queue_id) WHERE status IN ('enqueued', 'retrying', 'leased');
+CREATE INDEX idx_inbound_event_queue_room ON inbound_event_queue (room_id, origin_ts);
+CREATE INDEX idx_inbound_event_queue_status_due_lease ON inbound_event_queue (status, next_due_at, lease_until);
+CREATE INDEX idx_inbound_event_queue_status_enqueued ON inbound_event_queue (status, enqueued_at);
+CREATE INDEX idx_inbound_event_queue_status_producer_enqueued ON inbound_event_queue (status, producer, enqueued_at);
+CREATE INDEX idx_outbox_actionable_priority_created_at ON outbox (priority, created_at, id) WHERE status IN (0, 3);
+CREATE INDEX idx_outbox_actionable_subject ON outbox (subject) WHERE status IN (0, 3);
+CREATE INDEX idx_outbox_pending_created_id ON outbox (created_at, id) WHERE status = 0;
+CREATE INDEX idx_outbox_pending_entry_id_created_at ON outbox (outbox_entry_id, created_at) WHERE status = 0 AND outbox_entry_id IS NOT NULL;
+CREATE INDEX idx_outbox_sent_updated_at ON outbox (updated_at, id) WHERE status = 1;
+CREATE INDEX idx_outbox_status_priority_created_at ON outbox (status, priority, created_at);
+CREATE INDEX idx_sync_sequence_log_actionable_status_created_at ON sync_sequence_log (status, created_at) WHERE status IN (1, 2);
+CREATE INDEX idx_sync_sequence_log_actionable_status_last_requested_at ON sync_sequence_log (status, last_requested_at) WHERE status IN (1, 2) AND last_requested_at IS NOT NULL;
+CREATE INDEX idx_sync_sequence_log_actionable_status_updated_at ON sync_sequence_log (status, updated_at) WHERE status IN (1, 2);
+CREATE INDEX idx_sync_sequence_log_host_entry_status_counter ON sync_sequence_log (host_id, entry_id, counter DESC, status) WHERE entry_id IS NOT NULL;
+CREATE INDEX idx_sync_sequence_log_host_status ON sync_sequence_log (host_id, status);
+CREATE INDEX idx_sync_sequence_log_payload_resolution ON sync_sequence_log (entry_id, payload_type, status) WHERE entry_id IS NOT NULL;
+CREATE INDEX idx_sync_sequence_log_resolved_host_counter ON sync_sequence_log (host_id, counter) WHERE status IN (0, 3, 4, 5, 8);

--- a/knowledge/features/sync/receive-path.md
+++ b/knowledge/features/sync/receive-path.md
@@ -8,6 +8,10 @@ status: stable
 generated: { by: codex/gpt-5, at: 2026-08-06T00:25:30+02:00 }
 stale_after: 2026-11-02
 sources:
+  - id: metrics-panel
+    resource: ../../../lib/features/sync/ui/matrix_stats/matrix_metrics_panel.dart
+    title: Serialized Matrix metrics refreshes
+    last_modified: 2026-09-05
   - id: queue
     resource: ../../../lib/features/sync/queue
     title: Inbound queue pipeline
@@ -330,6 +334,28 @@ The backfill settings page hosts the operator surface:
 - `_AdvancedRecoveryGroup` drives
   `QueuePipelineCoordinator.triggerBridge()` (kick catch-up), retry of skipped
   rows, and the reset / retire-stuck backfill controls.
+
+The Matrix metrics panel polls every five seconds while foregrounded. Initial,
+periodic, and manual metrics loads share one in-flight guard. Periodic ticks skip
+an outstanding load; refresh, retry, and rescan actions request at most one
+trailing load so changes made during the outstanding probe are observed without
+parallel aggregate queries. Disposal discards an outstanding result and prevents
+its trailing refresh; completion of an earlier retry/rescan action also cannot
+refresh providers after disposal. The underlying queue depth emitter separately coalesces
+mutation-driven depth snapshots; its bounded aggregate excludes applied history,
+while an explicit full statistics read also counts the applied ledger.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Loading: initial load, foreground tick, or manual refresh
+    Loading --> Loading: periodic tick skips, manual action marks rerun
+    Loading --> Loading: completed probe with pending manual rerun
+    Loading --> Idle: completed probe without rerun, or failure
+    Idle --> Disposed: dispose
+    Loading --> Disposed: dispose, discard result and pending rerun
+    Disposed --> [*]
+```
 
 `QueuePipelineCoordinator.collectHistory` exists but is wired into no production
 UI; it is exercised only by tests.

--- a/lib/features/sync/ui/matrix_stats/matrix_metrics_panel.dart
+++ b/lib/features/sync/ui/matrix_stats/matrix_metrics_panel.dart
@@ -33,6 +33,8 @@ class MatrixSyncMetricsPanelState extends ConsumerState<MatrixSyncMetricsPanel>
   Timer? _pollTimer;
   bool _appActive = true;
   bool _inFlight = false;
+  bool _refreshPending = false;
+  bool _pendingForceTimestamp = false;
   String? _lastSignature;
 
   /// Cadence at which this panel polls `MatrixService.getSyncMetrics`
@@ -40,11 +42,10 @@ class MatrixSyncMetricsPanelState extends ConsumerState<MatrixSyncMetricsPanel>
   /// previous 2-second cadence drove the
   /// `SELECT … GROUP BY status, producer FROM inbound_event_queue`
   /// aggregate to 223 hits/day on the 2026-05-12 desktop slow_queries
-  /// log (each ~200-700 ms — plan is fine, cost is writer-lock
-  /// contention compounding at 30 polls/min). 5 s still feels live to
-  /// a user watching the panel and removes the 60% of polls that
-  /// were contributing nothing actionable. `_inFlight` continues to
-  /// guard against a slow probe overlapping itself.
+  /// log. Those timings include executor waiting and do not isolate SQL
+  /// execution or prove writer-lock contention. The 5-second interval
+  /// reduces periodic probe frequency by 60%. All panel probes share
+  /// `_inFlight`, including initial and manual refreshes.
   @visibleForTesting
   static const Duration pollInterval = Duration(seconds: 5);
 
@@ -58,28 +59,40 @@ class MatrixSyncMetricsPanelState extends ConsumerState<MatrixSyncMetricsPanel>
 
   void _startPolling() {
     _pollTimer?.cancel();
-    _pollTimer = Timer.periodic(pollInterval, (_) async {
+    _pollTimer = Timer.periodic(pollInterval, (_) {
       if (!_appActive || _inFlight) return;
-      _inFlight = true;
-      try {
-        final v2 = await ref.read(matrixServiceProvider).getSyncMetrics();
-        final map = v2?.toMap();
-        if (!mounted || map == null || map.isEmpty) return;
-        final signature = metricsMapSignature(map);
-        if (signature != _lastSignature) {
-          _applyMetricsUpdate(map);
-        }
-      } finally {
-        _inFlight = false;
-      }
+      unawaited(_refreshOnce());
     });
   }
 
+  /// Serializes initial, periodic, and manual probes. A manual action during
+  /// a probe schedules one trailing load so its post-action state is observed.
   Future<void> _refreshOnce({bool forceTimestamp = false}) async {
-    final m = await ref.read(matrixServiceProvider).getSyncMetrics();
-    final map = m?.toMap();
-    if (!mounted || map == null || map.isEmpty) return;
-    _applyMetricsUpdate(map, forceTimestamp: forceTimestamp);
+    if (_inFlight) {
+      _refreshPending = true;
+      _pendingForceTimestamp |= forceTimestamp;
+      return;
+    }
+    _inFlight = true;
+    var forceNextTimestamp = forceTimestamp;
+    try {
+      do {
+        _refreshPending = false;
+        _pendingForceTimestamp = false;
+        final m = await ref.read(matrixServiceProvider).getSyncMetrics();
+        final map = m?.toMap();
+        if (!mounted) return;
+        if (map != null && map.isNotEmpty) {
+          if (forceNextTimestamp ||
+              metricsMapSignature(map) != _lastSignature) {
+            _applyMetricsUpdate(map, forceTimestamp: forceNextTimestamp);
+          }
+        }
+        forceNextTimestamp = _pendingForceTimestamp;
+      } while (_refreshPending);
+    } finally {
+      _inFlight = false;
+    }
   }
 
   void _applyMetricsUpdate(
@@ -111,6 +124,7 @@ class MatrixSyncMetricsPanelState extends ConsumerState<MatrixSyncMetricsPanel>
   }
 
   void _refreshDiagnostics({bool forceTimestamp = false}) {
+    if (!mounted) return;
     ref
       ..invalidate(matrixSyncMetricsFutureProvider)
       ..invalidate(matrixDiagnosticsTextProvider);

--- a/test/features/sync/ui/matrix_stats/matrix_metrics_panel_test.dart
+++ b/test/features/sync/ui/matrix_stats/matrix_metrics_panel_test.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/sync/matrix/pipeline/sync_metrics.dart';
 import 'package:lotti/features/sync/ui/matrix_stats/matrix_metrics_panel.dart';
+import 'package:lotti/features/sync/ui/matrix_stats/metrics_section.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -35,6 +38,180 @@ void main() {
     when(() => mockMatrixService.forceRescan()).thenAnswer((_) async {});
     when(() => mockMatrixService.retryNow()).thenAnswer((_) async {});
   });
+
+  testWidgets('initial metrics load prevents overlapping timer polls', (
+    tester,
+  ) async {
+    final initial = Completer<SyncMetrics?>();
+    when(
+      () => mockMatrixService.getSyncMetrics(),
+    ).thenAnswer((_) => initial.future);
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        const MatrixSyncMetricsPanel(),
+        overrides: [matrixServiceProvider.overrideWithValue(mockMatrixService)],
+      ),
+    );
+    await _pumpPollCycle(tester);
+    await _pumpPollCycle(tester);
+    verify(() => mockMatrixService.getSyncMetrics()).called(1);
+    initial.complete(SyncMetrics.fromMap({'dbApplied': 7}));
+    await tester.pump();
+    await tester.pump();
+    expect(
+      tester
+          .widget<SyncMetricsSection>(find.byType(SyncMetricsSection))
+          .metrics['dbApplied'],
+      7,
+    );
+    await _pumpPollCycle(tester);
+    verify(() => mockMatrixService.getSyncMetrics()).called(1);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets(
+    'manual refreshes during a slow poll coalesce into one fresh load',
+    (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const MatrixSyncMetricsPanel(),
+          overrides: [
+            matrixServiceProvider.overrideWithValue(mockMatrixService),
+          ],
+        ),
+      );
+      await tester.pump();
+      clearInteractions(mockMatrixService);
+      final pending = Completer<SyncMetrics?>();
+      final refreshed = Completer<SyncMetrics?>();
+      var calls = 0;
+      when(() => mockMatrixService.getSyncMetrics()).thenAnswer((_) {
+        calls++;
+        return calls == 1 ? pending.future : refreshed.future;
+      });
+      await _pumpPollCycle(tester);
+      for (var i = 0; i < 3; i++) {
+        await tester.tap(
+          find.byKey(
+            Key(
+              i == 0 ? 'matrixStats.retryNow' : 'matrixStats.refresh.metrics',
+            ),
+          ),
+        );
+        await tester.pump();
+      }
+      expect(
+        calls,
+        1,
+        reason: 'manual actions must not overlap the running poll',
+      );
+      pending.complete(SyncMetrics.fromMap({'dbApplied': 3}));
+      await tester.pump();
+      expect(
+        calls,
+        2,
+        reason: 'one trailing load must observe post-action state',
+      );
+      await _pumpPollCycle(tester);
+      expect(calls, 2);
+      refreshed.complete(SyncMetrics.fromMap({'dbApplied': 8}));
+      await tester.pump();
+      await tester.pump();
+      expect(
+        tester
+            .widget<SyncMetricsSection>(find.byType(SyncMetricsSection))
+            .metrics['dbApplied'],
+        8,
+      );
+      await tester.pumpWidget(const SizedBox.shrink());
+    },
+  );
+
+  testWidgets('disposal discards a pending manual refresh', (tester) async {
+    final pending = Completer<SyncMetrics?>();
+    when(
+      () => mockMatrixService.getSyncMetrics(),
+    ).thenAnswer((_) => pending.future);
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        const MatrixSyncMetricsPanel(),
+        overrides: [matrixServiceProvider.overrideWithValue(mockMatrixService)],
+      ),
+    );
+    await tester.tap(find.byKey(const Key('matrixStats.refresh.metrics')));
+    await tester.pump();
+    await tester.pumpWidget(const SizedBox.shrink());
+    pending.complete(SyncMetrics.fromMap({'dbApplied': 9}));
+    await tester.pump();
+    await _pumpPollCycle(tester);
+    verify(() => mockMatrixService.getSyncMetrics()).called(1);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('null metrics result still runs the pending manual refresh', (
+    tester,
+  ) async {
+    final pending = Completer<SyncMetrics?>();
+    var calls = 0;
+    when(() => mockMatrixService.getSyncMetrics()).thenAnswer((_) {
+      calls++;
+      return calls == 1
+          ? pending.future
+          : Future.value(SyncMetrics.fromMap({'dbApplied': 11}));
+    });
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        const MatrixSyncMetricsPanel(),
+        overrides: [matrixServiceProvider.overrideWithValue(mockMatrixService)],
+      ),
+    );
+    await tester.tap(find.byKey(const Key('matrixStats.refresh.metrics')));
+    await tester.pump();
+    expect(calls, 1);
+    pending.complete(null);
+    await tester.pump();
+    await tester.pump();
+    expect(calls, 2);
+    expect(
+      tester
+          .widget<SyncMetricsSection>(find.byType(SyncMetricsSection))
+          .metrics['dbApplied'],
+      11,
+    );
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  for (final action in ['forceRescan', 'retryNow']) {
+    testWidgets(
+      '$action completing after disposal does not refresh providers',
+      (tester) async {
+        final pending = Completer<void>();
+        when(
+          () => mockMatrixService.forceRescan(),
+        ).thenAnswer((_) => pending.future);
+        when(
+          () => mockMatrixService.retryNow(),
+        ).thenAnswer((_) => pending.future);
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            const MatrixSyncMetricsPanel(),
+            overrides: [
+              matrixServiceProvider.overrideWithValue(mockMatrixService),
+            ],
+          ),
+        );
+        await tester.pump();
+        clearInteractions(mockMatrixService);
+        await tester.tap(find.byKey(Key('matrixStats.$action')));
+        await tester.pump();
+        await tester.pumpWidget(const SizedBox.shrink());
+        pending.complete();
+        await tester.pump();
+        expect(tester.takeException(), isNull);
+        verifyNever(() => mockMatrixService.getSyncMetrics());
+      },
+    );
+  }
 
   testWidgets('MatrixSyncMetricsPanel renders metrics and handles actions', (
     tester,

--- a/tool/benchmarks/sync_queue_queries.py
+++ b/tool/benchmarks/sync_queue_queries.py
@@ -1,0 +1,124 @@
+"""Warm single-connection SQLite benchmark, synthetic data only.
+Run: python3 tool/benchmarks/sync_queue_queries.py > sync-queue-benchmark.json
+Schema exported by SyncDatabase(inMemoryDatabase:true), sqlite_master at d9a4f2a99.
+No wall-time assertions: native VM instruction count and results are deterministic.
+"""
+import json
+import pathlib
+import sqlite3
+import statistics
+import tempfile
+import time
+
+SCHEMA = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / 'docs/perf/fixtures/sync-v29.sql'
+).read_text()
+QUERIES = {'pending_one': ('SELECT * FROM outbox WHERE status = 0 ORDER BY priority ASC, '
+                 'created_at ASC, id ASC LIMIT ?',
+                 (1,)),
+ 'pending_batch': ('SELECT * FROM outbox WHERE status = 0 ORDER BY priority ASC, '
+                   'created_at ASC, id ASC LIMIT ?',
+                   (20,)),
+ 'pending_exists_candidate': ('SELECT EXISTS(SELECT 1 FROM outbox WHERE status = 0) AS '
+                              'present',
+                              ()),
+ 'actionable_count': ('SELECT COUNT(*) AS cnt FROM outbox INDEXED BY '
+                      'idx_outbox_actionable_priority_created_at WHERE status IN (0, '
+                      '3)',
+                      ()),
+ 'actionable_count_unhinted': ('SELECT COUNT(*) AS cnt FROM outbox WHERE status IN (0, '
+                               '3)',
+                               ()),
+ 'queue_marker': ('SELECT * FROM queue_markers WHERE room_id = ?', ('room-0000',)),
+ 'depth_current': ('SELECT status, producer, COUNT(*) AS cnt, MIN(enqueued_at) AS '
+                   "oldest FROM inbound_event_queue WHERE status IN ('enqueued', "
+                   "'leased', 'retrying', 'abandoned') GROUP BY status, producer",
+                   ()),
+ 'depth_including_applied_legacy': ('SELECT status, producer, COUNT(*) AS cnt, '
+                                    'MIN(enqueued_at) AS oldest FROM '
+                                    "inbound_event_queue WHERE status IN ('enqueued', "
+                                    "'leased', 'retrying', 'abandoned', 'applied') "
+                                    'GROUP BY status, producer',
+                                    ()),
+ 'applied_count': ('SELECT COUNT(queue_id) AS cnt FROM inbound_event_queue INDEXED BY '
+                   "idx_inbound_event_queue_status_enqueued WHERE status = 'applied'",
+                   ())}
+
+# The dequeue companion may inspect sending leases even with no expired row.
+QUERIES['expired_sending_none'] = (
+    'SELECT * FROM outbox WHERE status = 3 AND updated_at < ? '
+    'ORDER BY priority ASC, created_at ASC, id ASC LIMIT ?',
+    (1700000000, 20),
+)
+QUERIES['expired_sending_all'] = (
+    'SELECT * FROM outbox WHERE status = 3 AND updated_at < ? '
+    'ORDER BY priority ASC, created_at ASC, id ASC LIMIT ?',
+    (1900000000, 20),
+)
+
+def measure(c, sql, args):
+    expected = c.execute(sql, args).fetchall()
+    times = []
+    for _ in range(21):
+        start = time.perf_counter_ns()
+        actual = c.execute(sql, args).fetchall()
+        times.append((time.perf_counter_ns() - start) / 1000000.0)
+        assert actual == expected
+    steps = 0
+
+    def step():
+        nonlocal steps
+        steps += 1
+        return 0
+    c.set_progress_handler(step, 1)
+    c.execute(sql, args).fetchall()
+    c.set_progress_handler(None, 0)
+    return {
+        'median_ms': statistics.median(times),
+        'p95_ms': sorted(times)[19],
+        'vm_steps': steps,
+        'result_rows': len(expected),
+        'plan': [r[3] for r in c.execute('EXPLAIN QUERY PLAN ' + sql, args)],
+    }
+
+
+results = []
+for history, active in [(0, 100), (100000, 0), (100000, 100), (100000, 10000), (100000, 100000)]:
+    with tempfile.TemporaryDirectory(prefix='lotti-sync-benchmark-') as tmp:
+        c = sqlite3.connect(str(pathlib.Path(tmp) / 'sync.sqlite'))
+        c.executescript(SCHEMA)
+        c.execute('PRAGMA journal_mode=WAL')
+        c.execute('PRAGMA synchronous=NORMAL')
+        payload = json.dumps({'synthetic': True, 'text': 'x' * 1000})
+        outbox = 'INSERT INTO outbox(created_at,updated_at,status,message,subject,priority) VALUES(?,?,?,?,?,?)'
+        c.executemany(outbox, ((1700000000 + i, 1700000000 + i, 1, payload, 'synthetic-history', i % 3) for i in range(history)))
+        c.executemany(outbox, ((1800000000 + i, 1800000000 + i, 0 if i % 2 == 0 else 3, payload, 'synthetic-active', i % 3) for i in range(active)))
+        inbound = 'INSERT INTO inbound_event_queue(event_id,room_id,origin_ts,producer,raw_json,enqueued_at,status) VALUES(?,?,?,?,?,?,?)'
+        statuses = ['enqueued', 'leased', 'retrying', 'abandoned']
+        c.executemany(inbound, ((f'history-{i}', 'room-0000', 1700000000000 + i, f'producer-{i % 3}', payload, 1700000000000 + i, 'applied') for i in range(history)))
+        c.executemany(inbound, ((f'active-{i}', 'room-0000', 1800000000000 + i, f'producer-{i % 3}', payload, 1800000000000 + i, statuses[i % 4]) for i in range(active)))
+        c.executemany('INSERT INTO queue_markers(room_id,last_applied_ts) VALUES(?,?)', ((f'room-{i:04}', 1700000000000 + i) for i in range(1 if history == 0 else 1000)))
+        c.commit()
+        assert c.execute(QUERIES['actionable_count'][0]).fetchone()[0] == active
+        assert c.execute(QUERIES['applied_count'][0]).fetchone()[0] == history
+        assert sum((r[2] for r in c.execute(QUERIES['depth_current'][0]))) == active
+        pending = c.execute(*QUERIES['pending_batch']).fetchall()
+        assert [r[0] for r in pending] == [history + i + 1 for i in sorted(range(0, active, 2), key=lambda i: (i % 3, i))[:20]]
+        for analyzed in [False, True]:
+            if analyzed:
+                c.execute('ANALYZE')
+            row = {'history': history, 'active': active, 'rooms': 1 if history == 0 else 1000, 'analyzed': analyzed, 'queries': {name: measure(c, *query) for name, query in QUERIES.items()}}
+            # Excludes commit/fsync; reads above also exclude Drift transport.
+            c.execute('SAVEPOINT insert_probe')
+            times = []
+            for i in range(21):
+                start = time.perf_counter_ns()
+                c.execute(outbox, (1900000000 + i, 1900000000 + i, 0, payload, 'synthetic-insert', i % 3))
+                times.append((time.perf_counter_ns() - start) / 1000000.0)
+            c.execute('ROLLBACK TO insert_probe')
+            c.execute('RELEASE insert_probe')
+            row['insert_no_commit'] = {'median_ms': statistics.median(times), 'p95_ms': sorted(times)[19]}
+            results.append(row)
+        c.close()
+print(json.dumps({'sqlite_version': sqlite3.sqlite_version, 'source_commit': 'd9a4f2a99', 'payload_bytes': len(payload), 'results': results}, indent=2))


### PR DESCRIPTION
The Matrix metrics panel could start another database statistics read while its initial load was still running, and each manual refresh during a slow poll started another overlapping read. All panel loads now share one in-flight guard; periodic ticks skip outstanding work, and manual actions retain one trailing refresh. Retry/rescan completions after disposal cannot invalidate providers.

The follow-up also benchmarks the remaining sync slow-query families against an exact fresh schema and synthetic aged datasets. Existing indexes keep pending reads and room-marker lookups bounded; active counts and depth aggregates scale with the active subset. No speculative index or query change is included. The report records the large-unexpired-lease stress boundary and the limits of isolated SQL timings.

- [Evidence, per-family decisions, and reproduction instructions](https://github.com/matthiasn/lotti/blob/codex/query-outbox-benchmarks/docs/perf/2026-09-05-sync-query-followup.md)
- Validation: 11 targeted widget tests pass through Dart MCP; all six new regressions fail with the fixes reverted. Full-worktree Dart MCP analysis is clean. Knowledge/Mermaid and changelog validation pass.
- No rendered layout, styling, or label changes. Benchmarks use synthetic data only and do not explain the historical shared executor stalls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented overlapping sync diagnostics requests during slow loads.
  - Opening the metrics panel, automatic polling, and manual refreshes now share active requests.
  - Manual refreshes during an ongoing load trigger one follow-up update.
  - Refresh, retry, and rescan actions remain safe when the panel is closed.
  - Prevented outdated results from updating a disposed metrics panel.

- **Documentation**
  - Documented the metrics panel’s five-second polling, refresh behavior, and lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->