### PR TITLE
fix(projects): dismissed steps leave the band, header and card borders hold

### DIFF
--- a/changelog.d/2026-09-06-project-ai-band-and-task-header.md
+++ b/changelog.d/2026-09-06-project-ai-band-and-task-header.md
@@ -1,0 +1,29 @@
+### Fixed
+- **Dismissing an AI-suggested next step did not make it go away.** The
+  suggestion stayed on the list with a strikethrough, so a project you had
+  triaged looked exactly as long as one you had not. A dismissed suggestion now
+  leaves the list immediately. Nothing is lost: it moves to the band's history,
+  which opens under the remaining suggestions, and that is where it can be
+  restored.
+- **The task count on a project could show the wrong number.** The blue badge
+  beside "Project Tasks" was a fixed-size circle, so a project with 153 tasks
+  read as "15", with the digits sitting off-centre. The badge now grows to fit
+  the number and stays centred.
+- **The Project Tasks header was laid out wrong.** The sort control and
+  "Add task" floated in the middle of the row instead of sitting against the
+  right edge, and the total estimate was wedged between the heading and its
+  count. The header now reads as the title with its count on the left and the
+  estimate, sort control and "Add task" together on the right, all on one line.
+- **Month headings cut the task card's outline open.** Each collapsible group
+  heading painted over the card's left and right edges, leaving the card border
+  visibly interrupted at every group. The outline is now continuous.
+- **AI analyses on image and audio entries were set too large.** An analysis
+  nested inside an entry card was rendered bigger than the entry's own text and
+  padded like a top-level card. It now matches the text editor's size and sits
+  in a tighter card.
+
+### Added
+- **Swipe to decide the project agent's proposed changes.** Proposed changes on
+  a project page now swipe like the ones on a task page and like the suggested
+  next steps beside them — right to confirm, left to reject, with the action
+  named on the band the swipe reveals.

--- a/knowledge/features/ai/execution-paths.md
+++ b/knowledge/features/ai/execution-paths.md
@@ -369,6 +369,14 @@ badges. In the nested tree the cards collapse binarily, so long analyses (full
 OCR) start fully collapsed to a Show more/Show less toggle plus the attribution
 pill, while short summaries stay visible.
 
+The body goes through `AgentMarkdownView`, so an analysis nested in an image or
+audio entry card sits at the editor's own `body.bodySmall` measure with the
+editor's heading mapping, instead of inheriting whatever the ambient theme
+would hand raw `GptMarkdown` — a nested analysis must not read louder than the
+entry text it belongs to. The collapsed TLDR takes the same measure. The card's
+inset is one spacing step tighter than a top-level card's for the same reason:
+it is a subordinate surface inside a card, not a page section.
+
 `fetchAiResponsesForImages` resolves them in bulk for task context:
 `AiInputRepository.generate` nests them per image log entry as
 `aiResponses: [{model, generatedAt, text}]`, and the agent capture path emits one

--- a/knowledge/features/design_system/component-contracts.md
+++ b/knowledge/features/design_system/component-contracts.md
@@ -176,6 +176,19 @@ the accent ink. The pattern it serves never removes the row: `confirmDismiss`
 fires the action and returns `false`, and the row snaps back to show its
 new state.
 
+`DesignSystemSwipeActions` (same directory) is that pattern as one wrapper.
+A row hands it a `DesignSystemSwipeAction` per direction — palette, glyph,
+label, callback — and it owns everything else: the `Dismissible`, the
+direction derived from which sides were wired, the shared threshold, the clip
+to the row's radius, and the `confirmDismiss` that always returns `false`.
+Give it neither direction and it returns the child untouched, which is how a
+decided or disabled row opts out without swallowing drag gestures. It also
+absorbs a `Dismissible` sharp edge: a secondary background is rejected without
+a primary one, so a one-direction row hands the same band to both slots and
+lets `direction` keep the unused one out of reach. The project AI card's next
+steps and proposal rows are the adopters, which is what makes the same drag
+mean the same thing there as on a task page.
+
 `DesignSystemFloatingActionButton` is circular and icon-only by default and
 takes its `semanticLabel` for assistive technology. Passing a `label` extends
 it into a worded pill: same height, same token background and radius, growing

--- a/knowledge/features/projects.md
+++ b/knowledge/features/projects.md
@@ -338,14 +338,23 @@ renders two bands inside the card: the newest run's **recommended next steps**
 (`ProjectNextStepRow`, one per step) and the agent's **proposed changes**
 (`ProjectProposalRow`, reusing Task Details' `RowActions` rail). A step offers
 **Add task** and **Dismiss** as labelled controls, and on touch the same two
-by swipe — right adds, left dismisses, each named on the band the row reveals
-(`DesignSystemSwipeActionBackground`), and the row snaps back rather than
-leaving. A decided step keeps its place with an *Added* (its link focuses the
-task in the list below), *Done* or *Dismissed* tag and an Undo — eight
-seconds for an addition, as long as the run is current for a dismissal. A
-failed creation keeps the row with Retry and the failure copy. Phones show
-three rows before "Show N more"; more than one open step adds **Add all as
-tasks** and **Dismiss all**.
+by swipe — right adds, left dismisses. Proposal rows swipe the same way (right
+confirms, left rejects), so the gesture means the same thing in both bands and
+on a task page. Both go through `DesignSystemSwipeActions`, the one wrapper
+that owns the direction, the threshold and the *never actually dismiss*
+contract; each surface supplies only its palette and its labels, and the band
+it reveals names what letting go will do
+(`DesignSystemSwipeActionBackground`).
+
+**A dismissal removes the step from the band at once** — dismissed is
+dismissed. An addition is what keeps its row, with an *Added* tag whose link
+focuses the task in the list below (or *Done* when the service created no
+task) and an Undo for eight seconds. There is no dismissed row state and no
+inline undo for one: the step moves to the band's history, which is disclosed
+under the open rows whenever any step has been decided, and the history row is
+where the dismissal is taken back. A failed creation keeps the row with Retry
+and the failure copy. Phones show three rows before "Show N more"; more than
+one open step adds **Add all as tasks** and **Dismiss all**.
 
 Proposals go through `ProjectProposalService` (`projectProposalServiceProvider`,
 kept alive for the session): `confirm` and `reject` delegate to the change
@@ -390,19 +399,25 @@ stateDiagram-v2
   busy --> done: created without a task id
   busy --> failed: creation refused
   failed --> busy: Retry
-  pending --> dismissed: Dismiss
-  failed --> dismissed: Dismiss
+  pending --> dismissed: Dismiss (row leaves the band)
+  failed --> dismissed: Dismiss (row leaves the band)
   added --> pending: Undo (within eight seconds)
-  dismissed --> pending: Undo
+  dismissed --> pending: Undo (from the history)
   done --> pending: Undo
 ```
 
-A run whose every step was already decided when the page opened collapses to
-`ProjectNextStepsSummary` — one line with the tally and when the agent last
-looked, plus a history disclosure — while decisions made on the page stay
-inline until the next visit. An empty run renders `ProjectNextStepsEmpty`
-with the same "last looked" age. The pure pieces (outcome mapping, tally,
-phone cap, age buckets) live in `project_next_steps_model.dart`. The
+A run with nothing left open — decided before the page opened, or emptied by
+the decisions just made — collapses to `ProjectNextStepsSummary`: one line
+with the tally and when the agent last looked, over the same history
+disclosure. An empty run renders `ProjectNextStepsEmpty` with the same "last
+looked" age. `ProjectNextStepsHistory` is the shared list behind both
+disclosures; it renders one quiet row per decided step and offers Undo on the
+dismissed ones. Every surface that shows an outcome takes a
+`ProjectNextStepOutcomeReader` rather than reading the entity, so the panel's
+optimistic overlay reaches the tally and the history rows too and a decision
+made a moment ago counts before the snapshot carries it. The pure pieces
+(outcome mapping, tally, phone cap, age buckets) live in
+`project_next_steps_model.dart`. The
 replacement, undo and migration lifecycle lives in
 [project and event agents](agents/project-and-event-agents.md#tools-and-recommendations).
 
@@ -477,6 +492,14 @@ groups are unchanged, and folding a group only removes its list sliver, which
 `MultiSliver` handles without the geometry assertion the plain pinned
 persistent header used to trip.
 
+`DecoratedSliver` paints the panel's outline *behind* its slivers, so that
+opaque full-width fill erases the card's left and right hairlines wherever a
+group starts — the card outline looked cut open at every group header. The
+header repaints them itself, as a **foreground** decoration: a border side in
+`decoration` would inset the header's content by a hairline and knock its
+label out of line with the rows beneath it, while a foreground decoration
+paints over the fill without touching layout.
+
 A `ProjectTaskFocus` (task id, request number, `scroll`) asks the panel to
 light one row up — the hover wash, held for `highlightDuration` — and, with
 `scroll` on, to bring it into view. The detail content owns the current focus
@@ -488,6 +511,21 @@ list is lazy, jumps to the group's header (always built) and looks for the
 row on the following frames, stepping one viewport further each time until it
 exists or `maxScrollAttempts` run out; the row is then eased into view with
 `Scrollable.ensureVisible`.
+
+The header reads left to right as *title, count badge*, then a trailing rail
+of *total estimate, sort control, Add task*, all on one vertical centre. The
+count badge belongs to the heading it counts; the estimate is a value of the
+list, so it joins the controls rather than trailing the badge. One tight
+`Expanded` around the heading owns all the slack, which is what keeps the rail
+flush against the card's right edge — a `Spacer` beside loose `Flexible`s
+split the free space three ways instead, stranding the controls mid-row with
+unused space behind them.
+
+`CountDotBadge` is a stadium with a minimum diameter, not a fixed circle: one
+or two digits still read as the round dot, and a longer count grows the pill
+instead of clipping. As a fixed circle a project with 153 tasks rendered as
+"15", off-centre — the badge looked both wrong and mis-set. It takes a
+`semanticsLabel` because the digits alone say nothing about what is counted.
 
 The header survives what used to break it: the title truncates before
 anything overflows, and in its compact form — below 480 pt of header width (a

--- a/knowledge/features/projects.md
+++ b/knowledge/features/projects.md
@@ -406,10 +406,15 @@ stateDiagram-v2
   done --> pending: Undo
 ```
 
-A run with nothing left open — decided before the page opened, or emptied by
-the decisions just made — collapses to `ProjectNextStepsSummary`: one line
-with the tally and when the agent last looked, over the same history
-disclosure. An empty run renders `ProjectNextStepsEmpty` with the same "last
+The band collapses to `ProjectNextStepsSummary` — one line with the tally and
+when the agent last looked, over the same history disclosure — in two cases:
+the run was already fully decided when the page opened, or every row has since
+been **dismissed**, leaving nothing on the list. An addition does *not* collapse
+the band: an added step keeps its row and its link to the task it created, so a
+run whose last open step was added stays expanded until the next visit. The
+collapse decision is latched per run, and restoring a step from the history
+lifts it again — otherwise an Undo on a run that opened decided would leave the
+summary standing over a step that is open again. An empty run renders `ProjectNextStepsEmpty` with the same "last
 looked" age. `ProjectNextStepsHistory` is the shared list behind both
 disclosures; it renders one quiet row per decided step and offers Undo on the
 dismissed ones. Every surface that shows an outcome takes a

--- a/lib/features/ai/ui/ai_response_summary.dart
+++ b/lib/features/ai/ui/ai_response_summary.dart
@@ -1,5 +1,5 @@
-import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/agents/ui/widgets/agent_markdown_view.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/ui/ai_response_summary_modal.dart';
 import 'package:lotti/features/ai/ui/generated_prompt_card.dart';
@@ -8,7 +8,6 @@ import 'package:lotti/features/ai_consumption/ui/widgets/ai_attribution_summary.
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
-import 'package:lotti/utils/markdown_link_utils.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
 import 'package:material_ui/material_ui.dart';
 
@@ -34,6 +33,11 @@ const _fadeOutPreviewMaxHeight = 200.0;
 /// cards, but without their accent-blended fill and badges — so a response
 /// nested inside an entry card reads as recognizably AI-generated content
 /// without becoming a second elevated card.
+///
+/// The body renders through [AgentMarkdownView], so an analysis sits at the
+/// same `body.bodySmall` measure as the entry text it belongs to rather than
+/// shouting over it, and the card's inset is one step tighter than a top-level
+/// card's — it is a nested surface, not a page section.
 ///
 /// Prompt-generation responses short-circuit to [GeneratedPromptCard].
 ///
@@ -176,16 +180,14 @@ class _AiResponseSummaryState extends State<AiResponseSummary> {
       );
     }
 
