### PR TITLE
chore(release): 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2]
+
+### Added
+- **Transcribe recordings directly on your device with sherpa-onnx.** Add the
+  embedded speech provider and download multilingual Whisper Tiny or Base.
+  Transcription then works without a server or internet connection, and model
+  downloads can be removed independently on each device.
+
+### Fixed
+- **"Brief me" on a person's page failed with "Could not request the
+  briefing."** The relationship agent only looked for an AI route on the
+  person themselves or on its own configuration — neither of which any screen
+  sets — and otherwise insisted on one specific cloud model. It now also uses
+  the default AI profile of the person's category, the same way a spoken
+  check-in already picks its transcription model, so a briefing works with
+  whatever profile you route that category through. A cloud provider is still
+  named for consent before the run.
+
 ## [1.1.1]
 
 ### Added

--- a/changelog.d/2026-09-06-embedded-sherpa-transcription.md
+++ b/changelog.d/2026-09-06-embedded-sherpa-transcription.md
@@ -1,5 +1,0 @@
-### Added
-- **Transcribe recordings directly on your device with sherpa-onnx.** Add the
-  embedded speech provider and download multilingual Whisper Tiny or Base.
-  Transcription then works without a server or internet connection, and model
-  downloads can be removed independently on each device.

--- a/changelog.d/2026-09-06-relationship-briefing-category-profile.md
+++ b/changelog.d/2026-09-06-relationship-briefing-category-profile.md
@@ -1,9 +1,0 @@
-### Fixed
-- **"Brief me" on a person's page failed with "Could not request the
-  briefing."** The relationship agent only looked for an AI route on the
-  person themselves or on its own configuration — neither of which any screen
-  sets — and otherwise insisted on one specific cloud model. It now also uses
-  the default AI profile of the person's category, the same way a spoken
-  check-in already picks its transcription model, so a briefing works with
-  whatever profile you route that category through. A cloud provider is still
-  named for consent before the run.

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -40,6 +40,12 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="1.1.2" date="2026-09-06">
+      <description>
+        <p>Added: transcribe recordings directly on your device with sherpa-onnx. Add the embedded speech provider and download multilingual Whisper Tiny or Base. Transcription then works without a server or internet connection, and model downloads can be removed independently on each device.</p>
+        <p>Fixed: "Brief me" on a person's page failed with "Could not request the briefing." The relationship agent only looked for an AI route on the person themselves or on its own configuration - neither of which any screen sets - and otherwise insisted on one specific cloud model. It now also uses the default AI profile of the person's category, the same way a spoken check-in already picks its transcription model, so a briefing works with whatever profile you route that category through. A cloud provider is still named for consent before the run.</p>
+      </description>
+    </release>
     <release version="1.1.1" date="2026-09-06">
       <description>
         <p>Added: a database integrity check in Settings → Advanced → Maintenance. It verifies that the journal, sync, agent, editor and search files are sound and names any that are not.</p>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.1.1+4375
+version: 1.1.2+4376
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
Prepare **1.1.2+4376**.

### Added
- **Transcribe recordings directly on your device with sherpa-onnx.** Add the
  embedded speech provider and download multilingual Whisper Tiny or Base.
  Transcription then works without a server or internet connection, and model
  downloads can be removed independently on each device.

### Fixed
- **"Brief me" on a person's page failed with "Could not request the
  briefing."** The relationship agent only looked for an AI route on the
  person themselves or on its own configuration — neither of which any screen
  sets — and otherwise insisted on one specific cloud model. It now also uses
  the default AI profile of the person's category, the same way a spoken
  check-in already picks its transcription model, so a briefing works with
  whatever profile you route that category through. A cloud provider is still
  named for consent before the run.

Validation: strict fragment validation, changelog/version consistency, and XML parsing. Full analysis and tests run in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added on-device transcription for recordings using embedded speech recognition.
  - Download multilingual Whisper Tiny or Base models for offline transcription.
  - Remove downloaded transcription models independently on each device.

- **Bug Fixes**
  - Fixed the “Brief me” action on person pages so it can use the default AI profile configured for the person’s category.
  - Briefings now work with the selected category routing while still identifying the cloud provider for consent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->