### PR TITLE
perf: reduce latest agent query work and document remaining hotspots

### DIFF
--- a/changelog.d/2026-09-05-agent-latest-read-performance.md
+++ b/changelog.d/2026-09-05-agent-latest-read-performance.md
@@ -1,0 +1,4 @@
+### Changed
+- **Agent status refreshes use less database work.** Latest-state and report
+  lookups now check for newer records directly, reducing work when refreshing
+  many agents.

--- a/docs/perf/2026-09-05-agent-query-followup.md
+++ b/docs/perf/2026-09-05-agent-query-followup.md
@@ -1,0 +1,122 @@
+# Agent query follow-up — 2026-09-05
+
+The original archive identified frequent agent reads but did not isolate native
+SQLite time from executor queueing and transport. This experiment measures native
+SQLite plus Python row materialization on synthetic data, independently of those
+shared stalls. No profile database or log arguments are used.
+
+## Result on the common case
+
+Current state and report/soul-head updates normally overwrite stable ids. On a
+fixture of 900 such agents, requesting 897 existing ids plus an absent id within
+the production chunk cap, replacing window ranking with an indexed `NOT EXISTS`
+newer-row check reduced warm native time from **4.176 to 3.030 ms** and first-read
+time on a new SQLite connection from **5.285 to 3.708 ms**. Approximate VM work
+fell from **82,500 to 46,800 instructions**. These are modest native-query gains,
+not an end-to-end latency claim.
+
+For the pending-wake variant where every latest row has cleared its wake, the
+same fixture returned zero rows in **2.738 versus 1.365 ms** warm. The anti-join
+always checks newer records independently of their wake fields, so an older
+matching wake cannot be promoted when its newer record cleared it.
+
+## Reproduce
+
+Run `python3 tool/perf/agent_latest_queries.py` from the repository root. The
+script creates and removes private temporary databases, loads the checked-in
+agent entity table and indexes, extracts the current `latestEntitiesByAgentIds`
+SQL from production, and compares it with the preceding window query. Output
+includes plans, returned cardinalities, median timings and approximate SQLite VM
+instruction counts. It fails if full result equality fails or if the current
+multi-agent query exceeds 70% of the baseline VM instruction count. Python's
+standard SQLite 3.45.1 was used on Linux ARM64.
+
+There are 100 synthetic agents with 1, 100 or 500 records each, plus 900 agents
+with one record each, containing 2,048 bytes of JSON padding. Scenarios request
+one or many existing agents plus an absent agent, with/without subtype and
+with/without an outer JSON predicate. Rows include equal creation times,
+tombstones, and newer states that clear the predicate. Twelve paired runs
+alternate variant order on the same connection. First-read measurements use
+separate newly opened SQLite connections; OS page caches are not flushed.
+
+| Records per agent | Requested existing agents | Window warm ms | Anti-join warm ms | Window cold connection ms | Anti-join cold connection ms |
+|---|---:|---:|---:|---:|---:|
+| 1 | 100 | 0.371 | 0.244 | 0.686 | 0.482 |
+| 1 | 897 | 4.176 | 3.030 | 5.285 | 3.708 |
+| 100 (stress) | 100 | 33.095 | 3.616 | 30.216 | 3.836 |
+| 500 (stress) | 100 | 157.872 | 17.252 | 152.864 | 17.489 |
+
+These are type-only cases without an outer predicate. The old query carries
+all candidate payloads through a window. The replacement scans candidate index
+entries and rejects a row if a greater `(created_at, id)` pair exists in the
+same active agent/type[/subtype] partition. It does not hydrate non-winners for
+the no-predicate variant. No migration, new index or cross-call cache is needed.
+
+Work remains linear in the number of candidate records. At 100 versus 500
+records per agent, the replacement executes approximately 239,400 versus
+1,187,500 instructions: roughly five times the work for five times the records,
+not quadratic growth. JSON outer predicates may be evaluated on historical
+candidates before the indexed exclusion; the stress case with that predicate
+costs 14.317 / 64.680 ms. The logical winner semantics remain identical.
+
+The progress callback counts in units of 100; a reported zero for a tiny PK query
+means fewer than 100 instructions, not no work. The VM-work budget is independent
+of wall-clock load. Tests in `agent_repo_core_test.dart` additionally capture,
+execute and explain the actual repository statement through real Drift to guard
+indexed newer-row checks without a historical window scan. Compatibility tests
+cover outer-filter rejection, ties, duplicate/missing ids, tombstones, chunk
+boundaries, transaction read-your-writes and rollback. Those compatibility tests
+are expected to pass before and after the performance change.
+
+## Alternatives rejected
+
+A correlated `LIMIT 1` seek per requested agent was dramatically faster on the
+large-history stress case but regressed fresh-connection performance on the
+normal one-row case: **4.605 to 5.721 ms**, with only a small warm gain
+(**3.817 to 3.595 ms**) in that comparison run. Another in-memory run also found
+a slight warm regression. It is not the shipped query.
+
+Ranking only ids and hydrating winners afterward reduced large-payload cost,
+but its common-case gains were smaller than the anti-join and one subtype
+scenario regressed slightly. The selected anti-join improved both single-row
+and aged fixtures across the tested subtype and outer-predicate cases.
+
+## Other original query families
+
+- **PK batch (shape 2):** one-row warm reads remain around 0.006 ms for all three
+  ages, using the primary-key index. Already coalesced in the repository; this
+  benchmark does not justify another cache or index.
+- **Agent/type history (shape 1):** `LIMIT 1` stays near 0.016 ms through the
+  existing ordered index. Unlimited reads return 1 / 91 / 455 live rows and cost
+  approximately 0.015 / 0.141 / 0.698 ms. Their work grows with returned content.
+  Current query providers bound previews to 50 or 200 messages; full chat
+  projection, observation reads, prompt reconstruction and recommendation
+  workflows also have intentionally unrestricted calls. Truncating those calls
+  without changing their consumer contract would discard relevant history.
+- **Agent/type/subtype (shape 21):** the one-row ordered lookup remains around
+  0.016–0.017 ms through the existing subtype index.
+- **Lifecycle identities (shape 4):** a separate fixture has 900 or 9,000 identity
+  rows, 10% active, with the same payload padding. The current forced type index
+  returns 90 or 900 rows in approximately 0.773 or 10.119 ms warm. This isolates
+  real cardinality-dependent JSON filtering work, but does not establish those
+  cardinalities, lifecycle selectivity or timings on the user's database.
+  Goal consumers now share their identity provider. No new lifecycle cache or
+  schema index is included without evidence that remaining calls justify it.
+- **Latest-per-agent (shapes 5/15):** the measured fix above covers both subtype
+  and type-only reads, with the outer predicate kept out of the newer-row check.
+
+## Limits
+
+Current state updates preserve state ids, and report/soul head writers reuse
+`existingHead?.id` (`wake_output_writer.dart`, `event_agent_workflow.dart` and
+`soul_version_ops.dart`). The one-row-per-agent fixtures are therefore the
+relevant common case. The 100/500-row partitions are stress cases for multiple
+records, not the expected growth model of these stable registers or a measured
+cardinality from the log archive.
+
+Python uses a different SQLite build from the app. Targeted Dart tests verify
+SQL compatibility and behavior with the app's dependency. The experiment excludes
+Dart JSON decoding, isolates, transaction contention, OS suspend/resume and I/O
+stalls. It cannot explain the historical 13–15-second or 17-minute shared delays.
+Post-fix logs and workload cardinalities remain necessary to measure the real
+application effect and choose any further lifecycle or call-site optimization.

