### PR TITLE
feat(relationships): band the People list, add the summary card and the desktop split

### DIFF
--- a/changelog.d/2026-09-06-people-list-redesign.md
+++ b/changelog.d/2026-09-06-people-list-redesign.md
@@ -1,0 +1,10 @@
+### Changed
+- **The People list now reads like the rest of the app.** People are banded
+  into *Due*, *On track* and *Not enrolled*, with the lapsed ones first; a
+  summary card at the top counts who is due right now against everyone the
+  agent is watching and names who lapses next and on which day. Each row says
+  what the last contact was and when (`Call · Today 12:44 · Weekly`), and the
+  pill tells the truth: a lapsed cadence reads *3 days over* instead of a
+  confusing "Due Sun". An important person is marked with a sparkle rather
+  than a star. On desktop the tab becomes a list/detail split like Tasks, with
+  the person's page beside the list and a labelled *Add person* button.

--- a/docs/implementation_plans/2026-09-06_people_redesign.md
+++ b/docs/implementation_plans/2026-09-06_people_redesign.md
@@ -1,0 +1,86 @@
+# People section redesign — implementation plan
+
+Design: `~/Desktop/design_handover/people_handover/design_response/` (Claude Design,
+2026-09-06, answering `HANDOVER.md` and `AGENT_CARD_CONCEPT.md` in the same folder).
+Approved by the product owner on 2026-09-06 ("implement the redesign as in the zip").
+
+The person page becomes a sibling of the task page: a cover-style hero, a header block
+with the cadence fact and health band as pills, the relationship-agent card with a
+suggestions band, a Next time card, then section cards for check-ins, contact channels
+and tasks, above a bottom action bar. Desktop uses the Tasks list/detail split. The
+People list gains grouping, a summary card and truthful pills.
+
+## Decisions carried over from the design (do not relitigate)
+
+| Topic | Decision |
+|---|---|
+| Header | Cover-style hero (teal wash, no imagery) with persona avatar overlapping the fold; full wrapping name; nickname + last contact as the teal one-liner; back · Talk to agent · edit · kebab (delete, link contact). |
+| Star | Dropped. "Important" appears in the eyebrow and as the agent card's enrolment state; the switch stays in the edit sheet. |
+| Desktop | List/detail split (Tasks pattern): rail · 416 px list pane · detail pane with an 880 px centred column. Chat renders in the detail pane. |
+| List | Grouped Due · On track · Not enrolled, due-first; row = avatar, name + sparkle (important), one mono status line (`Call · Today 12:44 · weekly`), truthful pill (`5 days over` warning, never "Due Sun"). Summary card mirrors the Goals list. |
+| Check-ins | Rows in one section card: mono `timestamp · type · duration`, tinted sentiment pill (Delightful=success, Good=teal, Neutral=grey, Strained=warning, Difficult=error), narrative, topic tags. |
+| Post-call offer | A highlighted state at the top of the Check-ins card naming channel, start time and elapsed time. |
+| Duration | Wheel; inline when the value is known (prefilled from the call), collapsed behind a Duration field otherwise; "No duration" is a wheel position; `dateTo − dateFrom`, no schema change. |
+| Brief me | Becomes *Update now* in the controls footer; the empty state keeps a primary *Brief now*. |
+| Next time | Its own card between the briefing and the check-ins, from the latest check-in. |
+| Chat entry | Page header ("Talk to agent"), not the card footer. |
+| Confirm all | Only when every pending suggestion is the same kind. |
+| Tokens | Existing tokens only; the tinted pills need named `tint-*` washes — flagged, not invented. |
+
+## Increments (one pull request each)
+
+### A · People list and the desktop split
+- `RelationshipListItem` gains the latest check-in's interaction type (one aggregate
+  query, no N+1: extend `latestCheckInTimes` to return the newest check-in row per
+  person).
+- Grouping (Due · On track · Not enrolled) with counts; row status line and truthful pill
+  (`{n} days over`, `Due {weekday}` within a week, `On track`, `Not enrolled`,
+  `Dormant`/`Archived`); sparkle replaces the star.
+- Summary card: due-now count over enrolled count, next due person and day, not-enrolled
+  count; empty and all-clear variants.
+- Header: labelled *Add person* button on desktop; import icon with tooltip on phones.
+- Desktop split via `NavService.desktopSelectedRelationshipId`, `RelationshipsLocation`
+  mirroring `ProjectsLocation`, the shared pane-width controller and the empty state.
+- Tests: grouping/pill logic as property tests, row and summary widgets, split behaviour.
+
+### B · Person page
+- Hero (`GlassBackButton`, glass actions: Talk to agent, edit, kebab with delete and
+  link-contact), header block (eyebrow, name, one-liner, pills: cadence fact, health
+  band, next due), `DesignSystemSectionCard` sections in the design's order, bottom
+  action bar (Log check-in · mic · actionable channel) replacing the floating button.
+- Next time card from the latest check-in; Check-ins card with rows and the post-call
+  state at the top; Reach card with the privacy line and 40 px circular actions; Tasks
+  card with status glyphs.
+- Desktop detail pane hosts the page in an 880 px column; the tab bar stays hidden on
+  phones.
+
+### C · Relationship agent card
+- States: not enrolled (Mark important), enrolled without briefing (Next look · Brief
+  now), thinking, current (cost pill, freshness, controls footer with Update now,
+  automatic updates, model row), out of date, failed (reason inline, Choose a model),
+  due (Log check-in · Call).
+- Suggestions band over the generic change-set ledger, hidden while empty; the agent
+  tools that would fill it (schedule a call, create a task) are a separate project.
+
+### D · Check-in capture with duration
+- Order: how it felt → what you talked about (+ Speak instead) → when and how long
+  (type chips · Started date+time · Duration wheel) → More (folded). Pinned Save.
+- Prefilled source strip; duration prefilled from the pending marker's start time;
+  wheel positions none · 5 · 10 · 15 · 20 · 30 · 45 min · 1 h · 1 h 30 · 2 h · 3 h ·
+  Custom; ranked by the user's own picks (estimate precedent).
+- Desktop dialog with delete bottom-left. Check-in rows show the duration.
+
+### E · Form, import, chat
+- Edit person in three cards (Who · Important + cadence · How to reach them), category
+  as a colour dot, privacy lines, "Add channel · or from contacts".
+- Import review: cadence presets appear when Important is on; subtitle names the count.
+- Chat: agent header (sparkle avatar, subtitle), desktop chat inside the detail pane with
+  an Agent internals button.
+
+Every increment: 100 % patch coverage, every new label in every catalog, a changelog
+fragment, before/after captures from the handover recipe (`capture/` in the handover
+folder), README and knowledge concept kept in step.
+
+## Out of this plan
+The suggestion-producing agent tools (S1 schedule a call onto the day plan, S2 create
+and link a task, S3 add to a task) and the `tint-*` design tokens.

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -20,6 +20,10 @@ sources:
     resource: ../../lib/classes/relationship_data.dart
     title: RelationshipData, RelationshipStatus, ContactChannel
     last_modified: 2026-08-14
+  - id: list-model
+    resource: ../../lib/features/relationships/ui/model/people_list_model.dart
+    title: The People list's bands, pills and summary — pure logic
+    last_modified: 2026-09-06
   - id: adr-0038
     resource: ../../docs/adr/0038-relationship-domain-model.md
     title: ADR 0038 — Relationship domain model
@@ -146,9 +150,51 @@ freshly added person lands at the top rather than the bottom.
 Computing that naively is one query per person. Instead
 `JournalDb.latestCheckInTimes` runs **a single `GROUP BY subtype` aggregate**
 over `type = 'CheckIn'` rows, returning `relationshipId → MAX(dateFrom)` for the
-whole table at once; `getRelationshipsByRecency` joins it in Dart. Both halves
-route through `_queryWithPrivateFilter`, so a hidden check-in does not leak into
-recency ordering.
+whole table at once. The list also needs *what* the last contact was, so
+`latestCheckIns` resolves that aggregate to its rows in **one further query** —
+the ids and the instants as `IN` lists, the exact `(subtype, dateFrom)` pair
+kept on the raw row before deserialising — and `getRelationshipsByRecency`
+joins the result in Dart as `RelationshipListItem.lastCheckIn`. Every half
+routes through `_queryWithPrivateFilter`, so a hidden check-in does not leak
+into recency ordering or into the status line.
+
+# The People list and the desktop split
+
+The list (design 2026-09-06 §2–3) is three bands in display order — **Due**
+(enrolled, cadence lapsed), **On track** (enrolled, not lapsed), **Not
+enrolled** (not important, or dormant/archived) — each most-recent contact
+first, under a summary card that counts the due against the enrolled, names
+who lapses next and on which day, and counts the not-enrolled. *Enrolled*
+means `important` **and** active: the consent switch alone does not enrol a
+dormant person (ADR 0039).
+
+All of that is pure logic in
+[`ui/model/people_list_model.dart`](../../lib/features/relationships/ui/model/people_list_model.dart)
+— bands, the truthful pill (`{n} days over` when lapsed, `Due {weekday}`
+within seven days, `On track`, `Not enrolled`, `Dormant`, `Archived`), the
+summary — covered by Glados properties (partition, per-band order,
+order-invariance, band⇔pill agreement, summary⇔bands agreement). The widgets
+(`PeopleListRow`, `PeopleSummaryCard`) only render what the model says; the
+row's status line composes the interaction label, the mono timestamp and the
+cadence label, and never "Tracking since …".
+
+On desktop `RelationshipsPage` is the Tasks/Projects list-detail split:
+`RelationshipsLocation` mirrors the URL's person id into
+`NavService.desktopSelectedRelationshipId` and pushes no detail page, the list
+pane takes the shared pane-width controller, and the right pane hosts the
+person's page or the empty state. The route stays the single source of truth —
+tapping a row still beams to `/people/<id>`. The chat stacks as its own page on
+every layout. Phones keep the list alone.
+
+```mermaid
+flowchart LR
+  URL["/people/&lt;id&gt;"] --> Loc[RelationshipsLocation]
+  Loc -->|phone| Push[push RelationshipDetailsPage]
+  Loc -->|desktop| Sel[desktopSelectedRelationshipId = id]
+  Sel --> Split[RelationshipsPage split: list pane · divider · detail pane]
+  Split -->|row wears surface.selected| Row[PeopleListRow]
+  Split --> Pane[detail pane: RelationshipDetailsPage or empty state]
+```
 
 # Status lifecycle
 

--- a/lib/beamer/locations/relationships_location.dart
+++ b/lib/beamer/locations/relationships_location.dart
@@ -2,11 +2,18 @@ import 'package:beamer/beamer.dart';
 import 'package:lotti/features/relationships/ui/pages/relationship_chat_page.dart';
 import 'package:lotti/features/relationships/ui/pages/relationship_details_page.dart';
 import 'package:lotti/features/relationships/ui/pages/relationships_page.dart';
+import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:material_ui/material_ui.dart';
 
 /// The flag-gated People tab (`enable_relationships`): the list of tracked
 /// relationships and the per-person detail with its check-in log.
