### PR TITLE
fix(db): honour the private flag in every series, range and count read

### DIFF
--- a/changelog.d/2026-09-05-private-entries-hidden-everywhere.md
+++ b/changelog.d/2026-09-05-private-entries-hidden-everywhere.md
@@ -1,0 +1,7 @@
+### Fixed
+- **Private entries stayed visible in several places while "Show private
+  entries" was off.** Dashboards and health charts (measurements, weight and
+  other quantitative data, workouts, surveys, habit completions), the calendar
+  day view, the Daily OS list of a day's recordings and the import badge count
+  all showed or counted private entries regardless of the switch. Every one of
+  them now honours it.

--- a/changelog.d/2026-09-05-private-entries-hidden-everywhere.md
+++ b/changelog.d/2026-09-05-private-entries-hidden-everywhere.md
@@ -4,4 +4,5 @@
   other quantitative data, workouts, surveys, habit completions), the calendar
   day view, the Daily OS list of a day's recordings and the import badge count
   all showed or counted private entries regardless of the switch. Every one of
-  them now honours it.
+  them now honours it, and open dashboards refresh the moment the switch is
+  flipped instead of showing the old rows for up to five minutes.

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -532,9 +532,18 @@ allowlist holds:
 - **Counts.** `countAllJournalEntries` and `countJournalEntries` — totals
   for progress reporting and the About page, not rows. The import badge count
   gates like any list, since it is derived from entries the badge leads to.
-- **Nothing else.** Every list, series and range read gates: the calendar
-  range read, the Daily OS day audio list and the data series behind
-  dashboards and health charts included, since 2026-09-05.
+- **Nothing else the user sees.** Every list, series and range read gates:
+  the calendar range read, the Daily OS day audio list and the data series
+  behind dashboards and health charts included, since 2026-09-05. What is not
+  a display read stays unfiltered on purpose, because the flag is a display
+  preference: the health import's checkpoints (`latestQuantByType`,
+  `findLatestWorkout`), and the `…IncludingPrivate` twins of the measurement,
+  habit-completion and quantitative reads used by the search reindex, the
+  sleep repair sweep and the auto-completion write guard — a guard that could
+  not see a private skip would write a second completion over it. The chart
+  controllers and the Daily OS activity projection refetch on
+  `PRIVATE_FLAG_TOGGLED`, so a cached chart does not keep showing rows the
+  user just hid.
 
 So the shape is: **lists, searches and batches thin out private entries; fetching
 one entity you already have the id for does not.** That is coherent with what the

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -496,7 +496,7 @@ undercounts the gate badly:
 |-----------|-------|
 | `_queryWithPrivateFilter` | `journal_queries`, `definitions`, `project_queries`, `links_ratings` |
 | **`privateStatuses` passed as a parameter**, so the caller decides | `task_queries`, `task_query_builders`, `task_due_queries` |
-| **Raw SQL reading the flag directly** | `insights_queries` uses a `private_flag` CTE; `data_queries` uses a direct `config_flags` subquery in `getHabitCompletionRecordsInRange` |
+| **Raw SQL reading the flag directly** | `insights_queries` uses a `private_flag` CTE; every `data_queries` series read, the calendar range read and the import-flag count carry a direct `config_flags` subquery in their `.drift` query, as does `getHabitCompletionRecordsInRange` |
 
 Of the ten query-bearing mixins, **nine gate on private one of these ways**. The
 exception is `_JournalDbEntityOps`, which is maintenance and write operations
@@ -529,14 +529,12 @@ allowlist holds:
   device holds every row), the sequence-log population stream, the purge walk,
   the search reindex (hits resolve through the gated id-batch read), the demo
   reseed inventory.
-- **Counts.** `countAllJournalEntries`, `countJournalEntries`,
-  `countImportFlagEntries` — numbers, not rows.
-- **Not gated today, listed rather than silently so.** `getDayAudioEntries`,
-  the calendar range read (`sortedCalenderEntriesInRange`) and the data series
-  by type behind dashboards and health charts (measurements, quantitative,
-  workouts, surveys, habit completions). Whether they should gate is a product
-  decision, tracked as lotti3-0qaz; until it is made the audit keeps them
-  explicit.
+- **Counts.** `countAllJournalEntries` and `countJournalEntries` — totals
+  for progress reporting and the About page, not rows. The import badge count
+  gates like any list, since it is derived from entries the badge leads to.
+- **Nothing else.** Every list, series and range read gates: the calendar
+  range read, the Daily OS day audio list and the data series behind
+  dashboards and health charts included, since 2026-09-05.
 
 So the shape is: **lists, searches and batches thin out private entries; fetching
 one entity you already have the id for does not.** That is coherent with what the

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -817,6 +817,17 @@ SELECT * FROM journal
   AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   ORDER BY date_from DESC;
 
+-- The unfiltered twin of measurementsByType: for reindexing, repair and automation
+-- guards, which must see every row. Display reads use the gated one.
+measurementsByTypeAllPrivate:
+SELECT * FROM journal
+  WHERE type = 'MeasurementEntry'
+  AND subtype = :subtype
+  AND date_from >= :rangeStart
+  AND date_to <= :rangeEnd
+  AND deleted = false
+  ORDER BY date_from DESC;
+
 habitCompletionsByHabitId:
 SELECT * FROM journal
   WHERE type = 'HabitCompletionEntry'
@@ -825,6 +836,17 @@ SELECT * FROM journal
   AND date_to <= :rangeEnd
   AND deleted = false
   AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
+  ORDER BY date_from DESC;
+
+-- The unfiltered twin of habitCompletionsByHabitId: for reindexing, repair and automation
+-- guards, which must see every row. Display reads use the gated one.
+habitCompletionsByHabitIdAllPrivate:
+SELECT * FROM journal
+  WHERE type = 'HabitCompletionEntry'
+  AND subtype = :habitId
+  AND date_from >= :rangeStart
+  AND date_to <= :rangeEnd
+  AND deleted = false
   ORDER BY date_from DESC;
 
 quantitativeByType:
@@ -837,12 +859,22 @@ SELECT * FROM journal
   AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   ORDER BY date_from DESC;
 
+-- The unfiltered twin of quantitativeByType: for reindexing, repair and automation
+-- guards, which must see every row. Display reads use the gated one.
+quantitativeByTypeAllPrivate:
+SELECT * FROM journal
+  WHERE type = 'QuantitativeEntry'
+  AND subtype = :subtype
+  AND date_from >= :rangeStart
+  AND date_to <= :rangeEnd
+  AND deleted = false
+  ORDER BY date_from DESC;
+
 latestQuantByType:
 SELECT * FROM journal
   WHERE type = 'QuantitativeEntry'
   AND subtype = :subtype
   AND deleted = false
-  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   ORDER BY date_from DESC
   LIMIT 1;
 
@@ -859,7 +891,6 @@ findLatestWorkout:
 SELECT * FROM journal
   WHERE type = 'WorkoutEntry'
   AND deleted = false
-  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   ORDER BY date_to DESC
   LIMIT 1;
 

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -466,6 +466,7 @@ sortedCalenderEntriesInRange:
 SELECT * FROM journal
   WHERE type in ('JournalEntry', 'WorkoutEntry', 'JournalEvent') AND
   deleted = false
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   AND date_from >= :rangeStart
   AND date_to <= :rangeEnd
   ORDER BY date_from DESC;
@@ -813,6 +814,7 @@ SELECT * FROM journal
   AND date_from >= :rangeStart
   AND date_to <= :rangeEnd
   AND deleted = false
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   ORDER BY date_from DESC;
 
 habitCompletionsByHabitId:
@@ -822,6 +824,7 @@ SELECT * FROM journal
   AND date_from >= :rangeStart
   AND date_to <= :rangeEnd
   AND deleted = false
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   ORDER BY date_from DESC;
 
 quantitativeByType:
@@ -831,6 +834,7 @@ SELECT * FROM journal
   AND date_from >= :rangeStart
   AND date_to <= :rangeEnd
   AND deleted = false
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   ORDER BY date_from DESC;
 
 latestQuantByType:
@@ -838,6 +842,7 @@ SELECT * FROM journal
   WHERE type = 'QuantitativeEntry'
   AND subtype = :subtype
   AND deleted = false
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   ORDER BY date_from DESC
   LIMIT 1;
 
@@ -847,12 +852,14 @@ SELECT * FROM journal
   AND date_from >= :rangeStart
   AND date_to <= :rangeEnd
   AND deleted = false
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   ORDER BY date_from DESC;
 
 findLatestWorkout:
 SELECT * FROM journal
   WHERE type = 'WorkoutEntry'
   AND deleted = false
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   ORDER BY date_to DESC
   LIMIT 1;
 
@@ -865,6 +872,7 @@ SELECT * FROM journal
   AND date_from >= :rangeStart
   AND date_from < :rangeEnd
   AND deleted = false
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   ORDER BY date_from DESC;
 
 workoutTypes:
@@ -872,6 +880,7 @@ SELECT DISTINCT subtype FROM journal
   WHERE type = 'WorkoutEntry'
   AND subtype IS NOT NULL
   AND deleted = false
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   ORDER BY subtype ASC;
 
 surveysByType:
@@ -881,6 +890,7 @@ SELECT * FROM journal
   AND date_from >= :rangeStart
   AND date_to <= :rangeEnd
   AND deleted = false
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   ORDER BY date_from DESC;
 
 countJournalEntries:
