### PR TITLE
fix(relationships): route the briefing through the category's default profile

### DIFF
--- a/changelog.d/2026-09-06-relationship-briefing-category-profile.md
+++ b/changelog.d/2026-09-06-relationship-briefing-category-profile.md
@@ -1,0 +1,9 @@
+### Fixed
+- **"Brief me" on a person's page failed with "Could not request the
+  briefing."** The relationship agent only looked for an AI route on the
+  person themselves or on its own configuration — neither of which any screen
+  sets — and otherwise insisted on one specific cloud model. It now also uses
+  the default AI profile of the person's category, the same way a spoken
+  check-in already picks its transcription model, so a briefing works with
+  whatever profile you route that category through. A cloud provider is still
+  named for consent before the run.

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -419,14 +419,25 @@ removed:
   completion stream (shutdown, runtime teardown) fails the turn rather than
   leaving the caller on a future that can no longer complete, which would
   strand the composer disabled.
+- **One resolution chain, first resolvable wins.**
+  `resolveRelationshipAgentModel` routes inference through the person's own
+  profile (`RelationshipData.profileId`), then the agent config's profile,
+  then the **default profile of the person's category** (the `JournalDb`
+  read the automation resolver uses for a spoken check-in's transcript), then
+  the validated default model (ADR 0040 Decision 6, ADR 0059 Decision 7).
+  The category step is the one an ordinary setup actually reaches: no screen
+  pins a profile on a person and agent creation sets none, so without it a
+  user who routes the category through their own profile had no route at
+  all and "Brief me" failed with a generic toast. A dangling id at any step
+  falls through to the next.
 - **Disclosure fails closed.** The "Brief me" card resolves the agent's
-  model to a provider name; a cloud provider is named in a consent dialog
-  first (ADR 0037), and an unresolvable profile is treated as cloud. The
-  relationship read is unfiltered — Phase B resolves through the person's
-  own profile whatever this device's private-entry display preference, so
-  the dialog must see the same row — and a route that resolves to nothing
-  at all throws (the card surfaces the failure) rather than reading as
-  "local, proceed silently".
+  model to a provider name through that same chain; a cloud provider is
+  named in a consent dialog first (ADR 0037), and an unresolvable profile is
+  treated as cloud. The relationship read is unfiltered — Phase B resolves
+  through the person's own profile whatever this device's private-entry
+  display preference, so the dialog must see the same row — and a route that
+  resolves to nothing at all throws (the card surfaces the failure and logs
+  the reason) rather than reading as "local, proceed silently".
 
 ## The briefing wears the shared AI panel
 

--- a/lib/features/relationships/README.md
+++ b/lib/features/relationships/README.md
@@ -50,9 +50,8 @@ the `enable_relationships` flag):
   briefing renders as Markdown and its "Read more" and "Open agent
   internals" behave exactly as they do on a task ("Brief me" names the cloud
   provider first, per ADR 0037) — and `/people/<id>/chat`
-  opens the per-person agent chat. The briefing's model comes from the
-  person's own profile, else the default profile of their category, else the
-  validated default model. Banners surface through the
+  opens the per-person agent chat. A briefing runs on the AI profile of the
+  person's category unless the person has one of their own. Banners surface through the
   kind-agnostic channel (`lib/features/nudges/`), tapping through to the
   person.
 

--- a/lib/features/relationships/README.md
+++ b/lib/features/relationships/README.md
@@ -50,7 +50,9 @@ the `enable_relationships` flag):
   briefing renders as Markdown and its "Read more" and "Open agent
   internals" behave exactly as they do on a task ("Brief me" names the cloud
   provider first, per ADR 0037) — and `/people/<id>/chat`
-  opens the per-person agent chat. Banners surface through the
+  opens the per-person agent chat. The briefing's model comes from the
+  person's own profile, else the default profile of their category, else the
+  validated default model. Banners surface through the
   kind-agnostic channel (`lib/features/nudges/`), tapping through to the
   person.
 

--- a/lib/features/relationships/state/relationship_agent_providers.dart
+++ b/lib/features/relationships/state/relationship_agent_providers.dart
@@ -19,6 +19,7 @@ import 'package:lotti/features/relationships/service/relationship_chat_service.d
 import 'package:lotti/features/relationships/service/relationship_reminder_service.dart';
 import 'package:lotti/features/relationships/workflow/relationship_agent_workflow.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/providers/service_providers.dart' show journalDbProvider;
 
 /// The OS-reminder projection of the cadence verdict (ADR 0039, plan v2
 /// phase 8) — durable inbox rows first, OS alarms second.
