### PR TITLE
feat: add Whisper Large v3 and improve on-device model setup

### DIFF
--- a/changelog.d/2026-09-06-whisper-large.md
+++ b/changelog.d/2026-09-06-whisper-large.md
@@ -2,3 +2,13 @@
 - **Whisper Large v3 is available for on-device transcription.** Download the
   full multilingual model from the sherpa-onnx provider settings and select it
   for transcription. The INT8 download is about 1.78 GB.
+
+### Changed
+- **On-device speech models are easier to manage.** Compact download controls
+  show model size, language coverage and installation progress. Failed model
+  setup can be retried without downloading the files again.
+
+### Fixed
+- **sherpa-onnx appears when adding your first provider**, including on Linux.
+- **Large speech models start faster.** Readiness checks reuse verification for
+  unchanged files instead of repeatedly reading the model before transcription.

--- a/changelog.d/2026-09-06-whisper-large.md
+++ b/changelog.d/2026-09-06-whisper-large.md
@@ -1,0 +1,4 @@
+### Added
+- **Whisper Large v3 is available for on-device transcription.** Download the
+  full multilingual model from the sherpa-onnx provider settings and select it
+  for transcription. The INT8 download is about 1.78 GB.

--- a/knowledge/features/ai/embedded-speech.md
+++ b/knowledge/features/ai/embedded-speech.md
@@ -37,7 +37,28 @@ an API key nor a server URL. Its curated catalog contains multilingual int8
 Whisper Large v3, Tiny and Base exports. Large v3 uses the full model with
 INT8 weights (about 1.78 GB of downloaded files). Model files are downloaded
 only after the user presses Download in the provider's model section. Model names are upstream
-product names; surrounding controls are localized.
+product names; surrounding controls are localized. Sherpa appears in both the
+first-run and full provider pickers, without a desktop-only restriction.
+
+The model section groups compact download actions beside model identity and
+localized download size/language metadata. Actions wrap below the metadata on
+narrow screens. Installation shows a named progress bar and percentage; removal
+has its own busy action. Downloaded status describes device files, while inference
+profiles select the model to use.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Idle
+  Idle --> Installing: download
+  Installing --> Idle: success or error
+  Idle --> Removing: remove local files
+  Removing --> Idle: success or error
+  Idle --> Configuring: retry configuration
+  Configuring --> Idle: success or error
+```
+
+While an operation runs, that model's other actions are disabled. A failed
+removal preserves any outstanding configuration error and its retry action.
 
 Text, image-input, and multi-turn chat calls reject this ASR-only provider
 before constructing an HTTP client, including when stale configuration carries
@@ -46,7 +67,15 @@ an old server URL.
 Configuration rows sync normally; downloaded files do not. Files live below
 application support in `sherpa_models/<model>/<revision>/`. The manifest pins
 Hugging Face revisions, byte lengths, and SHA-256 digests. Unknown model ids
-cannot become paths or download URLs. Availability probes treat unknown synced
+cannot become paths or download URLs. Installation verifies every artifact's
+checksum. Readiness checks cache verification in memory against each file's size,
+modification time and change time; unchanged files need only a metadata probe.
+Concurrent cold probes share verification, and a successful installation seeds
+the cache without reading the published weights again. Changed files are hashed
+again, missing files are unavailable, and install/remove invalidate cached
+verification. A fresh process verifies existing files once. This cache avoids
+repeated gigabyte-scale reads during settings, discovery and transcription; it
+is not protection against modifications that preserve all cached metadata. Availability probes treat unknown synced
 ids as unavailable; explicit installation rejects them.
 
 ```mermaid
@@ -68,7 +97,9 @@ after downloads and removals. Both operations also republish changed sync-node
 capabilities without requiring an app restart. A failed broadcast does not undo
 the successful local file operation. If model configuration persistence fails
 after installation, the row retains its downloaded state and shows a separate
-configuration error; deletion remains available.
+configuration error. Retry saves only the missing configuration, reusing verified
+files and preserving existing model identities and edits. During retry, the Retry
+button stays busy and removal is disabled; deletion remains available afterward.
 Removing a model during its download is rejected.
 
 # Runtime flow

--- a/knowledge/features/ai/embedded-speech.md
+++ b/knowledge/features/ai/embedded-speech.md
@@ -34,8 +34,9 @@ sources:
 
 `InferenceProviderType.sherpa` is an embedded ASR provider. It requires neither
 an API key nor a server URL. Its curated catalog contains multilingual int8
-Whisper Tiny and Base exports. Model files are downloaded only after the user
-presses Download in the provider's model section. Model names are upstream
+Whisper Large v3, Tiny and Base exports. Large v3 uses the full model with
+INT8 weights (about 1.78 GB of downloaded files). Model files are downloaded
+only after the user presses Download in the provider's model section. Model names are upstream
 product names; surrounding controls are localized.
 
 Text, image-input, and multi-turn chat calls reject this ASR-only provider

