### PR TITLE
feat(db): correlate slow queries with transaction lifetimes

### DIFF
--- a/docs/perf/2026-09-05-transaction-wait-investigation.md
+++ b/docs/perf/2026-09-05-transaction-wait-investigation.md
@@ -1,0 +1,64 @@
+# Transaction waits: evidence and remaining uncertainty
+
+The September log review found unrelated, indexed queries completing after
+similar multi-second or multi-minute waits. Their recorded duration wraps an
+executor await. A clean query plan does not distinguish executor queueing,
+isolate transport, SQLite execution, disk work, or application suspension.
+The historical records do not establish which of these caused the stalls.
+
+## Reproduced mechanism
+
+The repository pins Drift 2.34.4. Its remote executor server waits for the
+active transaction to finish before dispatching unrelated work on that
+executor. Transaction creation is lazy: the opening await acquires that turn.
+Application work between statements can therefore extend the wait even when
+each statement uses an efficient index. Read pools can route reads elsewhere,
+so transaction overlap is not sufficient evidence of blocking.
+
+The regression named `native transaction delays an unrelated indexed read
+until commit` in
+[`slow_query_logging_test.dart`](../../test/database/slow_query_logging_test.dart)
+reproduces the mechanism with real `NativeDatabase.memory()` execution:
+
+1. Create a synthetic primary-key table and open a transaction.
+2. Insert a row inside that transaction.
+3. Start an unrelated primary-key read through the parent executor.
+4. Yield a microtask and assert the read has not completed.
+5. Commit, then assert the read returns the inserted row and its timing entry
+   identifies the overlapping transaction.
+
+This is a deterministic regression without timed sleeps. It demonstrates
+executor serialization and diagnostic correlation, not historical causality,
+disk contention, a production read pool, or a measured performance gain.
+
+## Diagnostic change
+
+The interceptor now observes transaction acquisition, completion, and lifetime
+alongside queries. The authoritative field definitions, lifecycle, gate
+behavior, and attribution limits are in
+[persistence](../../knowledge/architecture/persistence.md#transaction-overlap).
+Transaction origins are captured when the optional stack setting is enabled.
+No SQL query, index, SQLite pragma, or transaction boundary changes here.
+
+Diagnostics must preserve database behavior. A regression also reproduced a
+reporter exception escaping after an acknowledged transaction opening. The
+interceptor now contains reporter exceptions. Tests cover successful commit,
+original SQL failures, failed commit followed by rollback, failed rollback,
+nested transactions, repeated opening awaits, and disabling logging during a
+transaction. Mutating transaction observation, safe reporting, origin capture,
+and lifetime formatting separately makes the corresponding regressions fail.
+
+## Next capture
+
+With slow-query logging enabled before the workload, compare query timing
+bounds with transaction opening and completion records in the same connection.
+Keep lifetime spans separate from SQL counts and avoid double-counting records
+duplicated in the super-slow file. An overlapping long transaction and its
+origin identify a concrete path to investigate; absence of overlap does not
+rule out an unobserved transaction or another kind of shared stall.
+
+Exact native-versus-queue attribution still requires worker-side timing
+correlated across Drift's isolate transport. Application lifecycle and disk
+telemetry would be needed to distinguish suspension or storage stalls. These
+measurements are not present in the original archive, so no claim is made that
+the historical longest waits have been fixed or fully explained.

--- a/knowledge/architecture/logging-and-diagnostics.md
+++ b/knowledge/architecture/logging-and-diagnostics.md
@@ -5,7 +5,7 @@ description: Twenty-four opt-in logging domains, where their lines land, and why
 resource: ../../lib/services/logging_domains.dart
 tags: [architecture, logging, diagnostics, observability]
 status: stable
-generated: { by: codex/gpt-6, at: 2026-09-05T14:55:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-05T19:28:47Z }
 stale_after: 2027-01-11
 sources:
   - id: log-domains
@@ -28,6 +28,10 @@ sources:
     resource: ../../lib/services/window_service.dart
     title: Ordered shutdown and final log flush
     last_modified: 2026-08-01
+  - id: slow-query-logging
+    resource: ../../lib/database/slow_query_logging.dart
+    title: SlowQueryInterceptor
+    last_modified: 2026-09-05
 ---
 
 # A closed set of domains
@@ -169,15 +173,17 @@ remain available locally under the error policy above.
 # Slow queries
 
 The database layer has its own gate, described in
-[persistence](persistence.md). `SlowQueryInterceptor` wraps every connection but
-stays inert until its logging domain is enabled, so it costs nothing in normal
-use. `LoggingService` keeps that gate in sync with the config flag alongside the
-general logging gate.
+[persistence](persistence.md#slow-query-capture). `SlowQueryInterceptor` wraps
+every connection. Timing bookkeeping still runs with logging disabled, while
+file output, plans, and transaction tracking are gated. `LoggingService` keeps
+that gate in sync with the config flag alongside the general logging gate.
 
 **It has two tiers, and they write different files** — 10 ms to `slow_queries`,
 200 ms to `super_slow_queries` with an `EXPLAIN QUERY PLAN` attached. Start with
 the second file, since it is the only one carrying a plan; the thresholds and what
-each tier is for are in [persistence](persistence.md).
+each tier is for are in [persistence](persistence.md). The files also contain
+transaction operations and lifetime spans; their interpretation and limits
+are documented under [transaction overlap](persistence.md#transaction-overlap).
 
 # Where to look
 

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -5,7 +5,7 @@ description: The eleven Drift/SQLite databases, attachment storage, how connecti
 resource: ../../lib/database
 tags: [architecture, persistence, drift, sqlite, migrations]
 status: stable
-generated: { by: claude-code/fable-5.1, at: 2026-09-05T14:00:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-05T19:28:47Z }
 stale_after: 2027-03-05
 sources:
   - id: sync-db
@@ -39,7 +39,11 @@ sources:
   - id: db-common
     resource: ../../lib/database/common.dart
     title: openDbConnection, pragmas, backups
-    last_modified: 2026-06-05
+    last_modified: 2026-09-05
+  - id: slow-query-logging
+    resource: ../../lib/database/slow_query_logging.dart
+    title: Executor and transaction timing diagnostics
+    last_modified: 2026-09-05
   - id: journal-db
     resource: ../../lib/database/database.dart
     title: JournalDb
@@ -171,7 +175,7 @@ flowchart TD
   | `journal_mode` | `WAL` | Concurrent readers during writes |
   | `busy_timeout` | `5000` | Wait rather than fail on contention |
   | `synchronous` | `NORMAL` | WAL-appropriate durability/speed trade |
-  | `wal_autocheckpoint` | `200` pages | Lowered from SQLite's 1000. Slow-query capture caught a 9-minute stall on a `sync_sequence_log` read whose p95 is under 60 ms — a checkpoint pause, not a bad plan. Shorter WAL means smaller, more frequent checkpoints and a narrower starvation window. |
+  | `wal_autocheckpoint` | `200` pages | Lowered from SQLite's 1000, targeting smaller, more frequent checkpoints. Executor timing alone does not establish that checkpoints caused historical stalls. |
 
 - **`PRAGMA foreign_keys = ON` is connection-local**, so `JournalDb` re-applies
   it in `beforeOpen` on every connection, not once at migration time.
@@ -205,6 +209,55 @@ The background factory's setup callbacks expose SQLite setup or isolate startup,
 not a per-call native timing hook. Exact queue/native attribution would need a
 worker-side executor measurement with a correlation identifier transported
 through the isolate protocol. The current metadata makes no such attribution.
+
+## Transaction overlap
+
+When logging is enabled as `beginTransaction` runs, the interceptor assigns a
+local transaction ID and records its parent ID for nested transactions.
+`transaction.open` times the first `ensureOpen` await, which includes acquiring
+the executor's transaction turn. `transaction.commit` and
+`transaction.rollback` time their respective executor awaits. They use
+`scope=executorAwait`, just like queries.
+
+The separate `operation=transaction`, `scope=transactionLifetime` record covers
+the opening acknowledgement through the ending acknowledgement. Its statement
+is the outcome (`COMMIT`, `ROLLBACK`, or `ROLLBACK_FAILED`), not another SQL
+execution. It includes application work between queries and the end await;
+it is not exact lock-hold time. Do not add these spans to statement duration
+totals. All transaction records use the same reporting thresholds and duplicate
+super-slow records to both files.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Created: beginTransaction while logging enabled
+  Created --> Opening: first ensureOpen
+  Opening --> Active: opening acknowledged
+  Opening --> [*]: opening fails
+  Active --> Active: statements or failed commit
+  Active --> [*]: successful commit or completed rollback attempt
+```
+
+`TRANSACTION` rows attach the owning `id`, optional `parent`, and
+`activeAtStart` IDs to operations. Active means the opening acknowledgement
+has arrived and the end has not; the transaction's own ID can appear in its
+active list. These IDs belong to one interceptor instance, so correlate them
+within that database connection and timing window, not across app sessions.
+Overlap is evidence of concurrent transaction lifetime, not proof that it
+blocked a query: read pools may bypass that executor. Transactions still
+opening are excluded from the active list.
+
+A failed commit retains its observation for Drift's subsequent rollback;
+rollback completion releases it even if rollback throws. Reporter failures are
+contained so diagnostics cannot turn an acknowledged BEGIN or COMMIT into an
+application failure, or replace the original database exception.
+
+Visibility is deliberately incomplete: transactions created before the gate
+is enabled are not tracked, and unfinished transactions have no lifetime
+record. Disabling logging suppresses output but completed transactions still
+release their observations. The optional first-call stack setting captures
+each transaction's initiating stack, reused for its opening and lifetime;
+ordinary SQL retains one capture per unique statement. Stack rows are emitted
+only in the super-slow file and retain application frames.
 
 The threshold deliberately does not catch N+1 chains: each individual link sits
 under the bar. Counting round-trips in tests catches those chains;
@@ -505,9 +558,9 @@ snapshot just written is always among the three, even if the device clock
 has moved backwards since the previous one, and a failed snapshot never costs
 an existing one.
 That helper is a **legacy per-database fallback**, not a supported profile
-backup. It copies only the main SQLite file, has no store identity, manifest,
-checksum, media coverage, encryption, coordinated quiescence, or restore path.
-A raw copy is not safe while WAL-backed writers are active.
+backup. It has no store identity, manifest, checksum, media coverage,
+encryption, coordinated quiescence, or restore path. The corruption fallback's
+raw copy is not safe while WAL-backed writers are active.
 
 The implementation-consumable profile inventory now lives in
 `ProfileBackupCatalog`. It includes authoritative databases, media and sync

--- a/lib/database/common.dart
+++ b/lib/database/common.dart
@@ -258,11 +258,10 @@ Future<void> backupBeforeMigration(
 /// read-pool isolates) inherits these settings.
 ///
 /// `wal_autocheckpoint` is lowered from SQLite's default of 1000 pages to
-/// 200 pages (~800 KB at the default 4 KB page size). A shorter WAL means
-/// smaller, more frequent checkpoints and a narrower window in which a
-/// checkpoint can starve a reader — slow-query capture observed a 9-minute
-/// stall on a `sync_sequence_log` read whose p95 is <60 ms, consistent
-/// with a WAL checkpoint pause rather than a bad plan.
+/// 200 pages (~800 KB at the default 4 KB page size), targeting smaller,
+/// more frequent checkpoints. Slow-query executor timings do not isolate
+/// checkpoint work from queueing, transport, or application suspension;
+/// they cannot establish the cause of historical multi-minute stalls.
 void _setupDatabase(Database database) {
   database
     ..execute('PRAGMA journal_mode = WAL;')

--- a/lib/database/slow_query_logging.dart
+++ b/lib/database/slow_query_logging.dart
@@ -29,8 +29,9 @@ abstract final class SlowQueryLoggingGate {
   /// the same statement do **not** capture again, so the boot wave
   /// produces one trace per unique query shape — exactly what we need
   /// to identify which Riverpod provider / widget mounted each fetch.
-  /// Off by default because capturing stack traces costs a few hundred
-  /// microseconds per first call.
+  /// Transactions additionally capture their origin when each transaction is
+  /// created, so repeated transactions retain distinct initiating call sites.
+  /// Off by default because capturing stack traces adds diagnostic overhead.
   static bool captureFirstCallStack = false;
 
   /// Internal set of statements already traced for this process.
@@ -58,6 +59,10 @@ class SlowQueryLogEntry {
     this.startedAt,
     this.completedAt,
     this.inFlightAtStart,
+    this.scope = 'executorAwait',
+    this.transactionId,
+    this.parentTransactionId,
+    this.activeTransactionIdsAtStart,
   });
 
   final String databaseName;
@@ -65,11 +70,13 @@ class SlowQueryLogEntry {
   final String statement;
   final List<Object?> arguments;
 
-  /// Awaited executor duration, including scheduling and isolate transport.
-  /// This is not a measurement of native SQLite execution alone.
+  /// Awaited executor duration, including scheduling and isolate transport,
+  /// or acknowledged transaction lifetime as identified by [scope]. Neither
+  /// measures native SQLite execution alone.
   final Duration elapsed;
 
-  /// Wall-clock bounds captured around the executor await, before EXPLAIN.
+  /// Wall-clock bounds around the executor await (before EXPLAIN), or the
+  /// opening and ending acknowledgements for a transaction lifetime.
   /// Optional for manually constructed and logging-disabled entries.
   final DateTime? startedAt;
   final DateTime? completedAt;
@@ -77,6 +84,19 @@ class SlowQueryLogEntry {
   /// Calls awaiting this interceptor's executor when this call started,
   /// including this call. This is observed concurrency, not a queue length.
   final int? inFlightAtStart;
+
+  /// Identifies executor awaits versus the observed lifetime of a transaction.
+  /// Neither scope measures native SQLite execution or exact lock hold time.
+  final String scope;
+
+  /// IDs local to this interceptor, correlated by database and timing bounds.
+  final int? transactionId;
+  final int? parentTransactionId;
+
+  /// Transactions whose opening acknowledgement has arrived but whose end has
+  /// not been acknowledged when this operation starts. Overlap is not proof
+  /// that these transactions blocked the operation (read pools may bypass it).
+  final List<int>? activeTransactionIdsAtStart;
 
   /// True when the query exceeded the interceptor's super-slow threshold and
   /// should be replicated to the dedicated super-slow log file.
@@ -87,11 +107,9 @@ class SlowQueryLogEntry {
   /// failed.
   final List<String>? queryPlan;
 
-  /// Stack trace captured at the *first* invocation of this statement
-  /// when [SlowQueryLoggingGate.captureFirstCallStack] is enabled. Lets
-  /// us pinpoint the Riverpod provider / widget that originates each
-  /// boot-wave query. Null on subsequent invocations or when capture is
-  /// disabled.
+  /// First-invocation statement stack, or the initiating stack for this
+  /// transaction's opening and lifetime, when
+  /// [SlowQueryLoggingGate.captureFirstCallStack] is enabled.
   final StackTrace? callerStack;
 
   String get formattedStatement =>
@@ -117,6 +135,131 @@ class SlowQueryInterceptor extends QueryInterceptor {
   final Duration threshold;
   final SlowQueryReporter reporter;
   int _inFlight = 0;
+  int _nextTransactionId = 0;
+  final _transactions = Map<QueryExecutor, _ObservedTransaction>.identity();
+
+  List<int> _activeTransactionIds() => [
+    for (final tx in _transactions.values)
+      if (tx.lifetime != null) tx.id,
+  ];
+
+  @override
+  TransactionExecutor beginTransaction(QueryExecutor parent) {
+    final executor = parent.beginTransaction();
+    if (SlowQueryLoggingGate.isEnabled) {
+      _transactions[executor] = _ObservedTransaction(
+        id: ++_nextTransactionId,
+        parentId: _transactions[parent]?.id,
+        callerStack: SlowQueryLoggingGate.captureFirstCallStack
+            ? StackTrace.current
+            : null,
+      );
+    }
+    return executor;
+  }
+
+  @override
+  Future<bool> ensureOpen(
+    QueryExecutor executor,
+    QueryExecutorUser user,
+  ) async {
+    final tx = _transactions[executor];
+    if (tx == null || tx.openRequested) {
+      return executor.ensureOpen(user);
+    }
+    tx.openRequested = true;
+    try {
+      return await _measure(
+        executor: executor,
+        operation: 'transaction.open',
+        statement: 'BEGIN',
+        arguments: const [],
+        callerStackOverride: tx.callerStack,
+        run: () async {
+          final opened = await executor.ensureOpen(user);
+          tx
+            ..openedAt = clock.now()
+            ..lifetime = (Stopwatch()..start())
+            ..activeIdsAtOpen = _activeTransactionIds();
+          return opened;
+        },
+      );
+    } catch (_) {
+      _transactions.remove(executor);
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> commitTransaction(TransactionExecutor inner) async {
+    await _measure(
+      executor: inner,
+      operation: 'transaction.commit',
+      statement: 'COMMIT',
+      arguments: const [],
+      run: inner.send,
+    );
+    // Drift retains the transaction after a failed commit so it can roll back.
+    _finishTransaction(inner, 'COMMIT');
+  }
+
+  @override
+  Future<void> rollbackTransaction(TransactionExecutor inner) async {
+    var succeeded = false;
+    try {
+      await _measure(
+        executor: inner,
+        operation: 'transaction.rollback',
+        statement: 'ROLLBACK',
+        arguments: const [],
+        run: inner.rollback,
+      );
+      succeeded = true;
+    } finally {
+      // Drift releases remote transactions even when rollback throws.
+      _finishTransaction(inner, succeeded ? 'ROLLBACK' : 'ROLLBACK_FAILED');
+    }
+  }
+
+  void _finishTransaction(QueryExecutor executor, String outcome) {
+    final tx = _transactions.remove(executor);
+    final lifetime = tx?.lifetime;
+    if (tx == null || lifetime == null) return;
+    lifetime.stop();
+    if (!SlowQueryLoggingGate.isEnabled || lifetime.elapsed < threshold) return;
+    _reportSafely(
+      SlowQueryLogEntry(
+        databaseName: databaseName,
+        operation: 'transaction',
+        statement: outcome,
+        arguments: const [],
+        elapsed: lifetime.elapsed,
+        scope: 'transactionLifetime',
+        isSuperSlow: lifetime.elapsed >= superSlowThreshold,
+        startedAt: tx.openedAt,
+        completedAt: clock.now(),
+        transactionId: tx.id,
+        parentTransactionId: tx.parentId,
+        activeTransactionIdsAtStart: tx.activeIdsAtOpen,
+        callerStack: tx.callerStack,
+      ),
+    );
+  }
+
+  void _reportSafely(SlowQueryLogEntry entry) {
+    try {
+      reporter(entry);
+    } catch (error, stackTrace) {
+      // Observability must never turn a successful BEGIN/COMMIT into an
+      // apparent failure, or hide the original database exception.
+      DevLogger.error(
+        name: 'DB_SLOW_QUERY',
+        message: 'Failed to report database timing',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
 
   /// Queries whose elapsed time crosses this threshold also have their
   /// `EXPLAIN QUERY PLAN` captured (selects only) and are duplicated to the
@@ -142,10 +285,13 @@ class SlowQueryInterceptor extends QueryInterceptor {
           '${elapsedMs.toStringAsFixed(3)}ms '
           'args=${entry.arguments.length} '
           '${entry.formattedStatement}'
-          '${entry.startedAt == null ? '' : '\n  TIMING: scope=executorAwait '
+          '${entry.startedAt == null ? '' : '\n  TIMING: scope=${entry.scope} '
                     'started=${entry.startedAt!.toIso8601String()} '
                     'completed=${entry.completedAt?.toIso8601String()} '
-                    'inFlightAtStart=${entry.inFlightAtStart}'}';
+                    'inFlightAtStart=${entry.inFlightAtStart}'}'
+          '${entry.transactionId == null && (entry.activeTransactionIdsAtStart?.isEmpty ?? true) ? '' : '\n  TRANSACTION: id=${entry.transactionId} '
+                    'parent=${entry.parentTransactionId} '
+                    'activeAtStart=${entry.activeTransactionIdsAtStart}'}';
       _SlowQueryFileSink.instance.append(logFile, line);
 
       if (entry.isSuperSlow) {
@@ -221,11 +367,13 @@ class SlowQueryInterceptor extends QueryInterceptor {
   }
 
   Future<T> _measure<T>({
+    required QueryExecutor executor,
     required String operation,
     required String statement,
     required List<Object?> arguments,
     required Future<T> Function() run,
     Future<List<String>> Function()? capturePlan,
+    StackTrace? callerStackOverride,
   }) async {
     // Capture the caller stack BEFORE awaiting `run()`. By the time
     // the interceptor reports, drift's executor is deep in the call
@@ -233,12 +381,15 @@ class SlowQueryInterceptor extends QueryInterceptor {
     // here keeps the frames that show which provider / widget kicked
     // off the query. Gated to one capture per unique statement so the
     // diagnostic is one-shot.
-    StackTrace? callerStack;
-    if (SlowQueryLoggingGate.captureFirstCallStack &&
+    var callerStack = callerStackOverride;
+    if (callerStack == null &&
+        SlowQueryLoggingGate.captureFirstCallStack &&
         SlowQueryLoggingGate.markStatementSeenAndIsFirst(statement)) {
       callerStack = StackTrace.current;
     }
     final startedAt = SlowQueryLoggingGate.isEnabled ? clock.now() : null;
+    final tx = _transactions[executor];
+    final activeIds = startedAt == null ? null : _activeTransactionIds();
     final inFlightAtStart = ++_inFlight;
     final stopwatch = Stopwatch()..start();
     try {
@@ -264,7 +415,7 @@ class SlowQueryInterceptor extends QueryInterceptor {
             );
           }
         }
-        reporter(
+        _reportSafely(
           SlowQueryLogEntry(
             databaseName: databaseName,
             operation: operation,
@@ -277,6 +428,9 @@ class SlowQueryInterceptor extends QueryInterceptor {
             startedAt: startedAt,
             completedAt: completedAt,
             inFlightAtStart: inFlightAtStart,
+            transactionId: tx?.id,
+            parentTransactionId: tx?.parentId,
+            activeTransactionIdsAtStart: activeIds,
           ),
         );
       }
@@ -316,6 +470,7 @@ class SlowQueryInterceptor extends QueryInterceptor {
         .toList(growable: false);
 
     return _measure(
+      executor: executor,
       operation: 'batch[$statementCount]',
       statement: preview,
       arguments: allArguments,
@@ -330,6 +485,7 @@ class SlowQueryInterceptor extends QueryInterceptor {
     List<Object?> args,
   ) {
     return _measure(
+      executor: executor,
       operation: 'custom',
       statement: statement,
       arguments: args,
@@ -344,6 +500,7 @@ class SlowQueryInterceptor extends QueryInterceptor {
     List<Object?> args,
   ) {
     return _measure(
+      executor: executor,
       operation: 'delete',
       statement: statement,
       arguments: args,
@@ -358,6 +515,7 @@ class SlowQueryInterceptor extends QueryInterceptor {
     List<Object?> args,
   ) {
     return _measure(
+      executor: executor,
       operation: 'insert',
       statement: statement,
       arguments: args,
@@ -372,6 +530,7 @@ class SlowQueryInterceptor extends QueryInterceptor {
     List<Object?> args,
   ) {
     return _measure(
+      executor: executor,
       operation: 'select',
       statement: statement,
       arguments: args,
@@ -387,12 +546,29 @@ class SlowQueryInterceptor extends QueryInterceptor {
     List<Object?> args,
   ) {
     return _measure(
+      executor: executor,
       operation: 'update',
       statement: statement,
       arguments: args,
       run: () => executor.runUpdate(statement, args),
     );
   }
+}
+
+class _ObservedTransaction {
+  _ObservedTransaction({
+    required this.id,
+    required this.parentId,
+    this.callerStack,
+  });
+
+  final int id;
+  final int? parentId;
+  final StackTrace? callerStack;
+  bool openRequested = false;
+  DateTime? openedAt;
+  Stopwatch? lifetime;
+  List<int>? activeIdsAtOpen;
 }
 
 class _SlowQueryFileSink {

--- a/test/database/slow_query_logging_test.dart
+++ b/test/database/slow_query_logging_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:clock/clock.dart';
 
 import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/slow_query_logging.dart';
 import 'package:lotti/services/dev_logger.dart';
@@ -1327,6 +1328,350 @@ void main() {
     });
   });
 
+  group('transaction diagnostics', () {
+    late MockQueryExecutor parent;
+    late MockTransactionExecutor inner;
+    late MockQueryExecutorUser user;
+    late List<SlowQueryLogEntry> entries;
+    late QueryExecutor connection;
+
+    setUp(() {
+      SlowQueryLoggingGate.isEnabled = true;
+      parent = MockQueryExecutor();
+      inner = MockTransactionExecutor();
+      user = MockQueryExecutorUser();
+      entries = [];
+      when(parent.beginTransaction).thenReturn(inner);
+      when(() => inner.ensureOpen(user)).thenAnswer((_) async => true);
+      when(inner.send).thenAnswer((_) async {});
+      when(inner.rollback).thenAnswer((_) async {});
+      when(() => inner.runCustom('INSIDE', const [])).thenAnswer((_) async {});
+      when(
+        () => parent.runCustom('OUTSIDE', const []),
+      ).thenAnswer((_) async {});
+      connection = parent.interceptWith(
+        SlowQueryInterceptor(
+          databaseName: 'transactions',
+          threshold: Duration.zero,
+          reporter: entries.add,
+        ),
+      );
+    });
+
+    tearDown(resetSlowQueryLoggingGate);
+
+    test(
+      'reports acquisition and lifetime around a successful transaction',
+      () async {
+        final tx = connection.beginTransaction();
+        expect(await tx.ensureOpen(user), isTrue);
+        await tx.runCustom('INSIDE');
+        await connection.runCustom('OUTSIDE');
+        await tx.send();
+        await connection.runCustom('OUTSIDE');
+
+        expect(entries.map((entry) => entry.operation), [
+          'transaction.open',
+          'custom',
+          'custom',
+          'transaction.commit',
+          'transaction',
+          'custom',
+        ]);
+        expect(entries[1].transactionId, 1);
+        expect(entries[1].activeTransactionIdsAtStart, [1]);
+        expect(entries[2].transactionId, isNull);
+        expect(entries[2].activeTransactionIdsAtStart, [1]);
+        expect(entries[4].scope, 'transactionLifetime');
+        expect(entries.last.activeTransactionIdsAtStart, isEmpty);
+        expect(
+          entries
+              .where((entry) => entry.operation == 'transaction')
+              .single
+              .statement,
+          'COMMIT',
+        );
+        verify(() => inner.ensureOpen(user)).called(1);
+        verify(inner.send).called(1);
+      },
+    );
+
+    test('failed commit preserves the transaction until rollback', () async {
+      final failure = StateError('synthetic commit failure');
+      when(inner.send).thenAnswer((_) async => throw failure);
+      final tx = connection.beginTransaction();
+      await tx.ensureOpen(user);
+      await expectLater(tx.send(), throwsA(same(failure)));
+      await connection.runCustom('OUTSIDE');
+      await tx.rollback();
+      await connection.runCustom('OUTSIDE');
+
+      expect(entries.map((entry) => entry.operation), [
+        'transaction.open',
+        'transaction.commit',
+        'custom',
+        'transaction.rollback',
+        'transaction',
+        'custom',
+      ]);
+      expect(entries[2].activeTransactionIdsAtStart, [1]);
+      expect(entries.last.activeTransactionIdsAtStart, isEmpty);
+      expect(
+        entries
+            .where((entry) => entry.operation == 'transaction')
+            .single
+            .statement,
+        'ROLLBACK',
+      );
+      verify(inner.rollback).called(1);
+    });
+
+    test(
+      'reporter failures cannot alter transaction results or mask SQL errors',
+      () async {
+        final sqlFailure = StateError('original SQL failure');
+        connection = parent.interceptWith(
+          SlowQueryInterceptor(
+            databaseName: 'throwing_reporter',
+            threshold: Duration.zero,
+            reporter: (_) => throw StateError('synthetic reporting failure'),
+          ),
+        );
+        final tx = connection.beginTransaction();
+        expect(await tx.ensureOpen(user), isTrue);
+        await tx.runCustom('INSIDE');
+        await tx.send();
+        verify(inner.send).called(1);
+        verifyNever(inner.rollback);
+
+        when(
+          () => parent.runCustom('OUTSIDE', const []),
+        ).thenAnswer((_) async => throw sqlFailure);
+        await expectLater(
+          connection.runCustom('OUTSIDE'),
+          throwsA(same(sqlFailure)),
+        );
+      },
+    );
+
+    test('nested transaction IDs preserve the still-active parent', () async {
+      final nested = MockTransactionExecutor();
+      when(inner.beginTransaction).thenReturn(nested);
+      when(() => nested.ensureOpen(user)).thenAnswer((_) async => true);
+      when(nested.send).thenAnswer((_) async {});
+      final tx = connection.beginTransaction();
+      await tx.ensureOpen(user);
+      final child = tx.beginTransaction();
+      await child.ensureOpen(user);
+      await child.send();
+      await tx.runCustom('INSIDE');
+      await tx.rollback();
+      await connection.runCustom('OUTSIDE');
+      final childSpan = entries.firstWhere(
+        (entry) => entry.operation == 'transaction' && entry.transactionId == 2,
+      );
+      expect(childSpan.parentTransactionId, 1);
+      expect(childSpan.activeTransactionIdsAtStart, [1, 2]);
+      final parentQuery = entries.firstWhere(
+        (entry) => entry.statement == 'INSIDE',
+      );
+      expect(parentQuery.transactionId, 1);
+      expect(parentQuery.activeTransactionIdsAtStart, [1]);
+      expect(entries.last.activeTransactionIdsAtStart, isEmpty);
+    });
+
+    test(
+      'acquisition is reported once and pending opens are not active',
+      () async {
+        final opened = Completer<bool>();
+        when(() => inner.ensureOpen(user)).thenAnswer((_) => opened.future);
+        final tx = connection.beginTransaction();
+        final first = tx.ensureOpen(user);
+        final second = tx.ensureOpen(user);
+        await connection.runCustom('OUTSIDE');
+        expect(entries.single.activeTransactionIdsAtStart, isEmpty);
+        opened.complete(true);
+        expect(await first, isTrue);
+        expect(await second, isTrue);
+        await connection.runCustom('OUTSIDE');
+        expect(entries.last.activeTransactionIdsAtStart, [1]);
+        expect(
+          entries.where((entry) => entry.operation == 'transaction.open'),
+          hasLength(1),
+        );
+        await tx.rollback();
+      },
+    );
+
+    test('failed opening and rollback release their observations', () async {
+      final failure = StateError('synthetic open failure');
+      when(() => inner.ensureOpen(user)).thenAnswer((_) async => throw failure);
+      final failed = connection.beginTransaction();
+      await expectLater(failed.ensureOpen(user), throwsA(same(failure)));
+      await failed.rollback();
+      expect(
+        entries.where((entry) => entry.operation == 'transaction'),
+        isEmpty,
+      );
+      when(() => inner.ensureOpen(user)).thenAnswer((_) async => true);
+      final tx = connection.beginTransaction();
+      await tx.ensureOpen(user);
+      when(inner.rollback).thenAnswer((_) async => throw failure);
+      await expectLater(tx.rollback(), throwsA(same(failure)));
+      await connection.runCustom('OUTSIDE');
+      expect(entries.last.activeTransactionIdsAtStart, isEmpty);
+      expect(
+        entries
+            .firstWhere((entry) => entry.operation == 'transaction')
+            .statement,
+        'ROLLBACK_FAILED',
+      );
+    });
+
+    test(
+      'native transaction delays an unrelated indexed read until commit',
+      () async {
+        final native = NativeDatabase.memory().interceptWith(
+          SlowQueryInterceptor(
+            databaseName: 'native_transaction',
+            threshold: Duration.zero,
+            reporter: entries.add,
+          ),
+        );
+        addTearDown(native.close);
+        await native.ensureOpen(user);
+        await native.runCustom(
+          'CREATE TABLE markers (id INTEGER PRIMARY KEY, value TEXT)',
+        );
+        final tx = native.beginTransaction();
+        await tx.ensureOpen(user);
+        await tx.runInsert('INSERT INTO markers VALUES (?, ?)', [
+          1,
+          'synthetic',
+        ]);
+        var completed = false;
+        final read = native
+            .runSelect('SELECT value FROM markers WHERE id = ?', [1])
+            .then((rows) {
+              completed = true;
+              return rows;
+            });
+        await Future<void>.value();
+        expect(completed, isFalse);
+        await tx.send();
+        expect(await read, [
+          {'value': 'synthetic'},
+        ]);
+        final query = entries.firstWhere(
+          (entry) => entry.operation == 'select',
+        );
+        expect(query.transactionId, isNull);
+        expect(query.activeTransactionIdsAtStart, [1]);
+        final span = entries.firstWhere(
+          (entry) => entry.operation == 'transaction',
+        );
+        expect(span.scope, 'transactionLifetime');
+        expect(span.transactionId, 1);
+      },
+    );
+
+    test('disabled diagnostics preserve transaction delegation', () async {
+      SlowQueryLoggingGate.isEnabled = false;
+      final tx = connection.beginTransaction();
+      expect(await tx.ensureOpen(user), isTrue);
+      await tx.runCustom('INSIDE');
+      await tx.send();
+      expect(entries, isEmpty);
+      verify(() => inner.runCustom('INSIDE', const [])).called(1);
+      verify(inner.send).called(1);
+    });
+
+    test(
+      'completed lifetimes retain their own origin and timing bounds',
+      () async {
+        SlowQueryLoggingGate.captureFirstCallStack = true;
+        var now = DateTime.utc(2026, 9, 5, 12);
+        final start = now;
+        await withClock(Clock(() => now), () async {
+          final tx = connection.beginTransaction();
+          await tx.ensureOpen(user);
+          now = now.add(const Duration(seconds: 4));
+          await tx.send();
+          final next = connection.beginTransaction();
+          await next.ensureOpen(user);
+          now = now.add(const Duration(seconds: 2));
+          await next.rollback();
+        });
+        final spans = entries
+            .where((entry) => entry.operation == 'transaction')
+            .toList();
+        expect(spans.map((entry) => entry.transactionId), [1, 2]);
+        expect(spans.first.startedAt, start);
+        expect(spans.first.completedAt, start.add(const Duration(seconds: 4)));
+        expect(spans.last.startedAt, spans.first.completedAt);
+        expect(spans.last.completedAt, now);
+        final openings = entries
+            .where((entry) => entry.operation == 'transaction.open')
+            .toList();
+        expect(spans.first.callerStack, same(openings.first.callerStack));
+        expect(spans.last.callerStack, same(openings.last.callerStack));
+        expect(
+          spans.first.callerStack.toString(),
+          isNot(spans.last.callerStack.toString()),
+        );
+        for (final span in spans) {
+          expect(span.scope, 'transactionLifetime');
+          expect(
+            span.callerStack.toString(),
+            contains('slow_query_logging_test.dart'),
+          );
+        }
+      },
+    );
+
+    test(
+      'turning logging off during a transaction still releases its observation',
+      () async {
+        final tx = connection.beginTransaction();
+        await tx.ensureOpen(user);
+        SlowQueryLoggingGate.isEnabled = false;
+        await tx.send();
+        SlowQueryLoggingGate.isEnabled = true;
+        await connection.runCustom('OUTSIDE');
+        expect(
+          entries.where((entry) => entry.operation == 'transaction'),
+          isEmpty,
+        );
+        expect(entries.last.activeTransactionIdsAtStart, isEmpty);
+      },
+    );
+
+    test(
+      'a lifetime reporter failure cannot undo a successful commit',
+      () async {
+        connection = parent.interceptWith(
+          SlowQueryInterceptor(
+            databaseName: 'lifetime_reporter',
+            threshold: Duration.zero,
+            reporter: (entry) {
+              if (entry.operation == 'transaction') {
+                throw StateError('lifetime report failed');
+              }
+              entries.add(entry);
+            },
+          ),
+        );
+        final tx = connection.beginTransaction();
+        await tx.ensureOpen(user);
+        await tx.send();
+        await connection.runCustom('OUTSIDE');
+        verify(inner.send).called(1);
+        verifyNever(inner.rollback);
+        expect(entries.last.activeTransactionIdsAtStart, isEmpty);
+      },
+    );
+  });
+
   group('integration: interceptor + fileReporter end-to-end', () {
     late Directory tempDir;
     late MockQueryExecutor mockExecutor;
@@ -1382,5 +1727,45 @@ void main() {
       expect(content, contains('args=1'));
       expect(content, contains('SELECT * FROM items WHERE id = ?'));
     });
+
+    test(
+      'transaction file records distinguish lifetime from SQL and identify overlap',
+      () async {
+        final report = SlowQueryInterceptor.fileReporter(
+          documentsDirectoryPath: tempDir.path,
+        );
+        report(
+          SlowQueryLogEntry(
+            databaseName: 'sync.sqlite',
+            operation: 'transaction',
+            statement: 'COMMIT',
+            arguments: const [],
+            elapsed: const Duration(seconds: 3),
+            startedAt: DateTime.utc(2026, 9, 5, 12),
+            completedAt: DateTime.utc(2026, 9, 5, 12, 0, 3),
+            scope: 'transactionLifetime',
+            transactionId: 2,
+            parentTransactionId: 1,
+            activeTransactionIdsAtStart: const [1, 2],
+            isSuperSlow: true,
+          ),
+        );
+        await SlowQueryInterceptor.flushPendingFileWrites();
+        final files = Directory(
+          '${tempDir.path}/logs',
+        ).listSync().whereType<File>().toList();
+        expect(files, hasLength(2));
+        for (final file in files) {
+          final text = file.readAsStringSync();
+          expect(text, contains('transaction 3000.000ms'));
+          expect(text, contains('TIMING: scope=transactionLifetime'));
+          expect(
+            text,
+            contains('TRANSACTION: id=2 parent=1 activeAtStart=[1, 2]'),
+          );
+          expect(text, isNot(contains('scope=executorAwait')));
+        }
+      },
+    );
   });
 }

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -1530,6 +1530,20 @@ class MockPlayerStream extends Mock implements PlayerStream {}
 
 class MockQueryExecutor extends Mock implements drift.QueryExecutor {}
 
+class MockTransactionExecutor extends Mock
+    implements drift.TransactionExecutor {}
+
+class MockQueryExecutorUser extends Mock implements drift.QueryExecutorUser {
+  @override
+  int get schemaVersion => 1;
+
+  @override
+  Future<void> beforeOpen(
+    drift.QueryExecutor executor,
+    drift.OpeningDetails details,
+  ) async {}
+}
+
 class MockPathProviderPlatform extends Mock
     with MockPlatformInterfaceMixin
     implements PathProviderPlatform {}


### PR DESCRIPTION
Slow-query logs previously showed how long an executor call took, but could not identify overlapping transactions. Add transaction acquisition/end timings, completed lifetime spans, local parent/owner IDs and optional origin stacks. Query records identify transactions already active when the call began.

A real in-memory SQLite regression demonstrates an unrelated indexed read waiting until a transaction commits. This proves a possible mechanism, **not the cause of the historical multi-second/minute stalls**. Lifetime spans include application work and must be kept separate from SQL totals; read pools and transactions begun before logging remain explicit limits. No SQL, index, pragma, or transaction boundary changes.

Reporting exceptions are contained so diagnostics cannot change an acknowledged BEGIN/COMMIT result or mask the original SQL error. The persistence documentation and investigation report explain the fields and limits, and remove unsupported checkpoint attribution.

Validation:
- 60 targeted tests pass via Dart MCP, including native execution, nested/failed transactions, gate changes, and file output.
- Mutating transaction tracking, safe reporting, origin retention, and lifetime formatting independently makes their regressions fail; restored implementation passes.
- Full-worktree Dart MCP analyzer reports no errors.
- `make knowledge_check`: 529 diagrams parsed, no failures.
- Independent implementation and documentation review completed without remaining findings.

Companion investigations: #4164 (sync metrics and queue benchmarks), #4165 (agent latest-row optimization and pending-wake benchmarks).