--- a/docs/perf/2026-09-05-pending-wake-investigation.md
+++ b/docs/perf/2026-09-05-pending-wake-investigation.md
@@ -1,0 +1,215 @@
+# Pending scheduled-wake query investigation — 2026-09-05
+
+The current pending-list SQL scales with the **pending set**, not accumulated
+agent history. This follow-up found no justification for another index or a
+scheduler cache. The historical long delays remain unexplained by this isolated
+benchmark; the archived logs do not record returned-row counts.
+
+## Scope and method
+
+Investigated source at `d9a4f2a99`, specifically
+`AgentDatabase.getPendingScheduledWakeRecords` (archive query shape 8), its
+repository adapter, `pendingWakeRecordsProvider`, and the separate due-record
+path in `ScheduledWakeManager`. The archive contained 4,637 calls over the slow
+logging threshold, including 1,976 in September. Those are **slow-call counts**,
+not total request frequency. The September slow-only median was 41.8 ms and p95
+114.9 ms; its maximum was 2,126.7 ms. They measure the executor await rather than
+isolated SQLite execution.
+
+The reproducer below loads the actual current entity schema and SQL from source
+into a Python SQLite 3.45.1 database on Linux ARM64. This is the system Python
+engine, not the app native engine: `pubspec.lock` pins Dart `sqlite3` 3.5.2,
+which is a package version rather than the SQLite runtime version. It varies 0,
+10,000 and 100,000 history rows independently of 0, 10, 1,000 and 10,000 pending
+rows. Half the history rows are consumed scheduled wakes; half are another
+entity type. Synthetic wake payloads are about 310–320 bytes. Each case has one
+warmup followed by 21 samples. SQL timings include `fetchall()` materialization
+into Python tuples. Separate JSON decoding timings are Python diagnostics,
+**not Dart/Freezed hydration timings**. These runs exclude Drift isolate
+transport, transaction contention and application load; warm timings also
+exclude file I/O and SQLite page-cache misses.
+
+`ANALYZE` runs after each fixture update. The SQLite progress handler counts
+100-opcode blocks in one further query execution, outside timing samples;
+reported work is rounded down to that resolution. Fixture insertion and index
+maintenance are not included. No real user data or databases are used.
+
+Each fixture is also backed up to a temporary synthetic database. Each query's
+first read opens a fresh SQLite connection to that snapshot; this has a cold
+SQLite page/statement cache but a potentially warm operating-system cache from
+the backup. The first-read timer includes query preparation and fetching, not
+opening the connection. These are **not cold physical-disk measurements** and
+are single observations rather than percentiles. Snapshot files are cleaned up
+at the end. Warm measurements use the original in-memory database.
+
+## Results
+
+| History rows | Pending rows returned | Fresh connection ms | Warm fetch median ms | Warm fetch p95 ms | JSON decode median ms | Approximate VM steps |
+|---|---|---|---|---|---|---|
+| 0 | 0 | 0.367 | 0.001 | 0.001 | 0.000 | 0 |
+| 0 | 10 | 0.119 | 0.013 | 0.016 | 0.014 | 100 |
+| 0 | 1,000 | 1.522 | 1.007 | 1.253 | 1.449 | 13,000 |
+| 0 | 10,000 | 15.519 | 11.780 | 14.905 | 17.807 | 130,000 |
+| 10,000 | 0 | 0.173 | 0.001 | 0.002 | 0.000 | 0 |
+| 10,000 | 10 | 0.671 | 0.013 | 0.016 | 0.014 | 100 |
+| 10,000 | 1,000 | 1.434 | 1.209 | 2.353 | 1.623 | 13,000 |
+| 10,000 | 10,000 | 13.277 | 11.721 | 15.728 | 16.659 | 130,000 |
+| 100,000 | 0 | 0.139 | 0.001 | 0.001 | 0.000 | 0 |
+| 100,000 | 10 | 0.155 | 0.012 | 0.014 | 0.013 | 100 |
+| 100,000 | 1,000 | 1.546 | 1.025 | 1.159 | 1.363 | 13,000 |
+| 100,000 | 10,000 | 13.713 | 11.436 | 12.826 | 15.342 | 130,000 |
+
+Every pending-list plan is:
+
+```text
+SCAN agent_entities USING INDEX idx_agent_entities_pending_scheduled_wake_at
+```
+
+This is a walk over the pending partial index, not a scan of the entire entity
+table. There is no temporary sort. With 10,000 pending wakes, the query returns
+about 3.2 MB of serialized JSON and performs approximately 130,000 VM steps.
+The caller requests every pending wake, so that growth is expected. This stress
+case is not an estimate of the user's actual pending-set size.
+
+The 10 ms slow-log threshold is crossed by the complete fetch around the
+10,000-row stress point on this machine; 1,000 rows remain around 1 ms.
+That is a bracket, not a measured exact crossover, and it excludes application
+hydration and contention. First reads of the snapshot include schema/query
+preparation and page-cache work; none approach the logged multi-second stalls.
+
+The due-record query uses:
+
+```text
+SEARCH agent_entities USING INDEX idx_agent_entities_pending_scheduled_wake_at (<expr><?)
+```
+
+Its cutoff selects only the first five pending records. With nonempty pending
+fixtures it returns five rows regardless of history or pending-set size, taking
+roughly 0.006–0.008 ms median in this run. Its VM work stays near 100 steps.
+SQLite's plan renders the inclusive bound as `<expr><?`; the source predicate
+remains `<= ?1`, and the reproducer verifies all five rows including the cutoff.
+
+## Refresh and hydration audit
+
+`AgentRepoEvolution.getPendingScheduledWakeRecords` has one production caller:
+`pendingWakeRecordsProvider`. That provider is shared by the sidebar activity
+summary, sidebar queue, agent settings count and pending-wakes view model. They
+watch the same provider instance; there is no separate query per mounted
+consumer in one provider container.
+
+The provider refreshes on the global `agentNotification` topic. For each build,
+it reads identities, the complete pending scheduled-record list, then one batch
+of latest states filtered for pending wake fields. It explicitly includes agents
+from scheduled records in the state request. That inclusion is necessary:
+workspace-scoped wakes do not require a state-level wake field. Scheduled
+records are decoded once in the repository before the merged timeline is built.
+The complete identity/state objects support labels, linked subjects and cancel
+actions; an SQL projection is not an established improvement here.
+
+`UpdateNotifications` already batches UI-only and local notifications over
+100 ms, and sync notifications over one second. Separate origin batches can
+still emit separately. The global topic is broad, but identity, lifecycle,
+state wake fields and scheduled records can all change the merged result.
+`persistedStateChangedNotifier` carries an affected id and the global topic,
+not an entity-type-specific change classification. Filtering global events or
+caching just the scheduled list without a complete invalidation contract could
+hide cancellations, sync updates or newly scheduled work. This audit does not
+prove that every current refresh is necessary; it establishes why a blanket
+cache or event filter is not justified by the archive alone.
+
+`ScheduledWakeManager` does **not** call the all-pending listing. Its startup,
+hourly, explicit and lease retry passes use due-range reads. Overlapping checks
+already coalesce with one requested rerun. Fresh reads around awaited identity
+and state writes protect cancellation and lifecycle transitions. The generation
+guards and restart handoff prevent stopped passes from launching work. These
+reads must not be removed merely because their SQL shapes repeat in the logs.
+
+## Disposition
+
+No runtime change is proposed for this query family. Before changing it, capture
+pending rows returned, payload size and refresh origin alongside executor timing
+in a representative post-fix workload. If a genuinely large pending backlog is
+confirmed, investigate why records remain pending before imposing a limit that
+would hide real wakes. If repeated scans dominate despite a small pending set,
+measure shared executor waiting and the entire provider build; the isolated SQL
+cost here does not explain the archived delays.
+
+The existing `agent_database_test.dart` contains a pending/due index-plan check.
+This investigation adds no Dart code or tests, so it does not claim a new Dart
+regression fix or a Flutter performance measurement. The reproducer asserts
+returned counts, pending status and chronological order for every case.
+
+## Reproduce
+
+From the repository root, run this Python program. It reads the current source,
+creates in-memory databases plus temporary synthetic snapshots, and prints all cardinalities, plans and raw
+summary measurements. Python's standard library is sufficient.
+
+```python
+import datetime, json, pathlib, sqlite3, statistics, tempfile, time
+root = pathlib.Path.cwd()
+schema = (root / 'lib/features/agents/database/agent_database.drift').read_text().split('CREATE TABLE agent_links')[0]
+source = (root / 'lib/features/agents/database/agent_database.dart').read_text()
+def query(method):
+    return source.split('Selectable<AgentEntity> ' + method + '(')[1].split("r'''", 1)[1].split("'''", 1)[0]
+queries = {'pending': query('getPendingScheduledWakeRecords'), 'due': query('getDueScheduledWakeRecords')}
+base = datetime.datetime(2026, 9, 5)
+cutoff = (base + datetime.timedelta(minutes=4)).isoformat(timespec='milliseconds')
+scratch = tempfile.TemporaryDirectory(prefix='lotti-wake-benchmark-')
+snapshot = pathlib.Path(scratch.name) / 'synthetic.sqlite'
+report = {'sqlite': sqlite3.sqlite_version, 'clock': 'perf_counter', 'samples': 21, 'measurements': []}
+for history in (0, 10000, 100000):
+    db = sqlite3.connect(':memory:')
+    db.executescript(schema)
+    def rows(count, pending):
+        for i in range(count):
+            kind = 'scheduledWake' if pending or i % 2 == 0 else 'agentState'
+            stamp = (base + datetime.timedelta(minutes=i)).isoformat(timespec='milliseconds')
+            key = ('pending-' if pending else 'history-') + str(i)
+            payload = {'runtimeType': kind, 'id': key, 'agentId': f'agent-{i % 100}', 'scheduledAt': stamp, 'status': 'pending' if pending else 'consumed', 'reason': 'synthetic scheduled work', 'updatedAt': stamp, 'vectorClock': None, 'workspaceKey': f'day:synthetic-{i}', 'triggerTokens': [f'synthetic-token-{i}']}
+            yield (key, f'agent-{i % 100}', kind, None, None, 1788566400, 1788566400, None, json.dumps(payload), 1)
+    db.executemany('INSERT INTO agent_entities VALUES (?,?,?,?,?,?,?,?,?,?)', rows(history, False))
+    for pending in (0, 10, 1000, 10000):
+        db.execute("DELETE FROM agent_entities WHERE id LIKE 'pending-%'")
+        db.executemany('INSERT INTO agent_entities VALUES (?,?,?,?,?,?,?,?,?,?)', rows(pending, True))
+        db.commit()
+        db.execute('ANALYZE')
+        snapshot.unlink(missing_ok=True)
+        disk = sqlite3.connect(snapshot)
+        db.backup(disk)
+        disk.close()
+        for name, sql in queries.items():
+            args = {'1': cutoff} if name == 'due' else ()
+            cold = sqlite3.connect(snapshot)
+            start = time.perf_counter()
+            cold_result = cold.execute(sql, args).fetchall()
+            cold_ms = (time.perf_counter() - start) * 1000
+            cold.close()
+            plan = [r[3] for r in db.execute('EXPLAIN QUERY PLAN ' + sql, args)]
+            timings, decoded = [], []
+            for iteration in range(22):
+                start = time.perf_counter()
+                result = db.execute(sql, args).fetchall()
+                elapsed = (time.perf_counter() - start) * 1000
+                start = time.perf_counter()
+                payloads = [json.loads(r[8]) for r in result]
+                decoding = (time.perf_counter() - start) * 1000
+                if iteration:
+                    timings.append(elapsed)
+                    decoded.append(decoding)
+            assert cold_result == result
+            assert len(result) == (min(pending, 5) if name == 'due' else pending)
+            assert all(p['status'] == 'pending' for p in payloads)
+            assert [p['scheduledAt'] for p in payloads] == sorted(p['scheduledAt'] for p in payloads)
+            callbacks = [0]
+            def progress():
+                callbacks[0] += 1
+                return 0
+            db.set_progress_handler(progress, 100)
+            db.execute(sql, args).fetchall()
+            db.set_progress_handler(None, 0)
+            report['measurements'].append({'historyRows': history, 'pendingRows': pending, 'query': name, 'returnedRows': len(result), 'serializedBytes': sum(len(r[8].encode()) for r in result), 'freshConnectionMs': round(cold_ms, 3), 'medianMs': round(statistics.median(timings), 3), 'p95Ms': round(sorted(timings)[19], 3), 'jsonDecodeMedianMs': round(statistics.median(decoded), 3), 'vmStepsRoundedDown100': callbacks[0] * 100, 'plan': plan})
+    db.close()
+scratch.cleanup()
+print(json.dumps(report, indent=2))
+```