+///
+/// On desktop the person page lives in the list/detail split's right pane
+/// (the Projects pattern): the location mirrors the URL's person id into
+/// `NavService.desktopSelectedRelationshipId` and pushes no detail page.
+/// The chat still stacks as its own page on every layout.
 class RelationshipsLocation extends BeamLocation<BeamState> {
   RelationshipsLocation(RouteInformation super.routeInformation);
 
@@ -21,6 +28,11 @@ class RelationshipsLocation extends BeamLocation<BeamState> {
   List<BeamPage> buildPages(BuildContext context, BeamState state) {
     final relationshipId = state.pathParameters['relationshipId'];
     final messages = context.messages;
+    final navService = getIt<NavService>();
+    final isDesktop = navService.isDesktopMode;
+    if (isDesktop) {
+      navService.desktopSelectedRelationshipId.value = relationshipId;
+    }
     return [
       BeamPage(
         key: const ValueKey('people'),
@@ -30,7 +42,7 @@ class RelationshipsLocation extends BeamLocation<BeamState> {
       // The detail page's own SliverAppBar shows the person's name; the
       // BeamPage title is left unset so the window/tab bar falls back to
       // the app name rather than misreading "People" for one person.
-      if (relationshipId != null)
+      if (!isDesktop && relationshipId != null)
         BeamPage(
           key: ValueKey('people-details-$relationshipId'),
           child: RelationshipDetailsPage(relationshipId: relationshipId),

--- a/lib/database/database_relationship_queries.dart
+++ b/lib/database/database_relationship_queries.dart
@@ -80,7 +80,8 @@ mixin _JournalDbRelationshipQueries on _$JournalDb, _JournalDbConfigFlags {
   /// query — the ids and the instants as `IN` lists, the exact pair kept on
   /// the raw row — so the People list can say what the last contact was
   /// without a per-person query. Respects the private-entry filter for the
-  /// same reason the aggregate does.
+  /// same reason the aggregate does. Two rows on the same instant resolve
+  /// to the lowest id, so the answer is stable across loads.
   Future<Map<String, CheckInEntry>> latestCheckIns() async {
     final times = await latestCheckInTimes();
     if (times.isEmpty) return const {};
@@ -88,17 +89,27 @@ mixin _JournalDbRelationshipQueries on _$JournalDb, _JournalDbConfigFlags {
     final instants = times.values.toSet().toList(growable: false);
 
     Future<List<JournalDbEntity>> run({List<bool>? privateStatuses}) {
-      return (select(journal)..where((t) {
-            var predicate =
-                t.type.equals('CheckIn') &
-                t.deleted.equals(false) &
-                t.subtype.isIn(ids) &
-                t.dateFrom.isIn(instants);
-            if (privateStatuses != null) {
-              predicate = predicate & t.private.isIn(privateStatuses);
-            }
-            return predicate;
-          }))
+      return (select(journal)
+            ..where((t) {
+              var predicate =
+                  t.type.equals('CheckIn') &
+                  t.deleted.equals(false) &
+                  t.subtype.isIn(ids) &
+                  t.dateFrom.isIn(instants);
+              if (privateStatuses != null) {
+                predicate = predicate & t.private.isIn(privateStatuses);
+              }
+              return predicate;
+            })
+            // Two check-ins stamped to the same instant (a call and the
+            // message that followed it) tie on the aggregate. Without an
+            // order, whichever row SQLite happens to return first would win
+            // and the People row could show a different interaction on the
+            // next load; the id breaks the tie the same way every time.
+            ..orderBy([
+              (t) => OrderingTerm.desc(t.dateFrom),
+              (t) => OrderingTerm.asc(t.id),
+            ]))
           .get();
     }
 

--- a/lib/database/database_relationship_queries.dart
+++ b/lib/database/database_relationship_queries.dart
@@ -75,6 +75,49 @@ mixin _JournalDbRelationshipQueries on _$JournalDb, _JournalDbConfigFlags {
     };
   }
 
+  /// The newest non-deleted check-in per relationship id: the
+  /// [latestCheckInTimes] aggregate resolved to its rows in ONE further
+  /// query — the ids and the instants as `IN` lists, the exact pair kept on
+  /// the raw row — so the People list can say what the last contact was
+  /// without a per-person query. Respects the private-entry filter for the
+  /// same reason the aggregate does.
+  Future<Map<String, CheckInEntry>> latestCheckIns() async {
+    final times = await latestCheckInTimes();
+    if (times.isEmpty) return const {};
+    final ids = times.keys.toList(growable: false);
+    final instants = times.values.toSet().toList(growable: false);
+
+    Future<List<JournalDbEntity>> run({List<bool>? privateStatuses}) {
+      return (select(journal)..where((t) {
+            var predicate =
+                t.type.equals('CheckIn') &
+                t.deleted.equals(false) &
+                t.subtype.isIn(ids) &
+                t.dateFrom.isIn(instants);
+            if (privateStatuses != null) {
+              predicate = predicate & t.private.isIn(privateStatuses);
+            }
+            return predicate;
+          }))
+          .get();
+    }
+
+    final rows = await _queryWithPrivateFilter(
+      allPrivate: run,
+      filtered: (statuses) => run(privateStatuses: statuses),
+    );
+    final latest = <String, CheckInEntry>{};
+    for (final row in rows) {
+      final id = row.subtype;
+      if (id == null || latest.containsKey(id) || times[id] != row.dateFrom) {
+        continue;
+      }
+      final entity = fromDbEntity(row);
+      if (entity is CheckInEntry) latest[id] = entity;
+    }
+    return latest;
+  }
+
   /// The live tasks among [ids], for resolving a relationship's linked
   /// tasks. Relationship → check-in and relationship → task links share the
   /// `RelationshipLink` type, so the caller cannot tell them apart from the

--- a/lib/features/relationships/README.md
+++ b/lib/features/relationships/README.md
@@ -25,7 +25,10 @@ the `enable_relationships` flag):
   (create, edit, delete — relationship deletion cascades to its check-ins,
   ADR 0037 §5) plus the recency-ordered list used by the People tab.
 - `ui/` + `state/` — the flag-gated **People tab** (`/people`, its own
-  beamer location): the relationship list ordered by last-check-in recency,
+  beamer location): the People list — banded *Due · On track · Not enrolled*
+  under a summary card that counts who is due now and names who lapses next,
+  each row naming the last contact (`Call · Today 12:44 · Weekly`) with a
+  truthful cadence pill, and on desktop a list/detail split like Tasks —
   the per-person detail page (status/cadence/nickname chips, contact
   channels, a linked-tasks section — `RelationshipLink` both ways, with a
   task picker that also creates the task when none exists yet, and per-row

--- a/lib/features/relationships/repository/relationship_repository.dart
+++ b/lib/features/relationships/repository/relationship_repository.dart
@@ -17,8 +17,16 @@ import 'package:lotti/utils/consts.dart';
 /// (null when no check-in exists yet).
 typedef RelationshipListItem = ({
   RelationshipEntry relationship,
-  DateTime? lastCheckInAt,
+
+  /// The newest check-in, so the list can say what the last contact was
+  /// (`Call · Today 12:44`), not only when.
+  CheckInEntry? lastCheckIn,
 });
+
+/// The instant of the newest check-in, or null for a person without one.
+extension RelationshipListItemRecency on RelationshipListItem {
+  DateTime? get lastCheckInAt => lastCheckIn?.meta.dateFrom;
+}
 
 /// Repository for relationship and check-in CRUD (ADR 0038).
 ///
@@ -78,13 +86,13 @@ class RelationshipRepository {
     return entity is RelationshipEntry ? entity : null;
   }
 
-  /// Returns all non-deleted relationships with their latest check-in time,
+  /// Returns all non-deleted relationships with their newest check-in,
   /// most recently interacted-with first (plan v2 phase 2). People without a
   /// check-in yet sort by tracking start instead, so a freshly added person
   /// starts at the top rather than the bottom.
   Future<List<RelationshipListItem>> getRelationshipsByRecency() async {
     final relationships = await _journalDb.getRelationships();
-    final latestByRelationship = await _journalDb.latestCheckInTimes();
+    final latestByRelationship = await _journalDb.latestCheckIns();
 
     DateTime recency(RelationshipListItem item) =>
         item.lastCheckInAt ?? item.relationship.meta.dateFrom;
@@ -93,7 +101,7 @@ class RelationshipRepository {
       for (final relationship in relationships)
         (
           relationship: relationship,
-          lastCheckInAt: latestByRelationship[relationship.id],
+          lastCheckIn: latestByRelationship[relationship.id],
         ),
     ]..sort((a, b) => recency(b).compareTo(recency(a)));
   }

--- a/lib/features/relationships/ui/model/people_list_model.dart
+++ b/lib/features/relationships/ui/model/people_list_model.dart
@@ -1,6 +1,7 @@
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/relationship_data.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
+import 'package:lotti/features/relationships/runtime/relationship_agent_phase_a.dart';
 import 'package:lotti/features/relationships/ui/shared/relationship_timestamps.dart';
 
 /// The three bands of the People list, in display order (design 2026-09-06
@@ -11,13 +12,15 @@ enum PeopleListGroup { due, onTrack, notEnrolled }
 /// What the trailing pill on a People row says — a *truthful* read of the
 /// cadence (HANDOVER P5: an overdue person must never read as "Due Sun").
 enum PeopleCadencePillKind {
-  /// Cadence lapsed: `{n} days over`, warning tint.
+  /// Cadence lapsed — `{n} days over`, or `Due today` on the due day itself
+  /// — warning tint.
   overdue,
 
   /// Due within the coming week: `Due {weekday}`.
   dueSoon,
 
-  /// Enrolled and fine, or enrolled with no cadence set.
+  /// Enrolled and fine (an enrolled person always has a cadence — the
+  /// runtime's default stands in for an unset one).
   onTrack,
 
   /// Active but not important — the agent is not watching.
@@ -34,7 +37,8 @@ enum PeopleCadencePillKind {
 typedef PeopleCadencePill = ({
   PeopleCadencePillKind kind,
 
-  /// Whole days over for the `overdue` kind; zero otherwise.
+  /// Whole days over for the `overdue` kind (zero on the due day itself);
+  /// zero for every other kind.
   int daysOver,
 
   /// The due date for the `dueSoon` kind; null otherwise.
@@ -49,7 +53,7 @@ typedef PeopleListSection = ({
 
 /// The numbers the summary card above the list shows.
 typedef PeopleSummary = ({
-  /// Enrolled people whose cadence has lapsed.
+  /// Enrolled people whose cadence has lapsed, the due day included.
   int dueNow,
 
   /// People the agent watches: important *and* active.
@@ -76,29 +80,42 @@ bool isEnrolled(RelationshipEntry relationship) =>
     relationship.data.important &&
     relationship.data.status is RelationshipActive;
 
-/// Whole days the cadence is over (positive) or still ahead (negative), or
-/// null when the person has no cadence.
+/// The cadence the runtime actually applies to this person: the stored
+/// value, or the production default when an enrolled person has none set
+/// (ADR 0039 Decision 2 — the same substitution the deterministic tier
+/// makes, so the list never says "on track" to someone the agent is about
+/// to nudge). Null for a person who is not enrolled: the runtime clears
+/// their reminders rather than scheduling any, so they have no due date.
+int? effectiveCadenceDaysOf(RelationshipEntry relationship) {
+  if (!isEnrolled(relationship)) return null;
+  return relationship.data.checkInCadenceDays ?? relationshipDefaultCadenceDays;
+}
+
+/// Whole days the cadence is over (positive), zero on the due day itself,
+/// negative while still ahead — or null for a person who is not enrolled.
 int? peopleOverdueDaysOf(RelationshipListItem item, {DateTime? now}) =>
     cadenceOverdueDays(
       lastCheckInAt: item.lastCheckInAt,
       trackingStartedAt: item.relationship.meta.dateFrom,
-      cadenceDays: item.relationship.data.checkInCadenceDays,
+      cadenceDays: effectiveCadenceDaysOf(item.relationship),
       now: now,
     );
 
-/// When the cadence lapses, or null without a cadence.
+/// When the cadence lapses, or null for a person who is not enrolled.
 DateTime? peopleDueDateOf(RelationshipListItem item, {DateTime? now}) =>
     cadenceDueDate(
       lastCheckInAt: item.lastCheckInAt,
       trackingStartedAt: item.relationship.meta.dateFrom,
-      cadenceDays: item.relationship.data.checkInCadenceDays,
+      cadenceDays: effectiveCadenceDaysOf(item.relationship),
       now: now,
     );
 
-/// The band a row belongs to.
+/// The band a row belongs to. Due *on* the due day, not only after it — the
+/// runtime marks the cadence due once the current day is no longer before
+/// the due day, and the list must agree with the nudge it sends.
 PeopleListGroup peopleListGroupOf(RelationshipListItem item, {DateTime? now}) {
   if (!isEnrolled(item.relationship)) return PeopleListGroup.notEnrolled;
-  return (peopleOverdueDaysOf(item, now: now) ?? 0) > 0
+  return (peopleOverdueDaysOf(item, now: now) ?? -1) >= 0
       ? PeopleListGroup.due
       : PeopleListGroup.onTrack;
 }
@@ -117,11 +134,9 @@ PeopleCadencePill peopleCadencePillOf(
     };
     return (kind: kind, daysOver: 0, dueAt: null);
   }
-  final overdue = peopleOverdueDaysOf(item, now: now);
-  if (overdue == null) {
-    return (kind: PeopleCadencePillKind.onTrack, daysOver: 0, dueAt: null);
-  }
-  if (overdue > 0) {
+  // Enrolled: the effective cadence is never null, so neither is this.
+  final overdue = peopleOverdueDaysOf(item, now: now)!;
+  if (overdue >= 0) {
     return (
       kind: PeopleCadencePillKind.overdue,
       daysOver: overdue,
@@ -182,7 +197,7 @@ PeopleSummary peopleSummaryOf(
     }
     enrolled++;
     final overdue = peopleOverdueDaysOf(item, now: now);
-    if (overdue != null && overdue > 0) {
+    if (overdue != null && overdue >= 0) {
       dueNow++;
       continue;
     }

--- a/lib/features/relationships/ui/model/people_list_model.dart
+++ b/lib/features/relationships/ui/model/people_list_model.dart
@@ -1,0 +1,202 @@
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/relationship_data.dart';
+import 'package:lotti/features/relationships/repository/relationship_repository.dart';
+import 'package:lotti/features/relationships/ui/shared/relationship_timestamps.dart';
+
+/// The three bands of the People list, in display order (design 2026-09-06
+/// §2): people whose cadence has lapsed, people the agent is watching and
+/// who are fine, and people it is not watching at all.
+enum PeopleListGroup { due, onTrack, notEnrolled }
+
+/// What the trailing pill on a People row says — a *truthful* read of the
+/// cadence (HANDOVER P5: an overdue person must never read as "Due Sun").
+enum PeopleCadencePillKind {
+  /// Cadence lapsed: `{n} days over`, warning tint.
+  overdue,
+
+  /// Due within the coming week: `Due {weekday}`.
+  dueSoon,
+
+  /// Enrolled and fine, or enrolled with no cadence set.
+  onTrack,
+
+  /// Active but not important — the agent is not watching.
+  notEnrolled,
+
+  /// Kept, not nurtured (ADR 0039: excluded from cadence).
+  dormant,
+
+  /// Closed.
+  archived,
+}
+
+/// The pill for one row: its kind plus the fact it names.
+typedef PeopleCadencePill = ({
+  PeopleCadencePillKind kind,
+
+  /// Whole days over for the `overdue` kind; zero otherwise.
+  int daysOver,
+
+  /// The due date for the `dueSoon` kind; null otherwise.
+  DateTime? dueAt,
+});
+
+/// One band of the list and the rows in it, most recent contact first.
+typedef PeopleListSection = ({
+  PeopleListGroup group,
+  List<RelationshipListItem> items,
+});
+
+/// The numbers the summary card above the list shows.
+typedef PeopleSummary = ({
+  /// Enrolled people whose cadence has lapsed.
+  int dueNow,
+
+  /// People the agent watches: important *and* active.
+  int enrolled,
+
+  /// Everyone else.
+  int notEnrolled,
+
+  /// The enrolled, not-yet-due person whose cadence lapses next.
+  RelationshipListItem? nextDue,
+
+  /// When [nextDue]'s cadence lapses.
+  DateTime? nextDueAt,
+});
+
+/// How far ahead "due soon" looks, in days. A person due within the coming
+/// week gets `Due {weekday}` instead of `On track`.
+const int peopleDueSoonWindowDays = 7;
+
+/// Whether the agent watches this person: the `important` consent switch is
+/// on *and* the relationship is active. A dormant or archived important
+/// person is kept but not nurtured (ADR 0039), so they are not enrolled.
+bool isEnrolled(RelationshipEntry relationship) =>
+    relationship.data.important &&
+    relationship.data.status is RelationshipActive;
+
+/// Whole days the cadence is over (positive) or still ahead (negative), or
+/// null when the person has no cadence.
+int? peopleOverdueDaysOf(RelationshipListItem item, {DateTime? now}) =>
+    cadenceOverdueDays(
+      lastCheckInAt: item.lastCheckInAt,
+      trackingStartedAt: item.relationship.meta.dateFrom,
+      cadenceDays: item.relationship.data.checkInCadenceDays,
+      now: now,
+    );
+
+/// When the cadence lapses, or null without a cadence.
+DateTime? peopleDueDateOf(RelationshipListItem item, {DateTime? now}) =>
+    cadenceDueDate(
+      lastCheckInAt: item.lastCheckInAt,
+      trackingStartedAt: item.relationship.meta.dateFrom,
+      cadenceDays: item.relationship.data.checkInCadenceDays,
+      now: now,
+    );
+
+/// The band a row belongs to.
+PeopleListGroup peopleListGroupOf(RelationshipListItem item, {DateTime? now}) {
+  if (!isEnrolled(item.relationship)) return PeopleListGroup.notEnrolled;
+  return (peopleOverdueDaysOf(item, now: now) ?? 0) > 0
+      ? PeopleListGroup.due
+      : PeopleListGroup.onTrack;
+}
+
+/// The row's pill.
+PeopleCadencePill peopleCadencePillOf(
+  RelationshipListItem item, {
+  DateTime? now,
+}) {
+  final relationship = item.relationship;
+  if (!isEnrolled(relationship)) {
+    final kind = switch (relationship.data.status) {
+      RelationshipDormant() => PeopleCadencePillKind.dormant,
+      RelationshipArchived() => PeopleCadencePillKind.archived,
+      RelationshipActive() => PeopleCadencePillKind.notEnrolled,
+    };
+    return (kind: kind, daysOver: 0, dueAt: null);
+  }
+  final overdue = peopleOverdueDaysOf(item, now: now);
+  if (overdue == null) {
+    return (kind: PeopleCadencePillKind.onTrack, daysOver: 0, dueAt: null);
+  }
+  if (overdue > 0) {
+    return (
+      kind: PeopleCadencePillKind.overdue,
+      daysOver: overdue,
+      dueAt: null,
+    );
+  }
+  if (overdue >= -peopleDueSoonWindowDays) {
+    return (
+      kind: PeopleCadencePillKind.dueSoon,
+      daysOver: 0,
+      dueAt: peopleDueDateOf(item, now: now),
+    );
+  }
+  return (kind: PeopleCadencePillKind.onTrack, daysOver: 0, dueAt: null);
+}
+
+/// The most recent contact, or the tracking start for a person without one,
+/// so a freshly added person sorts to the top of their band.
+DateTime peopleRecencyOf(RelationshipListItem item) =>
+    item.lastCheckInAt ?? item.relationship.meta.dateFrom;
+
+/// The list split into its bands, empty bands omitted, each band most recent
+/// contact first. Favorites do not get a band of their own — `important`
+/// decides enrolment, and the sparkle on the name is a marker.
+List<PeopleListSection> peopleListSections(
+  List<RelationshipListItem> items, {
+  DateTime? now,
+}) {
+  final byGroup = <PeopleListGroup, List<RelationshipListItem>>{};
+  for (final item in items) {
+    byGroup.putIfAbsent(peopleListGroupOf(item, now: now), () => []).add(item);
+  }
+  return [
+    for (final group in PeopleListGroup.values)
+      if (byGroup[group] case final rows? when rows.isNotEmpty)
+        (
+          group: group,
+          items: rows
+            ..sort((a, b) => peopleRecencyOf(b).compareTo(peopleRecencyOf(a))),
+        ),
+  ];
+}
+
+/// The summary card's numbers over the whole list.
+PeopleSummary peopleSummaryOf(
+  List<RelationshipListItem> items, {
+  DateTime? now,
+}) {
+  var dueNow = 0;
+  var enrolled = 0;
+  var notEnrolled = 0;
+  RelationshipListItem? nextDue;
+  DateTime? nextDueAt;
+  for (final item in items) {
+    if (!isEnrolled(item.relationship)) {
+      notEnrolled++;
+      continue;
+    }
+    enrolled++;
+    final overdue = peopleOverdueDaysOf(item, now: now);
+    if (overdue != null && overdue > 0) {
+      dueNow++;
+      continue;
+    }
+    final due = peopleDueDateOf(item, now: now);
+    if (due != null && (nextDueAt == null || due.isBefore(nextDueAt))) {
+      nextDue = item;
+      nextDueAt = due;
+    }
+  }
+  return (
+    dueNow: dueNow,
+    enrolled: enrolled,
+    notEnrolled: notEnrolled,
+    nextDue: nextDue,
+    nextDueAt: nextDueAt,
+  );
+}

--- a/lib/features/relationships/ui/pages/relationships_page.dart
+++ b/lib/features/relationships/ui/pages/relationships_page.dart
@@ -1,27 +1,155 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/headers/tab_section_header.dart';
+import 'package:lotti/features/design_system/components/navigation/desktop_detail_empty_state.dart';
+import 'package:lotti/features/design_system/components/navigation/resizable_divider.dart';
+import 'package:lotti/features/design_system/state/pane_width_controller.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/keyboard/ui/list_detail_focus_traversal.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
 import 'package:lotti/features/relationships/service/contacts_service.dart';
 import 'package:lotti/features/relationships/state/relationships_providers.dart';
+import 'package:lotti/features/relationships/ui/model/people_list_model.dart';
 import 'package:lotti/features/relationships/ui/pages/contact_import_page.dart';
-import 'package:lotti/features/relationships/ui/shared/persona_avatar.dart';
-import 'package:lotti/features/relationships/ui/shared/relationship_timestamps.dart';
+import 'package:lotti/features/relationships/ui/pages/relationship_details_page.dart';
+import 'package:lotti/features/relationships/ui/widgets/people_list_row.dart';
+import 'package:lotti/features/relationships/ui/widgets/people_summary_card.dart';
 import 'package:lotti/features/relationships/ui/widgets/relationship_form_modal.dart';
+import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/widgets/nav_bar/bottom_nav_safe_navigator.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
 import 'package:material_ui/material_ui.dart';
 
-/// The People tab (design plan §1): a left-aligned display header with one
-/// add affordance (a 34px teal circle `＋`), and one row per person — persona
-/// avatar, name with an inline star when favorited, a status line (the last
-/// meaningful event or a quiet-streak) with a cadence-state dot, and a
-/// trailing cadence pill. Rows sort due-first then by recency; favorites
-/// are a marker, not a section.
+/// The People tab (design 2026-09-06 §2–3).
+///
+/// Phones show the list scaffold alone; tapping a row beams to
+/// `/people/<id>`. Desktop renders the Tasks/Projects list-detail split: the
+/// list scaffold in a resizable left pane (width from
+/// [paneWidthControllerProvider] via a [ResizableDivider]) and, on the right,
+/// the page of the person selected in
+/// `NavService.desktopSelectedRelationshipId` — written by the location from
+/// the URL, so the route stays the single source of truth — or the empty
+/// state. With a selection the list can move offstage into focus mode while
+/// keeping its state.
 class RelationshipsPage extends ConsumerWidget {
   const RelationshipsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!isDesktopLayout(context)) {
+      return const _PeopleListScaffold(selectedRelationshipId: null);
+    }
+    final tokens = context.designTokens;
+    final paneWidths = ref.watch(paneWidthControllerProvider);
+    // Scales the flat default proportionally on large windows — see
+    // scaledPaneWidth's doc comment. A no-op once the user has dragged the
+    // list pane to any other width.
+    final resolvedListPane = resolvedPaneWidth(
+      storedWidth: paneWidths.listPaneWidth,
+      flatDefault: defaultListPaneWidth,
+      minValue: minListPaneWidth,
+      maxValue: maxListPaneWidth,
+      screenWidth: MediaQuery.sizeOf(context).width,
+      onDelta: (delta) => ref
+          .read(paneWidthControllerProvider.notifier)
+          .updateListPaneWidth(delta, allowWhileCollapsed: true),
+    );
+    final listPaneWidth = resolvedListPane.width;
+    final paneController = ref.read(paneWidthControllerProvider.notifier);
+
+    return ColoredBox(
+      color: tokens.colors.background.level01,
+      child: ValueListenableBuilder<String?>(
+        valueListenable: getIt<NavService>().desktopSelectedRelationshipId,
+        builder: (context, selectedId, _) {
+          final canHideListPane = selectedId != null;
+          final listPaneVisible =
+              !paneWidths.listPaneCollapsed || !canHideListPane;
+          return ListDetailFocusTraversal(
+            debugLabel: 'people-split',
+            listPaneVisible: listPaneVisible,
+            canHideListPane: canHideListPane,
+            onListPaneVisibilityChanged: (visible) {
+              if (visible) {
+                paneController.expandListPane();
+              } else {
+                paneController.collapseListPane();
+              }
+            },
+            listPane: SizedBox(
+              width: listPaneWidth,
+              child: _PeopleListScaffold(selectedRelationshipId: selectedId),
+            ),
+            divider: ResizableDivider(
+              currentValue: listPaneWidth,
+              minValue: minListPaneWidth,
+              maxValue: maxListPaneWidth,
+              onDrag: resolvedListPane.onDrag,
+            ),
+            detailPane: selectedId != null
+                ? _PeopleDetailPane(
+                    key: ValueKey(selectedId),
+                    relationshipId: selectedId,
+                  )
+                : DesktopDetailEmptyState(
+                    message: context.messages.relationshipsSelectPersonHint,
+                    icon: LottiIcons.people,
+                  ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// The desktop detail pane: the person's page, plus the show-list-pane
+/// button while the list is folded away (the Projects pane's shape).
+class _PeopleDetailPane extends StatelessWidget {
+  const _PeopleDetailPane({required this.relationshipId, super.key});
+
+  final String relationshipId;
+
+  @override
+  Widget build(BuildContext context) {
+    final splitController = ListDetailFocusTraversal.maybeOf(context);
+    final tokens = context.designTokens;
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        RelationshipDetailsPage(relationshipId: relationshipId),
+        if (splitController?.listPaneVisible == false)
+          SafeArea(
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: Padding(
+                padding: EdgeInsets.only(
+                  left: tokens.spacing.step5,
+                  top: tokens.spacing.step4,
+                ),
+                child: TabHeaderIconButton(
+                  key: const ValueKey('people-show-list-pane'),
+                  icon: LottiIcons.sidebar,
+                  tooltip: context.messages.listPaneShowTooltip,
+                  onPressed: splitController!.showListPane,
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+/// The list itself: header, summary card, then the rows in their bands.
+class _PeopleListScaffold extends ConsumerWidget {
+  const _PeopleListScaffold({required this.selectedRelationshipId});
+
+  /// The person whose page fills the desktop detail pane; null on phones.
+  final String? selectedRelationshipId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -71,19 +199,10 @@ class RelationshipsPage extends ConsumerWidget {
                   ),
                 ),
                 [] => SliverToBoxAdapter(child: _EmptyState()),
-                final list => () {
-                  final sorted = sortPeopleForList(list);
-                  return SliverList.separated(
-                    itemCount: sorted.length,
-                    separatorBuilder: (_, _) => Divider(
-                      height: 1,
-                      thickness: 1,
-                      color: tokens.colors.decorative.level01,
-                    ),
-                    itemBuilder: (context, index) =>
-                        _RelationshipRow(item: sorted[index]),
-                  );
-                }(),
+                final list => _PeopleList(
+                  items: list,
+                  selectedRelationshipId: selectedRelationshipId,
+                ),
               },
             ),
           ],
@@ -93,10 +212,79 @@ class RelationshipsPage extends ConsumerWidget {
   }
 }
 
-/// The left-aligned `People` title with a count caption and the single add
-/// affordance (design plan §0.3 / §1). Not a Material `AppBar` — the title is
-/// left-aligned display type, and the import-from-contacts door sits beside
-/// the add circle (a distinct action, not a second add affordance).
+/// The summary card and the banded rows, as one sliver list.
+class _PeopleList extends StatelessWidget {
+  const _PeopleList({
+    required this.items,
+    required this.selectedRelationshipId,
+  });
+
+  final List<RelationshipListItem> items;
+  final String? selectedRelationshipId;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final sections = peopleListSections(items);
+    final children = <Widget>[
+      PeopleSummaryCard(summary: peopleSummaryOf(items)),
+      for (final section in sections) ...[
+        Padding(
+          padding: EdgeInsets.fromLTRB(
+            tokens.spacing.step4,
+            tokens.spacing.step5,
+            tokens.spacing.step4,
+            tokens.spacing.step2,
+          ),
+          child: _GroupHeading(
+            group: section.group,
+            count: section.items.length,
+          ),
+        ),
+        for (final item in section.items)
+          PeopleListRow(
+            key: ValueKey('people-row-${item.relationship.id}'),
+            item: item,
+            selected: item.relationship.id == selectedRelationshipId,
+            onTap: () => beamToNamed('/people/${item.relationship.id}'),
+          ),
+      ],
+    ];
+    return SliverList(delegate: SliverChildListDelegate(children));
+  }
+}
+
+/// A band's caption: `Due · 1`, `On track · 3`, `Not enrolled · 1`.
+class _GroupHeading extends StatelessWidget {
+  const _GroupHeading({required this.group, required this.count});
+
+  final PeopleListGroup group;
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    final label = switch (group) {
+      PeopleListGroup.due => messages.relationshipsGroupDue,
+      PeopleListGroup.onTrack => messages.relationshipCadenceOnTrack,
+      PeopleListGroup.notEnrolled => messages.relationshipNotEnrolled,
+    };
+    return Text(
+      '$label · $count',
+      key: ValueKey('people-group-${group.name}'),
+      style: tokens.typography.styles.others.caption.copyWith(
+        color: tokens.colors.text.mediumEmphasis,
+        fontWeight: tokens.typography.weight.semiBold,
+      ),
+    );
+  }
+}
+
+/// The left-aligned `People` title with a count caption and the add
+/// affordance: a labelled button on desktop, the teal circle on phones —
+/// beside the import-from-contacts door, which exists only where there is
+/// an address book (ADR 0041 §2).
 class _PeopleHeader extends ConsumerWidget {
   const _PeopleHeader({required this.itemCount});
 
@@ -106,6 +294,7 @@ class _PeopleHeader extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final tokens = context.designTokens;
     final messages = context.messages;
+    final isDesktop = isDesktopLayout(context);
 
     return Padding(
       padding: EdgeInsets.fromLTRB(
@@ -132,9 +321,7 @@ class _PeopleHeader extends ConsumerWidget {
             ),
           ],
           const Spacer(),
-          // Import is a distinct door, not a second add affordance; hidden on
-          // desktop where there is no address book (ADR 0041 §2).
-          if (ref.read(contactsServiceProvider).isSupported)
+          if (ref.read(contactsServiceProvider).isSupported) ...[
             _IconButton(
               icon: LottiIcons.contactImport,
               tooltip: messages.relationshipImportAction,
@@ -144,10 +331,19 @@ class _PeopleHeader extends ConsumerWidget {
                 ),
               ),
             ),
-          SizedBox(width: tokens.spacing.step2),
-          _AddPersonButton(
-            onTap: () => showRelationshipCreateModal(context: context),
-          ),
+            SizedBox(width: tokens.spacing.step2),
+          ],
+          if (isDesktop)
+            DesignSystemButton(
+              key: const ValueKey('people-add-person-button'),
+              label: messages.relationshipCreateTitle,
+              leadingIcon: LottiIcons.add,
+              onPressed: () => showRelationshipCreateModal(context: context),
+            )
+          else
+            _AddPersonButton(
+              onTap: () => showRelationshipCreateModal(context: context),
+            ),
         ],
       ),
     );
@@ -253,249 +449,4 @@ class _EmptyState extends StatelessWidget {
       ),
     );
   }
-}
-
-/// One person row (design plan §1): 40px persona avatar, name + inline star,
-/// a cadence-state dot + status line, and a trailing cadence pill.
-class _RelationshipRow extends StatelessWidget {
-  const _RelationshipRow({required this.item});
-
-  final RelationshipListItem item;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    final relationship = item.relationship;
-    final data = relationship.data;
-    final cadenceDays = data.checkInCadenceDays;
-
-    return InkWell(
-      onTap: () => beamToNamed('/people/${relationship.id}'),
-      child: Padding(
-        padding: EdgeInsets.symmetric(
-          horizontal: tokens.spacing.step4,
-          vertical: tokens.spacing.step3,
-        ),
-        child: Row(
-          children: [
-            PersonaAvatar(
-              initial: personaInitial(data.title),
-              id: relationship.id,
-            ),
-            SizedBox(width: tokens.spacing.step4),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Row(
-                    children: [
-                      Flexible(
-                        child: Text(
-                          data.title,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: tokens.typography.styles.body.bodyLarge
-                              .copyWith(
-                                fontWeight: tokens.typography.weight.semiBold,
-                                color: tokens.colors.text.highEmphasis,
-                              ),
-                        ),
-                      ),
-                      if (data.important) ...[
-                        SizedBox(width: tokens.spacing.step2),
-                        Icon(
-                          LottiIconsFilled.star,
-                          size: 11,
-                          color: tokens.colors.interactive.enabled,
-                        ),
-                      ],
-                    ],
-                  ),
-                  SizedBox(height: tokens.spacing.step1),
-                  Row(
-                    children: [
-                      _CadenceStateDot(
-                        cadenceDays: cadenceDays,
-                        lastCheckInAt: item.lastCheckInAt,
-                        trackingStartedAt: relationship.meta.dateFrom,
-                      ),
-                      SizedBox(width: tokens.spacing.step2),
-                      Flexible(
-                        child: Text(
-                          _statusLine(
-                            context,
-                            item,
-                            cadenceDays,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: tokens.typography.styles.others.caption
-                              .copyWith(
-                                color: tokens.colors.text.mediumEmphasis,
-                              ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-            SizedBox(width: tokens.spacing.step3),
-            _CadencePill(
-              cadenceDays: cadenceDays,
-              lastCheckInAt: item.lastCheckInAt,
-              trackingStartedAt: relationship.meta.dateFrom,
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  /// The status line: the last meaningful event (with its mono timestamp),
-  /// or the quiet-streak caption. "Tracking since …" is dropped entirely
-  /// (design plan §0.8) — a person added today has not been contacted today.
-  String _statusLine(
-    BuildContext context,
-    RelationshipListItem item,
-    int? cadenceDays,
-  ) {
-    final messages = context.messages;
-    final last = item.lastCheckInAt;
-    if (last != null) {
-      return messages.relationshipCheckedInLabel(
-        relationshipTimestampLabelOf(context, last),
-      );
-    }
-    final streak = quietStreakDays(
-      lastCheckInAt: null,
-      trackingStartedAt: item.relationship.meta.dateFrom,
-    );
-    if (streak == 0) return messages.relationshipJustAdded;
-    return messages.relationshipQuietForDays(streak);
-  }
-}
-
-/// The 7px cadence-state dot: teal when on track, warning when due, neutral
-/// when there is no cadence (design plan §0.6 / §1).
-class _CadenceStateDot extends StatelessWidget {
-  const _CadenceStateDot({
-    required this.cadenceDays,
-    required this.lastCheckInAt,
-    required this.trackingStartedAt,
-  });
-
-  final int? cadenceDays;
-  final DateTime? lastCheckInAt;
-  final DateTime trackingStartedAt;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    final overdue = cadenceOverdueDays(
-      lastCheckInAt: lastCheckInAt,
-      trackingStartedAt: trackingStartedAt,
-      cadenceDays: cadenceDays,
-    );
-    final color = switch (overdue) {
-      null => tokens.colors.text.highEmphasis.withValues(alpha: 0.38),
-      <= 0 => tokens.colors.interactive.enabled,
-      _ => tokens.colors.alert.warning.defaultColor,
-    };
-    return Container(
-      width: 7,
-      height: 7,
-      decoration: BoxDecoration(color: color, shape: BoxShape.circle),
-    );
-  }
-}
-
-/// The trailing cadence pill: quiet/on-track when not due, warning-tinted
-/// `Due {day}` when overdue (design plan §1).
-class _CadencePill extends StatelessWidget {
-  const _CadencePill({
-    required this.cadenceDays,
-    required this.lastCheckInAt,
-    required this.trackingStartedAt,
-  });
-
-  final int? cadenceDays;
-  final DateTime? lastCheckInAt;
-  final DateTime trackingStartedAt;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    final messages = context.messages;
-
-    if (cadenceDays == null) return const SizedBox.shrink();
-
-    final due = cadenceDueDate(
-      lastCheckInAt: lastCheckInAt,
-      trackingStartedAt: trackingStartedAt,
-      cadenceDays: cadenceDays,
-    );
-    final overdue = cadenceOverdueDays(
-      lastCheckInAt: lastCheckInAt,
-      trackingStartedAt: trackingStartedAt,
-      cadenceDays: cadenceDays,
-    );
-
-    final dueOverdue = (overdue ?? 0) > 0;
-    final label = dueOverdue
-        ? messages.relationshipDueDay(relationshipWeekdayLabelOf(context, due!))
-        : messages.relationshipCadenceOnTrack;
-    final fg = dueOverdue
-        ? tokens.colors.alert.warning.defaultColor
-        : tokens.colors.text.mediumEmphasis;
-    final bg = dueOverdue
-        ? tokens.colors.alert.warning.defaultColor.withValues(alpha: 0.16)
-        : tokens.colors.surface.enabled;
-
-    return Container(
-      padding: EdgeInsets.symmetric(
-        horizontal: tokens.spacing.step3,
-        vertical: tokens.spacing.step1,
-      ),
-      decoration: BoxDecoration(
-        color: bg,
-        borderRadius: BorderRadius.circular(tokens.radii.badgesPills),
-      ),
-      child: Text(
-        label,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: tokens.typography.styles.others.caption.copyWith(
-          color: fg,
-          fontWeight: tokens.typography.weight.semiBold,
-          height: 1,
-        ),
-      ),
-    );
-  }
-}
-
-/// Sort the list due-first, then by last-contact recency (design plan §1).
-/// Favorites do NOT get a separate section; the star is a marker.
-List<RelationshipListItem> sortPeopleForList(List<RelationshipListItem> items) {
-  final due = <RelationshipListItem>[];
-  final rest = <RelationshipListItem>[];
-  for (final item in items) {
-    final overdue = cadenceOverdueDays(
-      lastCheckInAt: item.lastCheckInAt,
-      trackingStartedAt: item.relationship.meta.dateFrom,
-      cadenceDays: item.relationship.data.checkInCadenceDays,
-    );
-    if ((overdue ?? 0) > 0) {
-      due.add(item);
-    } else {
-      rest.add(item);
-    }
-  }
-  DateTime recency(RelationshipListItem i) =>
-      i.lastCheckInAt ?? i.relationship.meta.dateFrom;
-  due.sort((a, b) => recency(b).compareTo(recency(a)));
-  rest.sort((a, b) => recency(b).compareTo(recency(a)));
-  return [...due, ...rest];
 }

--- a/lib/features/relationships/ui/shared/relationship_timestamps.dart
+++ b/lib/features/relationships/ui/shared/relationship_timestamps.dart
@@ -87,6 +87,19 @@ DateTime _dayBefore(DateTime anchor) =>
 /// the date is already implied by the beat's position.
 String relationshipTimeLabel(DateTime at) => _hhMm(at);
 
+/// A mono day label without a time (`Thu 23 Jul`), for a date that is a
+/// deadline rather than an event — the summary card's next due day, the
+/// row's `first due` note.
+String relationshipDayLabel(DateTime at, {String? locale}) =>
+    _shortDayMonth(at, locale);
+
+/// [relationshipDayLabel] resolved against the widget tree's locale.
+String relationshipDayLabelOf(BuildContext context, DateTime at) =>
+    relationshipDayLabel(
+      at,
+      locale: Localizations.localeOf(context).toString(),
+    );
+
 /// A mono weekday-only label (`Thu`), used by the cadence due pill, in the
 /// locale's own abbreviation.
 String relationshipWeekdayLabel(DateTime at, {String? locale}) =>

--- a/lib/features/relationships/ui/widgets/people_list_row.dart
+++ b/lib/features/relationships/ui/widgets/people_list_row.dart
@@ -1,0 +1,181 @@
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/relationships/repository/relationship_repository.dart';
+import 'package:lotti/features/relationships/ui/model/people_list_model.dart';
+import 'package:lotti/features/relationships/ui/shared/persona_avatar.dart';
+import 'package:lotti/features/relationships/ui/shared/relationship_timestamps.dart';
+import 'package:lotti/features/relationships/ui/widgets/check_in_capture_sheet.dart';
+import 'package:lotti/features/relationships/ui/widgets/relationship_form_modal.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:material_ui/material_ui.dart';
+
+/// One person on the People list (design 2026-09-06 §2): the persona
+/// avatar, the name with a sparkle for an important person, one mono status
+/// line (`Call · Today 12:44 · Weekly`), and the truthful cadence pill.
+///
+/// On desktop the row of the person whose page fills the detail pane wears
+/// the selected wash; on phones nothing is ever selected.
+class PeopleListRow extends StatelessWidget {
+  const PeopleListRow({
+    required this.item,
+    required this.onTap,
+    this.selected = false,
+    super.key,
+  });
+
+  final RelationshipListItem item;
+  final VoidCallback onTap;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final relationship = item.relationship;
+    final data = relationship.data;
+
+    return Material(
+      color: selected
+          ? tokens.colors.surface.selected
+          : tokens.colors.background.level01,
+      borderRadius: BorderRadius.circular(tokens.radii.m),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: EdgeInsets.symmetric(
+            horizontal: tokens.spacing.step4,
+            vertical: tokens.spacing.step3,
+          ),
+          child: Row(
+            children: [
+              PersonaAvatar(
+                initial: personaInitial(data.title),
+                id: relationship.id,
+              ),
+              SizedBox(width: tokens.spacing.step4),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Row(
+                      children: [
+                        Flexible(
+                          child: Text(
+                            data.title,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: tokens.typography.styles.body.bodyLarge
+                                .copyWith(
+                                  fontWeight: tokens.typography.weight.semiBold,
+                                  color: tokens.colors.text.highEmphasis,
+                                ),
+                          ),
+                        ),
+                        if (data.important) ...[
+                          SizedBox(width: tokens.spacing.step2),
+                          Icon(
+                            LottiIcons.aiSpark,
+                            key: const ValueKey('people-row-important'),
+                            size: tokens.spacing.step3,
+                            color: tokens.colors.interactive.enabled,
+                          ),
+                        ],
+                      ],
+                    ),
+                    SizedBox(height: tokens.spacing.step1),
+                    Text(
+                      peopleStatusLineOf(context, item),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: relationshipTimestampStyle(
+                        tokens,
+                        color: tokens.colors.text.mediumEmphasis,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              SizedBox(width: tokens.spacing.step3),
+              PeopleCadencePillWidget(pill: peopleCadencePillOf(item)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The row's status line: the last contact (`Call · Today 12:44`) or `Just
+/// added`, then the cadence, then — for a person not yet contacted — when the
+/// first check-in falls due.
+String peopleStatusLineOf(BuildContext context, RelationshipListItem item) {
+  final messages = context.messages;
+  final cadence = relationshipCadenceLabel(
+    context,
+    item.relationship.data.checkInCadenceDays,
+  );
+  final last = item.lastCheckIn;
+  if (last != null) {
+    return [
+      checkInInteractionLabel(context, last.data.interactionType),
+      relationshipTimestampLabelOf(context, last.meta.dateFrom),
+      cadence,
+    ].join(' · ');
+  }
+  final firstDue = peopleDueDateOf(item);
+  return [
+    messages.relationshipJustAdded,
+    cadence,
+    if (firstDue != null)
+      messages.relationshipFirstDue(relationshipDayLabelOf(context, firstDue)),
+  ].join(' · ');
+}
+
+/// The truthful cadence pill: warning-tinted `{n} days over` when the cadence
+/// lapsed, and a quiet read-out otherwise (`Due Thu`, `On track`,
+/// `Not enrolled`, `Dormant`, `Archived`).
+class PeopleCadencePillWidget extends StatelessWidget {
+  const PeopleCadencePillWidget({required this.pill, super.key});
+
+  final PeopleCadencePill pill;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    final label = switch (pill.kind) {
+      PeopleCadencePillKind.overdue => messages.relationshipDaysOver(
+        pill.daysOver,
+      ),
+      PeopleCadencePillKind.dueSoon => messages.relationshipDueDay(
+        relationshipWeekdayLabelOf(context, pill.dueAt!),
+      ),
+      PeopleCadencePillKind.onTrack => messages.relationshipCadenceOnTrack,
+      PeopleCadencePillKind.notEnrolled => messages.relationshipNotEnrolled,
+      PeopleCadencePillKind.dormant => messages.relationshipStatusDormant,
+      PeopleCadencePillKind.archived => messages.relationshipStatusArchived,
+    };
+    if (pill.kind == PeopleCadencePillKind.overdue) {
+      return DsPill(
+        key: const ValueKey('people-row-pill-overdue'),
+        variant: DsPillVariant.tinted,
+        shape: DsPillShape.tag,
+        color: tokens.colors.alert.warning.defaultColor,
+        // The warning hue as ink on its own wash fails contrast; the colour
+        // identity rides the tint (the health chip's rule).
+        labelColor: tokens.colors.text.highEmphasis,
+        label: label,
+      );
+    }
+    // A quiet read-out on the solid surface fill, never the dashed `muted`
+    // shell — that one says "unset", and a cadence that is on track is set.
+    return DsPill(
+      variant: DsPillVariant.filled,
+      shape: DsPillShape.tag,
+      labelColor: tokens.colors.text.mediumEmphasis,
+      label: label,
+    );
+  }
+}

--- a/lib/features/relationships/ui/widgets/people_list_row.dart
+++ b/lib/features/relationships/ui/widgets/people_list_row.dart
@@ -107,30 +107,36 @@ class PeopleListRow extends StatelessWidget {
   }
 }
 
-/// The row's status line: the last contact (`Call · Today 12:44`) or `Just
-/// added`, then the cadence, then — for a person not yet contacted — when the
-/// first check-in falls due.
+/// The row's status line: the last contact (`Call · Today 12:44 · Weekly`)
+/// or `Just added · Monthly · first due Sun 16 Aug`. Each line is one
+/// catalog message, so a locale can reorder its parts.
+///
+/// The cadence named is the one the runtime applies: an enrolled person
+/// without a stored cadence reads as the production default, not as "no
+/// cadence"; a person who is not enrolled reads their stored setting and is
+/// never given a first-due day, because the runtime schedules none for them.
 String peopleStatusLineOf(BuildContext context, RelationshipListItem item) {
   final messages = context.messages;
+  final relationship = item.relationship;
   final cadence = relationshipCadenceLabel(
     context,
-    item.relationship.data.checkInCadenceDays,
+    effectiveCadenceDaysOf(relationship) ??
+        relationship.data.checkInCadenceDays,
   );
   final last = item.lastCheckIn;
   if (last != null) {
-    return [
+    return messages.relationshipStatusLineContacted(
       checkInInteractionLabel(context, last.data.interactionType),
       relationshipTimestampLabelOf(context, last.meta.dateFrom),
       cadence,
-    ].join(' · ');
+    );
   }
   final firstDue = peopleDueDateOf(item);
-  return [
-    messages.relationshipJustAdded,
+  if (firstDue == null) return messages.relationshipStatusLineAdded(cadence);
+  return messages.relationshipStatusLineAddedFirstDue(
     cadence,
-    if (firstDue != null)
-      messages.relationshipFirstDue(relationshipDayLabelOf(context, firstDue)),
-  ].join(' · ');
+    relationshipDayLabelOf(context, firstDue),
+  );
 }
 
 /// The truthful cadence pill: warning-tinted `{n} days over` when the cadence
@@ -146,6 +152,8 @@ class PeopleCadencePillWidget extends StatelessWidget {
     final tokens = context.designTokens;
     final messages = context.messages;
     final label = switch (pill.kind) {
+      PeopleCadencePillKind.overdue when pill.daysOver == 0 =>
+        messages.relationshipDueToday,
       PeopleCadencePillKind.overdue => messages.relationshipDaysOver(
         pill.daysOver,
       ),

--- a/lib/features/relationships/ui/widgets/people_summary_card.dart
+++ b/lib/features/relationships/ui/widgets/people_summary_card.dart
@@ -1,0 +1,117 @@
+import 'package:lotti/features/design_system/components/cards/design_system_section_card.dart';
+import 'package:lotti/features/design_system/components/dividers/design_system_divider.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/relationships/ui/model/people_list_model.dart';
+import 'package:lotti/features/relationships/ui/shared/relationship_timestamps.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:material_ui/material_ui.dart';
+
+/// The card above the People list (design 2026-09-06 §2, the Goals list's
+/// summary card): how many enrolled people are due right now, who lapses
+/// next and when, and how many people the agent is not watching at all.
+///
+/// The due count carries the warning ink only while it is non-zero — a calm
+/// morning reads as a quiet `0 / 4 enrolled`, not as a warning about nothing.
+class PeopleSummaryCard extends StatelessWidget {
+  const PeopleSummaryCard({required this.summary, super.key});
+
+  final PeopleSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    final styles = tokens.typography.styles;
+    final nextDue = summary.nextDue;
+    final nextDueAt = summary.nextDueAt;
+    // The nickname where there is one: the card names a person the way the
+    // user talks about them ("Next due Bo"), and a full name wraps the line.
+    final nextDueName =
+        nextDue?.relationship.data.nickname ?? nextDue?.relationship.data.title;
+    final nextDueLabel = nextDueName == null || nextDueAt == null
+        ? messages.relationshipsSummaryNoneDue
+        : messages.relationshipsSummaryNextDue(
+            nextDueName,
+            relationshipDayLabelOf(context, nextDueAt),
+          );
+
+    return DesignSystemSectionCard(
+      key: const ValueKey('people-summary-card'),
+      padding: EdgeInsets.all(tokens.spacing.step4),
+      child: Row(
+        children: [
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                messages.relationshipsSummaryDueNow,
+                style: styles.others.caption.copyWith(
+                  color: tokens.colors.text.lowEmphasis,
+                ),
+              ),
+              SizedBox(height: tokens.spacing.step1),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.baseline,
+                textBaseline: TextBaseline.alphabetic,
+                children: [
+                  Text(
+                    '${summary.dueNow}',
+                    key: const ValueKey('people-summary-due-count'),
+                    style: styles.heading.heading1.copyWith(
+                      color: summary.dueNow > 0
+                          ? tokens.colors.alert.warning.defaultColor
+                          : tokens.colors.text.highEmphasis,
+                    ),
+                  ),
+                  SizedBox(width: tokens.spacing.step2),
+                  Text(
+                    messages.relationshipsSummaryEnrolled(summary.enrolled),
+                    style: styles.body.bodyMedium.copyWith(
+                      color: tokens.colors.text.mediumEmphasis,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          Padding(
+            padding: EdgeInsets.symmetric(horizontal: tokens.spacing.step4),
+            child: DesignSystemDivider(
+              orientation: DesignSystemDividerOrientation.vertical,
+              length: tokens.spacing.step10,
+            ),
+          ),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  nextDueLabel,
+                  key: const ValueKey('people-summary-next-due'),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: styles.body.bodyMedium.copyWith(
+                    color: tokens.colors.text.highEmphasis,
+                  ),
+                ),
+                if (summary.notEnrolled > 0) ...[
+                  SizedBox(height: tokens.spacing.step1),
+                  Text(
+                    messages.relationshipsSummaryNotEnrolled(
+                      summary.notEnrolled,
+                    ),
+                    style: styles.others.caption.copyWith(
+                      color: tokens.colors.text.lowEmphasis,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4478,7 +4478,7 @@
   "relationshipsPageTitle": "Lidé",
   "relationshipsSelectPersonHint": "Vyber osobu a zobrazí se její stránka.",
   "relationshipsSummaryDueNow": "Teď na řadě",
-  "relationshipsSummaryEnrolled": "/ {count} sledovaných",
+  "relationshipsSummaryEnrolled": "{count, plural, =1{/ 1 sledovaná} few{/ {count} sledované} other{/ {count} sledovaných}}",
   "@relationshipsSummaryEnrolled": {
     "placeholders": {
       "count": {
@@ -4497,8 +4497,8 @@
       }
     }
   },
-  "relationshipsSummaryNoneDue": "Nikdo nečeká",
-  "relationshipsSummaryNotEnrolled": "{count, plural, =1{1 osoba nesledována} few{{count} osoby nesledovány} other{{count} osob nesledováno}}",
+  "relationshipsSummaryNoneDue": "Nikdo není na řadě",
+  "relationshipsSummaryNotEnrolled": "{count, plural, =1{1 nesledovaná osoba} few{{count} nesledované osoby} other{{count} nesledovaných osob}}",
   "@relationshipsSummaryNotEnrolled": {
     "placeholders": {
       "count": {

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4518,7 +4518,7 @@
       }
     }
   },
-  "relationshipStatusLineAddedFirstDue": "Právě přidáno · {cadence} · poprvé {day}",
+  "relationshipStatusLineAddedFirstDue": "Právě přidáno · {cadence} · poprvé do {day}",
   "@relationshipStatusLineAddedFirstDue": {
     "placeholders": {
       "cadence": {

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4362,6 +4362,14 @@
   "relationshipContactMissing": "Tento kontakt v tomto zařízení není",
   "relationshipContactNoChanges": "Není co nového zkopírovat",
   "relationshipCreateTitle": "Přidat osobu",
+  "relationshipDaysOver": "{count, plural, =1{1 den po termínu} few{{count} dny po termínu} other{{count} dní po termínu}}",
+  "@relationshipDaysOver": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDeleteConfirmMessage": "Smažou se i všechny záznamy kontaktů. Tohle nelze vrátit zpět.",
   "relationshipDeleteConfirmTitle": "Smazat {name}?",
   "relationshipDueDay": "Do {day}",
@@ -4377,6 +4385,14 @@
   "relationshipErrorDeleteFailed": "Osobu se nepodařilo smazat. Zkus to prosím znovu.",
   "relationshipErrorLinkTaskFailed": "Úkol se nepodařilo propojit. Zkus to prosím znovu.",
   "relationshipErrorUpdateFailed": "Změny se nepodařilo uložit. Zkus to prosím znovu.",
+  "relationshipFirstDue": "poprvé {day}",
+  "@relationshipFirstDue": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipHealthNeedsAttention": "Vyžaduje pozornost",
   "relationshipHealthSteady": "Stabilní",
   "relationshipHealthStrained": "Napjatý",
@@ -4433,6 +4449,7 @@
   "relationshipNicknameLabel": "Přezdívka",
   "relationshipNoCheckIns": "Zatím žádné záznamy — přidej první po dalším rozhovoru.",
   "relationshipNoLinkedTasks": "Zatím žádné propojené úkoly.",
+  "relationshipNotEnrolled": "Nesledováno",
   "relationshipNotFound": "Tahle osoba už není sledovaná.",
   "relationshipNudgesOn": "připomínky zapnuty",
   "@relationshipNudgesOn": {
@@ -4464,7 +4481,38 @@
     "description": "Relationships redesign label."
   },
   "relationshipsEmptyState": "Přidej lidi, se kterými chceš zůstat v kontaktu.",
+  "relationshipsGroupDue": "Na řadě",
   "relationshipsPageTitle": "Lidé",
+  "relationshipsSelectPersonHint": "Vyber osobu a zobrazí se její stránka.",
+  "relationshipsSummaryDueNow": "Teď na řadě",
+  "relationshipsSummaryEnrolled": "/ {count} sledovaných",
+  "@relationshipsSummaryEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipsSummaryNextDue": "Další: {name} · {day}",
+  "@relationshipsSummaryNextDue": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipsSummaryNoneDue": "Nikdo nečeká",
+  "relationshipsSummaryNotEnrolled": "{count, plural, =1{1 osoba nesledována} few{{count} osoby nesledovány} other{{count} osob nesledováno}}",
+  "@relationshipsSummaryNotEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipStatusActive": "Aktivní",
   "relationshipStatusArchived": "Archivované",
   "relationshipStatusDormant": "Spící",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4380,19 +4380,12 @@
       }
     }
   },
+  "relationshipDueToday": "Dnes na řadě",
   "relationshipEditTitle": "Upravit osobu",
   "relationshipErrorCreateFailed": "Osobu se nepodařilo uložit. Zkus to prosím znovu.",
   "relationshipErrorDeleteFailed": "Osobu se nepodařilo smazat. Zkus to prosím znovu.",
   "relationshipErrorLinkTaskFailed": "Úkol se nepodařilo propojit. Zkus to prosím znovu.",
   "relationshipErrorUpdateFailed": "Změny se nepodařilo uložit. Zkus to prosím znovu.",
-  "relationshipFirstDue": "poprvé {day}",
-  "@relationshipFirstDue": {
-    "placeholders": {
-      "day": {
-        "type": "String"
-      }
-    }
-  },
   "relationshipHealthNeedsAttention": "Vyžaduje pozornost",
   "relationshipHealthSteady": "Stabilní",
   "relationshipHealthStrained": "Napjatý",
@@ -4517,6 +4510,39 @@
   "relationshipStatusArchived": "Archivované",
   "relationshipStatusDormant": "Spící",
   "relationshipStatusFieldLabel": "Stav",
+  "relationshipStatusLineAdded": "Právě přidáno · {cadence}",
+  "@relationshipStatusLineAdded": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineAddedFirstDue": "Právě přidáno · {cadence} · poprvé {day}",
+  "@relationshipStatusLineAddedFirstDue": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineContacted": "{type} · {time} · {cadence}",
+  "@relationshipStatusLineContacted": {
+    "placeholders": {
+      "type": {
+        "type": "String"
+      },
+      "time": {
+        "type": "String"
+      },
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipStayingInTouch": "Udržovat kontakt",
   "@relationshipStayingInTouch": {
     "description": "Relationships redesign label."

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4858,6 +4858,14 @@
   "relationshipContactMissing": "Den kontakt findes ikke på denne enhed",
   "relationshipContactNoChanges": "Intet nyt at kopiere",
   "relationshipCreateTitle": "Tilføj person",
+  "relationshipDaysOver": "{count, plural, =1{1 dag over tid} other{{count} dage over tid}}",
+  "@relationshipDaysOver": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDeleteConfirmMessage": "Deres check-ins slettes også. Det kan ikke fortrydes.",
   "relationshipDeleteConfirmTitle": "Slet {name}?",
   "relationshipDueDay": "Senest {day}",
@@ -4873,6 +4881,14 @@
   "relationshipErrorDeleteFailed": "Personen kunne ikke slettes. Prøv igen.",
   "relationshipErrorLinkTaskFailed": "Opgaven kunne ikke tilknyttes. Prøv igen.",
   "relationshipErrorUpdateFailed": "Ændringerne kunne ikke gemmes. Prøv igen.",
+  "relationshipFirstDue": "første gang {day}",
+  "@relationshipFirstDue": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipHealthNeedsAttention": "Kræver opmærksomhed",
   "relationshipHealthSteady": "Stabil",
   "relationshipHealthStrained": "Anstrengt",
@@ -4929,6 +4945,7 @@
   "relationshipNicknameLabel": "Kaldenavn",
   "relationshipNoCheckIns": "Ingen check-ins endnu — registrér et efter jeres næste snak.",
   "relationshipNoLinkedTasks": "Ingen opgaver linket endnu.",
+  "relationshipNotEnrolled": "Ikke fulgt",
   "relationshipNotFound": "Denne person følges ikke længere.",
   "relationshipNudgesOn": "påmindelser til",
   "@relationshipNudgesOn": {
@@ -4960,7 +4977,38 @@
     "description": "Relationships redesign label."
   },
   "relationshipsEmptyState": "Tilføj de mennesker, du vil holde kontakten med.",
+  "relationshipsGroupDue": "Skal kontaktes",
   "relationshipsPageTitle": "Personer",
+  "relationshipsSelectPersonHint": "Vælg en person for at se deres side.",
+  "relationshipsSummaryDueNow": "Skal kontaktes nu",
+  "relationshipsSummaryEnrolled": "/ {count} fulgt",
+  "@relationshipsSummaryEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipsSummaryNextDue": "Næste: {name} · {day}",
+  "@relationshipsSummaryNextDue": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipsSummaryNoneDue": "Ingen venter",
+  "relationshipsSummaryNotEnrolled": "{count, plural, =1{1 person ikke fulgt} other{{count} personer ikke fulgt}}",
+  "@relationshipsSummaryNotEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipStatusActive": "Aktiv",
   "relationshipStatusArchived": "Arkiveret",
   "relationshipStatusDormant": "Hvilende",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4858,7 +4858,7 @@
   "relationshipContactMissing": "Den kontakt findes ikke på denne enhed",
   "relationshipContactNoChanges": "Intet nyt at kopiere",
   "relationshipCreateTitle": "Tilføj person",
-  "relationshipDaysOver": "{count, plural, =1{1 dag over tid} other{{count} dage over tid}}",
+  "relationshipDaysOver": "{count, plural, =1{1 dag forsinket} other{{count} dage forsinket}}",
   "@relationshipDaysOver": {
     "placeholders": {
       "count": {

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4876,19 +4876,12 @@
       }
     }
   },
+  "relationshipDueToday": "Skal kontaktes i dag",
   "relationshipEditTitle": "Redigér person",
   "relationshipErrorCreateFailed": "Personen kunne ikke gemmes. Prøv igen.",
   "relationshipErrorDeleteFailed": "Personen kunne ikke slettes. Prøv igen.",
   "relationshipErrorLinkTaskFailed": "Opgaven kunne ikke tilknyttes. Prøv igen.",
   "relationshipErrorUpdateFailed": "Ændringerne kunne ikke gemmes. Prøv igen.",
-  "relationshipFirstDue": "første gang {day}",
-  "@relationshipFirstDue": {
-    "placeholders": {
-      "day": {
-        "type": "String"
-      }
-    }
-  },
   "relationshipHealthNeedsAttention": "Kræver opmærksomhed",
   "relationshipHealthSteady": "Stabil",
   "relationshipHealthStrained": "Anstrengt",
@@ -5013,6 +5006,39 @@
   "relationshipStatusArchived": "Arkiveret",
   "relationshipStatusDormant": "Hvilende",
   "relationshipStatusFieldLabel": "Status",
+  "relationshipStatusLineAdded": "Lige tilføjet · {cadence}",
+  "@relationshipStatusLineAdded": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineAddedFirstDue": "Lige tilføjet · {cadence} · første gang {day}",
+  "@relationshipStatusLineAddedFirstDue": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineContacted": "{type} · {time} · {cadence}",
+  "@relationshipStatusLineContacted": {
+    "placeholders": {
+      "type": {
+        "type": "String"
+      },
+      "time": {
+        "type": "String"
+      },
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipStayingInTouch": "Holde kontakten",
   "@relationshipStayingInTouch": {
     "description": "Relationships redesign label."

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -5014,7 +5014,7 @@
       }
     }
   },
-  "relationshipStatusLineAddedFirstDue": "Lige tilføjet · {cadence} · første gang {day}",
+  "relationshipStatusLineAddedFirstDue": "Lige tilføjet · {cadence} · første gang senest {day}",
   "@relationshipStatusLineAddedFirstDue": {
     "placeholders": {
       "cadence": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -4373,19 +4373,12 @@
       }
     }
   },
+  "relationshipDueToday": "Heute fällig",
   "relationshipEditTitle": "Person bearbeiten",
   "relationshipErrorCreateFailed": "Person konnte nicht gespeichert werden. Bitte versuch es erneut.",
   "relationshipErrorDeleteFailed": "Person konnte nicht gelöscht werden. Bitte versuch es erneut.",
   "relationshipErrorLinkTaskFailed": "Aufgabe konnte nicht verknüpft werden. Bitte versuch es erneut.",
   "relationshipErrorUpdateFailed": "Änderungen konnten nicht gespeichert werden. Bitte versuch es erneut.",
-  "relationshipFirstDue": "erstmals fällig {day}",
-  "@relationshipFirstDue": {
-    "placeholders": {
-      "day": {
-        "type": "String"
-      }
-    }
-  },
   "relationshipHealthNeedsAttention": "Braucht Aufmerksamkeit",
   "relationshipHealthSteady": "Stabil",
   "relationshipHealthStrained": "Angespannt",
@@ -4510,6 +4503,39 @@
   "relationshipStatusArchived": "Archiviert",
   "relationshipStatusDormant": "Ruhend",
   "relationshipStatusFieldLabel": "Status",
+  "relationshipStatusLineAdded": "Gerade hinzugefügt · {cadence}",
+  "@relationshipStatusLineAdded": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineAddedFirstDue": "Gerade hinzugefügt · {cadence} · erstmals fällig {day}",
+  "@relationshipStatusLineAddedFirstDue": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineContacted": "{type} · {time} · {cadence}",
+  "@relationshipStatusLineContacted": {
+    "placeholders": {
+      "type": {
+        "type": "String"
+      },
+      "time": {
+        "type": "String"
+      },
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipStayingInTouch": "Kontakt halten",
   "@relationshipStayingInTouch": {
     "description": "Relationships redesign label."

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -4511,7 +4511,7 @@
       }
     }
   },
-  "relationshipStatusLineAddedFirstDue": "Gerade hinzugefügt · {cadence} · erstmals fällig {day}",
+  "relationshipStatusLineAddedFirstDue": "Gerade hinzugefügt · {cadence} · erstmals fällig am {day}",
   "@relationshipStatusLineAddedFirstDue": {
     "placeholders": {
       "cadence": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -4355,7 +4355,7 @@
   "relationshipContactMissing": "Dieser Kontakt ist nicht auf diesem Gerät",
   "relationshipContactNoChanges": "Nichts Neues zu übernehmen",
   "relationshipCreateTitle": "Person hinzufügen",
-  "relationshipDaysOver": "{count, plural, =1{1 Tag drüber} other{{count} Tage drüber}}",
+  "relationshipDaysOver": "{count, plural, =1{1 Tag überfällig} other{{count} Tage überfällig}}",
   "@relationshipDaysOver": {
     "placeholders": {
       "count": {
@@ -4435,7 +4435,7 @@
   "relationshipNicknameLabel": "Spitzname",
   "relationshipNoCheckIns": "Noch keine Check-ins — erfasse einen nach eurem nächsten Gespräch.",
   "relationshipNoLinkedTasks": "Noch keine Aufgaben verknüpft.",
-  "relationshipNotEnrolled": "Nicht betreut",
+  "relationshipNotEnrolled": "Nicht im Blick",
   "relationshipNotFound": "Diese Person ist nicht mehr in deiner Liste.",
   "relationshipNudgesOn": "Erinnerungen an",
   "@relationshipNudgesOn": {
@@ -4471,7 +4471,7 @@
   "relationshipsPageTitle": "Menschen",
   "relationshipsSelectPersonHint": "Wähle eine Person, um ihre Seite zu sehen.",
   "relationshipsSummaryDueNow": "Jetzt fällig",
-  "relationshipsSummaryEnrolled": "/ {count} betreut",
+  "relationshipsSummaryEnrolled": "/ {count} im Blick",
   "@relationshipsSummaryEnrolled": {
     "placeholders": {
       "count": {
@@ -4491,7 +4491,7 @@
     }
   },
   "relationshipsSummaryNoneDue": "Niemand fällig",
-  "relationshipsSummaryNotEnrolled": "{count, plural, =1{1 Person nicht betreut} other{{count} Personen nicht betreut}}",
+  "relationshipsSummaryNotEnrolled": "{count, plural, =1{1 Person nicht im Blick} other{{count} Personen nicht im Blick}}",
   "@relationshipsSummaryNotEnrolled": {
     "placeholders": {
       "count": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -4355,6 +4355,14 @@
   "relationshipContactMissing": "Dieser Kontakt ist nicht auf diesem Gerät",
   "relationshipContactNoChanges": "Nichts Neues zu übernehmen",
   "relationshipCreateTitle": "Person hinzufügen",
+  "relationshipDaysOver": "{count, plural, =1{1 Tag drüber} other{{count} Tage drüber}}",
+  "@relationshipDaysOver": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDeleteConfirmMessage": "Auch alle Check-ins werden gelöscht. Das lässt sich nicht rückgängig machen.",
   "relationshipDeleteConfirmTitle": "{name} löschen?",
   "relationshipDueDay": "Fällig {day}",
@@ -4370,6 +4378,14 @@
   "relationshipErrorDeleteFailed": "Person konnte nicht gelöscht werden. Bitte versuch es erneut.",
   "relationshipErrorLinkTaskFailed": "Aufgabe konnte nicht verknüpft werden. Bitte versuch es erneut.",
   "relationshipErrorUpdateFailed": "Änderungen konnten nicht gespeichert werden. Bitte versuch es erneut.",
+  "relationshipFirstDue": "erstmals fällig {day}",
+  "@relationshipFirstDue": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipHealthNeedsAttention": "Braucht Aufmerksamkeit",
   "relationshipHealthSteady": "Stabil",
   "relationshipHealthStrained": "Angespannt",
@@ -4426,6 +4442,7 @@
   "relationshipNicknameLabel": "Spitzname",
   "relationshipNoCheckIns": "Noch keine Check-ins — erfasse einen nach eurem nächsten Gespräch.",
   "relationshipNoLinkedTasks": "Noch keine Aufgaben verknüpft.",
+  "relationshipNotEnrolled": "Nicht betreut",
   "relationshipNotFound": "Diese Person ist nicht mehr in deiner Liste.",
   "relationshipNudgesOn": "Erinnerungen an",
   "@relationshipNudgesOn": {
@@ -4457,7 +4474,38 @@
     "description": "Relationships redesign label."
   },
   "relationshipsEmptyState": "Füge die Menschen hinzu, denen du nah bleiben willst.",
+  "relationshipsGroupDue": "Fällig",
   "relationshipsPageTitle": "Menschen",
+  "relationshipsSelectPersonHint": "Wähle eine Person, um ihre Seite zu sehen.",
+  "relationshipsSummaryDueNow": "Jetzt fällig",
+  "relationshipsSummaryEnrolled": "/ {count} betreut",
+  "@relationshipsSummaryEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipsSummaryNextDue": "Als Nächstes fällig: {name} · {day}",
+  "@relationshipsSummaryNextDue": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipsSummaryNoneDue": "Niemand fällig",
+  "relationshipsSummaryNotEnrolled": "{count, plural, =1{1 Person nicht betreut} other{{count} Personen nicht betreut}}",
+  "@relationshipsSummaryNotEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipStatusActive": "Aktiv",
   "relationshipStatusArchived": "Archiviert",
   "relationshipStatusDormant": "Ruhend",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6413,19 +6413,12 @@
       }
     }
   },
+  "relationshipDueToday": "Due today",
   "relationshipEditTitle": "Edit person",
   "relationshipErrorCreateFailed": "Could not save this person. Please try again.",
   "relationshipErrorDeleteFailed": "Could not delete this person. Please try again.",
   "relationshipErrorLinkTaskFailed": "Could not link the task. Please try again.",
   "relationshipErrorUpdateFailed": "Could not save the changes. Please try again.",
-  "relationshipFirstDue": "first due {day}",
-  "@relationshipFirstDue": {
-    "placeholders": {
-      "day": {
-        "type": "String"
-      }
-    }
-  },
   "relationshipHealthNeedsAttention": "Needs attention",
   "relationshipHealthSteady": "Steady",
   "relationshipHealthStrained": "Strained",
@@ -6636,6 +6629,39 @@
   "relationshipStatusArchived": "Archived",
   "relationshipStatusDormant": "Dormant",
   "relationshipStatusFieldLabel": "Status",
+  "relationshipStatusLineAdded": "Just added · {cadence}",
+  "@relationshipStatusLineAdded": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineAddedFirstDue": "Just added · {cadence} · first due {day}",
+  "@relationshipStatusLineAddedFirstDue": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineContacted": "{type} · {time} · {cadence}",
+  "@relationshipStatusLineContacted": {
+    "placeholders": {
+      "type": {
+        "type": "String"
+      },
+      "time": {
+        "type": "String"
+      },
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipStayingInTouch": "Staying in touch",
   "@relationshipStayingInTouch": {
     "description": "Relationships redesign label."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6388,6 +6388,14 @@
     "description": "Toast shown when the linked contact held nothing the person did not already have"
   },
   "relationshipCreateTitle": "Add person",
+  "relationshipDaysOver": "{count, plural, =1{1 day over} other{{count} days over}}",
+  "@relationshipDaysOver": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDeleteConfirmMessage": "Their check-ins are deleted too. This cannot be undone.",
   "relationshipDeleteConfirmTitle": "Delete {name}?",
   "@relationshipDeleteConfirmTitle": {
@@ -6410,6 +6418,14 @@
   "relationshipErrorDeleteFailed": "Could not delete this person. Please try again.",
   "relationshipErrorLinkTaskFailed": "Could not link the task. Please try again.",
   "relationshipErrorUpdateFailed": "Could not save the changes. Please try again.",
+  "relationshipFirstDue": "first due {day}",
+  "@relationshipFirstDue": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipHealthNeedsAttention": "Needs attention",
   "relationshipHealthSteady": "Steady",
   "relationshipHealthStrained": "Strained",
@@ -6539,6 +6555,7 @@
   "relationshipNicknameLabel": "Nickname",
   "relationshipNoCheckIns": "No check-ins yet — log one after you next talk.",
   "relationshipNoLinkedTasks": "No tasks linked yet.",
+  "relationshipNotEnrolled": "Not enrolled",
   "relationshipNotFound": "This person is no longer tracked.",
   "relationshipNudgesOn": "nudges on",
   "@relationshipNudgesOn": {
@@ -6583,7 +6600,38 @@
     "description": "Relationships redesign label."
   },
   "relationshipsEmptyState": "Add the people you want to stay close to.",
+  "relationshipsGroupDue": "Due",
   "relationshipsPageTitle": "People",
+  "relationshipsSelectPersonHint": "Select a person to see their page.",
+  "relationshipsSummaryDueNow": "Due now",
+  "relationshipsSummaryEnrolled": "/ {count} enrolled",
+  "@relationshipsSummaryEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipsSummaryNextDue": "Next due {name} · {day}",
+  "@relationshipsSummaryNextDue": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipsSummaryNoneDue": "No one due",
+  "relationshipsSummaryNotEnrolled": "{count, plural, =1{1 person not enrolled} other{{count} people not enrolled}}",
+  "@relationshipsSummaryNotEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipStatusActive": "Active",
   "relationshipStatusArchived": "Archived",
   "relationshipStatusDormant": "Dormant",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4373,19 +4373,12 @@
       }
     }
   },
+  "relationshipDueToday": "Pendiente hoy",
   "relationshipEditTitle": "Editar persona",
   "relationshipErrorCreateFailed": "No se pudo guardar la persona. Inténtalo de nuevo.",
   "relationshipErrorDeleteFailed": "No se pudo eliminar la persona. Inténtalo de nuevo.",
   "relationshipErrorLinkTaskFailed": "No se pudo vincular la tarea. Inténtalo de nuevo.",
   "relationshipErrorUpdateFailed": "No se pudieron guardar los cambios. Inténtalo de nuevo.",
-  "relationshipFirstDue": "primer plazo {day}",
-  "@relationshipFirstDue": {
-    "placeholders": {
-      "day": {
-        "type": "String"
-      }
-    }
-  },
   "relationshipHealthNeedsAttention": "Necesita atención",
   "relationshipHealthSteady": "Estable",
   "relationshipHealthStrained": "Tensa",
@@ -4510,6 +4503,39 @@
   "relationshipStatusArchived": "Archivada",
   "relationshipStatusDormant": "En reposo",
   "relationshipStatusFieldLabel": "Estado",
+  "relationshipStatusLineAdded": "Recién añadido · {cadence}",
+  "@relationshipStatusLineAdded": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineAddedFirstDue": "Recién añadido · {cadence} · primer plazo {day}",
+  "@relationshipStatusLineAddedFirstDue": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineContacted": "{type} · {time} · {cadence}",
+  "@relationshipStatusLineContacted": {
+    "placeholders": {
+      "type": {
+        "type": "String"
+      },
+      "time": {
+        "type": "String"
+      },
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipStayingInTouch": "Mantener el contacto",
   "@relationshipStayingInTouch": {
     "description": "Relationships redesign label."

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4355,6 +4355,14 @@
   "relationshipContactMissing": "Ese contacto no está en este dispositivo",
   "relationshipContactNoChanges": "Nada nuevo que copiar",
   "relationshipCreateTitle": "Añadir persona",
+  "relationshipDaysOver": "{count, plural, =1{1 día de retraso} other{{count} días de retraso}}",
+  "@relationshipDaysOver": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDeleteConfirmMessage": "También se eliminarán todos sus registros. Esta acción no se puede deshacer.",
   "relationshipDeleteConfirmTitle": "¿Eliminar a {name}?",
   "relationshipDueDay": "Tope {day}",
@@ -4370,6 +4378,14 @@
   "relationshipErrorDeleteFailed": "No se pudo eliminar la persona. Inténtalo de nuevo.",
   "relationshipErrorLinkTaskFailed": "No se pudo vincular la tarea. Inténtalo de nuevo.",
   "relationshipErrorUpdateFailed": "No se pudieron guardar los cambios. Inténtalo de nuevo.",
+  "relationshipFirstDue": "primer plazo {day}",
+  "@relationshipFirstDue": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipHealthNeedsAttention": "Necesita atención",
   "relationshipHealthSteady": "Estable",
   "relationshipHealthStrained": "Tensa",
@@ -4426,6 +4442,7 @@
   "relationshipNicknameLabel": "Apodo",
   "relationshipNoCheckIns": "Aún no hay registros: añade uno tras vuestra próxima conversación.",
   "relationshipNoLinkedTasks": "Aún no hay tareas vinculadas.",
+  "relationshipNotEnrolled": "Sin seguimiento",
   "relationshipNotFound": "Esta persona ya no está en tu lista.",
   "relationshipNudgesOn": "avisos activos",
   "@relationshipNudgesOn": {
@@ -4457,7 +4474,38 @@
     "description": "Relationships redesign label."
   },
   "relationshipsEmptyState": "Añade a las personas de las que quieres estar cerca.",
+  "relationshipsGroupDue": "Pendientes",
   "relationshipsPageTitle": "Personas",
+  "relationshipsSelectPersonHint": "Elige a alguien para ver su página.",
+  "relationshipsSummaryDueNow": "Pendientes ahora",
+  "relationshipsSummaryEnrolled": "/ {count} en seguimiento",
+  "@relationshipsSummaryEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipsSummaryNextDue": "Próximo: {name} · {day}",
+  "@relationshipsSummaryNextDue": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipsSummaryNoneDue": "Nadie pendiente",
+  "relationshipsSummaryNotEnrolled": "{count, plural, =1{1 persona sin seguimiento} other{{count} personas sin seguimiento}}",
+  "@relationshipsSummaryNotEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipStatusActive": "Activa",
   "relationshipStatusArchived": "Archivada",
   "relationshipStatusDormant": "En reposo",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4479,7 +4479,7 @@
       }
     }
   },
-  "relationshipsSummaryNextDue": "Próximo: {name} · {day}",
+  "relationshipsSummaryNextDue": "Siguiente: {name} · {day}",
   "@relationshipsSummaryNextDue": {
     "placeholders": {
       "name": {
@@ -4511,7 +4511,7 @@
       }
     }
   },
-  "relationshipStatusLineAddedFirstDue": "Recién añadido · {cadence} · primer plazo {day}",
+  "relationshipStatusLineAddedFirstDue": "Recién añadido · {cadence} · vence por primera vez el {day}",
   "@relationshipStatusLineAddedFirstDue": {
     "placeholders": {
       "cadence": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4435,7 +4435,7 @@
   "relationshipNicknameLabel": "Surnom",
   "relationshipNoCheckIns": "Aucun échange noté — ajoute le premier après votre prochaine conversation.",
   "relationshipNoLinkedTasks": "Aucune tâche liée pour l'instant.",
-  "relationshipNotEnrolled": "Non suivi",
+  "relationshipNotEnrolled": "Non suivie",
   "relationshipNotFound": "Cette personne n'est plus dans ta liste.",
   "relationshipNudgesOn": "rappels activés",
   "@relationshipNudgesOn": {
@@ -4471,7 +4471,7 @@
   "relationshipsPageTitle": "Proches",
   "relationshipsSelectPersonHint": "Choisis une personne pour voir sa page.",
   "relationshipsSummaryDueNow": "À relancer maintenant",
-  "relationshipsSummaryEnrolled": "/ {count} suivis",
+  "relationshipsSummaryEnrolled": "/ {count} suivies",
   "@relationshipsSummaryEnrolled": {
     "placeholders": {
       "count": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4373,19 +4373,12 @@
       }
     }
   },
+  "relationshipDueToday": "À relancer aujourd'hui",
   "relationshipEditTitle": "Modifier la personne",
   "relationshipErrorCreateFailed": "Impossible d'enregistrer la personne. Réessaie.",
   "relationshipErrorDeleteFailed": "Impossible de supprimer la personne. Réessaie.",
   "relationshipErrorLinkTaskFailed": "Impossible de lier la tâche. Réessaie.",
   "relationshipErrorUpdateFailed": "Impossible d'enregistrer les modifications. Réessaie.",
-  "relationshipFirstDue": "première échéance {day}",
-  "@relationshipFirstDue": {
-    "placeholders": {
-      "day": {
-        "type": "String"
-      }
-    }
-  },
   "relationshipHealthNeedsAttention": "A besoin d'attention",
   "relationshipHealthSteady": "Stable",
   "relationshipHealthStrained": "Tendue",
@@ -4510,6 +4503,39 @@
   "relationshipStatusArchived": "Archivée",
   "relationshipStatusDormant": "En veille",
   "relationshipStatusFieldLabel": "Statut",
+  "relationshipStatusLineAdded": "Ajouté à l'instant · {cadence}",
+  "@relationshipStatusLineAdded": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineAddedFirstDue": "Ajouté à l'instant · {cadence} · première échéance {day}",
+  "@relationshipStatusLineAddedFirstDue": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineContacted": "{type} · {time} · {cadence}",
+  "@relationshipStatusLineContacted": {
+    "placeholders": {
+      "type": {
+        "type": "String"
+      },
+      "time": {
+        "type": "String"
+      },
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipStayingInTouch": "Rester en contact",
   "@relationshipStayingInTouch": {
     "description": "Relationships redesign label."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4355,6 +4355,14 @@
   "relationshipContactMissing": "Ce contact n’est pas sur cet appareil",
   "relationshipContactNoChanges": "Rien de nouveau à copier",
   "relationshipCreateTitle": "Ajouter une personne",
+  "relationshipDaysOver": "{count, plural, =1{1 jour de retard} other{{count} jours de retard}}",
+  "@relationshipDaysOver": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDeleteConfirmMessage": "Tous ses échanges seront aussi supprimés. Cette action est irréversible.",
   "relationshipDeleteConfirmTitle": "Supprimer {name} ?",
   "relationshipDueDay": "À relancer {day}",
@@ -4370,6 +4378,14 @@
   "relationshipErrorDeleteFailed": "Impossible de supprimer la personne. Réessaie.",
   "relationshipErrorLinkTaskFailed": "Impossible de lier la tâche. Réessaie.",
   "relationshipErrorUpdateFailed": "Impossible d'enregistrer les modifications. Réessaie.",
+  "relationshipFirstDue": "première échéance {day}",
+  "@relationshipFirstDue": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipHealthNeedsAttention": "A besoin d'attention",
   "relationshipHealthSteady": "Stable",
   "relationshipHealthStrained": "Tendue",
@@ -4426,6 +4442,7 @@
   "relationshipNicknameLabel": "Surnom",
   "relationshipNoCheckIns": "Aucun échange noté — ajoute le premier après votre prochaine conversation.",
   "relationshipNoLinkedTasks": "Aucune tâche liée pour l'instant.",
+  "relationshipNotEnrolled": "Non suivi",
   "relationshipNotFound": "Cette personne n'est plus dans ta liste.",
   "relationshipNudgesOn": "rappels activés",
   "@relationshipNudgesOn": {
@@ -4457,7 +4474,38 @@
     "description": "Relationships redesign label."
   },
   "relationshipsEmptyState": "Ajoute les personnes dont tu veux rester proche.",
+  "relationshipsGroupDue": "À relancer",
   "relationshipsPageTitle": "Proches",
+  "relationshipsSelectPersonHint": "Choisis une personne pour voir sa page.",
+  "relationshipsSummaryDueNow": "À relancer maintenant",
+  "relationshipsSummaryEnrolled": "/ {count} suivis",
+  "@relationshipsSummaryEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipsSummaryNextDue": "Prochaine échéance {name} · {day}",
+  "@relationshipsSummaryNextDue": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipsSummaryNoneDue": "Personne à relancer",
+  "relationshipsSummaryNotEnrolled": "{count, plural, =1{1 personne non suivie} other{{count} personnes non suivies}}",
+  "@relationshipsSummaryNotEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipStatusActive": "Active",
   "relationshipStatusArchived": "Archivée",
   "relationshipStatusDormant": "En veille",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4876,19 +4876,12 @@
       }
     }
   },
+  "relationshipDueToday": "In scadenza oggi",
   "relationshipEditTitle": "Modifica persona",
   "relationshipErrorCreateFailed": "Impossibile salvare la persona. Riprova.",
   "relationshipErrorDeleteFailed": "Impossibile eliminare la persona. Riprova.",
   "relationshipErrorLinkTaskFailed": "Impossibile collegare l'attività. Riprova.",
   "relationshipErrorUpdateFailed": "Impossibile salvare le modifiche. Riprova.",
-  "relationshipFirstDue": "prima scadenza {day}",
-  "@relationshipFirstDue": {
-    "placeholders": {
-      "day": {
-        "type": "String"
-      }
-    }
-  },
   "relationshipHealthNeedsAttention": "Serve attenzione",
   "relationshipHealthSteady": "Stabile",
   "relationshipHealthStrained": "Tesa",
@@ -5013,6 +5006,39 @@
   "relationshipStatusArchived": "Archiviata",
   "relationshipStatusDormant": "In pausa",
   "relationshipStatusFieldLabel": "Stato",
+  "relationshipStatusLineAdded": "Appena aggiunto · {cadence}",
+  "@relationshipStatusLineAdded": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineAddedFirstDue": "Appena aggiunto · {cadence} · prima scadenza {day}",
+  "@relationshipStatusLineAddedFirstDue": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineContacted": "{type} · {time} · {cadence}",
+  "@relationshipStatusLineContacted": {
+    "placeholders": {
+      "type": {
+        "type": "String"
+      },
+      "time": {
+        "type": "String"
+      },
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipStayingInTouch": "Restare in contatto",
   "@relationshipStayingInTouch": {
     "description": "Relationships redesign label."

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4938,7 +4938,7 @@
   "relationshipNicknameLabel": "Soprannome",
   "relationshipNoCheckIns": "Nessun contatto registrato — aggiungine uno dopo la prossima conversazione.",
   "relationshipNoLinkedTasks": "Nessuna attività collegata.",
-  "relationshipNotEnrolled": "Non seguito",
+  "relationshipNotEnrolled": "Non seguita",
   "relationshipNotFound": "Questa persona non è più nella tua lista.",
   "relationshipNudgesOn": "promemoria attivi",
   "@relationshipNudgesOn": {
@@ -4974,7 +4974,7 @@
   "relationshipsPageTitle": "Persone",
   "relationshipsSelectPersonHint": "Scegli una persona per vedere la sua pagina.",
   "relationshipsSummaryDueNow": "Da sentire ora",
-  "relationshipsSummaryEnrolled": "/ {count} seguiti",
+  "relationshipsSummaryEnrolled": "{count, plural, =1{/ 1 seguita} other{/ {count} seguite}}",
   "@relationshipsSummaryEnrolled": {
     "placeholders": {
       "count": {
@@ -4982,7 +4982,7 @@
       }
     }
   },
-  "relationshipsSummaryNextDue": "Prossimo: {name} · {day}",
+  "relationshipsSummaryNextDue": "Prossima scadenza: {name} · {day}",
   "@relationshipsSummaryNextDue": {
     "placeholders": {
       "name": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4858,6 +4858,14 @@
   "relationshipContactMissing": "Quel contatto non è su questo dispositivo",
   "relationshipContactNoChanges": "Niente di nuovo da copiare",
   "relationshipCreateTitle": "Aggiungi persona",
+  "relationshipDaysOver": "{count, plural, =1{1 giorno di ritardo} other{{count} giorni di ritardo}}",
+  "@relationshipDaysOver": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDeleteConfirmMessage": "Verranno eliminati anche tutti i contatti registrati. L'azione non si può annullare.",
   "relationshipDeleteConfirmTitle": "Eliminare {name}?",
   "relationshipDueDay": "Entro {day}",
@@ -4873,6 +4881,14 @@
   "relationshipErrorDeleteFailed": "Impossibile eliminare la persona. Riprova.",
   "relationshipErrorLinkTaskFailed": "Impossibile collegare l'attività. Riprova.",
   "relationshipErrorUpdateFailed": "Impossibile salvare le modifiche. Riprova.",
+  "relationshipFirstDue": "prima scadenza {day}",
+  "@relationshipFirstDue": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipHealthNeedsAttention": "Serve attenzione",
   "relationshipHealthSteady": "Stabile",
   "relationshipHealthStrained": "Tesa",
@@ -4929,6 +4945,7 @@
   "relationshipNicknameLabel": "Soprannome",
   "relationshipNoCheckIns": "Nessun contatto registrato — aggiungine uno dopo la prossima conversazione.",
   "relationshipNoLinkedTasks": "Nessuna attività collegata.",
+  "relationshipNotEnrolled": "Non seguito",
   "relationshipNotFound": "Questa persona non è più nella tua lista.",
   "relationshipNudgesOn": "promemoria attivi",
   "@relationshipNudgesOn": {
@@ -4960,7 +4977,38 @@
     "description": "Relationships redesign label."
   },
   "relationshipsEmptyState": "Aggiungi le persone a cui vuoi restare vicino.",
+  "relationshipsGroupDue": "In scadenza",
   "relationshipsPageTitle": "Persone",
+  "relationshipsSelectPersonHint": "Scegli una persona per vedere la sua pagina.",
+  "relationshipsSummaryDueNow": "Da sentire ora",
+  "relationshipsSummaryEnrolled": "/ {count} seguiti",
+  "@relationshipsSummaryEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipsSummaryNextDue": "Prossimo: {name} · {day}",
+  "@relationshipsSummaryNextDue": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipsSummaryNoneDue": "Nessuno in scadenza",
+  "relationshipsSummaryNotEnrolled": "{count, plural, =1{1 persona non seguita} other{{count} persone non seguite}}",
+  "@relationshipsSummaryNotEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipStatusActive": "Attiva",
   "relationshipStatusArchived": "Archiviata",
   "relationshipStatusDormant": "In pausa",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -18583,6 +18583,12 @@ abstract class AppLocalizations {
   /// **'Add person'**
   String get relationshipCreateTitle;
 
+  /// No description provided for @relationshipDaysOver.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 day over} other{{count} days over}}'**
+  String relationshipDaysOver(int count);
+
   /// No description provided for @relationshipDeleteConfirmMessage.
   ///
   /// In en, this message translates to:
@@ -18630,6 +18636,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not save the changes. Please try again.'**
   String get relationshipErrorUpdateFailed;
+
+  /// No description provided for @relationshipFirstDue.
+  ///
+  /// In en, this message translates to:
+  /// **'first due {day}'**
+  String relationshipFirstDue(String day);
 
   /// No description provided for @relationshipHealthNeedsAttention.
   ///
@@ -18847,6 +18859,12 @@ abstract class AppLocalizations {
   /// **'No tasks linked yet.'**
   String get relationshipNoLinkedTasks;
 
+  /// No description provided for @relationshipNotEnrolled.
+  ///
+  /// In en, this message translates to:
+  /// **'Not enrolled'**
+  String get relationshipNotEnrolled;
+
   /// No description provided for @relationshipNotFound.
   ///
   /// In en, this message translates to:
@@ -18907,11 +18925,53 @@ abstract class AppLocalizations {
   /// **'Add the people you want to stay close to.'**
   String get relationshipsEmptyState;
 
+  /// No description provided for @relationshipsGroupDue.
+  ///
+  /// In en, this message translates to:
+  /// **'Due'**
+  String get relationshipsGroupDue;
+
   /// No description provided for @relationshipsPageTitle.
   ///
   /// In en, this message translates to:
   /// **'People'**
   String get relationshipsPageTitle;
+
+  /// No description provided for @relationshipsSelectPersonHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Select a person to see their page.'**
+  String get relationshipsSelectPersonHint;
+
+  /// No description provided for @relationshipsSummaryDueNow.
+  ///
+  /// In en, this message translates to:
+  /// **'Due now'**
+  String get relationshipsSummaryDueNow;
+
+  /// No description provided for @relationshipsSummaryEnrolled.
+  ///
+  /// In en, this message translates to:
+  /// **'/ {count} enrolled'**
+  String relationshipsSummaryEnrolled(int count);
+
+  /// No description provided for @relationshipsSummaryNextDue.
+  ///
+  /// In en, this message translates to:
+  /// **'Next due {name} · {day}'**
+  String relationshipsSummaryNextDue(String name, String day);
+
+  /// No description provided for @relationshipsSummaryNoneDue.
+  ///
+  /// In en, this message translates to:
+  /// **'No one due'**
+  String get relationshipsSummaryNoneDue;
+
+  /// No description provided for @relationshipsSummaryNotEnrolled.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 person not enrolled} other{{count} people not enrolled}}'**
+  String relationshipsSummaryNotEnrolled(int count);
 
   /// No description provided for @relationshipStatusActive.
   ///

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -18607,6 +18607,12 @@ abstract class AppLocalizations {
   /// **'Due {day}'**
   String relationshipDueDay(String day);
 
+  /// No description provided for @relationshipDueToday.
+  ///
+  /// In en, this message translates to:
+  /// **'Due today'**
+  String get relationshipDueToday;
+
   /// No description provided for @relationshipEditTitle.
   ///
   /// In en, this message translates to:
@@ -18636,12 +18642,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not save the changes. Please try again.'**
   String get relationshipErrorUpdateFailed;
-
-  /// No description provided for @relationshipFirstDue.
-  ///
-  /// In en, this message translates to:
-  /// **'first due {day}'**
-  String relationshipFirstDue(String day);
 
   /// No description provided for @relationshipHealthNeedsAttention.
   ///
@@ -18996,6 +18996,28 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Status'**
   String get relationshipStatusFieldLabel;
+
+  /// No description provided for @relationshipStatusLineAdded.
+  ///
+  /// In en, this message translates to:
+  /// **'Just added · {cadence}'**
+  String relationshipStatusLineAdded(String cadence);
+
+  /// No description provided for @relationshipStatusLineAddedFirstDue.
+  ///
+  /// In en, this message translates to:
+  /// **'Just added · {cadence} · first due {day}'**
+  String relationshipStatusLineAddedFirstDue(String cadence, String day);
+
+  /// No description provided for @relationshipStatusLineContacted.
+  ///
+  /// In en, this message translates to:
+  /// **'{type} · {time} · {cadence}'**
+  String relationshipStatusLineContacted(
+    String type,
+    String time,
+    String cadence,
+  );
 
   /// Relationships redesign label.
   ///

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -11236,6 +11236,18 @@ class AppLocalizationsCs extends AppLocalizations {
   String get relationshipCreateTitle => 'Přidat osobu';
 
   @override
+  String relationshipDaysOver(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dní po termínu',
+      few: '$count dny po termínu',
+      one: '1 den po termínu',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get relationshipDeleteConfirmMessage =>
       'Smažou se i všechny záznamy kontaktů. Tohle nelze vrátit zpět.';
 
@@ -11267,6 +11279,11 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Změny se nepodařilo uložit. Zkus to prosím znovu.';
+
+  @override
+  String relationshipFirstDue(String day) {
+    return 'poprvé $day';
+  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Vyžaduje pozornost';
@@ -11416,6 +11433,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get relationshipNoLinkedTasks => 'Zatím žádné propojené úkoly.';
 
   @override
+  String get relationshipNotEnrolled => 'Nesledováno';
+
+  @override
   String get relationshipNotFound => 'Tahle osoba už není sledovaná.';
 
   @override
@@ -11459,7 +11479,42 @@ class AppLocalizationsCs extends AppLocalizations {
       'Přidej lidi, se kterými chceš zůstat v kontaktu.';
 
   @override
+  String get relationshipsGroupDue => 'Na řadě';
+
+  @override
   String get relationshipsPageTitle => 'Lidé';
+
+  @override
+  String get relationshipsSelectPersonHint =>
+      'Vyber osobu a zobrazí se její stránka.';
+
+  @override
+  String get relationshipsSummaryDueNow => 'Teď na řadě';
+
+  @override
+  String relationshipsSummaryEnrolled(int count) {
+    return '/ $count sledovaných';
+  }
+
+  @override
+  String relationshipsSummaryNextDue(String name, String day) {
+    return 'Další: $name · $day';
+  }
+
+  @override
+  String get relationshipsSummaryNoneDue => 'Nikdo nečeká';
+
+  @override
+  String relationshipsSummaryNotEnrolled(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count osob nesledováno',
+      few: '$count osoby nesledovány',
+      one: '1 osoba nesledována',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipStatusActive => 'Aktivní';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -11262,6 +11262,9 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get relationshipDueToday => 'Dnes na řadě';
+
+  @override
   String get relationshipEditTitle => 'Upravit osobu';
 
   @override
@@ -11279,11 +11282,6 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Změny se nepodařilo uložit. Zkus to prosím znovu.';
-
-  @override
-  String relationshipFirstDue(String day) {
-    return 'poprvé $day';
-  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Vyžaduje pozornost';
@@ -11527,6 +11525,25 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Stav';
+
+  @override
+  String relationshipStatusLineAdded(String cadence) {
+    return 'Právě přidáno · $cadence';
+  }
+
+  @override
+  String relationshipStatusLineAddedFirstDue(String cadence, String day) {
+    return 'Právě přidáno · $cadence · poprvé $day';
+  }
+
+  @override
+  String relationshipStatusLineContacted(
+    String type,
+    String time,
+    String cadence,
+  ) {
+    return '$type · $time · $cadence';
+  }
 
   @override
   String get relationshipStayingInTouch => 'Udržovat kontakt';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -11533,7 +11533,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String relationshipStatusLineAddedFirstDue(String cadence, String day) {
-    return 'Právě přidáno · $cadence · poprvé $day';
+    return 'Právě přidáno · $cadence · poprvé do $day';
   }
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -11491,7 +11491,14 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String relationshipsSummaryEnrolled(int count) {
-    return '/ $count sledovaných';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '/ $count sledovaných',
+      few: '/ $count sledované',
+      one: '/ 1 sledovaná',
+    );
+    return '$_temp0';
   }
 
   @override
@@ -11500,16 +11507,16 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get relationshipsSummaryNoneDue => 'Nikdo nečeká';
+  String get relationshipsSummaryNoneDue => 'Nikdo není na řadě';
 
   @override
   String relationshipsSummaryNotEnrolled(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count osob nesledováno',
-      few: '$count osoby nesledovány',
-      one: '1 osoba nesledována',
+      other: '$count nesledovaných osob',
+      few: '$count nesledované osoby',
+      one: '1 nesledovaná osoba',
     );
     return '$_temp0';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -11097,6 +11097,9 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get relationshipDueToday => 'Skal kontaktes i dag';
+
+  @override
   String get relationshipEditTitle => 'Redigér person';
 
   @override
@@ -11114,11 +11117,6 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Ændringerne kunne ikke gemmes. Prøv igen.';
-
-  @override
-  String relationshipFirstDue(String day) {
-    return 'første gang $day';
-  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Kræver opmærksomhed';
@@ -11357,6 +11355,25 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Status';
+
+  @override
+  String relationshipStatusLineAdded(String cadence) {
+    return 'Lige tilføjet · $cadence';
+  }
+
+  @override
+  String relationshipStatusLineAddedFirstDue(String cadence, String day) {
+    return 'Lige tilføjet · $cadence · første gang $day';
+  }
+
+  @override
+  String relationshipStatusLineContacted(
+    String type,
+    String time,
+    String cadence,
+  ) {
+    return '$type · $time · $cadence';
+  }
 
   @override
   String get relationshipStayingInTouch => 'Holde kontakten';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -11072,6 +11072,17 @@ class AppLocalizationsDa extends AppLocalizations {
   String get relationshipCreateTitle => 'Tilføj person';
 
   @override
+  String relationshipDaysOver(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dage over tid',
+      one: '1 dag over tid',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get relationshipDeleteConfirmMessage =>
       'Deres check-ins slettes også. Det kan ikke fortrydes.';
 
@@ -11103,6 +11114,11 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Ændringerne kunne ikke gemmes. Prøv igen.';
+
+  @override
+  String relationshipFirstDue(String day) {
+    return 'første gang $day';
+  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Kræver opmærksomhed';
@@ -11249,6 +11265,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get relationshipNoLinkedTasks => 'Ingen opgaver linket endnu.';
 
   @override
+  String get relationshipNotEnrolled => 'Ikke fulgt';
+
+  @override
   String get relationshipNotFound => 'Denne person følges ikke længere.';
 
   @override
@@ -11291,7 +11310,41 @@ class AppLocalizationsDa extends AppLocalizations {
       'Tilføj de mennesker, du vil holde kontakten med.';
 
   @override
+  String get relationshipsGroupDue => 'Skal kontaktes';
+
+  @override
   String get relationshipsPageTitle => 'Personer';
+
+  @override
+  String get relationshipsSelectPersonHint =>
+      'Vælg en person for at se deres side.';
+
+  @override
+  String get relationshipsSummaryDueNow => 'Skal kontaktes nu';
+
+  @override
+  String relationshipsSummaryEnrolled(int count) {
+    return '/ $count fulgt';
+  }
+
+  @override
+  String relationshipsSummaryNextDue(String name, String day) {
+    return 'Næste: $name · $day';
+  }
+
+  @override
+  String get relationshipsSummaryNoneDue => 'Ingen venter';
+
+  @override
+  String relationshipsSummaryNotEnrolled(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count personer ikke fulgt',
+      one: '1 person ikke fulgt',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipStatusActive => 'Aktiv';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -11363,7 +11363,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String relationshipStatusLineAddedFirstDue(String cadence, String day) {
-    return 'Lige tilføjet · $cadence · første gang $day';
+    return 'Lige tilføjet · $cadence · første gang senest $day';
   }
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -11076,8 +11076,8 @@ class AppLocalizationsDa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count dage over tid',
-      one: '1 dag over tid',
+      other: '$count dage forsinket',
+      one: '1 dag forsinket',
     );
     return '$_temp0';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -11141,6 +11141,17 @@ class AppLocalizationsDe extends AppLocalizations {
   String get relationshipCreateTitle => 'Person hinzufügen';
 
   @override
+  String relationshipDaysOver(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Tage drüber',
+      one: '1 Tag drüber',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get relationshipDeleteConfirmMessage =>
       'Auch alle Check-ins werden gelöscht. Das lässt sich nicht rückgängig machen.';
 
@@ -11172,6 +11183,11 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Änderungen konnten nicht gespeichert werden. Bitte versuch es erneut.';
+
+  @override
+  String relationshipFirstDue(String day) {
+    return 'erstmals fällig $day';
+  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Braucht Aufmerksamkeit';
@@ -11318,6 +11334,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get relationshipNoLinkedTasks => 'Noch keine Aufgaben verknüpft.';
 
   @override
+  String get relationshipNotEnrolled => 'Nicht betreut';
+
+  @override
   String get relationshipNotFound =>
       'Diese Person ist nicht mehr in deiner Liste.';
 
@@ -11361,7 +11380,41 @@ class AppLocalizationsDe extends AppLocalizations {
       'Füge die Menschen hinzu, denen du nah bleiben willst.';
 
   @override
+  String get relationshipsGroupDue => 'Fällig';
+
+  @override
   String get relationshipsPageTitle => 'Menschen';
+
+  @override
+  String get relationshipsSelectPersonHint =>
+      'Wähle eine Person, um ihre Seite zu sehen.';
+
+  @override
+  String get relationshipsSummaryDueNow => 'Jetzt fällig';
+
+  @override
+  String relationshipsSummaryEnrolled(int count) {
+    return '/ $count betreut';
+  }
+
+  @override
+  String relationshipsSummaryNextDue(String name, String day) {
+    return 'Als Nächstes fällig: $name · $day';
+  }
+
+  @override
+  String get relationshipsSummaryNoneDue => 'Niemand fällig';
+
+  @override
+  String relationshipsSummaryNotEnrolled(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Personen nicht betreut',
+      one: '1 Person nicht betreut',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipStatusActive => 'Aktiv';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -11433,7 +11433,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String relationshipStatusLineAddedFirstDue(String cadence, String day) {
-    return 'Gerade hinzugefügt · $cadence · erstmals fällig $day';
+    return 'Gerade hinzugefügt · $cadence · erstmals fällig am $day';
   }
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -11166,6 +11166,9 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get relationshipDueToday => 'Heute fällig';
+
+  @override
   String get relationshipEditTitle => 'Person bearbeiten';
 
   @override
@@ -11183,11 +11186,6 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Änderungen konnten nicht gespeichert werden. Bitte versuch es erneut.';
-
-  @override
-  String relationshipFirstDue(String day) {
-    return 'erstmals fällig $day';
-  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Braucht Aufmerksamkeit';
@@ -11427,6 +11425,25 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Status';
+
+  @override
+  String relationshipStatusLineAdded(String cadence) {
+    return 'Gerade hinzugefügt · $cadence';
+  }
+
+  @override
+  String relationshipStatusLineAddedFirstDue(String cadence, String day) {
+    return 'Gerade hinzugefügt · $cadence · erstmals fällig $day';
+  }
+
+  @override
+  String relationshipStatusLineContacted(
+    String type,
+    String time,
+    String cadence,
+  ) {
+    return '$type · $time · $cadence';
+  }
 
   @override
   String get relationshipStayingInTouch => 'Kontakt halten';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -11145,8 +11145,8 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Tage drüber',
-      one: '1 Tag drüber',
+      other: '$count Tage überfällig',
+      one: '1 Tag überfällig',
     );
     return '$_temp0';
   }
@@ -11332,7 +11332,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get relationshipNoLinkedTasks => 'Noch keine Aufgaben verknüpft.';
 
   @override
-  String get relationshipNotEnrolled => 'Nicht betreut';
+  String get relationshipNotEnrolled => 'Nicht im Blick';
 
   @override
   String get relationshipNotFound =>
@@ -11392,7 +11392,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String relationshipsSummaryEnrolled(int count) {
-    return '/ $count betreut';
+    return '/ $count im Blick';
   }
 
   @override
@@ -11408,8 +11408,8 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Personen nicht betreut',
-      one: '1 Person nicht betreut',
+      other: '$count Personen nicht im Blick',
+      one: '1 Person nicht im Blick',
     );
     return '$_temp0';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -11043,6 +11043,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get relationshipDueToday => 'Due today';
+
+  @override
   String get relationshipEditTitle => 'Edit person';
 
   @override
@@ -11060,11 +11063,6 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Could not save the changes. Please try again.';
-
-  @override
-  String relationshipFirstDue(String day) {
-    return 'first due $day';
-  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Needs attention';
@@ -11301,6 +11299,25 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Status';
+
+  @override
+  String relationshipStatusLineAdded(String cadence) {
+    return 'Just added · $cadence';
+  }
+
+  @override
+  String relationshipStatusLineAddedFirstDue(String cadence, String day) {
+    return 'Just added · $cadence · first due $day';
+  }
+
+  @override
+  String relationshipStatusLineContacted(
+    String type,
+    String time,
+    String cadence,
+  ) {
+    return '$type · $time · $cadence';
+  }
 
   @override
   String get relationshipStayingInTouch => 'Staying in touch';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -11018,6 +11018,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String get relationshipCreateTitle => 'Add person';
 
   @override
+  String relationshipDaysOver(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count days over',
+      one: '1 day over',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get relationshipDeleteConfirmMessage =>
       'Their check-ins are deleted too. This cannot be undone.';
 
@@ -11049,6 +11060,11 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Could not save the changes. Please try again.';
+
+  @override
+  String relationshipFirstDue(String day) {
+    return 'first due $day';
+  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Needs attention';
@@ -11193,6 +11209,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get relationshipNoLinkedTasks => 'No tasks linked yet.';
 
   @override
+  String get relationshipNotEnrolled => 'Not enrolled';
+
+  @override
   String get relationshipNotFound => 'This person is no longer tracked.';
 
   @override
@@ -11235,7 +11254,41 @@ class AppLocalizationsEn extends AppLocalizations {
       'Add the people you want to stay close to.';
 
   @override
+  String get relationshipsGroupDue => 'Due';
+
+  @override
   String get relationshipsPageTitle => 'People';
+
+  @override
+  String get relationshipsSelectPersonHint =>
+      'Select a person to see their page.';
+
+  @override
+  String get relationshipsSummaryDueNow => 'Due now';
+
+  @override
+  String relationshipsSummaryEnrolled(int count) {
+    return '/ $count enrolled';
+  }
+
+  @override
+  String relationshipsSummaryNextDue(String name, String day) {
+    return 'Next due $name · $day';
+  }
+
+  @override
+  String get relationshipsSummaryNoneDue => 'No one due';
+
+  @override
+  String relationshipsSummaryNotEnrolled(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count people not enrolled',
+      one: '1 person not enrolled',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipStatusActive => 'Active';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -11237,6 +11237,17 @@ class AppLocalizationsEs extends AppLocalizations {
   String get relationshipCreateTitle => 'Añadir persona';
 
   @override
+  String relationshipDaysOver(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count días de retraso',
+      one: '1 día de retraso',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get relationshipDeleteConfirmMessage =>
       'También se eliminarán todos sus registros. Esta acción no se puede deshacer.';
 
@@ -11268,6 +11279,11 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'No se pudieron guardar los cambios. Inténtalo de nuevo.';
+
+  @override
+  String relationshipFirstDue(String day) {
+    return 'primer plazo $day';
+  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Necesita atención';
@@ -11414,6 +11430,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get relationshipNoLinkedTasks => 'Aún no hay tareas vinculadas.';
 
   @override
+  String get relationshipNotEnrolled => 'Sin seguimiento';
+
+  @override
   String get relationshipNotFound => 'Esta persona ya no está en tu lista.';
 
   @override
@@ -11456,7 +11475,41 @@ class AppLocalizationsEs extends AppLocalizations {
       'Añade a las personas de las que quieres estar cerca.';
 
   @override
+  String get relationshipsGroupDue => 'Pendientes';
+
+  @override
   String get relationshipsPageTitle => 'Personas';
+
+  @override
+  String get relationshipsSelectPersonHint =>
+      'Elige a alguien para ver su página.';
+
+  @override
+  String get relationshipsSummaryDueNow => 'Pendientes ahora';
+
+  @override
+  String relationshipsSummaryEnrolled(int count) {
+    return '/ $count en seguimiento';
+  }
+
+  @override
+  String relationshipsSummaryNextDue(String name, String day) {
+    return 'Próximo: $name · $day';
+  }
+
+  @override
+  String get relationshipsSummaryNoneDue => 'Nadie pendiente';
+
+  @override
+  String relationshipsSummaryNotEnrolled(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count personas sin seguimiento',
+      one: '1 persona sin seguimiento',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipStatusActive => 'Activa';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -11492,7 +11492,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String relationshipsSummaryNextDue(String name, String day) {
-    return 'Próximo: $name · $day';
+    return 'Siguiente: $name · $day';
   }
 
   @override
@@ -11528,7 +11528,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String relationshipStatusLineAddedFirstDue(String cadence, String day) {
-    return 'Recién añadido · $cadence · primer plazo $day';
+    return 'Recién añadido · $cadence · vence por primera vez el $day';
   }
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -11262,6 +11262,9 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get relationshipDueToday => 'Pendiente hoy';
+
+  @override
   String get relationshipEditTitle => 'Editar persona';
 
   @override
@@ -11279,11 +11282,6 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'No se pudieron guardar los cambios. Inténtalo de nuevo.';
-
-  @override
-  String relationshipFirstDue(String day) {
-    return 'primer plazo $day';
-  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Necesita atención';
@@ -11522,6 +11520,25 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Estado';
+
+  @override
+  String relationshipStatusLineAdded(String cadence) {
+    return 'Recién añadido · $cadence';
+  }
+
+  @override
+  String relationshipStatusLineAddedFirstDue(String cadence, String day) {
+    return 'Recién añadido · $cadence · primer plazo $day';
+  }
+
+  @override
+  String relationshipStatusLineContacted(
+    String type,
+    String time,
+    String cadence,
+  ) {
+    return '$type · $time · $cadence';
+  }
 
   @override
   String get relationshipStayingInTouch => 'Mantener el contacto';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -11270,6 +11270,17 @@ class AppLocalizationsFr extends AppLocalizations {
   String get relationshipCreateTitle => 'Ajouter une personne';
 
   @override
+  String relationshipDaysOver(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count jours de retard',
+      one: '1 jour de retard',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get relationshipDeleteConfirmMessage =>
       'Tous ses échanges seront aussi supprimés. Cette action est irréversible.';
 
@@ -11301,6 +11312,11 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Impossible d\'enregistrer les modifications. Réessaie.';
+
+  @override
+  String relationshipFirstDue(String day) {
+    return 'première échéance $day';
+  }
 
   @override
   String get relationshipHealthNeedsAttention => 'A besoin d\'attention';
@@ -11447,6 +11463,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get relationshipNoLinkedTasks => 'Aucune tâche liée pour l\'instant.';
 
   @override
+  String get relationshipNotEnrolled => 'Non suivi';
+
+  @override
   String get relationshipNotFound =>
       'Cette personne n\'est plus dans ta liste.';
 
@@ -11490,7 +11509,41 @@ class AppLocalizationsFr extends AppLocalizations {
       'Ajoute les personnes dont tu veux rester proche.';
 
   @override
+  String get relationshipsGroupDue => 'À relancer';
+
+  @override
   String get relationshipsPageTitle => 'Proches';
+
+  @override
+  String get relationshipsSelectPersonHint =>
+      'Choisis une personne pour voir sa page.';
+
+  @override
+  String get relationshipsSummaryDueNow => 'À relancer maintenant';
+
+  @override
+  String relationshipsSummaryEnrolled(int count) {
+    return '/ $count suivis';
+  }
+
+  @override
+  String relationshipsSummaryNextDue(String name, String day) {
+    return 'Prochaine échéance $name · $day';
+  }
+
+  @override
+  String get relationshipsSummaryNoneDue => 'Personne à relancer';
+
+  @override
+  String relationshipsSummaryNotEnrolled(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count personnes non suivies',
+      one: '1 personne non suivie',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipStatusActive => 'Active';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -11461,7 +11461,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get relationshipNoLinkedTasks => 'Aucune tâche liée pour l\'instant.';
 
   @override
-  String get relationshipNotEnrolled => 'Non suivi';
+  String get relationshipNotEnrolled => 'Non suivie';
 
   @override
   String get relationshipNotFound =>
@@ -11521,7 +11521,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String relationshipsSummaryEnrolled(int count) {
-    return '/ $count suivis';
+    return '/ $count suivies';
   }
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -11295,6 +11295,9 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get relationshipDueToday => 'À relancer aujourd\'hui';
+
+  @override
   String get relationshipEditTitle => 'Modifier la personne';
 
   @override
@@ -11312,11 +11315,6 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Impossible d\'enregistrer les modifications. Réessaie.';
-
-  @override
-  String relationshipFirstDue(String day) {
-    return 'première échéance $day';
-  }
 
   @override
   String get relationshipHealthNeedsAttention => 'A besoin d\'attention';
@@ -11556,6 +11554,25 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Statut';
+
+  @override
+  String relationshipStatusLineAdded(String cadence) {
+    return 'Ajouté à l\'instant · $cadence';
+  }
+
+  @override
+  String relationshipStatusLineAddedFirstDue(String cadence, String day) {
+    return 'Ajouté à l\'instant · $cadence · première échéance $day';
+  }
+
+  @override
+  String relationshipStatusLineContacted(
+    String type,
+    String time,
+    String cadence,
+  ) {
+    return '$type · $time · $cadence';
+  }
 
   @override
   String get relationshipStayingInTouch => 'Rester en contact';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -11408,7 +11408,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get relationshipNoLinkedTasks => 'Nessuna attività collegata.';
 
   @override
-  String get relationshipNotEnrolled => 'Non seguito';
+  String get relationshipNotEnrolled => 'Non seguita';
 
   @override
   String get relationshipNotFound =>
@@ -11468,12 +11468,18 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String relationshipsSummaryEnrolled(int count) {
-    return '/ $count seguiti';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '/ $count seguite',
+      one: '/ 1 seguita',
+    );
+    return '$_temp0';
   }
 
   @override
   String relationshipsSummaryNextDue(String name, String day) {
-    return 'Prossimo: $name · $day';
+    return 'Prossima scadenza: $name · $day';
   }
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -11216,6 +11216,17 @@ class AppLocalizationsIt extends AppLocalizations {
   String get relationshipCreateTitle => 'Aggiungi persona';
 
   @override
+  String relationshipDaysOver(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count giorni di ritardo',
+      one: '1 giorno di ritardo',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get relationshipDeleteConfirmMessage =>
       'Verranno eliminati anche tutti i contatti registrati. L\'azione non si può annullare.';
 
@@ -11247,6 +11258,11 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Impossibile salvare le modifiche. Riprova.';
+
+  @override
+  String relationshipFirstDue(String day) {
+    return 'prima scadenza $day';
+  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Serve attenzione';
@@ -11394,6 +11410,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get relationshipNoLinkedTasks => 'Nessuna attività collegata.';
 
   @override
+  String get relationshipNotEnrolled => 'Non seguito';
+
+  @override
   String get relationshipNotFound =>
       'Questa persona non è più nella tua lista.';
 
@@ -11437,7 +11456,41 @@ class AppLocalizationsIt extends AppLocalizations {
       'Aggiungi le persone a cui vuoi restare vicino.';
 
   @override
+  String get relationshipsGroupDue => 'In scadenza';
+
+  @override
   String get relationshipsPageTitle => 'Persone';
+
+  @override
+  String get relationshipsSelectPersonHint =>
+      'Scegli una persona per vedere la sua pagina.';
+
+  @override
+  String get relationshipsSummaryDueNow => 'Da sentire ora';
+
+  @override
+  String relationshipsSummaryEnrolled(int count) {
+    return '/ $count seguiti';
+  }
+
+  @override
+  String relationshipsSummaryNextDue(String name, String day) {
+    return 'Prossimo: $name · $day';
+  }
+
+  @override
+  String get relationshipsSummaryNoneDue => 'Nessuno in scadenza';
+
+  @override
+  String relationshipsSummaryNotEnrolled(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count persone non seguite',
+      one: '1 persona non seguita',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipStatusActive => 'Attiva';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -11241,6 +11241,9 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get relationshipDueToday => 'In scadenza oggi';
+
+  @override
   String get relationshipEditTitle => 'Modifica persona';
 
   @override
@@ -11258,11 +11261,6 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Impossibile salvare le modifiche. Riprova.';
-
-  @override
-  String relationshipFirstDue(String day) {
-    return 'prima scadenza $day';
-  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Serve attenzione';
@@ -11503,6 +11501,25 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Stato';
+
+  @override
+  String relationshipStatusLineAdded(String cadence) {
+    return 'Appena aggiunto · $cadence';
+  }
+
+  @override
+  String relationshipStatusLineAddedFirstDue(String cadence, String day) {
+    return 'Appena aggiunto · $cadence · prima scadenza $day';
+  }
+
+  @override
+  String relationshipStatusLineContacted(
+    String type,
+    String time,
+    String cadence,
+  ) {
+    return '$type · $time · $cadence';
+  }
 
   @override
   String get relationshipStayingInTouch => 'Restare in contatto';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -11091,6 +11091,17 @@ class AppLocalizationsNl extends AppLocalizations {
   String get relationshipCreateTitle => 'Persoon toevoegen';
 
   @override
+  String relationshipDaysOver(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dagen te laat',
+      one: '1 dag te laat',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get relationshipDeleteConfirmMessage =>
       'Ook alle check-ins worden verwijderd. Dit kan niet ongedaan worden gemaakt.';
 
@@ -11122,6 +11133,11 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Kon de wijzigingen niet opslaan. Probeer het opnieuw.';
+
+  @override
+  String relationshipFirstDue(String day) {
+    return 'eerste keer $day';
+  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Vraagt aandacht';
@@ -11268,6 +11284,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get relationshipNoLinkedTasks => 'Nog geen gekoppelde taken.';
 
   @override
+  String get relationshipNotEnrolled => 'Niet gevolgd';
+
+  @override
   String get relationshipNotFound =>
       'Deze persoon staat niet meer in je lijst.';
 
@@ -11311,7 +11330,41 @@ class AppLocalizationsNl extends AppLocalizations {
       'Voeg de mensen toe met wie je dichtbij wilt blijven.';
 
   @override
+  String get relationshipsGroupDue => 'Aan de beurt';
+
+  @override
   String get relationshipsPageTitle => 'Mensen';
+
+  @override
+  String get relationshipsSelectPersonHint =>
+      'Kies iemand om de pagina te zien.';
+
+  @override
+  String get relationshipsSummaryDueNow => 'Nu aan de beurt';
+
+  @override
+  String relationshipsSummaryEnrolled(int count) {
+    return '/ $count gevolgd';
+  }
+
+  @override
+  String relationshipsSummaryNextDue(String name, String day) {
+    return 'Volgende: $name · $day';
+  }
+
+  @override
+  String get relationshipsSummaryNoneDue => 'Niemand aan de beurt';
+
+  @override
+  String relationshipsSummaryNotEnrolled(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count personen niet gevolgd',
+      one: '1 persoon niet gevolgd',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipStatusActive => 'Actief';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -11116,6 +11116,9 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get relationshipDueToday => 'Vandaag aan de beurt';
+
+  @override
   String get relationshipEditTitle => 'Persoon bewerken';
 
   @override
@@ -11133,11 +11136,6 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Kon de wijzigingen niet opslaan. Probeer het opnieuw.';
-
-  @override
-  String relationshipFirstDue(String day) {
-    return 'eerste keer $day';
-  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Vraagt aandacht';
@@ -11377,6 +11375,25 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Status';
+
+  @override
+  String relationshipStatusLineAdded(String cadence) {
+    return 'Net toegevoegd · $cadence';
+  }
+
+  @override
+  String relationshipStatusLineAddedFirstDue(String cadence, String day) {
+    return 'Net toegevoegd · $cadence · eerste keer $day';
+  }
+
+  @override
+  String relationshipStatusLineContacted(
+    String type,
+    String time,
+    String cadence,
+  ) {
+    return '$type · $time · $cadence';
+  }
 
   @override
   String get relationshipStayingInTouch => 'Contact houden';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -11383,7 +11383,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String relationshipStatusLineAddedFirstDue(String cadence, String day) {
-    return 'Net toegevoegd · $cadence · eerste keer $day';
+    return 'Net toegevoegd · $cadence · eerste keer voor $day';
   }
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -11203,6 +11203,9 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get relationshipDueToday => 'Pendente hoje';
+
+  @override
   String get relationshipEditTitle => 'Editar pessoa';
 
   @override
@@ -11220,11 +11223,6 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Não foi possível salvar as alterações. Tente novamente.';
-
-  @override
-  String relationshipFirstDue(String day) {
-    return 'primeiro prazo $day';
-  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Precisa de atenção';
@@ -11462,6 +11460,25 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Status';
+
+  @override
+  String relationshipStatusLineAdded(String cadence) {
+    return 'Adicionado agora · $cadence';
+  }
+
+  @override
+  String relationshipStatusLineAddedFirstDue(String cadence, String day) {
+    return 'Adicionado agora · $cadence · primeiro prazo $day';
+  }
+
+  @override
+  String relationshipStatusLineContacted(
+    String type,
+    String time,
+    String cadence,
+  ) {
+    return '$type · $time · $cadence';
+  }
 
   @override
   String get relationshipStayingInTouch => 'Manter contato';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -11427,12 +11427,12 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String relationshipsSummaryEnrolled(int count) {
-    return '/ $count acompanhados';
+    return '/ $count em acompanhamento';
   }
 
   @override
   String relationshipsSummaryNextDue(String name, String day) {
-    return 'Próximo: $name · $day';
+    return 'A seguir: $name · $day';
   }
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -11178,6 +11178,17 @@ class AppLocalizationsPt extends AppLocalizations {
   String get relationshipCreateTitle => 'Adicionar pessoa';
 
   @override
+  String relationshipDaysOver(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dias de atraso',
+      one: '1 dia de atraso',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get relationshipDeleteConfirmMessage =>
       'Todos os registros dessa pessoa também serão excluídos. Isso não pode ser desfeito.';
 
@@ -11209,6 +11220,11 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Não foi possível salvar as alterações. Tente novamente.';
+
+  @override
+  String relationshipFirstDue(String day) {
+    return 'primeiro prazo $day';
+  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Precisa de atenção';
@@ -11354,6 +11370,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get relationshipNoLinkedTasks => 'Nenhuma tarefa vinculada ainda.';
 
   @override
+  String get relationshipNotEnrolled => 'Sem acompanhamento';
+
+  @override
   String get relationshipNotFound => 'Esta pessoa não está mais na sua lista.';
 
   @override
@@ -11396,7 +11415,41 @@ class AppLocalizationsPt extends AppLocalizations {
       'Adicione as pessoas de quem você quer ficar perto.';
 
   @override
+  String get relationshipsGroupDue => 'Pendentes';
+
+  @override
   String get relationshipsPageTitle => 'Pessoas';
+
+  @override
+  String get relationshipsSelectPersonHint =>
+      'Escolhe uma pessoa para ver a página dela.';
+
+  @override
+  String get relationshipsSummaryDueNow => 'Pendentes agora';
+
+  @override
+  String relationshipsSummaryEnrolled(int count) {
+    return '/ $count acompanhados';
+  }
+
+  @override
+  String relationshipsSummaryNextDue(String name, String day) {
+    return 'Próximo: $name · $day';
+  }
+
+  @override
+  String get relationshipsSummaryNoneDue => 'Ninguém pendente';
+
+  @override
+  String relationshipsSummaryNotEnrolled(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count pessoas sem acompanhamento',
+      one: '1 pessoa sem acompanhamento',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipStatusActive => 'Ativo';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -11297,6 +11297,18 @@ class AppLocalizationsRo extends AppLocalizations {
   String get relationshipCreateTitle => 'Adăugați o persoană';
 
   @override
+  String relationshipDaysOver(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count de zile întârziere',
+      few: '$count zile întârziere',
+      one: '1 zi întârziere',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get relationshipDeleteConfirmMessage =>
       'Se vor șterge și toate înregistrările asociate. Acțiunea nu poate fi anulată.';
 
@@ -11328,6 +11340,11 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Modificările nu au putut fi salvate. Încercați din nou.';
+
+  @override
+  String relationshipFirstDue(String day) {
+    return 'prima scadență $day';
+  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Necesită atenție';
@@ -11478,6 +11495,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get relationshipNoLinkedTasks => 'Nicio sarcină asociată încă.';
 
   @override
+  String get relationshipNotEnrolled => 'Neurmărit';
+
+  @override
   String get relationshipNotFound => 'Această persoană nu mai este urmărită.';
 
   @override
@@ -11520,7 +11540,42 @@ class AppLocalizationsRo extends AppLocalizations {
       'Adăugați persoanele de care doriți să rămâneți aproape.';
 
   @override
+  String get relationshipsGroupDue => 'Scadente';
+
+  @override
   String get relationshipsPageTitle => 'Persoane';
+
+  @override
+  String get relationshipsSelectPersonHint =>
+      'Selectați o persoană pentru a-i vedea pagina.';
+
+  @override
+  String get relationshipsSummaryDueNow => 'Scadente acum';
+
+  @override
+  String relationshipsSummaryEnrolled(int count) {
+    return '/ $count urmărite';
+  }
+
+  @override
+  String relationshipsSummaryNextDue(String name, String day) {
+    return 'Următorul: $name · $day';
+  }
+
+  @override
+  String get relationshipsSummaryNoneDue => 'Nimeni scadent';
+
+  @override
+  String relationshipsSummaryNotEnrolled(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count de persoane neurmărite',
+      few: '$count persoane neurmărite',
+      one: '1 persoană neurmărită',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipStatusActive => 'Activă';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -11323,6 +11323,9 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get relationshipDueToday => 'Scadent astăzi';
+
+  @override
   String get relationshipEditTitle => 'Editați persoana';
 
   @override
@@ -11340,11 +11343,6 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Modificările nu au putut fi salvate. Încercați din nou.';
-
-  @override
-  String relationshipFirstDue(String day) {
-    return 'prima scadență $day';
-  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Necesită atenție';
@@ -11588,6 +11586,25 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Stare';
+
+  @override
+  String relationshipStatusLineAdded(String cadence) {
+    return 'Adăugat acum · $cadence';
+  }
+
+  @override
+  String relationshipStatusLineAddedFirstDue(String cadence, String day) {
+    return 'Adăugat acum · $cadence · prima scadență $day';
+  }
+
+  @override
+  String relationshipStatusLineContacted(
+    String type,
+    String time,
+    String cadence,
+  ) {
+    return '$type · $time · $cadence';
+  }
 
   @override
   String get relationshipStayingInTouch => 'Menținerea contactului';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -11301,9 +11301,9 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count de zile întârziere',
-      few: '$count zile întârziere',
-      one: '1 zi întârziere',
+      other: '$count de zile de întârziere',
+      few: '$count zile de întârziere',
+      one: '1 zi de întârziere',
     );
     return '$_temp0';
   }
@@ -11493,7 +11493,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get relationshipNoLinkedTasks => 'Nicio sarcină asociată încă.';
 
   @override
-  String get relationshipNotEnrolled => 'Neurmărit';
+  String get relationshipNotEnrolled => 'Neurmărită';
 
   @override
   String get relationshipNotFound => 'Această persoană nu mai este urmărită.';
@@ -11552,16 +11552,23 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String relationshipsSummaryEnrolled(int count) {
-    return '/ $count urmărite';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '/ $count de urmărite',
+      few: '/ $count urmărite',
+      one: '/ 1 urmărită',
+    );
+    return '$_temp0';
   }
 
   @override
   String relationshipsSummaryNextDue(String name, String day) {
-    return 'Următorul: $name · $day';
+    return 'Urmează: $name · $day';
   }
 
   @override
-  String get relationshipsSummaryNoneDue => 'Nimeni scadent';
+  String get relationshipsSummaryNoneDue => 'Nimeni nu este scadent';
 
   @override
   String relationshipsSummaryNotEnrolled(int count) {

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -11375,7 +11375,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String relationshipStatusLineAddedFirstDue(String cadence, String day) {
-    return 'Nyss tillagd · $cadence · första gången $day';
+    return 'Nyss tillagd · $cadence · första gången senast $day';
   }
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -11088,8 +11088,8 @@ class AppLocalizationsSv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count dagar försenade',
-      one: '1 dag försenad',
+      other: 'försenad med $count dagar',
+      one: 'försenad med 1 dag',
     );
     return '$_temp0';
   }
@@ -11334,7 +11334,13 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String relationshipsSummaryEnrolled(int count) {
-    return '/ $count följda';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '/ $count följda',
+      one: '/ 1 följd',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -11084,6 +11084,17 @@ class AppLocalizationsSv extends AppLocalizations {
   String get relationshipCreateTitle => 'Lägg till person';
 
   @override
+  String relationshipDaysOver(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dagar försenade',
+      one: '1 dag försenad',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get relationshipDeleteConfirmMessage =>
       'Alla avstämningar tas också bort. Det går inte att ångra.';
 
@@ -11115,6 +11126,11 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Ändringarna kunde inte sparas. Försök igen.';
+
+  @override
+  String relationshipFirstDue(String day) {
+    return 'första gången $day';
+  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Behöver uppmärksamhet';
@@ -11261,6 +11277,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get relationshipNoLinkedTasks => 'Inga uppgifter länkade än.';
 
   @override
+  String get relationshipNotEnrolled => 'Följs inte';
+
+  @override
   String get relationshipNotFound => 'Den här personen följs inte längre.';
 
   @override
@@ -11303,7 +11322,41 @@ class AppLocalizationsSv extends AppLocalizations {
       'Lägg till människorna du vill hålla kontakten med.';
 
   @override
+  String get relationshipsGroupDue => 'Dags';
+
+  @override
   String get relationshipsPageTitle => 'Personer';
+
+  @override
+  String get relationshipsSelectPersonHint =>
+      'Välj en person för att se deras sida.';
+
+  @override
+  String get relationshipsSummaryDueNow => 'Dags nu';
+
+  @override
+  String relationshipsSummaryEnrolled(int count) {
+    return '/ $count följda';
+  }
+
+  @override
+  String relationshipsSummaryNextDue(String name, String day) {
+    return 'Nästa: $name · $day';
+  }
+
+  @override
+  String get relationshipsSummaryNoneDue => 'Ingen väntar';
+
+  @override
+  String relationshipsSummaryNotEnrolled(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count personer följs inte',
+      one: '1 person följs inte',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipStatusActive => 'Aktiv';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -11109,6 +11109,9 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get relationshipDueToday => 'Dags i dag';
+
+  @override
   String get relationshipEditTitle => 'Redigera person';
 
   @override
@@ -11126,11 +11129,6 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get relationshipErrorUpdateFailed =>
       'Ändringarna kunde inte sparas. Försök igen.';
-
-  @override
-  String relationshipFirstDue(String day) {
-    return 'första gången $day';
-  }
 
   @override
   String get relationshipHealthNeedsAttention => 'Behöver uppmärksamhet';
@@ -11369,6 +11367,25 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get relationshipStatusFieldLabel => 'Status';
+
+  @override
+  String relationshipStatusLineAdded(String cadence) {
+    return 'Nyss tillagd · $cadence';
+  }
+
+  @override
+  String relationshipStatusLineAddedFirstDue(String cadence, String day) {
+    return 'Nyss tillagd · $cadence · första gången $day';
+  }
+
+  @override
+  String relationshipStatusLineContacted(
+    String type,
+    String time,
+    String cadence,
+  ) {
+    return '$type · $time · $cadence';
+  }
 
   @override
   String get relationshipStayingInTouch => 'Hålla kontakten';

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -5013,7 +5013,7 @@
       }
     }
   },
-  "relationshipStatusLineAddedFirstDue": "Net toegevoegd · {cadence} · eerste keer {day}",
+  "relationshipStatusLineAddedFirstDue": "Net toegevoegd · {cadence} · eerste keer voor {day}",
   "@relationshipStatusLineAddedFirstDue": {
     "placeholders": {
       "cadence": {

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4857,6 +4857,14 @@
   "relationshipContactMissing": "Dat contact staat niet op dit apparaat",
   "relationshipContactNoChanges": "Niets nieuws om te kopiëren",
   "relationshipCreateTitle": "Persoon toevoegen",
+  "relationshipDaysOver": "{count, plural, =1{1 dag te laat} other{{count} dagen te laat}}",
+  "@relationshipDaysOver": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDeleteConfirmMessage": "Ook alle check-ins worden verwijderd. Dit kan niet ongedaan worden gemaakt.",
   "relationshipDeleteConfirmTitle": "{name} verwijderen?",
   "relationshipDueDay": "Voor {day}",
@@ -4872,6 +4880,14 @@
   "relationshipErrorDeleteFailed": "Kon de persoon niet verwijderen. Probeer het opnieuw.",
   "relationshipErrorLinkTaskFailed": "Kon de taak niet koppelen. Probeer het opnieuw.",
   "relationshipErrorUpdateFailed": "Kon de wijzigingen niet opslaan. Probeer het opnieuw.",
+  "relationshipFirstDue": "eerste keer {day}",
+  "@relationshipFirstDue": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipHealthNeedsAttention": "Vraagt aandacht",
   "relationshipHealthSteady": "Stabiel",
   "relationshipHealthStrained": "Gespannen",
@@ -4928,6 +4944,7 @@
   "relationshipNicknameLabel": "Bijnaam",
   "relationshipNoCheckIns": "Nog geen check-ins — leg er een vast na jullie volgende gesprek.",
   "relationshipNoLinkedTasks": "Nog geen gekoppelde taken.",
+  "relationshipNotEnrolled": "Niet gevolgd",
   "relationshipNotFound": "Deze persoon staat niet meer in je lijst.",
   "relationshipNudgesOn": "herinneringen aan",
   "@relationshipNudgesOn": {
@@ -4959,7 +4976,38 @@
     "description": "Relationships redesign label."
   },
   "relationshipsEmptyState": "Voeg de mensen toe met wie je dichtbij wilt blijven.",
+  "relationshipsGroupDue": "Aan de beurt",
   "relationshipsPageTitle": "Mensen",
+  "relationshipsSelectPersonHint": "Kies iemand om de pagina te zien.",
+  "relationshipsSummaryDueNow": "Nu aan de beurt",
+  "relationshipsSummaryEnrolled": "/ {count} gevolgd",
+  "@relationshipsSummaryEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipsSummaryNextDue": "Volgende: {name} · {day}",
+  "@relationshipsSummaryNextDue": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipsSummaryNoneDue": "Niemand aan de beurt",
+  "relationshipsSummaryNotEnrolled": "{count, plural, =1{1 persoon niet gevolgd} other{{count} personen niet gevolgd}}",
+  "@relationshipsSummaryNotEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipStatusActive": "Actief",
   "relationshipStatusArchived": "Gearchiveerd",
   "relationshipStatusDormant": "Sluimerend",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4875,19 +4875,12 @@
       }
     }
   },
+  "relationshipDueToday": "Vandaag aan de beurt",
   "relationshipEditTitle": "Persoon bewerken",
   "relationshipErrorCreateFailed": "Kon de persoon niet opslaan. Probeer het opnieuw.",
   "relationshipErrorDeleteFailed": "Kon de persoon niet verwijderen. Probeer het opnieuw.",
   "relationshipErrorLinkTaskFailed": "Kon de taak niet koppelen. Probeer het opnieuw.",
   "relationshipErrorUpdateFailed": "Kon de wijzigingen niet opslaan. Probeer het opnieuw.",
-  "relationshipFirstDue": "eerste keer {day}",
-  "@relationshipFirstDue": {
-    "placeholders": {
-      "day": {
-        "type": "String"
-      }
-    }
-  },
   "relationshipHealthNeedsAttention": "Vraagt aandacht",
   "relationshipHealthSteady": "Stabiel",
   "relationshipHealthStrained": "Gespannen",
@@ -5012,6 +5005,39 @@
   "relationshipStatusArchived": "Gearchiveerd",
   "relationshipStatusDormant": "Sluimerend",
   "relationshipStatusFieldLabel": "Status",
+  "relationshipStatusLineAdded": "Net toegevoegd · {cadence}",
+  "@relationshipStatusLineAdded": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineAddedFirstDue": "Net toegevoegd · {cadence} · eerste keer {day}",
+  "@relationshipStatusLineAddedFirstDue": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineContacted": "{type} · {time} · {cadence}",
+  "@relationshipStatusLineContacted": {
+    "placeholders": {
+      "type": {
+        "type": "String"
+      },
+      "time": {
+        "type": "String"
+      },
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipStayingInTouch": "Contact houden",
   "@relationshipStayingInTouch": {
     "description": "Relationships redesign label."

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4875,19 +4875,12 @@
       }
     }
   },
+  "relationshipDueToday": "Pendente hoje",
   "relationshipEditTitle": "Editar pessoa",
   "relationshipErrorCreateFailed": "Não foi possível salvar a pessoa. Tente novamente.",
   "relationshipErrorDeleteFailed": "Não foi possível excluir a pessoa. Tente novamente.",
   "relationshipErrorLinkTaskFailed": "Não foi possível associar a tarefa. Tente novamente.",
   "relationshipErrorUpdateFailed": "Não foi possível salvar as alterações. Tente novamente.",
-  "relationshipFirstDue": "primeiro prazo {day}",
-  "@relationshipFirstDue": {
-    "placeholders": {
-      "day": {
-        "type": "String"
-      }
-    }
-  },
   "relationshipHealthNeedsAttention": "Precisa de atenção",
   "relationshipHealthSteady": "Estável",
   "relationshipHealthStrained": "Tensa",
@@ -5012,6 +5005,39 @@
   "relationshipStatusArchived": "Arquivado",
   "relationshipStatusDormant": "Adormecido",
   "relationshipStatusFieldLabel": "Status",
+  "relationshipStatusLineAdded": "Adicionado agora · {cadence}",
+  "@relationshipStatusLineAdded": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineAddedFirstDue": "Adicionado agora · {cadence} · primeiro prazo {day}",
+  "@relationshipStatusLineAddedFirstDue": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineContacted": "{type} · {time} · {cadence}",
+  "@relationshipStatusLineContacted": {
+    "placeholders": {
+      "type": {
+        "type": "String"
+      },
+      "time": {
+        "type": "String"
+      },
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipStayingInTouch": "Manter contato",
   "@relationshipStayingInTouch": {
     "description": "Relationships redesign label."

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4973,7 +4973,7 @@
   "relationshipsPageTitle": "Pessoas",
   "relationshipsSelectPersonHint": "Escolhe uma pessoa para ver a página dela.",
   "relationshipsSummaryDueNow": "Pendentes agora",
-  "relationshipsSummaryEnrolled": "/ {count} acompanhados",
+  "relationshipsSummaryEnrolled": "/ {count} em acompanhamento",
   "@relationshipsSummaryEnrolled": {
     "placeholders": {
       "count": {
@@ -4981,7 +4981,7 @@
       }
     }
   },
-  "relationshipsSummaryNextDue": "Próximo: {name} · {day}",
+  "relationshipsSummaryNextDue": "A seguir: {name} · {day}",
   "@relationshipsSummaryNextDue": {
     "placeholders": {
       "name": {

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4857,6 +4857,14 @@
   "relationshipContactMissing": "Esse contacto não está neste dispositivo",
   "relationshipContactNoChanges": "Nada de novo para copiar",
   "relationshipCreateTitle": "Adicionar pessoa",
+  "relationshipDaysOver": "{count, plural, =1{1 dia de atraso} other{{count} dias de atraso}}",
+  "@relationshipDaysOver": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDeleteConfirmMessage": "Todos os registros dessa pessoa também serão excluídos. Isso não pode ser desfeito.",
   "relationshipDeleteConfirmTitle": "Excluir {name}?",
   "relationshipDueDay": "Até {day}",
@@ -4872,6 +4880,14 @@
   "relationshipErrorDeleteFailed": "Não foi possível excluir a pessoa. Tente novamente.",
   "relationshipErrorLinkTaskFailed": "Não foi possível associar a tarefa. Tente novamente.",
   "relationshipErrorUpdateFailed": "Não foi possível salvar as alterações. Tente novamente.",
+  "relationshipFirstDue": "primeiro prazo {day}",
+  "@relationshipFirstDue": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipHealthNeedsAttention": "Precisa de atenção",
   "relationshipHealthSteady": "Estável",
   "relationshipHealthStrained": "Tensa",
@@ -4928,6 +4944,7 @@
   "relationshipNicknameLabel": "Apelido",
   "relationshipNoCheckIns": "Nenhum registro ainda — adicione um após a próxima conversa.",
   "relationshipNoLinkedTasks": "Nenhuma tarefa vinculada ainda.",
+  "relationshipNotEnrolled": "Sem acompanhamento",
   "relationshipNotFound": "Esta pessoa não está mais na sua lista.",
   "relationshipNudgesOn": "lembretes ativos",
   "@relationshipNudgesOn": {
@@ -4959,7 +4976,38 @@
     "description": "Relationships redesign label."
   },
   "relationshipsEmptyState": "Adicione as pessoas de quem você quer ficar perto.",
+  "relationshipsGroupDue": "Pendentes",
   "relationshipsPageTitle": "Pessoas",
+  "relationshipsSelectPersonHint": "Escolhe uma pessoa para ver a página dela.",
+  "relationshipsSummaryDueNow": "Pendentes agora",
+  "relationshipsSummaryEnrolled": "/ {count} acompanhados",
+  "@relationshipsSummaryEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipsSummaryNextDue": "Próximo: {name} · {day}",
+  "@relationshipsSummaryNextDue": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipsSummaryNoneDue": "Ninguém pendente",
+  "relationshipsSummaryNotEnrolled": "{count, plural, =1{1 pessoa sem acompanhamento} other{{count} pessoas sem acompanhamento}}",
+  "@relationshipsSummaryNotEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipStatusActive": "Ativo",
   "relationshipStatusArchived": "Arquivado",
   "relationshipStatusDormant": "Adormecido",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4355,6 +4355,14 @@
   "relationshipContactMissing": "Acel contact nu se află pe acest dispozitiv",
   "relationshipContactNoChanges": "Nu este nimic nou de copiat",
   "relationshipCreateTitle": "Adăugați o persoană",
+  "relationshipDaysOver": "{count, plural, =1{1 zi întârziere} few{{count} zile întârziere} other{{count} de zile întârziere}}",
+  "@relationshipDaysOver": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDeleteConfirmMessage": "Se vor șterge și toate înregistrările asociate. Acțiunea nu poate fi anulată.",
   "relationshipDeleteConfirmTitle": "Ștergeți {name}?",
   "relationshipDueDay": "Până {day}",
@@ -4370,6 +4378,14 @@
   "relationshipErrorDeleteFailed": "Persoana nu a putut fi ștearsă. Încercați din nou.",
   "relationshipErrorLinkTaskFailed": "Sarcina nu a putut fi asociată. Încercați din nou.",
   "relationshipErrorUpdateFailed": "Modificările nu au putut fi salvate. Încercați din nou.",
+  "relationshipFirstDue": "prima scadență {day}",
+  "@relationshipFirstDue": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipHealthNeedsAttention": "Necesită atenție",
   "relationshipHealthSteady": "Stabilă",
   "relationshipHealthStrained": "Tensionată",
@@ -4426,6 +4442,7 @@
   "relationshipNicknameLabel": "Poreclă",
   "relationshipNoCheckIns": "Nicio înregistrare încă — adăugați una după următoarea conversație.",
   "relationshipNoLinkedTasks": "Nicio sarcină asociată încă.",
+  "relationshipNotEnrolled": "Neurmărit",
   "relationshipNotFound": "Această persoană nu mai este urmărită.",
   "relationshipNudgesOn": "memento-uri active",
   "@relationshipNudgesOn": {
@@ -4457,7 +4474,38 @@
     "description": "Relationships redesign label."
   },
   "relationshipsEmptyState": "Adăugați persoanele de care doriți să rămâneți aproape.",
+  "relationshipsGroupDue": "Scadente",
   "relationshipsPageTitle": "Persoane",
+  "relationshipsSelectPersonHint": "Selectați o persoană pentru a-i vedea pagina.",
+  "relationshipsSummaryDueNow": "Scadente acum",
+  "relationshipsSummaryEnrolled": "/ {count} urmărite",
+  "@relationshipsSummaryEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipsSummaryNextDue": "Următorul: {name} · {day}",
+  "@relationshipsSummaryNextDue": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipsSummaryNoneDue": "Nimeni scadent",
+  "relationshipsSummaryNotEnrolled": "{count, plural, =1{1 persoană neurmărită} few{{count} persoane neurmărite} other{{count} de persoane neurmărite}}",
+  "@relationshipsSummaryNotEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipStatusActive": "Activă",
   "relationshipStatusArchived": "Arhivată",
   "relationshipStatusDormant": "Inactivă",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4373,19 +4373,12 @@
       }
     }
   },
+  "relationshipDueToday": "Scadent astăzi",
   "relationshipEditTitle": "Editați persoana",
   "relationshipErrorCreateFailed": "Persoana nu a putut fi salvată. Încercați din nou.",
   "relationshipErrorDeleteFailed": "Persoana nu a putut fi ștearsă. Încercați din nou.",
   "relationshipErrorLinkTaskFailed": "Sarcina nu a putut fi asociată. Încercați din nou.",
   "relationshipErrorUpdateFailed": "Modificările nu au putut fi salvate. Încercați din nou.",
-  "relationshipFirstDue": "prima scadență {day}",
-  "@relationshipFirstDue": {
-    "placeholders": {
-      "day": {
-        "type": "String"
-      }
-    }
-  },
   "relationshipHealthNeedsAttention": "Necesită atenție",
   "relationshipHealthSteady": "Stabilă",
   "relationshipHealthStrained": "Tensionată",
@@ -4510,6 +4503,39 @@
   "relationshipStatusArchived": "Arhivată",
   "relationshipStatusDormant": "Inactivă",
   "relationshipStatusFieldLabel": "Stare",
+  "relationshipStatusLineAdded": "Adăugat acum · {cadence}",
+  "@relationshipStatusLineAdded": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineAddedFirstDue": "Adăugat acum · {cadence} · prima scadență {day}",
+  "@relationshipStatusLineAddedFirstDue": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineContacted": "{type} · {time} · {cadence}",
+  "@relationshipStatusLineContacted": {
+    "placeholders": {
+      "type": {
+        "type": "String"
+      },
+      "time": {
+        "type": "String"
+      },
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipStayingInTouch": "Menținerea contactului",
   "@relationshipStayingInTouch": {
     "description": "Relationships redesign label."

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4355,7 +4355,7 @@
   "relationshipContactMissing": "Acel contact nu se află pe acest dispozitiv",
   "relationshipContactNoChanges": "Nu este nimic nou de copiat",
   "relationshipCreateTitle": "Adăugați o persoană",
-  "relationshipDaysOver": "{count, plural, =1{1 zi întârziere} few{{count} zile întârziere} other{{count} de zile întârziere}}",
+  "relationshipDaysOver": "{count, plural, =1{1 zi de întârziere} few{{count} zile de întârziere} other{{count} de zile de întârziere}}",
   "@relationshipDaysOver": {
     "placeholders": {
       "count": {
@@ -4435,7 +4435,7 @@
   "relationshipNicknameLabel": "Poreclă",
   "relationshipNoCheckIns": "Nicio înregistrare încă — adăugați una după următoarea conversație.",
   "relationshipNoLinkedTasks": "Nicio sarcină asociată încă.",
-  "relationshipNotEnrolled": "Neurmărit",
+  "relationshipNotEnrolled": "Neurmărită",
   "relationshipNotFound": "Această persoană nu mai este urmărită.",
   "relationshipNudgesOn": "memento-uri active",
   "@relationshipNudgesOn": {
@@ -4471,7 +4471,7 @@
   "relationshipsPageTitle": "Persoane",
   "relationshipsSelectPersonHint": "Selectați o persoană pentru a-i vedea pagina.",
   "relationshipsSummaryDueNow": "Scadente acum",
-  "relationshipsSummaryEnrolled": "/ {count} urmărite",
+  "relationshipsSummaryEnrolled": "{count, plural, =1{/ 1 urmărită} few{/ {count} urmărite} other{/ {count} de urmărite}}",
   "@relationshipsSummaryEnrolled": {
     "placeholders": {
       "count": {
@@ -4479,7 +4479,7 @@
       }
     }
   },
-  "relationshipsSummaryNextDue": "Următorul: {name} · {day}",
+  "relationshipsSummaryNextDue": "Urmează: {name} · {day}",
   "@relationshipsSummaryNextDue": {
     "placeholders": {
       "name": {
@@ -4490,7 +4490,7 @@
       }
     }
   },
-  "relationshipsSummaryNoneDue": "Nimeni scadent",
+  "relationshipsSummaryNoneDue": "Nimeni nu este scadent",
   "relationshipsSummaryNotEnrolled": "{count, plural, =1{1 persoană neurmărită} few{{count} persoane neurmărite} other{{count} de persoane neurmărite}}",
   "@relationshipsSummaryNotEnrolled": {
     "placeholders": {

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4858,7 +4858,7 @@
   "relationshipContactMissing": "Den kontakten finns inte på den här enheten",
   "relationshipContactNoChanges": "Inget nytt att kopiera",
   "relationshipCreateTitle": "Lägg till person",
-  "relationshipDaysOver": "{count, plural, =1{1 dag försenad} other{{count} dagar försenade}}",
+  "relationshipDaysOver": "{count, plural, =1{försenad med 1 dag} other{försenad med {count} dagar}}",
   "@relationshipDaysOver": {
     "placeholders": {
       "count": {
@@ -4974,7 +4974,7 @@
   "relationshipsPageTitle": "Personer",
   "relationshipsSelectPersonHint": "Välj en person för att se deras sida.",
   "relationshipsSummaryDueNow": "Dags nu",
-  "relationshipsSummaryEnrolled": "/ {count} följda",
+  "relationshipsSummaryEnrolled": "{count, plural, =1{/ 1 följd} other{/ {count} följda}}",
   "@relationshipsSummaryEnrolled": {
     "placeholders": {
       "count": {

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4858,6 +4858,14 @@
   "relationshipContactMissing": "Den kontakten finns inte på den här enheten",
   "relationshipContactNoChanges": "Inget nytt att kopiera",
   "relationshipCreateTitle": "Lägg till person",
+  "relationshipDaysOver": "{count, plural, =1{1 dag försenad} other{{count} dagar försenade}}",
+  "@relationshipDaysOver": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDeleteConfirmMessage": "Alla avstämningar tas också bort. Det går inte att ångra.",
   "relationshipDeleteConfirmTitle": "Ta bort {name}?",
   "relationshipDueDay": "Senast {day}",
@@ -4873,6 +4881,14 @@
   "relationshipErrorDeleteFailed": "Personen kunde inte tas bort. Försök igen.",
   "relationshipErrorLinkTaskFailed": "Uppgiften kunde inte länkas. Försök igen.",
   "relationshipErrorUpdateFailed": "Ändringarna kunde inte sparas. Försök igen.",
+  "relationshipFirstDue": "första gången {day}",
+  "@relationshipFirstDue": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipHealthNeedsAttention": "Behöver uppmärksamhet",
   "relationshipHealthSteady": "Stabil",
   "relationshipHealthStrained": "Ansträngd",
@@ -4929,6 +4945,7 @@
   "relationshipNicknameLabel": "Smeknamn",
   "relationshipNoCheckIns": "Inga avstämningar än — logga en efter ert nästa samtal.",
   "relationshipNoLinkedTasks": "Inga uppgifter länkade än.",
+  "relationshipNotEnrolled": "Följs inte",
   "relationshipNotFound": "Den här personen följs inte längre.",
   "relationshipNudgesOn": "påminnelser på",
   "@relationshipNudgesOn": {
@@ -4960,7 +4977,38 @@
     "description": "Relationships redesign label."
   },
   "relationshipsEmptyState": "Lägg till människorna du vill hålla kontakten med.",
+  "relationshipsGroupDue": "Dags",
   "relationshipsPageTitle": "Personer",
+  "relationshipsSelectPersonHint": "Välj en person för att se deras sida.",
+  "relationshipsSummaryDueNow": "Dags nu",
+  "relationshipsSummaryEnrolled": "/ {count} följda",
+  "@relationshipsSummaryEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipsSummaryNextDue": "Nästa: {name} · {day}",
+  "@relationshipsSummaryNextDue": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipsSummaryNoneDue": "Ingen väntar",
+  "relationshipsSummaryNotEnrolled": "{count, plural, =1{1 person följs inte} other{{count} personer följs inte}}",
+  "@relationshipsSummaryNotEnrolled": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipStatusActive": "Aktiv",
   "relationshipStatusArchived": "Arkiverad",
   "relationshipStatusDormant": "Vilande",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -5014,7 +5014,7 @@
       }
     }
   },
-  "relationshipStatusLineAddedFirstDue": "Nyss tillagd · {cadence} · första gången {day}",
+  "relationshipStatusLineAddedFirstDue": "Nyss tillagd · {cadence} · första gången senast {day}",
   "@relationshipStatusLineAddedFirstDue": {
     "placeholders": {
       "cadence": {

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4876,19 +4876,12 @@
       }
     }
   },
+  "relationshipDueToday": "Dags i dag",
   "relationshipEditTitle": "Redigera person",
   "relationshipErrorCreateFailed": "Personen kunde inte sparas. Försök igen.",
   "relationshipErrorDeleteFailed": "Personen kunde inte tas bort. Försök igen.",
   "relationshipErrorLinkTaskFailed": "Uppgiften kunde inte länkas. Försök igen.",
   "relationshipErrorUpdateFailed": "Ändringarna kunde inte sparas. Försök igen.",
-  "relationshipFirstDue": "första gången {day}",
-  "@relationshipFirstDue": {
-    "placeholders": {
-      "day": {
-        "type": "String"
-      }
-    }
-  },
   "relationshipHealthNeedsAttention": "Behöver uppmärksamhet",
   "relationshipHealthSteady": "Stabil",
   "relationshipHealthStrained": "Ansträngd",
@@ -5013,6 +5006,39 @@
   "relationshipStatusArchived": "Arkiverad",
   "relationshipStatusDormant": "Vilande",
   "relationshipStatusFieldLabel": "Status",
+  "relationshipStatusLineAdded": "Nyss tillagd · {cadence}",
+  "@relationshipStatusLineAdded": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineAddedFirstDue": "Nyss tillagd · {cadence} · första gången {day}",
+  "@relationshipStatusLineAddedFirstDue": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      },
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipStatusLineContacted": "{type} · {time} · {cadence}",
+  "@relationshipStatusLineContacted": {
+    "placeholders": {
+      "type": {
+        "type": "String"
+      },
+      "time": {
+        "type": "String"
+      },
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipStayingInTouch": "Hålla kontakten",
   "@relationshipStayingInTouch": {
     "description": "Relationships redesign label."

--- a/lib/services/nav_service.dart
+++ b/lib/services/nav_service.dart
@@ -245,6 +245,12 @@ class NavService {
   );
   final ValueNotifier<String?> desktopSelectedProjectId =
       ValueNotifier<String?>(null);
+
+  /// Desktop split-pane People selection — the person whose page fills the
+  /// right pane, or `null` for the empty state. Written exclusively by
+  /// `RelationshipsLocation` from the URL, like the projects slot.
+  final ValueNotifier<String?> desktopSelectedRelationshipId =
+      ValueNotifier<String?>(null);
   final ValueNotifier<String?> desktopSelectedDashboardId =
       ValueNotifier<String?>(null);
 
@@ -952,6 +958,7 @@ class NavService {
     desktopTaskDetailStack.dispose();
     desktopSelectedTaskId.dispose();
     desktopSelectedProjectId.dispose();
+    desktopSelectedRelationshipId.dispose();
     desktopSelectedDashboardId.dispose();
     desktopSelectedEntryId.dispose();
     desktopSelectedEntryLinkedFromId.dispose();

--- a/test/beamer/locations/relationships_location_test.dart
+++ b/test/beamer/locations/relationships_location_test.dart
@@ -4,12 +4,34 @@ import 'package:lotti/beamer/locations/relationships_location.dart';
 import 'package:lotti/features/relationships/ui/pages/relationship_chat_page.dart';
 import 'package:lotti/features/relationships/ui/pages/relationship_details_page.dart';
 import 'package:lotti/features/relationships/ui/pages/relationships_page.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:material_ui/material_ui.dart';
+import 'package:mocktail/mocktail.dart';
 
+import '../../mocks/mocks.dart';
 import '../../widget_test_utils.dart';
 
 void main() {
   group('RelationshipsLocation', () {
+    late MockNavService navService;
+    late ValueNotifier<String?> selected;
+
+    setUp(() {
+      navService = MockNavService();
+      selected = ValueNotifier<String?>(null);
+      when(() => navService.isDesktopMode).thenReturn(false);
+      when(
+        () => navService.desktopSelectedRelationshipId,
+      ).thenReturn(selected);
+      getIt.registerSingleton<NavService>(navService);
+    });
+
+    tearDown(() async {
+      selected.dispose();
+      await getIt.unregister<NavService>();
+    });
+
     // buildPages resolves localized page titles, so it needs a real,
     // localization-carrying context rather than a mock.
     Future<BuildContext> localizedContext(WidgetTester tester) async {
@@ -95,6 +117,43 @@ void main() {
         pages.map((page) => page.child),
         isNot(contains(isA<RelationshipChatPage>())),
       );
+    });
+
+    group('on desktop', () {
+      setUp(() => when(() => navService.isDesktopMode).thenReturn(true));
+
+      testWidgets('mirrors the person id into the split-pane selection and '
+          'pushes no detail page', (tester) async {
+        final context = await localizedContext(tester);
+
+        final pages = pagesFor(context, '/people/rel-1');
+
+        expect(pages, hasLength(1));
+        expect(pages.single.child, isA<RelationshipsPage>());
+        expect(selected.value, 'rel-1');
+      });
+
+      testWidgets('the bare list route clears the selection', (tester) async {
+        selected.value = 'rel-1';
+        final context = await localizedContext(tester);
+
+        pagesFor(context, '/people');
+
+        expect(selected.value, isNull);
+      });
+
+      testWidgets('the chat still stacks as its own page above the list', (
+        tester,
+      ) async {
+        final context = await localizedContext(tester);
+
+        final pages = pagesFor(context, '/people/rel-1/chat');
+
+        expect(pages, hasLength(2));
+        expect(pages[0].child, isA<RelationshipsPage>());
+        expect(pages[1].child, isA<RelationshipChatPage>());
+        expect(selected.value, 'rel-1');
+      });
     });
   });
 }

--- a/test/database/database_relationship_queries_test.dart
+++ b/test/database/database_relationship_queries_test.dart
@@ -303,6 +303,78 @@ void main() {
     );
 
     test(
+      'latestCheckIns resolves the newest live check-in row per relationship '
+      'in one further query and respects the private filter',
+      () async {
+        await db!.updateJournalEntity(
+          checkIn('a-old', relationshipId: 'rel-a', at: baseTime),
+        );
+        await db!.updateJournalEntity(
+          checkIn(
+            'a-new',
+            relationshipId: 'rel-a',
+            at: baseTime.add(const Duration(days: 2)),
+          ),
+        );
+        // A deleted newer row must not shadow the live one.
+        await db!.updateJournalEntity(
+          checkIn(
+            'a-deleted',
+            relationshipId: 'rel-a',
+            at: baseTime.add(const Duration(days: 5)),
+            deletedAt: baseTime.add(const Duration(days: 6)),
+          ),
+        );
+        // rel-b's newest is private; its older one is public — with private
+        // entries hidden the OLDER public row is the newest visible one.
+        await db!.updateJournalEntity(
+          checkIn('b-public', relationshipId: 'rel-b', at: baseTime),
+        );
+        await db!.updateJournalEntity(
+          checkIn(
+            'b-private',
+            relationshipId: 'rel-b',
+            at: baseTime.add(const Duration(days: 1)),
+            private: true,
+          ),
+        );
+        // The same instant as a-new on ANOTHER person: the pair must be
+        // matched, not only the instant.
+        await db!.updateJournalEntity(
+          checkIn(
+            'c-same-instant',
+            relationshipId: 'rel-c',
+            at: baseTime.add(const Duration(days: 2)),
+          ),
+        );
+
+        Future<void> setPrivateFlag({required bool status}) =>
+            db!.upsertConfigFlag(
+              ConfigFlag(
+                name: privateFlag,
+                description: 'Show private entries?',
+                status: status,
+              ),
+            );
+
+        await setPrivateFlag(status: true);
+        final shown = await db!.latestCheckIns();
+        expect(
+          shown.map((id, entry) => MapEntry(id, entry.meta.id)),
+          {'rel-a': 'a-new', 'rel-b': 'b-private', 'rel-c': 'c-same-instant'},
+        );
+        expect(shown['rel-a']!.data.relationshipId, 'rel-a');
+
+        await setPrivateFlag(status: false);
+        final hidden = await db!.latestCheckIns();
+        expect(
+          hidden.map((id, entry) => MapEntry(id, entry.meta.id)),
+          {'rel-a': 'a-new', 'rel-b': 'b-public', 'rel-c': 'c-same-instant'},
+        );
+      },
+    );
+
+    test(
       'latestCheckInTimes aggregates the newest live check-in per '
       'relationship and respects the private filter',
       () async {

--- a/test/database/database_relationship_queries_test.dart
+++ b/test/database/database_relationship_queries_test.dart
@@ -67,11 +67,12 @@ void main() {
     required DateTime at,
     bool private = false,
     DateTime? deletedAt,
+    CheckInInteractionType interactionType = CheckInInteractionType.call,
   }) => JournalEntity.checkIn(
     meta: meta(id, dateFrom: at, private: private, deletedAt: deletedAt),
     data: CheckInData(
       relationshipId: relationshipId,
-      interactionType: CheckInInteractionType.call,
+      interactionType: interactionType,
     ),
   );
 
@@ -371,6 +372,38 @@ void main() {
           hidden.map((id, entry) => MapEntry(id, entry.meta.id)),
           {'rel-a': 'a-new', 'rel-b': 'b-public', 'rel-c': 'c-same-instant'},
         );
+      },
+    );
+
+    test(
+      'latestCheckIns breaks a same-instant tie by id, so the interaction a '
+      'People row shows does not change between loads',
+      () async {
+        final at = baseTime.add(const Duration(days: 3));
+        // The message is inserted first so that natural (insertion) order
+        // and id order disagree — only a deterministic ORDER BY picks the
+        // call both times.
+        await db!.updateJournalEntity(
+          checkIn(
+            'd-2-message',
+            relationshipId: 'rel-d',
+            at: at,
+            interactionType: CheckInInteractionType.message,
+          ),
+        );
+        await db!.updateJournalEntity(
+          checkIn('d-1-call', relationshipId: 'rel-d', at: at),
+        );
+
+        final first = await db!.latestCheckIns();
+        final again = await db!.latestCheckIns();
+
+        expect(first['rel-d']!.meta.id, 'd-1-call');
+        expect(
+          first['rel-d']!.data.interactionType,
+          CheckInInteractionType.call,
+        );
+        expect(again['rel-d']!.meta.id, 'd-1-call');
       },
     );
 

--- a/test/features/relationships/repository/relationship_repository_test.dart
+++ b/test/features/relationships/repository/relationship_repository_test.dart
@@ -723,10 +723,19 @@ void main() {
         ).thenAnswer((_) async => [cara, ben, anna]);
         // Anna was checked in on yesterday — she outranks everyone; Ben's
         // last check-in predates Cara's tracking start.
-        when(() => mockDb.latestCheckInTimes()).thenAnswer(
+        CheckInEntry latest(String relationshipId, DateTime at) => CheckInEntry(
+          meta: meta(
+            'check-$relationshipId',
+          ).copyWith(dateFrom: at, dateTo: at),
+          data: CheckInData(
+            relationshipId: relationshipId,
+            interactionType: CheckInInteractionType.videoCall,
+          ),
+        );
+        when(() => mockDb.latestCheckIns()).thenAnswer(
           (_) async => {
-            'anna': DateTime(2026, 8, 12),
-            'ben': DateTime(2026, 8, 7),
+            'anna': latest('anna', DateTime(2026, 8, 12)),
+            'ben': latest('ben', DateTime(2026, 8, 7)),
           },
         );
 
@@ -737,8 +746,15 @@ void main() {
           ['anna', 'cara', 'ben'],
         );
         expect(items.first.lastCheckInAt, DateTime(2026, 8, 12));
+        // The whole check-in rides along, so the list can say what the last
+        // contact was, not only when.
+        expect(
+          items.first.lastCheckIn?.data.interactionType,
+          CheckInInteractionType.videoCall,
+        );
         // Cara has no check-in: recency is her tracking start.
         expect(items[1].lastCheckInAt, isNull);
+        expect(items[1].lastCheckIn, isNull);
       },
     );
   });

--- a/test/features/relationships/state/relationships_providers_test.dart
+++ b/test/features/relationships/state/relationships_providers_test.dart
@@ -45,7 +45,18 @@ void main() {
 
   RelationshipListItem item(String id, {DateTime? lastCheckInAt}) => (
     relationship: relationship(id),
-    lastCheckInAt: lastCheckInAt,
+    lastCheckIn: lastCheckInAt == null
+        ? null
+        : CheckInEntry(
+            meta: meta('check-$id').copyWith(
+              dateFrom: lastCheckInAt,
+              dateTo: lastCheckInAt,
+            ),
+            data: CheckInData(
+              relationshipId: id,
+              interactionType: CheckInInteractionType.call,
+            ),
+          ),
   );
 
   CheckInEntry checkIn(String id, String relationshipId) => CheckInEntry(

--- a/test/features/relationships/ui/model/people_list_model_test.dart
+++ b/test/features/relationships/ui/model/people_list_model_test.dart
@@ -189,12 +189,18 @@ void main() {
           PeopleCadencePillKind.archived => PeopleListGroup.notEnrolled,
         };
         expect(group, expectedGroup, reason: item.relationship.id);
+        // Due ON the due day counts as due — the runtime's rule.
         if (pill.kind == PeopleCadencePillKind.overdue) {
-          expect(pill.daysOver, greaterThan(0));
+          expect(pill.daysOver, greaterThanOrEqualTo(0));
         } else {
           expect(pill.daysOver, 0);
         }
         expect(pill.dueAt != null, pill.kind == PeopleCadencePillKind.dueSoon);
+        // A person who is not enrolled has no deadline in any form.
+        if (group == PeopleListGroup.notEnrolled) {
+          expect(peopleDueDateOf(item, now: _now), isNull);
+          expect(peopleOverdueDaysOf(item, now: _now), isNull);
+        }
       }
     }, tags: 'glados');
 
@@ -256,6 +262,18 @@ void main() {
       expect(pill.daysOver, 1);
     });
 
+    test('the due day itself already counts as due — the runtime marks the '
+        'cadence due once the day is no longer before the due day, and the '
+        'list must agree with the nudge it sends', () {
+      // Weekly, contacted seven days ago (plus an hour): due today.
+      final item = person(daysAgo: 7);
+      final pill = peopleCadencePillOf(item, now: _now);
+      expect(pill.kind, PeopleCadencePillKind.overdue);
+      expect(pill.daysOver, 0);
+      expect(peopleListGroupOf(item, now: _now), PeopleListGroup.due);
+      expect(peopleSummaryOf([item], now: _now).dueNow, 1);
+    });
+
     test('due seven days out is still "due soon"; eight is on track', () {
       // Weekly cadence, contacted today → due in seven days.
       expect(
@@ -282,19 +300,38 @@ void main() {
       );
     });
 
-    test('enrolled without a cadence is on track, never due', () {
+    test('an enrolled person without a stored cadence follows the runtime '
+        'default (ADR 0039 Decision 2) instead of being on track forever', () {
+      // Tracking since 1 Jun with no cadence set: the runtime applies the
+      // 30-day default, so by 13 Aug the cadence has lapsed — as the nudge
+      // the runtime would send says.
       expect(
-        peopleCadencePillOf(person(cadenceDays: null), now: _now).kind,
+        effectiveCadenceDaysOf(person(cadenceDays: null).relationship),
+        30,
+      );
+      final pill = peopleCadencePillOf(person(cadenceDays: null), now: _now);
+      expect(pill.kind, PeopleCadencePillKind.overdue);
+      expect(
+        pill.daysOver,
+        _now.difference(_trackingStart.add(const Duration(days: 30))).inDays,
+      );
+      // Contacted this morning, the default keeps them on track for a month.
+      expect(
+        peopleCadencePillOf(
+          person(cadenceDays: null, daysAgo: 0),
+          now: _now,
+        ).kind,
         PeopleCadencePillKind.onTrack,
       );
     });
 
-    test('not important is not enrolled, whatever the cadence says', () {
-      final pill = peopleCadencePillOf(
-        person(important: false, daysAgo: 40),
-        now: _now,
-      );
+    test('not important is not enrolled, whatever the cadence says — and '
+        'carries no deadline, because the runtime schedules none', () {
+      final item = person(important: false, daysAgo: 40);
+      final pill = peopleCadencePillOf(item, now: _now);
       expect(pill.kind, PeopleCadencePillKind.notEnrolled);
+      expect(effectiveCadenceDaysOf(item.relationship), isNull);
+      expect(peopleDueDateOf(item, now: _now), isNull);
     });
 
     test('an important but dormant or archived person is kept, not nurtured '

--- a/test/features/relationships/ui/model/people_list_model_test.dart
+++ b/test/features/relationships/ui/model/people_list_model_test.dart
@@ -1,0 +1,330 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
+import 'package:lotti/classes/check_in_data.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/relationship_data.dart';
+import 'package:lotti/features/relationships/repository/relationship_repository.dart';
+import 'package:lotti/features/relationships/ui/model/people_list_model.dart';
+
+/// A Thursday, mid-morning — every date below is relative to it.
+final _now = DateTime(2026, 8, 13, 10, 30);
+final _trackingStart = DateTime(2026, 6, 1, 9);
+
+/// One generated person, before it gets an id.
+typedef _Spec = ({
+  bool important,
+  int statusIndex,
+  int? cadenceDays,
+  int? daysSinceLastCheckIn,
+});
+
+RelationshipListItem _itemFrom(
+  String id,
+  _Spec spec, {
+  DateTime? trackingStart,
+}) {
+  final start = trackingStart ?? _trackingStart;
+  final status = switch (spec.statusIndex) {
+    0 => RelationshipStatus.active(id: 's-$id', createdAt: start, utcOffset: 0),
+    1 => RelationshipStatus.dormant(
+      id: 's-$id',
+      createdAt: start,
+      utcOffset: 0,
+    ),
+    _ => RelationshipStatus.archived(
+      id: 's-$id',
+      createdAt: start,
+      utcOffset: 0,
+    ),
+  };
+  final lastAt = spec.daysSinceLastCheckIn == null
+      ? null
+      : _now.subtract(Duration(days: spec.daysSinceLastCheckIn!, hours: 1));
+  return (
+    relationship: RelationshipEntry(
+      meta: Metadata(
+        id: id,
+        createdAt: start,
+        updatedAt: start,
+        dateFrom: start,
+        dateTo: start,
+      ),
+      data: RelationshipData(
+        title: id,
+        important: spec.important,
+        checkInCadenceDays: spec.cadenceDays,
+        status: status,
+      ),
+    ),
+    lastCheckIn: lastAt == null
+        ? null
+        : CheckInEntry(
+            meta: Metadata(
+              id: 'check-$id',
+              createdAt: lastAt,
+              updatedAt: lastAt,
+              dateFrom: lastAt,
+              dateTo: lastAt,
+            ),
+            data: CheckInData(
+              relationshipId: id,
+              interactionType: CheckInInteractionType.call,
+            ),
+          ),
+  );
+}
+
+List<RelationshipListItem> _itemsFrom(List<_Spec> specs) => [
+  for (final (index, spec) in specs.indexed) _itemFrom('p$index', spec),
+];
+
+extension _AnyPeople on glados.Any {
+  glados.Generator<_Spec> get personSpec =>
+      glados.any.combine5<bool, int, int, int, int, _Spec>(
+        glados.any.bool,
+        glados.IntAnys(this).intInRange(0, 3),
+        glados.IntAnys(this).intInRange(0, 5),
+        glados.IntAnys(this).intInRange(0, 120),
+        glados.IntAnys(this).intInRange(0, 3),
+        (important, statusIndex, cadenceIndex, daysAgo, hasCheckIn) => (
+          important: important,
+          statusIndex: statusIndex,
+          cadenceDays: const [null, 7, 14, 30, 90][cadenceIndex],
+          daysSinceLastCheckIn: hasCheckIn == 0 ? null : daysAgo,
+        ),
+      );
+
+  glados.Generator<List<_Spec>> get people => glados.any.list(personSpec);
+}
+
+void main() {
+  group('peopleListSections — properties', () {
+    glados.Glados(
+      glados.any.people,
+      glados.ExploreConfig(numRuns: 200),
+    ).test('partitions the list: every person lands in exactly one band, '
+        'bands are non-empty and in display order', (specs) {
+      final items = _itemsFrom(specs);
+      final sections = peopleListSections(items, now: _now);
+
+      final ids = [
+        for (final section in sections)
+          for (final item in section.items) item.relationship.id,
+      ];
+      expect(ids.toSet(), {for (final item in items) item.relationship.id});
+      expect(ids, hasLength(items.length));
+      for (final section in sections) {
+        expect(section.items, isNotEmpty);
+      }
+      final groupOrder = [for (final s in sections) s.group.index];
+      expect(groupOrder, List.of(groupOrder)..sort());
+      expect(groupOrder.toSet(), hasLength(groupOrder.length));
+    }, tags: 'glados');
+
+    glados.Glados(
+      glados.any.people,
+      glados.ExploreConfig(numRuns: 200),
+    ).test('within a band the most recent contact comes first', (specs) {
+      for (final section in peopleListSections(_itemsFrom(specs), now: _now)) {
+        final recency = section.items.map(peopleRecencyOf).toList();
+        for (var i = 1; i < recency.length; i++) {
+          expect(recency[i - 1].isBefore(recency[i]), isFalse);
+        }
+      }
+    }, tags: 'glados');
+
+    glados.Glados2(
+      glados.any.people,
+      glados.any.int,
+      glados.ExploreConfig(numRuns: 200),
+    ).test('is a pure function of the set of people, not their order', (
+      specs,
+      seed,
+    ) {
+      final items = _itemsFrom(specs);
+      final shuffled = List.of(items)..shuffle(Random(seed));
+      final a = peopleListSections(items, now: _now);
+      final b = peopleListSections(shuffled, now: _now);
+      List<List<String>> shape(List<PeopleListSection> sections) => [
+        for (final s in sections)
+          [s.group.name, for (final i in s.items) i.relationship.id],
+      ];
+      // Ties on recency are the only freedom left; make them deterministic
+      // by id before comparing.
+      List<List<String>> normalised(List<PeopleListSection> sections) => [
+        for (final s in sections)
+          [
+            s.group.name,
+            ...(s.items.map((i) => i.relationship.id).toList()..sort(
+              (x, y) {
+                final ix = s.items.firstWhere((i) => i.relationship.id == x);
+                final iy = s.items.firstWhere((i) => i.relationship.id == y);
+                final byRecency = peopleRecencyOf(
+                  iy,
+                ).compareTo(peopleRecencyOf(ix));
+                return byRecency != 0 ? byRecency : x.compareTo(y);
+              },
+            )),
+          ],
+      ];
+      expect(normalised(b), normalised(a));
+      expect(shape(a).length, shape(b).length);
+    }, tags: 'glados');
+
+    glados.Glados(
+      glados.any.people,
+      glados.ExploreConfig(numRuns: 200),
+    ).test('the band and the pill never disagree about a person', (specs) {
+      for (final item in _itemsFrom(specs)) {
+        final group = peopleListGroupOf(item, now: _now);
+        final pill = peopleCadencePillOf(item, now: _now);
+        final expectedGroup = switch (pill.kind) {
+          PeopleCadencePillKind.overdue => PeopleListGroup.due,
+          PeopleCadencePillKind.dueSoon ||
+          PeopleCadencePillKind.onTrack => PeopleListGroup.onTrack,
+          PeopleCadencePillKind.notEnrolled ||
+          PeopleCadencePillKind.dormant ||
+          PeopleCadencePillKind.archived => PeopleListGroup.notEnrolled,
+        };
+        expect(group, expectedGroup, reason: item.relationship.id);
+        if (pill.kind == PeopleCadencePillKind.overdue) {
+          expect(pill.daysOver, greaterThan(0));
+        } else {
+          expect(pill.daysOver, 0);
+        }
+        expect(pill.dueAt != null, pill.kind == PeopleCadencePillKind.dueSoon);
+      }
+    }, tags: 'glados');
+
+    glados.Glados(
+      glados.any.people,
+      glados.ExploreConfig(numRuns: 200),
+    ).test('the summary counts what the bands hold, and names the earliest '
+        'due among the on-track people', (specs) {
+      final items = _itemsFrom(specs);
+      final sections = {
+        for (final s in peopleListSections(items, now: _now)) s.group: s.items,
+      };
+      final summary = peopleSummaryOf(items, now: _now);
+      final due = sections[PeopleListGroup.due] ?? const [];
+      final onTrack = sections[PeopleListGroup.onTrack] ?? const [];
+      final notEnrolled = sections[PeopleListGroup.notEnrolled] ?? const [];
+
+      expect(summary.dueNow, due.length);
+      expect(summary.enrolled, due.length + onTrack.length);
+      expect(summary.notEnrolled, notEnrolled.length);
+
+      final candidates = [
+        for (final item in onTrack)
+          if (peopleDueDateOf(item, now: _now) case final d?) (item, d),
+      ];
+      if (candidates.isEmpty) {
+        expect(summary.nextDue, isNull);
+        expect(summary.nextDueAt, isNull);
+      } else {
+        final earliest = candidates
+            .map((c) => c.$2)
+            .reduce((a, b) => a.isBefore(b) ? a : b);
+        expect(summary.nextDueAt, earliest);
+        expect(
+          peopleDueDateOf(summary.nextDue!, now: _now),
+          earliest,
+        );
+        expect(onTrack, contains(summary.nextDue));
+      }
+    }, tags: 'glados');
+  });
+
+  group('peopleCadencePillOf — the edges', () {
+    RelationshipListItem person({
+      bool important = true,
+      int statusIndex = 0,
+      int? cadenceDays = 7,
+      int? daysAgo,
+    }) => _itemFrom('x', (
+      important: important,
+      statusIndex: statusIndex,
+      cadenceDays: cadenceDays,
+      daysSinceLastCheckIn: daysAgo,
+    ));
+
+    test('one day past the cadence is overdue by one', () {
+      final pill = peopleCadencePillOf(person(daysAgo: 8), now: _now);
+      expect(pill.kind, PeopleCadencePillKind.overdue);
+      expect(pill.daysOver, 1);
+    });
+
+    test('due seven days out is still "due soon"; eight is on track', () {
+      // Weekly cadence, contacted today → due in seven days.
+      expect(
+        peopleCadencePillOf(person(daysAgo: 0), now: _now).kind,
+        PeopleCadencePillKind.dueSoon,
+      );
+      // Fortnightly, contacted six days ago → due in eight.
+      expect(
+        peopleCadencePillOf(
+          person(cadenceDays: 14, daysAgo: 6),
+          now: _now,
+        ).kind,
+        PeopleCadencePillKind.onTrack,
+      );
+    });
+
+    test('a person never contacted counts from the tracking start', () {
+      // Tracking since 1 Jun, weekly: long lapsed by 13 Aug.
+      final pill = peopleCadencePillOf(person(), now: _now);
+      expect(pill.kind, PeopleCadencePillKind.overdue);
+      expect(
+        pill.daysOver,
+        _now.difference(_trackingStart.add(const Duration(days: 7))).inDays,
+      );
+    });
+
+    test('enrolled without a cadence is on track, never due', () {
+      expect(
+        peopleCadencePillOf(person(cadenceDays: null), now: _now).kind,
+        PeopleCadencePillKind.onTrack,
+      );
+    });
+
+    test('not important is not enrolled, whatever the cadence says', () {
+      final pill = peopleCadencePillOf(
+        person(important: false, daysAgo: 40),
+        now: _now,
+      );
+      expect(pill.kind, PeopleCadencePillKind.notEnrolled);
+    });
+
+    test('an important but dormant or archived person is kept, not nurtured '
+        '(ADR 0039)', () {
+      expect(
+        peopleCadencePillOf(
+          person(statusIndex: 1, daysAgo: 40),
+          now: _now,
+        ).kind,
+        PeopleCadencePillKind.dormant,
+      );
+      expect(
+        peopleCadencePillOf(
+          person(statusIndex: 2, daysAgo: 40),
+          now: _now,
+        ).kind,
+        PeopleCadencePillKind.archived,
+      );
+      expect(
+        peopleListGroupOf(person(statusIndex: 1), now: _now),
+        PeopleListGroup.notEnrolled,
+      );
+    });
+  });
+
+  test('peopleSummaryOf on an empty list is all zeros and names no one', () {
+    final summary = peopleSummaryOf(const [], now: _now);
+    expect(summary.dueNow, 0);
+    expect(summary.enrolled, 0);
+    expect(summary.notEnrolled, 0);
+    expect(summary.nextDue, isNull);
+  });
+}

--- a/test/features/relationships/ui/pages/relationships_page_test.dart
+++ b/test/features/relationships/ui/pages/relationships_page_test.dart
@@ -3,14 +3,19 @@ import 'dart:async';
 import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/check_in_data.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/relationship_data.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/relationships/model/imported_contact.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
 import 'package:lotti/features/relationships/service/contacts_service.dart';
+import 'package:lotti/features/relationships/ui/pages/relationship_details_page.dart';
 import 'package:lotti/features/relationships/ui/pages/relationships_page.dart';
 import 'package:lotti/features/relationships/ui/shared/persona_avatar.dart';
+import 'package:lotti/features/relationships/ui/widgets/people_list_row.dart';
+import 'package:lotti/features/relationships/ui/widgets/people_summary_card.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/db_notification.dart';
@@ -26,7 +31,6 @@ import '../../../../widget_test_utils.dart';
 /// Counts pushes so a test can tell which navigator a route landed on.
 class _RecordingNavigatorObserver extends NavigatorObserver {
   int pushes = 0;
-
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     // The observer sees the host route itself; only later pushes count.
@@ -40,19 +44,14 @@ class _RecordingNavigatorObserver extends NavigatorObserver {
 class _SupportedContactsService implements ContactsService {
   @override
   bool get isSupported => true;
-
   @override
   Future<ContactsAccess> requestReadAccess() async => ContactsAccess.denied;
-
   @override
   Future<ImportedContact?> pickSingle() async => null;
-
   @override
   Future<List<ImportedContact>> readAll() async => const [];
-
   @override
   Future<ImportedContact?> readById(String id) async => null;
-
   @override
   Future<void> openSystemSettings() async {}
 }
@@ -69,6 +68,8 @@ void main() {
     bool important = false,
     int? cadenceDays,
     DateTime? lastCheckInAt,
+    CheckInInteractionType lastType = CheckInInteractionType.call,
+    RelationshipStatus? status,
   }) => (
     relationship: RelationshipEntry(
       meta: Metadata(
@@ -82,14 +83,27 @@ void main() {
         title: title,
         important: important,
         checkInCadenceDays: cadenceDays,
-        status: RelationshipStatus.active(
-          id: 'status-$id',
-          createdAt: testDate,
-          utcOffset: 0,
-        ),
+        status:
+            status ??
+            RelationshipStatus.active(
+              id: 'status-$id',
+              createdAt: testDate,
+              utcOffset: 0,
+            ),
       ),
     ),
-    lastCheckInAt: lastCheckInAt,
+    lastCheckIn: lastCheckInAt == null
+        ? null
+        : CheckInEntry(
+            meta: Metadata(
+              id: 'check-$id',
+              createdAt: lastCheckInAt,
+              updatedAt: lastCheckInAt,
+              dateFrom: lastCheckInAt,
+              dateTo: lastCheckInAt,
+            ),
+            data: CheckInData(relationshipId: id, interactionType: lastType),
+          ),
   );
 
   setUp(() {
@@ -294,21 +308,22 @@ void main() {
       expect(find.text('Ben'), findsOneWidget);
       // Persona avatars replace the bare person icon.
       expect(find.byType(PersonaAvatar), findsNWidgets(2));
-      // Exactly one star: Anna is important, Ben is not. The star is inline
-      // with the name (11px), not a trailing app-bar icon.
-      expect(find.byIcon(LottiIconsFilled.star), findsOneWidget);
-      // The status line is the last meaningful event, mono — "Checked in …",
-      // never "Tracking since …" (design plan §0.8).
-      final context = tester.element(find.byType(RelationshipsPage));
+      // Exactly one sparkle: Anna is important, Ben is not (the star is
+      // gone — it read as a toggle it was not).
       expect(
-        find.text(
-          context.messages.relationshipCheckedInLabel('Yesterday 18:00'),
-        ),
+        find.byKey(const ValueKey('people-row-important')),
         findsOneWidget,
       );
-      // Ben has no check-in: the quiet-streak caption (here 0 days → "Just
-      // added"), never "Tracking since …".
-      expect(find.text(context.messages.relationshipJustAdded), findsOneWidget);
+      expect(find.byIcon(LottiIconsFilled.star), findsNothing);
+      // The status line is the last contact — what, when, cadence — in mono,
+      // never "Tracking since …".
+      expect(find.text('Call · Yesterday 18:00 · No cadence'), findsOneWidget);
+      // Ben has no check-in: "Just added", then the cadence.
+      final context = tester.element(find.byType(RelationshipsPage));
+      expect(
+        find.text('${context.messages.relationshipJustAdded} · No cadence'),
+        findsOneWidget,
+      );
       expect(
         find.text('Add the people you want to stay close to.'),
         findsNothing,
@@ -438,53 +453,103 @@ void main() {
     expect(find.byIcon(LottiIcons.add), findsNWidgets(2));
   });
 
-  testWidgets('sorts due people ahead of on-track people', (tester) async {
-    // Anna: due (last check-in 10 days ago, weekly cadence).
-    // Ben:  on track (last check-in today, weekly cadence).
-    when(() => mockRepository.getRelationshipsByRecency()).thenAnswer(
-      (_) async => [
-        item(
-          'rel-ben',
-          title: 'Ben',
-          cadenceDays: 7,
-          lastCheckInAt: DateTime(2026, 8, 13, 9),
-        ),
-        item(
-          'rel-anna',
-          title: 'Anna',
-          cadenceDays: 7,
-          lastCheckInAt: DateTime(2026, 8, 3, 9),
-        ),
-      ],
-    );
+  /// Five people across the three bands, seen on Thursday 13 Aug 10:30:
+  /// Anna lapsed (weekly, last contact 3 Aug → due Mon 10 Aug, 3 days over),
+  /// Ben due within the week (weekly, contacted this morning → Thu 20 Aug),
+  /// Cara on track (monthly, 1 Aug → 31 Aug), Dan not important, Eve
+  /// important but dormant.
+  List<RelationshipListItem> crew() => [
+    item(
+      'rel-dan',
+      title: 'Dan',
+      lastCheckInAt: DateTime(2026, 8, 12, 18),
+      lastType: CheckInInteractionType.inPerson,
+    ),
+    item(
+      'rel-cara',
+      title: 'Cara',
+      important: true,
+      cadenceDays: 30,
+      lastCheckInAt: DateTime(2026, 8, 1, 9),
+    ),
+    item(
+      'rel-ben',
+      title: 'Ben',
+      important: true,
+      cadenceDays: 7,
+      lastCheckInAt: DateTime(2026, 8, 13, 9),
+    ),
+    item(
+      'rel-anna',
+      title: 'Anna',
+      important: true,
+      cadenceDays: 7,
+      lastCheckInAt: DateTime(2026, 8, 3, 9),
+    ),
+    item(
+      'rel-eve',
+      title: 'Eve',
+      important: true,
+      cadenceDays: 7,
+      status: RelationshipStatus.dormant(
+        id: 'status-eve',
+        createdAt: testDate,
+        utcOffset: 0,
+      ),
+    ),
+  ];
+
+  testWidgets('bands the list Due · On track · Not enrolled with counts, '
+      'lapsed first, and every pill tells the truth', (tester) async {
+    when(
+      () => mockRepository.getRelationshipsByRecency(),
+    ).thenAnswer((_) async => crew());
 
     await withClock(Clock.fixed(testDate), () async {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
     });
 
-    // Anna (due) renders above Ben (on track).
-    expect(find.text('Anna'), findsOneWidget);
-    expect(find.text('Ben'), findsOneWidget);
-    // The due pill is the warning-tinted "Due {day}" label.
-    final context = tester.element(find.byType(RelationshipsPage));
-    // Anna's last check-in was 2026-08-03; +7 days of cadence is
-    // 2026-08-10, a Monday.
-    final dueLabel = find.text(
-      context.messages.relationshipDueDay('Mon'),
-    );
-    expect(dueLabel, findsOneWidget);
-    expect(
-      find.text(context.messages.relationshipCadenceOnTrack),
-      findsOneWidget,
-    );
-    // Anna's row sits above Ben's: her text is found first in the column.
-    final annaCenter = tester.getCenter(find.text('Anna'));
-    final benCenter = tester.getCenter(find.text('Ben'));
-    expect(annaCenter.dy, lessThan(benCenter.dy));
+    expect(find.text('Due · 1'), findsOneWidget);
+    expect(find.text('On track · 2'), findsOneWidget);
+    expect(find.text('Not enrolled · 2'), findsOneWidget);
+
+    // Never "Due Mon" for a lapse that happened last Monday (P5).
+    expect(find.text('3 days over'), findsOneWidget);
+    expect(find.text('Due Mon'), findsNothing);
+    expect(find.text('Due Thu'), findsOneWidget);
+    expect(find.text('On track'), findsOneWidget);
+    expect(find.text('Not enrolled'), findsOneWidget);
+    expect(find.text('Dormant'), findsOneWidget);
+
+    double y(String name) => tester.getCenter(find.text(name)).dy;
+    expect(y('Anna'), lessThan(y('Ben')));
+    expect(y('Ben'), lessThan(y('Cara')));
+    expect(y('Cara'), lessThan(y('Dan')));
+    expect(y('Cara'), lessThan(y('Eve')));
   });
 
-  testWidgets('a person with no cadence shows no cadence pill', (tester) async {
+  testWidgets('the summary card counts the bands and names who lapses next', (
+    tester,
+  ) async {
+    when(
+      () => mockRepository.getRelationshipsByRecency(),
+    ).thenAnswer((_) async => crew());
+
+    await withClock(Clock.fixed(testDate), () async {
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+    });
+
+    expect(find.byType(PeopleSummaryCard), findsOneWidget);
+    expect(find.text('1'), findsOneWidget);
+    expect(find.text('/ 3 enrolled'), findsOneWidget);
+    expect(find.text('Next due Ben · Thu 20 Aug'), findsOneWidget);
+    expect(find.text('2 people not enrolled'), findsOneWidget);
+  });
+
+  testWidgets('a person who is not important reads Not enrolled, with no '
+      'cadence claim', (tester) async {
     when(() => mockRepository.getRelationshipsByRecency()).thenAnswer(
       (_) async => [item('rel-1', title: 'Anna')],
     );
@@ -493,11 +558,119 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Anna'), findsOneWidget);
-    final context = tester.element(find.byType(RelationshipsPage));
-    expect(
-      find.text(context.messages.relationshipCadenceOnTrack),
-      findsNothing,
-    );
+    expect(find.text('Not enrolled · 1'), findsOneWidget);
+    expect(find.text('Not enrolled'), findsOneWidget);
+    expect(find.text('On track'), findsNothing);
+    expect(find.byType(PeopleSummaryCard), findsOneWidget);
+  });
+
+  group('desktop split', () {
+    late MockNavService navService;
+    late ValueNotifier<String?> selected;
+
+    setUp(() {
+      navService = MockNavService();
+      selected = ValueNotifier<String?>(null);
+      when(() => navService.isDesktopMode).thenReturn(true);
+      when(
+        () => navService.desktopSelectedRelationshipId,
+      ).thenReturn(selected);
+      final settingsDb = MockSettingsDb();
+      when(
+        () => settingsDb.itemsByKeys(any()),
+      ).thenAnswer((_) async => <String, String?>{});
+      when(() => settingsDb.itemByKey(any())).thenAnswer((_) async => null);
+      when(
+        () => settingsDb.saveSettingsItem(any(), any()),
+      ).thenAnswer((_) async => 1);
+      getIt
+        ..registerSingleton<NavService>(navService)
+        ..registerSingleton<SettingsDb>(settingsDb);
+    });
+
+    tearDown(() async {
+      selected.dispose();
+      await getIt.unregister<NavService>();
+      await getIt.unregister<SettingsDb>();
+    });
+
+    Future<void> pumpDesktop(WidgetTester tester) async {
+      tester.view
+        ..physicalSize = const Size(1280, 800)
+        ..devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      await withClock(Clock.fixed(testDate), () async {
+        await tester.pumpWidget(
+          makeTestableWidgetNoScroll(
+            const RelationshipsPage(),
+            mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+            overrides: [
+              relationshipRepositoryProvider.overrideWithValue(mockRepository),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+      });
+    }
+
+    testWidgets('with no selection the list pane sits beside the empty state, '
+        'and the add affordance is a labelled button', (tester) async {
+      when(
+        () => mockRepository.getRelationshipsByRecency(),
+      ).thenAnswer((_) async => crew());
+
+      await pumpDesktop(tester);
+
+      expect(find.text('Anna'), findsOneWidget);
+      final context = tester.element(find.byType(RelationshipsPage));
+      expect(
+        find.text(context.messages.relationshipsSelectPersonHint),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('people-add-person-button')),
+        findsOneWidget,
+      );
+      // The phone's bare add circle is gone on desktop.
+      expect(
+        findMaterialTooltip(context.messages.relationshipCreateTitle),
+        findsNothing,
+      );
+      expect(find.byType(RelationshipDetailsPage), findsNothing);
+    });
+
+    testWidgets('the selected person fills the detail pane and wears the '
+        'selected wash on the list', (tester) async {
+      when(
+        () => mockRepository.getRelationshipsByRecency(),
+      ).thenAnswer((_) async => crew());
+      final anna = crew().firstWhere((i) => i.relationship.id == 'rel-anna');
+      when(
+        () => mockRepository.getRelationshipById('rel-anna'),
+      ).thenAnswer((_) async => anna.relationship);
+      when(
+        () => mockRepository.getCheckInsForRelationship('rel-anna'),
+      ).thenAnswer((_) async => [anna.lastCheckIn!]);
+      when(
+        () => mockRepository.getLinkedTasks('rel-anna'),
+      ).thenAnswer((_) async => []);
+      selected.value = 'rel-anna';
+
+      await pumpDesktop(tester);
+
+      expect(find.byType(RelationshipDetailsPage), findsOneWidget);
+      // The page's own app bar names the person, so the name appears twice:
+      // once on the list, once on the page.
+      expect(find.text('Anna'), findsNWidgets(2));
+      final selectedRow = tester.widget<PeopleListRow>(
+        find.byKey(const ValueKey('people-row-rel-anna')),
+      );
+      final otherRow = tester.widget<PeopleListRow>(
+        find.byKey(const ValueKey('people-row-rel-ben')),
+      );
+      expect(selectedRow.selected, isTrue);
+      expect(otherRow.selected, isFalse);
+    });
   });
 }
 

--- a/test/features/relationships/ui/pages/relationships_page_test.dart
+++ b/test/features/relationships/ui/pages/relationships_page_test.dart
@@ -1,13 +1,17 @@
 import 'dart:async';
 
 import 'package:clock/clock.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/check_in_data.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/relationship_data.dart';
 import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/features/design_system/components/navigation/resizable_divider.dart';
+import 'package:lotti/features/design_system/state/pane_width_controller.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/keyboard/ui/list_detail_focus_traversal.dart';
 import 'package:lotti/features/relationships/model/imported_contact.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
 import 'package:lotti/features/relationships/service/contacts_service.dart';
@@ -317,7 +321,9 @@ void main() {
       expect(find.byIcon(LottiIconsFilled.star), findsNothing);
       // The status line is the last contact — what, when, cadence — in mono,
       // never "Tracking since …".
-      expect(find.text('Call · Yesterday 18:00 · No cadence'), findsOneWidget);
+      // Anna is enrolled without a stored cadence: the line names the
+      // runtime's monthly default, never "No cadence".
+      expect(find.text('Call · Yesterday 18:00 · Monthly'), findsOneWidget);
       // Ben has no check-in: "Just added", then the cadence.
       final context = tester.element(find.byType(RelationshipsPage));
       expect(
@@ -637,6 +643,94 @@ void main() {
         findsNothing,
       );
       expect(find.byType(RelationshipDetailsPage), findsNothing);
+    });
+
+    testWidgets('the labelled Add person button opens the create form', (
+      tester,
+    ) async {
+      when(
+        () => mockRepository.getRelationshipsByRecency(),
+      ).thenAnswer((_) async => crew());
+
+      await pumpDesktop(tester);
+      await tester.tap(find.byKey(const ValueKey('people-add-person-button')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Name'), findsOneWidget);
+      expect(find.text('Status'), findsNothing);
+    });
+
+    testWidgets('dragging the divider widens the list pane', (tester) async {
+      when(
+        () => mockRepository.getRelationshipsByRecency(),
+      ).thenAnswer((_) async => crew());
+
+      await pumpDesktop(tester);
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(RelationshipsPage)),
+      );
+      expect(
+        container.read(paneWidthControllerProvider).listPaneWidth,
+        defaultListPaneWidth,
+      );
+
+      await tester.drag(find.byType(ResizableDivider), const Offset(40, 0));
+      await tester.pump();
+
+      expect(
+        container.read(paneWidthControllerProvider).listPaneWidth,
+        defaultListPaneWidth + 40,
+      );
+      // Let the persist debounce fire so no timer leaks past the test.
+      await tester.pump(persistDebounce);
+    });
+
+    testWidgets('with a person selected the list can fold away and come '
+        'back through the show-list-pane button', (tester) async {
+      when(
+        () => mockRepository.getRelationshipsByRecency(),
+      ).thenAnswer((_) async => crew());
+      final anna = crew().firstWhere((i) => i.relationship.id == 'rel-anna');
+      when(
+        () => mockRepository.getRelationshipById('rel-anna'),
+      ).thenAnswer((_) async => anna.relationship);
+      when(
+        () => mockRepository.getCheckInsForRelationship('rel-anna'),
+      ).thenAnswer((_) async => []);
+      when(
+        () => mockRepository.getLinkedTasks('rel-anna'),
+      ).thenAnswer((_) async => []);
+      selected.value = 'rel-anna';
+
+      await pumpDesktop(tester);
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(RelationshipsPage)),
+      );
+      // The split's controller is exposed to its descendants; the detail
+      // page is one.
+      ListDetailFocusTraversal.maybeOf(
+        tester.element(find.byType(RelationshipDetailsPage)),
+      )!.hideListPane();
+      await tester.pumpAndSettle();
+      expect(
+        container.read(paneWidthControllerProvider).listPaneCollapsed,
+        isTrue,
+      );
+      expect(find.byType(ResizableDivider), findsNothing);
+      expect(
+        find.byKey(const ValueKey('people-show-list-pane')),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.byKey(const ValueKey('people-show-list-pane')));
+      await tester.pumpAndSettle();
+      expect(
+        container.read(paneWidthControllerProvider).listPaneCollapsed,
+        isFalse,
+      );
+      expect(find.byType(ResizableDivider), findsOneWidget);
+      // Let the persist debounce fire so no timer leaks past the test.
+      await tester.pump(persistDebounce);
     });
 
     testWidgets('the selected person fills the detail pane and wears the '

--- a/test/features/relationships/ui/widgets/people_list_row_test.dart
+++ b/test/features/relationships/ui/widgets/people_list_row_test.dart
@@ -136,10 +136,29 @@ void main() {
       expect(find.text('On track'), findsOneWidget);
     });
 
-    testWidgets('enrolled without a cadence is still on track', (tester) async {
-      await pump(tester, item(cadenceDays: null));
-      expect(find.text('On track'), findsOneWidget);
+    testWidgets('due today says so, in the warning tint', (tester) async {
+      // Weekly, last contact a week ago this morning → due today.
+      await pump(tester, item(lastCheckInAt: DateTime(2026, 8, 6, 9)));
+      expect(find.text('Due today'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('people-row-pill-overdue')),
+        findsOneWidget,
+      );
     });
+
+    testWidgets(
+      'an enrolled person without a stored cadence follows the '
+      "runtime's monthly default — the line names it, the pill counts by it",
+      (tester) async {
+        // Tracking since 1 Jul, contacted 3 Aug: monthly default → due 2 Sep.
+        await pump(
+          tester,
+          item(cadenceDays: null, lastCheckInAt: DateTime(2026, 8, 3, 9)),
+        );
+        expect(find.text('Call · Mon 3 Aug 09:00 · Monthly'), findsOneWidget);
+        expect(find.text('On track'), findsOneWidget);
+      },
+    );
 
     testWidgets('not important: not enrolled, whatever the cadence says', (
       tester,
@@ -150,6 +169,15 @@ void main() {
       );
       expect(find.text('Not enrolled'), findsOneWidget);
       expect(find.textContaining('days over'), findsNothing);
+      // The stored setting is still what the line names.
+      expect(find.text('Call · Mon 3 Aug 09:00 · Weekly'), findsOneWidget);
+    });
+
+    testWidgets('a person who is not enrolled is never given a first-due '
+        'day — the runtime schedules none for them', (tester) async {
+      await pump(tester, item(important: false, cadenceDays: 30));
+      expect(find.text('Just added · Monthly'), findsOneWidget);
+      expect(find.textContaining('first due'), findsNothing);
     });
 
     testWidgets('dormant and archived name their status', (tester) async {

--- a/test/features/relationships/ui/widgets/people_list_row_test.dart
+++ b/test/features/relationships/ui/widgets/people_list_row_test.dart
@@ -1,0 +1,213 @@
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/check_in_data.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/relationship_data.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/relationships/repository/relationship_repository.dart';
+import 'package:lotti/features/relationships/ui/model/people_list_model.dart';
+import 'package:lotti/features/relationships/ui/widgets/people_list_row.dart';
+import 'package:material_ui/material_ui.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  // A Thursday, mid-morning.
+  final now = DateTime(2026, 8, 13, 10, 30);
+  final trackingStart = DateTime(2026, 7, 1, 9);
+
+  RelationshipListItem item({
+    String id = 'rel-1',
+    String title = 'Anna',
+    bool important = true,
+    int? cadenceDays = 7,
+    DateTime? lastCheckInAt,
+    CheckInInteractionType lastType = CheckInInteractionType.call,
+    RelationshipStatus? status,
+  }) => (
+    relationship: RelationshipEntry(
+      meta: Metadata(
+        id: id,
+        createdAt: trackingStart,
+        updatedAt: trackingStart,
+        dateFrom: trackingStart,
+        dateTo: trackingStart,
+      ),
+      data: RelationshipData(
+        title: title,
+        important: important,
+        checkInCadenceDays: cadenceDays,
+        status:
+            status ??
+            RelationshipStatus.active(
+              id: 'status-$id',
+              createdAt: trackingStart,
+              utcOffset: 0,
+            ),
+      ),
+    ),
+    lastCheckIn: lastCheckInAt == null
+        ? null
+        : CheckInEntry(
+            meta: Metadata(
+              id: 'check-$id',
+              createdAt: lastCheckInAt,
+              updatedAt: lastCheckInAt,
+              dateFrom: lastCheckInAt,
+              dateTo: lastCheckInAt,
+            ),
+            data: CheckInData(relationshipId: id, interactionType: lastType),
+          ),
+  );
+
+  Future<void> pump(
+    WidgetTester tester,
+    RelationshipListItem item, {
+    bool selected = false,
+    VoidCallback? onTap,
+  }) => withClock(Clock.fixed(now), () async {
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        PeopleListRow(item: item, selected: selected, onTap: onTap ?? () {}),
+      ),
+    );
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('the status line is the last contact — what, when, cadence — '
+      'in the mono caption', (tester) async {
+    await pump(tester, item(lastCheckInAt: DateTime(2026, 8, 13, 9, 5)));
+
+    final line = find.text('Call · Today 09:05 · Weekly');
+    expect(line, findsOneWidget);
+    expect(tester.widget<Text>(line).style?.fontFamily, 'Inconsolata');
+  });
+
+  testWidgets('a person never contacted reads Just added, the cadence, and '
+      'when the first check-in falls due', (tester) async {
+    await pump(tester, item(cadenceDays: 30));
+
+    // Tracking started 1 Jul; a monthly cadence falls due on 31 Jul.
+    expect(
+      find.text('Just added · Monthly · first due Fri 31 Jul'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('the sparkle marks an important person and nobody else', (
+    tester,
+  ) async {
+    await pump(tester, item());
+    expect(find.byKey(const ValueKey('people-row-important')), findsOneWidget);
+
+    await pump(tester, item(important: false));
+    expect(find.byKey(const ValueKey('people-row-important')), findsNothing);
+  });
+
+  group('the pill tells the truth about the cadence', () {
+    testWidgets('lapsed: days over, warning-tinted — never "Due Sun"', (
+      tester,
+    ) async {
+      // Weekly, last contact 3 Aug 09:00 → due 10 Aug → 3 days over on the 13th.
+      await pump(tester, item(lastCheckInAt: DateTime(2026, 8, 3, 9)));
+
+      expect(find.text('3 days over'), findsOneWidget);
+      expect(find.textContaining('Due '), findsNothing);
+      final pill = tester.widget<DsPill>(
+        find.byKey(const ValueKey('people-row-pill-overdue')),
+      );
+      final tokens = tester.element(find.byType(PeopleListRow)).designTokens;
+      expect(pill.variant, DsPillVariant.tinted);
+      expect(pill.color, tokens.colors.alert.warning.defaultColor);
+    });
+
+    testWidgets('due within the week: the weekday', (tester) async {
+      // Weekly, last contact this morning → due Thu 20 Aug.
+      await pump(tester, item(lastCheckInAt: DateTime(2026, 8, 13, 9)));
+      expect(find.text('Due Thu'), findsOneWidget);
+    });
+
+    testWidgets('further out: on track', (tester) async {
+      await pump(
+        tester,
+        item(cadenceDays: 30, lastCheckInAt: DateTime(2026, 8, 1, 9)),
+      );
+      expect(find.text('On track'), findsOneWidget);
+    });
+
+    testWidgets('enrolled without a cadence is still on track', (tester) async {
+      await pump(tester, item(cadenceDays: null));
+      expect(find.text('On track'), findsOneWidget);
+    });
+
+    testWidgets('not important: not enrolled, whatever the cadence says', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        item(important: false, lastCheckInAt: DateTime(2026, 8, 3, 9)),
+      );
+      expect(find.text('Not enrolled'), findsOneWidget);
+      expect(find.textContaining('days over'), findsNothing);
+    });
+
+    testWidgets('dormant and archived name their status', (tester) async {
+      await pump(
+        tester,
+        item(
+          status: RelationshipStatus.dormant(
+            id: 'd',
+            createdAt: trackingStart,
+            utcOffset: 0,
+          ),
+        ),
+      );
+      expect(find.text('Dormant'), findsOneWidget);
+
+      await pump(
+        tester,
+        item(
+          status: RelationshipStatus.archived(
+            id: 'a',
+            createdAt: trackingStart,
+            utcOffset: 0,
+          ),
+        ),
+      );
+      expect(find.text('Archived'), findsOneWidget);
+    });
+  });
+
+  testWidgets('the selected row wears the selected wash; an unselected one '
+      'sits on the page surface', (tester) async {
+    await pump(tester, item(), selected: true);
+    final tokens = tester.element(find.byType(PeopleListRow)).designTokens;
+    Material material() => tester.widget<Material>(
+      find.descendant(
+        of: find.byType(PeopleListRow),
+        matching: find.byType(Material),
+      ),
+    );
+    expect(material().color, tokens.colors.surface.selected);
+
+    await pump(tester, item());
+    expect(material().color, tokens.colors.background.level01);
+  });
+
+  testWidgets('tapping anywhere on the row fires onTap', (tester) async {
+    var taps = 0;
+    await pump(tester, item(), onTap: () => taps++);
+    await tester.tap(find.text('Anna'));
+    expect(taps, 1);
+  });
+
+  test(
+    'peopleCadencePillOf and the row agree on the kinds the row renders',
+    () {
+      // Every kind the model can produce has a rendering branch; this pins the
+      // enum so a new kind cannot be added without the row learning its label.
+      expect(PeopleCadencePillKind.values, hasLength(6));
+    },
+  );
+}

--- a/test/features/relationships/ui/widgets/people_summary_card_test.dart
+++ b/test/features/relationships/ui/widgets/people_summary_card_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/relationship_data.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/relationships/repository/relationship_repository.dart';
+import 'package:lotti/features/relationships/ui/model/people_list_model.dart';
+import 'package:lotti/features/relationships/ui/widgets/people_summary_card.dart';
+import 'package:material_ui/material_ui.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  final at = DateTime(2026, 8);
+
+  RelationshipListItem person(String title, {String? nickname}) => (
+    relationship: RelationshipEntry(
+      meta: Metadata(
+        id: 'rel-$title',
+        createdAt: at,
+        updatedAt: at,
+        dateFrom: at,
+        dateTo: at,
+      ),
+      data: RelationshipData(
+        title: title,
+        nickname: nickname,
+        important: true,
+        status: RelationshipStatus.active(id: 's', createdAt: at, utcOffset: 0),
+      ),
+    ),
+    lastCheckIn: null,
+  );
+
+  PeopleSummary summary({
+    int dueNow = 0,
+    int enrolled = 4,
+    int notEnrolled = 0,
+    RelationshipListItem? nextDue,
+    DateTime? nextDueAt,
+  }) => (
+    dueNow: dueNow,
+    enrolled: enrolled,
+    notEnrolled: notEnrolled,
+    nextDue: nextDue,
+    nextDueAt: nextDueAt,
+  );
+
+  Future<void> pump(WidgetTester tester, PeopleSummary summary) async {
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(PeopleSummaryCard(summary: summary)),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Color numeralColor(WidgetTester tester) => tester
+      .widget<Text>(find.byKey(const ValueKey('people-summary-due-count')))
+      .style!
+      .color!;
+
+  testWidgets('names the due count over the enrolled count, who is due next '
+      'and on which day, and how many are not enrolled', (tester) async {
+    await pump(
+      tester,
+      summary(
+        dueNow: 1,
+        notEnrolled: 1,
+        nextDue: person('Bo'),
+        nextDueAt: DateTime(2026, 7, 23),
+      ),
+    );
+
+    expect(find.text('Due now'), findsOneWidget);
+    expect(find.text('1'), findsOneWidget);
+    expect(find.text('/ 4 enrolled'), findsOneWidget);
+    // 2026-07-23 is a Thursday; the day carries no time — it is a deadline.
+    expect(find.text('Next due Bo · Thu 23 Jul'), findsOneWidget);
+    expect(find.text('1 person not enrolled'), findsOneWidget);
+    // A non-zero due count is the one thing on the card that may shout.
+    final tokens = tester.element(find.byType(PeopleSummaryCard)).designTokens;
+    expect(numeralColor(tester), tokens.colors.alert.warning.defaultColor);
+  });
+
+  testWidgets('a calm morning reads as a quiet zero — no warning ink, and '
+      'no not-enrolled line when everyone is enrolled', (tester) async {
+    await pump(
+      tester,
+      summary(nextDue: person('Mira'), nextDueAt: DateTime(2026, 8, 24)),
+    );
+
+    expect(find.text('0'), findsOneWidget);
+    final tokens = tester.element(find.byType(PeopleSummaryCard)).designTokens;
+    expect(numeralColor(tester), tokens.colors.text.highEmphasis);
+    expect(find.textContaining('not enrolled'), findsNothing);
+    expect(find.text('Next due Mira · Mon 24 Aug'), findsOneWidget);
+  });
+
+  testWidgets('names the next-due person by nickname when they have one — '
+      'the way the user talks about them', (tester) async {
+    await pump(
+      tester,
+      summary(
+        nextDue: person('Captain Bo Glacier', nickname: 'Bo'),
+        nextDueAt: DateTime(2026, 7, 23),
+      ),
+    );
+
+    expect(find.text('Next due Bo · Thu 23 Jul'), findsOneWidget);
+    expect(find.textContaining('Captain'), findsNothing);
+  });
+
+  testWidgets('with nobody ahead on a cadence it says so instead of naming '
+      'no one', (tester) async {
+    await pump(tester, summary(enrolled: 2, notEnrolled: 3));
+
+    expect(find.text('No one due'), findsOneWidget);
+    expect(find.text('3 people not enrolled'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Increment A of the People redesign — the list, per the Claude Design handover
of 2026-09-06 (`~/Desktop/design_handover/people_handover/design_response/`;
plan in `docs/implementation_plans/2026-09-06_people_redesign.md`).

- **Bands with counts**: *Due · On track · Not enrolled*, lapsed people first,
  most recent contact first within a band. *Enrolled* = important **and**
  active (ADR 0039).
- **Summary card** above the list: due-now count over the enrolled count
  (warning ink only when non-zero), who lapses next by nickname and on which
  day, how many are not enrolled.
- **Rows**: persona avatar, name + sparkle for an important person (the star
  is gone), one mono status line (`Call · Today 12:44 · Weekly`, or
  `Just added · Monthly · first due Sun 16 Aug`), and a truthful pill —
  `3 days over` (warning tint) when lapsed, `Due Thu` within the week,
  `On track`, `Not enrolled`, `Dormant`, `Archived`. Never "Due Sun" for a
  lapse that happened last Sunday (handover P5).
- **Desktop**: the Tasks/Projects list/detail split. `RelationshipsLocation`
  mirrors the URL's person id into `NavService.desktopSelectedRelationshipId`
  and pushes no detail page; the list pane uses the shared pane-width
  controller; the right pane hosts the person's page (still the current one —
  increment B redesigns it) or the empty state. A labelled *Add person* button
  replaces the bare circle on desktop.
- **Data**: `RelationshipListItem` now carries the newest check-in itself.
  `JournalDb.latestCheckIns()` resolves the existing `GROUP BY` aggregate to
  its rows in one further query (ids and instants as `IN` lists, the exact
  pair kept on the raw row), private-filtered like the aggregate — still no
  per-person query.
- The bands, pills and summary are pure logic in
  `ui/model/people_list_model.dart`.
- Ten new labels in all twelve catalogs; changelog fragment; README and
  knowledge concept updated.

## Verification

- Analyzer clean on everything touched; `make changelog_check` and
  `make okf_check` green.
- 120 tests across the touched files: Glados properties on the model
  (partition, per-band order, order-invariance, band⇔pill agreement,
  summary⇔bands agreement) plus edge examples; widget tests for the summary
  card and the row (status line, sparkle, every pill kind, selected wash);
  the page tests rewritten for bands, summary and the desktop split; location
  tests for the desktop branch; repository, provider and database tests for
  the newest-check-in query (private filter, same-instant collision).

## Screenshots

Penguin-crew fixture, captured with the handover recipe at the base commit
and at this one.

| Frame | Before | After |
|---|---|---|
| `people_list_banner_desktop_dark` | [before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/before/people_list_banner_desktop_dark.png) | [after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/after/people_list_banner_desktop_dark.png) |
| `people_list_banner_desktop_light` | [before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/before/people_list_banner_desktop_light.png) | [after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/after/people_list_banner_desktop_light.png) |
| `people_list_banner_mobile_dark` | [before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/before/people_list_banner_mobile_dark.png) | [after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/after/people_list_banner_mobile_dark.png) |
| `people_list_banner_mobile_light` | [before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/before/people_list_banner_mobile_light.png) | [after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/after/people_list_banner_mobile_light.png) |
| `people_list_desktop_dark` | [before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/before/people_list_desktop_dark.png) | [after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/after/people_list_desktop_dark.png) |
| `people_list_desktop_light` | [before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/before/people_list_desktop_light.png) | [after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/after/people_list_desktop_light.png) |
| `people_list_empty_desktop_dark` | [before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/before/people_list_empty_desktop_dark.png) | [after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/after/people_list_empty_desktop_dark.png) |
| `people_list_empty_desktop_light` | [before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/before/people_list_empty_desktop_light.png) | [after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/after/people_list_empty_desktop_light.png) |
| `people_list_empty_mobile_dark` | [before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/before/people_list_empty_mobile_dark.png) | [after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/after/people_list_empty_mobile_dark.png) |
| `people_list_empty_mobile_light` | [before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/before/people_list_empty_mobile_light.png) | [after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/after/people_list_empty_mobile_light.png) |
| `people_list_mobile_dark` | [before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/before/people_list_mobile_dark.png) | [after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/after/people_list_mobile_dark.png) |
| `people_list_mobile_light` | [before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/before/people_list_mobile_light.png) | [after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-list-redesign/48eabe3bc72b8cc183139832079c4d4fb077d131/after/people_list_mobile_light.png) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redesigned the People list with Due, On track, and Not enrolled sections.
  - Added summaries for due contacts, enrollment totals, and the next person due.
  - Added richer contact history, cadence pills, overdue indicators, and importance markers.
  - Added a desktop list/detail split view and clearer Add person action.
  - Added localized People-list labels across supported languages.

- **Documentation**
  - Updated People feature documentation and implementation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->