@@ -889,7 +899,8 @@ SELECT COUNT(*) FROM journal
 
 countImportFlagEntries:
 SELECT COUNT(*) FROM journal
-  WHERE deleted = false AND flag = 1;
+  WHERE deleted = false AND flag = 1
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'));
 
 countInProgressTasks:
 SELECT COUNT(*) FROM journal

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -6741,6 +6741,22 @@ abstract class _$JournalDb extends GeneratedDatabase {
     ).asyncMap(journal.mapFromRow);
   }
 
+  Selectable<JournalDbEntity> measurementsByTypeAllPrivate(
+    String? subtype,
+    DateTime rangeStart,
+    DateTime rangeEnd,
+  ) {
+    return customSelect(
+      'SELECT * FROM journal WHERE type = \'MeasurementEntry\' AND subtype = ?1 AND date_from >= ?2 AND date_to <= ?3 AND deleted = FALSE ORDER BY date_from DESC',
+      variables: [
+        Variable<String>(subtype),
+        Variable<DateTime>(rangeStart),
+        Variable<DateTime>(rangeEnd),
+      ],
+      readsFrom: {journal},
+    ).asyncMap(journal.mapFromRow);
+  }
+
   Selectable<JournalDbEntity> habitCompletionsByHabitId(
     String? habitId,
     DateTime rangeStart,
@@ -6754,6 +6770,22 @@ abstract class _$JournalDb extends GeneratedDatabase {
         Variable<DateTime>(rangeEnd),
       ],
       readsFrom: {journal, configFlags},
+    ).asyncMap(journal.mapFromRow);
+  }
+
+  Selectable<JournalDbEntity> habitCompletionsByHabitIdAllPrivate(
+    String? habitId,
+    DateTime rangeStart,
+    DateTime rangeEnd,
+  ) {
+    return customSelect(
+      'SELECT * FROM journal WHERE type = \'HabitCompletionEntry\' AND subtype = ?1 AND date_from >= ?2 AND date_to <= ?3 AND deleted = FALSE ORDER BY date_from DESC',
+      variables: [
+        Variable<String>(habitId),
+        Variable<DateTime>(rangeStart),
+        Variable<DateTime>(rangeEnd),
+      ],
+      readsFrom: {journal},
     ).asyncMap(journal.mapFromRow);
   }
 
@@ -6773,11 +6805,27 @@ abstract class _$JournalDb extends GeneratedDatabase {
     ).asyncMap(journal.mapFromRow);
   }
 
+  Selectable<JournalDbEntity> quantitativeByTypeAllPrivate(
+    String? subtype,
+    DateTime rangeStart,
+    DateTime rangeEnd,
+  ) {
+    return customSelect(
+      'SELECT * FROM journal WHERE type = \'QuantitativeEntry\' AND subtype = ?1 AND date_from >= ?2 AND date_to <= ?3 AND deleted = FALSE ORDER BY date_from DESC',
+      variables: [
+        Variable<String>(subtype),
+        Variable<DateTime>(rangeStart),
+        Variable<DateTime>(rangeEnd),
+      ],
+      readsFrom: {journal},
+    ).asyncMap(journal.mapFromRow);
+  }
+
   Selectable<JournalDbEntity> latestQuantByType(String? subtype) {
     return customSelect(
-      'SELECT * FROM journal WHERE type = \'QuantitativeEntry\' AND subtype = ?1 AND deleted = FALSE AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) ORDER BY date_from DESC LIMIT 1',
+      'SELECT * FROM journal WHERE type = \'QuantitativeEntry\' AND subtype = ?1 AND deleted = FALSE ORDER BY date_from DESC LIMIT 1',
       variables: [Variable<String>(subtype)],
-      readsFrom: {journal, configFlags},
+      readsFrom: {journal},
     ).asyncMap(journal.mapFromRow);
   }
 