-    final ai = context.designTokens.colors.aiCard;
+    final tokens = context.designTokens;
+    final ai = tokens.colors.aiCard;
+    final bodyStyle = tokens.typography.styles.body.bodySmall.copyWith(
+      color: ai.bodyText,
+    );
 
-    final content = DefaultTextStyle.merge(
-      style: TextStyle(color: ai.bodyText),
-      child: SelectionArea(
-        child: GptMarkdown(
-          aiResponse.data.response,
-          onLinkTap: handleMarkdownLinkTap,
-        ),
-      ),
+    final content = SelectionArea(
+      child: AgentMarkdownView(aiResponse.data.response, style: bodyStyle),
     );
 
     final responseContent = GestureDetector(
@@ -212,10 +214,7 @@ class _AiResponseSummaryState extends State<AiResponseSummary> {
     if (!isCollapsed) {
       body = responseContent;
     } else if (tldr != null) {
-      body = DefaultTextStyle.merge(
-        style: TextStyle(color: ai.bodyText),
-        child: SelectionArea(child: Text(tldr)),
-      );
+      body = SelectionArea(child: Text(tldr, style: bodyStyle));
     } else {
       body = null;
     }
@@ -229,7 +228,9 @@ class _AiResponseSummaryState extends State<AiResponseSummary> {
         borderRadius: BorderRadius.circular(AppTheme.cardBorderRadius),
         border: Border.all(color: ai.borderSoft),
       ),
-      padding: const EdgeInsets.all(AppTheme.cardPadding),
+      // One step tighter than a top-level card: this surface is nested inside
+      // an entry card and should not spend a full card inset on its own.
+      padding: EdgeInsets.all(tokens.spacing.step4),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/lib/features/design_system/components/lists/design_system_swipe_actions.dart
+++ b/lib/features/design_system/components/lists/design_system_swipe_actions.dart
@@ -1,0 +1,109 @@
+import 'package:lotti/features/design_system/components/lists/design_system_swipe_action_background.dart';
+import 'package:material_ui/material_ui.dart';
+
+/// One direction of a [DesignSystemSwipeActions] row: what the revealed band
+/// says, and what letting go there does.
+@immutable
+class DesignSystemSwipeAction {
+  const DesignSystemSwipeAction({
+    required this.color,
+    required this.foregroundColor,
+    required this.icon,
+    required this.label,
+    required this.onTrigger,
+  });
+
+  /// Fill of the band the row is dragged off, and the ink on it. The pair is
+  /// chosen per surface so a band always matches the palette it sits in.
+  final Color color;
+  final Color foregroundColor;
+  final IconData icon;
+
+  /// Names the action on the band, so a swipe always says what it will do.
+  final String label;
+  final VoidCallback onTrigger;
+}
+
+/// Wraps a row so a horizontal swipe decides it, with the action named on the
+/// band the drag reveals.
+///
+/// The row always snaps back: these surfaces keep a decided row in place with
+/// its outcome tag rather than letting it fly out, so the gesture triggers the
+/// callback and the row's own state does the rest. Give a direction no action
+/// and that direction does not drag; give neither and the child is returned
+/// untouched, which is how a row that is already decided (or disabled) opts
+/// out.
+///
+/// This is the one swipe mechanic behind the AI bands and the lists that share
+/// their gestures — a surface picks its palette and its labels, never its own
+/// thresholds or dismissal semantics.
+class DesignSystemSwipeActions extends StatelessWidget {
+  const DesignSystemSwipeActions({
+    required this.swipeKey,
+    required this.borderRadius,
+    required this.child,
+    this.startToEnd,
+    this.endToStart,
+    super.key,
+  });
+
+  /// Fraction of the row's width a drag must cross to trigger.
+  static const double threshold = 0.4;
+
+  /// Identity of the dragged row, required by the underlying [Dismissible].
+  final Key swipeKey;
+
+  /// Corner radius of the row, used to clip the revealed band to its shape.
+  final BorderRadius borderRadius;
+
+  /// Dragging the row towards the trailing edge (right, in LTR).
+  final DesignSystemSwipeAction? startToEnd;
+
+  /// Dragging the row towards the leading edge (left, in LTR).
+  final DesignSystemSwipeAction? endToStart;
+
+  final Widget child;
+
+  static Widget _band(DesignSystemSwipeAction action, Alignment alignment) =>
+      DesignSystemSwipeActionBackground(
+        alignment: alignment,
+        color: action.color,
+        foregroundColor: action.foregroundColor,
+        icon: action.icon,
+        label: action.label,
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final start = startToEnd;
+    final end = endToStart;
+    if (start == null && end == null) return child;
+
+    return ClipRRect(
+      borderRadius: borderRadius,
+      child: Dismissible(
+        key: swipeKey,
+        direction: start == null
+            ? DismissDirection.endToStart
+            : end == null
+            ? DismissDirection.startToEnd
+            : DismissDirection.horizontal,
+        dismissThresholds: const {
+          DismissDirection.startToEnd: threshold,
+          DismissDirection.endToStart: threshold,
+        },
+        // [Dismissible] refuses a secondary background without a primary one,
+        // so a one-direction row hands the same band to both slots; `direction`
+        // is what keeps the unused one from ever being dragged into view.
+        background: _band(start ?? end!, Alignment.centerLeft),
+        secondaryBackground: _band(end ?? start!, Alignment.centerRight),
+        // Never actually dismiss: the row stays where it is and changes state.
+        confirmDismiss: (direction) async {
+          (direction == DismissDirection.startToEnd ? start : end)?.onTrigger();
+          return false;
+        },
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/features/projects/ui/widgets/next_steps/project_next_step_row.dart
+++ b/lib/features/projects/ui/widgets/next_steps/project_next_step_row.dart
@@ -3,7 +3,7 @@ import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/tools/project_tool_definitions.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_inline_action.dart';
-import 'package:lotti/features/design_system/components/lists/design_system_swipe_action_background.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_swipe_actions.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_showcase_chips.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -12,17 +12,22 @@ import 'package:material_ui/material_ui.dart';
 /// What the row is doing right now, layered over the step's durable outcome:
 /// [busy] and [failed] are transient states of the current attempt, the rest
 /// mirror `projectNextStepOutcome`.
-enum ProjectNextStepRowState { pending, busy, added, done, dismissed, failed }
+///
+/// There is no dismissed state: a dismissed step leaves the list the moment it
+/// is dismissed and is shown — and undone — from the band's history instead.
+enum ProjectNextStepRowState { pending, busy, added, done, failed }
 
 /// One recommended next step inside the project AI card.
 ///
 /// The title, rationale and priority stay put whatever happens to the step;
 /// only the action strip changes. A pending step offers one labelled primary
 /// (**Add task**) and one labelled secondary (**Dismiss**), never a bare
-/// glyph. A decided step keeps its place with a quiet tag — *Added* with a
-/// link to the task, *Done*, or *Dismissed* — and, while the decision is still
-/// reversible, an Undo. A failed attempt shows what went wrong under the
-/// controls and offers Retry instead of leaving the row blank.
+/// glyph. A step that produced something keeps its place with a quiet tag —
+/// *Added* with a link to the task, or *Done* — and, while the decision is
+/// still reversible, an Undo. A dismissed step is not rendered at all; the
+/// band removes it and keeps it in its history. A failed attempt shows what
+/// went wrong under the controls and offers Retry instead of leaving the row
+/// blank.
 ///
 /// Above [wideBreakpoint] the strip sits beside the text; below it the strip
 /// stacks under the text so a phone title keeps the full row width instead
@@ -66,9 +71,7 @@ class ProjectNextStepRow extends StatelessWidget {
   final VoidCallback? onOpenTask;
 
   bool get _decided => switch (state) {
-    ProjectNextStepRowState.added ||
-    ProjectNextStepRowState.done ||
-    ProjectNextStepRowState.dismissed => true,
+    ProjectNextStepRowState.added || ProjectNextStepRowState.done => true,
     ProjectNextStepRowState.pending ||
     ProjectNextStepRowState.busy ||
     ProjectNextStepRowState.failed => false,
@@ -78,7 +81,6 @@ class ProjectNextStepRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final ai = tokens.colors.aiCard;
-    final dismissed = state == ProjectNextStepRowState.dismissed;
     final rationale = step.rationale?.trim() ?? '';
     final priority = parseTaskPriority(step.priority);
 
@@ -89,9 +91,7 @@ class ProjectNextStepRow extends StatelessWidget {
         Text(
           step.title,
           style: tokens.typography.styles.body.bodyMedium.copyWith(
-            color: dismissed ? ai.metaText : ai.titleText,
-            decoration: dismissed ? TextDecoration.lineThrough : null,
-            decorationColor: ai.metaText,
+            color: ai.titleText,
           ),
         ),
         if (rationale.isNotEmpty) ...[
@@ -175,48 +175,32 @@ class ProjectNextStepRow extends StatelessWidget {
     );
 
     // On touch a pending row also decides by swipe — right to add the task,
-    // left to dismiss — with the action named on the band it reveals. The
-    // row snaps back rather than leaving: it stays in place with its tag.
-    final swipeable =
-        enabled &&
-        state == ProjectNextStepRowState.pending &&
-        (onAddTask != null || onDismiss != null);
-    if (!swipeable) return card;
+    // left to dismiss — with the action named on the band it reveals, through
+    // the same shared mechanic the proposal rows use.
+    final swipeable = enabled && state == ProjectNextStepRowState.pending;
     final messages = context.messages;
-    return ClipRRect(
+    return DesignSystemSwipeActions(
+      swipeKey: ValueKey('project-next-step-swipe-${step.id}'),
       borderRadius: BorderRadius.circular(tokens.radii.s),
-      child: Dismissible(
-        key: ValueKey('project-next-step-swipe-${step.id}'),
-        direction: onAddTask == null
-            ? DismissDirection.endToStart
-            : onDismiss == null
-            ? DismissDirection.startToEnd
-            : DismissDirection.horizontal,
-        dismissThresholds: const {
-          DismissDirection.startToEnd: 0.4,
-          DismissDirection.endToStart: 0.4,
-        },
-        background: DesignSystemSwipeActionBackground(
-          alignment: Alignment.centerLeft,
-          color: ai.accentSoft,
-          foregroundColor: ai.accent,
-          icon: LottiIcons.add,
-          label: messages.projectActionAddTask,
-        ),
-        secondaryBackground: DesignSystemSwipeActionBackground(
-          alignment: Alignment.centerRight,
-          color: ai.subtleWashStrong,
-          foregroundColor: ai.metaText,
-          icon: LottiIcons.close,
-          label: messages.projectNextStepDismiss,
-        ),
-        confirmDismiss: (direction) async {
-          (direction == DismissDirection.startToEnd ? onAddTask : onDismiss)
-              ?.call();
-          return false;
-        },
-        child: card,
-      ),
+      startToEnd: !swipeable || onAddTask == null
+          ? null
+          : DesignSystemSwipeAction(
+              color: ai.accentSoft,
+              foregroundColor: ai.accent,
+              icon: LottiIcons.add,
+              label: messages.projectActionAddTask,
+              onTrigger: onAddTask!,
+            ),
+      endToStart: !swipeable || onDismiss == null
+          ? null
+          : DesignSystemSwipeAction(
+              color: ai.subtleWashStrong,
+              foregroundColor: ai.metaText,
+              icon: LottiIcons.close,
+              label: messages.projectNextStepDismiss,
+              onTrigger: onDismiss!,
+            ),
+      child: card,
     );
   }
 }
@@ -314,14 +298,6 @@ class _ActionStrip extends StatelessWidget {
           icon: LottiIcons.confirm,
           iconColor: ai.accent,
           label: messages.projectNextStepDone,
-        ),
-        if (row.canUndo) undo,
-      ],
-      ProjectNextStepRowState.dismissed => [
-        _OutcomeTag(
-          icon: LottiIcons.close,
-          iconColor: ai.metaText,
-          label: messages.projectNextStepDismissed,
         ),
         if (row.canUndo) undo,
       ],

--- a/lib/features/projects/ui/widgets/next_steps/project_next_steps_model.dart
+++ b/lib/features/projects/ui/widgets/next_steps/project_next_steps_model.dart
@@ -6,6 +6,12 @@ import 'package:lotti/features/agents/model/agent_enums.dart';
 /// resolved step without one was marked done by an older surface.
 enum ProjectNextStepOutcome { pending, added, done, dismissed }
 
+/// Reads the outcome the band shows for one step. The band overlays the
+/// decision the user has just made on the stored one, so every surface that
+/// renders an outcome takes the reader rather than reaching for the entity.
+typedef ProjectNextStepOutcomeReader =
+    ProjectNextStepOutcome Function(ProjectRecommendationEntity step);
+
 /// The outcome the band shows for [step].
 ProjectNextStepOutcome projectNextStepOutcome(
   ProjectRecommendationEntity step,
@@ -29,15 +35,18 @@ class ProjectNextStepsTally {
     required this.dismissed,
   });
 
+  /// [outcomeOf] defaults to the stored outcome; the band passes its own
+  /// reader so a decision made a moment ago counts before the snapshot does.
   factory ProjectNextStepsTally.of(
-    Iterable<ProjectRecommendationEntity> steps,
-  ) {
+    Iterable<ProjectRecommendationEntity> steps, {
+    ProjectNextStepOutcomeReader outcomeOf = projectNextStepOutcome,
+  }) {
     var pending = 0;
     var added = 0;
     var done = 0;
     var dismissed = 0;
     for (final step in steps) {
-      switch (projectNextStepOutcome(step)) {
+      switch (outcomeOf(step)) {
         case ProjectNextStepOutcome.pending:
           pending++;
         case ProjectNextStepOutcome.added:

--- a/lib/features/projects/ui/widgets/next_steps/project_next_steps_summary.dart
+++ b/lib/features/projects/ui/widgets/next_steps/project_next_steps_summary.dart
@@ -22,10 +22,12 @@ String formatProjectNextStepsAge(AppLocalizations messages, Duration elapsed) {
   };
 }
 
-/// The one-line stand-in for a run whose every step has been decided: what
-/// happened, when the agent last looked, and a disclosure to the per-step
-/// history. Replaces the full row list only once the user comes back to the
-/// page; the decisions they just made stay inline until then.
+/// The one-line stand-in for a run with nothing left open: what happened, when
+/// the agent last looked, and a disclosure to the per-step history.
+///
+/// The band reaches this state as soon as no step is still open — because the
+/// run was already decided when the page opened, or because the user has just
+/// dismissed or added the last of them.
 class ProjectNextStepsSummary extends StatelessWidget {
   const ProjectNextStepsSummary({
     required this.steps,
@@ -33,6 +35,9 @@ class ProjectNextStepsSummary extends StatelessWidget {
     required this.now,
     required this.historyOpen,
     required this.onToggleHistory,
+    this.onUndo,
+    this.busyStepIds = const <String>{},
+    this.outcomeOf = projectNextStepOutcome,
     super.key,
   });
 
@@ -42,12 +47,22 @@ class ProjectNextStepsSummary extends StatelessWidget {
   final bool historyOpen;
   final VoidCallback onToggleHistory;
 
+  /// Puts a dismissed step back on the open list. Omitted where the history
+  /// is read-only.
+  final ValueChanged<ProjectRecommendationEntity>? onUndo;
+
+  /// Steps whose undo is in flight; their control shows as busy.
+  final Set<String> busyStepIds;
+
+  /// How each step's outcome is read — see [ProjectNextStepOutcomeReader].
+  final ProjectNextStepOutcomeReader outcomeOf;
+
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final ai = tokens.colors.aiCard;
     final messages = context.messages;
-    final tally = ProjectNextStepsTally.of(steps);
+    final tally = ProjectNextStepsTally.of(steps, outcomeOf: outcomeOf);
     final parts = [
       if (tally.added > 0) messages.projectNextStepsCountAdded(tally.added),
       if (tally.done > 0) messages.projectNextStepsCountDone(tally.done),
@@ -103,24 +118,83 @@ class ProjectNextStepsSummary extends StatelessWidget {
         ),
         if (historyOpen) ...[
           SizedBox(height: tokens.spacing.step2),
-          for (final step in steps) _HistoryRow(step: step),
+          ProjectNextStepsHistory(
+            steps: steps,
+            onUndo: onUndo,
+            busyStepIds: busyStepIds,
+            outcomeOf: outcomeOf,
+          ),
         ],
       ],
     );
   }
 }
 
+/// The per-step record of a run: one quiet row per step with the outcome it
+/// ended in, and — for a step the user dismissed — the Undo that puts it back
+/// on the open list.
+///
+/// Dismissing removes a step from the band immediately, so this list is the
+/// only place a dismissal can be taken back. It is shown both under the
+/// one-line summary of a finished run and, while open steps remain, behind
+/// the band's own history disclosure.
+class ProjectNextStepsHistory extends StatelessWidget {
+  const ProjectNextStepsHistory({
+    required this.steps,
+    this.onUndo,
+    this.busyStepIds = const <String>{},
+    this.outcomeOf = projectNextStepOutcome,
+    super.key,
+  });
+
+  final List<ProjectRecommendationEntity> steps;
+  final ValueChanged<ProjectRecommendationEntity>? onUndo;
+  final Set<String> busyStepIds;
+
+  /// How each step's outcome is read — see [ProjectNextStepOutcomeReader].
+  final ProjectNextStepOutcomeReader outcomeOf;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (final step in steps)
+          _HistoryRow(
+            key: ValueKey('project-next-step-history-${step.id}'),
+            step: step,
+            outcome: outcomeOf(step),
+            onUndo: onUndo == null ? null : () => onUndo!(step),
+            busy: busyStepIds.contains(step.id),
+          ),
+      ],
+    );
+  }
+}
+
 class _HistoryRow extends StatelessWidget {
-  const _HistoryRow({required this.step});
+  const _HistoryRow({
+    required this.step,
+    required this.outcome,
+    this.onUndo,
+    this.busy = false,
+    super.key,
+  });
 
   final ProjectRecommendationEntity step;
+  final ProjectNextStepOutcome outcome;
+
+  /// Offered only on a dismissed step — the one outcome this list can undo.
+  final VoidCallback? onUndo;
+  final bool busy;
 
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final ai = tokens.colors.aiCard;
     final messages = context.messages;
-    final (icon, color, tag) = switch (projectNextStepOutcome(step)) {
+    final (icon, color, tag) = switch (outcome) {
       ProjectNextStepOutcome.added => (
         LottiIcons.confirm,
         ai.accent,
@@ -171,6 +245,19 @@ class _HistoryRow extends StatelessWidget {
                 color: ai.metaText,
               ),
             ),
+            if (onUndo != null &&
+                outcome == ProjectNextStepOutcome.dismissed) ...[
+              SizedBox(width: tokens.spacing.step3),
+              IntrinsicWidth(
+                child: DesignSystemInlineAction(
+                  onTap: busy ? null : onUndo,
+                  semanticsLabel: messages.designSystemUndoLabel,
+                  label: messages.designSystemUndoLabel,
+                  leadingIcon: LottiIcons.undo,
+                  ink: tokens.colors.interactive.enabled,
+                ),
+              ),
+            ],
           ],
         ),
       ),

--- a/lib/features/projects/ui/widgets/next_steps/project_proposal_row.dart
+++ b/lib/features/projects/ui/widgets/next_steps/project_proposal_row.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_widgets_part.dart';
 import 'package:lotti/features/agents/ui/localized_change_summary.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_inline_action.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_swipe_actions.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:material_ui/material_ui.dart';
@@ -13,8 +16,10 @@ import 'package:material_ui/material_ui.dart';
 ///
 /// A pending row carries the task agent's reject/confirm disc rail, so the
 /// same gesture applies the same kind of change on a task page and a project
-/// page. A decided row keeps its place with the shared resolved tag instead of
-/// leaving the band, so what was just done stays legible.
+/// page, and decides by swipe too — right to confirm, left to reject — the way
+/// the task card's proposals and the recommended next steps above it do. A
+/// decided row keeps its place with the shared resolved tag instead of leaving
+/// the band, so what was just done stays legible.
 class ProjectProposalRow extends StatelessWidget {
   const ProjectProposalRow({
     required this.changeSet,
@@ -55,7 +60,7 @@ class ProjectProposalRow extends StatelessWidget {
         localizedChangeSummary(context.messages, item.toolName, item.args) ??
         item.humanSummary;
 
-    return DecoratedBox(
+    final card = DecoratedBox(
       decoration: BoxDecoration(
         color: decided ? ai.subtleWash : ai.row,
         borderRadius: BorderRadius.circular(tokens.radii.s),
@@ -103,6 +108,32 @@ class ProjectProposalRow extends StatelessWidget {
           ],
         ),
       ),
+    );
+
+    final messages = context.messages;
+    final swipeable = enabled && !decided && !busy;
+    return DesignSystemSwipeActions(
+      swipeKey: ValueKey('project-proposal-swipe-${changeSet.id}:$itemIndex'),
+      borderRadius: BorderRadius.circular(tokens.radii.s),
+      startToEnd: swipeable
+          ? DesignSystemSwipeAction(
+              color: ai.accentSoft,
+              foregroundColor: ai.accent,
+              icon: LottiIcons.confirm,
+              label: messages.changeSetSwipeConfirm,
+              onTrigger: () => unawaited(onConfirm()),
+            )
+          : null,
+      endToStart: swipeable
+          ? DesignSystemSwipeAction(
+              color: ai.subtleWashStrong,
+              foregroundColor: ai.metaText,
+              icon: LottiIcons.close,
+              label: messages.changeSetSwipeReject,
+              onTrigger: () => unawaited(onReject()),
+            )
+          : null,
+      child: card,
     );
   }
 }

--- a/lib/features/projects/ui/widgets/project_recommendations_panel.dart
+++ b/lib/features/projects/ui/widgets/project_recommendations_panel.dart
@@ -524,6 +524,12 @@ class _ProjectRecommendationsPanelState
       _historyOpen = false;
       _openHistoryDisclosed = false;
     }
+    // Restoring a step from the history reopens the run. The latch above is
+    // only re-evaluated when the run changes, so without this an Undo on a
+    // run that was already decided when the page opened would leave the
+    // summary standing and the restored step reading as passive history with
+    // no Add task or Dismiss until the user left and came back.
+    if (_collapsed && tally.pending > 0) _collapsed = false;
 
     if (steps.isEmpty) {
       return ProjectNextStepsEmpty(

--- a/lib/features/projects/ui/widgets/project_recommendations_panel.dart
+++ b/lib/features/projects/ui/widgets/project_recommendations_panel.dart
@@ -26,12 +26,13 @@ import 'package:material_ui/material_ui.dart';
 /// its own heading because they ask different questions — advice the user
 /// may turn into a task, versus a mutation the user authorises.
 ///
-/// Every decision leaves its row in place with a tag; nothing is removed on
-/// tap and nothing on the page is invalidated by hand. The service notifies
-/// the agent's update stream, the snapshot provider re-reads, and the row
-/// changes state where it stands. A run whose every step was already decided
-/// when the page opened collapses to a one-line summary with a history
-/// disclosure; decisions made while the page is open stay inline.
+/// Adding a task leaves the step's row in place with a tag, so the task it
+/// created stays linked from where it was decided. **Dismissing takes the step
+/// off the list at once** — dismissed is dismissed — and the step lives on only
+/// in the band's history, which is where the dismissal can be undone. Nothing
+/// on the page is invalidated by hand: the service notifies the agent's update
+/// stream, the snapshot provider re-reads, and the rows follow. Once no step is
+/// open the band collapses to a one-line summary over the same history.
 class ProjectRecommendationsPanel extends ConsumerStatefulWidget {
   const ProjectRecommendationsPanel({
     required this.projectId,
@@ -75,15 +76,21 @@ class _ProjectRecommendationsPanelState
   /// need cleaning up).
   final _failures = <String, ({bool retryable, String? message})>{};
 
-  /// Row states the user just produced, shown until the snapshot catches up
-  /// so a decided row never flickers back through "pending".
-  final _optimistic = <String, ProjectNextStepRowState>{};
+  /// Outcomes the user just produced, applied until the snapshot catches up
+  /// so a decided step never flickers back through "pending".
+  final _optimistic = <String, ProjectNextStepOutcome>{};
   final _undoDeadlines = <String, DateTime>{};
   final _undoTimers = <String, Timer>{};
 
   /// Task ids created this session, so "Open task" works before the snapshot
   /// carries the id.
   final _createdTasks = <String, String>{};
+
+  /// Whether the history of already-decided steps is disclosed under the open
+  /// rows. Independent of [_historyOpen], which belongs to the collapsed
+  /// summary.
+  bool _openHistoryDisclosed = false;
+
   final _busyProposals = <String>{};
 
   /// Proposals decided this session, kept visible with their tag after the
@@ -111,15 +118,10 @@ class _ProjectRecommendationsPanelState
 
   // ---------------------------------------------------------------- steps --
 
-  ProjectNextStepRowState _rowState(ProjectRecommendationEntity step) {
-    if (_busySteps.contains(step.id)) return ProjectNextStepRowState.busy;
-    if (_failures.containsKey(step.id)) return ProjectNextStepRowState.failed;
-    final durable = switch (projectNextStepOutcome(step)) {
-      ProjectNextStepOutcome.pending => ProjectNextStepRowState.pending,
-      ProjectNextStepOutcome.added => ProjectNextStepRowState.added,
-      ProjectNextStepOutcome.done => ProjectNextStepRowState.done,
-      ProjectNextStepOutcome.dismissed => ProjectNextStepRowState.dismissed,
-    };
+  /// The step's durable outcome, with the decision the user just made laid
+  /// over it until the snapshot carries that decision itself.
+  ProjectNextStepOutcome _outcome(ProjectRecommendationEntity step) {
+    final durable = projectNextStepOutcome(step);
     final optimistic = _optimistic[step.id];
     if (optimistic == null) return durable;
     if (optimistic == durable) {
@@ -130,10 +132,28 @@ class _ProjectRecommendationsPanelState
     return optimistic;
   }
 
+  /// A dismissed step is off the list the moment it is dismissed; it is
+  /// reachable — and undoable — only through the history.
+  bool _isDismissed(ProjectRecommendationEntity step) =>
+      _outcome(step) == ProjectNextStepOutcome.dismissed;
+
+  ProjectNextStepRowState _rowState(ProjectRecommendationEntity step) {
+    if (_busySteps.contains(step.id)) return ProjectNextStepRowState.busy;
+    if (_failures.containsKey(step.id)) return ProjectNextStepRowState.failed;
+    return switch (_outcome(step)) {
+      ProjectNextStepOutcome.pending => ProjectNextStepRowState.pending,
+      ProjectNextStepOutcome.added => ProjectNextStepRowState.added,
+      // A dismissed step never reaches a row, and a superseded one reads as
+      // decided, like the model says.
+      ProjectNextStepOutcome.done ||
+      ProjectNextStepOutcome.dismissed => ProjectNextStepRowState.done,
+    };
+  }
+
   bool _canUndo(ProjectRecommendationEntity step, ProjectNextStepRowState s) {
     if (!widget.enabled) return false;
     return switch (s) {
-      ProjectNextStepRowState.dismissed || ProjectNextStepRowState.done => true,
+      ProjectNextStepRowState.done => true,
       ProjectNextStepRowState.added =>
         _undoDeadlines[step.id]?.isAfter(_now) ?? false,
       ProjectNextStepRowState.pending ||
@@ -166,8 +186,8 @@ class _ProjectRecommendationsPanelState
       if (result.success) {
         final taskId = result.mutatedEntityId;
         _optimistic[step.id] = taskId == null
-            ? ProjectNextStepRowState.done
-            : ProjectNextStepRowState.added;
+            ? ProjectNextStepOutcome.done
+            : ProjectNextStepOutcome.added;
         if (taskId != null) {
           _createdTasks[step.id] = taskId;
           widget.onTaskCreated?.call(taskId);
@@ -206,7 +226,7 @@ class _ProjectRecommendationsPanelState
       () => ref
           .read(projectRecommendationServiceProvider)
           .dismissRecommendation(step.id),
-      settled: ProjectNextStepRowState.dismissed,
+      settled: ProjectNextStepOutcome.dismissed,
     );
   }
 
@@ -216,7 +236,7 @@ class _ProjectRecommendationsPanelState
       () => ref
           .read(projectRecommendationServiceProvider)
           .restoreRecommendation(step.id),
-      settled: ProjectNextStepRowState.pending,
+      settled: ProjectNextStepOutcome.pending,
       // Only a successful restore forfeits the undo window and the task
       // link; a refused undo leaves the row exactly as it was.
       onSuccess: () {
@@ -230,7 +250,7 @@ class _ProjectRecommendationsPanelState
   Future<void> _transition(
     ProjectRecommendationEntity step,
     Future<bool> Function() run, {
-    required ProjectNextStepRowState settled,
+    required ProjectNextStepOutcome settled,
     VoidCallback? onSuccess,
   }) async {
     if (_busySteps.contains(step.id)) return;
@@ -393,7 +413,9 @@ class _ProjectRecommendationsPanelState
         ? const <ProjectRecommendationEntity>[]
         : snapshot.steps
               .where(
-                (step) => _rowState(step) == ProjectNextStepRowState.pending,
+                (step) =>
+                    !_isDismissed(step) &&
+                    _rowState(step) == ProjectNextStepRowState.pending,
               )
               .toList();
 
@@ -492,7 +514,7 @@ class _ProjectRecommendationsPanelState
     final tokens = context.designTokens;
     final messages = context.messages;
     final steps = snapshot.steps;
-    final tally = ProjectNextStepsTally.of(steps);
+    final tally = ProjectNextStepsTally.of(steps, outcomeOf: _outcome);
 
     if (!_collapseDecided || _collapseRun != snapshot.runCreatedAt) {
       _collapseDecided = true;
@@ -500,6 +522,7 @@ class _ProjectRecommendationsPanelState
       _collapsed = tally.allDecided;
       _showAllSteps = false;
       _historyOpen = false;
+      _openHistoryDisclosed = false;
     }
 
     if (steps.isEmpty) {
@@ -508,21 +531,34 @@ class _ProjectRecommendationsPanelState
         now: now,
       );
     }
-    if (_collapsed) {
+
+    // A dismissal removes its step from the band at once, so the list the user
+    // reads is the run minus everything they threw away.
+    final listed = steps.where((step) => !_isDismissed(step)).toList();
+    final decided = steps
+        .where((step) => _outcome(step) != ProjectNextStepOutcome.pending)
+        .toList();
+
+    if (_collapsed || listed.isEmpty) {
       return ProjectNextStepsSummary(
         steps: steps,
         runCreatedAt: snapshot.runCreatedAt,
         now: now,
         historyOpen: _historyOpen,
         onToggleHistory: () => setState(() => _historyOpen = !_historyOpen),
+        onUndo: widget.enabled && !_bulkBusy
+            ? (step) => unawaited(_undo(step))
+            : null,
+        busyStepIds: _busySteps,
+        outcomeOf: _outcome,
       );
     }
 
     final phone =
         MediaQuery.sizeOf(context).width < ProjectNextStepRow.wideBreakpoint;
     final visible = visibleProjectNextSteps(
-      steps,
-      cap: phone ? ProjectRecommendationsPanel.phoneStepCap : steps.length,
+      listed,
+      cap: phone ? ProjectRecommendationsPanel.phoneStepCap : listed.length,
       showAll: _showAllSteps,
     );
 
@@ -558,21 +594,56 @@ class _ProjectRecommendationsPanelState
               },
             ),
           ),
-        if (visible.length < steps.length)
+        if (visible.length < listed.length)
           Align(
             alignment: AlignmentDirectional.centerStart,
             child: DesignSystemInlineAction(
               onTap: () => setState(() => _showAllSteps = true),
               semanticsLabel: messages.projectNextStepsShowMore(
-                steps.length - visible.length,
+                listed.length - visible.length,
               ),
               label: messages.projectNextStepsShowMore(
-                steps.length - visible.length,
+                listed.length - visible.length,
               ),
               leadingIcon: LottiIcons.chevronDown,
               ink: tokens.colors.interactive.enabled,
             ),
           ),
+        // With steps still open the band has no summary line to hang the
+        // history off, so it carries its own disclosure — the only route back
+        // to a dismissal.
+        if (decided.isNotEmpty) ...[
+          SizedBox(height: tokens.spacing.step2),
+          Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: IntrinsicWidth(
+              child: DesignSystemInlineAction(
+                onTap: () => setState(
+                  () => _openHistoryDisclosed = !_openHistoryDisclosed,
+                ),
+                semanticsLabel: _openHistoryDisclosed
+                    ? messages.projectNextStepsHideHistory
+                    : messages.projectNextStepsShowHistory,
+                label: _openHistoryDisclosed
+                    ? messages.projectNextStepsHideHistory
+                    : messages.projectNextStepsShowHistory,
+                leadingIcon: _openHistoryDisclosed
+                    ? LottiIcons.chevronUp
+                    : LottiIcons.chevronDown,
+                ink: tokens.colors.interactive.enabled,
+              ),
+            ),
+          ),
+          if (_openHistoryDisclosed)
+            ProjectNextStepsHistory(
+              steps: decided,
+              onUndo: widget.enabled && !_bulkBusy
+                  ? (step) => unawaited(_undo(step))
+                  : null,
+              busyStepIds: _busySteps,
+              outcomeOf: _outcome,
+            ),
+        ],
         if (pending.length > 1) ...[
           SizedBox(height: tokens.spacing.step2),
           Wrap(

--- a/lib/features/projects/ui/widgets/project_tasks_panel.dart
+++ b/lib/features/projects/ui/widgets/project_tasks_panel.dart
@@ -412,52 +412,67 @@ class _ProjectTasksPanelHeader extends StatelessWidget {
         // ellipsis.
         final showDuration = !compact;
         final addTaskEnabled = !isAddingTask && isAddTaskEnabled;
+        final taskCount = record.highlightedTaskSummaries.length;
+        // One tight `Expanded` owns all the slack, so the actions sit flush
+        // against the right edge. A `Spacer` beside loose `Flexible`s used to
+        // split the free space three ways instead, leaving the sort control
+        // and Add task stranded mid-row with unused space after them.
+        // Every element shares the row's default centre line.
         return Row(
           children: [
-            Flexible(
-              child: Semantics(
-                header: true,
-                child: Text(
-                  messages.projectShowcaseProjectTasksTab,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: tokens.typography.styles.subtitle.subtitle2.copyWith(
-                    color: ShowcasePalette.highText(context),
-                  ),
-                ),
-              ),
-            ),
-            SizedBox(width: tokens.spacing.step2),
-            CountDotBadge(count: record.highlightedTaskSummaries.length),
-            if (showDuration) ...[
-              SizedBox(width: tokens.spacing.step2),
-              Flexible(
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(
-                      LottiIcons.timer,
-                      size: tokens.typography.lineHeight.caption,
-                      color: ShowcasePalette.timeGreen(context),
-                    ),
-                    SizedBox(width: tokens.spacing.step1),
-                    Flexible(
+            Expanded(
+              child: Row(
+                children: [
+                  Flexible(
+                    child: Semantics(
+                      header: true,
                       child: Text(
-                        showcaseFormatDuration(
-                          record.highlightedTasksTotalDuration,
-                        ),
+                        messages.projectShowcaseProjectTasksTab,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: tokens.typography.styles.others.caption.copyWith(
-                          color: ShowcasePalette.timeGreen(context),
-                        ),
+                        style: tokens.typography.styles.subtitle.subtitle2
+                            .copyWith(
+                              color: ShowcasePalette.highText(context),
+                            ),
                       ),
                     ),
-                  ],
-                ),
+                  ),
+                  SizedBox(width: tokens.spacing.step2),
+                  CountDotBadge(
+                    count: taskCount,
+                    semanticsLabel: messages.projectTasksGroupCount(taskCount),
+                  ),
+                ],
               ),
+            ),
+            // The total estimate reads as a value belonging to the list, not
+            // as part of the heading, so it joins the trailing rail with the
+            // controls rather than trailing the count badge.
+            if (showDuration) ...[
+              SizedBox(width: tokens.spacing.step3),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    LottiIcons.timer,
+                    size: tokens.typography.lineHeight.caption,
+                    color: ShowcasePalette.timeGreen(context),
+                  ),
+                  SizedBox(width: tokens.spacing.step1),
+                  Text(
+                    showcaseFormatDuration(
+                      record.highlightedTasksTotalDuration,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: tokens.typography.styles.others.caption.copyWith(
+                      color: ShowcasePalette.timeGreen(context),
+                    ),
+                  ),
+                ],
+              ),
+              SizedBox(width: tokens.spacing.step2),
             ],
-            const Spacer(),
             if (onOptionsChanged case final onChanged?)
               if (MediaQuery.sizeOf(context).width >= kDesktopBreakpoint)
                 DesignSystemPopoverAnchor(
@@ -555,6 +570,7 @@ class _ProjectTaskGroupHeader extends StatelessWidget {
       color: ShowcasePalette.lowText(context),
     );
     final duration = group.totalDuration;
+    final border = ShowcasePalette.border(context);
     return Semantics(
       button: true,
       expanded: expanded,
@@ -566,8 +582,18 @@ class _ProjectTaskGroupHeader extends StatelessWidget {
             decoration: BoxDecoration(
               // Opaque: the header stays pinned while rows scroll beneath it.
               color: ShowcasePalette.surface(context),
+              border: Border(bottom: BorderSide(color: border)),
+            ),
+            // The panel's outline is painted *behind* the slivers by the
+            // enclosing `DecoratedSliver`, so the opaque full-width fill above
+            // would erase the card's left and right hairlines wherever a group
+            // starts. The header repaints them over itself — as a foreground
+            // decoration, which paints without insetting the row's content the
+            // way a border side in [decoration] would.
+            foregroundDecoration: BoxDecoration(
               border: Border(
-                bottom: BorderSide(color: ShowcasePalette.border(context)),
+                left: BorderSide(color: border),
+                right: BorderSide(color: border),
               ),
             ),
             padding: EdgeInsets.symmetric(

--- a/lib/features/projects/ui/widgets/shared_tag_widgets.dart
+++ b/lib/features/projects/ui/widgets/shared_tag_widgets.dart
@@ -502,29 +502,51 @@ class TaskStatePill extends StatelessWidget {
   }
 }
 
-/// A circular badge with a count, used in panel headers.
+/// A pill badge with a count, used in panel headers.
+///
+/// A one- or two-digit count still reads as the round dot; a longer one grows
+/// the pill sideways instead of clipping the number, which is what made a
+/// three-digit task count render as its first two digits, off-centre. The
+/// digits stay centred on both axes at every width, and [semanticsLabel]
+/// gives the bare number a meaning for screen readers.
 class CountDotBadge extends StatelessWidget {
-  const CountDotBadge({required this.count, super.key});
+  const CountDotBadge({required this.count, this.semanticsLabel, super.key});
 
   final int count;
+
+  /// Spoken instead of the bare digits — the count alone says nothing about
+  /// what is being counted.
+  final String? semanticsLabel;
 
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
+    final diameter = tokens.spacing.step5 + tokens.spacing.step1;
 
-    return Container(
-      width: tokens.spacing.step5 + tokens.spacing.step1,
-      height: tokens.spacing.step5 + tokens.spacing.step1,
-      decoration: BoxDecoration(
-        color: ShowcasePalette.infoBlue(context),
-        shape: BoxShape.circle,
-      ),
-      alignment: Alignment.center,
-      child: Text(
-        '$count',
-        style: tokens.typography.styles.others.caption.copyWith(
-          color: ShowcasePalette.tagText(context),
-          fontFeatures: numericBadgeFontFeatures,
+    return Semantics(
+      label: semanticsLabel,
+      excludeSemantics: semanticsLabel != null,
+      child: Container(
+        constraints: BoxConstraints(minWidth: diameter, minHeight: diameter),
+        decoration: ShapeDecoration(
+          color: ShowcasePalette.infoBlue(context),
+          shape: const StadiumBorder(),
+        ),
+        padding: EdgeInsets.symmetric(horizontal: tokens.spacing.step1),
+        // Centres the digits inside the minimum box without letting the badge
+        // expand to whatever room the header happens to offer — which is what
+        // a `Container.alignment` would do here.
+        child: Center(
+          widthFactor: 1,
+          heightFactor: 1,
+          child: Text(
+            '$count',
+            textAlign: TextAlign.center,
+            style: tokens.typography.styles.others.caption.copyWith(
+              color: ShowcasePalette.tagText(context),
+              fontFeatures: numericBadgeFontFeatures,
+            ),
+          ),
         ),
       ),
     );

--- a/test/features/ai/ui/ai_response_summary_test.dart
+++ b/test/features/ai/ui/ai_response_summary_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/agents/ui/widgets/agent_markdown_view.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/ui/ai_response_summary.dart';
 import 'package:lotti/features/ai/ui/generated_prompt_card.dart';
@@ -438,10 +439,11 @@ Style: isometric digital art. --ar 16:9
           'The placard confirms the sardine pod docks on 05.10.2026 at '
           '14:30 UTC at the orbital penguin habitat.';
 
-      AiResponseEntry buildResponse(String text) =>
+      AiResponseEntry buildResponse(String text, {String? tldr}) =>
           testAiResponseEntry.copyWith(
             data: testAiResponseEntry.data.copyWith(
               response: text,
+              tldr: tldr,
               type: AiResponseType.imageAnalysis,
             ),
           );
@@ -451,12 +453,13 @@ Style: isometric digital art. --ar 16:9
         required String text,
         bool collapsible = false,
         bool fadeOut = false,
+        String? tldr,
       }) {
         return tester.pumpWidget(
           WidgetTestBench(
             child: SingleChildScrollView(
               child: AiResponseSummary(
-                buildResponse(text),
+                buildResponse(text, tldr: tldr),
                 fadeOut: fadeOut,
                 collapsible: collapsible,
               ),
@@ -479,6 +482,69 @@ Style: isometric digital art. --ar 16:9
         );
         return container.decoration! as BoxDecoration;
       }
+
+      Container card(WidgetTester tester) => tester.widget<Container>(
+        find.byWidgetPredicate(
+          (w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration! as BoxDecoration).color ==
+                  dsTokensLight.colors.aiCard.background.withValues(
+                    alpha: 0.5,
+                  ),
+        ),
+      );
+
+      testWidgets(
+        'the body sits at the editor measure, never louder than the entry '
+        'text it belongs to',
+        (tester) async {
+          await pumpSummary(tester, text: shortSummaryText);
+
+          final body = tester.widget<AgentMarkdownView>(
+            find.byType(AgentMarkdownView),
+          );
+          final editorBody = dsTokensLight.typography.styles.body.bodySmall;
+          expect(
+            body.style?.fontSize,
+            editorBody.fontSize,
+            reason:
+                'An analysis nested in an entry card reads at the same size '
+                'as the entry text editor, not larger.',
+          );
+          expect(body.style?.color, dsTokensLight.colors.aiCard.bodyText);
+        },
+      );
+
+      testWidgets('a collapsed TLDR reads at the same measure as the body', (
+        tester,
+      ) async {
+        await pumpSummary(
+          tester,
+          text: longOcrText,
+          collapsible: true,
+          tldr: 'The short version.',
+        );
+
+        final tldr = tester.widget<Text>(find.text('The short version.'));
+        expect(
+          tldr.style?.fontSize,
+          dsTokensLight.typography.styles.body.bodySmall.fontSize,
+        );
+      });
+
+      testWidgets('the nested card spends a tighter inset than a top-level '
+          'card', (tester) async {
+        await pumpSummary(tester, text: shortSummaryText);
+
+        expect(
+          card(tester).padding,
+          EdgeInsets.all(dsTokensLight.spacing.step4),
+          reason:
+              'A surface nested inside an entry card should not spend a full '
+              'card inset of its own.',
+        );
+      });
 
       testWidgets(
         'renders the tinted aiCard surface: background fill, soft accent '

--- a/test/features/design_system/components/lists/design_system_swipe_actions_test.dart
+++ b/test/features/design_system/components/lists/design_system_swipe_actions_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_swipe_action_background.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_swipe_actions.dart';
+import 'package:material_ui/material_ui.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  DesignSystemSwipeAction action(String label, VoidCallback onTrigger) =>
+      DesignSystemSwipeAction(
+        color: const Color(0xFF102030),
+        foregroundColor: const Color(0xFFAABBCC),
+        icon: Icons.check,
+        label: label,
+        onTrigger: onTrigger,
+      );
+
+  Widget subject({
+    DesignSystemSwipeAction? startToEnd,
+    DesignSystemSwipeAction? endToStart,
+  }) => makeTestableWidgetWithScaffold(
+    SizedBox(
+      width: 400,
+      child: DesignSystemSwipeActions(
+        swipeKey: const ValueKey('row'),
+        borderRadius: BorderRadius.circular(8),
+        startToEnd: startToEnd,
+        endToStart: endToStart,
+        child: const SizedBox(height: 64, child: Text('Row')),
+      ),
+    ),
+  );
+
+  testWidgets('a row with no action is left untouched by the wrapper', (
+    tester,
+  ) async {
+    await tester.pumpWidget(subject());
+
+    expect(find.text('Row'), findsOneWidget);
+    expect(
+      find.byType(Dismissible),
+      findsNothing,
+      reason: 'A row that cannot be decided must not swallow drag gestures.',
+    );
+  });
+
+  testWidgets('the wired directions are the only ones that drag', (
+    tester,
+  ) async {
+    void noop() {}
+
+    await tester.pumpWidget(subject(startToEnd: action('Confirm', noop)));
+    expect(
+      tester.widget<Dismissible>(find.byType(Dismissible)).direction,
+      DismissDirection.startToEnd,
+    );
+
+    await tester.pumpWidget(subject(endToStart: action('Reject', noop)));
+    expect(
+      tester.widget<Dismissible>(find.byType(Dismissible)).direction,
+      DismissDirection.endToStart,
+    );
+
+    await tester.pumpWidget(
+      subject(
+        startToEnd: action('Confirm', noop),
+        endToStart: action('Reject', noop),
+      ),
+    );
+    expect(
+      tester.widget<Dismissible>(find.byType(Dismissible)).direction,
+      DismissDirection.horizontal,
+    );
+  });
+
+  testWidgets('each direction triggers its own action and the row stays', (
+    tester,
+  ) async {
+    var confirmed = 0;
+    var rejected = 0;
+    await tester.pumpWidget(
+      subject(
+        startToEnd: action('Confirm', () => confirmed++),
+        endToStart: action('Reject', () => rejected++),
+      ),
+    );
+
+    await tester.drag(find.text('Row'), const Offset(300, 0));
+    await tester.pumpAndSettle();
+    expect(confirmed, 1);
+    expect(rejected, 0);
+    expect(
+      find.text('Row'),
+      findsOneWidget,
+      reason: 'The row snaps back — its own state records the decision.',
+    );
+
+    await tester.drag(find.text('Row'), const Offset(-300, 0));
+    await tester.pumpAndSettle();
+    expect(rejected, 1);
+    expect(confirmed, 1);
+    expect(find.text('Row'), findsOneWidget);
+  });
+
+  testWidgets('a drag short of the threshold decides nothing', (tester) async {
+    var confirmed = 0;
+    await tester.pumpWidget(
+      subject(startToEnd: action('Confirm', () => confirmed++)),
+    );
+
+    // Well under `threshold` of the 400 pt row.
+    await tester.drag(find.text('Row'), const Offset(40, 0));
+    await tester.pumpAndSettle();
+    expect(confirmed, 0);
+  });
+
+  testWidgets('a one-direction row still names its action while dragging', (
+    tester,
+  ) async {
+    await tester.pumpWidget(subject(endToStart: action('Reject', () {})));
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.text('Row')),
+    );
+    await gesture.moveBy(const Offset(-60, 0));
+    await tester.pump();
+
+    expect(find.text('Reject'), findsOneWidget);
+    expect(
+      find.byType(DesignSystemSwipeActionBackground),
+      findsWidgets,
+      reason: 'The revealed band comes from the shared design-system band.',
+    );
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+}

--- a/test/features/projects/ui/widgets/next_steps/project_next_step_row_test.dart
+++ b/test/features/projects/ui/widgets/next_steps/project_next_step_row_test.dart
@@ -235,27 +235,30 @@ void main() {
     expect(find.text('Undo'), findsOneWidget);
   });
 
-  testWidgets('a dismissed step strikes its title and offers Undo', (
-    tester,
-  ) async {
-    var undone = 0;
-    await tester.pumpWidget(
-      subject(
-        ProjectNextStepRow(
-          step: step,
-          state: ProjectNextStepRowState.dismissed,
-          canUndo: true,
-          onUndo: () => undone++,
+  testWidgets(
+    'a done step keeps its title unstruck and offers Undo while reversible',
+    (tester) async {
+      var undone = 0;
+      await tester.pumpWidget(
+        subject(
+          ProjectNextStepRow(
+            step: step,
+            state: ProjectNextStepRowState.done,
+            canUndo: true,
+            onUndo: () => undone++,
+          ),
         ),
-      ),
-    );
+      );
 
-    final titleStyle = tester.widget<Text>(find.text(title)).style;
-    expect(titleStyle?.decoration, TextDecoration.lineThrough);
-    expect(find.text('Dismissed'), findsOneWidget);
-    await tester.tap(find.text('Undo'));
-    expect(undone, 1);
-  });
+      // A dismissal leaves the band entirely, so no row ever strikes its
+      // title through; the remaining decided states read as outcomes.
+      final titleStyle = tester.widget<Text>(find.text(title)).style;
+      expect(titleStyle?.decoration, isNot(TextDecoration.lineThrough));
+      expect(find.text('Done'), findsOneWidget);
+      await tester.tap(find.text('Undo'));
+      expect(undone, 1);
+    },
+  );
 
   testWidgets('a failed attempt explains itself and offers Retry', (
     tester,

--- a/test/features/projects/ui/widgets/next_steps/project_proposal_row_test.dart
+++ b/test/features/projects/ui/widgets/next_steps/project_proposal_row_test.dart
@@ -165,4 +165,93 @@ void main() {
     expect(find.text('Dismissed'), findsOneWidget);
     expect(find.byType(RowActions), findsNothing);
   });
+
+  group('swipe', () {
+    ProjectProposalRow row({
+      int itemIndex = 0,
+      bool busy = false,
+      bool enabled = true,
+      Future<void> Function()? onConfirm,
+      Future<void> Function()? onReject,
+    }) => ProjectProposalRow(
+      changeSet: changeSet,
+      itemIndex: itemIndex,
+      busy: busy,
+      enabled: enabled,
+      onConfirm: onConfirm ?? () async {},
+      onReject: onReject ?? () async {},
+    );
+
+    testWidgets('a pending proposal confirms right and rejects left', (
+      tester,
+    ) async {
+      var confirmed = 0;
+      var rejected = 0;
+      await tester.pumpWidget(
+        subject(
+          row(
+            onConfirm: () async => confirmed++,
+            onReject: () async => rejected++,
+          ),
+        ),
+      );
+
+      await tester.drag(
+        find.text('Create task: Pack fish'),
+        const Offset(400, 0),
+      );
+      await tester.pumpAndSettle();
+      expect(confirmed, 1);
+      expect(rejected, 0);
+      expect(
+        find.text('Create task: Pack fish'),
+        findsOneWidget,
+        reason: 'The row stays in place and takes its tag, as on a task page.',
+      );
+
+      await tester.drag(
+        find.text('Create task: Pack fish'),
+        const Offset(-400, 0),
+      );
+      await tester.pumpAndSettle();
+      expect(rejected, 1);
+      expect(confirmed, 1);
+    });
+
+    testWidgets('a decided, busy or disabled row does not swipe', (
+      tester,
+    ) async {
+      // Already confirmed.
+      await tester.pumpWidget(subject(row(itemIndex: 1)));
+      expect(find.byType(Dismissible), findsNothing);
+
+      await tester.pumpWidget(subject(row(busy: true)));
+      expect(
+        find.byType(Dismissible),
+        findsNothing,
+        reason: 'A decision already in flight must not be repeated by a drag.',
+      );
+
+      await tester.pumpWidget(subject(row(enabled: false)));
+      expect(find.byType(Dismissible), findsNothing);
+    });
+
+    testWidgets('the drag names what letting go will do', (tester) async {
+      await tester.pumpWidget(subject(row()));
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.text('Create task: Pack fish')),
+      );
+      await gesture.moveBy(const Offset(80, 0));
+      await tester.pump();
+      expect(find.text('Confirm'), findsOneWidget);
+
+      await gesture.moveBy(const Offset(-200, 0));
+      await tester.pump();
+      expect(find.text('Reject'), findsOneWidget);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+  });
 }

--- a/test/features/projects/ui/widgets/project_recommendations_panel_test.dart
+++ b/test/features/projects/ui/widgets/project_recommendations_panel_test.dart
@@ -162,13 +162,18 @@ void main() {
 
     expect(find.text('Recommended next steps'), findsOneWidget);
     expect(find.text('1 pending'), findsNWidgets(2));
-    expect(find.text('Dismissed'), findsOneWidget);
+    expect(
+      find.text('Split the first wave'),
+      findsNothing,
+      reason: 'A dismissed step is off the list — dismissed is dismissed.',
+    );
+    expect(find.text('Dismissed'), findsNothing);
     expect(find.text('Added'), findsOneWidget);
     expect(find.text('Open task'), findsOneWidget);
     expect(
       find.text('Undo'),
-      findsOneWidget,
-      reason: 'A dismissal stays undoable; a stored addition does not.',
+      findsNothing,
+      reason: 'A stored addition is past its undo window.',
     );
     expect(find.text('Proposed changes'), findsOneWidget);
     expect(find.text('Create task: Pack fish'), findsOneWidget);
@@ -179,10 +184,21 @@ void main() {
     );
     final tops = [
       'Confirm the escort',
-      'Split the first wave',
       'Brief the elders',
     ].map((title) => tester.getTopLeft(find.text(title)).dy).toList();
     expect(tops, orderedEquals([...tops]..sort()));
+
+    // The dismissal is not gone, only out of the way: the history discloses it
+    // under the open rows, and that is where it can be taken back.
+    await tester.tap(find.text('Show history'));
+    await tester.pump();
+    expect(find.text('Split the first wave'), findsOneWidget);
+    expect(find.text('Dismissed'), findsOneWidget);
+    expect(
+      find.text('Undo'),
+      findsOneWidget,
+      reason: 'Only the dismissed history row offers Undo.',
+    );
   });
 
   testWidgets(
@@ -326,26 +342,45 @@ void main() {
     expect(find.text('Open task'), findsNothing);
   });
 
-  testWidgets('Dismiss and Undo flip the row in place', (tester) async {
+  testWidgets('Dismiss removes the row; the history takes it back', (
+    tester,
+  ) async {
     when(
       () => service.dismissRecommendation('s1'),
     ).thenAnswer((_) async => true);
     when(
       () => service.restoreRecommendation('s1'),
     ).thenAnswer((_) async => true);
-    await pumpSubject(tester, subject(items: steps.sublist(0, 1)));
+    await pumpSubject(tester, subject(items: steps.sublist(0, 2)));
 
-    await tester.tap(find.text('Dismiss'));
+    await tester.tap(find.text('Dismiss').first);
     await settle(tester);
     verify(() => service.dismissRecommendation('s1')).called(1);
-    expect(find.text('Dismissed'), findsOneWidget);
+    expect(
+      find.text('Confirm the escort'),
+      findsNothing,
+      reason: 'The dismissed step leaves the list at once.',
+    );
+    expect(find.text('Split the first wave'), findsOneWidget);
+
+    await tester.tap(find.text('Show history'));
+    await tester.pump();
     expect(find.text('Confirm the escort'), findsOneWidget);
+    expect(find.text('Dismissed'), findsOneWidget);
 
     await tester.tap(find.text('Undo'));
     await settle(tester);
     verify(() => service.restoreRecommendation('s1')).called(1);
-    expect(find.text('Dismissed'), findsNothing);
-    expect(find.text('Add task'), findsOneWidget);
+    expect(
+      find.text('Dismissed'),
+      findsNothing,
+      reason: 'Nothing is left in the history to show.',
+    );
+    expect(
+      find.text('Add task'),
+      findsNWidgets(2),
+      reason: 'The restored step is open again, beside the untouched one.',
+    );
   });
 
   testWidgets('a refused Undo keeps the tag and says so', (tester) async {
@@ -367,10 +402,17 @@ void main() {
       ),
     );
 
+    await tester.tap(find.text('Show history'));
+    await tester.pump();
     await tester.tap(find.text('Undo'));
     await settle(tester);
 
-    expect(find.text('Dismissed'), findsOneWidget);
+    expect(
+      find.text('Dismissed'),
+      findsOneWidget,
+      reason: 'A refused restore leaves the history row exactly as it was.',
+    );
+    expect(find.text('Split the first wave'), findsOneWidget);
     expect(find.text(updateError), findsOneWidget);
   });
 
@@ -431,6 +473,11 @@ void main() {
     expect(added, ['s1', 's2', 's4']);
     expect(find.text('Added'), findsNWidgets(3));
     expect(find.text('Add all as tasks'), findsNothing);
+    expect(
+      find.text('Brief the elders'),
+      findsNothing,
+      reason: 'The already-dismissed step was never a row to act on.',
+    );
 
     await pumpSubject(
       tester,
@@ -440,7 +487,13 @@ void main() {
     await settle(tester);
     await settle(tester);
     expect(dismissed, ['s1', 's2']);
+    // Every step is gone from the list; the band says what happened and keeps
+    // both dismissals in its history.
+    expect(find.textContaining('Last run: 2 dismissed'), findsOneWidget);
+    await tester.tap(find.text('Show history'));
+    await tester.pump();
     expect(find.text('Dismissed'), findsNWidgets(2));
+    expect(find.text('Undo'), findsNWidgets(2));
   });
 
   testWidgets('a phone shows three rows until Show more', (tester) async {
@@ -501,21 +554,46 @@ void main() {
     },
   );
 
-  testWidgets('decisions made on the page keep their rows inline', (
-    tester,
-  ) async {
-    when(
-      () => service.dismissRecommendation(any()),
-    ).thenAnswer((_) async => true);
-    await pumpSubject(tester, subject(items: steps.sublist(0, 1)));
+  testWidgets(
+    'an addition made on the page keeps its row; a dismissal empties the band',
+    (tester) async {
+      when(() => service.createTask('s1')).thenAnswer(
+        (_) async => const ToolExecutionResult(
+          success: true,
+          output: '',
+          mutatedEntityId: 'task-1',
+        ),
+      );
+      when(
+        () => service.dismissRecommendation(any()),
+      ).thenAnswer((_) async => true);
+      await pumpSubject(tester, subject(items: steps.sublist(0, 2)));
 
-    await tester.tap(find.text('Dismiss'));
-    await settle(tester);
+      await tester.tap(find.text('Add task').first);
+      await settle(tester);
+      expect(find.textContaining('Last run:'), findsNothing);
+      expect(
+        find.text('Confirm the escort'),
+        findsOneWidget,
+        reason: 'An addition keeps its row, linked to the task it made.',
+      );
 
-    expect(find.textContaining('Last run:'), findsNothing);
-    expect(find.text('Dismissed'), findsOneWidget);
-    expect(find.text('Confirm the escort'), findsOneWidget);
-  });
+      await tester.tap(find.text('Dismiss'));
+      await settle(tester);
+
+      // The added row stays — it links the task it made — while the dismissed
+      // one is off the list, reachable only from the history under it.
+      expect(find.text('Confirm the escort'), findsOneWidget);
+      expect(find.text('Added'), findsOneWidget);
+      expect(find.text('Split the first wave'), findsNothing);
+      expect(find.textContaining('Last run:'), findsNothing);
+
+      await tester.tap(find.text('Show history'));
+      await tester.pump();
+      expect(find.text('Split the first wave'), findsOneWidget);
+      expect(find.text('Dismissed'), findsOneWidget);
+    },
+  );
 
   testWidgets('an empty run explains itself with when the agent last looked', (
     tester,

--- a/test/features/projects/ui/widgets/project_recommendations_panel_test.dart
+++ b/test/features/projects/ui/widgets/project_recommendations_panel_test.dart
@@ -555,6 +555,58 @@ void main() {
   );
 
   testWidgets(
+    "undoing from a decided run's history reopens the step with its controls",
+    (tester) async {
+      when(
+        () => service.restoreRecommendation('s2'),
+      ).thenAnswer((_) async => true);
+      await pumpSubject(
+        tester,
+        subject(
+          items: [
+            step(
+              's1',
+              'Confirm the escort',
+              status: ProjectRecommendationStatus.resolved,
+              createdTaskId: 'task-1',
+            ),
+            step(
+              's2',
+              'Split the first wave',
+              position: 1,
+              status: ProjectRecommendationStatus.dismissed,
+            ),
+          ],
+        ),
+      );
+
+      // The run was already decided when the page opened, so the band starts
+      // collapsed to its summary.
+      expect(find.textContaining('Last run:'), findsOneWidget);
+      await tester.tap(find.text('Show history'));
+      await tester.pump();
+      await tester.tap(find.text('Undo'));
+      await settle(tester);
+
+      verify(() => service.restoreRecommendation('s2')).called(1);
+      // The collapse decision is latched per run, so without reopening it the
+      // restored step would stay stuck in the summary as passive history.
+      expect(
+        find.textContaining('Last run:'),
+        findsNothing,
+        reason: 'A step is open again, so the band is no longer a summary.',
+      );
+      expect(find.text('Split the first wave'), findsOneWidget);
+      expect(
+        find.text('Add task'),
+        findsOneWidget,
+        reason: 'The restored step is actionable, not passive history.',
+      );
+      expect(find.text('Dismiss'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
     'an addition made on the page keeps its row; a dismissal empties the band',
     (tester) async {
       when(() => service.createTask('s1')).thenAnswer(

--- a/test/features/projects/ui/widgets/project_tasks_panel_test.dart
+++ b/test/features/projects/ui/widgets/project_tasks_panel_test.dart
@@ -12,6 +12,8 @@ import 'package:lotti/features/projects/ui/model/project_task_groups.dart';
 import 'package:lotti/features/projects/ui/model/project_task_list_options.dart';
 import 'package:lotti/features/projects/ui/widgets/project_task_list_options_sheet.dart';
 import 'package:lotti/features/projects/ui/widgets/project_tasks_panel.dart';
+import 'package:lotti/features/projects/ui/widgets/shared_tag_widgets.dart';
+import 'package:lotti/features/projects/ui/widgets/showcase/showcase_palette.dart';
 import 'package:material_ui/material_ui.dart';
 
 import '../../../../test_utils/material_ui_finders.dart';
@@ -421,6 +423,168 @@ void main() {
       expect(find.text('3'), findsOneWidget, reason: 'count badge');
       expect(find.text('3h 40m'), findsOneWidget, reason: 'total estimate');
     });
+
+    testWidgets(
+      'the header reads title, count, then a trailing rail flush to the right',
+      (tester) async {
+        await tester.pumpWidget(
+          wrapSliver(
+            ProjectTasksSliverPanel(
+              record: record,
+              now: now,
+              onOptionsChanged: (_) {},
+              onAddTask: () {},
+            ),
+            width: 900,
+          ),
+        );
+        await tester.pump();
+
+        final header = tester.getRect(find.text('Project Tasks'));
+        final badge = tester.getRect(find.byType(CountDotBadge));
+        final duration = tester.getRect(find.text('3h 40m'));
+        final sort = tester.getRect(find.byIcon(LottiIcons.sort));
+        final addTask = tester.getRect(find.text('Add task'));
+
+        // The count belongs to the heading it counts; the estimate is a value
+        // of the list and joins the controls in the trailing rail.
+        expect(badge.left, greaterThan(header.right));
+        expect(duration.left, greaterThan(badge.right));
+        expect(sort.left, greaterThan(duration.right));
+        expect(
+          addTask.left,
+          greaterThan(sort.right),
+          reason: 'Sort sits with the actions, immediately before Add task.',
+        );
+
+        // A `Spacer` beside loose `Flexible`s used to split the free space
+        // three ways, stranding the controls mid-row with slack behind them.
+        final panel = tester.getRect(find.byType(CustomScrollView));
+        expect(
+          panel.right - tester.getRect(find.byType(DesignSystemButton)).right,
+          lessThan(40),
+          reason: 'The actions end at the card edge, not somewhere before it.',
+        );
+        expect(
+          badge.left - header.right,
+          lessThan(40),
+          reason: 'The badge stays beside its heading, not adrift from it.',
+        );
+      },
+    );
+
+    testWidgets('every header element is centred on one another', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        wrapSliver(
+          ProjectTasksSliverPanel(
+            record: record,
+            now: now,
+            onOptionsChanged: (_) {},
+            onAddTask: () {},
+          ),
+          width: 900,
+        ),
+      );
+      await tester.pump();
+
+      final centre = tester.getRect(find.text('Project Tasks')).center.dy;
+      for (final finder in [
+        find.byType(CountDotBadge),
+        find.text('3h 40m'),
+        // The rows carry a timer glyph too; the header's is the first built.
+        find.byIcon(LottiIcons.timer).first,
+        find.byIcon(LottiIcons.sort),
+        find.text('Add task'),
+      ]) {
+        expect(
+          tester.getRect(finder).center.dy,
+          closeTo(centre, 1.5),
+          reason: 'Header elements share one vertical centre.',
+        );
+      }
+    });
+
+    testWidgets(
+      'a pinned group header repaints the card outline it paints over',
+      (tester) async {
+        await tester.pumpWidget(
+          wrapSliver(ProjectTasksSliverPanel(record: record, now: now)),
+        );
+        await tester.pump();
+
+        // The panel's outline is painted behind the slivers, so the header's
+        // opaque full-width fill would erase the card's left and right
+        // hairlines wherever a group starts. It has to carry them itself.
+        final header = find.byKey(
+          const ValueKey('project-task-group-month:2026-9'),
+        );
+        expect(header, findsOneWidget);
+        final decorated = tester.widget<Container>(
+          find.descendant(of: header, matching: find.byType(Container)).first,
+        );
+        final sides =
+            (decorated.foregroundDecoration! as BoxDecoration).border!
+                as Border;
+        final border = ShowcasePalette.border(
+          tester.element(find.text('September 2026')),
+        );
+        expect(sides.left.color, border);
+        expect(sides.right.color, border);
+        expect(sides.left.width, BorderWidths.hairline);
+        expect(
+          sides.top,
+          BorderSide.none,
+          reason: 'Only the sides are missing; the top would double a divider.',
+        );
+
+        // The hairlines only land on the card's own outline if the header
+        // spans the panel edge to edge.
+        final panel = tester.getRect(find.byType(CustomScrollView));
+        final headerRect = tester.getRect(header);
+        expect(headerRect.left, closeTo(panel.left, 0.01));
+        expect(headerRect.right, closeTo(panel.right, 0.01));
+
+        // Carried as a foreground decoration, the sides paint over the fill
+        // without insetting the row's content the way a border side in
+        // `decoration` would.
+        expect(
+          (decorated.decoration! as BoxDecoration).border,
+          isA<Border>().having(
+            (b) => b.left,
+            'left',
+            BorderSide.none,
+          ),
+          reason: 'The laid-out border stays the bottom rule only.',
+        );
+      },
+    );
+
+    testWidgets(
+      'the compact header drops the estimate and shrinks Add task to a glyph',
+      (tester) async {
+        await tester.pumpWidget(
+          wrapSliver(
+            ProjectTasksSliverPanel(
+              record: record,
+              now: now,
+              onOptionsChanged: (_) {},
+              onAddTask: () {},
+            ),
+            width: 360,
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('3h 40m'), findsNothing);
+        expect(find.text('Add task'), findsNothing);
+        expect(find.text('Project Tasks'), findsOneWidget);
+        expect(find.byType(CountDotBadge), findsOneWidget);
+        expect(find.byIcon(LottiIcons.add), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      },
+    );
 
     testWidgets(
       'groups by creation month, newest first, and folds done tasks',

--- a/test/features/projects/ui/widgets/shared_widgets_test.dart
+++ b/test/features/projects/ui/widgets/shared_widgets_test.dart
@@ -487,6 +487,84 @@ void main() {
 
       expect(find.text('7'), findsOneWidget);
     });
+
+    testWidgets(
+      'a three-digit count renders whole and centred instead of being clipped '
+      'by a fixed circle',
+      (tester) async {
+        // The badge used to be a fixed 18pt circle, so a project with 153
+        // tasks read as "15" — the third digit fell outside the box, and what
+        // was left sat off-centre. The pill has to grow instead.
+        Future<Rect> badgeRect(int count) async {
+          await tester.pumpWidget(
+            wrap(
+              Align(
+                alignment: Alignment.topLeft,
+                child: CountDotBadge(count: count),
+              ),
+            ),
+          );
+          await tester.pump();
+          return tester.getRect(find.byType(CountDotBadge));
+        }
+
+        final oneDigit = await badgeRect(7);
+        final threeDigits = await badgeRect(153);
+        expect(
+          threeDigits.width,
+          greaterThan(oneDigit.width),
+          reason:
+              'A fixed-diameter circle would clip "153" to "15"; the pill has '
+              'to make room for the digits it is given.',
+        );
+
+        final label = tester.getRect(find.text('153'));
+        expect(
+          label.width,
+          lessThanOrEqualTo(threeDigits.width),
+          reason: 'The whole number has to fit inside the badge.',
+        );
+        expect(label.center.dx, closeTo(threeDigits.center.dx, 0.5));
+        expect(label.center.dy, closeTo(threeDigits.center.dy, 0.5));
+      },
+    );
+
+    testWidgets('a short count keeps the round dot', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const Align(
+            alignment: Alignment.topLeft,
+            child: CountDotBadge(count: 7),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final badge = tester.getSize(find.byType(CountDotBadge));
+      expect(
+        badge.width,
+        badge.height,
+        reason: 'One digit still reads as a circle, not a stretched pill.',
+      );
+    });
+
+    testWidgets('the bare number is given a meaning for screen readers', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        wrap(const CountDotBadge(count: 4, semanticsLabel: '4 tasks')),
+      );
+      await tester.pump();
+
+      expect(find.bySemanticsLabel('4 tasks'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('4'),
+        findsNothing,
+        reason: 'The digits alone are excluded once they have a label.',
+      );
+      handle.dispose();
+    });
   });
 
   group('NoResultsPane', () {


### PR DESCRIPTION
Five defects found while reviewing the running app after the projects AI section landed, plus the swipe gap that came with it.

## Dismissed next steps stay on the list

A dismissed suggestion kept its row with a strikethrough, so a project you had triaged looked exactly as long as one you had not. Dismissed is now dismissed: the step leaves the band immediately and lives on in the band's **history**, disclosed under the open rows, which is where the dismissal is undone — the pattern the task agent card already uses. `ProjectNextStepRowState.dismissed` is gone rather than left unreachable, and `ProjectNextStepsHistory` is now shared by the collapsed summary and the open-rows disclosure.

Every surface that renders an outcome takes a `ProjectNextStepOutcomeReader` instead of reading the entity, so the panel's optimistic overlay reaches the tally and the history rows too — a dismissal counts before the snapshot carries it.

| before | after |
|---|---|
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-ai-band-and-task-header/6f4445b0a1ea2587bd5fef9787ce407105d09442/before/project_next_steps_desktop_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-ai-band-and-task-header/6f4445b0a1ea2587bd5fef9787ce407105d09442/after/project_next_steps_desktop_dark.png) |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-ai-band-and-task-header/6f4445b0a1ea2587bd5fef9787ce407105d09442/before/project_next_steps_mobile_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-ai-band-and-task-header/6f4445b0a1ea2587bd5fef9787ce407105d09442/after/project_next_steps_mobile_dark.png) |

## Project Tasks header

Three separate faults in one row, all visible in the pair below.

- **The count was wrong because it was clipped.** `CountDotBadge` was a fixed 18pt circle, so a project with 153 tasks rendered as "15", digits spilling out and off-centre. It is a stadium with a minimum diameter now: round for one or two digits, growing beyond, and it takes a `semanticsLabel` because bare digits say nothing about what is counted.
- **The actions were not right-aligned.** A `Spacer` beside two loose `Flexible`s split the free space three ways, so the sort control and Add task sat mid-row with unused space behind them. One tight `Expanded` around the heading owns the slack instead.
- **The total estimate was in the wrong place.** It was wedged between the heading and its count; it is a value of the list, not part of the heading, so it joins the trailing rail before the sort control.

## Month group headings cut the card open

`DecoratedSliver` paints the panel outline *behind* its slivers, so a pinned group heading's opaque full-width fill erased the card's left and right hairlines at every group. The heading repaints them as a **foreground** decoration — a border side in `decoration` would inset its label a hairline out of line with the rows beneath it.

| before | after |
|---|---|
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-ai-band-and-task-header/6f4445b0a1ea2587bd5fef9787ce407105d09442/before/project_tasks_header_desktop_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-ai-band-and-task-header/6f4445b0a1ea2587bd5fef9787ce407105d09442/after/project_tasks_header_desktop_dark.png) |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-ai-band-and-task-header/6f4445b0a1ea2587bd5fef9787ce407105d09442/before/project_tasks_header_mobile_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-ai-band-and-task-header/6f4445b0a1ea2587bd5fef9787ce407105d09442/after/project_tasks_header_mobile_dark.png) |

## AI analyses on image and audio entries were set too large

The body rendered through raw `GptMarkdown`, inheriting the ambient theme, so a nested analysis read louder than the entry text it belongs to, in a card padded like a top-level one. It goes through the existing `AgentMarkdownView` now — the editor's own `body.bodySmall` measure and heading mapping — in a card one spacing step tighter. The collapsed TLDR takes the same measure.

| before | after |
|---|---|
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-ai-band-and-task-header/6f4445b0a1ea2587bd5fef9787ce407105d09442/before/ai_response_card_desktop_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-ai-band-and-task-header/6f4445b0a1ea2587bd5fef9787ce407105d09442/after/ai_response_card_desktop_dark.png) |
| ![before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-ai-band-and-task-header/6f4445b0a1ea2587bd5fef9787ce407105d09442/before/ai_response_card_mobile_dark.png) | ![after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/project-ai-band-and-task-header/6f4445b0a1ea2587bd5fef9787ce407105d09442/after/ai_response_card_mobile_dark.png) |

## Swipe on the project AI card's proposals

Proposal rows on a project page did not swipe, though the task page's proposals and the next steps beside them did. Both bands now go through **`DesignSystemSwipeActions`** (new, `design_system/components/lists/`): one wrapper owning the `Dismissible`, the direction derived from which sides were wired, the shared threshold, the clip, and the never-actually-dismiss contract. A surface passes only its palette and its labels. Give it neither direction and it returns the child untouched, so a decided or disabled row does not swallow drag gestures. It also absorbs a `Dismissible` sharp edge — a secondary background is rejected without a primary one, so a one-direction row hands the same band to both slots and lets `direction` keep the unused one out of reach.

## Notes for review

- **`aiCard.*` tokens are already in the bundle.** The pending action item is done: `color.aiCard` (18 entries) is in `assets/design_system/tokens.json` and generated as `DsColorsAiCard`. There is no `color-mix`/`--interactive` workaround left anywhere, and nothing here depends on a missing token.
- Regression coverage was re-run **with each fix reverted** — the badge, group-border and AI-card tests fail against the old code, so they are testing the fix and not the tree.
- Screenshot fixtures are Project Waddle (the penguin demo world) only.
- Docs updated in the same change: `knowledge/features/projects.md`, `knowledge/features/ai/execution-paths.md`, `knowledge/features/design_system/component-contracts.md`. `make analyze`, `make knowledge_check`, `make okf_check` and `make changelog_check` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added swipe gestures to accept or reject proposed project changes.
  - Dismissed AI recommendations now move to a collapsible history section with Undo.
  - Task count badges expand to display larger numbers without clipping.

- **Bug Fixes**
  - Improved Project Tasks header alignment and border rendering, including month transitions.
  - Standardized AI analysis text sizing and spacing across content types.
  - Improved compact-width task controls and accessibility labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->