--- a/knowledge/features/agents/persistence-and-sync.md
+++ b/knowledge/features/agents/persistence-and-sync.md
@@ -5,7 +5,7 @@ description: The agent.sqlite entity and link model, bulk-read chunking, and exa
 resource: ../../../lib/features/agents/database/agent_database.dart
 tags: [agents, persistence, sync, privacy, drift]
 status: stable
-generated: { by: codex/gpt-5, at: 2026-08-10T01:20:00+02:00 }
+generated: { by: codex/gpt-6, at: 2026-09-05T19:00:00Z }
 stale_after: 2026-10-12
 sources:
   - id: error-logging
@@ -232,14 +232,25 @@ result is otherwise unspecified. The consumers are first-wins
 `unifiedSuggestionList`), so an unordered compound could let an older
 retry/audit decision override the newest one.
 
-`latestEntitiesByAgentIds` accepts an `outerPredicate` that is applied to the
-outer `WHERE rn = 1` — i.e. it filters the *winning* row per agent, after
-ranking. `getAgentStatesWithPendingWakes` uses it to return only agents that
-actually have a wake pending, instead of returning every agent's latest state
-for the pending-wakes screen to discard. Applying such a predicate inside the
-ranked subquery would be a correctness bug: it could promote an older row that
-satisfies it over a newer one that does not, resurrecting state the newest row
-had cleared.
+# Latest reads exclude candidates with a newer row
+
+`latestEntitiesByAgentIds` scans the active agent/type index for requested ids,
+with an optional subtype. A correlated `NOT EXISTS` check uses the matching
+ordered index to reject each candidate that has a greater `(created_at, id)`
+pair in its partition. This avoids carrying historical payloads through a
+window function. Candidate index work still grows with history; there is no
+constant-work or cross-call caching guarantee. Chunking, per-chunk agent-id
+ordering and transaction zones remain unchanged.
+
+Its `outerPredicate` filters the selected result **without constraining the
+newer-row check**. `getAgentStatesWithPendingWakes` uses it to exclude the latest
+states whose wakes are cleared. Adding that predicate inside `NOT EXISTS`
+could promote an older matching state and resurrect a cleared wake. SQLite may
+evaluate independent candidate predicates in any physical order; the newer-row
+check always sees newer records regardless of their wake fields.
+
+The reproducible experiment and limitations are in
+[the agent query benchmark](../../../docs/perf/2026-09-05-agent-query-followup.md).
 
 # The agent identity list is cached
 