@@ -6791,9 +6839,9 @@ abstract class _$JournalDb extends GeneratedDatabase {
 
   Selectable<JournalDbEntity> findLatestWorkout() {
     return customSelect(
-      'SELECT * FROM journal WHERE type = \'WorkoutEntry\' AND deleted = FALSE AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) ORDER BY date_to DESC LIMIT 1',
+      'SELECT * FROM journal WHERE type = \'WorkoutEntry\' AND deleted = FALSE ORDER BY date_to DESC LIMIT 1',
       variables: [],
-      readsFrom: {journal, configFlags},
+      readsFrom: {journal},
     ).asyncMap(journal.mapFromRow);
   }
 

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -6051,9 +6051,9 @@ abstract class _$JournalDb extends GeneratedDatabase {
     DateTime rangeEnd,
   ) {
     return customSelect(
-      'SELECT * FROM journal WHERE type IN (\'JournalEntry\', \'WorkoutEntry\', \'JournalEvent\') AND deleted = FALSE AND date_from >= ?1 AND date_to <= ?2 ORDER BY date_from DESC',
+      'SELECT * FROM journal WHERE type IN (\'JournalEntry\', \'WorkoutEntry\', \'JournalEvent\') AND deleted = FALSE AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) AND date_from >= ?1 AND date_to <= ?2 ORDER BY date_from DESC',
       variables: [Variable<DateTime>(rangeStart), Variable<DateTime>(rangeEnd)],
-      readsFrom: {journal},
+      readsFrom: {journal, configFlags},
     ).asyncMap(journal.mapFromRow);
   }
 
@@ -6731,13 +6731,13 @@ abstract class _$JournalDb extends GeneratedDatabase {
     DateTime rangeEnd,
   ) {
     return customSelect(
-      'SELECT * FROM journal WHERE type = \'MeasurementEntry\' AND subtype = ?1 AND date_from >= ?2 AND date_to <= ?3 AND deleted = FALSE ORDER BY date_from DESC',
+      'SELECT * FROM journal WHERE type = \'MeasurementEntry\' AND subtype = ?1 AND date_from >= ?2 AND date_to <= ?3 AND deleted = FALSE AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) ORDER BY date_from DESC',
       variables: [
         Variable<String>(subtype),
         Variable<DateTime>(rangeStart),
         Variable<DateTime>(rangeEnd),
       ],
-      readsFrom: {journal},
+      readsFrom: {journal, configFlags},
     ).asyncMap(journal.mapFromRow);
   }
 
@@ -6747,13 +6747,13 @@ abstract class _$JournalDb extends GeneratedDatabase {
     DateTime rangeEnd,
   ) {
     return customSelect(
-      'SELECT * FROM journal WHERE type = \'HabitCompletionEntry\' AND subtype = ?1 AND date_from >= ?2 AND date_to <= ?3 AND deleted = FALSE ORDER BY date_from DESC',
+      'SELECT * FROM journal WHERE type = \'HabitCompletionEntry\' AND subtype = ?1 AND date_from >= ?2 AND date_to <= ?3 AND deleted = FALSE AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) ORDER BY date_from DESC',
       variables: [
         Variable<String>(habitId),
         Variable<DateTime>(rangeStart),
         Variable<DateTime>(rangeEnd),
       ],
-      readsFrom: {journal},
+      readsFrom: {journal, configFlags},
     ).asyncMap(journal.mapFromRow);
   }
 
@@ -6763,37 +6763,37 @@ abstract class _$JournalDb extends GeneratedDatabase {
     DateTime rangeEnd,
   ) {
     return customSelect(
-      'SELECT * FROM journal WHERE type = \'QuantitativeEntry\' AND subtype = ?1 AND date_from >= ?2 AND date_to <= ?3 AND deleted = FALSE ORDER BY date_from DESC',
+      'SELECT * FROM journal WHERE type = \'QuantitativeEntry\' AND subtype = ?1 AND date_from >= ?2 AND date_to <= ?3 AND deleted = FALSE AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) ORDER BY date_from DESC',
       variables: [
         Variable<String>(subtype),
         Variable<DateTime>(rangeStart),
         Variable<DateTime>(rangeEnd),
       ],
-      readsFrom: {journal},
+      readsFrom: {journal, configFlags},
     ).asyncMap(journal.mapFromRow);
   }
 
   Selectable<JournalDbEntity> latestQuantByType(String? subtype) {
     return customSelect(
-      'SELECT * FROM journal WHERE type = \'QuantitativeEntry\' AND subtype = ?1 AND deleted = FALSE ORDER BY date_from DESC LIMIT 1',
+      'SELECT * FROM journal WHERE type = \'QuantitativeEntry\' AND subtype = ?1 AND deleted = FALSE AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) ORDER BY date_from DESC LIMIT 1',
       variables: [Variable<String>(subtype)],
-      readsFrom: {journal},
+      readsFrom: {journal, configFlags},
     ).asyncMap(journal.mapFromRow);
   }
 
   Selectable<JournalDbEntity> workouts(DateTime rangeStart, DateTime rangeEnd) {
     return customSelect(
-      'SELECT * FROM journal WHERE type = \'WorkoutEntry\' AND date_from >= ?1 AND date_to <= ?2 AND deleted = FALSE ORDER BY date_from DESC',
+      'SELECT * FROM journal WHERE type = \'WorkoutEntry\' AND date_from >= ?1 AND date_to <= ?2 AND deleted = FALSE AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) ORDER BY date_from DESC',
       variables: [Variable<DateTime>(rangeStart), Variable<DateTime>(rangeEnd)],
-      readsFrom: {journal},
+      readsFrom: {journal, configFlags},
     ).asyncMap(journal.mapFromRow);
   }
 
   Selectable<JournalDbEntity> findLatestWorkout() {
     return customSelect(
-      'SELECT * FROM journal WHERE type = \'WorkoutEntry\' AND deleted = FALSE ORDER BY date_to DESC LIMIT 1',
+      'SELECT * FROM journal WHERE type = \'WorkoutEntry\' AND deleted = FALSE AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) ORDER BY date_to DESC LIMIT 1',
       variables: [],
-      readsFrom: {journal},
+      readsFrom: {journal, configFlags},
     ).asyncMap(journal.mapFromRow);
   }
 
@@ -6803,21 +6803,21 @@ abstract class _$JournalDb extends GeneratedDatabase {
     DateTime rangeEnd,
   ) {
     return customSelect(
-      'SELECT * FROM journal WHERE type = \'WorkoutEntry\' AND subtype = ?1 AND date_from >= ?2 AND date_from < ?3 AND deleted = FALSE ORDER BY date_from DESC',
+      'SELECT * FROM journal WHERE type = \'WorkoutEntry\' AND subtype = ?1 AND date_from >= ?2 AND date_from < ?3 AND deleted = FALSE AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) ORDER BY date_from DESC',
       variables: [
         Variable<String>(workoutType),
         Variable<DateTime>(rangeStart),
         Variable<DateTime>(rangeEnd),
       ],
-      readsFrom: {journal},
+      readsFrom: {journal, configFlags},
     ).asyncMap(journal.mapFromRow);
   }
 
   Selectable<String?> workoutTypes() {
     return customSelect(
-      'SELECT DISTINCT subtype FROM journal WHERE type = \'WorkoutEntry\' AND subtype IS NOT NULL AND deleted = FALSE ORDER BY subtype ASC',
+      'SELECT DISTINCT subtype FROM journal WHERE type = \'WorkoutEntry\' AND subtype IS NOT NULL AND deleted = FALSE AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) ORDER BY subtype ASC',
       variables: [],
-      readsFrom: {journal},
+      readsFrom: {journal, configFlags},
     ).map((QueryRow row) => row.readNullable<String>('subtype'));
   }
 
@@ -6827,13 +6827,13 @@ abstract class _$JournalDb extends GeneratedDatabase {
     DateTime rangeEnd,
   ) {
     return customSelect(
-      'SELECT * FROM journal WHERE type = \'SurveyEntry\' AND subtype LIKE ?1 AND date_from >= ?2 AND date_to <= ?3 AND deleted = FALSE ORDER BY date_from DESC',
+      'SELECT * FROM journal WHERE type = \'SurveyEntry\' AND subtype LIKE ?1 AND date_from >= ?2 AND date_to <= ?3 AND deleted = FALSE AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) ORDER BY date_from DESC',
       variables: [
         Variable<String>(subtype),
         Variable<DateTime>(rangeStart),
         Variable<DateTime>(rangeEnd),
       ],
-      readsFrom: {journal},
+      readsFrom: {journal, configFlags},
     ).asyncMap(journal.mapFromRow);
   }
 
@@ -6847,9 +6847,9 @@ abstract class _$JournalDb extends GeneratedDatabase {
 
   Selectable<int> countImportFlagEntries() {
     return customSelect(
-      'SELECT COUNT(*) AS _c0 FROM journal WHERE deleted = FALSE AND flag = 1',
+      'SELECT COUNT(*) AS _c0 FROM journal WHERE deleted = FALSE AND flag = 1 AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\'))',
       variables: [],
-      readsFrom: {journal},
+      readsFrom: {journal, configFlags},
     ).map((QueryRow row) => row.read<int>('_c0'));
   }
 

--- a/lib/database/database_data_queries.dart
+++ b/lib/database/database_data_queries.dart
@@ -12,6 +12,24 @@ mixin _JournalDbDataQueries on _$JournalDb, _JournalDbConfigFlags {
     return res.map(fromDbEntity).toList();
   }
 
+  /// Every measurement of [type] in the window, private ones included.
+  ///
+  /// For the search reindex that follows a definition edit, not for display:
+  /// the private flag is a display preference, and an index rebuilt from the
+  /// visible rows only would leave the hidden ones searchable by stale text.
+  Future<List<JournalEntity>> getMeasurementsByTypeIncludingPrivate({
+    required String type,
+    required DateTime rangeStart,
+    required DateTime rangeEnd,
+  }) async {
+    final res = await measurementsByTypeAllPrivate(
+      type,
+      rangeStart,
+      rangeEnd,
+    ).get();
+    return res.map(fromDbEntity).toList();
+  }
+
   /// Returns habit completions for [habitId] in the inclusive
   /// [rangeStart]/[rangeEnd] window.
   ///
@@ -24,6 +42,24 @@ mixin _JournalDbDataQueries on _$JournalDb, _JournalDbConfigFlags {
     required DateTime rangeEnd,
   }) async {
     final res = await habitCompletionsByHabitId(
+      habitId,
+      rangeStart,
+      rangeEnd,
+    ).get();
+    return latestHabitCompletionsByDay(res.map(fromDbEntity));
+  }
+
+  /// [getHabitCompletionsByHabitId] with private completions included.
+  ///
+  /// For the auto-completion engine's "anything already recorded wins"
+  /// guard, not for display: a private skip must still stop an automatic
+  /// success from being written over it while private entries are hidden.
+  Future<List<JournalEntity>> getHabitCompletionsByHabitIdIncludingPrivate({
+    required String habitId,
+    required DateTime rangeStart,
+    required DateTime rangeEnd,
+  }) async {
+    final res = await habitCompletionsByHabitIdAllPrivate(
       habitId,
       rangeStart,
       rangeEnd,
@@ -176,6 +212,27 @@ mixin _JournalDbDataQueries on _$JournalDb, _JournalDbConfigFlags {
     return res.map(fromDbEntity).toList();
   }
 
+  /// Every quantitative entry of [type] in the window, private ones included.
+  ///
+  /// For the sleep repair sweep, not for display: a repair that walks only
+  /// the visible rows leaves the hidden ones unrepaired.
+  Future<List<JournalEntity>> getQuantitativeByTypeIncludingPrivate({
+    required String type,
+    required DateTime rangeStart,
+    required DateTime rangeEnd,
+  }) async {
+    final res = await quantitativeByTypeAllPrivate(
+      type,
+      rangeStart,
+      rangeEnd,
+    ).get();
+    return res.map(fromDbEntity).toList();
+  }
+
+  /// The newest stored entry of [type], private ones included: the health
+  /// import's checkpoint for its next delta, never shown to the user. Gating
+  /// it on the private flag would re-import up to the default window whenever
+  /// the newest sample happens to be private.
   Future<QuantitativeEntry?> latestQuantitativeByType(String type) async {
     final dbEntities = await latestQuantByType(type).get();
     if (dbEntities.isEmpty) {
@@ -188,6 +245,8 @@ mixin _JournalDbDataQueries on _$JournalDb, _JournalDbConfigFlags {
     return fromDbEntity(dbEntities.first) as QuantitativeEntry;
   }
 
+  /// The newest stored workout, private ones included: the health import's
+  /// checkpoint for its next workout delta, never shown to the user.
   Future<WorkoutEntry?> latestWorkout() async {
     final dbEntities = await findLatestWorkout().get();
     if (dbEntities.isEmpty) {

--- a/lib/database/database_journal_queries.dart
+++ b/lib/database/database_journal_queries.dart
@@ -5,16 +5,19 @@ part of 'database.dart';
 /// range reads (also coalesced), and the vector-clock streams used by
 /// sync backfill.
 mixin _JournalDbJournalQueries on _$JournalDb, _JournalDbConfigFlags {
-  /// All live Daily OS audio entries for [dayId], served by the denormalized
-  /// `idx_journal_day_audio` index rather than scanning serialized rows.
+  /// All live Daily OS audio entries for [dayId] the private flag lets the
+  /// user see, served by the denormalized `idx_journal_day_audio` index
+  /// rather than scanning serialized rows.
   Future<List<JournalAudio>> getDayAudioEntries(String dayId) async {
+    final privateStatuses = await _visiblePrivateStatuses();
     final rows =
         await (select(journal)
               ..where(
                 (row) =>
                     row.type.equals('JournalAudio') &
                     row.deleted.equals(false) &
-                    row.dayId.equals(dayId),
+                    row.dayId.equals(dayId) &
+                    row.private.isIn(privateStatuses),
               )
               ..orderBy([
                 (row) => OrderingTerm.asc(row.dateFrom),

--- a/lib/features/daily_os_next/state/day_activity_provider.dart
+++ b/lib/features/daily_os_next/state/day_activity_provider.dart
@@ -35,7 +35,9 @@ final dayActivityProvider = FutureProvider.autoDispose
     .family<List<DayActivityEntry>, DateTime>((ref, date) async {
       ref
         ..watch(dayProcessingOutboxChangesProvider)
-        ..watch(agentUpdateStreamProvider(audioNotification));
+        ..watch(agentUpdateStreamProvider(audioNotification))
+        // The day audio read gates on the private flag.
+        ..watch(agentUpdateStreamProvider(privateToggleNotification));
       final captures = await ref.watch(capturesForDateProvider(date).future);
       final planEntity = await ref.watch(
         draftedPlanForDateProvider(date).future,

--- a/lib/features/dashboards/state/health_chart_controller.dart
+++ b/lib/features/dashboards/state/health_chart_controller.dart
@@ -57,7 +57,10 @@ class HealthChartDataController extends AsyncNotifier<List<JournalEntity>> {
     _updateSubscription = _updateNotifications.updateStream.listen((
       affectedIds,
     ) async {
-      if (affectedIds.contains(healthDataType)) {
+      // The private toggle changes which rows the gated read returns, so it
+      // must refetch like a data change would.
+      if (affectedIds.contains(healthDataType) ||
+          affectedIds.contains(privateToggleNotification)) {
         final latest = await _fetch();
         if (latest != state.value) {
           state = AsyncData(latest);

--- a/lib/features/dashboards/state/measurables_controller.dart
+++ b/lib/features/dashboards/state/measurables_controller.dart
@@ -146,7 +146,10 @@ class MeasurableChartDataController extends AsyncNotifier<List<JournalEntity>> {
     _updateSubscription = _updateNotifications.updateStream.listen((
       affectedIds,
     ) async {
-      if (affectedIds.contains(measurableDataTypeId)) {
+      // The private toggle changes which rows the gated read returns, so it
+      // must refetch like a data change would.
+      if (affectedIds.contains(measurableDataTypeId) ||
+          affectedIds.contains(privateToggleNotification)) {
         final latest = await _fetch();
         if (ref.mounted && latest != state.value) {
           state = AsyncData(latest);

--- a/lib/features/dashboards/state/survey_chart_controller.dart
+++ b/lib/features/dashboards/state/survey_chart_controller.dart
@@ -50,7 +50,10 @@ class SurveyChartDataController extends AsyncNotifier<List<JournalEntity>> {
     _updateSubscription = _updateNotifications.updateStream.listen((
       affectedIds,
     ) async {
-      if (affectedIds.contains(surveyNotification)) {
+      // The private toggle changes which rows the gated read returns, so it
+      // must refetch like a data change would.
+      if (affectedIds.contains(surveyNotification) ||
+          affectedIds.contains(privateToggleNotification)) {
         final latest = await _fetch();
         if (latest != state.value) {
           state = AsyncData(latest);

--- a/lib/features/dashboards/state/workout_chart_controller.dart
+++ b/lib/features/dashboards/state/workout_chart_controller.dart
@@ -61,7 +61,10 @@ class WorkoutChartDataController extends AsyncNotifier<List<JournalEntity>> {
     _updateSubscription = _updateNotifications.updateStream.listen((
       affectedIds,
     ) async {
-      if (affectedIds.contains(workoutNotification)) {
+      // The private toggle changes which rows the gated read returns, so it
+      // must refetch like a data change would.
+      if (affectedIds.contains(workoutNotification) ||
+          affectedIds.contains(privateToggleNotification)) {
         final latest = await _fetch();
         if (latest != state.value) {
           state = AsyncData(latest);

--- a/lib/features/habits/service/habit_auto_completion_service.dart
+++ b/lib/features/habits/service/habit_auto_completion_service.dart
@@ -214,12 +214,16 @@ class HabitAutoCompletionService {
     final dayStart = DateTime(day.year, day.month, day.day);
     final dayEnd = DateTime(day.year, day.month, day.day + 1);
     // Anything already recorded for the day — manual, skip, or an earlier
-    // auto completion — wins; the engine only fills empty days.
-    final existing = await _journalDb.getHabitCompletionsByHabitId(
-      habitId: habit.id,
-      rangeStart: dayStart,
-      rangeEnd: dayEnd,
-    );
+    // auto completion — wins; the engine only fills empty days. Private
+    // completions count too: the private flag hides them from view, and a
+    // guard that could not see them would write a second completion over a
+    // deliberate skip.
+    final existing = await _journalDb
+        .getHabitCompletionsByHabitIdIncludingPrivate(
+          habitId: habit.id,
+          rangeStart: dayStart,
+          rangeEnd: dayEnd,
+        );
     if (existing.isNotEmpty || _disposed) return;
 
     // A past day is evaluated at its last instant so nothing of it is

--- a/lib/features/sync/matrix/sync_event_processor_apply.dart
+++ b/lib/features/sync/matrix/sync_event_processor_apply.dart
@@ -70,11 +70,12 @@ extension SyncEventProcessorApply on SyncEventProcessor {
             fts5Db != null &&
             measurementDefinitionAffectsFts(previousMeasurable, measurable)) {
           try {
-            final entries = await journalDb.getMeasurementsByType(
-              type: measurable.id,
-              rangeStart: DateTime(1),
-              rangeEnd: DateTime(9999, 12, 31, 23, 59, 59, 999),
-            );
+            final entries = await journalDb
+                .getMeasurementsByTypeIncludingPrivate(
+                  type: measurable.id,
+                  rangeStart: DateTime(1),
+                  rangeEnd: DateTime(9999, 12, 31, 23, 59, 59, 999),
+                );
             await fts5Db.reindexMeasurements(measurable, entries);
           } catch (exception, stackTrace) {
             // Search rows are derived. Keep the synced definition even if its

--- a/lib/logic/persistence_definition_ops.dart
+++ b/lib/logic/persistence_definition_ops.dart
@@ -109,7 +109,7 @@ class PersistenceDefinitionOps extends PersistenceCollaboratorBase {
 
   Future<void> _reindexMeasurements(MeasurableDataType dataType) async {
     try {
-      final entries = await journalDb.getMeasurementsByType(
+      final entries = await journalDb.getMeasurementsByTypeIncludingPrivate(
         type: dataType.id,
         rangeStart: DateTime(1),
         rangeEnd: DateTime(9999, 12, 31, 23, 59, 59, 999),

--- a/lib/logic/sleep_asleep_backfill_service.dart
+++ b/lib/logic/sleep_asleep_backfill_service.dart
@@ -94,11 +94,12 @@ class SleepAsleepBackfillService {
     for (final stageType in sleepStagesDuplicatedAsAsleep) {
       for (var year = _firstYear; year <= lastYear; year++) {
         try {
-          final entities = await journalDb.getQuantitativeByType(
-            type: stageType,
-            rangeStart: DateTime(year),
-            rangeEnd: DateTime(year + 1).add(_windowOverhang),
-          );
+          final entities = await journalDb
+              .getQuantitativeByTypeIncludingPrivate(
+                type: stageType,
+                rangeStart: DateTime(year),
+                rangeEnd: DateTime(year + 1).add(_windowOverhang),
+              );
           for (final entity in entities.whereType<QuantitativeEntry>()) {
             if (!visited.add(entity.id)) continue;
             outcomes.add(await _restoreCopy(entity));

--- a/test/architecture/private_visibility_gate_test.dart
+++ b/test/architecture/private_visibility_gate_test.dart
@@ -37,19 +37,6 @@ const _ungatedNamedQueries = <String, String>{
   'emptyJournalSelection': 'WHERE 1 = 0: the placeholder for an empty filter',
   // Numbers, not rows.
   'countJournalEntries': 'a count for maintenance progress',
-  'countImportFlagEntries': 'a count for the import badge',
-  // Not gated today. Listed here rather than silently so; whether they
-  // should gate is the product decision tracked in lotti3-0qaz.
-  'sortedCalenderEntriesInRange': 'not gated today: the calendar range read',
-  'measurementsByType': 'not gated today: dashboard measurement series',
-  'habitCompletionsByHabitId': 'not gated today: habit completion series',
-  'quantitativeByType': 'not gated today: health quantitative series',
-  'latestQuantByType': 'not gated today: latest health quantitative value',
-  'workouts': 'not gated today: workout series',
-  'findLatestWorkout': 'not gated today: latest workout',
-  'workoutsByType': 'not gated today: workout series by type',
-  'workoutTypes': 'not gated today: distinct workout types',
-  'surveysByType': 'not gated today: survey completion series',
 };
 
 /// Dart declarations (`lib/…/file.dart:name`) that read journal rows —
@@ -97,9 +84,6 @@ const _ungatedDeclarations = <String, String>{
   // Numbers, not rows.
   'lib/database/database_journal_queries.dart:countAllJournalEntries':
       'a count for progress reporting, deleted rows included',
-  // Not gated today (lotti3-0qaz).
-  'lib/database/database_journal_queries.dart:getDayAudioEntries':
-      'not gated today: the Daily OS audio entries of a day',
 };
 
 /// Files whose journal SQL is not a read path at all.

--- a/test/architecture/private_visibility_gate_test.dart
+++ b/test/architecture/private_visibility_gate_test.dart
@@ -35,6 +35,18 @@ const _ungatedNamedQueries = <String, String>{
   'orderedJournalInterval': 'historical re-sync walks every row for peers',
   // No rows at all.
   'emptyJournalSelection': 'WHERE 1 = 0: the placeholder for an empty filter',
+  // Health-import checkpoints: the newest stored sample decides the next
+  // delta window and is never shown.
+  'latestQuantByType': 'health-import checkpoint, never displayed',
+  'findLatestWorkout': 'health-import checkpoint, never displayed',
+  // The unfiltered twins behind the *IncludingPrivate reads: reindexing,
+  // repair and automation guards must see every row.
+  'measurementsByTypeAllPrivate':
+      'the search reindex after a definition edit must cover hidden rows',
+  'habitCompletionsByHabitIdAllPrivate':
+      'the auto-completion guard must see a private skip or it writes over it',
+  'quantitativeByTypeAllPrivate':
+      'the sleep repair sweep must cover hidden rows',
   // Numbers, not rows.
   'countJournalEntries': 'a count for maintenance progress',
 };

--- a/test/database/database_data_queries_test.dart
+++ b/test/database/database_data_queries_test.dart
@@ -828,52 +828,55 @@ void main() {
       Set<String> ids(Iterable<JournalEntity> entities) =>
           entities.map((e) => e.meta.id).toSet();
 
+      // The private row is always the newer one, so a "latest" read changes
+      // its answer with the flag rather than merely its count.
+      Future<void> seedSeries() async {
+        final rows = <JournalEntity>[
+          measurement('measurement-public', at),
+          asPrivate(measurement('measurement-private', at.add(hour))),
+          buildHabitCompletionEntry(
+            id: 'habit-public',
+            habitId: habitFlossing.id,
+            timestamp: at,
+          ),
+          // A day later: completions collapse to one per day.
+          asPrivate(
+            buildHabitCompletionEntry(
+              id: 'habit-private',
+              habitId: habitFlossing.id,
+              timestamp: at.add(const Duration(days: 1)),
+            ),
+          ),
+          buildQuantitativeEntry(
+            id: 'weight-public',
+            dataType: 'weight',
+            timestamp: at,
+          ),
+          asPrivate(
+            buildQuantitativeEntry(
+              id: 'weight-private',
+              dataType: 'weight',
+              timestamp: at.add(hour),
+            ),
+          ),
+          workout('workout-public', at, 'running'),
+          asPrivate(workout('workout-private-run', at.add(hour), 'running')),
+          asPrivate(
+            workout('workout-private-swim', at.add(hour * 2), 'swimming'),
+          ),
+          survey('survey-public', at),
+          asPrivate(survey('survey-private', at.add(hour))),
+        ];
+        for (final row in rows) {
+          await db!.updateJournalEntity(row);
+        }
+      }
+
       test(
         'every series read hides private entries while the flag is off and '
         'shows them while it is on',
         () async {
-          // The private row is always the newer one, so the "latest" reads
-          // change their answer with the flag rather than merely their count.
-          final rows = <JournalEntity>[
-            measurement('measurement-public', at),
-            asPrivate(measurement('measurement-private', at.add(hour))),
-            buildHabitCompletionEntry(
-              id: 'habit-public',
-              habitId: habitFlossing.id,
-              timestamp: at,
-            ),
-            // A day later: completions collapse to one per day.
-            asPrivate(
-              buildHabitCompletionEntry(
-                id: 'habit-private',
-                habitId: habitFlossing.id,
-                timestamp: at.add(const Duration(days: 1)),
-              ),
-            ),
-            buildQuantitativeEntry(
-              id: 'weight-public',
-              dataType: 'weight',
-              timestamp: at,
-            ),
-            asPrivate(
-              buildQuantitativeEntry(
-                id: 'weight-private',
-                dataType: 'weight',
-                timestamp: at.add(hour),
-              ),
-            ),
-            workout('workout-public', at, 'running'),
-            asPrivate(workout('workout-private-run', at.add(hour), 'running')),
-            asPrivate(
-              workout('workout-private-swim', at.add(hour * 2), 'swimming'),
-            ),
-            survey('survey-public', at),
-            asPrivate(survey('survey-private', at.add(hour))),
-          ];
-          for (final row in rows) {
-            await db!.updateJournalEntity(row);
-          }
-
+          await seedSeries();
           final reads =
               <
                 ({
@@ -920,14 +923,6 @@ void main() {
                   off: {'weight-public'},
                 ),
                 (
-                  name: 'latestQuantitativeByType',
-                  read: () async => {
-                    (await db!.latestQuantitativeByType('weight'))!.meta.id,
-                  },
-                  on: {'weight-private'},
-                  off: {'weight-public'},
-                ),
-                (
                   name: 'getWorkouts',
                   read: () async => ids(
                     await db!.getWorkouts(
@@ -952,12 +947,6 @@ void main() {
                     ),
                   ),
                   on: {'workout-public', 'workout-private-run'},
-                  off: {'workout-public'},
-                ),
-                (
-                  name: 'latestWorkout',
-                  read: () async => {(await db!.latestWorkout())!.meta.id},
-                  on: {'workout-private-swim'},
                   off: {'workout-public'},
                 ),
                 (
@@ -992,6 +981,54 @@ void main() {
               reason: '${read.name}, flag off',
             );
           }
+        },
+      );
+
+      test(
+        'import checkpoints and the reindex, repair and automation reads see '
+        'private rows while the flag is off',
+        () async {
+          await seedSeries();
+          await disablePrivate();
+
+          // Health-import checkpoints: the newest stored sample, whatever its
+          // flag, or the import re-reads the whole default window.
+          expect(
+            (await db!.latestQuantitativeByType('weight'))!.meta.id,
+            'weight-private',
+          );
+          expect((await db!.latestWorkout())!.meta.id, 'workout-private-swim');
+
+          expect(
+            ids(
+              await db!.getMeasurementsByTypeIncludingPrivate(
+                type: measurableWater.id,
+                rangeStart: rangeStart,
+                rangeEnd: rangeEnd,
+              ),
+            ),
+            {'measurement-public', 'measurement-private'},
+          );
+          expect(
+            ids(
+              await db!.getHabitCompletionsByHabitIdIncludingPrivate(
+                habitId: habitFlossing.id,
+                rangeStart: rangeStart,
+                rangeEnd: rangeEnd,
+              ),
+            ),
+            {'habit-public', 'habit-private'},
+          );
+          expect(
+            ids(
+              await db!.getQuantitativeByTypeIncludingPrivate(
+                type: 'weight',
+                rangeStart: rangeStart,
+                rangeEnd: rangeEnd,
+              ),
+            ),
+            {'weight-public', 'weight-private'},
+          );
         },
       );
     });

--- a/test/database/database_data_queries_test.dart
+++ b/test/database/database_data_queries_test.dart
@@ -9,6 +9,7 @@ import 'package:lotti/database/database.dart';
 import 'package:lotti/database/journal_db/config_flags.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/dev_logger.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:research_package/model.dart';
 
@@ -747,6 +748,252 @@ void main() {
         );
         expect(workouts, isEmpty);
       });
+    });
+
+    group('Private flag -', () {
+      final at = DateTime(2024, 6, 10, 12);
+      final rangeStart = DateTime(2024, 6, 1);
+      final rangeEnd = DateTime(2024, 6, 30);
+      const hour = Duration(hours: 1);
+
+      Future<void> disablePrivate() => db!.upsertConfigFlag(
+        const ConfigFlag(
+          name: privateFlag,
+          description: 'Show private entries?',
+          status: false,
+        ),
+      );
+
+      JournalEntity asPrivate(JournalEntity entity) =>
+          entity.copyWith(meta: entity.meta.copyWith(private: true));
+
+      // The fixture itself is private; the helper makes the public baseline
+      // explicit and asPrivate flips it back.
+      JournalEntity measurement(String id, DateTime when) =>
+          testMeasurementChocolateEntry.copyWith(
+            meta: testMeasurementChocolateEntry.meta.copyWith(
+              id: id,
+              createdAt: when,
+              updatedAt: when,
+              dateFrom: when,
+              dateTo: when,
+              private: false,
+            ),
+            data: testMeasurementChocolateEntry.data.copyWith(
+              dataTypeId: measurableWater.id,
+              dateFrom: when,
+              dateTo: when,
+            ),
+          );
+
+      JournalEntity workout(String id, DateTime when, String type) =>
+          testWorkoutRunning.copyWith(
+            meta: testWorkoutRunning.meta.copyWith(
+              id: id,
+              createdAt: when,
+              updatedAt: when,
+              dateFrom: when,
+              dateTo: when.add(hour),
+              private: false,
+            ),
+            data: testWorkoutRunning.data.copyWith(
+              id: id,
+              workoutType: type,
+              dateFrom: when,
+              dateTo: when.add(hour),
+            ),
+          );
+
+      JournalEntity survey(String id, DateTime when) => JournalEntity.survey(
+        meta: Metadata(
+          id: id,
+          createdAt: when,
+          updatedAt: when,
+          dateFrom: when,
+          dateTo: when.add(const Duration(minutes: 10)),
+          starred: false,
+          private: false,
+        ),
+        data: SurveyData(
+          taskResult: RPTaskResult(identifier: 'phq9')
+            ..startDate = when
+            ..endDate = when.add(const Duration(minutes: 10)),
+          scoreDefinitions: const {
+            'Total': {'q1'},
+          },
+          calculatedScores: const {'Total': 3},
+        ),
+      );
+
+      Set<String> ids(Iterable<JournalEntity> entities) =>
+          entities.map((e) => e.meta.id).toSet();
+
+      test(
+        'every series read hides private entries while the flag is off and '
+        'shows them while it is on',
+        () async {
+          // The private row is always the newer one, so the "latest" reads
+          // change their answer with the flag rather than merely their count.
+          final rows = <JournalEntity>[
+            measurement('measurement-public', at),
+            asPrivate(measurement('measurement-private', at.add(hour))),
+            buildHabitCompletionEntry(
+              id: 'habit-public',
+              habitId: habitFlossing.id,
+              timestamp: at,
+            ),
+            // A day later: completions collapse to one per day.
+            asPrivate(
+              buildHabitCompletionEntry(
+                id: 'habit-private',
+                habitId: habitFlossing.id,
+                timestamp: at.add(const Duration(days: 1)),
+              ),
+            ),
+            buildQuantitativeEntry(
+              id: 'weight-public',
+              dataType: 'weight',
+              timestamp: at,
+            ),
+            asPrivate(
+              buildQuantitativeEntry(
+                id: 'weight-private',
+                dataType: 'weight',
+                timestamp: at.add(hour),
+              ),
+            ),
+            workout('workout-public', at, 'running'),
+            asPrivate(workout('workout-private-run', at.add(hour), 'running')),
+            asPrivate(
+              workout('workout-private-swim', at.add(hour * 2), 'swimming'),
+            ),
+            survey('survey-public', at),
+            asPrivate(survey('survey-private', at.add(hour))),
+          ];
+          for (final row in rows) {
+            await db!.updateJournalEntity(row);
+          }
+
+          final reads =
+              <
+                ({
+                  String name,
+                  Future<Set<String>> Function() read,
+                  Set<String> on,
+                  Set<String> off,
+                })
+              >[
+                (
+                  name: 'getMeasurementsByType',
+                  read: () async => ids(
+                    await db!.getMeasurementsByType(
+                      type: measurableWater.id,
+                      rangeStart: rangeStart,
+                      rangeEnd: rangeEnd,
+                    ),
+                  ),
+                  on: {'measurement-public', 'measurement-private'},
+                  off: {'measurement-public'},
+                ),
+                (
+                  name: 'getHabitCompletionsByHabitId',
+                  read: () async => ids(
+                    await db!.getHabitCompletionsByHabitId(
+                      habitId: habitFlossing.id,
+                      rangeStart: rangeStart,
+                      rangeEnd: rangeEnd,
+                    ),
+                  ),
+                  on: {'habit-public', 'habit-private'},
+                  off: {'habit-public'},
+                ),
+                (
+                  name: 'getQuantitativeByType',
+                  read: () async => ids(
+                    await db!.getQuantitativeByType(
+                      type: 'weight',
+                      rangeStart: rangeStart,
+                      rangeEnd: rangeEnd,
+                    ),
+                  ),
+                  on: {'weight-public', 'weight-private'},
+                  off: {'weight-public'},
+                ),
+                (
+                  name: 'latestQuantitativeByType',
+                  read: () async => {
+                    (await db!.latestQuantitativeByType('weight'))!.meta.id,
+                  },
+                  on: {'weight-private'},
+                  off: {'weight-public'},
+                ),
+                (
+                  name: 'getWorkouts',
+                  read: () async => ids(
+                    await db!.getWorkouts(
+                      rangeStart: rangeStart,
+                      rangeEnd: rangeEnd,
+                    ),
+                  ),
+                  on: {
+                    'workout-public',
+                    'workout-private-run',
+                    'workout-private-swim',
+                  },
+                  off: {'workout-public'},
+                ),
+                (
+                  name: 'getWorkoutsByType',
+                  read: () async => ids(
+                    await db!.getWorkoutsByType(
+                      workoutType: 'running',
+                      rangeStart: rangeStart,
+                      rangeEnd: rangeEnd,
+                    ),
+                  ),
+                  on: {'workout-public', 'workout-private-run'},
+                  off: {'workout-public'},
+                ),
+                (
+                  name: 'latestWorkout',
+                  read: () async => {(await db!.latestWorkout())!.meta.id},
+                  on: {'workout-private-swim'},
+                  off: {'workout-public'},
+                ),
+                (
+                  name: 'getWorkoutTypes',
+                  read: () async => (await db!.getWorkoutTypes()).toSet(),
+                  on: {'running', 'swimming'},
+                  off: {'running'},
+                ),
+                (
+                  name: 'getSurveyCompletionsByType',
+                  read: () async => ids(
+                    await db!.getSurveyCompletionsByType(
+                      type: 'phq9',
+                      rangeStart: rangeStart,
+                      rangeEnd: rangeEnd,
+                    ),
+                  ),
+                  on: {'survey-public', 'survey-private'},
+                  off: {'survey-public'},
+                ),
+              ];
+
+          // The flag is on by default in this harness.
+          for (final read in reads) {
+            expect(await read.read(), read.on, reason: '${read.name}, flag on');
+          }
+          await disablePrivate();
+          for (final read in reads) {
+            expect(
+              await read.read(),
+              read.off,
+              reason: '${read.name}, flag off',
+            );
+          }
+        },
+      );
     });
   });
 }

--- a/test/database/database_journal_queries_test.dart
+++ b/test/database/database_journal_queries_test.dart
@@ -1244,6 +1244,116 @@ void main() {
         ),
       );
 
+      JournalEntity asPrivate(JournalEntity entity) =>
+          entity.copyWith(meta: entity.meta.copyWith(private: true));
+
+      test(
+        'getDayAudioEntries drops private recordings while the flag is off',
+        () async {
+          DayAudioContext context(String sessionId, DateTime capturedAt) =>
+              DayAudioContext(
+                dayId: 'dayplan-2026-07-18',
+                planDate: capturedAt,
+                recordingSessionId: sessionId,
+                activityEntryId: 'activity-$sessionId',
+                processingJobId: 'transcribe_$sessionId',
+                capturedAt: capturedAt,
+                intent: 'dayPlan',
+              );
+          final public = buildAudioEntry(
+            id: 'day-audio-public',
+            timestamp: DateTime(2026, 7, 18, 8),
+            audioDirectory: '/audio/',
+            audioFile: 'public.wav',
+            dayContext: context('session-public', DateTime(2026, 7, 18, 8)),
+          );
+          final private = asPrivate(
+            buildAudioEntry(
+              id: 'day-audio-private',
+              timestamp: DateTime(2026, 7, 18, 9),
+              audioDirectory: '/audio/',
+              audioFile: 'private.wav',
+              dayContext: context('session-private', DateTime(2026, 7, 18, 9)),
+            ),
+          );
+          await db!.upsertJournalDbEntity(toDbEntity(public));
+          await db!.upsertJournalDbEntity(toDbEntity(private));
+
+          Future<List<String>> read() async => (await db!.getDayAudioEntries(
+            'dayplan-2026-07-18',
+          )).map((entry) => entry.meta.id).toList();
+          expect(await read(), ['day-audio-public', 'day-audio-private']);
+          await disablePrivate();
+          expect(await read(), ['day-audio-public']);
+        },
+      );
+
+      test(
+        'sortedCalendarEntries drops private entries while the flag is off',
+        () async {
+          final base = DateTime(2024, 11, 20, 9);
+          await db!.upsertJournalDbEntity(
+            toDbEntity(
+              buildJournalEntry(
+                id: 'calendar-public',
+                timestamp: base,
+                text: 'public',
+              ),
+            ),
+          );
+          await db!.upsertJournalDbEntity(
+            toDbEntity(
+              buildJournalEntry(
+                id: 'calendar-private',
+                timestamp: base.add(const Duration(hours: 1)),
+                text: 'private',
+                privateFlag: true,
+              ),
+            ),
+          );
+
+          Future<List<String>> read() async => (await db!.sortedCalendarEntries(
+            rangeStart: DateTime(2024, 11, 20),
+            rangeEnd: DateTime(2024, 11, 21),
+          )).map((entry) => entry.meta.id).toList();
+          expect(await read(), ['calendar-private', 'calendar-public']);
+          await disablePrivate();
+          expect(await read(), ['calendar-public']);
+        },
+      );
+
+      test(
+        'getCountImportFlagEntries leaves private flagged entries out while '
+        'the flag is off',
+        () async {
+          final base = DateTime(2024, 11, 12, 9);
+          await db!.upsertJournalDbEntity(
+            toDbEntity(
+              buildJournalEntry(
+                id: 'import-public',
+                timestamp: base,
+                text: 'public',
+                flag: EntryFlag.import,
+              ),
+            ),
+          );
+          await db!.upsertJournalDbEntity(
+            toDbEntity(
+              buildJournalEntry(
+                id: 'import-private',
+                timestamp: base,
+                text: 'private',
+                flag: EntryFlag.import,
+                privateFlag: true,
+              ),
+            ),
+          );
+          expect(await db!.getCountImportFlagEntries(), 2);
+          await disablePrivate();
+          expect(await db!.getCountImportFlagEntries(), 1);
+        },
+      );
+
       test(
         'getJournalEntitiesForIds filtered path drops private entries and '
         'sorts by date desc',

--- a/test/features/daily_os_next/state/day_activity_provider_test.dart
+++ b/test/features/daily_os_next/state/day_activity_provider_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -12,6 +13,7 @@ import 'package:lotti/features/daily_os_next/state/day_activity_provider.dart';
 import 'package:lotti/features/daily_os_next/state/day_agent_provider.dart';
 import 'package:lotti/features/daily_os_next/state/day_processing_runtime_provider.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
@@ -45,7 +47,10 @@ void main() {
     if (root.existsSync()) root.deleteSync(recursive: true);
   });
 
-  ProviderContainer makeContainer(MockAgentRepository repository) {
+  ProviderContainer makeContainer(
+    MockAgentRepository repository, {
+    Stream<Set<String>> Function(String key)? updates,
+  }) {
     final container = ProviderContainer(
       overrides: [
         dayProcessingOutboxRepositoryProvider.overrideWithValue(outbox),
@@ -53,7 +58,8 @@ void main() {
         draftedPlanForDateProvider.overrideWith((ref, date) async => null),
         agentRepositoryProvider.overrideWithValue(repository),
         agentUpdateStreamProvider.overrideWith(
-          (ref, agentId) => const Stream<Set<String>>.empty(),
+          (ref, agentId) =>
+              updates?.call(agentId) ?? const Stream<Set<String>>.empty(),
         ),
       ],
     );
@@ -98,6 +104,36 @@ void main() {
       );
     },
   );
+
+  test('re-runs the projection when the private flag toggles', () async {
+    final repository = MockAgentRepository();
+    when(
+      () => repository.getEntitiesByIds(any()),
+    ).thenAnswer((_) async => const {});
+    final toggles = StreamController<Set<String>>.broadcast();
+    addTearDown(toggles.close);
+    final container = makeContainer(
+      repository,
+      updates: (key) => key == privateToggleNotification
+          ? toggles.stream
+          : const Stream<Set<String>>.empty(),
+    );
+    // Keep the autoDispose provider alive across the rebuild.
+    final subscription = container.listen(
+      dayActivityProvider(date),
+      (_, _) {},
+    );
+    addTearDown(subscription.close);
+    await container.read(dayActivityProvider(date).future);
+    verify(() => journalDb.getDayAudioEntries(dayId)).called(1);
+
+    // The day audio read gates on the flag, so flipping it must re-run the
+    // projection rather than leave the previous rows on screen.
+    toggles.add({privateToggleNotification});
+    await pumpEventQueue();
+    await container.read(dayActivityProvider(date).future);
+    verify(() => journalDb.getDayAudioEntries(dayId)).called(1);
+  });
 
   test(
     'loads an offline day projection from its resolved dependencies',

--- a/test/features/dashboards/state/health_chart_controller_test.dart
+++ b/test/features/dashboards/state/health_chart_controller_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/dashboards/state/health_chart_controller.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
@@ -128,6 +129,140 @@ void main() {
 
         // Trigger notification for this health type
         updateController.add({dataType});
+
+        // Wait for the refresh to complete
+        await refreshed.future;
+
+        verify(
+          () => mocks.journalDb.getQuantitativeByType(
+            type: dataType,
+            rangeStart: any(named: 'rangeStart'),
+            rangeEnd: any(named: 'rangeEnd'),
+          ),
+        ).called(2);
+
+        await updateController.close();
+      },
+    );
+  });
+
+  group('HealthObservationsController', () {
+    final rangeStart = DateTime(2024, 3, 10);
+    final rangeEnd = DateTime(2024, 3, 15);
+    const dataType = 'HealthDataType.WEIGHT';
+
+    test('aggregates data via aggregateByType', () async {
+      final entities = [
+        makeQuantitativeEntry(
+          dateFrom: DateTime(2024, 3, 12, 10),
+          value: 72.5,
+          dataType: dataType,
+        ),
+        makeQuantitativeEntry(
+          dateFrom: DateTime(2024, 3, 13, 11),
+          value: 73.0,
+          dataType: dataType,
+          id: 'entry2',
+        ),
+      ];
+
+      when(
+        () => mocks.journalDb.getQuantitativeByType(
+          type: any(named: 'type'),
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).thenAnswer((_) async => entities);
+
+      final container = ProviderContainer();
+
+      // Ensure the data controller has loaded first
+      await container.read(
+        healthChartDataControllerProvider((
+          healthDataType: dataType,
+          rangeStart: rangeStart,
+          rangeEnd: rangeEnd,
+        )).future,
+      );
+
+      final result = await container.read(
+        healthObservationsControllerProvider((
+          healthDataType: dataType,
+          rangeStart: rangeStart,
+          rangeEnd: rangeEnd,
+        )).future,
+      );
+
+      // WEIGHT uses 'none' aggregation, so one observation per entry
+      expect(result, hasLength(2));
+      expect(result[0].value, 72.5);
+      expect(result[1].value, 73.0);
+
+      container.dispose();
+    });
+
+    test(
+      'refreshes when update notification contains healthDataType (private toggle)',
+      () async {
+        final updateController = StreamController<Set<String>>.broadcast();
+        when(
+          () => mocks.updateNotifications.updateStream,
+        ).thenAnswer((_) => updateController.stream);
+
+        final firstEntities = [
+          makeQuantitativeEntry(
+            dateFrom: DateTime(2024, 3, 12),
+            value: 72.0,
+            dataType: dataType,
+          ),
+        ];
+        final secondEntities = [
+          makeQuantitativeEntry(
+            dateFrom: DateTime(2024, 3, 12),
+            value: 73.0,
+            dataType: dataType,
+            id: 'updated',
+          ),
+        ];
+
+        var callCount = 0;
+        when(
+          () => mocks.journalDb.getQuantitativeByType(
+            type: any(named: 'type'),
+            rangeStart: any(named: 'rangeStart'),
+            rangeEnd: any(named: 'rangeEnd'),
+          ),
+        ).thenAnswer((_) async {
+          callCount++;
+          return callCount == 1 ? firstEntities : secondEntities;
+        });
+
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        final provider = healthChartDataControllerProvider((
+          healthDataType: dataType,
+          rangeStart: rangeStart,
+          rangeEnd: rangeEnd,
+        ));
+
+        // Initial load
+        await container.read(provider.future);
+
+        // Listen for the refresh to complete
+        final refreshed = Completer<List<JournalEntity>>();
+        container.listen<AsyncValue<List<JournalEntity>>>(
+          provider,
+          (_, next) {
+            if (next is AsyncData<List<JournalEntity>> &&
+                !refreshed.isCompleted) {
+              refreshed.complete(next.value);
+            }
+          },
+        );
+
+        // Trigger notification for this health type
+        updateController.add({privateToggleNotification});
 
         // Wait for the refresh to complete
         await refreshed.future;

--- a/test/features/dashboards/state/measurables_controller_test.dart
+++ b/test/features/dashboards/state/measurables_controller_test.dart
@@ -301,6 +301,55 @@ void main() {
       expect(updated, hasLength(2));
     });
 
+    test(
+      'updates state when affected id arrives on update stream (private toggle)',
+      () async {
+        final entry1 = makeEntry(DateTime(2024, 3, 12, 9), 42);
+        final entry2 = makeEntry(DateTime(2024, 3, 13, 9), 84);
+
+        final streamController = StreamController<Set<String>>.broadcast();
+        var callCount = 0;
+        when(
+          () => mockUpdateNotifications.updateStream,
+        ).thenAnswer((_) => streamController.stream);
+        when(
+          () => mockJournalDb.getMeasurementsByType(
+            type: typeId,
+            rangeStart: rangeStart,
+            rangeEnd: rangeEnd,
+          ),
+        ).thenAnswer((_) async {
+          callCount++;
+          return callCount == 1 ? [entry1] : [entry1, entry2];
+        });
+
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        addTearDown(streamController.close);
+
+        final params = (
+          measurableDataTypeId: typeId,
+          rangeStart: rangeStart,
+          rangeEnd: rangeEnd,
+        );
+
+        // Read initial state.
+        final initial = await container.read(
+          measurableChartDataControllerProvider(params).future,
+        );
+        expect(initial, hasLength(1));
+
+        // Emit an update that contains our type id — triggers _listen().
+        streamController.add({privateToggleNotification});
+        await pumpEventQueue();
+
+        final updated = await container.read(
+          measurableChartDataControllerProvider(params).future,
+        );
+        expect(updated, hasLength(2));
+      },
+    );
+
     test('ignores update stream events for unrelated ids', () async {
       final entry = makeEntry(DateTime(2024, 3, 12, 9), 42);
 

--- a/test/features/dashboards/state/survey_chart_controller_test.dart
+++ b/test/features/dashboards/state/survey_chart_controller_test.dart
@@ -140,6 +140,79 @@ void main() {
       await updateController.close();
     });
 
+    test('refreshes on surveyNotification (private toggle)', () async {
+      final updateController = StreamController<Set<String>>.broadcast();
+      when(
+        () => mocks.updateNotifications.updateStream,
+      ).thenAnswer((_) => updateController.stream);
+
+      final firstEntities = [
+        makeSurveyEntry(
+          dateFrom: DateTime(2024, 3, 12),
+          calculatedScores: {'Positive Affect Score': 35},
+        ),
+      ];
+      final secondEntities = [
+        makeSurveyEntry(
+          dateFrom: DateTime(2024, 3, 12),
+          calculatedScores: {'Positive Affect Score': 40},
+          id: 'updated',
+        ),
+      ];
+
+      var callCount = 0;
+      when(
+        () => mocks.journalDb.getSurveyCompletionsByType(
+          type: any(named: 'type'),
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).thenAnswer((_) async {
+        callCount++;
+        return callCount == 1 ? firstEntities : secondEntities;
+      });
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final provider = surveyChartDataControllerProvider((
+        surveyType: surveyType,
+        rangeStart: rangeStart,
+        rangeEnd: rangeEnd,
+      ));
+
+      // Initial load
+      await container.read(provider.future);
+
+      // Listen for the refresh to complete
+      final refreshed = Completer<List<JournalEntity>>();
+      container.listen<AsyncValue<List<JournalEntity>>>(
+        provider,
+        (_, next) {
+          if (next is AsyncData<List<JournalEntity>> &&
+              !refreshed.isCompleted) {
+            refreshed.complete(next.value);
+          }
+        },
+      );
+
+      // Trigger survey notification
+      updateController.add({privateToggleNotification});
+
+      // Wait for the refresh to complete
+      await refreshed.future;
+
+      verify(
+        () => mocks.journalDb.getSurveyCompletionsByType(
+          type: surveyType,
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).called(2);
+
+      await updateController.close();
+    });
+
     test('does not refresh on unrelated notification', () async {
       final updateController = StreamController<Set<String>>.broadcast();
       when(

--- a/test/features/dashboards/state/workout_chart_controller_test.dart
+++ b/test/features/dashboards/state/workout_chart_controller_test.dart
@@ -126,6 +126,57 @@ void main() {
 
       await updateController.close();
     });
+
+    test('refreshes on workoutNotification (private toggle)', () async {
+      final updateController = StreamController<Set<String>>.broadcast();
+      when(
+        () => mocks.updateNotifications.updateStream,
+      ).thenAnswer((_) => updateController.stream);
+
+      when(
+        () => mocks.journalDb.getWorkouts(
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).thenAnswer((_) async => []);
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final provider = workoutChartDataControllerProvider((
+        rangeStart: rangeStart,
+        rangeEnd: rangeEnd,
+      ));
+
+      // Initial load
+      await container.read(provider.future);
+
+      // Listen for the refresh to complete
+      final refreshed = Completer<List<JournalEntity>>();
+      container.listen<AsyncValue<List<JournalEntity>>>(
+        provider,
+        (_, next) {
+          if (next is AsyncData<List<JournalEntity>> &&
+              !refreshed.isCompleted) {
+            refreshed.complete(next.value);
+          }
+        },
+      );
+
+      updateController.add({privateToggleNotification});
+
+      // Wait for the refresh to complete
+      await refreshed.future;
+
+      verify(
+        () => mocks.journalDb.getWorkouts(
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).called(2);
+
+      await updateController.close();
+    });
   });
 
   group('WorkoutObservationsController', () {

--- a/test/features/habits/service/habit_auto_completion_service_test.dart
+++ b/test/features/habits/service/habit_auto_completion_service_test.dart
@@ -85,7 +85,7 @@ void main() {
     );
     when(() => entitiesCache.getHabitById(any())).thenReturn(null);
     when(
-      () => journalDb.getHabitCompletionsByHabitId(
+      () => journalDb.getHabitCompletionsByHabitIdIncludingPrivate(
         habitId: any(named: 'habitId'),
         rangeStart: any(named: 'rangeStart'),
         rangeEnd: any(named: 'rangeEnd'),

--- a/test/features/sync/matrix/sync_event_processor_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_test.dart
@@ -591,7 +591,7 @@ void main() {
       () => journalDb.getMeasurableDataTypeById(renamed.id),
     ).thenAnswer((_) async => measurableHydration);
     when(
-      () => journalDb.getMeasurementsByType(
+      () => journalDb.getMeasurementsByTypeIncludingPrivate(
         type: renamed.id,
         rangeStart: any(named: 'rangeStart'),
         rangeEnd: any(named: 'rangeEnd'),

--- a/test/logic/persistence_definition_ops_test.dart
+++ b/test/logic/persistence_definition_ops_test.dart
@@ -99,7 +99,7 @@ void main() {
       () => mocks.journalDb.upsertEntityDefinition(renamed),
     ).thenAnswer((_) async => 1);
     when(
-      () => mocks.journalDb.getMeasurementsByType(
+      () => mocks.journalDb.getMeasurementsByTypeIncludingPrivate(
         type: previous.id,
         rangeStart: any(named: 'rangeStart'),
         rangeEnd: any(named: 'rangeEnd'),
@@ -145,7 +145,7 @@ void main() {
 
       verifyNoMoreInteractions(fts5Db);
       verifyNever(
-        () => mocks.journalDb.getMeasurementsByType(
+        () => mocks.journalDb.getMeasurementsByTypeIncludingPrivate(
           type: any(named: 'type'),
           rangeStart: any(named: 'rangeStart'),
           rangeEnd: any(named: 'rangeEnd'),

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -813,9 +813,7 @@ void main() {
       expect(await getIt<JournalDb>().getTasksCount(statuses: ['DONE']), 0);
       expect(await getIt<JournalDb>().getWipCount(), 0);
 
-      await getIt<JournalDb>()
-          .purgeDeleted(backup: false)
-          .drain<void>();
+      await getIt<JournalDb>().purgeDeleted(backup: false).drain<void>();
     });
 
     test('create and retrieve workout entry', () async {

--- a/test/logic/sleep_asleep_backfill_service_test.dart
+++ b/test/logic/sleep_asleep_backfill_service_test.dart
@@ -60,7 +60,7 @@ void main() {
     );
 
     when(
-      () => journalDb.getQuantitativeByType(
+      () => journalDb.getQuantitativeByTypeIncludingPrivate(
         type: any(named: 'type'),
         rangeStart: any(named: 'rangeStart'),
         rangeEnd: any(named: 'rangeEnd'),
@@ -90,7 +90,7 @@ void main() {
     String dataType = 'HealthDataType.SLEEP_LIGHT',
   }) {
     when(
-      () => journalDb.getQuantitativeByType(
+      () => journalDb.getQuantitativeByTypeIncludingPrivate(
         type: dataType,
         rangeStart: DateTime(year),
         rangeEnd: any(named: 'rangeEnd'),
@@ -159,7 +159,7 @@ void main() {
       await service.backfill(now: now);
 
       final types = verify(
-        () => journalDb.getQuantitativeByType(
+        () => journalDb.getQuantitativeByTypeIncludingPrivate(
           type: captureAny(named: 'type'),
           rangeStart: any(named: 'rangeStart'),
           rangeEnd: any(named: 'rangeEnd'),
@@ -177,7 +177,7 @@ void main() {
 
     test('keeps going after a window that throws', () async {
       when(
-        () => journalDb.getQuantitativeByType(
+        () => journalDb.getQuantitativeByTypeIncludingPrivate(
           type: 'HealthDataType.SLEEP_LIGHT',
           rangeStart: DateTime(2015),
           rangeEnd: any(named: 'rangeEnd'),


### PR DESCRIPTION
Closes the product decision from #4167 (Beads lotti3-0qaz): every journal read respects the privacy switch.

## What changes

The audit merged in #4167 listed eleven reads as "not gated today". All of them now honour "Show private entries":

- **Data series** behind dashboards and health charts: `measurementsByType`, `habitCompletionsByHabitId`, `quantitativeByType`, `latestQuantByType`, `workouts`, `workoutsByType`, `findLatestWorkout`, `workoutTypes`, `surveysByType`.
- **The calendar range read** `sortedCalenderEntriesInRange`.
- **The Daily OS day audio list** `getDayAudioEntries`.
- **The import badge count** `countImportFlagEntries`, since it is derived from entries the badge leads to.

## What stays unfiltered, and why (review follow-up)

The flag is a display preference, so reads that are not display keep seeing every row. Following the split the relationship queries already use, each has an `…IncludingPrivate` twin backed by an unfiltered `…AllPrivate` named query, listed in the audit with its reason:

- the search reindex after a measurable definition edit (local and sync apply), so hidden rows do not keep stale index text;
- the auto-completion engine's "anything already recorded wins" guard, so a private skip still stops an automatic success from being written over it;
- the sleep repair sweep;
- the health import's checkpoints (`latestQuantByType`, `findLatestWorkout`), which have no display caller and stay un-gated.

The workout, health, survey and measurables chart controllers and the Daily OS activity projection now refetch on `PRIVATE_FLAG_TOGGLED`, so a cached chart does not keep showing rows the user just hid.

## How

The `.drift` queries carry the same `private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))` predicate that `journalEntityIdsByCategory`, `countTasksGroupedByCategory` and `workEntriesInDateRange` already use. Because the subquery reads `config_flags`, Drift also re-emits any stream on these queries when the flag toggles. The day audio read is Drift Dart API and filters on `_visiblePrivateStatuses()` like the relationship queries. No schema change, no version bump.

Still ungated on purpose, and listed in the audit with reasons: by-id resolution (the flag changes what browsing surfaces, not what an identifier resolves to), sync and maintenance walks (every device holds every row), and the two totals for progress reporting and the About page.

## Tests

- A table-driven test seeds one public and one private row per entity type, with the private row newer so the "latest" reads change their answer rather than only their count, and asserts all nine series reads in both flag states.
- Day audio, calendar range and import count each get a flag on/off test.
- The audit's allowlist loses its twelve "not gated today" entries; it would fail if any still bypassed the flag.
- Every new test was run with its fix removed and failed: the day audio predicate deleted; the schema file reverted and regenerated; the unfiltered twins and checkpoints gated and regenerated; the five refresh wirings reverted.

Concept updated: the mechanism table names these queries and the "genuinely not filtered" section now reads "nothing else". Changelog fragment included since this is user-visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Private entries are now consistently hidden when “Show private entries” is disabled.
  * Dashboards, health charts, calendar views, Daily OS recordings, and import counts now respect private-entry visibility.
  * Private measurements, workouts, surveys, habit completions, and quantitative data no longer appear or affect totals unless enabled.
  * Dashboards and Daily OS views now refresh immediately when the private-entry setting changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