--- a/lib/features/ai/speech/sherpa_model_repository.dart
+++ b/lib/features/ai/speech/sherpa_model_repository.dart
@@ -123,6 +123,7 @@ class SherpaModelRepository {
   final Future<Directory> Function() _supportDirectory;
   final List<SherpaModel> models;
   final _downloads = <String, Future<String>>{};
+  final _verifiedFiles = <String, ({FileStat stat, Future<bool> result})>{};
 
   SherpaModel model(String id) => models.firstWhere(
     (model) => model.id == id,
@@ -140,14 +141,39 @@ class SherpaModelRepository {
   Future<bool> isAvailable(String id) async =>
       models.any((model) => model.id == id) && await isInstalled(id);
 
+  /// Hash each file once per process, then probe its size and timestamps.
+  /// Changed files are verified again; installs and removals invalidate the cache.
   Future<bool> isInstalled(String id) async {
     final spec = model(id);
     final directory = await modelDirectory(id);
     for (final artifact in spec.files) {
       final file = File(p.join(directory, artifact.name));
-      if (!await _matches(file, artifact)) return false;
+      if (!await _isVerified(file, artifact)) return false;
     }
     return true;
+  }
+
+  Future<bool> _isVerified(File file, SherpaModelFile artifact) async {
+    final stat = file.statSync();
+    if (stat.type != FileSystemEntityType.file || stat.size != artifact.bytes) {
+      _verifiedFiles.remove(file.path);
+      return false;
+    }
+    final cached = _verifiedFiles[file.path];
+    if (cached != null &&
+        cached.stat.size == stat.size &&
+        cached.stat.modified == stat.modified &&
+        cached.stat.changed == stat.changed) {
+      return cached.result;
+    }
+    final result = _matches(file, artifact);
+    _verifiedFiles[file.path] = (stat: stat, result: result);
+    try {
+      return await result;
+    } catch (_) {
+      _verifiedFiles.remove(file.path);
+      rethrow;
+    }
   }
 
   Future<bool> _matches(File file, SherpaModelFile artifact) async =>
@@ -166,6 +192,7 @@ class SherpaModelRepository {
 
   Future<String> _install(String id, void Function(double)? onProgress) async {
     final spec = model(id);
+    _verifiedFiles.clear();
     final directory = await modelDirectory(id);
     await Directory(directory).create(recursive: true);
     var completed = 0;
@@ -176,6 +203,11 @@ class SherpaModelRepository {
           onProgress?.call((completed + received) / spec.bytes);
         });
       }
+      // Installation already checked the digest; routine discovery can reuse it.
+      _verifiedFiles[file.path] = (
+        stat: file.statSync(),
+        result: Future.value(true),
+      );
       completed += artifact.bytes;
       onProgress?.call(completed / spec.bytes);
     }
@@ -223,6 +255,7 @@ class SherpaModelRepository {
     if (_downloads.containsKey(id)) {
       throw StateError('Cannot remove a model while it is downloading');
     }
+    _verifiedFiles.clear();
     final directory = Directory(await modelDirectory(id));
     if (directory.existsSync()) await directory.delete(recursive: true);
   }

--- a/lib/features/ai/speech/sherpa_model_repository.dart
+++ b/lib/features/ai/speech/sherpa_model_repository.dart
@@ -41,6 +41,28 @@ class SherpaModel {
 /// Fixed upstream revisions prevent model downloads changing beneath a build.
 const sherpaModels = [
   SherpaModel(
+    id: 'large-v3',
+    name: 'Whisper Large v3',
+    revision: '2a6507094dd6020d939d78e3f1834a1d06267fca',
+    files: [
+      SherpaModelFile(
+        'large-v3-encoder.int8.onnx',
+        766671985,
+        'd531cf17248acc43e8c09b472a0877055e770877857a5332fc1304b36534ec85',
+      ),
+      SherpaModelFile(
+        'large-v3-decoder.int8.onnx',
+        1008265203,
+        'ebc6bfd88e162a46cb3edee8a7e727e1dcbc65cabecb19e2573695e4d495e1af',
+      ),
+      SherpaModelFile(
+        'large-v3-tokens.txt',
+        816730,
+        'b34b360dbb493e781e479794586d661700670d65564001f23024971d1f2fa126',
+      ),
+    ],
+  ),
+  SherpaModel(
     id: 'tiny',
     name: 'Whisper Tiny',
     revision: '65176e2deb88badc814a94058666cadccc29b61c',

--- a/lib/features/ai/ui/settings/widgets/ftue/ai_pick_provider_modal.dart
+++ b/lib/features/ai/ui/settings/widgets/ftue/ai_pick_provider_modal.dart
@@ -102,7 +102,7 @@ class AiPickProviderModal extends StatefulWidget {
 
   /// Default tile lineup matching the design: Melious.ai (RECOMMENDED) →
   /// Mistral → Gemini → Alibaba (NEW) → OpenAI → Anthropic (NEW) →
-  /// oMLX (DESKTOP ONLY) → Ollama (DESKTOP ONLY) → Voxtral
+  /// sherpa-onnx (ON DEVICE) → oMLX (DESKTOP ONLY) → Ollama (DESKTOP ONLY) → Voxtral
   /// (DESKTOP ONLY). Hosted providers land before the local options so the
   /// desktop providers stay last in the list. Exposed as a static so
   /// tests can re-use the same spec the modal ships with without instantiating
@@ -124,6 +124,7 @@ class AiPickProviderModal extends StatefulWidget {
           providerType: InferenceProviderType.anthropic,
           badge: AiPickProviderBadge.newcomer,
         ),
+        AiPickProviderTileSpec(providerType: InferenceProviderType.sherpa),
         AiPickProviderTileSpec(
           providerType: InferenceProviderType.omlx,
           badge: AiPickProviderBadge.desktopOnly,
@@ -156,7 +157,6 @@ class AiPickProviderModal extends StatefulWidget {
           providerType: InferenceProviderType.nebiusAiStudio,
         ),
         AiPickProviderTileSpec(providerType: InferenceProviderType.openRouter),
-        AiPickProviderTileSpec(providerType: InferenceProviderType.sherpa),
         AiPickProviderTileSpec(providerType: InferenceProviderType.whisper),
       ];
 

--- a/lib/features/ai/ui/settings/widgets/sherpa_models_section.dart
+++ b/lib/features/ai/ui/settings/widgets/sherpa_models_section.dart
@@ -1,12 +1,17 @@
 import 'dart:developer' as developer;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/speech/sherpa_installed_models_provider.dart';
 import 'package:lotti/features/ai/speech/sherpa_model_repository.dart';
 import 'package:lotti/features/ai/util/known_models.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_icon_action.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_grouped_list.dart';
+import 'package:lotti/features/design_system/components/progress_bars/design_system_progress_bar.dart';
+import 'package:lotti/features/design_system/components/spinners/design_system_spinner.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/sync/services/sync_node_profile_broadcaster.dart';
 import 'package:lotti/get_it.dart';
@@ -26,18 +31,29 @@ class SherpaModelsSection extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Text(context.messages.sherpaProviderDescription),
-        for (final model in sherpaModels)
-          Padding(
-            padding: EdgeInsets.only(top: tokens.spacing.step4),
-            child: _ModelDownload(model: model, providerId: providerId),
-          ),
+        SizedBox(height: tokens.spacing.step4),
+        DesignSystemGroupedList(
+          padding: EdgeInsets.zero,
+          children: [
+            for (final model in sherpaModels)
+              _ModelDownload(
+                key: ValueKey('sherpa-model-${model.id}'),
+                model: model,
+                providerId: providerId,
+              ),
+          ],
+        ),
       ],
     );
   }
 }
 
 class _ModelDownload extends ConsumerStatefulWidget {
-  const _ModelDownload({required this.model, required this.providerId});
+  const _ModelDownload({
+    required this.model,
+    required this.providerId,
+    super.key,
+  });
 
   final SherpaModel model;
   final String providerId;
@@ -46,9 +62,13 @@ class _ModelDownload extends ConsumerStatefulWidget {
   ConsumerState<_ModelDownload> createState() => _ModelDownloadState();
 }
 
+enum _ModelOperation { installing, removing, configuring }
+
 class _ModelDownloadState extends ConsumerState<_ModelDownload> {
   late Future<bool> _installed;
   double? _progress;
+  _ModelOperation? _operation;
+  bool get _busy => _operation != null;
   bool _failed = false;
   bool _configurationFailed = false;
 
@@ -61,11 +81,12 @@ class _ModelDownloadState extends ConsumerState<_ModelDownload> {
   }
 
   Future<void> _download() async {
-    if (_progress != null) return;
+    if (_busy) return;
     final models = ref.read(sherpaModelRepositoryProvider);
     final container = ProviderScope.containerOf(context, listen: false);
     final configs = ref.read(aiConfigRepositoryProvider);
     setState(() {
+      _operation = _ModelOperation.installing;
       _progress = 0;
       _failed = false;
       _configurationFailed = false;
@@ -83,35 +104,57 @@ class _ModelDownloadState extends ConsumerState<_ModelDownload> {
         });
       }
       await _modelsChanged(container);
-      try {
-        // A synced row may already exist. Re-create only a missing/deleted row,
-        // so downloading does not rewrite its profile references or user edits.
-        final existing = await configs.getConfigsByType(AiConfigType.model);
-        if (!existing.whereType<AiConfigModel>().any(
-          (model) =>
-              model.inferenceProviderId == widget.providerId &&
-              model.providerModelId == widget.model.id,
-        )) {
-          final known = sherpaSpeechModels.firstWhere(
-            (model) => model.providerModelId == widget.model.id,
-          );
-          await configs.saveConfig(
-            known.toAiConfigModel(
-              id: generateModelId(
-                widget.providerId,
-                widget.model.id,
-              ),
-              inferenceProviderId: widget.providerId,
-            ),
-          );
-        }
-      } catch (_) {
-        if (mounted) setState(() => _configurationFailed = true);
-      }
+      await _saveConfiguration(configs);
     } catch (_) {
       if (mounted) setState(() => _failed = true);
     } finally {
-      if (mounted) setState(() => _progress = null);
+      if (mounted) {
+        setState(() {
+          _progress = null;
+          _operation = null;
+        });
+      }
+    }
+  }
+
+  /// Retry the synced configuration independently of verified device files.
+  Future<void> _retryConfiguration() async {
+    if (_busy) return;
+    final configs = ref.read(aiConfigRepositoryProvider);
+    setState(() {
+      _operation = _ModelOperation.configuring;
+      _failed = false;
+    });
+    await _saveConfiguration(configs);
+    if (mounted) setState(() => _operation = null);
+  }
+
+  Future<void> _saveConfiguration(AiConfigRepository configs) async {
+    try {
+      // A synced row may already exist. Re-create only a missing/deleted row,
+      // so downloading does not rewrite its profile references or user edits.
+      final existing = await configs.getConfigsByType(AiConfigType.model);
+      if (!existing.whereType<AiConfigModel>().any(
+        (model) =>
+            model.inferenceProviderId == widget.providerId &&
+            model.providerModelId == widget.model.id,
+      )) {
+        final known = sherpaSpeechModels.firstWhere(
+          (model) => model.providerModelId == widget.model.id,
+        );
+        await configs.saveConfig(
+          known.toAiConfigModel(
+            id: generateModelId(
+              widget.providerId,
+              widget.model.id,
+            ),
+            inferenceProviderId: widget.providerId,
+          ),
+        );
+      }
+      if (mounted) setState(() => _configurationFailed = false);
+    } catch (_) {
+      if (mounted) setState(() => _configurationFailed = true);
     }
   }
 
@@ -131,12 +174,12 @@ class _ModelDownloadState extends ConsumerState<_ModelDownload> {
   }
 
   Future<void> _remove() async {
+    if (_busy) return;
     final models = ref.read(sherpaModelRepositoryProvider);
     final container = ProviderScope.containerOf(context, listen: false);
     setState(() {
-      _progress = 0;
+      _operation = _ModelOperation.removing;
       _failed = false;
-      _configurationFailed = false;
     });
     try {
       await models.remove(widget.model.id);
@@ -144,12 +187,13 @@ class _ModelDownloadState extends ConsumerState<_ModelDownload> {
       if (mounted) {
         setState(() {
           _installed = Future.value(false);
+          _configurationFailed = false;
         });
       }
     } catch (_) {
       if (mounted) setState(() => _failed = true);
     } finally {
-      if (mounted) setState(() => _progress = null);
+      if (mounted) setState(() => _operation = null);
     }
   }
 
@@ -157,54 +201,126 @@ class _ModelDownloadState extends ConsumerState<_ModelDownload> {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
+    final numberFormat = NumberFormat.decimalPattern(messages.localeName);
+    final metadata = widget.model.bytes >= 1000000000
+        ? messages.sherpaModelSizeGB(
+            NumberFormat(
+              '0.00',
+              messages.localeName,
+            ).format(widget.model.bytes / 1000000000),
+          )
+        : messages.sherpaModelSizeMB(
+            numberFormat.format((widget.model.bytes / 1000000).ceil()),
+          );
     return FutureBuilder<bool>(
       future: _installed,
-      builder: (context, snapshot) => Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Text(
-            widget.model.name,
-            style: tokens.typography.styles.subtitle.subtitle2,
-          ),
-          SizedBox(height: tokens.spacing.step3),
-          if (_progress != null)
-            LinearProgressIndicator(value: _progress)
-          else if (snapshot.connectionState == ConnectionState.waiting)
-            const LinearProgressIndicator()
-          else if (snapshot.data ?? false)
+      builder: (context, snapshot) => Padding(
+        padding: EdgeInsets.all(tokens.spacing.step4),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
             Wrap(
-              spacing: tokens.spacing.step3,
+              alignment: WrapAlignment.spaceBetween,
               crossAxisAlignment: WrapCrossAlignment.center,
+              spacing: tokens.spacing.step4,
+              runSpacing: tokens.spacing.step3,
               children: [
-                Text(messages.sherpaModelInstalled),
-                DesignSystemButton(
-                  label: messages.sherpaDeleteModel,
-                  onPressed: _remove,
+                Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      widget.model.name,
+                      style: tokens.typography.styles.subtitle.subtitle2,
+                    ),
+                    SizedBox(height: tokens.spacing.step2),
+                    Text(
+                      metadata,
+                      style: tokens.typography.styles.body.bodySmall.copyWith(
+                        color: tokens.colors.text.mediumEmphasis,
+                      ),
+                    ),
+                  ],
                 ),
+                if (_progress != null)
+                  const SizedBox.shrink()
+                else if (snapshot.connectionState == ConnectionState.waiting)
+                  const DesignSystemSpinner(
+                    size: IconSizes.s,
+                    strokeWidth: BorderWidths.emphasis,
+                  )
+                else if (snapshot.data ?? false)
+                  Wrap(
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    spacing: tokens.spacing.step2,
+                    children: [
+                      Text(
+                        messages.sherpaModelInstalled,
+                        style: tokens.typography.styles.body.bodySmall.copyWith(
+                          color: tokens.colors.text.mediumEmphasis,
+                        ),
+                      ),
+                      DesignSystemIconAction(
+                        icon: LottiIcons.delete,
+                        tooltip: messages.sherpaDeleteModel(widget.model.name),
+                        isBusy: _operation == _ModelOperation.removing,
+                        onPressed: _busy ? null : _remove,
+                      ),
+                    ],
+                  )
+                else
+                  DesignSystemButton(
+                    label: messages.sherpaDownloadAction,
+                    semanticsLabel: messages.sherpaDownloadModel(
+                      widget.model.name,
+                    ),
+                    leadingIcon: LottiIcons.download,
+                    variant: DesignSystemButtonVariant.outlined,
+                    tapTargetSize: MaterialTapTargetSize.padded,
+                    onPressed: _download,
+                  ),
               ],
-            )
-          else
-            DesignSystemButton(
-              label: messages.sherpaDownloadModel(
-                (widget.model.bytes / 1000000).ceil().toString(),
-              ),
-              onPressed: _download,
             ),
-          if (_configurationFailed)
-            Text(
-              messages.sherpaModelConfigurationError,
-              style: tokens.typography.styles.body.bodySmall.copyWith(
-                color: tokens.colors.alert.error.ink,
+            if (_progress != null) ...[
+              SizedBox(height: tokens.spacing.step3),
+              DesignSystemProgressBar(
+                value: _progress!,
+                label: messages.sherpaInstallingModel,
+                semanticsLabel: messages.sherpaDownloadModel(widget.model.name),
+                progressText: NumberFormat.percentPattern(
+                  messages.localeName,
+                ).format(_progress!.clamp(0, 1)),
               ),
-            ),
-          if (_failed || snapshot.hasError)
-            Text(
-              messages.sherpaModelError,
-              style: tokens.typography.styles.body.bodySmall.copyWith(
-                color: tokens.colors.alert.error.ink,
+            ],
+            if (_configurationFailed) ...[
+              SizedBox(height: tokens.spacing.step3),
+              Text(
+                messages.sherpaModelConfigurationError,
+                style: tokens.typography.styles.body.bodySmall.copyWith(
+                  color: tokens.colors.alert.error.ink,
+                ),
               ),
-            ),
-        ],
+              Align(
+                alignment: AlignmentDirectional.centerStart,
+                child: DesignSystemButton(
+                  label: messages.aiProviderConnectionRetryButton,
+                  isLoading: _operation == _ModelOperation.configuring,
+                  variant: DesignSystemButtonVariant.tertiary,
+                  onPressed: _busy ? null : _retryConfiguration,
+                ),
+              ),
+            ],
+            if (_failed || snapshot.hasError) ...[
+              SizedBox(height: tokens.spacing.step3),
+              Text(
+                messages.sherpaModelError,
+                style: tokens.typography.styles.body.bodySmall.copyWith(
+                  color: tokens.colors.alert.error.ink,
+                ),
+              ),
+            ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/ai/util/known_models_data.dart
+++ b/lib/features/ai/util/known_models_data.dart
@@ -778,6 +778,15 @@ const List<KnownModel> mistralModels = [
 /// Multilingual int8 Whisper exports for embedded, device-local transcription.
 const sherpaSpeechModels = [
   KnownModel(
+    providerModelId: 'large-v3',
+    name: 'Whisper Large v3',
+    inputModalities: [Modality.audio],
+    outputModalities: [Modality.text],
+    isReasoningModel: false,
+    publisher: 'OpenAI',
+    description: 'OpenAI Whisper Large v3 · ONNX INT8',
+  ),
+  KnownModel(
     providerModelId: 'tiny',
     name: 'Whisper Tiny',
     inputModalities: [Modality.audio],

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4915,13 +4915,45 @@
   "settingsV2UnimplementedTitle": "Panel zatím není k dispozici",
   "settingsWhatsNewSubtitle": "Podívej se na nejnovější aktualizace a funkce",
   "settingsWhatsNewTitle": "Co je nového",
-  "sherpaDeleteModel": "Smazat stažený model",
-  "sherpaDownloadModel": "Stáhnout ({size} MB)",
+  "sherpaDeleteModel": "Odebrat {model} z tohoto zařízení",
+  "@sherpaDeleteModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaDownloadAction": "Stáhnout",
+  "sherpaDownloadModel": "Stáhnout {model}",
+  "@sherpaDownloadModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaInstallingModel": "Instalace modelu",
   "sherpaModelConfigurationError": "Model je stažený, ale jeho konfiguraci se nepodařilo uložit.",
   "sherpaModelError": "Operace s modelem se nezdařila. Zkus to znovu.",
   "sherpaModelInstalled": "Staženo",
   "sherpaModelNotInstalled": "Stáhni si model do tohoto zařízení",
-  "sherpaProviderDescription": "Přepisuj na tomto zařízení bez serveru. Stáhni si níže uvedený model.",
+  "sherpaModelSizeGB": "{size} GB · Vícejazyčný",
+  "@sherpaModelSizeGB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaModelSizeMB": "{size} MB · Vícejazyčný",
+  "@sherpaModelSizeMB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaProviderDescription": "Přepisuj na tomto zařízení bez serveru. Stáhni model a pak ho vyber ve svém inferenčním profilu.",
   "sidebarActiveSectionTitle": "Aktivita",
   "sidebarActivityCollapseTooltip": "Sbalit aktivitu",
   "sidebarActivityExpandTooltip": "Rozbalit aktivitu",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -5444,13 +5444,45 @@
   "settingsV2UnimplementedTitle": "Panel endnu ikke implementeret",
   "settingsWhatsNewSubtitle": "Se de seneste opdateringer og funktioner",
   "settingsWhatsNewTitle": "Hvad er nyt",
-  "sherpaDeleteModel": "Slet downloadet model",
-  "sherpaDownloadModel": "Download ({size} MB)",
+  "sherpaDeleteModel": "Fjern {model} fra denne enhed",
+  "@sherpaDeleteModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaDownloadAction": "Download",
+  "sherpaDownloadModel": "Download {model}",
+  "@sherpaDownloadModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaInstallingModel": "Installerer model",
   "sherpaModelConfigurationError": "Modellen er downloadet, men dens konfiguration kunne ikke gemmes.",
   "sherpaModelError": "Modelhandlingen mislykkedes. Prøv igen.",
   "sherpaModelInstalled": "Downloadet",
   "sherpaModelNotInstalled": "Download en model på denne enhed",
-  "sherpaProviderDescription": "Transskriber på denne enhed uden en server. Download en model nedenfor.",
+  "sherpaModelSizeGB": "{size} GB · Flersproget",
+  "@sherpaModelSizeGB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaModelSizeMB": "{size} MB · Flersproget",
+  "@sherpaModelSizeMB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaProviderDescription": "Transskriber på denne enhed uden en server. Download en model, og vælg den derefter i din inferensprofil.",
   "sidebarActiveSectionTitle": "Aktivitet",
   "sidebarActivityCollapseTooltip": "Kollapsaktivitet",
   "sidebarActivityExpandTooltip": "Udvid aktiviteten",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -4908,13 +4908,45 @@
   "settingsV2UnimplementedTitle": "Bereich noch nicht verfügbar",
   "settingsWhatsNewSubtitle": "Sieh dir die neuesten Neuigkeiten und Funktionen an",
   "settingsWhatsNewTitle": "Was gibt's Neues",
-  "sherpaDeleteModel": "Heruntergeladenes Modell löschen",
-  "sherpaDownloadModel": "Herunterladen ({size} MB)",
+  "sherpaDeleteModel": "{model} von diesem Gerät entfernen",
+  "@sherpaDeleteModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaDownloadAction": "Herunterladen",
+  "sherpaDownloadModel": "{model} herunterladen",
+  "@sherpaDownloadModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaInstallingModel": "Modell wird installiert",
   "sherpaModelConfigurationError": "Das Modell wurde heruntergeladen, aber seine Konfiguration konnte nicht gespeichert werden.",
   "sherpaModelError": "Modellaktion fehlgeschlagen. Versuch es erneut.",
   "sherpaModelInstalled": "Heruntergeladen",
   "sherpaModelNotInstalled": "Lade ein Modell auf dieses Gerät herunter",
-  "sherpaProviderDescription": "Transkribiere auf diesem Gerät ohne Server. Lade unten ein Modell herunter.",
+  "sherpaModelSizeGB": "{size} GB · Mehrsprachig",
+  "@sherpaModelSizeGB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaModelSizeMB": "{size} MB · Mehrsprachig",
+  "@sherpaModelSizeMB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaProviderDescription": "Transkribiere auf diesem Gerät ohne Server. Lade ein Modell herunter und wähle es dann in deinem Inferenzprofil aus.",
   "sidebarActiveSectionTitle": "Aktivität",
   "sidebarActivityCollapseTooltip": "Aktivität einklappen",
   "sidebarActivityExpandTooltip": "Aktivität ausklappen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7083,20 +7083,45 @@
   "settingsV2UnimplementedTitle": "Panel not yet implemented",
   "settingsWhatsNewSubtitle": "See the latest updates and features",
   "settingsWhatsNewTitle": "What's New",
-  "sherpaDeleteModel": "Delete downloaded model",
-  "sherpaDownloadModel": "Download ({size} MB)",
+  "sherpaDeleteModel": "Remove {model} from this device",
+  "@sherpaDeleteModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaDownloadAction": "Download",
+  "sherpaDownloadModel": "Download {model}",
   "@sherpaDownloadModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaInstallingModel": "Installing model",
+  "sherpaModelConfigurationError": "Model downloaded, but its configuration could not be saved.",
+  "sherpaModelError": "Model operation failed. Try again.",
+  "sherpaModelInstalled": "Downloaded",
+  "sherpaModelNotInstalled": "Download a model on this device",
+  "sherpaModelSizeGB": "{size} GB · Multilingual",
+  "@sherpaModelSizeGB": {
     "placeholders": {
       "size": {
         "type": "String"
       }
     }
   },
-  "sherpaModelConfigurationError": "Model downloaded, but its configuration could not be saved.",
-  "sherpaModelError": "Model operation failed. Try again.",
-  "sherpaModelInstalled": "Downloaded",
-  "sherpaModelNotInstalled": "Download a model on this device",
-  "sherpaProviderDescription": "Transcribe on this device without a server. Download a model below.",
+  "sherpaModelSizeMB": "{size} MB · Multilingual",
+  "@sherpaModelSizeMB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaProviderDescription": "Transcribe on this device without a server. Download a model, then select it in your inference profile.",
   "sidebarActiveSectionTitle": "Activity",
   "sidebarActivityCollapseTooltip": "Collapse activity",
   "sidebarActivityExpandTooltip": "Expand activity",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4908,13 +4908,45 @@
   "settingsV2UnimplementedTitle": "Panel aún no disponible",
   "settingsWhatsNewSubtitle": "Mira las últimas actualizaciones y funciones",
   "settingsWhatsNewTitle": "Novedades",
-  "sherpaDeleteModel": "Eliminar el modelo descargado",
-  "sherpaDownloadModel": "Descargar ({size} MB)",
+  "sherpaDeleteModel": "Eliminar {model} de este dispositivo",
+  "@sherpaDeleteModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaDownloadAction": "Descargar",
+  "sherpaDownloadModel": "Descargar {model}",
+  "@sherpaDownloadModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaInstallingModel": "Instalando modelo",
   "sherpaModelConfigurationError": "El modelo se ha descargado, pero no se ha podido guardar su configuración.",
   "sherpaModelError": "La operación del modelo falló. Inténtalo de nuevo.",
   "sherpaModelInstalled": "Descargado",
   "sherpaModelNotInstalled": "Descarga un modelo en este dispositivo",
-  "sherpaProviderDescription": "Transcribe en este dispositivo sin servidor. Descarga un modelo abajo.",
+  "sherpaModelSizeGB": "{size} GB · Multilingüe",
+  "@sherpaModelSizeGB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaModelSizeMB": "{size} MB · Multilingüe",
+  "@sherpaModelSizeMB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaProviderDescription": "Transcribe en este dispositivo sin servidor. Descarga un modelo y selecciónalo en tu perfil de inferencia.",
   "sidebarActiveSectionTitle": "Actividad",
   "sidebarActivityCollapseTooltip": "Contraer actividad",
   "sidebarActivityExpandTooltip": "Expandir actividad",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4908,13 +4908,45 @@
   "settingsV2UnimplementedTitle": "Volet non encore disponible",
   "settingsWhatsNewSubtitle": "Découvre les dernières mises à jour et fonctionnalités",
   "settingsWhatsNewTitle": "Quoi de neuf",
-  "sherpaDeleteModel": "Supprimer le modèle téléchargé",
-  "sherpaDownloadModel": "Télécharger ({size} Mo)",
+  "sherpaDeleteModel": "Supprimer {model} de cet appareil",
+  "@sherpaDeleteModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaDownloadAction": "Télécharger",
+  "sherpaDownloadModel": "Télécharger {model}",
+  "@sherpaDownloadModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaInstallingModel": "Installation du modèle",
   "sherpaModelConfigurationError": "Le modèle a été téléchargé, mais sa configuration n’a pas pu être enregistrée.",
   "sherpaModelError": "L’opération sur le modèle a échoué. Réessaie.",
   "sherpaModelInstalled": "Téléchargé",
   "sherpaModelNotInstalled": "Télécharge un modèle sur cet appareil",
-  "sherpaProviderDescription": "Transcris sur cet appareil sans serveur. Télécharge un modèle ci-dessous.",
+  "sherpaModelSizeGB": "{size} GB · Multilingue",
+  "@sherpaModelSizeGB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaModelSizeMB": "{size} MB · Multilingue",
+  "@sherpaModelSizeMB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaProviderDescription": "Transcris sur cet appareil sans serveur. Télécharge un modèle, puis sélectionne-le dans ton profil d’inférence.",
   "sidebarActiveSectionTitle": "Activité",
   "sidebarActivityCollapseTooltip": "Réduire l’activité",
   "sidebarActivityExpandTooltip": "Développer l’activité",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -5444,13 +5444,45 @@
   "settingsV2UnimplementedTitle": "Pannello non ancora implementato",
   "settingsWhatsNewSubtitle": "Visualizza gli ultimi aggiornamenti e le funzionalità",
   "settingsWhatsNewTitle": "Che cosa è nuovo",
-  "sherpaDeleteModel": "Elimina il modello scaricato",
-  "sherpaDownloadModel": "Scarica ({size} MB)",
+  "sherpaDeleteModel": "Rimuovi {model} da questo dispositivo",
+  "@sherpaDeleteModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaDownloadAction": "Scarica",
+  "sherpaDownloadModel": "Scarica {model}",
+  "@sherpaDownloadModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaInstallingModel": "Installazione del modello",
   "sherpaModelConfigurationError": "Il modello è stato scaricato, ma non è stato possibile salvare la sua configurazione.",
   "sherpaModelError": "Operazione sul modello non riuscita. Riprova.",
   "sherpaModelInstalled": "Scaricato",
   "sherpaModelNotInstalled": "Scarica un modello su questo dispositivo",
-  "sherpaProviderDescription": "Trascrivi su questo dispositivo senza un server. Scarica un modello qui sotto.",
+  "sherpaModelSizeGB": "{size} GB · Multilingue",
+  "@sherpaModelSizeGB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaModelSizeMB": "{size} MB · Multilingue",
+  "@sherpaModelSizeMB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaProviderDescription": "Trascrivi su questo dispositivo senza un server. Scarica un modello, poi selezionalo nel tuo profilo di inferenza.",
   "sidebarActiveSectionTitle": "Attività",
   "sidebarActivityCollapseTooltip": "L'attività di colata",
   "sidebarActivityExpandTooltip": "Attività all'estero",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -21202,14 +21202,26 @@ abstract class AppLocalizations {
   /// No description provided for @sherpaDeleteModel.
   ///
   /// In en, this message translates to:
-  /// **'Delete downloaded model'**
-  String get sherpaDeleteModel;
+  /// **'Remove {model} from this device'**
+  String sherpaDeleteModel(String model);
+
+  /// No description provided for @sherpaDownloadAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Download'**
+  String get sherpaDownloadAction;
 
   /// No description provided for @sherpaDownloadModel.
   ///
   /// In en, this message translates to:
-  /// **'Download ({size} MB)'**
-  String sherpaDownloadModel(String size);
+  /// **'Download {model}'**
+  String sherpaDownloadModel(String model);
+
+  /// No description provided for @sherpaInstallingModel.
+  ///
+  /// In en, this message translates to:
+  /// **'Installing model'**
+  String get sherpaInstallingModel;
 
   /// No description provided for @sherpaModelConfigurationError.
   ///
@@ -21235,10 +21247,22 @@ abstract class AppLocalizations {
   /// **'Download a model on this device'**
   String get sherpaModelNotInstalled;
 
+  /// No description provided for @sherpaModelSizeGB.
+  ///
+  /// In en, this message translates to:
+  /// **'{size} GB · Multilingual'**
+  String sherpaModelSizeGB(String size);
+
+  /// No description provided for @sherpaModelSizeMB.
+  ///
+  /// In en, this message translates to:
+  /// **'{size} MB · Multilingual'**
+  String sherpaModelSizeMB(String size);
+
   /// No description provided for @sherpaProviderDescription.
   ///
   /// In en, this message translates to:
-  /// **'Transcribe on this device without a server. Download a model below.'**
+  /// **'Transcribe on this device without a server. Download a model, then select it in your inference profile.'**
   String get sherpaProviderDescription;
 
   /// No description provided for @sidebarActiveSectionTitle.

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -12759,12 +12759,20 @@ class AppLocalizationsCs extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Co je nového';
 
   @override
-  String get sherpaDeleteModel => 'Smazat stažený model';
+  String sherpaDeleteModel(String model) {
+    return 'Odebrat $model z tohoto zařízení';
+  }
 
   @override
-  String sherpaDownloadModel(String size) {
-    return 'Stáhnout ($size MB)';
+  String get sherpaDownloadAction => 'Stáhnout';
+
+  @override
+  String sherpaDownloadModel(String model) {
+    return 'Stáhnout $model';
   }
+
+  @override
+  String get sherpaInstallingModel => 'Instalace modelu';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12781,8 +12789,18 @@ class AppLocalizationsCs extends AppLocalizations {
   String get sherpaModelNotInstalled => 'Stáhni si model do tohoto zařízení';
 
   @override
+  String sherpaModelSizeGB(String size) {
+    return '$size GB · Vícejazyčný';
+  }
+
+  @override
+  String sherpaModelSizeMB(String size) {
+    return '$size MB · Vícejazyčný';
+  }
+
+  @override
   String get sherpaProviderDescription =>
-      'Přepisuj na tomto zařízení bez serveru. Stáhni si níže uvedený model.';
+      'Přepisuj na tomto zařízení bez serveru. Stáhni model a pak ho vyber ve svém inferenčním profilu.';
 
   @override
   String get sidebarActiveSectionTitle => 'Aktivita';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -12596,12 +12596,20 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Hvad er nyt';
 
   @override
-  String get sherpaDeleteModel => 'Slet downloadet model';
+  String sherpaDeleteModel(String model) {
+    return 'Fjern $model fra denne enhed';
+  }
 
   @override
-  String sherpaDownloadModel(String size) {
-    return 'Download ($size MB)';
+  String get sherpaDownloadAction => 'Download';
+
+  @override
+  String sherpaDownloadModel(String model) {
+    return 'Download $model';
   }
+
+  @override
+  String get sherpaInstallingModel => 'Installerer model';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12617,8 +12625,18 @@ class AppLocalizationsDa extends AppLocalizations {
   String get sherpaModelNotInstalled => 'Download en model på denne enhed';
 
   @override
+  String sherpaModelSizeGB(String size) {
+    return '$size GB · Flersproget';
+  }
+
+  @override
+  String sherpaModelSizeMB(String size) {
+    return '$size MB · Flersproget';
+  }
+
+  @override
   String get sherpaProviderDescription =>
-      'Transskriber på denne enhed uden en server. Download en model nedenfor.';
+      'Transskriber på denne enhed uden en server. Download en model, og vælg den derefter i din inferensprofil.';
 
   @override
   String get sidebarActiveSectionTitle => 'Aktivitet';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -12678,12 +12678,20 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Was gibt\'s Neues';
 
   @override
-  String get sherpaDeleteModel => 'Heruntergeladenes Modell löschen';
+  String sherpaDeleteModel(String model) {
+    return '$model von diesem Gerät entfernen';
+  }
 
   @override
-  String sherpaDownloadModel(String size) {
-    return 'Herunterladen ($size MB)';
+  String get sherpaDownloadAction => 'Herunterladen';
+
+  @override
+  String sherpaDownloadModel(String model) {
+    return '$model herunterladen';
   }
+
+  @override
+  String get sherpaInstallingModel => 'Modell wird installiert';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12701,8 +12709,18 @@ class AppLocalizationsDe extends AppLocalizations {
       'Lade ein Modell auf dieses Gerät herunter';
 
   @override
+  String sherpaModelSizeGB(String size) {
+    return '$size GB · Mehrsprachig';
+  }
+
+  @override
+  String sherpaModelSizeMB(String size) {
+    return '$size MB · Mehrsprachig';
+  }
+
+  @override
   String get sherpaProviderDescription =>
-      'Transkribiere auf diesem Gerät ohne Server. Lade unten ein Modell herunter.';
+      'Transkribiere auf diesem Gerät ohne Server. Lade ein Modell herunter und wähle es dann in deinem Inferenzprofil aus.';
 
   @override
   String get sidebarActiveSectionTitle => 'Aktivität';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -12521,12 +12521,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsWhatsNewTitle => 'What\'s New';
 
   @override
-  String get sherpaDeleteModel => 'Delete downloaded model';
+  String sherpaDeleteModel(String model) {
+    return 'Remove $model from this device';
+  }
 
   @override
-  String sherpaDownloadModel(String size) {
-    return 'Download ($size MB)';
+  String get sherpaDownloadAction => 'Download';
+
+  @override
+  String sherpaDownloadModel(String model) {
+    return 'Download $model';
   }
+
+  @override
+  String get sherpaInstallingModel => 'Installing model';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12542,8 +12550,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sherpaModelNotInstalled => 'Download a model on this device';
 
   @override
+  String sherpaModelSizeGB(String size) {
+    return '$size GB · Multilingual';
+  }
+
+  @override
+  String sherpaModelSizeMB(String size) {
+    return '$size MB · Multilingual';
+  }
+
+  @override
   String get sherpaProviderDescription =>
-      'Transcribe on this device without a server. Download a model below.';
+      'Transcribe on this device without a server. Download a model, then select it in your inference profile.';
 
   @override
   String get sidebarActiveSectionTitle => 'Activity';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -12771,12 +12771,20 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Novedades';
 
   @override
-  String get sherpaDeleteModel => 'Eliminar el modelo descargado';
+  String sherpaDeleteModel(String model) {
+    return 'Eliminar $model de este dispositivo';
+  }
 
   @override
-  String sherpaDownloadModel(String size) {
-    return 'Descargar ($size MB)';
+  String get sherpaDownloadAction => 'Descargar';
+
+  @override
+  String sherpaDownloadModel(String model) {
+    return 'Descargar $model';
   }
+
+  @override
+  String get sherpaInstallingModel => 'Instalando modelo';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12794,8 +12802,18 @@ class AppLocalizationsEs extends AppLocalizations {
       'Descarga un modelo en este dispositivo';
 
   @override
+  String sherpaModelSizeGB(String size) {
+    return '$size GB · Multilingüe';
+  }
+
+  @override
+  String sherpaModelSizeMB(String size) {
+    return '$size MB · Multilingüe';
+  }
+
+  @override
   String get sherpaProviderDescription =>
-      'Transcribe en este dispositivo sin servidor. Descarga un modelo abajo.';
+      'Transcribe en este dispositivo sin servidor. Descarga un modelo y selecciónalo en tu perfil de inferencia.';
 
   @override
   String get sidebarActiveSectionTitle => 'Actividad';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -12816,12 +12816,20 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Quoi de neuf';
 
   @override
-  String get sherpaDeleteModel => 'Supprimer le modèle téléchargé';
+  String sherpaDeleteModel(String model) {
+    return 'Supprimer $model de cet appareil';
+  }
 
   @override
-  String sherpaDownloadModel(String size) {
-    return 'Télécharger ($size Mo)';
+  String get sherpaDownloadAction => 'Télécharger';
+
+  @override
+  String sherpaDownloadModel(String model) {
+    return 'Télécharger $model';
   }
+
+  @override
+  String get sherpaInstallingModel => 'Installation du modèle';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12838,8 +12846,18 @@ class AppLocalizationsFr extends AppLocalizations {
   String get sherpaModelNotInstalled => 'Télécharge un modèle sur cet appareil';
 
   @override
+  String sherpaModelSizeGB(String size) {
+    return '$size GB · Multilingue';
+  }
+
+  @override
+  String sherpaModelSizeMB(String size) {
+    return '$size MB · Multilingue';
+  }
+
+  @override
   String get sherpaProviderDescription =>
-      'Transcris sur cet appareil sans serveur. Télécharge un modèle ci-dessous.';
+      'Transcris sur cet appareil sans serveur. Télécharge un modèle, puis sélectionne-le dans ton profil d’inférence.';
 
   @override
   String get sidebarActiveSectionTitle => 'Activité';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -12762,12 +12762,20 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Che cosa è nuovo';
 
   @override
-  String get sherpaDeleteModel => 'Elimina il modello scaricato';
+  String sherpaDeleteModel(String model) {
+    return 'Rimuovi $model da questo dispositivo';
+  }
 
   @override
-  String sherpaDownloadModel(String size) {
-    return 'Scarica ($size MB)';
+  String get sherpaDownloadAction => 'Scarica';
+
+  @override
+  String sherpaDownloadModel(String model) {
+    return 'Scarica $model';
   }
+
+  @override
+  String get sherpaInstallingModel => 'Installazione del modello';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12785,8 +12793,18 @@ class AppLocalizationsIt extends AppLocalizations {
       'Scarica un modello su questo dispositivo';
 
   @override
+  String sherpaModelSizeGB(String size) {
+    return '$size GB · Multilingue';
+  }
+
+  @override
+  String sherpaModelSizeMB(String size) {
+    return '$size MB · Multilingue';
+  }
+
+  @override
   String get sherpaProviderDescription =>
-      'Trascrivi su questo dispositivo senza un server. Scarica un modello qui sotto.';
+      'Trascrivi su questo dispositivo senza un server. Scarica un modello, poi selezionalo nel tuo profilo di inferenza.';
 
   @override
   String get sidebarActiveSectionTitle => 'Attività';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -12621,12 +12621,20 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Wat is er nieuw?';
 
   @override
-  String get sherpaDeleteModel => 'Gedownload model verwijderen';
+  String sherpaDeleteModel(String model) {
+    return '$model van dit apparaat verwijderen';
+  }
 
   @override
-  String sherpaDownloadModel(String size) {
-    return 'Downloaden ($size MB)';
+  String get sherpaDownloadAction => 'Downloaden';
+
+  @override
+  String sherpaDownloadModel(String model) {
+    return '$model downloaden';
   }
+
+  @override
+  String get sherpaInstallingModel => 'Model installeren';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12642,8 +12650,18 @@ class AppLocalizationsNl extends AppLocalizations {
   String get sherpaModelNotInstalled => 'Download een model op dit apparaat';
 
   @override
+  String sherpaModelSizeGB(String size) {
+    return '$size GB · Meertalig';
+  }
+
+  @override
+  String sherpaModelSizeMB(String size) {
+    return '$size MB · Meertalig';
+  }
+
+  @override
   String get sherpaProviderDescription =>
-      'Transcribeer op dit apparaat zonder server. Download hieronder een model.';
+      'Transcribeer op dit apparaat zonder server. Download een model en selecteer het vervolgens in je inferentieprofiel.';
 
   @override
   String get sidebarActiveSectionTitle => 'Activiteit';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -12715,12 +12715,20 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Novidades';
 
   @override
-  String get sherpaDeleteModel => 'Eliminar o modelo descarregado';
+  String sherpaDeleteModel(String model) {
+    return 'Remover $model deste dispositivo';
+  }
 
   @override
-  String sherpaDownloadModel(String size) {
-    return 'Descarregar ($size MB)';
+  String get sherpaDownloadAction => 'Baixar';
+
+  @override
+  String sherpaDownloadModel(String model) {
+    return 'Baixar $model';
   }
+
+  @override
+  String get sherpaInstallingModel => 'Instalando modelo';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12738,8 +12746,18 @@ class AppLocalizationsPt extends AppLocalizations {
       'Transfere um modelo para este dispositivo';
 
   @override
+  String sherpaModelSizeGB(String size) {
+    return '$size GB · Multilíngue';
+  }
+
+  @override
+  String sherpaModelSizeMB(String size) {
+    return '$size MB · Multilíngue';
+  }
+
+  @override
   String get sherpaProviderDescription =>
-      'Transcreve neste dispositivo sem um servidor. Descarrega um modelo abaixo.';
+      'Transcreva neste dispositivo sem servidor. Baixe um modelo e selecione-o no seu perfil de inferência.';
 
   @override
   String get sidebarActiveSectionTitle => 'Atividade';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -12840,12 +12840,20 @@ class AppLocalizationsRo extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Ce este nou';
 
   @override
-  String get sherpaDeleteModel => 'Ștergeți modelul descărcat';
+  String sherpaDeleteModel(String model) {
+    return 'Eliminați $model de pe acest dispozitiv';
+  }
 
   @override
-  String sherpaDownloadModel(String size) {
-    return 'Descărcare ($size MB)';
+  String get sherpaDownloadAction => 'Descărcați';
+
+  @override
+  String sherpaDownloadModel(String model) {
+    return 'Descărcați $model';
   }
+
+  @override
+  String get sherpaInstallingModel => 'Se instalează modelul';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12863,8 +12871,18 @@ class AppLocalizationsRo extends AppLocalizations {
       'Descărcați un model pe acest dispozitiv';
 
   @override
+  String sherpaModelSizeGB(String size) {
+    return '$size GB · Multilingv';
+  }
+
+  @override
+  String sherpaModelSizeMB(String size) {
+    return '$size MB · Multilingv';
+  }
+
+  @override
   String get sherpaProviderDescription =>
-      'Transcrieți pe acest dispozitiv fără server. Descărcați un model mai jos.';
+      'Transcrieți pe acest dispozitiv fără un server. Descărcați un model, apoi selectați-l în profilul dumneavoastră de inferență.';
 
   @override
   String get sidebarActiveSectionTitle => 'Activitate';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -12608,12 +12608,20 @@ class AppLocalizationsSv extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Vad är nytt';
 
   @override
-  String get sherpaDeleteModel => 'Ta bort nedladdad modell';
+  String sherpaDeleteModel(String model) {
+    return 'Ta bort $model från den här enheten';
+  }
 
   @override
-  String sherpaDownloadModel(String size) {
-    return 'Ladda ner ($size MB)';
+  String get sherpaDownloadAction => 'Ladda ner';
+
+  @override
+  String sherpaDownloadModel(String model) {
+    return 'Ladda ner $model';
   }
+
+  @override
+  String get sherpaInstallingModel => 'Installerar modell';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12630,8 +12638,18 @@ class AppLocalizationsSv extends AppLocalizations {
       'Ladda ner en modell på den här enheten';
 
   @override
+  String sherpaModelSizeGB(String size) {
+    return '$size GB · Flerspråkig';
+  }
+
+  @override
+  String sherpaModelSizeMB(String size) {
+    return '$size MB · Flerspråkig';
+  }
+
+  @override
   String get sherpaProviderDescription =>
-      'Transkribera på den här enheten utan server. Ladda ner en modell nedan.';
+      'Transkribera på den här enheten utan server. Ladda ner en modell och välj den sedan i din inferensprofil.';
 
   @override
   String get sidebarActiveSectionTitle => 'Verksamhet';

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -5443,13 +5443,45 @@
   "settingsV2UnimplementedTitle": "Panel nog niet geïmplementeerd",
   "settingsWhatsNewSubtitle": "Zie de laatste updates en functies",
   "settingsWhatsNewTitle": "Wat is er nieuw?",
-  "sherpaDeleteModel": "Gedownload model verwijderen",
-  "sherpaDownloadModel": "Downloaden ({size} MB)",
+  "sherpaDeleteModel": "{model} van dit apparaat verwijderen",
+  "@sherpaDeleteModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaDownloadAction": "Downloaden",
+  "sherpaDownloadModel": "{model} downloaden",
+  "@sherpaDownloadModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaInstallingModel": "Model installeren",
   "sherpaModelConfigurationError": "Het model is gedownload, maar de configuratie kon niet worden opgeslagen.",
   "sherpaModelError": "Modelbewerking mislukt. Probeer het opnieuw.",
   "sherpaModelInstalled": "Gedownload",
   "sherpaModelNotInstalled": "Download een model op dit apparaat",
-  "sherpaProviderDescription": "Transcribeer op dit apparaat zonder server. Download hieronder een model.",
+  "sherpaModelSizeGB": "{size} GB · Meertalig",
+  "@sherpaModelSizeGB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaModelSizeMB": "{size} MB · Meertalig",
+  "@sherpaModelSizeMB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaProviderDescription": "Transcribeer op dit apparaat zonder server. Download een model en selecteer het vervolgens in je inferentieprofiel.",
   "sidebarActiveSectionTitle": "Activiteit",
   "sidebarActivityCollapseTooltip": "Inklappen",
   "sidebarActivityExpandTooltip": "Activiteiten uitbreiden",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -5443,13 +5443,45 @@
   "settingsV2UnimplementedTitle": "Painel ainda não implementado",
   "settingsWhatsNewSubtitle": "Veja as últimas atualizações e recursos",
   "settingsWhatsNewTitle": "Novidades",
-  "sherpaDeleteModel": "Eliminar o modelo descarregado",
-  "sherpaDownloadModel": "Descarregar ({size} MB)",
+  "sherpaDeleteModel": "Remover {model} deste dispositivo",
+  "@sherpaDeleteModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaDownloadAction": "Baixar",
+  "sherpaDownloadModel": "Baixar {model}",
+  "@sherpaDownloadModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaInstallingModel": "Instalando modelo",
   "sherpaModelConfigurationError": "O modelo foi descarregado, mas não foi possível guardar a sua configuração.",
   "sherpaModelError": "A operação do modelo falhou. Tenta novamente.",
   "sherpaModelInstalled": "Descarregado",
   "sherpaModelNotInstalled": "Transfere um modelo para este dispositivo",
-  "sherpaProviderDescription": "Transcreve neste dispositivo sem um servidor. Descarrega um modelo abaixo.",
+  "sherpaModelSizeGB": "{size} GB · Multilíngue",
+  "@sherpaModelSizeGB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaModelSizeMB": "{size} MB · Multilíngue",
+  "@sherpaModelSizeMB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaProviderDescription": "Transcreva neste dispositivo sem servidor. Baixe um modelo e selecione-o no seu perfil de inferência.",
   "sidebarActiveSectionTitle": "Atividade",
   "sidebarActivityCollapseTooltip": "Recolher atividade",
   "sidebarActivityExpandTooltip": "Expandir atividade",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4908,13 +4908,45 @@
   "settingsV2UnimplementedTitle": "Panoul nu este încă implementat",
   "settingsWhatsNewSubtitle": "Vedeți cele mai recente actualizări și funcționalități",
   "settingsWhatsNewTitle": "Ce este nou",
-  "sherpaDeleteModel": "Ștergeți modelul descărcat",
-  "sherpaDownloadModel": "Descărcare ({size} MB)",
+  "sherpaDeleteModel": "Eliminați {model} de pe acest dispozitiv",
+  "@sherpaDeleteModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaDownloadAction": "Descărcați",
+  "sherpaDownloadModel": "Descărcați {model}",
+  "@sherpaDownloadModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaInstallingModel": "Se instalează modelul",
   "sherpaModelConfigurationError": "Modelul a fost descărcat, dar configurația sa nu a putut fi salvată.",
   "sherpaModelError": "Operațiunea asupra modelului a eșuat. Încercați din nou.",
   "sherpaModelInstalled": "Descărcat",
   "sherpaModelNotInstalled": "Descărcați un model pe acest dispozitiv",
-  "sherpaProviderDescription": "Transcrieți pe acest dispozitiv fără server. Descărcați un model mai jos.",
+  "sherpaModelSizeGB": "{size} GB · Multilingv",
+  "@sherpaModelSizeGB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaModelSizeMB": "{size} MB · Multilingv",
+  "@sherpaModelSizeMB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaProviderDescription": "Transcrieți pe acest dispozitiv fără un server. Descărcați un model, apoi selectați-l în profilul dumneavoastră de inferență.",
   "sidebarActiveSectionTitle": "Activitate",
   "sidebarActivityCollapseTooltip": "Restrângeți activitatea",
   "sidebarActivityExpandTooltip": "Extindeți activitatea",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -5444,13 +5444,45 @@
   "settingsV2UnimplementedTitle": "Panelen har ännu inte implementerats",
   "settingsWhatsNewSubtitle": "Se de senaste uppdateringarna och funktionerna",
   "settingsWhatsNewTitle": "Vad är nytt",
-  "sherpaDeleteModel": "Ta bort nedladdad modell",
-  "sherpaDownloadModel": "Ladda ner ({size} MB)",
+  "sherpaDeleteModel": "Ta bort {model} från den här enheten",
+  "@sherpaDeleteModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaDownloadAction": "Ladda ner",
+  "sherpaDownloadModel": "Ladda ner {model}",
+  "@sherpaDownloadModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaInstallingModel": "Installerar modell",
   "sherpaModelConfigurationError": "Modellen har laddats ner, men dess konfiguration kunde inte sparas.",
   "sherpaModelError": "Modellåtgärden misslyckades. Försök igen.",
   "sherpaModelInstalled": "Nedladdad",
   "sherpaModelNotInstalled": "Ladda ner en modell på den här enheten",
-  "sherpaProviderDescription": "Transkribera på den här enheten utan server. Ladda ner en modell nedan.",
+  "sherpaModelSizeGB": "{size} GB · Flerspråkig",
+  "@sherpaModelSizeGB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaModelSizeMB": "{size} MB · Flerspråkig",
+  "@sherpaModelSizeMB": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "sherpaProviderDescription": "Transkribera på den här enheten utan server. Ladda ner en modell och välj den sedan i din inferensprofil.",
   "sidebarActiveSectionTitle": "Verksamhet",
   "sidebarActivityCollapseTooltip": "Kollapsaktivitet",
   "sidebarActivityExpandTooltip": "Utöka verksamheten",

--- a/test/features/ai/speech/sherpa_model_repository_test.dart
+++ b/test/features/ai/speech/sherpa_model_repository_test.dart
@@ -59,6 +59,18 @@ void main() {
     return repo;
   }
 
+  MockIoFile trackedFile(File file) {
+    final tracked = MockIoFile();
+    when(() => tracked.path).thenReturn(file.path);
+    when(tracked.statSync).thenAnswer((_) => file.statSync());
+    when(tracked.existsSync).thenAnswer((_) => file.existsSync());
+    when(tracked.length).thenAnswer((_) => file.length());
+    when(
+      tracked.openRead,
+    ).thenAnswer((_) => Stream.value(file.readAsBytesSync()));
+    return tracked;
+  }
+
   test(
     'publishes verified files, reports progress, and reuses installation',
     () async {
@@ -134,6 +146,86 @@ void main() {
     await repo.install('tiny');
     expect(await File(p.join(path, 'model.onnx')).readAsBytes(), data);
   });
+
+  test(
+    'readiness hashes unchanged files once and rechecks modified files',
+    () async {
+      final repo = repository(
+        MockClient((_) async => http.Response.bytes(data, 200)),
+      );
+      final path = await repo.modelDirectory('tiny');
+      final file = File(p.join(path, 'model.onnx'));
+      await file.parent.create(recursive: true);
+      await file.writeAsBytes(data);
+      await file.setLastModified(DateTime.utc(2026));
+      final tracked = trackedFile(file);
+      await IOOverrides.runZoned(() async {
+        expect(
+          await Future.wait([
+            repo.isInstalled('tiny'),
+            repo.isAvailable('tiny'),
+          ]),
+          [true, true],
+        );
+        expect(await repo.isInstalled('tiny'), isTrue);
+        verify(tracked.openRead).called(1);
+        await file.writeAsBytes(List.filled(data.length, 0));
+        await file.setLastModified(DateTime.utc(2026, 2));
+        expect(await repo.isAvailable('tiny'), isFalse);
+        verify(tracked.openRead).called(1);
+        await file.delete();
+        expect(await repo.isInstalled('tiny'), isFalse);
+        verifyNever(tracked.openRead);
+      }, createFile: (_) => tracked);
+    },
+  );
+
+  test(
+    'installation seeds verification and removal invalidates readiness',
+    () async {
+      final repo = repository(
+        MockClient((_) async => http.Response.bytes(data, 200)),
+      );
+      final path = await repo.install('tiny');
+      final file = File(p.join(path, 'model.onnx'));
+      final tracked = trackedFile(file);
+      await IOOverrides.runZoned(() async {
+        expect(await repo.isAvailable('tiny'), isTrue);
+        verifyNever(tracked.openRead);
+      }, createFile: (_) => tracked);
+      await repo.remove('tiny');
+      expect(await repo.isAvailable('tiny'), isFalse);
+      await repo.install('tiny');
+      expect(await repo.isAvailable('tiny'), isTrue);
+    },
+  );
+
+  test(
+    'failed verification can be retried without caching the IO error',
+    () async {
+      final repo = repository(
+        MockClient((_) async => http.Response.bytes(data, 200)),
+      );
+      final file = File(
+        p.join(await repo.modelDirectory('tiny'), 'model.onnx'),
+      );
+      await file.parent.create(recursive: true);
+      await file.writeAsBytes(data);
+      final tracked = trackedFile(file);
+      when(
+        tracked.openRead,
+      ).thenAnswer((_) => Stream.error(const FileSystemException('busy')));
+      await IOOverrides.runZoned(() async {
+        await expectLater(
+          repo.isAvailable('tiny'),
+          throwsA(isA<FileSystemException>()),
+        );
+        when(tracked.openRead).thenAnswer((_) => Stream.value(data));
+        expect(await repo.isAvailable('tiny'), isTrue);
+        verify(tracked.openRead).called(2);
+      }, createFile: (_) => tracked);
+    },
+  );
 
   test('concurrent installs share one download', () async {
     final response = Completer<http.Response>();

--- a/test/features/ai/ui/settings/widgets/ftue/ai_pick_provider_modal_dispatch_test.dart
+++ b/test/features/ai/ui/settings/widgets/ftue/ai_pick_provider_modal_dispatch_test.dart
@@ -28,7 +28,6 @@ void main() {
           InferenceProviderType.genericOpenAi,
           InferenceProviderType.nebiusAiStudio,
           InferenceProviderType.openRouter,
-          InferenceProviderType.sherpa,
           InferenceProviderType.whisper,
         ]);
         // Every enum value is present exactly once — guard against
@@ -46,7 +45,6 @@ void main() {
           InferenceProviderType.genericOpenAi,
           InferenceProviderType.nebiusAiStudio,
           InferenceProviderType.openRouter,
-          InferenceProviderType.sherpa,
           InferenceProviderType.whisper,
         };
         for (final spec in AiPickProviderModal.allTypesTiles.where(

--- a/test/features/ai/ui/settings/widgets/ftue/ai_pick_provider_modal_test.dart
+++ b/test/features/ai/ui/settings/widgets/ftue/ai_pick_provider_modal_test.dart
@@ -12,7 +12,7 @@ void main() {
   group('AiPickProviderModal.defaultTiles — static spec', () {
     test(
       'lineup matches the design: '
-      'Melious → Mistral → Gemini → Alibaba → OpenAI → Anthropic → oMLX → Ollama → Voxtral',
+      'Melious → Mistral → Gemini → Alibaba → OpenAI → Anthropic → sherpa-onnx → oMLX → Ollama → Voxtral',
       () {
         expect(
           AiPickProviderModal.defaultTiles.map((t) => t.providerType).toList(),
@@ -23,6 +23,7 @@ void main() {
             InferenceProviderType.alibaba,
             InferenceProviderType.openAi,
             InferenceProviderType.anthropic,
+            InferenceProviderType.sherpa,
             InferenceProviderType.omlx,
             InferenceProviderType.ollama,
             InferenceProviderType.voxtral,
@@ -233,49 +234,60 @@ void main() {
       },
     );
 
-    testWidgets(
-      'Continue carries the LATEST radio selection — proves the modal '
-      'forwards the picked tile, not the seeded one',
-      (tester) async {
-        await tester.binding.setSurfaceSize(const Size(800, 1100));
-        addTearDown(() => tester.binding.setSurfaceSize(null));
-        AiPickProviderResult? captured;
-        await tester.pumpWidget(
-          makeTestableWidget(
-            Builder(
-              builder: (ctx) => Center(
-                child: TextButton(
-                  onPressed: () async {
-                    captured = await Navigator.of(ctx).push(
-                      MaterialPageRoute<AiPickProviderResult>(
-                        builder: (_) => const AiPickProviderModal(
-                          tiles: AiPickProviderModal.defaultTiles,
-                          initialSelection: InferenceProviderType.gemini,
+    for (final providerType in [
+      InferenceProviderType.anthropic,
+      InferenceProviderType.sherpa,
+    ]) {
+      testWidgets(
+        'Continue carries the LATEST radio selection — proves the modal '
+        'forwards the picked tile, not the seeded one ($providerType)',
+        (tester) async {
+          await tester.binding.setSurfaceSize(const Size(800, 1100));
+          addTearDown(() => tester.binding.setSurfaceSize(null));
+          AiPickProviderResult? captured;
+          await tester.pumpWidget(
+            makeTestableWidget(
+              Builder(
+                builder: (ctx) => Center(
+                  child: TextButton(
+                    onPressed: () async {
+                      captured = await Navigator.of(ctx).push(
+                        MaterialPageRoute<AiPickProviderResult>(
+                          builder: (_) => const AiPickProviderModal(
+                            tiles: AiPickProviderModal.defaultTiles,
+                            initialSelection: InferenceProviderType.gemini,
+                          ),
                         ),
-                      ),
-                    );
-                  },
-                  child: const Text('open'),
+                      );
+                    },
+                    child: const Text('open'),
+                  ),
                 ),
               ),
             ),
-          ),
-        );
+          );
 
-        await tester.tap(find.text('open'));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
-        final messages = hL10n(tester);
-        // Pick Anthropic.
-        await tester.tap(find.text(messages.aiProviderAnthropicName));
-        await tester.pump();
-        await tester.tap(find.text(messages.aiPickProviderContinueButton));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
+          await tester.tap(find.text('open'));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 300));
+          final messages = hL10n(tester);
+          // Pick the requested provider, including embedded ASR before FTUE dismissal.
+          await tester.tap(
+            find.text(
+              providerType == InferenceProviderType.sherpa
+                  ? messages.aiProviderSherpaName
+                  : messages.aiProviderAnthropicName,
+            ),
+          );
+          await tester.pump();
+          await tester.tap(find.text(messages.aiPickProviderContinueButton));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 300));
 
-        expect(captured!.providerType, InferenceProviderType.anthropic);
-      },
-    );
+          expect(captured!.providerType, providerType);
+        },
+      );
+    }
 
     testWidgets(
       "Don't show again pops with the dontShowAgain sentinel — no "

--- a/test/features/ai/ui/settings/widgets/sherpa_models_section_test.dart
+++ b/test/features/ai/ui/settings/widgets/sherpa_models_section_test.dart
@@ -47,6 +47,32 @@ void main() {
   }
 
   testWidgets(
+    'downloads Whisper Large v3 and saves a selectable speech model',
+    (
+      tester,
+    ) async {
+      when(
+        () => models.install('large-v3', onProgress: any(named: 'onProgress')),
+      ).thenAnswer((_) async => '/large-model');
+      await pump(tester);
+      final download = find.text('Download (1776 MB)');
+      await tester.ensureVisible(download);
+      await tester.tap(download);
+      await tester.pumpAndSettle();
+      final saved =
+          verify(() => configs.saveConfig(captureAny())).captured.single
+              as AiConfigModel;
+      expect(saved.providerModelId, 'large-v3');
+      expect(saved.name, 'Whisper Large v3');
+      expect(saved.inferenceProviderId, 'sherpa-provider');
+      expect(saved.inputModalities, [Modality.audio]);
+      expect(saved.outputModalities, [Modality.text]);
+      expect(find.text('Downloaded'), findsOneWidget);
+      expect(download, findsNothing);
+    },
+  );
+
+  testWidgets(
     'downloads only on request and creates a usable model row on success',
     (tester) async {
       final finished = Completer<String>();

--- a/test/features/ai/ui/settings/widgets/sherpa_models_section_test.dart
+++ b/test/features/ai/ui/settings/widgets/sherpa_models_section_test.dart
@@ -5,19 +5,27 @@ import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/speech/sherpa_model_repository.dart';
 import 'package:lotti/features/ai/ui/settings/widgets/sherpa_models_section.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_icon_action.dart';
+import 'package:lotti/features/design_system/components/progress_bars/design_system_progress_bar.dart';
 import 'package:lotti/features/sync/services/sync_node_profile_broadcaster.dart';
 import 'package:lotti/get_it.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../../helpers/fallbacks.dart';
 import '../../../../../mocks/mocks.dart';
+import '../../../../../test_utils/screenshot_harness.dart' show loadAppFonts;
 import '../../../../../widget_test_utils.dart';
 
 void main() {
   late MockSherpaModelRepository models;
   late MockAiConfigRepository configs;
   late MockSyncNodeProfileBroadcaster broadcaster;
-  setUpAll(registerAllFallbackValues);
+  setUpAll(() async {
+    registerAllFallbackValues();
+    await loadAppFonts();
+  });
   setUp(() async {
     await setUpTestGetIt();
     broadcaster = MockSyncNodeProfileBroadcaster();
@@ -33,10 +41,23 @@ void main() {
   });
   tearDown(tearDownTestGetIt);
 
-  Future<void> pump(WidgetTester tester) async {
+  Finder downloadFor(String id) => find.descendant(
+    of: find.byKey(ValueKey('sherpa-model-$id')),
+    matching: find.widgetWithText(DesignSystemButton, 'Download'),
+  );
+
+  Future<void> pump(
+    WidgetTester tester, {
+    double textScale = 1,
+    Locale? locale,
+  }) async {
     await tester.pumpWidget(
       makeTestableWidget(
-        const SherpaModelsSection(providerId: 'sherpa-provider'),
+        MediaQuery(
+          data: MediaQueryData(textScaler: TextScaler.linear(textScale)),
+          child: const SherpaModelsSection(providerId: 'sherpa-provider'),
+        ),
+        locale: locale,
         overrides: [
           sherpaModelRepositoryProvider.overrideWithValue(models),
           aiConfigRepositoryProvider.overrideWithValue(configs),
@@ -55,7 +76,7 @@ void main() {
         () => models.install('large-v3', onProgress: any(named: 'onProgress')),
       ).thenAnswer((_) async => '/large-model');
       await pump(tester);
-      final download = find.text('Download (1776 MB)');
+      final download = downloadFor('large-v3');
       await tester.ensureVisible(download);
       await tester.tap(download);
       await tester.pumpAndSettle();
@@ -86,9 +107,19 @@ void main() {
       verifyNever(
         () => models.install(any(), onProgress: any(named: 'onProgress')),
       );
-      await tester.tap(find.text('Download (104 MB)'));
+      await tester.tap(downloadFor('tiny'));
       await tester.pump();
       verifyNever(() => configs.saveConfig(any()));
+      expect(find.text('50%'), findsOneWidget);
+      expect(
+        tester
+            .widget<DesignSystemProgressBar>(
+              find.byType(DesignSystemProgressBar),
+            )
+            .value,
+        0.5,
+      );
+      expect(downloadFor('tiny'), findsNothing);
       finished.complete('/model');
       await tester.pumpAndSettle();
       final saved =
@@ -110,10 +141,10 @@ void main() {
         () => models.install('tiny', onProgress: any(named: 'onProgress')),
       ).thenThrow(StateError('failed'));
       await pump(tester);
-      await tester.tap(find.text('Download (104 MB)'));
+      await tester.tap(downloadFor('tiny'));
       await tester.pumpAndSettle();
       expect(find.text('Model operation failed. Try again.'), findsOneWidget);
-      expect(find.text('Download (104 MB)'), findsOneWidget);
+      expect(downloadFor('tiny'), findsOneWidget);
       verifyNever(() => configs.saveConfig(any()));
     },
   );
@@ -124,12 +155,12 @@ void main() {
       when(() => models.isInstalled('tiny')).thenAnswer((_) async => true);
       when(() => models.remove('tiny')).thenAnswer((_) async {});
       await pump(tester);
-      await tester.tap(find.text('Delete downloaded model'));
+      await tester.tap(find.byType(DesignSystemIconAction));
       await tester.pumpAndSettle();
       verify(() => models.remove('tiny')).called(1);
       verify(() => broadcaster.broadcastIfChanged()).called(1);
       verifyNever(() => configs.saveConfig(any()));
-      expect(find.text('Download (104 MB)'), findsOneWidget);
+      expect(downloadFor('tiny'), findsOneWidget);
       expect(find.text('Downloaded'), findsNothing);
       expect(find.text('Model operation failed. Try again.'), findsNothing);
     },
@@ -140,11 +171,11 @@ void main() {
       when(() => models.isInstalled('tiny')).thenAnswer((_) async => true);
       when(() => models.remove('tiny')).thenThrow(StateError('busy'));
       await pump(tester);
-      await tester.tap(find.text('Delete downloaded model'));
+      await tester.tap(find.byType(DesignSystemIconAction));
       await tester.pumpAndSettle();
       expect(find.text('Downloaded'), findsOneWidget);
       expect(find.text('Model operation failed. Try again.'), findsOneWidget);
-      expect(find.text('Delete downloaded model'), findsOneWidget);
+      expect(find.byType(DesignSystemIconAction), findsOneWidget);
       verifyNever(() => configs.saveConfig(any()));
     },
   );
@@ -169,10 +200,10 @@ void main() {
         }
         when(() => models.remove('tiny')).thenAnswer((_) async {});
         await pump(tester);
-        await tester.tap(find.text('Download (104 MB)'));
+        await tester.tap(downloadFor('tiny'));
         await tester.pumpAndSettle();
         expect(find.text('Downloaded'), findsOneWidget);
-        expect(find.text('Download (104 MB)'), findsNothing);
+        expect(downloadFor('tiny'), findsNothing);
         expect(find.text('Model operation failed. Try again.'), findsNothing);
         expect(
           find.text(
@@ -181,10 +212,10 @@ void main() {
           findsOneWidget,
         );
         verify(() => broadcaster.broadcastIfChanged()).called(1);
-        await tester.tap(find.text('Delete downloaded model'));
+        await tester.tap(find.byType(DesignSystemIconAction));
         await tester.pumpAndSettle();
         verify(() => models.remove('tiny')).called(1);
-        expect(find.text('Download (104 MB)'), findsOneWidget);
+        expect(downloadFor('tiny'), findsOneWidget);
         expect(
           find.text(
             'Model downloaded, but its configuration could not be saved.',
@@ -193,6 +224,148 @@ void main() {
         );
       },
     );
+  }
+
+  testWidgets(
+    'retries configuration without downloading verified files again',
+    (tester) async {
+      when(
+        () => models.install('tiny', onProgress: any(named: 'onProgress')),
+      ).thenAnswer((_) async => '/model');
+      when(
+        () => configs.saveConfig(any()),
+      ).thenThrow(StateError('database busy'));
+      await pump(tester);
+      await tester.tap(downloadFor('tiny'));
+      await tester.pumpAndSettle();
+      expect(
+        find.text(
+          'Model downloaded, but its configuration could not be saved.',
+        ),
+        findsOneWidget,
+      );
+      final retryFinished = Completer<void>();
+      when(
+        () => configs.saveConfig(any()),
+      ).thenAnswer((_) => retryFinished.future);
+      await tester.tap(find.text('Retry'));
+      await tester.pump();
+      expect(
+        tester
+            .widget<DesignSystemButton>(
+              find.widgetWithText(DesignSystemButton, 'Retry'),
+            )
+            .isLoading,
+        isTrue,
+      );
+      expect(
+        tester
+            .widget<DesignSystemIconAction>(find.byType(DesignSystemIconAction))
+            .onPressed,
+        isNull,
+      );
+      retryFinished.complete();
+      await tester.pumpAndSettle();
+      expect(
+        find.text(
+          'Model downloaded, but its configuration could not be saved.',
+        ),
+        findsNothing,
+      );
+      expect(find.text('Downloaded'), findsOneWidget);
+      verify(
+        () => models.install('tiny', onProgress: any(named: 'onProgress')),
+      ).called(1);
+      verify(() => configs.saveConfig(any())).called(2);
+    },
+  );
+
+  testWidgets('failed removal preserves configuration retry', (tester) async {
+    when(
+      () => models.install('tiny', onProgress: any(named: 'onProgress')),
+    ).thenAnswer((_) async => '/model');
+    when(
+      () => configs.saveConfig(any()),
+    ).thenThrow(StateError('database busy'));
+    when(() => models.remove('tiny')).thenThrow(StateError('file busy'));
+    await pump(tester);
+    await tester.tap(downloadFor('tiny'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(DesignSystemIconAction));
+    await tester.pumpAndSettle();
+    expect(find.text('Retry'), findsOneWidget);
+    when(() => configs.saveConfig(any())).thenAnswer((_) async {});
+    await tester.tap(find.text('Retry'));
+    await tester.pumpAndSettle();
+    expect(
+      find.text('Model downloaded, but its configuration could not be saved.'),
+      findsNothing,
+    );
+    verify(() => configs.saveConfig(any())).called(2);
+    verify(
+      () => models.install('tiny', onProgress: any(named: 'onProgress')),
+    ).called(1);
+  });
+
+  testWidgets('removal stays busy without displaying download progress', (
+    tester,
+  ) async {
+    when(() => models.isInstalled('tiny')).thenAnswer((_) async => true);
+    final removed = Completer<void>();
+    when(() => models.remove('tiny')).thenAnswer((_) => removed.future);
+    await pump(tester);
+    final action = find.byType(DesignSystemIconAction);
+    await tester.tap(action);
+    await tester.pump();
+    expect(tester.widget<DesignSystemIconAction>(action).isBusy, isTrue);
+    expect(find.byType(DesignSystemProgressBar), findsNothing);
+    await tester.tap(action);
+    verify(() => models.remove('tiny')).called(1);
+    removed.complete();
+    await tester.pumpAndSettle();
+    expect(downloadFor('tiny'), findsOneWidget);
+    expect(find.text('Downloaded'), findsNothing);
+  });
+
+  for (final width in [320.0, 800.0]) {
+    testWidgets('download actions remain compact and usable at width $width', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(Size(width, 1200));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await pump(tester, textScale: 1.5, locale: const Locale('de'));
+      final row = find.byKey(const ValueKey('sherpa-model-large-v3'));
+      final action = find.descendant(
+        of: row,
+        matching: find.byType(DesignSystemButton),
+      );
+      final rowRect = tester.getRect(row);
+      final actionRect = tester.getRect(action);
+      expect(actionRect.width, lessThan(rowRect.width));
+      expect(actionRect.left, greaterThanOrEqualTo(rowRect.left));
+      expect(actionRect.right, lessThanOrEqualTo(rowRect.right));
+      expect(find.text('1,78 GB · Mehrsprachig'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+      final semantics = tester.ensureSemantics();
+      try {
+        expect(
+          find.bySemanticsLabel('Whisper Large v3 herunterladen'),
+          findsOneWidget,
+        );
+      } finally {
+        semantics.dispose();
+      }
+      when(
+        () => models.install('large-v3', onProgress: any(named: 'onProgress')),
+      ).thenAnswer((_) async => '/model');
+      await tester.ensureVisible(action);
+      await tester.tap(action);
+      await tester.pumpAndSettle();
+      expect(find.text('1,78 GB · Mehrsprachig'), findsOneWidget);
+      verify(
+        () => models.install('large-v3', onProgress: any(named: 'onProgress')),
+      ).called(1);
+    });
   }
 
   testWidgets('redownload preserves existing model identity and user edits', (
@@ -215,11 +388,11 @@ void main() {
       () => configs.getConfigsByType(AiConfigType.model),
     ).thenAnswer((_) async => [existing]);
     await pump(tester);
-    await tester.tap(find.text('Download (104 MB)'));
+    await tester.tap(downloadFor('tiny'));
     await tester.pumpAndSettle();
     verifyNever(() => configs.saveConfig(any()));
     expect(find.text('Downloaded'), findsOneWidget);
-    expect(find.text('Download (104 MB)'), findsNothing);
+    expect(downloadFor('tiny'), findsNothing);
   });
   testWidgets('a sync failure does not undo a successful model download', (
     tester,
@@ -231,7 +404,7 @@ void main() {
       () => models.install('tiny', onProgress: any(named: 'onProgress')),
     ).thenAnswer((_) async => '/model');
     await pump(tester);
-    await tester.tap(find.text('Download (104 MB)'));
+    await tester.tap(downloadFor('tiny'));
     await tester.pumpAndSettle();
     expect(find.text('Downloaded'), findsOneWidget);
     expect(find.text('Model operation failed. Try again.'), findsNothing);


### PR DESCRIPTION
Adds full multilingual Whisper Large v3 (INT8, about 1.78 GB) to on-device transcription, with pinned upstream revisions, artifact sizes and SHA-256 checksums. Sherpa is also available in the first-run Add provider picker, fixing the missing option reported on Linux.

Model downloads now use compact outlined actions in a grouped list, with persistent size/language metadata, named installation progress, quieter removal, and configuration retry without another download. Actions wrap on narrow screens and use localized labels and model-specific accessibility names. A three-person UX, visual, and state review panel critiqued two iterations; its final reviews found no remaining blockers.

Readiness checks reuse verification for unchanged files, avoiding repeated gigabyte-scale reads before transcription. Installation still validates every artifact; size/timestamp changes and install/remove invalidate cached verification. Existing model identities, profile selections and automatic fallback ordering remain intact.

Validation: analyzer reports no errors/warnings/infos; targeted model repository, download UI, provider picker and model catalog tests pass. New regressions were also run with their fixes reverted and failed as expected. All three real Large v3 artifacts were downloaded and verified, and the production native worker successfully transcribed the upstream public WAV sample. Knowledge/Mermaid and changelog checks pass. CI runs the full suite.

Before/after screenshots were captured on phone and desktop in both themes, plus the provider picker. Public image upload is pending the R2 credentials location for this workspace; no images are committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Whisper Large v3 for multilingual, on-device transcription.
  - Download the approximately 1.78 GB INT8 model from sherpa-onnx settings and select it for local transcription.
  - Model controls now show size, language coverage, installation progress, and clearer download/removal actions.
  - Sherpa-onnx is available in both first-run and full provider pickers.

- **Bug Fixes**
  - Failed setup or removal operations can be retried without unnecessary re-downloads.
  - Large speech models start faster after verification checks.

- **Documentation**
  - Expanded embedded speech documentation with model management and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->