@@ -264,10 +275,9 @@ The cache lives on `AgentRepoCore`, and three rules keep it honest:
   would publish a row the database no longer has. `AgentRepoCore` marks its
   transactions with a zone value so the load can tell.
 
-Latest-per-agent batch reads are backed by active-row indexes that include the
-`(created_at DESC, id DESC)` ranking order for both type-only and
-type-plus-subtype lookups, so the window-function query needs no temp sort for
-the final order term.
+Latest-per-agent checks use active-row indexes that include the
+`(created_at DESC, id DESC)` order for both type-only and type-plus-subtype
+lookups. The newer-row range check requires no historical payload sort.
 
 Due and pending scheduled-wake reads pin
 `idx_agent_entities_pending_scheduled_wake_at`. The partial expression index

--- a/lib/features/agents/database/agent_repo_core.dart
+++ b/lib/features/agents/database/agent_repo_core.dart
@@ -240,8 +240,9 @@ class AgentRepoCore {
   /// many independent callers (Riverpod provider families resolving one row
   /// each) firing concurrently, not of one loop that could be batched at its
   /// call site. The plan was always a clean primary-key seek; the cost was
-  /// ~19 ms of isolate round trip per call. Coalescing at this layer fixes
-  /// every such caller at once, including ones that have no single place to
+  /// ~19 ms of executor await per call (including queueing and transport).
+  /// Coalescing at this layer reduces the round trips for
+  /// every such caller, including ones that have no single place to
   /// batch.
   ///
   /// See `docs/perf/2026-08-01_slow-queries-investigation.md`.
@@ -259,8 +260,8 @@ class AgentRepoCore {
   /// agent_entities WHERE id = ? AND deleted_at IS NULL` — all from
   /// the per-row `Future.wait` fan-out in `_collectObservationPayloads`
   /// (project_agent_workflow.dart and task_agent_workflow.dart). The
-  /// plan was a clean PK seek; the cost was the writer-lock queue
-  /// wait piling up behind each independent isolate hop.
+  /// plan was a clean PK seek; the logged executor time included queueing
+  /// and isolate transport, without identifying which component dominated.
   ///
   /// Chunking guards the bulk path against SQLite's host-variable
   /// limit (default 999): an unbounded caller (e.g.
@@ -316,11 +317,12 @@ class AgentRepoCore {
   /// [type] (and optionally [subtype]). Shared batched read used by the
   /// state/head latest-per-agent lookups in this class and in
   /// [AgentRepoQueries].
-  /// [outerPredicate] is appended to the outer `WHERE rn = 1` — i.e. it filters
-  /// the *winning* row per agent, after ranking. Filtering inside the ranked
-  /// subquery instead would be a correctness bug: it could promote an older row
-  /// that satisfies the predicate over a newer one that does not, resurrecting
-  /// state the newest row had cleared.
+  /// A candidate is returned only when an indexed check finds no newer row in
+  /// its agent/type partition. This avoids carrying historical payloads through
+  /// a window function; candidate index work still grows with partition size.
+  /// [outerPredicate] filters the winner without constraining the newer-row
+  /// check. Applying it to that check could promote an older matching row over
+  /// a newer non-matching row, resurrecting state the newest row had cleared.
   Future<List<AgentDomainEntity>> latestEntitiesByAgentIds({
     required Iterable<String> agentIds,
     required String type,
@@ -328,31 +330,36 @@ class AgentRepoCore {
     String outerPredicate = '',
   }) async {
     final result = <AgentDomainEntity>[];
-    // Every chunk binds its own ids plus the type, the optional subtype, and
-    // whatever `outerPredicate` needs — all against one 999-variable budget.
+    // Every chunk binds its ids plus the type and optional subtype against
+    // one 999-variable budget. The outer predicate has no bound parameters.
     final reserved = 1 + (subtype == null ? 0 : 1);
     for (final chunk in sqliteInClauseChunks(agentIds, reserve: reserved)) {
       final placeholders = List.filled(chunk.length, '?').join(', ');
       final subtypePredicate = subtype == null ? '' : 'AND subtype = ? ';
+      final newerSubtypePredicate = subtype == null
+          ? ''
+          : 'AND newer.subtype = entity.subtype';
       final rows = await _db
           .customSelect(
             '''
-              SELECT id, agent_id, type, subtype, thread_id, created_at,
-                updated_at, deleted_at, serialized, schema_version
-              FROM (
-                SELECT agent_entities.*,
-                  ROW_NUMBER() OVER (
-                    PARTITION BY agent_id
-                    ORDER BY created_at DESC, id DESC
-                  ) AS rn
-                FROM agent_entities
-                WHERE agent_id IN ($placeholders)
-                  AND type = ?
-                  $subtypePredicate
-                  AND deleted_at IS NULL
-              )
-              WHERE rn = 1
+              SELECT entity.*
+              FROM agent_entities AS entity
+              WHERE agent_id IN ($placeholders)
+                AND type = ?
+                $subtypePredicate
+                AND deleted_at IS NULL
+                AND NOT EXISTS (
+                  SELECT 1
+                  FROM agent_entities AS newer
+                  WHERE newer.agent_id = entity.agent_id
+                    AND newer.type = entity.type
+                    $newerSubtypePredicate
+                    AND newer.deleted_at IS NULL
+                    AND (newer.created_at, newer.id) >
+                      (entity.created_at, entity.id)
+                )
                 $outerPredicate
+              ORDER BY entity.agent_id
             ''',
             variables: [
               ...chunk.map(Variable.withString),
@@ -571,8 +578,8 @@ class AgentRepoCore {
   /// On an install with ~900 agents that is ~900 rows decoded from JSON on
   /// every agent-update notification; the 2026-06/07 slow-query logs show 2,050
   /// full-population reads of this shape in 14 days (`args=901`), each around
-  /// 32 ms. The predicate is applied *after* ranking, so an agent whose newest
-  /// state cleared its wake is correctly excluded.
+  /// 32 ms. The predicate is applied *after* newest-row selection, so an agent
+  /// whose newest state cleared its wake is correctly excluded.
   Future<Map<String, AgentStateEntity>> getAgentStatesWithPendingWakes(
     List<String> agentIds, {
     Iterable<String> alsoIncludeAgentIds = const <String>[],

--- a/test/features/agents/database/agent_repo_core_test.dart
+++ b/test/features/agents/database/agent_repo_core_test.dart
@@ -12,6 +12,9 @@ import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/attention_negotiation.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../mocks/mocks.dart';
 
 import '../test_data/entity_factories.dart';
 import '../test_data/soul_factories.dart';
@@ -733,9 +736,196 @@ void main() {
   });
 
   group('latestEntitiesByAgentIds', () {
+    for (final subtype in [null, 'state']) {
+      test(
+        'uses indexed newer-row checks without a window with subtype $subtype',
+        () async {
+          await core.upsertEntity(
+            makeTestState(
+              id: 'winner',
+              agentId: 'agent',
+              updatedAt: testDate,
+            ),
+          );
+          await db.customStatement(
+            "UPDATE agent_entities SET subtype = 'state'",
+          );
+          final forwardingDb = MockAgentDatabase();
+          when(() => forwardingDb.agentEntities).thenReturn(db.agentEntities);
+          late String query;
+          late List<Variable> variables;
+          when(
+            () => forwardingDb.customSelect(
+              any(),
+              variables: any(named: 'variables'),
+              readsFrom: any(named: 'readsFrom'),
+            ),
+          ).thenAnswer((invocation) {
+            query = invocation.positionalArguments.single as String;
+            variables = invocation.namedArguments[#variables] as List<Variable>;
+            return db.customSelect(
+              query,
+              variables: variables,
+              readsFrom: {db.agentEntities},
+            );
+          });
+          final rows = await AgentRepoCore(forwardingDb)
+              .latestEntitiesByAgentIds(
+                agentIds: ['agent', 'missing'],
+                type: AgentEntityTypes.agentState,
+                subtype: subtype,
+              );
+          expect(rows.single.id, 'winner');
+          final plan = await db
+              .customSelect('EXPLAIN QUERY PLAN $query', variables: variables)
+              .get();
+          final details = plan
+              .map((row) => row.read<String>('detail'))
+              .join('\n');
+          // Execute and explain the actual repository statement, not a copied
+          // query. Indexed searches alone are insufficient: the old window also
+          // used this index but carried historical payloads through ranking.
+          expect(details, contains('CORRELATED SCALAR SUBQUERY'));
+          expect(
+            details,
+            contains(
+              subtype == null
+                  ? 'idx_agent_entities_active_agent_type_created_id'
+                  : 'idx_agent_entities_active_agent_type_sub_created_id',
+            ),
+          );
+          expect(details, isNot(contains('SCAN (subquery-')));
+        },
+      );
+    }
+
+    test(
+      'preserves ties, tombstones, missing agents and outer filters',
+      () async {
+        for (final agentId in ['agent-b', 'agent-a']) {
+          for (final (id, revision, date) in [
+            ('old', 1, DateTime(2026, 3, 14)),
+            ('tie-a', 2, testDate),
+            ('tie-z', 3, testDate),
+          ]) {
+            await core.upsertEntity(
+              makeTestState(
+                id: '$agentId-$id',
+                agentId: agentId,
+                revision: revision,
+                updatedAt: date,
+              ),
+            );
+          }
+        }
+        await core.upsertEntity(
+          makeTestState(
+            id: 'deleted-newer',
+            agentId: 'agent-a',
+            updatedAt: DateTime(2026, 3, 16),
+          ),
+        );
+        await db.customStatement(
+          "UPDATE agent_entities SET deleted_at = 1 WHERE id = 'deleted-newer'",
+        );
+        final latest = await core.latestEntitiesByAgentIds(
+          agentIds: ['agent-b', 'missing', 'agent-a', 'agent-a'],
+          type: AgentEntityTypes.agentState,
+        );
+        expect(latest.map((entity) => entity.id), [
+          'agent-a-tie-z',
+          'agent-b-tie-z',
+        ]);
+        // The current winners do not satisfy the predicate. Older matching
+        // states must not be promoted into the result.
+        expect(
+          await core.latestEntitiesByAgentIds(
+            agentIds: ['agent-b', 'agent-a'],
+            type: AgentEntityTypes.agentState,
+            outerPredicate: r"AND json_extract(serialized, '$.revision') = 1",
+          ),
+          isEmpty,
+        );
+      },
+    );
+
+    test('latest reads observe transaction writes and rollback', () async {
+      await core.upsertEntity(
+        makeTestState(
+          id: 'committed',
+          agentId: 'agent',
+          updatedAt: testDate,
+        ),
+      );
+      await expectLater(
+        core.runInTransaction(() async {
+          await core.upsertEntity(
+            makeTestState(
+              id: 'uncommitted',
+              agentId: 'agent',
+              updatedAt: DateTime(2026, 3, 16),
+            ),
+          );
+          final inside = await core.latestEntitiesByAgentIds(
+            agentIds: ['agent'],
+            type: AgentEntityTypes.agentState,
+          );
+          expect(inside.single.id, 'uncommitted');
+          throw StateError('rollback');
+        }),
+        throwsStateError,
+      );
+      final outside = await core.latestEntitiesByAgentIds(
+        agentIds: ['agent'],
+        type: AgentEntityTypes.agentState,
+      );
+      expect(outside.single.id, 'committed');
+    });
+
+    test(
+      'newer rows from other types or subtypes do not hide the winner',
+      () async {
+        await core.upsertEntity(
+          makeTestState(
+            id: 'wanted',
+            agentId: 'agent',
+            updatedAt: testDate,
+          ),
+        );
+        await core.upsertEntity(
+          makeTestState(
+            id: 'other-subtype',
+            agentId: 'agent',
+            updatedAt: DateTime(2026, 3, 16),
+          ),
+        );
+        await core.upsertEntity(
+          makeTestIdentity(
+            id: 'other-type',
+            agentId: 'agent',
+            createdAt: DateTime(2026, 3, 17),
+          ),
+        );
+        await db.customStatement(
+          "UPDATE agent_entities SET subtype = 'wanted' WHERE id = 'wanted'",
+        );
+        final filtered = await core.latestEntitiesByAgentIds(
+          agentIds: ['agent'],
+          type: AgentEntityTypes.agentState,
+          subtype: 'wanted',
+        );
+        expect(filtered.single.id, 'wanted');
+        final unfiltered = await core.latestEntitiesByAgentIds(
+          agentIds: ['agent'],
+          type: AgentEntityTypes.agentState,
+        );
+        expect(unfiltered.single.id, 'other-subtype');
+      },
+    );
+
     test('keeps only the newest row per agent', () async {
       // AgentStateEntity has no `createdAt`; the row's `created_at` column is
-      // written from `updatedAt`, which is what the ROW_NUMBER ordering uses.
+      // written from `updatedAt`, which is what the newest-row ordering uses.
       await core.upsertEntity(
         makeTestState(
           id: 'state-old',

--- a/tool/perf/agent_latest_queries.py
+++ b/tool/perf/agent_latest_queries.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Synthetic agent-query experiment; never opens a profile database.
+
+Run from the repository root: python3 tool/perf/agent_latest_queries.py
+Uses the checked-in table/index DDL and current repository query. Timings exclude
+Dart, JSON decoding, isolate transport, and database queueing. Reopened connections
+have cold SQLite page caches, not cold OS caches. Output is JSON on stdout.
+"""
+import json
+import pathlib
+import sqlite3
+import statistics
+import tempfile
+import time
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SOURCE = ROOT / 'lib/features/agents/database/agent_repo_core.dart'
+DDL = (ROOT / 'lib/features/agents/database/agent_database.drift').read_text().split('CREATE TABLE agent_links')[0]
+OLD = '''SELECT id, agent_id, type, subtype, thread_id, created_at,
+updated_at, deleted_at, serialized, schema_version FROM (
+SELECT agent_entities.*, ROW_NUMBER() OVER (
+PARTITION BY agent_id ORDER BY created_at DESC, id DESC) AS rn
+FROM agent_entities WHERE agent_id IN ({ids}) AND type = ?
+{subtype} AND deleted_at IS NULL) WHERE rn = 1 {predicate}'''
+
+
+def queries(count, subtype=False, predicate=''):
+    body = SOURCE.read_text().split('Future<List<AgentDomainEntity>> latestEntitiesByAgentIds')[1]
+    current = body.split("'''", 2)[1]
+    subtype_sql = 'AND subtype = ?' if subtype else ''
+    current = current.replace('$placeholders', ', '.join(['?'] * count))
+    current = current.replace('$subtypePredicate', subtype_sql).replace('$outerPredicate', predicate)
+    current = current.replace('$newerSubtypePredicate', 'AND newer.subtype = entity.subtype' if subtype else '')
+    old = OLD.format(ids=','.join(['?'] * count), subtype=subtype_sql, predicate=predicate)
+    return {'window': old, 'current': current}
+
+
+def elapsed(conn, sql, args):
+    start = time.perf_counter_ns()
+    rows = conn.execute(sql, args).fetchall()
+    return (time.perf_counter_ns() - start) / 1e6, rows
+
+
+def compare(path, statements, args):
+    conn = sqlite3.connect(path)
+    expected = None
+    plans, cold, samples, steps = {}, {}, {name: [] for name in statements}, {}
+    for name, sql in statements.items():
+        plans[name] = [r[3] for r in conn.execute('EXPLAIN QUERY PLAN ' + sql, args)]
+        fresh = sqlite3.connect(path)
+        cold[name], rows = elapsed(fresh, sql, args)
+        fresh.close()
+        if expected is None:
+            expected = rows
+        assert rows == expected, name
+        # Count VM instructions in chunks of 100; deterministic work, no timing
+        # threshold. Rounded down by at most 99 instructions per execution.
+        ticks = [0]
+        def tick():
+            ticks[0] += 1
+            return 0
+        conn.set_progress_handler(tick, 100)
+        assert conn.execute(sql, args).fetchall() == expected
+        conn.set_progress_handler(None, 0)
+        steps[name] = ticks[0] * 100
+    for turn in range(12):
+        order = list(statements)
+        if turn % 2:
+            order.reverse()
+        for name in order:
+            ms, rows = elapsed(conn, statements[name], args)
+            assert rows == expected
+            samples[name].append(ms)
+    conn.close()
+    return {'rows': len(expected), 'cold_connection_ms': cold,
+            'warm_median_ms': {n: statistics.median(v) for n, v in samples.items()},
+            'approx_vm_steps': steps, 'plans': plans}
+
+
+def main():
+    results = {'sqlite_version': sqlite3.sqlite_version, 'payload_padding_bytes': 2048,
+               'iterations_per_variant': 12, 'cases': []}
+    with tempfile.TemporaryDirectory(prefix='lotti-agent-benchmark-') as directory:
+        for agent_count, history in ((100, 1), (900, 1), (100, 100), (100, 500)):
+            path = pathlib.Path(directory) / f'agents-{agent_count}-{history}.sqlite'
+            conn = sqlite3.connect(path)
+            conn.executescript(DDL)
+            def rows():
+                for agent in range(agent_count):
+                    for revision in range(history):
+                        # Ties, cleared latest predicates and tombstones are
+                        # intentional, as are absent requested agents below.
+                        payload = json.dumps({'nextWakeAt': '2026-09-06' if revision % 2 else None,
+                                              'padding': 'x' * 2048})
+                        yield (f'{agent:04}-{revision:04}', f'a{agent:04}', 'agentState', 'state',
+                               None, revision // 2, revision, 1 if revision % 11 == 10 else None,
+                               payload, 1)
+            conn.executemany('INSERT INTO agent_entities VALUES (?,?,?,?,?,?,?,?,?,?)', rows())
+            conn.commit()
+            conn.close()
+            for count in (1, min(agent_count, 897)):
+                ids = [f'a{agent:04}' for agent in range(count)] + ['missing']
+                for subtype in (False, True):
+                    for predicate in ('', "AND json_extract(serialized, '$.nextWakeAt') IS NOT NULL"):
+                        args = ids + ['agentState'] + (['state'] if subtype else [])
+                        result = compare(path, queries(len(ids), subtype, predicate), args)
+                        if count > 1:
+                            assert result['approx_vm_steps']['current'] < 0.7 * result['approx_vm_steps']['window'], result
+                        results['cases'].append({'history_per_agent': history, 'total_rows': agent_count * history,
+                                                 'requested_existing_agents': count, 'subtype': subtype,
+                                                 'outer_predicate': bool(predicate), **result})
+            # Shape 1: existing ordered limit and unlimited history; shape 2 PK.
+            for label, sql, args in (
+                ('entity_pk', 'SELECT * FROM agent_entities WHERE id IN (?) AND deleted_at IS NULL', [f'0000-{history-1:04}']),
+                ('history_limit_1', 'SELECT * FROM agent_entities WHERE agent_id=? AND type=? AND deleted_at IS NULL ORDER BY created_at DESC LIMIT ?', ['a0000', 'agentState', 1]),
+                ('subtype_limit_1', 'SELECT * FROM agent_entities WHERE agent_id=? AND type=? AND subtype=? AND deleted_at IS NULL ORDER BY created_at DESC LIMIT ?', ['a0000', 'agentState', 'state', 1]),
+                ('history_unlimited', 'SELECT * FROM agent_entities WHERE agent_id=? AND type=? AND deleted_at IS NULL ORDER BY created_at DESC LIMIT ?', ['a0000', 'agentState', -1]),
+            ):
+                results['cases'].append({'shape': label, 'history_per_agent': history,
+                                         **compare(path, {label: sql}, args)})
+        for count in (900, 9000):
+            path = pathlib.Path(directory) / f'identities-{count}.sqlite'
+            conn = sqlite3.connect(path)
+            conn.executescript(DDL)
+            conn.executemany('INSERT INTO agent_entities VALUES (?,?,?,?,?,?,?,?,?,?)', (
+                (f'identity-{i}', f'agent-{i}', 'agent', None, None, i, i, None,
+                 json.dumps({'lifecycle': 'active' if i % 10 == 0 else 'dormant',
+                             'padding': 'x' * 2048}), 1) for i in range(count)))
+            conn.commit()
+            conn.close()
+            sql = "SELECT * FROM agent_entities INDEXED BY idx_agent_entities_active_type_created WHERE type=? AND deleted_at IS NULL AND json_extract(serialized, '$.lifecycle')=? ORDER BY created_at DESC"
+            results['cases'].append({'shape': 'lifecycle', 'identities': count,
+                                     **compare(path, {'current': sql}, ['agent', 'active'])})
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Latest-agent reads carried every candidate payload through window ranking. Use an indexed `NOT EXISTS` check for a newer `(created_at, id)` in the same active agent/type/subtype partition, preserving ties, deletions, chunking, transaction reads and the winner-only wake predicate.

On synthetic data matching the normal stable-ID pattern (900 agents, 897 requested), native warm query time fell from 4.176 to 3.030 ms and fresh SQLite-connection time from 5.285 to 3.708 ms. The query still scans candidate index entries as history grows; these measurements exclude Dart decoding, isolate/transaction waits and OS stalls. They do not explain the historical multi-second shared delays.

The reproducible benchmark compares full results across subtype, cleared-wake, tie, tombstone and missing-id cases, with alternating warm runs, fresh connections, plans and deterministic VM work counts. It documents rejected alternatives and stress-case limits. The accompanying pending-wake investigation confirms the existing partial index already scales with pending-set size and records the remaining workload/diagnostic questions.

Validation: all 48 targeted `agent_repo_core_test.dart` tests pass shuffled; whole-worktree Dart MCP analyzer reports no errors; formatter, knowledge validator/528 Mermaid diagrams and changelog check pass (one existing unrelated fragment-style warning). Both actual-query plan regressions and the VM-work guard fail when the production change is reverted, then pass restored. CI runs the full suite and coverage.