@@ -57,6 +58,20 @@ final relationshipAgentServiceProvider = Provider<RelationshipAgentService>(
   name: 'relationshipAgentServiceProvider',
 );
 
+/// The person's category default profile — the third step of the
+/// relationship-agent resolution chain (ADR 0040 Decision 6). The same
+/// `JournalDb` read the automation resolver uses, so a category's default
+/// routes the briefing exactly as it routes a spoken check-in's transcript.
+Future<String?> relationshipCategoryDefaultProfileId(
+  Ref ref,
+  String categoryId,
+) async {
+  final category = await ref
+      .read(journalDbProvider)
+      .getCategoryById(categoryId);
+  return category?.defaultProfileId;
+}
+
 /// Phase B — the lease-elected LLM tier (briefing, banner, chat).
 final relationshipAgentWorkflowProvider = Provider<RelationshipAgentWorkflow>(
   (ref) => RelationshipAgentWorkflow(
@@ -68,6 +83,8 @@ final relationshipAgentWorkflowProvider = Provider<RelationshipAgentWorkflow>(
     cloudInferenceRepository: ref.watch(cloudInferenceRepositoryProvider),
     aiConfigRepository: ref.watch(aiConfigRepositoryProvider),
     domainLogger: ref.watch(domainLoggerProvider),
+    categoryProfileLookup: (categoryId) =>
+        relationshipCategoryDefaultProfileId(ref, categoryId),
   ),
   name: 'relationshipAgentWorkflowProvider',
 );
@@ -179,6 +196,8 @@ relationshipBriefingDisclosureProvider = FutureProvider.autoDispose
         relationship: relationship,
         agentIdentity: identity is AgentIdentityEntity ? identity : null,
         aiConfigRepository: aiConfigRepository,
+        categoryProfileLookup: (categoryId) =>
+            relationshipCategoryDefaultProfileId(ref, categoryId),
       );
       if (resolved == null) {
         throw StateError(

--- a/lib/features/relationships/state/relationship_agent_providers.dart
+++ b/lib/features/relationships/state/relationship_agent_providers.dart
@@ -6,6 +6,7 @@ import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/agent_runtime_registry.dart';
 import 'package:lotti/features/ai/conversation/conversation_repository.dart';
+import 'package:lotti/features/ai/helpers/profile_automation_resolver.dart';
 import 'package:lotti/features/ai/helpers/profile_locality.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
@@ -59,18 +60,21 @@ final relationshipAgentServiceProvider = Provider<RelationshipAgentService>(
 );
 
 /// The person's category default profile — the third step of the
-/// relationship-agent resolution chain (ADR 0040 Decision 6). The same
-/// `JournalDb` read the automation resolver uses, so a category's default
-/// routes the briefing exactly as it routes a spoken check-in's transcript.
-Future<String?> relationshipCategoryDefaultProfileId(
-  Ref ref,
-  String categoryId,
-) async {
-  final category = await ref
-      .read(journalDbProvider)
-      .getCategoryById(categoryId);
-  return category?.defaultProfileId;
-}
+/// relationship-agent resolution chain (ADR 0040 Decision 6), shared by the
+/// workflow and the briefing disclosure so both consult the same read: the
+/// `JournalDb` category row the automation resolver uses for a spoken
+/// check-in's transcript, so a category's default routes the briefing
+/// exactly as it routes the transcript.
+final relationshipCategoryProfileLookupProvider =
+    Provider<CategoryProfileLookup>(
+      (ref) => (categoryId) async {
+        final category = await ref
+            .read(journalDbProvider)
+            .getCategoryById(categoryId);
+        return category?.defaultProfileId;
+      },
+      name: 'relationshipCategoryProfileLookupProvider',
+    );
 
 /// Phase B — the lease-elected LLM tier (briefing, banner, chat).
 final relationshipAgentWorkflowProvider = Provider<RelationshipAgentWorkflow>(
@@ -83,8 +87,7 @@ final relationshipAgentWorkflowProvider = Provider<RelationshipAgentWorkflow>(
     cloudInferenceRepository: ref.watch(cloudInferenceRepositoryProvider),
     aiConfigRepository: ref.watch(aiConfigRepositoryProvider),
     domainLogger: ref.watch(domainLoggerProvider),
-    categoryProfileLookup: (categoryId) =>
-        relationshipCategoryDefaultProfileId(ref, categoryId),
+    categoryProfileLookup: ref.watch(relationshipCategoryProfileLookupProvider),
   ),
   name: 'relationshipAgentWorkflowProvider',
 );
@@ -196,8 +199,9 @@ relationshipBriefingDisclosureProvider = FutureProvider.autoDispose
         relationship: relationship,
         agentIdentity: identity is AgentIdentityEntity ? identity : null,
         aiConfigRepository: aiConfigRepository,
-        categoryProfileLookup: (categoryId) =>
-            relationshipCategoryDefaultProfileId(ref, categoryId),
+        categoryProfileLookup: ref.watch(
+          relationshipCategoryProfileLookupProvider,
+        ),
       );
       if (resolved == null) {
         throw StateError(

--- a/lib/features/relationships/ui/widgets/relationship_briefing_card.dart
+++ b/lib/features/relationships/ui/widgets/relationship_briefing_card.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
@@ -121,7 +123,17 @@ class _RelationshipBriefingCardState
         tone: DesignSystemToastTone.success,
         title: messages.relationshipBriefingRequested,
       );
-    } catch (_) {
+    } catch (error, stackTrace) {
+      // The toast is generic on purpose (the card has no inline error
+      // state yet); the reason — most often "no inference provider
+      // resolves" — must at least reach the log, or the failure is
+      // undiagnosable from a device.
+      developer.log(
+        'Failed to request a briefing',
+        name: 'RelationshipBriefingCard',
+        error: error,
+        stackTrace: stackTrace,
+      );
       if (!mounted) return;
       context.showToast(
         tone: DesignSystemToastTone.error,

--- a/lib/features/relationships/workflow/relationship_agent_workflow.dart
+++ b/lib/features/relationships/workflow/relationship_agent_workflow.dart
@@ -17,6 +17,7 @@ import 'package:lotti/features/agents/workflow/agent_system_prompt.dart';
 import 'package:lotti/features/agents/workflow/carrierless_attribution.dart';
 import 'package:lotti/features/agents/workflow/wake_result.dart';
 import 'package:lotti/features/ai/conversation/conversation_repository.dart';
+import 'package:lotti/features/ai/helpers/profile_automation_resolver.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/inference_usage.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
@@ -73,23 +74,41 @@ typedef RelationshipModelResolution = ({
   String? profileId,
 });
 
-/// The single model-resolution chain for relationship-agent inference: the
-/// relationship's own AI profile (`RelationshipData.profileId`, ADR 0059
-/// Decision 7 / plan D6), then the agent config's profile, then the
-/// validated default model. Phase B and the briefing disclosure both
-/// resolve through here so the provider a consent surface names is the one
-/// that actually runs.
+/// The single model-resolution chain for relationship-agent inference
+/// (ADR 0040 Decision 6, ADR 0059 Decision 7 / plan D6), first resolvable
+/// wins: the relationship's own AI profile (`RelationshipData.profileId`),
+/// then the agent config's profile, then the **default profile of the
+/// person's category** (looked up through [categoryProfileLookup]), then the
+/// validated default model. Phase B and the briefing disclosure both resolve
+/// through here so the provider a consent surface names is the one that
+/// actually runs.
+///
+/// The category step is what makes "Brief me" work for the ordinary setup:
+/// no screen pins a profile on a person, agent creation sets none on the
+/// agent, and the validated default is one specific cloud model — a user
+/// whose category routes everything else through their own profile was
+/// left with no route at all, and the card reported only "could not request
+/// the briefing". A dangling id at any step falls through to the next; the
+/// lookup is optional so callers without a category source keep the
+/// two-step chain.
 Future<RelationshipModelResolution?> resolveRelationshipAgentModel({
   required RelationshipEntry? relationship,
   required AgentIdentityEntity? agentIdentity,
   required AiConfigRepository aiConfigRepository,
+  CategoryProfileLookup? categoryProfileLookup,
 }) async {
-  final profileId =
-      relationship?.data.profileId ?? agentIdentity?.config.profileId;
-  if (profileId != null) {
-    final profile = await ProfileResolver(
-      aiConfigRepository: aiConfigRepository,
-    ).resolveByProfileId(profileId);
+  final categoryId = relationship?.meta.categoryId;
+  final candidateProfileIds = <String>{
+    ?relationship?.data.profileId,
+    ?agentIdentity?.config.profileId,
+    if (categoryId != null && categoryProfileLookup != null)
+      ?await categoryProfileLookup(categoryId),
+  };
+  final profileResolver = ProfileResolver(
+    aiConfigRepository: aiConfigRepository,
+  );
+  for (final profileId in candidateProfileIds) {
+    final profile = await profileResolver.resolveByProfileId(profileId);
     if (profile != null) {
       return (
         modelId: profile.thinkingModelId,
@@ -134,6 +153,7 @@ class RelationshipAgentWorkflow with AgentErrorLogging {
     required this._aiConfigRepository,
     this._factsRenderer = const RelationshipFactsRenderer(),
     this._domainLogger,
+    this._categoryProfileLookup,
   });
 
   final AgentRepository _repository;
@@ -145,6 +165,10 @@ class RelationshipAgentWorkflow with AgentErrorLogging {
   final AiConfigRepository _aiConfigRepository;
   final RelationshipFactsRenderer _factsRenderer;
   final DomainLogger? _domainLogger;
+
+  /// The person's category default profile, the third step of
+  /// [resolveRelationshipAgentModel]. Null keeps the chain at two steps.
+  final CategoryProfileLookup? _categoryProfileLookup;
 
   @override
   DomainLogger? get domainLogger => _domainLogger;
@@ -317,6 +341,7 @@ class RelationshipAgentWorkflow with AgentErrorLogging {
       relationship: relationship,
       agentIdentity: agentIdentity,
       aiConfigRepository: _aiConfigRepository,
+      categoryProfileLookup: _categoryProfileLookup,
     );
     if (resolved == null) {
       // The escalation record is already consumed and Phase A will not

--- a/lib/features/relationships/workflow/relationship_agent_workflow.dart
+++ b/lib/features/relationships/workflow/relationship_agent_workflow.dart
@@ -88,34 +88,46 @@ typedef RelationshipModelResolution = ({
 /// agent, and the validated default is one specific cloud model — a user
 /// whose category routes everything else through their own profile was
 /// left with no route at all, and the card reported only "could not request
-/// the briefing". A dangling id at any step falls through to the next; the
-/// lookup is optional so callers without a category source keep the
-/// two-step chain.
+/// the briefing". A dangling id at any step falls through to the next. The
+/// category lookup runs only once the explicit profiles have failed to
+/// resolve — it is a database read, and a transient failure there must not
+/// take down a route the person or the agent already pins. The lookup is
+/// optional so callers without a category source keep the two-step chain.
 Future<RelationshipModelResolution?> resolveRelationshipAgentModel({
   required RelationshipEntry? relationship,
   required AgentIdentityEntity? agentIdentity,
   required AiConfigRepository aiConfigRepository,
   CategoryProfileLookup? categoryProfileLookup,
 }) async {
-  final categoryId = relationship?.meta.categoryId;
-  final candidateProfileIds = <String>{
-    ?relationship?.data.profileId,
-    ?agentIdentity?.config.profileId,
-    if (categoryId != null && categoryProfileLookup != null)
-      ?await categoryProfileLookup(categoryId),
-  };
   final profileResolver = ProfileResolver(
     aiConfigRepository: aiConfigRepository,
   );
-  for (final profileId in candidateProfileIds) {
+  Future<RelationshipModelResolution?> viaProfile(String profileId) async {
     final profile = await profileResolver.resolveByProfileId(profileId);
-    if (profile != null) {
-      return (
-        modelId: profile.thinkingModelId,
-        provider: profile.thinkingProvider,
-        geminiThinkingMode: profile.thinkingModel?.geminiThinkingMode,
-        profileId: profileId,
-      );
+    if (profile == null) return null;
+    return (
+      modelId: profile.thinkingModelId,
+      provider: profile.thinkingProvider,
+      geminiThinkingMode: profile.thinkingModel?.geminiThinkingMode,
+      profileId: profileId,
+    );
+  }
+
+  final explicitProfileIds = <String>{
+    ?relationship?.data.profileId,
+    ?agentIdentity?.config.profileId,
+  };
+  for (final profileId in explicitProfileIds) {
+    final resolved = await viaProfile(profileId);
+    if (resolved != null) return resolved;
+  }
+  final categoryId = relationship?.meta.categoryId;
+  if (categoryId != null && categoryProfileLookup != null) {
+    final categoryProfileId = await categoryProfileLookup(categoryId);
+    if (categoryProfileId != null &&
+        !explicitProfileIds.contains(categoryProfileId)) {
+      final resolved = await viaProfile(categoryProfileId);
+      if (resolved != null) return resolved;
     }
   }
   final direct = await resolveInferenceProviderWithModel(

--- a/test/features/relationships/state/relationship_agent_providers_test.dart
+++ b/test/features/relationships/state/relationship_agent_providers_test.dart
@@ -645,6 +645,9 @@ void main() {
       );
 
       await expectLater(disclosure(), throwsStateError);
+      // The shared stubs make every route fail, so the throw alone would
+      // pass without the category branch ever running: prove it ran.
+      verify(() => journalDb.getCategoryById('cat-1')).called(1);
     });
 
     test('a dangling profile id falls through to the default cloud model '

--- a/test/features/relationships/state/relationship_agent_providers_test.dart
+++ b/test/features/relationships/state/relationship_agent_providers_test.dart
@@ -24,10 +24,12 @@ import 'package:lotti/features/relationships/service/relationship_chat_service.d
 import 'package:lotti/features/relationships/state/relationship_agent_providers.dart';
 import 'package:lotti/features/relationships/workflow/relationship_agent_workflow.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/providers/service_providers.dart' show journalDbProvider;
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
+import '../../categories/test_utils.dart';
 
 void main() {
   setUpAll(registerAllFallbackValues);
@@ -368,6 +370,7 @@ void main() {
     late MockAiConfigRepository aiConfigRepository;
     late MockRelationshipRepository relationshipRepository;
     late MockAgentRepository agentRepository;
+    late MockJournalDb journalDb;
 
     final meliousProvider =
         AiConfig.inferenceProvider(
@@ -414,25 +417,27 @@ void main() {
             )
             as AiConfigInferenceProfile;
 
-    RelationshipEntry person({String? withProfileId}) => RelationshipEntry(
-      meta: Metadata(
-        id: relationshipId,
-        createdAt: DateTime(2026, 8),
-        updatedAt: DateTime(2026, 8),
-        dateFrom: DateTime(2026, 8),
-        dateTo: DateTime(2026, 8),
-      ),
-      data: RelationshipData(
-        title: 'Anna',
-        important: true,
-        profileId: withProfileId,
-        status: RelationshipStatus.active(
-          id: 'status-1',
-          createdAt: DateTime(2026, 8),
-          utcOffset: 0,
-        ),
-      ),
-    );
+    RelationshipEntry person({String? withProfileId, String? categoryId}) =>
+        RelationshipEntry(
+          meta: Metadata(
+            id: relationshipId,
+            createdAt: DateTime(2026, 8),
+            updatedAt: DateTime(2026, 8),
+            dateFrom: DateTime(2026, 8),
+            dateTo: DateTime(2026, 8),
+            categoryId: categoryId,
+          ),
+          data: RelationshipData(
+            title: 'Anna',
+            important: true,
+            profileId: withProfileId,
+            status: RelationshipStatus.active(
+              id: 'status-1',
+              createdAt: DateTime(2026, 8),
+              utcOffset: 0,
+            ),
+          ),
+        );
 
     setUp(() {
       aiConfigRepository = MockAiConfigRepository();
@@ -447,6 +452,10 @@ void main() {
       when(
         () => agentRepository.getEntity(any()),
       ).thenAnswer((_) async => null);
+      journalDb = MockJournalDb();
+      when(
+        () => journalDb.getCategoryById(any()),
+      ).thenAnswer((_) async => null);
     });
 
     Future<String?> disclosure() {
@@ -457,6 +466,7 @@ void main() {
             relationshipRepository,
           ),
           agentRepositoryProvider.overrideWithValue(agentRepository),
+          journalDbProvider.overrideWithValue(journalDb),
         ],
       );
       addTearDown(c.dispose);
@@ -570,6 +580,71 @@ void main() {
       ).thenAnswer((_) async => [acmeProvider, meliousProvider]);
 
       expect(await disclosure(), 'Acme');
+    });
+
+    test("the category's default profile routes when neither the person nor "
+        'the agent pins one — the ordinary setup, and the one that used to '
+        'throw (ADR 0040 Decision 6)', () async {
+      // The category routes through Acme; the validated default model is
+      // not in the catalogue, so a named provider proves the category step.
+      final acmeProvider =
+          AiConfig.inferenceProvider(
+                id: 'acme-provider',
+                baseUrl: 'https://api.acme.ai',
+                apiKey: 'key',
+                name: 'Acme',
+                createdAt: DateTime(2026),
+                inferenceProviderType: InferenceProviderType.melious,
+              )
+              as AiConfigInferenceProvider;
+      when(
+        () => relationshipRepository.getRelationshipByIdUnfiltered(
+          relationshipId,
+        ),
+      ).thenAnswer((_) async => person(categoryId: 'cat-1'));
+      when(() => journalDb.getCategoryById('cat-1')).thenAnswer(
+        (_) async => CategoryTestUtils.createTestCategory(
+          id: 'cat-1',
+          name: 'Family',
+          defaultProfileId: profileId,
+        ),
+      );
+      when(
+        () => aiConfigRepository.getConfigById(profileId),
+      ).thenAnswer((_) async => profile('model-acme'));
+      when(
+        () => aiConfigRepository.getConfigById('model-acme'),
+      ).thenAnswer((_) async => model('model-acme', 'acme-provider'));
+      when(
+        () => aiConfigRepository.getConfigById('acme-provider'),
+      ).thenAnswer((_) async => acmeProvider);
+      when(
+        () => aiConfigRepository.getConfigsByType(AiConfigType.model),
+      ).thenAnswer((_) async => [model('model-acme', 'acme-provider')]);
+      when(
+        () => aiConfigRepository.getConfigsByType(
+          AiConfigType.inferenceProvider,
+        ),
+      ).thenAnswer((_) async => [acmeProvider]);
+
+      expect(await disclosure(), 'Acme');
+    });
+
+    test('a category with no default profile leaves the chain where it was: '
+        'no route resolves and the provider throws', () async {
+      when(
+        () => relationshipRepository.getRelationshipByIdUnfiltered(
+          relationshipId,
+        ),
+      ).thenAnswer((_) async => person(categoryId: 'cat-1'));
+      when(() => journalDb.getCategoryById('cat-1')).thenAnswer(
+        (_) async => CategoryTestUtils.createTestCategory(
+          id: 'cat-1',
+          name: 'Family',
+        ),
+      );
+
+      await expectLater(disclosure(), throwsStateError);
     });
 
     test('a dangling profile id falls through to the default cloud model '

--- a/test/features/relationships/state/relationship_agent_providers_test.dart
+++ b/test/features/relationships/state/relationship_agent_providers_test.dart
@@ -363,6 +363,41 @@ void main() {
     );
   });
 
+  group('relationshipCategoryProfileLookupProvider', () {
+    test(
+      "answers the category's default profile through the journal db, "
+      'and null for a category without one or a category that is gone',
+      () async {
+        final journalDb = MockJournalDb();
+        when(() => journalDb.getCategoryById('cat-with')).thenAnswer(
+          (_) async => CategoryTestUtils.createTestCategory(
+            id: 'cat-with',
+            name: 'Family',
+            defaultProfileId: 'profile-family',
+          ),
+        );
+        when(() => journalDb.getCategoryById('cat-without')).thenAnswer(
+          (_) async => CategoryTestUtils.createTestCategory(
+            id: 'cat-without',
+            name: 'Work',
+          ),
+        );
+        when(
+          () => journalDb.getCategoryById('cat-gone'),
+        ).thenAnswer((_) async => null);
+        final c = ProviderContainer(
+          overrides: [journalDbProvider.overrideWithValue(journalDb)],
+        );
+        addTearDown(c.dispose);
+        final lookup = c.read(relationshipCategoryProfileLookupProvider);
+
+        expect(await lookup('cat-with'), 'profile-family');
+        expect(await lookup('cat-without'), isNull);
+        expect(await lookup('cat-gone'), isNull);
+      },
+    );
+  });
+
   group('relationshipBriefingDisclosureProvider', () {
     const relationshipId = 'person-1';
     const profileId = 'profile-1';

--- a/test/features/relationships/workflow/relationship_agent_workflow_test.dart
+++ b/test/features/relationships/workflow/relationship_agent_workflow_test.dart
@@ -1518,6 +1518,211 @@ void main() {
     expect(upserts.whereType<AgentReportEntity>(), hasLength(1));
   });
 
+  group('resolveRelationshipAgentModel — the chain (ADR 0040 Decision 6)', () {
+    final anthropicProvider =
+        AiConfig.inferenceProvider(
+              id: 'anthropic-provider',
+              baseUrl: 'https://api.anthropic.com',
+              apiKey: 'key',
+              name: 'Anthropic',
+              createdAt: DateTime(2026),
+              inferenceProviderType: InferenceProviderType.anthropic,
+            )
+            as AiConfigInferenceProvider;
+    final claudeModel =
+        AiConfig.model(
+              id: 'model-claude',
+              name: 'Claude',
+              providerModelId: 'claude-x',
+              inferenceProviderId: 'anthropic-provider',
+              createdAt: DateTime(2026),
+              inputModalities: const [Modality.text],
+              outputModalities: const [Modality.text],
+              isReasoningModel: true,
+              supportsFunctionCalling: true,
+              description: 'claude',
+            )
+            as AiConfigModel;
+
+    RelationshipEntry personInCategory({String? profileId}) =>
+        relationship(profileId: profileId).copyWith(
+          meta: meta(relationshipId).copyWith(categoryId: 'cat-1'),
+        );
+
+    /// The catalogue holds ONLY the category profile's model, so a resolved
+    /// route proves the category step and nothing else.
+    void stubCategoryProfileOnClaude() {
+      when(() => aiConfigRepository.getConfigById('profile-cat')).thenAnswer(
+        (_) async => AiConfig.inferenceProfile(
+          id: 'profile-cat',
+          name: 'Family profile',
+          createdAt: DateTime(2026),
+          thinkingModelId: 'model-claude',
+        ),
+      );
+      when(
+        () => aiConfigRepository.getConfigsByType(AiConfigType.model),
+      ).thenAnswer((_) async => [claudeModel]);
+      when(
+        () => aiConfigRepository.getConfigById('anthropic-provider'),
+      ).thenAnswer((_) async => anthropicProvider);
+    }
+
+    Future<String?> categoryLookup(String categoryId) async =>
+        categoryId == 'cat-1' ? 'profile-cat' : null;
+
+    test("the category's default profile routes when neither the person nor "
+        'the agent pins one — the ordinary setup', () async {
+      stubCategoryProfileOnClaude();
+
+      final resolved = await resolveRelationshipAgentModel(
+        relationship: personInCategory(),
+        agentIdentity: identity(),
+        aiConfigRepository: aiConfigRepository,
+        categoryProfileLookup: categoryLookup,
+      );
+
+      expect(resolved?.profileId, 'profile-cat');
+      expect(resolved?.modelId, 'claude-x');
+      expect(resolved?.provider.id, 'anthropic-provider');
+    });
+
+    test('without a category lookup the same person has no route at all — '
+        'the chain "Brief me" used to hit', () async {
+      stubCategoryProfileOnClaude();
+
+      final resolved = await resolveRelationshipAgentModel(
+        relationship: personInCategory(),
+        agentIdentity: identity(),
+        aiConfigRepository: aiConfigRepository,
+      );
+
+      expect(resolved, isNull);
+    });
+
+    test(
+      "the person's own profile still wins over the category default",
+      () async {
+        stubCategoryProfileOnClaude();
+        // The person's profile routes through the melious default model.
+        when(() => aiConfigRepository.getConfigById('profile-1')).thenAnswer(
+          (_) async => AiConfig.inferenceProfile(
+            id: 'profile-1',
+            name: 'Mine',
+            createdAt: DateTime(2026),
+            thinkingModelId: 'model-glm',
+          ),
+        );
+        when(
+          () => aiConfigRepository.getConfigsByType(AiConfigType.model),
+        ).thenAnswer((_) async => [claudeModel, glmModel]);
+        when(
+          () => aiConfigRepository.getConfigById('melious-provider'),
+        ).thenAnswer((_) async => meliousProvider);
+
+        final resolved = await resolveRelationshipAgentModel(
+          relationship: personInCategory(profileId: 'profile-1'),
+          agentIdentity: identity(),
+          aiConfigRepository: aiConfigRepository,
+          categoryProfileLookup: categoryLookup,
+        );
+
+        expect(resolved?.profileId, 'profile-1');
+        expect(resolved?.provider.id, 'melious-provider');
+      },
+    );
+
+    test('a dangling category default falls through to the validated default '
+        'model', () async {
+      stubGlmResolution();
+
+      final resolved = await resolveRelationshipAgentModel(
+        relationship: personInCategory(),
+        agentIdentity: identity(),
+        aiConfigRepository: aiConfigRepository,
+        categoryProfileLookup: (_) async => 'gone',
+      );
+
+      expect(resolved?.profileId, isNull);
+      expect(resolved?.provider.id, 'melious-provider');
+    });
+
+    test('a person without a category never consults the lookup', () async {
+      stubGlmResolution();
+
+      final resolved = await resolveRelationshipAgentModel(
+        relationship: relationship(),
+        agentIdentity: identity(),
+        aiConfigRepository: aiConfigRepository,
+        categoryProfileLookup: (_) async =>
+            throw StateError('lookup must not run without a category'),
+      );
+
+      expect(resolved?.provider.id, 'melious-provider');
+    });
+
+    test('the workflow routes a run through its own category lookup — a '
+        'briefing lands for a category-routed person where the two-step '
+        'chain failed', () async {
+      stubCategoryProfileOnClaude();
+      when(
+        () => relationshipRepository.getRelationshipByIdUnfiltered(
+          relationshipId,
+        ),
+      ).thenAnswer((_) async => personInCategory());
+      conversationRepository.sendMessageDelegate =
+          ({
+            required conversationId,
+            required message,
+            required model,
+            required provider,
+            required inferenceRepo,
+            tools,
+            toolChoice,
+            temperature = 0,
+            strategy,
+          }) async {
+            expect(model, 'claude-x');
+            expect(provider.name, 'Anthropic');
+            await strategy!.processToolCalls(
+              toolCalls: [
+                toolCall(
+                  RelationshipAgentToolNames.updateRelationshipReport,
+                  briefingArgs(),
+                ),
+              ],
+              manager: conversationManager,
+            );
+            return null;
+          };
+      final tokens = {relationshipEscalationWorkspaceKey('2026-08-08')};
+
+      // The default construction (no lookup) is the regression: no route.
+      final unwired = await run(tokens: tokens);
+      expect(unwired.success, isFalse);
+      expect(unwired.error, contains('no inference provider'));
+
+      workflow = RelationshipAgentWorkflow(
+        repository: repository,
+        syncService: syncService,
+        phaseA: RelationshipAgentPhaseA(
+          repository: repository,
+          syncService: syncService,
+          relationshipRepository: relationshipRepository,
+        ),
+        relationshipRepository: relationshipRepository,
+        conversationRepository: conversationRepository,
+        cloudInferenceRepository: MockCloudInferenceRepository(),
+        aiConfigRepository: aiConfigRepository,
+        categoryProfileLookup: categoryLookup,
+      );
+      upserts.clear();
+      final wired = await run(tokens: tokens);
+      expect(wired.success, isTrue);
+      expect(upserts.whereType<AgentReportEntity>(), hasLength(1));
+    });
+  });
+
   group('with the consumption pair registered', () {
     late MockAiAttributionService attribution;
 

--- a/test/features/relationships/workflow/relationship_agent_workflow_test.dart
+++ b/test/features/relationships/workflow/relationship_agent_workflow_test.dart
@@ -1647,6 +1647,29 @@ void main() {
       expect(resolved?.provider.id, 'melious-provider');
     });
 
+    test('an explicit profile resolves before the category lookup runs — a '
+        'failing category read cannot take down a pinned route', () async {
+      stubGlmResolution();
+      when(() => aiConfigRepository.getConfigById('profile-1')).thenAnswer(
+        (_) async => AiConfig.inferenceProfile(
+          id: 'profile-1',
+          name: 'Mine',
+          createdAt: DateTime(2026),
+          thinkingModelId: 'model-glm',
+        ),
+      );
+
+      final resolved = await resolveRelationshipAgentModel(
+        relationship: personInCategory(profileId: 'profile-1'),
+        agentIdentity: identity(),
+        aiConfigRepository: aiConfigRepository,
+        categoryProfileLookup: (_) async =>
+            throw StateError('the category read failed'),
+      );
+
+      expect(resolved?.profileId, 'profile-1');
+    });
+
     test('a person without a category never consults the lookup', () async {
       stubGlmResolution();
 


### PR DESCRIPTION
## Summary

"Brief me" on a person's page failed every time with the generic toast
"Could not request the briefing." for an ordinary setup.

**Root cause.** `resolveRelationshipAgentModel` resolved the relationship
agent's model through only three routes: a profile pinned on the person
(`RelationshipData.profileId`, which no screen sets), the agent config's
profile (never set at creation), and the validated default model (Melious
`glm-5.2` with a usable key). The default profile of the person's category —
the route ADR 0040 Decision 6 and ADR 0059 Decision 7 specify, and the one a
spoken check-in already uses for transcription — was skipped. With no route,
`relationshipBriefingDisclosureProvider` throws and the card swallowed the
reason into the toast without logging it.

**Fix.**
- The chain now tries the person's profile → the agent's profile → **the
  category's default profile** → the validated default model, first resolvable
  wins, dangling ids fall through. Both the disclosure dialog and the workflow
  run resolve through it, so the provider named for consent is the one that
  runs.
- The category lookup is the same `JournalDb.getCategoryById` read the
  automation resolver uses, wired in `relationship_agent_providers.dart`.
- The briefing card logs the error it used to swallow (toast copy unchanged;
  an inline error state is part of the pending People redesign).
- Knowledge concept and feature README describe the chain; changelog fragment
  added.

## Verification

- `fvm dart analyze` clean on the touched files, formatter run.
- Five unit tests on the chain, one workflow-level test (a category-routed
  person's briefing lands where the two-step chain returned "no inference
  provider"), two disclosure-provider tests (category default routes; a
  category without a default still throws). 89 tests pass across the three
  touched test files.
- Re-run with the category step removed: exactly the three category-route
  tests fail, everything else passes.
- `make changelog_check` and `make okf_check` green.

No UI change, so no screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the “Brief me” action for people whose AI routing comes from their category.
  * Briefings now use the appropriate AI profile and continue working when earlier profile references are unavailable.
  * Provider consent information now reflects the profile used for the briefing.
  * Improved error logging when a briefing cannot be generated.

* **Documentation**
  * Updated relationship feature documentation to describe AI profile selection and disclosure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->