### PR TITLE
feat(relationships): the person page — hero, header pills, section cards and the action bar

### DIFF
--- a/changelog.d/2026-09-06-person-page-redesign.md
+++ b/changelog.d/2026-09-06-person-page-redesign.md
@@ -1,0 +1,16 @@
+### Changed
+- **A person's page now reads like a task's.** A cover-style header carries
+  back, *Talk to agent*, edit and a menu (link contact, delete), with the
+  person's avatar hanging off it; below it the category and *Important*, the
+  full name, the nickname and when you last spoke, and pills that tell the
+  truth about the cadence (*On track · Weekly*, or *Due since Sat · 5 days
+  over*), the health band once a briefing exists, and the next due day. The
+  sections follow in one order — Briefing, *Next time* (what your latest
+  check-in asked you to bring up or avoid), Check-ins (`Today 12:44 · Call ·
+  11 min`, the sentiment as a coloured pill, topics as tags), *Reach* (the
+  person's channels, with the note that they stay on this device), Tasks — and
+  the page ends in a bar with *Log check-in*, a mic that starts a spoken
+  check-in straight away, and a call or email button for the first channel
+  your device can open. The floating button is gone. Coming back from a call
+  placed here, the offer to log it now says who you called, how long ago and
+  roughly how long it lasted.

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -219,8 +219,11 @@ under it — the task page's shape, on purpose:
 Every section, the check-in sliver and the action bar sit on
 `detailContentInsets` — the rule `DetailContentWidth` itself is built on: the
 content gutter plus, on a desktop-wide window, the centring that caps the
-column at `kDetailContentMaxWidth`. Exposed as a function because a sliver
-and a `bottomNavigationBar` cannot be children of that widget.
+column at `kDetailContentMaxWidth` **within the width the caller has**. Both
+the page and the bar measure that with a `LayoutBuilder`, because on the
+split the detail pane is narrower than the window and centring on the window
+would over-inset it. Exposed as a function because a sliver and a
+`bottomNavigationBar` cannot be children of that widget.
 
 The [action bar](../../lib/features/relationships/ui/widgets/relationship_action_bar.dart)
 resolves its third control once when built: the first channel, in the
@@ -872,8 +875,11 @@ deleted, or hidden while private entries are off, produces no prompt, because
 naming them would leak that they exist. The offer names its evidence — the
 channel, how many minutes ago, when it started and about how long it has been
 (`You called Pip 11 minutes ago — log it while it is fresh?` · `started
-12:33 · about 11 min`) — so it reads as "log the call you just had", and the
-minutes it quotes are the ones the capture sheet will prefill.
+12:33 · about 11 min`) — so it reads as "log the call you just had". The
+minutes it quotes travel into the capture sheet as `prefilledDuration` and
+are persisted as the check-in's end time (`dateTo − dateFrom`, no schema
+change), so the log's row shows the duration the offer promised; editing a
+check-in keeps its length when the start time moves.
 
 ```mermaid
 stateDiagram-v2

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -183,8 +183,11 @@ On desktop `RelationshipsPage` is the Tasks/Projects list-detail split:
 `NavService.desktopSelectedRelationshipId` and pushes no detail page, the list
 pane takes the shared pane-width controller, and the right pane hosts the
 person's page or the empty state. The route stays the single source of truth —
-tapping a row still beams to `/people/<id>`. The chat stacks as its own page on
-every layout. Phones keep the list alone.
+tapping a row still beams to `/people/<id>`, and the page's back control
+beams to `/people` to clear the selection (on a phone it pops). While the
+list pane is folded away, the page's hero carries the control that brings it
+back, so nothing is overlaid on the page's own chrome. The chat stacks as
+its own page on every layout. Phones keep the list alone.
 
 ```mermaid
 flowchart LR
@@ -195,6 +198,36 @@ flowchart LR
   Split -->|row wears surface.selected| Row[PeopleListRow]
   Split --> Pane[detail pane: RelationshipDetailsPage or empty state]
 ```
+
+# The person page
+
+`RelationshipDetailsPage` (design 2026-09-06 §2–3) is one `CustomScrollView`
+in the design's order, above a sticky glass action bar in the Scaffold's
+`bottomNavigationBar` slot with `extendBody` so the bar blurs what scrolls
+under it — the task page's shape, on purpose:
+
+| Sliver | Widget | Notes |
+|---|---|---|
+| Hero | [`PersonHeroAppBar`](../../lib/features/relationships/ui/widgets/person_header.dart) | A pinned `SliverPersistentHeader` of its own, not a `SliverAppBar`: the avatar hangs half its diameter below the header, and every layer of an app bar clips that overflow. Slivers paint back to front, so the earlier header paints its overhang over the block scrolling under it. The name appears in the bar only once the wash band has folded (`AnimatedSwitcher`, never an invisible duplicate). |
+| Header block | `PersonHeaderBlock` (same file) | Eyebrow · name · one-liner · pills. The pills come from the list model's rules, so the page and the list never disagree about *due*; the cadence pill names the **effective** cadence (`effectiveCadenceDaysOf`), i.e. the runtime default when none is set. The health band comes from the same `currentRelationshipReport` rule the briefing card uses. |
+| Briefing | `RelationshipBriefingCard` | Only when enrolled or a briefing exists; the page reads the report too, so the gap after the card is deterministic. |
+| Next time | `NextTimeCard` in [`person_page_cards.dart`](../../lib/features/relationships/ui/widgets/person_page_cards.dart) | From the latest check-in's *pay attention to* / *avoid*; `NextTimeCard.hasContent` is the one visibility rule, shared with the page. |
+| Post-call offer | `PostInteractionPrompt` | Renders nothing until a marker exists (below). |
+| Check-ins | [`CheckInsCardSliver`](../../lib/features/relationships/ui/widgets/check_ins_card.dart) | A `DecoratedSliver` wearing `DesignSystemSectionCard.decoration`, so the unbounded log stays lazy inside a card that matches the boxed ones. Rows supply their own `Material` — there is no card Material above them in a sliver. |
+| Reach · Tasks | `ReachCard`, [`LinkedTasksCard`](../../lib/features/relationships/ui/widgets/linked_tasks_card.dart) | Reach only with channels. |
+
+Every section, the check-in sliver and the action bar sit on
+`detailContentInsets` — the rule `DetailContentWidth` itself is built on: the
+content gutter plus, on a desktop-wide window, the centring that caps the
+column at `kDetailContentMaxWidth`. Exposed as a function because a sliver
+and a `bottomNavigationBar` cannot be children of that widget.
+
+The [action bar](../../lib/features/relationships/ui/widgets/relationship_action_bar.dart)
+resolves its third control once when built: the first channel, in the
+person's own order, for which `ContactLauncher.canLaunch` answers yes — a
+call on a phone, email on a desktop with a mail client, nothing where neither
+exists — and launches it through the same `launchContactAction` the Reach
+rows use, so the post-call marker is written the same way from both.
 
 # Status lifecycle
 
@@ -836,7 +869,11 @@ wins) and it expires after `pendingInteractionTtl`, so a call from yesterday
 does not greet the user the next morning. `PostInteractionPrompt` re-resolves
 the person through the repository rather than trusting the marker: a person
 deleted, or hidden while private entries are off, produces no prompt, because
-naming them would leak that they exist.
+naming them would leak that they exist. The offer names its evidence — the
+channel, how many minutes ago, when it started and about how long it has been
+(`You called Pip 11 minutes ago — log it while it is fresh?` · `started
+12:33 · about 11 min`) — so it reads as "log the call you just had", and the
+minutes it quotes are the ones the capture sheet will prefill.
 
 ```mermaid
 stateDiagram-v2

--- a/lib/features/design_system/components/cards/design_system_section_card.dart
+++ b/lib/features/design_system/components/cards/design_system_section_card.dart
@@ -29,6 +29,16 @@ class DesignSystemSectionCard extends StatelessWidget {
   final EdgeInsets? padding;
   final EdgeInsets? margin;
 
+  /// The card's surface, radius and hairline as one decoration, for a
+  /// section that has to be a sliver (a lazily built list inside a card)
+  /// and so cannot be a child of this widget — `DecoratedSliver` takes the
+  /// same decoration and the two stay indistinguishable.
+  static BoxDecoration decoration(DsTokens tokens) => BoxDecoration(
+    color: tokens.colors.background.level02,
+    borderRadius: BorderRadius.circular(tokens.radii.l),
+    border: Border.all(color: tokens.colors.decorative.level01),
+  );
+
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
@@ -36,11 +46,7 @@ class DesignSystemSectionCard extends StatelessWidget {
     final effectivePadding = padding ?? EdgeInsets.all(tokens.spacing.step5);
 
     final decorated = DecoratedBox(
-      decoration: BoxDecoration(
-        color: tokens.colors.background.level02,
-        borderRadius: radius,
-        border: Border.all(color: tokens.colors.decorative.level01),
-      ),
+      decoration: decoration(tokens),
       child: Material(
         type: MaterialType.transparency,
         borderRadius: radius,

--- a/lib/features/design_system/components/layout/detail_content_width.dart
+++ b/lib/features/design_system/components/layout/detail_content_width.dart
@@ -19,22 +19,20 @@ class DetailContentWidth extends StatelessWidget {
   final Widget child;
 
   @override
-  Widget build(BuildContext context) {
-    final screenWidth = MediaQuery.sizeOf(context).width;
-    final maxWidth = screenWidth >= kDesktopBreakpoint
-        ? kDetailContentMaxWidth
-        : double.infinity;
+  Widget build(BuildContext context) =>
+      Padding(padding: detailContentInsets(context), child: child);
+}
 
-    return Center(
-      child: ConstrainedBox(
-        constraints: BoxConstraints(maxWidth: maxWidth),
-        child: Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: context.designTokens.spacing.step5,
-          ),
-          child: child,
-        ),
-      ),
-    );
-  }
+/// The horizontal insets [DetailContentWidth] applies: the standard content
+/// gutter plus, on a desktop-breakpoint screen, the centring that caps the
+/// content at [kDetailContentMaxWidth]. Exposed for slivers and bars that
+/// have to share the column but cannot be a child of that widget.
+EdgeInsets detailContentInsets(BuildContext context) {
+  final tokens = context.designTokens;
+  final width = MediaQuery.sizeOf(context).width;
+  final overflow = width - kDetailContentMaxWidth;
+  final centring = width >= kDesktopBreakpoint && overflow > 0
+      ? overflow / 2
+      : 0.0;
+  return EdgeInsets.symmetric(horizontal: tokens.spacing.step5 + centring);
 }

--- a/lib/features/design_system/components/layout/detail_content_width.dart
+++ b/lib/features/design_system/components/layout/detail_content_width.dart
@@ -19,19 +19,31 @@ class DetailContentWidth extends StatelessWidget {
   final Widget child;
 
   @override
-  Widget build(BuildContext context) =>
-      Padding(padding: detailContentInsets(context), child: child);
+  Widget build(BuildContext context) => LayoutBuilder(
+    builder: (context, constraints) => Padding(
+      padding: detailContentInsets(
+        context,
+        availableWidth: constraints.maxWidth,
+      ),
+      child: child,
+    ),
+  );
 }
 
 /// The horizontal insets [DetailContentWidth] applies: the standard content
 /// gutter plus, on a desktop-breakpoint screen, the centring that caps the
-/// content at [kDetailContentMaxWidth]. Exposed for slivers and bars that
-/// have to share the column but cannot be a child of that widget.
-EdgeInsets detailContentInsets(BuildContext context) {
+/// content at [kDetailContentMaxWidth] within [availableWidth] — the width
+/// the caller actually has, which inside a list/detail split is the detail
+/// pane and not the window. Exposed for slivers and bars that have to share
+/// the column but cannot be children of that widget.
+EdgeInsets detailContentInsets(
+  BuildContext context, {
+  required double availableWidth,
+}) {
   final tokens = context.designTokens;
-  final width = MediaQuery.sizeOf(context).width;
-  final overflow = width - kDetailContentMaxWidth;
-  final centring = width >= kDesktopBreakpoint && overflow > 0
+  final desktop = MediaQuery.sizeOf(context).width >= kDesktopBreakpoint;
+  final overflow = availableWidth - kDetailContentMaxWidth;
+  final centring = desktop && overflow.isFinite && overflow > 0
       ? overflow / 2
       : 0.0;
   return EdgeInsets.symmetric(horizontal: tokens.spacing.step5 + centring);

--- a/lib/features/design_system/components/layout/detail_content_width.dart
+++ b/lib/features/design_system/components/layout/detail_content_width.dart
@@ -19,23 +19,36 @@ class DetailContentWidth extends StatelessWidget {
   final Widget child;
 
   @override
-  Widget build(BuildContext context) => LayoutBuilder(
-    builder: (context, constraints) => Padding(
-      padding: detailContentInsets(
-        context,
-        availableWidth: constraints.maxWidth,
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.sizeOf(context).width;
+    final maxWidth = screenWidth >= kDesktopBreakpoint
+        ? kDetailContentMaxWidth
+        : double.infinity;
+    // Center + ConstrainedBox, not a LayoutBuilder: a `SliverFillRemaining`
+    // asks its child for an intrinsic height, which a LayoutBuilder cannot
+    // answer — and loose constraints let a shrink-wrapping child sit
+    // centred in the column rather than being stretched across it.
+    return Center(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: maxWidth),
+        child: Padding(
+          padding: EdgeInsets.symmetric(
+            horizontal: context.designTokens.spacing.step5,
+          ),
+          child: child,
+        ),
       ),
-      child: child,
-    ),
-  );
+    );
+  }
 }
 
-/// The horizontal insets [DetailContentWidth] applies: the standard content
-/// gutter plus, on a desktop-breakpoint screen, the centring that caps the
-/// content at [kDetailContentMaxWidth] within [availableWidth] — the width
-/// the caller actually has, which inside a list/detail split is the detail
-/// pane and not the window. Exposed for slivers and bars that have to share
-/// the column but cannot be children of that widget.
+/// The same geometry as [DetailContentWidth], as insets: the standard
+/// content gutter plus, on a desktop-breakpoint screen, the centring that
+/// caps the content at [kDetailContentMaxWidth] within [availableWidth] —
+/// the width the caller actually has, which inside a list/detail split is
+/// the detail pane and not the window. For slivers and bars that have to
+/// share the column but cannot be children of that widget; they measure
+/// the width themselves.
 EdgeInsets detailContentInsets(
   BuildContext context, {
   required double availableWidth,

--- a/lib/features/relationships/README.md
+++ b/lib/features/relationships/README.md
@@ -29,11 +29,19 @@ the `enable_relationships` flag):
   under a summary card that counts who is due now and names who lapses next,
   each row naming the last contact (`Call · Today 12:44 · Weekly`) with a
   truthful cadence pill, and on desktop a list/detail split like Tasks —
-  the per-person detail page (status/cadence/nickname chips, contact
-  channels, a linked-tasks section — `RelationshipLink` both ways, with a
-  task picker that also creates the task when none exists yet, and per-row
-  unlink — and the check-in log, with edit and
-  delete actions), the add/edit person modal (name, nickname, importance,
+  the per-person page, a sibling of the task page: a cover-style hero
+  (back · Talk to agent · edit · a menu with link-contact and delete) with
+  the persona avatar hanging off it, a header block (category · Important,
+  the full name, nickname and last contact, then the cadence fact, the
+  health band and the next due day as pills), and section cards in the
+  design's order — Briefing · Next time (what the latest check-in asked to
+  bring up or avoid) · Check-ins (mono `timestamp · type · duration`, the
+  sentiment as a tinted pill, topics as tags) · Reach (channels with the
+  actions the device can service, under the privacy line) · Tasks
+  (`RelationshipLink` both ways, a picker that also creates the task when
+  none exists yet, per-row unlink) — above a sticky action bar: *Log
+  check-in*, a mic that opens the capture sheet already recording, and the
+  first channel the platform can open. The add/edit person modal (name, nickname, importance,
   cadence presets, status, and the manual contact-channel editor — desktop
   parity per ADR 0041 §2), and the check-in capture sheet (interaction
   type, date, user-set sentiment — never AI-filled, ADR 0038 — topics,

--- a/lib/features/relationships/ui/pages/relationship_details_page.dart
+++ b/lib/features/relationships/ui/pages/relationship_details_page.dart
@@ -210,13 +210,19 @@ class RelationshipDetailsPage extends ConsumerWidget {
           startSpeaking: true,
         ),
       ),
-      // Builder so MediaQuery.paddingOf reads the Scaffold-modified value.
-      body: Builder(
-        builder: (context) {
+      // A LayoutBuilder for two reasons: MediaQuery.paddingOf below it reads
+      // the Scaffold-modified value, and the column is centred within the
+      // width this page actually has — the detail pane on the desktop split,
+      // not the window.
+      body: LayoutBuilder(
+        builder: (context, constraints) {
           // Every section — and the check-in log, which is a sliver and so
           // cannot sit inside `DetailContentWidth` — on the one reading
           // column that widget gives boxed content.
-          final insets = detailContentInsets(context);
+          final insets = detailContentInsets(
+            context,
+            availableWidth: constraints.maxWidth,
+          );
           final bottomInset = MediaQuery.paddingOf(context).bottom;
           final gap = SizedBox(height: tokens.spacing.sectionGap);
           return CustomScrollView(

--- a/lib/features/relationships/ui/pages/relationship_details_page.dart
+++ b/lib/features/relationships/ui/pages/relationship_details_page.dart
@@ -3,37 +3,41 @@ import 'dart:developer' as developer;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/classes/relationship_data.dart';
-import 'package:lotti/classes/task.dart';
-import 'package:lotti/features/agents/state/task_agent_providers.dart';
-import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
-import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/design_system/components/layout/detail_content_width.dart';
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
 import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
-import 'package:lotti/features/journal/util/entry_tools.dart';
+import 'package:lotti/features/relationships/model/relationship_health_metrics.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
 import 'package:lotti/features/relationships/state/relationship_agent_providers.dart';
 import 'package:lotti/features/relationships/state/relationships_providers.dart';
 import 'package:lotti/features/relationships/ui/widgets/check_in_capture_sheet.dart';
-import 'package:lotti/features/relationships/ui/widgets/contact_link_action.dart';
-import 'package:lotti/features/relationships/ui/widgets/contact_quick_actions.dart';
+import 'package:lotti/features/relationships/ui/widgets/check_ins_card.dart';
+import 'package:lotti/features/relationships/ui/widgets/linked_tasks_card.dart';
+import 'package:lotti/features/relationships/ui/widgets/person_header.dart';
+import 'package:lotti/features/relationships/ui/widgets/person_page_cards.dart';
 import 'package:lotti/features/relationships/ui/widgets/post_interaction_prompt.dart';
+import 'package:lotti/features/relationships/ui/widgets/relationship_action_bar.dart';
 import 'package:lotti/features/relationships/ui/widgets/relationship_briefing_card.dart';
-import 'package:lotti/features/relationships/ui/widgets/relationship_form_modal.dart';
-import 'package:lotti/features/tasks/ui/linked_tasks/task_search_picker_body.dart';
-import 'package:lotti/features/tasks/ui/utils.dart';
+import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
-import 'package:lotti/logic/create/create_entry.dart';
+import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/widgets/modal/confirmation_modal.dart';
-import 'package:lotti/widgets/modal/modal_utils.dart';
-import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
 import 'package:material_ui/material_ui.dart';
 
-/// One person's page: header (name, status, importance, cadence) and the
-/// check-in log, newest first, with a log-check-in FAB. The app bar carries
-/// edit and delete actions; tapping a check-in opens it for editing.
+/// One person's page (design 2026-09-06 §2–3), a sibling of the task page:
+/// the cover-style hero with the header actions, the header block with the
+/// cadence fact and the health band as pills, then the section cards in the
+/// design's order — Briefing · Next time · Check-ins · Reach · Tasks — above
+/// the sticky action bar (Log check-in · mic · the actionable channel).
+///
+/// On the desktop split the same page fills the detail pane, with every
+/// section on one centred reading column. Deleting cascades through the
+/// repository, the agent and the reminder (the same three legs as before).
 class RelationshipDetailsPage extends ConsumerWidget {
   const RelationshipDetailsPage({required this.relationshipId, super.key});
 
@@ -115,6 +119,17 @@ class RelationshipDetailsPage extends ConsumerWidget {
     }
   }
 
+  /// Leaves the page. On a phone the page was pushed and pops; on the
+  /// desktop split it is the detail pane, and leaving means clearing the
+  /// selection so the list stands alone again.
+  void _back(BuildContext context) {
+    if (isDesktopLayout(context)) {
+      beamToNamed('/people');
+      return;
+    }
+    Navigator.of(context).maybePop();
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tokens = context.designTokens;
@@ -146,579 +161,121 @@ class RelationshipDetailsPage extends ConsumerWidget {
     final relationship = detail.relationship;
     final checkIns = detail.checkIns;
     final data = relationship.data;
+    final latest = checkIns.firstOrNull;
+    final item = (relationship: relationship, lastCheckIn: latest);
+    final categoryId = relationship.meta.categoryId;
+    final categoryName = categoryId == null
+        ? null
+        : getIt<EntitiesCacheService>().getCategoryById(categoryId)?.name;
+
+    // The standing briefing, read here as well as in the card: the header's
+    // band pill and the card's chip must agree on whether one exists.
+    final report = currentRelationshipReport(
+      ref
+          .watch(agentReportProvider(relationshipAgentIdFor(relationshipId)))
+          .value,
+    );
+    final healthBand = report == null
+        ? null
+        : relationshipHealthMetricsFromReport(report)?.band;
+    // The card renders nothing for someone not enrolled and never briefed;
+    // the gap that would follow it has to know that too.
+    final showBriefing = report != null || data.important;
+
+    final sections = <Widget>[
+      PersonHeaderBlock(
+        item: item,
+        categoryName: categoryName,
+        healthBand: healthBand,
+      ),
+      if (showBriefing) RelationshipBriefingCard(relationship: relationship),
+      if (NextTimeCard.hasContent(latest)) NextTimeCard(latest: latest),
+    ];
 
     return Scaffold(
-      // The page's primary action, so it wears the interactive accent every
-      // other create-here FAB in the app wears — Material's default
-      // `FloatingActionButton` painted it in the theme's secondary container
-      // instead, which read as a neutral pill beside the teal used for
-      // "Link task" a few rows below it.
-      floatingActionButton: DesignSystemBottomNavigationFabPadding(
-        child: DesignSystemFloatingActionButton(
-          key: const ValueKey('relationship-log-check-in-fab'),
-          semanticLabel: context.messages.relationshipLogCheckIn,
-          label: context.messages.relationshipLogCheckIn,
-          icon: LottiIcons.greeting,
-          onPressed: () => showCheckInCaptureSheet(
-            context: context,
-            relationshipId: relationshipId,
-          ),
+      backgroundColor: tokens.colors.background.level01,
+      // extendBody so the glass strip's BackdropFilter has body content
+      // underneath to blur; the Scaffold reserves the bar's height as the
+      // body's bottom inset, consumed by the trailing spacer below.
+      extendBody: true,
+      bottomNavigationBar: RelationshipActionBar(
+        relationship: relationship,
+        onLogCheckIn: () => showCheckInCaptureSheet(
+          context: context,
+          relationshipId: relationshipId,
+        ),
+        onSpeak: () => showCheckInCaptureSheet(
+          context: context,
+          relationshipId: relationshipId,
+          startSpeaking: true,
         ),
       ),
-      body: SafeArea(
-        child: CustomScrollView(
-          slivers: [
-            SliverAppBar(
-              pinned: true,
-              title: Text(data.title),
-              actions: [
-                if (data.important)
-                  Icon(
-                    LottiIcons.star,
-                    color: tokens.colors.interactive.enabled,
-                  ),
-                // Renders nothing on desktop, where channels are typed by
-                // hand (plan v2 phase 7 item 2).
-                ContactLinkAction(relationship: relationship),
-                IconButton(
-                  tooltip: context.messages.relationshipEditTitle,
-                  onPressed: () => showRelationshipEditModal(
-                    context: context,
-                    relationship: relationship,
-                  ),
-                  icon: const Icon(LottiIcons.edit),
-                ),
-                IconButton(
-                  tooltip: context.messages.deleteButton,
-                  onPressed: () => _handleDelete(context, ref, relationship),
-                  icon: const Icon(LottiIcons.delete),
-                ),
-              ],
-            ),
-            SliverPadding(
-              padding: EdgeInsets.fromLTRB(
-                tokens.spacing.step5,
-                tokens.spacing.step5,
-                tokens.spacing.step5,
-                tokens.spacing.step5 +
-                    DesignSystemBottomNavigationBar.occupiedHeight(context) +
-                    tokens.spacing.step12,
+      // Builder so MediaQuery.paddingOf reads the Scaffold-modified value.
+      body: Builder(
+        builder: (context) {
+          // Every section — and the check-in log, which is a sliver and so
+          // cannot sit inside `DetailContentWidth` — on the one reading
+          // column that widget gives boxed content.
+          final insets = detailContentInsets(context);
+          final bottomInset = MediaQuery.paddingOf(context).bottom;
+          final gap = SizedBox(height: tokens.spacing.sectionGap);
+          return CustomScrollView(
+            slivers: [
+              PersonHeroAppBar(
+                relationship: relationship,
+                contentInset: insets.left,
+                onBack: () => _back(context),
+                onTalkToAgent: () =>
+                    beamToNamed('/people/$relationshipId/chat'),
+                onDelete: () => _handleDelete(context, ref, relationship),
               ),
-              // The fixed sections stay in a list delegate; the check-in log
-              // grows without bound and renders lazily in its own builder
-              // sliver (the project-detail split: fixed sections + a builder
-              // list for the unbounded part).
-              sliver: SliverMainAxisGroup(
-                slivers: [
-                  SliverList(
-                    delegate: SliverChildListDelegate([
-                      _RelationshipHeader(data: data),
-                      SizedBox(height: tokens.spacing.sectionGap),
-                      // Above the briefing: returning from a call the user
-                      // just placed, the offer to log it is the most
-                      // time-sensitive thing on the page (plan v2 phase 7
-                      // item 5). Renders nothing the rest of the time.
-                      const PostInteractionPrompt(),
-                      // The executive briefing directly under the header —
-                      // the agent's standing voice on this page (plan v2
-                      // phase 5).
-                      RelationshipBriefingCard(relationship: relationship),
-                      if (data.contactChannels.isNotEmpty) ...[
-                        SizedBox(height: tokens.spacing.sectionGap),
-                        _SectionHeading(
-                          context.messages.relationshipContactChannelsLabel,
-                        ),
-                        SizedBox(height: tokens.spacing.step3),
-                        for (final channel in data.contactChannels)
-                          _ContactChannelRow(
-                            relationshipId: relationshipId,
-                            channel: channel,
-                          ),
-                      ],
-                      SizedBox(height: tokens.spacing.sectionGap),
-                      _LinkedTasksSection(
+              SliverPadding(
+                padding: insets,
+                sliver: SliverList(
+                  delegate: SliverChildListDelegate([
+                    for (final section in sections) ...[section, gap],
+                    // Renders nothing until the user comes back from a
+                    // call placed on this page; then it is the most
+                    // time-sensitive thing here, directly above the log
+                    // it offers to extend.
+                    const PostInteractionPrompt(),
+                  ]),
+                ),
+              ),
+              // The log grows without bound and renders lazily in its own
+              // sliver, inside the card decoration the boxed sections wear.
+              SliverPadding(
+                padding: insets,
+                sliver: CheckInsCardSliver(
+                  checkIns: checkIns,
+                  onOpen: (checkIn) =>
+                      showCheckInEditSheet(context: context, checkIn: checkIn),
+                ),
+              ),
+              SliverPadding(
+                padding: insets,
+                sliver: SliverList(
+                  delegate: SliverChildListDelegate([
+                    gap,
+                    if (data.contactChannels.isNotEmpty) ...[
+                      ReachCard(
                         relationshipId: relationshipId,
-                        tasks: detail.linkedTasks,
-                        categoryId: relationship.meta.categoryId,
+                        channels: data.contactChannels,
                       ),
-                      SizedBox(height: tokens.spacing.sectionGap),
-                      _SectionHeading(
-                        context.messages.relationshipCheckInsLabel,
-                      ),
-                      SizedBox(height: tokens.spacing.step3),
-                      if (checkIns.isEmpty)
-                        Text(
-                          context.messages.relationshipNoCheckIns,
-                          style: tokens.typography.styles.body.bodyMedium
-                              .copyWith(
-                                color: tokens.colors.text.mediumEmphasis,
-                              ),
-                        ),
-                    ]),
-                  ),
-                  if (checkIns.isNotEmpty)
-                    SliverList.separated(
-                      itemCount: checkIns.length,
-                      separatorBuilder: (_, _) =>
-                          SizedBox(height: tokens.spacing.cardItemSpacing),
-                      itemBuilder: (context, index) =>
-                          _CheckInRow(checkIn: checkIns[index]),
+                      gap,
+                    ],
+                    LinkedTasksCard(
+                      relationshipId: relationshipId,
+                      tasks: detail.linkedTasks,
+                      categoryId: categoryId,
                     ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _RelationshipHeader extends StatelessWidget {
-  const _RelationshipHeader({required this.data});
-
-  final RelationshipData data;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    final cadenceDays = data.checkInCadenceDays;
-
-    Widget chip(String label, IconData icon) => Chip(
-      avatar: Icon(icon, size: tokens.spacing.step4),
-      label: Text(label),
-      labelStyle: tokens.typography.styles.body.bodySmall.copyWith(
-        color: tokens.colors.text.mediumEmphasis,
-      ),
-    );
-
-    return Wrap(
-      spacing: tokens.spacing.step3,
-      runSpacing: tokens.spacing.step3,
-      children: [
-        chip(
-          relationshipStatusLabel(context, data.status),
-          LottiIcons.radioUnselected,
-        ),
-        if (cadenceDays != null)
-          chip(
-            relationshipCadenceLabel(context, cadenceDays),
-            LottiIcons.refresh,
-          ),
-        if (data.nickname != null) chip(data.nickname!, LottiIcons.moodGood),
-      ],
-    );
-  }
-}
-
-class _SectionHeading extends StatelessWidget {
-  const _SectionHeading(this.title);
-
-  final String title;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    return Text(
-      title,
-      style: tokens.typography.styles.subtitle.subtitle2.copyWith(
-        color: tokens.colors.text.highEmphasis,
-      ),
-    );
-  }
-}
-
-class _ContactChannelRow extends StatelessWidget {
-  const _ContactChannelRow({
-    required this.relationshipId,
-    required this.channel,
-  });
-
-  final String relationshipId;
-  final ContactChannel channel;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    final label = channel.label;
-
-    return ListTile(
-      dense: true,
-      contentPadding: EdgeInsets.zero,
-      leading: Icon(
-        contactChannelTypeIcon(channel.type),
-        color: tokens.colors.text.mediumEmphasis,
-      ),
-      title: Text(
-        channel.value,
-        style: tokens.typography.styles.body.bodyMedium.copyWith(
-          color: tokens.colors.text.highEmphasis,
-        ),
-      ),
-      subtitle: Text(
-        label == null || label.isEmpty
-            ? contactChannelTypeLabel(context, channel.type)
-            : label,
-        style: tokens.typography.styles.body.bodySmall.copyWith(
-          color: tokens.colors.text.lowEmphasis,
-        ),
-      ),
-      // Renders nothing until the platform confirms it can service an
-      // action, and nothing at all for a channel with no launchable scheme
-      // (plan v2 phase 7 item 4).
-      trailing: ContactQuickActions(
-        relationshipId: relationshipId,
-        channel: channel,
-      ),
-    );
-  }
-}
-
-/// Tasks linked to this person, with a picker to link more and per-row
-/// unlinking (plan v2 phase 2 item 3 — `RelationshipLink` both ways).
-class _LinkedTasksSection extends ConsumerWidget {
-  const _LinkedTasksSection({
-    required this.relationshipId,
-    required this.tasks,
-    this.categoryId,
-  });
-
-  final String relationshipId;
-  final List<Task> tasks;
-
-  /// The person's category, inherited by a task created from their picker so
-  /// it lands in the same life area the person does.
-  final String? categoryId;
-
-  /// Links [taskId] to this person.
-  ///
-  /// Answers false for a write that changed no row *and* for one that threw:
-  /// both mean the link the user asked for does not exist, and the caller —
-  /// which knows whether there is still a page to say so on — decides how to
-  /// report it.
-  Future<bool> _linkTask(
-    RelationshipRepository repository,
-    String taskId,
-  ) async {
-    try {
-      return await repository.linkTask(
-        relationshipId: relationshipId,
-        taskId: taskId,
-      );
-    } catch (error, stackTrace) {
-      developer.log(
-        'Failed to link task to relationship',
-        name: 'RelationshipDetailsPage',
-        error: error,
-        stackTrace: stackTrace,
-      );
-      return false;
-    }
-  }
-
-  /// Creates a task titled after the picker's query, for the person whose
-  /// page this is.
-  ///
-  /// Answering "there is no such task yet" without leaving the page: the
-  /// picker offers this on a search that matches nothing, and feeds whatever
-  /// comes back through its own pick callback — so creating and linking stay
-  /// the one path [_pickTask] already owns, error toast and all. The one
-  /// case that path cannot serve is a picker dismissed mid-write, handled
-  /// below.
-  ///
-  /// No `linkedId`: that writes a plain link, and this page writes its own
-  /// relationship-typed edge a moment later. `inheritContextFrom` carries the
-  /// one thing that must travel — a private person's task is private too —
-  /// without leaving a second edge to unpick.
-  Future<Task?> _createTask({
-    required BuildContext pageContext,
-    required BuildContext modalContext,
-    required WidgetRef ref,
-    required String title,
-  }) async {
-    // Read before the await: persistence can outlive the sheet, and a
-    // post-gap read on a disposed ref would strand a task already written.
-    final agentService = ref.read(taskAgentServiceProvider);
-    final repository = ref.read(relationshipRepositoryProvider);
-
-    Task? created;
-    try {
-      created = await createTask(
-        title: title,
-        categoryId: categoryId,
-        inheritContextFrom: relationshipId,
-      );
-    } catch (error, stackTrace) {
-      developer.log(
-        'Failed to create a task for the relationship',
-        name: 'RelationshipDetailsPage',
-        error: error,
-        stackTrace: stackTrace,
-      );
-    }
-    // Nothing was written. The picker stays open on the query that failed,
-    // which says more than a toast would: a snack bar raised from here is
-    // hosted by the page's messenger and renders *behind* the modal route it
-    // would be explaining.
-    if (created == null) return null;
-
-    // The same follow-up every other create flow performs, so a task created
-    // here is not the one left without its category's agent.
-    unawaited(autoAssignCategoryAgentWith(agentService, created));
-
-    if (modalContext.mounted) return created;
-
-    // Dismissed while the write was in flight. The task exists and the user
-    // asked for it to be linked, so handing back null here would leave it
-    // created, unlinked and unannounced — visible only as a stray row in the
-    // task list. Link it on the dependencies captured before the gap.
-    final linked = await _linkTask(repository, created.meta.id);
-    if (!linked && pageContext.mounted) {
-      pageContext.showToast(
-        tone: DesignSystemToastTone.error,
-        title: pageContext.messages.relationshipErrorLinkTaskFailed,
-      );
-    }
-    return null;
-  }
-
-  Future<void> _pickTask(BuildContext context, WidgetRef ref) async {
-    final repository = ref.read(relationshipRepositoryProvider);
-    final linkedIds = {for (final task in tasks) task.meta.id};
-
-    await ModalUtils.showSinglePageModal<void>(
-      context: context,
-      title: context.messages.relationshipLinkTaskButton,
-      padding: EdgeInsets.zero,
-      builder: (modalContext) => Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Flexible(
-            child: TaskSearchPickerBody(
-              excludeIds: {relationshipId, ...linkedIds},
-              onCreateTask: (title) => _createTask(
-                pageContext: context,
-                modalContext: modalContext,
-                ref: ref,
-                title: title,
-              ),
-              onTaskSelected: (task) async {
-                final linked = await _linkTask(repository, task.meta.id);
-                if (!modalContext.mounted) return;
-                Navigator.of(modalContext).pop();
-                // `createLink` answers false when the upsert changed no row,
-                // so a silent close would read as a link that worked.
-                if (!linked && context.mounted) {
-                  context.showToast(
-                    tone: DesignSystemToastTone.error,
-                    title: context.messages.relationshipErrorLinkTaskFailed,
-                  );
-                }
-              },
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Future<void> _unlinkTask(
-    BuildContext context,
-    WidgetRef ref,
-    Task task,
-  ) async {
-    final confirmed = await showConfirmationModal(
-      context: context,
-      message: context.messages.unlinkTaskConfirmNamed(
-        task.data.title.isEmpty
-            ? context.messages.taskUntitled
-            : task.data.title,
-      ),
-      confirmLabel: context.messages.unlinkTaskTitle,
-    );
-    if (!confirmed || !context.mounted) return;
-
-    try {
-      final removed = await ref
-          .read(relationshipRepositoryProvider)
-          .unlinkTask(relationshipId: relationshipId, taskId: task.meta.id);
-      if (!removed && context.mounted) {
-        context.showToast(
-          tone: DesignSystemToastTone.error,
-          title: context.messages.unlinkTaskFailedMessage,
-        );
-      }
-    } catch (error, stackTrace) {
-      developer.log(
-        'Failed to unlink task from relationship',
-        name: 'RelationshipDetailsPage',
-        error: error,
-        stackTrace: stackTrace,
-      );
-      if (context.mounted) {
-        context.showToast(
-          tone: DesignSystemToastTone.error,
-          title: context.messages.unlinkTaskFailedMessage,
-        );
-      }
-    }
-  }
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final tokens = context.designTokens;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            Expanded(
-              child: _SectionHeading(
-                context.messages.relationshipLinkedTasksLabel,
-              ),
-            ),
-            TextButton.icon(
-              onPressed: () => _pickTask(context, ref),
-              icon: const Icon(LottiIcons.link),
-              label: Text(context.messages.relationshipLinkTaskButton),
-            ),
-          ],
-        ),
-        if (tasks.isEmpty)
-          Text(
-            context.messages.relationshipNoLinkedTasks,
-            style: tokens.typography.styles.body.bodyMedium.copyWith(
-              color: tokens.colors.text.mediumEmphasis,
-            ),
-          )
-        else
-          for (final task in tasks)
-            ListTile(
-              dense: true,
-              contentPadding: EdgeInsets.zero,
-              leading: Icon(
-                LottiIcons.confirmCircled,
-                color: tokens.colors.text.mediumEmphasis,
-              ),
-              title: Text(
-                task.data.title.isEmpty
-                    ? context.messages.taskUntitled
-                    : task.data.title,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: tokens.typography.styles.body.bodyMedium.copyWith(
-                  color: tokens.colors.text.highEmphasis,
+                    SizedBox(height: bottomInset + tokens.spacing.sectionGap),
+                  ]),
                 ),
               ),
-              subtitle: Text(
-                taskLabelFromStatusString(
-                  task.data.status.toDbString,
-                  context,
-                ),
-                style: tokens.typography.styles.body.bodySmall.copyWith(
-                  color: tokens.colors.text.lowEmphasis,
-                ),
-              ),
-              trailing: IconButton(
-                tooltip: context.messages.unlinkTaskTitle,
-                onPressed: () => _unlinkTask(context, ref, task),
-                icon: const Icon(LottiIcons.linkOff),
-              ),
-              onTap: () => beamToNamed('/tasks/${task.meta.id}'),
-            ),
-      ],
-    );
-  }
-}
-
-class _CheckInRow extends StatelessWidget {
-  const _CheckInRow({required this.checkIn});
-
-  final CheckInEntry checkIn;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    final data = checkIn.data;
-    final narrative = checkIn.entryText?.plainText.trim();
-    final sentiment = data.sentiment;
-
-    return Card(
-      margin: EdgeInsets.zero,
-      clipBehavior: Clip.antiAlias,
-      child: InkWell(
-        onTap: () => showCheckInEditSheet(context: context, checkIn: checkIn),
-        child: Padding(
-          padding: EdgeInsets.all(tokens.spacing.cardPadding),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Icon(
-                    checkInInteractionIcon(data.interactionType),
-                    color: tokens.colors.text.mediumEmphasis,
-                  ),
-                  SizedBox(width: tokens.spacing.step3),
-                  Expanded(
-                    child: Text(
-                      checkInInteractionLabel(context, data.interactionType),
-                      style: tokens.typography.styles.body.bodyMedium.copyWith(
-                        color: tokens.colors.text.highEmphasis,
-                      ),
-                    ),
-                  ),
-                  Text(
-                    entryDateLabel(context, checkIn.meta.dateFrom),
-                    style: tokens.typography.styles.body.bodySmall.copyWith(
-                      color: tokens.colors.text.lowEmphasis,
-                    ),
-                  ),
-                ],
-              ),
-              if (sentiment != null) ...[
-                SizedBox(height: tokens.spacing.step3),
-                Text(
-                  checkInSentimentLabel(context, sentiment),
-                  style: tokens.typography.styles.body.bodySmall.copyWith(
-                    color: tokens.colors.text.mediumEmphasis,
-                  ),
-                ),
-              ],
-              if (narrative != null && narrative.isNotEmpty) ...[
-                SizedBox(height: tokens.spacing.step3),
-                Text(
-                  narrative,
-                  style: tokens.typography.styles.body.bodyMedium.copyWith(
-                    color: tokens.colors.text.mediumEmphasis,
-                  ),
-                ),
-              ],
-              if (data.topics.isNotEmpty) ...[
-                SizedBox(height: tokens.spacing.step3),
-                // Topics are this check-in's tags, so they wear the tag
-                // pill the rest of the app spends on labels — the tight
-                // `radii.xs` corner that says "read-out, not button".
-                Wrap(
-                  spacing: tokens.spacing.step2,
-                  runSpacing: tokens.spacing.step2,
-                  children: [
-                    for (final topic in data.topics)
-                      DsPill(
-                        variant: DsPillVariant.filled,
-                        shape: DsPillShape.tag,
-                        bordered: true,
-                        label: topic,
-                        labelColor: tokens.colors.text.mediumEmphasis,
-                      ),
-                  ],
-                ),
-              ],
             ],
-          ),
-        ),
+          );
+        },
       ),
     );
   }

--- a/lib/features/relationships/ui/pages/relationships_page.dart
+++ b/lib/features/relationships/ui/pages/relationships_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
-import 'package:lotti/features/design_system/components/headers/tab_section_header.dart';
 import 'package:lotti/features/design_system/components/navigation/desktop_detail_empty_state.dart';
 import 'package:lotti/features/design_system/components/navigation/resizable_divider.dart';
 import 'package:lotti/features/design_system/state/pane_width_controller.dart';
@@ -90,8 +89,10 @@ class RelationshipsPage extends ConsumerWidget {
               maxValue: maxListPaneWidth,
               onDrag: resolvedListPane.onDrag,
             ),
+            // The page carries its own show-list-pane control in the hero
+            // while the list is folded away, so nothing is overlaid here.
             detailPane: selectedId != null
-                ? _PeopleDetailPane(
+                ? RelationshipDetailsPage(
                     key: ValueKey(selectedId),
                     relationshipId: selectedId,
                   )
@@ -102,44 +103,6 @@ class RelationshipsPage extends ConsumerWidget {
           );
         },
       ),
-    );
-  }
-}
-
-/// The desktop detail pane: the person's page, plus the show-list-pane
-/// button while the list is folded away (the Projects pane's shape).
-class _PeopleDetailPane extends StatelessWidget {
-  const _PeopleDetailPane({required this.relationshipId, super.key});
-
-  final String relationshipId;
-
-  @override
-  Widget build(BuildContext context) {
-    final splitController = ListDetailFocusTraversal.maybeOf(context);
-    final tokens = context.designTokens;
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        RelationshipDetailsPage(relationshipId: relationshipId),
-        if (splitController?.listPaneVisible == false)
-          SafeArea(
-            child: Align(
-              alignment: Alignment.topLeft,
-              child: Padding(
-                padding: EdgeInsets.only(
-                  left: tokens.spacing.step5,
-                  top: tokens.spacing.step4,
-                ),
-                child: TabHeaderIconButton(
-                  key: const ValueKey('people-show-list-pane'),
-                  icon: LottiIcons.sidebar,
-                  tooltip: context.messages.listPaneShowTooltip,
-                  onPressed: splitController!.showListPane,
-                ),
-              ),
-            ),
-          ),
-      ],
     );
   }
 }

--- a/lib/features/relationships/ui/shared/relationship_timestamps.dart
+++ b/lib/features/relationships/ui/shared/relationship_timestamps.dart
@@ -100,6 +100,24 @@ String relationshipDayLabelOf(BuildContext context, DateTime at) =>
       locale: Localizations.localeOf(context).toString(),
     );
 
+/// A mono duration read-out for a check-in (`11 min`, `1 h`, `1 h 30`), or
+/// null for a check-in that has no duration — a message usually has none,
+/// and the row must then say nothing rather than `0 min`.
+String? relationshipDurationLabelOf(BuildContext context, Duration duration) {
+  final minutes = duration.inMinutes;
+  // Under a minute is not a duration worth a label — and never "0 min".
+  if (minutes <= 0) return null;
+  final messages = context.messages;
+  if (minutes < 60) return messages.relationshipDurationMinutes(minutes);
+  final hours = minutes ~/ 60;
+  final rest = minutes % 60;
+  if (rest == 0) return messages.relationshipDurationHours(hours);
+  return messages.relationshipDurationHoursMinutes(
+    hours,
+    rest.toString().padLeft(2, '0'),
+  );
+}
+
 /// A mono weekday-only label (`Thu`), used by the cadence due pill, in the
 /// locale's own abbreviation.
 String relationshipWeekdayLabel(DateTime at, {String? locale}) =>

--- a/lib/features/relationships/ui/widgets/check_in_capture_sheet.dart
+++ b/lib/features/relationships/ui/widgets/check_in_capture_sheet.dart
@@ -126,6 +126,7 @@ Future<CheckInEntry?> showCheckInCaptureSheet({
   required String relationshipId,
   CheckInInteractionType? prefilledInteractionType,
   DateTime? prefilledTime,
+  Duration? prefilledDuration,
   bool startSpeaking = false,
 }) {
   return ModalUtils.showSinglePageModal<CheckInEntry>(
@@ -135,6 +136,7 @@ Future<CheckInEntry?> showCheckInCaptureSheet({
       relationshipId: relationshipId,
       prefilledInteractionType: prefilledInteractionType,
       prefilledTime: prefilledTime,
+      prefilledDuration: prefilledDuration,
       startSpeaking: startSpeaking,
     ),
   );
@@ -166,6 +168,7 @@ class CheckInCaptureForm extends ConsumerStatefulWidget {
     this.initial,
     this.prefilledInteractionType,
     this.prefilledTime,
+    this.prefilledDuration,
     this.startSpeaking = false,
     super.key,
   });
@@ -183,6 +186,13 @@ class CheckInCaptureForm extends ConsumerStatefulWidget {
   /// Starting interaction time for a new check-in — when the call was
   /// actually placed, rather than when the user got round to logging it.
   final DateTime? prefilledTime;
+
+  /// How long the interaction lasted, when the caller already knows — the
+  /// post-call offer's elapsed time. Persisted as the check-in's end time
+  /// (`dateTo − dateFrom` is the duration; no schema change), so the
+  /// duration the offer quoted is the one the log shows. Ignored while
+  /// editing, where the existing check-in's own length is kept.
+  final Duration? prefilledDuration;
 
   /// Opens straight into a spoken check-in: the page's mic doorway, which
   /// means "say it" rather than "show me the form". The recording sheet is
@@ -202,6 +212,11 @@ class _CheckInCaptureFormState extends ConsumerState<CheckInCaptureForm> {
   late CheckInInteractionType _interactionType;
   late CheckInSentiment? _sentiment;
   late DateTime _interactionTime;
+
+  /// The check-in's length; zero means "no duration". Kept across a change
+  /// of the start time so editing when a call began does not erase how
+  /// long it ran.
+  late Duration _duration;
   bool _isSaving = false;
   bool _isTranscribing = false;
 
@@ -217,6 +232,12 @@ class _CheckInCaptureFormState extends ConsumerState<CheckInCaptureForm> {
   ProviderSubscription<String?>? _transcriptFailureSubscription;
 
   bool get _isEditing => widget.initial != null;
+
+  /// An existing check-in's length, or null when there is none to keep.
+  static Duration? _lengthOf(CheckInEntry? entry) {
+    if (entry == null) return null;
+    return entry.meta.dateTo.difference(entry.meta.dateFrom);
+  }
 
   @override
   void initState() {
@@ -243,6 +264,9 @@ class _CheckInCaptureFormState extends ConsumerState<CheckInCaptureForm> {
     _sentiment = data?.sentiment;
     _interactionTime =
         initial?.meta.dateFrom ?? widget.prefilledTime ?? clock.now();
+    final length =
+        _lengthOf(initial) ?? widget.prefilledDuration ?? Duration.zero;
+    _duration = length.isNegative ? Duration.zero : length;
     if (widget.startSpeaking) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) unawaited(_handleSpeak());
@@ -440,7 +464,7 @@ class _CheckInCaptureFormState extends ConsumerState<CheckInCaptureForm> {
           entryText: entryText,
           meta: initial.meta.copyWith(
             dateFrom: _interactionTime,
-            dateTo: _interactionTime,
+            dateTo: _interactionTime.add(_duration),
           ),
         );
         final success = await repository.updateCheckIn(updated);
@@ -458,6 +482,7 @@ class _CheckInCaptureFormState extends ConsumerState<CheckInCaptureForm> {
           data: data,
           entryText: entryText,
           dateFrom: _interactionTime,
+          dateTo: _interactionTime.add(_duration),
         );
         if (!mounted) return;
         if (created != null) {

--- a/lib/features/relationships/ui/widgets/check_in_capture_sheet.dart
+++ b/lib/features/relationships/ui/widgets/check_in_capture_sheet.dart
@@ -220,6 +220,12 @@ class _CheckInCaptureFormState extends ConsumerState<CheckInCaptureForm> {
   bool _isSaving = false;
   bool _isTranscribing = false;
 
+  /// Set synchronously the moment a spoken check-in starts and cleared once
+  /// the whole flow has ended, so the page's mic (`startSpeaking`) and a
+  /// press on *Speak* during the pre-flight awaits cannot open the recorder
+  /// twice. [_isTranscribing] only covers the wait that follows a recording.
+  bool _isSpeaking = false;
+
   /// The in-flight transcript wait, so dismissing the sheet stops it instead
   /// of leaving a database listener running out the timeout.
   CheckInTranscriptWait? _transcriptWait;
@@ -333,8 +339,18 @@ class _CheckInCaptureFormState extends ConsumerState<CheckInCaptureForm> {
   /// automatic-inference switch: this is a gesture, so it only needs a model,
   /// not the consent gate that governs unattended runs.
   Future<void> _handleSpeak() async {
-    if (_isSaving || _isTranscribing) return;
+    if (_isSaving || _isTranscribing || _isSpeaking) return;
+    setState(() => _isSpeaking = true);
+    try {
+      await _speak();
+    } finally {
+      // Whatever ended the flow — a refused pre-flight, a cancelled
+      // recording, a transcript, an error — the button comes back.
+      if (mounted) setState(() => _isSpeaking = false);
+    }
+  }
 
+  Future<void> _speak() async {
     // Every provider is read up front: each `await` below can outlive this
     // widget, and reading through `ref` after that throws.
     final messages = context.messages;
@@ -655,7 +671,9 @@ class _CheckInCaptureFormState extends ConsumerState<CheckInCaptureForm> {
             variant: DesignSystemButtonVariant.outlined,
             leadingIcon: LottiIcons.mic,
             isLoading: _isTranscribing,
-            onPressed: _isSaving || _isTranscribing ? null : _handleSpeak,
+            onPressed: _isSaving || _isTranscribing || _isSpeaking
+                ? null
+                : _handleSpeak,
           ),
         ),
         SizedBox(height: tokens.spacing.step5),

--- a/lib/features/relationships/ui/widgets/check_in_capture_sheet.dart
+++ b/lib/features/relationships/ui/widgets/check_in_capture_sheet.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:clock/clock.dart';
@@ -125,6 +126,7 @@ Future<CheckInEntry?> showCheckInCaptureSheet({
   required String relationshipId,
   CheckInInteractionType? prefilledInteractionType,
   DateTime? prefilledTime,
+  bool startSpeaking = false,
 }) {
   return ModalUtils.showSinglePageModal<CheckInEntry>(
     context: context,
@@ -133,6 +135,7 @@ Future<CheckInEntry?> showCheckInCaptureSheet({
       relationshipId: relationshipId,
       prefilledInteractionType: prefilledInteractionType,
       prefilledTime: prefilledTime,
+      startSpeaking: startSpeaking,
     ),
   );
 }
@@ -163,6 +166,7 @@ class CheckInCaptureForm extends ConsumerStatefulWidget {
     this.initial,
     this.prefilledInteractionType,
     this.prefilledTime,
+    this.startSpeaking = false,
     super.key,
   });
 
@@ -179,6 +183,12 @@ class CheckInCaptureForm extends ConsumerStatefulWidget {
   /// Starting interaction time for a new check-in — when the call was
   /// actually placed, rather than when the user got round to logging it.
   final DateTime? prefilledTime;
+
+  /// Opens straight into a spoken check-in: the page's mic doorway, which
+  /// means "say it" rather than "show me the form". The recording sheet is
+  /// launched after the first frame; everything else about the form is
+  /// unchanged, and cancelling the recording leaves the form as it was.
+  final bool startSpeaking;
 
   @override
   ConsumerState<CheckInCaptureForm> createState() => _CheckInCaptureFormState();
@@ -233,6 +243,11 @@ class _CheckInCaptureFormState extends ConsumerState<CheckInCaptureForm> {
     _sentiment = data?.sentiment;
     _interactionTime =
         initial?.meta.dateFrom ?? widget.prefilledTime ?? clock.now();
+    if (widget.startSpeaking) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) unawaited(_handleSpeak());
+      });
+    }
   }
 
   @override

--- a/lib/features/relationships/ui/widgets/check_ins_card.dart
+++ b/lib/features/relationships/ui/widgets/check_ins_card.dart
@@ -1,0 +1,213 @@
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/design_system/components/cards/design_system_section_card.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/relationships/ui/shared/relationship_timestamps.dart';
+import 'package:lotti/features/relationships/ui/shared/sentiment.dart';
+import 'package:lotti/features/relationships/ui/widgets/check_in_capture_sheet.dart';
+import 'package:lotti/features/relationships/ui/widgets/person_page_cards.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:material_ui/material_ui.dart';
+
+/// The Check-ins section of the person page (design 2026-09-06 §3): one
+/// section card holding the log, newest first — a count beside the title,
+/// one [CheckInRow] per check-in, or the empty hint.
+///
+/// A sliver rather than a box because the log grows without bound: the
+/// rows render lazily inside the card's decoration, the same split the
+/// project page makes between its fixed sections and its list. The card's
+/// surface is [DesignSystemSectionCard.decoration], so it is
+/// indistinguishable from the boxed cards above and below it.
+class CheckInsCardSliver extends StatelessWidget {
+  const CheckInsCardSliver({
+    required this.checkIns,
+    required this.onOpen,
+    super.key,
+  });
+
+  /// Newest first, as the repository hands them over.
+  final List<CheckInEntry> checkIns;
+
+  /// Opens one check-in for editing.
+  final ValueChanged<CheckInEntry> onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    final inset = tokens.spacing.step5;
+
+    return DecoratedSliver(
+      key: const ValueKey('person-check-ins-card'),
+      decoration: DesignSystemSectionCard.decoration(tokens),
+      sliver: SliverPadding(
+        padding: EdgeInsets.all(inset),
+        sliver: SliverMainAxisGroup(
+          slivers: [
+            SliverToBoxAdapter(
+              child: PersonCardHeader(
+                title: messages.relationshipCheckInsLabel,
+                caption: checkIns.isEmpty
+                    ? null
+                    : DsPill(
+                        key: const ValueKey('person-check-ins-count'),
+                        variant: DsPillVariant.filled,
+                        shape: DsPillShape.tag,
+                        labelColor: tokens.colors.text.mediumEmphasis,
+                        label: '${checkIns.length}',
+                      ),
+              ),
+            ),
+            if (checkIns.isEmpty)
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: EdgeInsets.only(top: tokens.spacing.step3),
+                  child: Text(
+                    messages.relationshipNoCheckIns,
+                    style: tokens.typography.styles.body.bodyMedium.copyWith(
+                      color: tokens.colors.text.mediumEmphasis,
+                    ),
+                  ),
+                ),
+              )
+            else
+              SliverList.separated(
+                itemCount: checkIns.length,
+                separatorBuilder: (_, _) =>
+                    Divider(height: 1, color: tokens.colors.decorative.level01),
+                itemBuilder: (context, index) {
+                  final checkIn = checkIns[index];
+                  return CheckInRow(
+                    key: ValueKey('check-in-row-${checkIn.meta.id}'),
+                    checkIn: checkIn,
+                    onTap: () => onOpen(checkIn),
+                  );
+                },
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// One check-in in the log: the interaction glyph in a circle, a mono meta
+/// line (`Today 12:44 · Call · 11 min`) beside the tinted sentiment pill,
+/// the narrative, and the topics as tag pills. The text keeps the row's
+/// width: the glyph column is the only thing beside it.
+class CheckInRow extends StatelessWidget {
+  const CheckInRow({required this.checkIn, required this.onTap, super.key});
+
+  final CheckInEntry checkIn;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final data = checkIn.data;
+    final narrative = checkIn.entryText?.plainText.trim();
+    final sentiment = data.sentiment;
+    final duration = relationshipDurationLabelOf(
+      context,
+      checkIn.meta.dateTo.difference(checkIn.meta.dateFrom),
+    );
+    final meta = [
+      relationshipTimestampLabelOf(context, checkIn.meta.dateFrom),
+      checkInInteractionLabel(context, data.interactionType),
+      ?duration,
+    ].join(' · ');
+
+    // The row supplies its own ink surface: inside a sliver there is no
+    // section-card Material above it to draw the press on.
+    return Material(
+      type: MaterialType.transparency,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: EdgeInsets.symmetric(vertical: tokens.spacing.step4),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: tokens.spacing.step8,
+                height: tokens.spacing.step8,
+                decoration: BoxDecoration(
+                  color: tokens.colors.background.level03,
+                  shape: BoxShape.circle,
+                ),
+                alignment: Alignment.center,
+                child: Icon(
+                  checkInInteractionIcon(data.interactionType),
+                  size: IconSizes.m,
+                  color: tokens.colors.text.mediumEmphasis,
+                ),
+              ),
+              SizedBox(width: tokens.spacing.step4),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Wrap(
+                      spacing: tokens.spacing.step3,
+                      runSpacing: tokens.spacing.step2,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: [
+                        Text(
+                          meta,
+                          key: const ValueKey('check-in-row-meta'),
+                          style: relationshipTimestampStyle(
+                            tokens,
+                            color: tokens.colors.text.lowEmphasis,
+                          ),
+                        ),
+                        if (sentiment != null)
+                          DsPill(
+                            key: const ValueKey('check-in-row-sentiment'),
+                            variant: DsPillVariant.tinted,
+                            shape: DsPillShape.tag,
+                            color: sentimentColor(tokens, sentiment),
+                            labelColor: tokens.colors.text.highEmphasis,
+                            label: checkInSentimentLabel(context, sentiment),
+                          ),
+                      ],
+                    ),
+                    if (narrative != null && narrative.isNotEmpty) ...[
+                      SizedBox(height: tokens.spacing.step2),
+                      Text(
+                        narrative,
+                        style: tokens.typography.styles.body.bodyMedium
+                            .copyWith(
+                              color: tokens.colors.text.highEmphasis,
+                            ),
+                      ),
+                    ],
+                    if (data.topics.isNotEmpty) ...[
+                      SizedBox(height: tokens.spacing.step3),
+                      // Topics are this check-in's tags, so they wear the tag
+                      // pill the rest of the app spends on labels — the tight
+                      // corner that says "read-out, not button".
+                      Wrap(
+                        spacing: tokens.spacing.step2,
+                        runSpacing: tokens.spacing.step2,
+                        children: [
+                          for (final topic in data.topics)
+                            DsPill(
+                              variant: DsPillVariant.filled,
+                              shape: DsPillShape.tag,
+                              bordered: true,
+                              label: topic,
+                              labelColor: tokens.colors.text.mediumEmphasis,
+                            ),
+                        ],
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/relationships/ui/widgets/contact_link_action.dart
+++ b/lib/features/relationships/ui/widgets/contact_link_action.dart
@@ -2,132 +2,66 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
 import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
-import 'package:lotti/features/design_system/theme/design_tokens.dart';
-import 'package:lotti/features/relationships/service/contacts_service.dart';
-import 'package:lotti/features/relationships/state/contact_import_controller.dart';
 import 'package:lotti/features/relationships/state/contact_link_controller.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:material_ui/material_ui.dart';
 
-/// What a linked person's overflow menu offers.
-enum _LinkMenuChoice { refresh, relink }
+/// Whether *this device* holds an OS-contact ref for the person (plan v2
+/// phase 7 item 2, ADR 0041). Refs written by other devices live under their
+/// own keys and deliberately do not count: offering "update from contact"
+/// for an address book this device does not have would resolve to nothing —
+/// or to the wrong person.
+bool contactIsLinkedOnThisDevice(
+  RelationshipEntry relationship,
+  String? refKey,
+) {
+  if (refKey == null) return false;
+  final ref = relationship.data.contactRefs[refKey];
+  return ref != null && ref.isNotEmpty;
+}
 
-/// Links a person to an OS contact, or refreshes the one they already have
-/// (plan v2 phase 7 item 2, ADR 0041).
+/// Runs one contact-link intent — link, refresh, or re-link — and turns its
+/// outcome into the one toast the user should see.
 ///
-/// Renders nothing where there is no address book, so the desktop app — which
-/// enters channels by hand (ADR 0041 §2) — never shows an action it cannot
-/// perform.
-///
-/// A person with no link on this device gets a single button. A person who is
-/// already linked gets a menu, because "copy anything new across" and "point
-/// this at a different contact" are genuinely different intents and silently
-/// picking one would be wrong either way.
-class ContactLinkAction extends ConsumerWidget {
-  const ContactLinkAction({required this.relationship, super.key});
+/// Neither `noChanges` nor `contactMissing` is a failure, but neither did
+/// what the user pressed for, so both read as a warning rather than a success
+/// (the design system has no neutral tone). Backing out of the picker is an
+/// answer, not a failure, and says nothing.
+Future<void> runContactLinkAction(
+  BuildContext context,
+  WidgetRef ref,
+  Future<ContactLinkOutcome> Function(ContactLinkController) action,
+) async {
+  final outcome = await action(ref.read(contactLinkControllerProvider));
+  if (!context.mounted) return;
 
-  final RelationshipEntry relationship;
+  final messages = context.messages;
+  final (title, tone) = switch (outcome) {
+    ContactLinkOutcome.linked => (
+      messages.relationshipContactLinked,
+      DesignSystemToastTone.success,
+    ),
+    ContactLinkOutcome.noChanges => (
+      messages.relationshipContactNoChanges,
+      DesignSystemToastTone.warning,
+    ),
+    ContactLinkOutcome.contactMissing => (
+      messages.relationshipContactMissing,
+      DesignSystemToastTone.warning,
+    ),
+    ContactLinkOutcome.saveFailed => (
+      messages.relationshipContactLinkFailed,
+      DesignSystemToastTone.error,
+    ),
+    // `unsupported` cannot arrive here — the menu never offers the intent
+    // without an address book — but stays in the switch so a new outcome
+    // has to be triaged rather than silently falling through to silence.
+    ContactLinkOutcome.cancelled || ContactLinkOutcome.unsupported => (
+      null,
+      DesignSystemToastTone.warning,
+    ),
+  };
 
-  /// Whether *this device* holds a ref for the person. Refs written by other
-  /// devices live under their own keys and deliberately do not count: a
-  /// menu offering "update from contact" for an address book this device
-  /// does not have would resolve to nothing — or to the wrong person.
-  bool _isLinked(String? refKey) {
-    if (refKey == null) return false;
-    final ref = relationship.data.contactRefs[refKey];
-    return ref != null && ref.isNotEmpty;
-  }
-
-  Future<void> _run(
-    BuildContext context,
-    WidgetRef ref,
-    Future<ContactLinkOutcome> Function(ContactLinkController) action,
-  ) async {
-    final outcome = await action(ref.read(contactLinkControllerProvider));
-    if (!context.mounted) return;
-
-    final messages = context.messages;
-    final (title, tone) = switch (outcome) {
-      ContactLinkOutcome.linked => (
-        messages.relationshipContactLinked,
-        DesignSystemToastTone.success,
-      ),
-      // Neither is a failure, but neither did what the user pressed for,
-      // so both read as a warning rather than a success. The design system
-      // has no neutral tone.
-      ContactLinkOutcome.noChanges => (
-        messages.relationshipContactNoChanges,
-        DesignSystemToastTone.warning,
-      ),
-      ContactLinkOutcome.contactMissing => (
-        messages.relationshipContactMissing,
-        DesignSystemToastTone.warning,
-      ),
-      ContactLinkOutcome.saveFailed => (
-        messages.relationshipContactLinkFailed,
-        DesignSystemToastTone.error,
-      ),
-      // Backing out of the picker is an answer, not a failure. `unsupported`
-      // cannot arrive here at all — the action is not rendered without an
-      // address book — but stays in the switch so a new outcome has to be
-      // triaged rather than silently falling through to silence.
-      ContactLinkOutcome.cancelled || ContactLinkOutcome.unsupported => (
-        null,
-        DesignSystemToastTone.warning,
-      ),
-    };
-
-    if (title == null) return;
-    context.showToast(tone: tone, title: title);
-  }
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    if (!ref.read(contactsServiceProvider).isSupported) {
-      return const SizedBox.shrink();
-    }
-
-    // While the key is still resolving (one frame at most — the host id is
-    // read from memory) the person renders as unlinked, which offers the
-    // link action; both of that frame's states are safe to act on.
-    final refKey = ref.watch(contactRefKeyProvider).value;
-    if (!_isLinked(refKey)) {
-      return IconButton(
-        tooltip: context.messages.relationshipLinkContact,
-        icon: const Icon(LottiIcons.findPerson),
-        onPressed: () => _run(
-          context,
-          ref,
-          (controller) => controller.linkContact(
-            relationship,
-          ),
-        ),
-      );
-    }
-
-    return PopupMenuButton<_LinkMenuChoice>(
-      tooltip: context.messages.relationshipUpdateFromContact,
-      icon: const Icon(LottiIcons.contactCard),
-      onSelected: (choice) => _run(
-        context,
-        ref,
-        (controller) => switch (choice) {
-          _LinkMenuChoice.refresh => controller.refreshFromContact(
-            relationship,
-          ),
-          _LinkMenuChoice.relink => controller.linkContact(relationship),
-        },
-      ),
-      itemBuilder: (context) => [
-        PopupMenuItem(
-          value: _LinkMenuChoice.refresh,
-          child: Text(context.messages.relationshipUpdateFromContact),
-        ),
-        PopupMenuItem(
-          value: _LinkMenuChoice.relink,
-          child: Text(context.messages.relationshipRelinkContact),
-        ),
-      ],
-    );
-  }
+  if (title == null) return;
+  context.showToast(tone: tone, title: title);
 }

--- a/lib/features/relationships/ui/widgets/contact_quick_actions.dart
+++ b/lib/features/relationships/ui/widgets/contact_quick_actions.dart
@@ -38,6 +38,49 @@ String _labelForAction(BuildContext context, ContactAction action) =>
       ContactAction.email => context.messages.relationshipActionEmail,
     };
 
+/// The icon a contact action wears wherever it is offered — the channel row
+/// and the page's action bar alike.
+IconData contactActionIcon(ContactAction action) => _iconForAction(action);
+
+/// The localized label of a contact action.
+String contactActionLabel(BuildContext context, ContactAction action) =>
+    _labelForAction(context, action);
+
+/// Hands [channel] to the platform for [action] and, on success, writes the
+/// device-local pending-interaction marker the next resume turns into a
+/// pre-filled check-in offer (ADR 0041 D4). A launch the platform refuses
+/// writes nothing — there was no conversation to log — and says so.
+///
+/// Shared by the channel row's buttons and the page's action bar, so both
+/// remember a placed call the same way.
+Future<void> launchContactAction(
+  BuildContext context,
+  WidgetRef ref, {
+  required String relationshipId,
+  required ContactChannel channel,
+  required ContactAction action,
+}) async {
+  final launcher = ref.read(contactLauncherProvider);
+  final store = ref.read(pendingInteractionStoreProvider);
+  final messages = context.messages;
+
+  final launched = await launcher.launch(channel, action);
+
+  if (!launched) {
+    if (!context.mounted) return;
+    context.showToast(
+      tone: DesignSystemToastTone.error,
+      title: messages.relationshipActionFailed,
+    );
+    return;
+  }
+
+  await store.remember(
+    relationshipId: relationshipId,
+    interactionType: interactionTypeForAction(action),
+  );
+}
+
 /// Call / message / email buttons for one contact channel (plan v2 phase 7
 /// item 4).
 ///
@@ -101,26 +144,13 @@ class _ContactQuickActionsState extends ConsumerState<ContactQuickActions> {
     setState(() => _available = available);
   }
 
-  Future<void> _handlePressed(ContactAction action) async {
-    final launcher = ref.read(contactLauncherProvider);
-    final store = ref.read(pendingInteractionStoreProvider);
-
-    final launched = await launcher.launch(widget.channel, action);
-
-    if (!launched) {
-      if (!mounted) return;
-      context.showToast(
-        tone: DesignSystemToastTone.error,
-        title: context.messages.relationshipActionFailed,
-      );
-      return;
-    }
-
-    await store.remember(
-      relationshipId: widget.relationshipId,
-      interactionType: interactionTypeForAction(action),
-    );
-  }
+  Future<void> _handlePressed(ContactAction action) => launchContactAction(
+    context,
+    ref,
+    relationshipId: widget.relationshipId,
+    channel: widget.channel,
+    action: action,
+  );
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/relationships/ui/widgets/linked_tasks_card.dart
+++ b/lib/features/relationships/ui/widgets/linked_tasks_card.dart
@@ -1,0 +1,295 @@
+import 'dart:async';
+import 'dart:developer' as developer;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/agents/state/task_agent_providers.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_inline_action.dart';
+import 'package:lotti/features/design_system/components/cards/design_system_section_card.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
+import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/relationships/repository/relationship_repository.dart';
+import 'package:lotti/features/relationships/ui/widgets/person_page_cards.dart';
+import 'package:lotti/features/tasks/ui/linked_tasks/linked_task_row.dart';
+import 'package:lotti/features/tasks/ui/linked_tasks/task_search_picker_body.dart';
+import 'package:lotti/features/tasks/ui/utils.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/logic/create/create_entry.dart';
+import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/widgets/modal/confirmation_modal.dart';
+import 'package:lotti/widgets/modal/modal_utils.dart';
+import 'package:material_ui/material_ui.dart';
+
+/// Tasks linked to this person (plan v2 phase 2 item 3 — `RelationshipLink`
+/// both ways), as one section card: a count beside the title, *Link task*
+/// in the header, one row per task with the task's status glyph and an
+/// unlink action, and the empty hint otherwise.
+///
+/// The picker also creates the task when none exists yet, and a task created
+/// here inherits the person's category and `private` flag.
+class LinkedTasksCard extends ConsumerWidget {
+  const LinkedTasksCard({
+    required this.relationshipId,
+    required this.tasks,
+    this.categoryId,
+    super.key,
+  });
+
+  final String relationshipId;
+  final List<Task> tasks;
+
+  /// The person's category, inherited by a task created from their picker so
+  /// it lands in the same life area the person does.
+  final String? categoryId;
+
+  /// Links [taskId] to this person.
+  ///
+  /// Answers false for a write that changed no row *and* for one that threw:
+  /// both mean the link the user asked for does not exist, and the caller —
+  /// which knows whether there is still a page to say so on — decides how to
+  /// report it.
+  Future<bool> _linkTask(
+    RelationshipRepository repository,
+    String taskId,
+  ) async {
+    try {
+      return await repository.linkTask(
+        relationshipId: relationshipId,
+        taskId: taskId,
+      );
+    } catch (error, stackTrace) {
+      developer.log(
+        'Failed to link task to relationship',
+        name: 'LinkedTasksCard',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return false;
+    }
+  }
+
+  /// Creates a task titled after the picker's query, for the person whose
+  /// page this is.
+  ///
+  /// Answering "there is no such task yet" without leaving the page: the
+  /// picker offers this on a search that matches nothing, and feeds whatever
+  /// comes back through its own pick callback — so creating and linking stay
+  /// the one path [_pickTask] already owns, error toast and all. The one
+  /// case that path cannot serve is a picker dismissed mid-write, handled
+  /// below.
+  ///
+  /// No `linkedId`: that writes a plain link, and this card writes its own
+  /// relationship-typed edge a moment later. `inheritContextFrom` carries the
+  /// one thing that must travel — a private person's task is private too —
+  /// without leaving a second edge to unpick.
+  Future<Task?> _createTask({
+    required BuildContext pageContext,
+    required BuildContext modalContext,
+    required WidgetRef ref,
+    required String title,
+  }) async {
+    // Read before the await: persistence can outlive the sheet, and a
+    // post-gap read on a disposed ref would strand a task already written.
+    final agentService = ref.read(taskAgentServiceProvider);
+    final repository = ref.read(relationshipRepositoryProvider);
+
+    Task? created;
+    try {
+      created = await createTask(
+        title: title,
+        categoryId: categoryId,
+        inheritContextFrom: relationshipId,
+      );
+    } catch (error, stackTrace) {
+      developer.log(
+        'Failed to create a task for the relationship',
+        name: 'LinkedTasksCard',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+    // Nothing was written. The picker stays open on the query that failed,
+    // which says more than a toast would: a snack bar raised from here is
+    // hosted by the page's messenger and renders *behind* the modal route it
+    // would be explaining.
+    if (created == null) return null;
+
+    // The same follow-up every other create flow performs, so a task created
+    // here is not the one left without its category's agent.
+    unawaited(autoAssignCategoryAgentWith(agentService, created));
+
+    if (modalContext.mounted) return created;
+
+    // Dismissed while the write was in flight. The task exists and the user
+    // asked for it to be linked, so handing back null here would leave it
+    // created, unlinked and unannounced — visible only as a stray row in the
+    // task list. Link it on the dependencies captured before the gap.
+    final linked = await _linkTask(repository, created.meta.id);
+    if (!linked && pageContext.mounted) {
+      pageContext.showToast(
+        tone: DesignSystemToastTone.error,
+        title: pageContext.messages.relationshipErrorLinkTaskFailed,
+      );
+    }
+    return null;
+  }
+
+  Future<void> _pickTask(BuildContext context, WidgetRef ref) async {
+    final repository = ref.read(relationshipRepositoryProvider);
+    final linkedIds = {for (final task in tasks) task.meta.id};
+
+    await ModalUtils.showSinglePageModal<void>(
+      context: context,
+      title: context.messages.relationshipLinkTaskButton,
+      padding: EdgeInsets.zero,
+      builder: (modalContext) => Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Flexible(
+            child: TaskSearchPickerBody(
+              excludeIds: {relationshipId, ...linkedIds},
+              onCreateTask: (title) => _createTask(
+                pageContext: context,
+                modalContext: modalContext,
+                ref: ref,
+                title: title,
+              ),
+              onTaskSelected: (task) async {
+                final linked = await _linkTask(repository, task.meta.id);
+                if (!modalContext.mounted) return;
+                Navigator.of(modalContext).pop();
+                // `createLink` answers false when the upsert changed no row,
+                // so a silent close would read as a link that worked.
+                if (!linked && context.mounted) {
+                  context.showToast(
+                    tone: DesignSystemToastTone.error,
+                    title: context.messages.relationshipErrorLinkTaskFailed,
+                  );
+                }
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _unlinkTask(
+    BuildContext context,
+    WidgetRef ref,
+    Task task,
+  ) async {
+    final confirmed = await showConfirmationModal(
+      context: context,
+      message: context.messages.unlinkTaskConfirmNamed(
+        task.data.title.isEmpty
+            ? context.messages.taskUntitled
+            : task.data.title,
+      ),
+      confirmLabel: context.messages.unlinkTaskTitle,
+    );
+    if (!confirmed || !context.mounted) return;
+
+    try {
+      final removed = await ref
+          .read(relationshipRepositoryProvider)
+          .unlinkTask(relationshipId: relationshipId, taskId: task.meta.id);
+      if (!removed && context.mounted) {
+        context.showToast(
+          tone: DesignSystemToastTone.error,
+          title: context.messages.unlinkTaskFailedMessage,
+        );
+      }
+    } catch (error, stackTrace) {
+      developer.log(
+        'Failed to unlink task from relationship',
+        name: 'LinkedTasksCard',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      if (context.mounted) {
+        context.showToast(
+          tone: DesignSystemToastTone.error,
+          title: context.messages.unlinkTaskFailedMessage,
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+
+    return DesignSystemSectionCard(
+      key: const ValueKey('person-tasks-card'),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          PersonCardHeader(
+            title: messages.relationshipLinkedTasksLabel,
+            caption: tasks.isEmpty
+                ? null
+                : DsPill(
+                    variant: DsPillVariant.filled,
+                    shape: DsPillShape.tag,
+                    labelColor: tokens.colors.text.mediumEmphasis,
+                    label: messages.relationshipTasksLinkedCount(tasks.length),
+                  ),
+            trailing: DesignSystemInlineAction(
+              key: const ValueKey('person-link-task'),
+              label: messages.relationshipLinkTaskButton,
+              semanticsLabel: messages.relationshipLinkTaskButton,
+              leadingIcon: LottiIcons.link,
+              onTap: () => _pickTask(context, ref),
+            ),
+          ),
+          SizedBox(height: tokens.spacing.step3),
+          if (tasks.isEmpty)
+            Text(
+              messages.relationshipNoLinkedTasks,
+              style: tokens.typography.styles.body.bodyMedium.copyWith(
+                color: tokens.colors.text.mediumEmphasis,
+              ),
+            )
+          else
+            for (final task in tasks)
+              DesignSystemListItem(
+                key: ValueKey('person-task-${task.meta.id}'),
+                size: DesignSystemListItemSize.small,
+                title: task.data.title.isEmpty
+                    ? messages.taskUntitled
+                    : task.data.title,
+                subtitle: taskLabelFromStatusString(
+                  task.data.status.toDbString,
+                  context,
+                ),
+                subtitleEmphasis: tokens.colors.text.lowEmphasis,
+                leading: StatusGlyph(
+                  status: task.data.status,
+                  tooltip: taskLabelFromStatusString(
+                    task.data.status.toDbString,
+                    context,
+                  ),
+                ),
+                trailingExtra: IconButton(
+                  tooltip: messages.unlinkTaskTitle,
+                  onPressed: () => _unlinkTask(context, ref, task),
+                  icon: Icon(
+                    LottiIcons.linkOff,
+                    size: IconSizes.m,
+                    color: tokens.colors.text.lowEmphasis,
+                  ),
+                ),
+                onTap: () => beamToNamed('/tasks/${task.meta.id}'),
+              ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/relationships/ui/widgets/person_header.dart
+++ b/lib/features/relationships/ui/widgets/person_header.dart
@@ -314,13 +314,15 @@ class PersonMenuButton extends ConsumerWidget {
 
     Widget item(IconData icon, String label, {Color? color}) => Row(
       children: [
-        Icon(icon, color: color),
+        Icon(icon, color: color ?? ink),
         SizedBox(width: tokens.spacing.step3),
         Expanded(
           child: Text(
             label,
             overflow: TextOverflow.ellipsis,
-            style: color == null ? null : TextStyle(color: color),
+            style: tokens.typography.styles.body.bodyMedium.copyWith(
+              color: color ?? ink,
+            ),
           ),
         ),
       ],

--- a/lib/features/relationships/ui/widgets/person_header.dart
+++ b/lib/features/relationships/ui/widgets/person_header.dart
@@ -1,0 +1,569 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/keyboard/ui/list_detail_focus_traversal.dart';
+import 'package:lotti/features/relationships/model/relationship_health_metrics.dart';
+import 'package:lotti/features/relationships/repository/relationship_repository.dart';
+import 'package:lotti/features/relationships/service/contacts_service.dart';
+import 'package:lotti/features/relationships/state/contact_import_controller.dart';
+import 'package:lotti/features/relationships/ui/model/people_list_model.dart';
+import 'package:lotti/features/relationships/ui/shared/persona_avatar.dart';
+import 'package:lotti/features/relationships/ui/shared/relationship_timestamps.dart';
+import 'package:lotti/features/relationships/ui/widgets/contact_link_action.dart';
+import 'package:lotti/features/relationships/ui/widgets/relationship_briefing_card.dart';
+import 'package:lotti/features/relationships/ui/widgets/relationship_form_modal.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/widgets/app_bar/glass_action_button.dart';
+import 'package:lotti/widgets/app_bar/glass_back_button.dart';
+import 'package:material_ui/material_ui.dart';
+
+/// The person page's cover-style hero (design 2026-09-06 §2–3): a teal wash
+/// with no imagery, carrying back · Talk to agent · edit · kebab, with the
+/// persona avatar overlapping its lower edge. Pinned, so the actions stay
+/// reachable while the page scrolls; once the wash band has folded away
+/// the bar names the person the hero itself leaves to the header block.
+///
+/// A persistent header of its own rather than a `SliverAppBar`: the avatar
+/// hangs below the header's extent, over the block that follows, and every
+/// layer of an app bar (its stack, its flexible space) clips that overflow.
+/// Slivers paint back to front, so the header — earlier in the list —
+/// paints its overhanging avatar over the content scrolling under it.
+class PersonHeroAppBar extends StatelessWidget {
+  const PersonHeroAppBar({
+    required this.relationship,
+    required this.onBack,
+    required this.onTalkToAgent,
+    required this.onDelete,
+    this.contentInset = 0,
+    super.key,
+  });
+
+  final RelationshipEntry relationship;
+  final VoidCallback onBack;
+  final VoidCallback onTalkToAgent;
+  final Future<void> Function() onDelete;
+
+  /// The page's horizontal content inset, so the avatar lines up with the
+  /// header block's left edge — the gutter on a phone, the centred column's
+  /// edge on a desktop window.
+  final double contentInset;
+
+  /// The wash band's extent below the toolbar: the avatar overlaps its lower
+  /// edge by half its diameter, so the band has to be tall enough to read
+  /// as a band rather than a stripe.
+  static double bandExtent(DsTokens tokens) => tokens.spacing.step12;
+
+  /// The avatar diameter; half of it hangs below the hero.
+  static double avatarSize(DsTokens tokens) => tokens.spacing.step11;
+
+  /// The wash itself: the interactive accent at the tint alpha over the page
+  /// surface — the same recipe every tone-tinted card fill uses.
+  static Color washColor(DsTokens tokens) => Color.alphaBlend(
+    tokens.colors.interactive.enabled.withValues(alpha: SurfaceAlphas.tint),
+    tokens.colors.background.level01,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    final desktop = isDesktopLayout(context);
+    final ink = tokens.colors.text.highEmphasis;
+    // On the desktop split the list pane can fold away; the hero then
+    // carries the control that brings it back, beside the back button, so
+    // the page never overlays a second bar on its own chrome.
+    final split = ListDetailFocusTraversal.maybeOf(context);
+    final listHidden = split != null && !split.listPaneVisible;
+    const glyphSize = GlassActionButton.defaultSize;
+
+    final leading = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        GlassBackButton(
+          onPressed: onBack,
+          iconColor: ink,
+          containerSize: glyphSize,
+        ),
+        if (listHidden) ...[
+          SizedBox(width: tokens.spacing.step2),
+          GlassActionButton(
+            key: const ValueKey('people-show-list-pane'),
+            tooltip: messages.listPaneShowTooltip,
+            semanticLabel: messages.listPaneShowTooltip,
+            onTap: split.showListPane,
+            child: Icon(LottiIcons.sidebar, size: IconSizes.l, color: ink),
+          ),
+        ],
+      ],
+    );
+
+    final actions = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (desktop)
+          DesignSystemButton(
+            key: const ValueKey('person-talk-to-agent'),
+            label: messages.goalChatTalkToAgent,
+            leadingIcon: LottiIcons.chat,
+            variant: DesignSystemButtonVariant.secondary,
+            size: DesignSystemButtonSize.dense,
+            onPressed: onTalkToAgent,
+          )
+        else
+          GlassActionButton(
+            key: const ValueKey('person-talk-to-agent'),
+            tooltip: messages.goalChatTalkToAgent,
+            semanticLabel: messages.goalChatTalkToAgent,
+            onTap: onTalkToAgent,
+            child: Icon(LottiIcons.chat, size: IconSizes.l, color: ink),
+          ),
+        SizedBox(width: tokens.spacing.step2),
+        GlassActionButton(
+          key: const ValueKey('person-edit'),
+          tooltip: messages.relationshipEditTitle,
+          semanticLabel: messages.relationshipEditTitle,
+          onTap: () => showRelationshipEditModal(
+            context: context,
+            relationship: relationship,
+          ),
+          child: Icon(LottiIcons.edit, size: IconSizes.l, color: ink),
+        ),
+        SizedBox(width: tokens.spacing.step2),
+        PersonMenuButton(relationship: relationship, onDelete: onDelete),
+      ],
+    );
+
+    return SliverPersistentHeader(
+      key: const ValueKey('person-hero'),
+      pinned: true,
+      delegate: _PersonHeroDelegate(
+        title: relationship.data.title,
+        titleStyle: tokens.typography.styles.subtitle.subtitle2.copyWith(
+          color: ink,
+        ),
+        wash: washColor(tokens),
+        topPadding: MediaQuery.paddingOf(context).top,
+        bandExtent: bandExtent(tokens),
+        collapseSlack: tokens.spacing.step2,
+        gutter: tokens.spacing.step3,
+        avatar: PersonaAvatar(
+          initial: personaInitial(relationship.data.title),
+          id: relationship.id,
+          size: avatarSize(tokens),
+        ),
+        avatarSize: avatarSize(tokens),
+        avatarInset: contentInset,
+        leading: leading,
+        actions: actions,
+      ),
+    );
+  }
+}
+
+/// The hero's layout at every scroll position: the wash behind everything,
+/// the toolbar row pinned under the status bar, the name swapped in once the
+/// band has folded, and the avatar hanging over the lower edge while the
+/// band is open.
+class _PersonHeroDelegate extends SliverPersistentHeaderDelegate {
+  const _PersonHeroDelegate({
+    required this.title,
+    required this.titleStyle,
+    required this.wash,
+    required this.topPadding,
+    required this.bandExtent,
+    required this.collapseSlack,
+    required this.gutter,
+    required this.avatar,
+    required this.avatarSize,
+    required this.avatarInset,
+    required this.leading,
+    required this.actions,
+  });
+
+  final String title;
+  final TextStyle titleStyle;
+  final Color wash;
+  final double topPadding;
+  final double bandExtent;
+
+  /// How close to fully collapsed counts as collapsed, so the name does not
+  /// wait for the last sub-pixel of the band.
+  final double collapseSlack;
+  final double gutter;
+  final Widget avatar;
+  final double avatarSize;
+  final double avatarInset;
+  final Widget leading;
+  final Widget actions;
+
+  @override
+  double get minExtent => topPadding + kToolbarHeight;
+
+  @override
+  double get maxExtent => minExtent + bandExtent;
+
+  @override
+  Widget build(
+    BuildContext context,
+    double shrinkOffset,
+    bool overlapsContent,
+  ) {
+    final collapsed = shrinkOffset >= bandExtent - collapseSlack;
+    final bandOpen = 1 - (shrinkOffset / bandExtent).clamp(0.0, 1.0);
+
+    return Stack(
+      clipBehavior: Clip.none,
+      fit: StackFit.expand,
+      children: [
+        ColoredBox(key: const ValueKey('person-hero-wash'), color: wash),
+        Positioned(
+          top: topPadding,
+          left: gutter,
+          right: gutter,
+          height: kToolbarHeight,
+          child: Row(
+            children: [
+              leading,
+              SizedBox(width: gutter),
+              Expanded(
+                // Swapped rather than faded: while the band is open the bar
+                // holds nothing at all, so the name exists exactly once on
+                // the page at any time.
+                child: AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 160),
+                  child: collapsed
+                      ? Text(
+                          title,
+                          key: const ValueKey('person-hero-title'),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: titleStyle,
+                        )
+                      : const SizedBox.shrink(),
+                ),
+              ),
+              SizedBox(width: gutter),
+              actions,
+            ],
+          ),
+        ),
+        // Fades with the band so it never sits on the collapsed toolbar's
+        // edge, over whatever has scrolled under it.
+        Positioned(
+          left: avatarInset,
+          bottom: -avatarSize / 2,
+          child: IgnorePointer(
+            child: Opacity(
+              key: const ValueKey('person-hero-avatar'),
+              opacity: bandOpen,
+              child: avatar,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  bool shouldRebuild(_PersonHeroDelegate oldDelegate) =>
+      title != oldDelegate.title ||
+      titleStyle != oldDelegate.titleStyle ||
+      wash != oldDelegate.wash ||
+      topPadding != oldDelegate.topPadding ||
+      bandExtent != oldDelegate.bandExtent ||
+      avatarSize != oldDelegate.avatarSize ||
+      avatarInset != oldDelegate.avatarInset ||
+      avatar != oldDelegate.avatar ||
+      leading != oldDelegate.leading ||
+      actions != oldDelegate.actions;
+}
+
+/// What the hero's kebab offers: the contact-link intents where there is an
+/// address book (ADR 0041), and delete — which says it takes the check-ins
+/// with it.
+enum PersonMenuAction { linkContact, refreshContact, relinkContact, delete }
+
+/// The hero's overflow menu.
+class PersonMenuButton extends ConsumerWidget {
+  const PersonMenuButton({
+    required this.relationship,
+    required this.onDelete,
+    super.key,
+  });
+
+  final RelationshipEntry relationship;
+  final Future<void> Function() onDelete;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    final ink = tokens.colors.text.highEmphasis;
+    final contactsSupported = ref.read(contactsServiceProvider).isSupported;
+    final linked =
+        contactsSupported &&
+        contactIsLinkedOnThisDevice(
+          relationship,
+          ref.watch(contactRefKeyProvider).value,
+        );
+
+    Widget item(IconData icon, String label, {Color? color}) => Row(
+      children: [
+        Icon(icon, color: color),
+        SizedBox(width: tokens.spacing.step3),
+        Expanded(
+          child: Text(
+            label,
+            overflow: TextOverflow.ellipsis,
+            style: color == null ? null : TextStyle(color: color),
+          ),
+        ),
+      ],
+    );
+
+    return PopupMenuButton<PersonMenuAction>(
+      key: const ValueKey('person-menu'),
+      tooltip: messages.relationshipMoreActions,
+      icon: Icon(LottiIcons.moreVertical, color: ink),
+      onSelected: (action) => unawaited(switch (action) {
+        PersonMenuAction.linkContact ||
+        PersonMenuAction.relinkContact => runContactLinkAction(
+          context,
+          ref,
+          (controller) => controller.linkContact(relationship),
+        ),
+        PersonMenuAction.refreshContact => runContactLinkAction(
+          context,
+          ref,
+          (controller) => controller.refreshFromContact(relationship),
+        ),
+        PersonMenuAction.delete => onDelete(),
+      }),
+      itemBuilder: (context) => [
+        if (contactsSupported && !linked)
+          PopupMenuItem(
+            value: PersonMenuAction.linkContact,
+            child: item(
+              LottiIcons.findPerson,
+              messages.relationshipLinkContact,
+            ),
+          ),
+        if (linked) ...[
+          PopupMenuItem(
+            value: PersonMenuAction.refreshContact,
+            child: item(
+              LottiIcons.contactCard,
+              messages.relationshipUpdateFromContact,
+            ),
+          ),
+          PopupMenuItem(
+            value: PersonMenuAction.relinkContact,
+            child: item(
+              LottiIcons.findPerson,
+              messages.relationshipRelinkContact,
+            ),
+          ),
+        ],
+        PopupMenuItem(
+          value: PersonMenuAction.delete,
+          child: item(
+            LottiIcons.delete,
+            messages.deleteButton,
+            color: tokens.colors.alert.error.ink,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// The header block under the hero, starting below the avatar that hangs
+/// off it: the eyebrow (`Penguin Operations · Important`), the full wrapping
+/// name, the teal one-liner (`"Pip" · last spoke Today 12:44`), and the
+/// pills — the cadence fact the deterministic tier always knows, the health
+/// band once a briefing exists, and the next due day.
+class PersonHeaderBlock extends StatelessWidget {
+  const PersonHeaderBlock({
+    required this.item,
+    required this.categoryName,
+    required this.healthBand,
+    super.key,
+  });
+
+  final RelationshipListItem item;
+  final String? categoryName;
+  final RelationshipHealthBand? healthBand;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    final data = item.relationship.data;
+
+    final eyebrow = [
+      ?categoryName,
+      if (data.important) messages.relationshipImportantLabel,
+    ].join(' · ');
+    final lastSpoke = item.lastCheckInAt == null
+        ? messages.relationshipJustAdded
+        : messages.relationshipLastSpoke(
+            relationshipTimestampLabelOf(context, item.lastCheckInAt!),
+          );
+    final oneLiner = [
+      if (data.nickname case final nickname? when nickname.isNotEmpty)
+        '"$nickname"',
+      lastSpoke,
+    ].join(' · ');
+
+    // No inset of its own: the page lays every section on the one content
+    // gutter and spaces them, so the block lines up with the cards below.
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Room for the half of the avatar that hangs off the hero.
+        SizedBox(
+          height:
+              PersonHeroAppBar.avatarSize(tokens) / 2 + tokens.spacing.step3,
+        ),
+        if (eyebrow.isNotEmpty) ...[
+          Text(
+            eyebrow,
+            key: const ValueKey('person-eyebrow'),
+            style: relationshipTimestampStyle(
+              tokens,
+              color: tokens.colors.text.lowEmphasis,
+            ),
+          ),
+          SizedBox(height: tokens.spacing.step2),
+        ],
+        Text(
+          data.title,
+          style: tokens.typography.styles.heading.heading2.copyWith(
+            color: tokens.colors.text.highEmphasis,
+          ),
+        ),
+        SizedBox(height: tokens.spacing.step1),
+        Text(
+          oneLiner,
+          key: const ValueKey('person-one-liner'),
+          style: tokens.typography.styles.body.bodyMedium.copyWith(
+            color: tokens.colors.interactive.enabled,
+          ),
+        ),
+        SizedBox(height: tokens.spacing.step4),
+        Wrap(
+          spacing: tokens.spacing.step2,
+          runSpacing: tokens.spacing.step2,
+          children: personHeaderPills(context, item, healthBand: healthBand),
+        ),
+      ],
+    );
+  }
+}
+
+/// The header pills, in order: the cadence fact (on track · cadence, or due
+/// since · days over), the health band, the next due day.
+List<Widget> personHeaderPills(
+  BuildContext context,
+  RelationshipListItem item, {
+  required RelationshipHealthBand? healthBand,
+}) {
+  final tokens = context.designTokens;
+  final messages = context.messages;
+  final pill = peopleCadencePillOf(item);
+  final quiet = tokens.colors.text.mediumEmphasis;
+  final pills = <Widget>[];
+
+  switch (pill.kind) {
+    case PeopleCadencePillKind.overdue:
+      pills.add(
+        DsPill(
+          key: const ValueKey('person-pill-due'),
+          variant: DsPillVariant.tinted,
+          shape: DsPillShape.tag,
+          color: tokens.colors.alert.warning.defaultColor,
+          labelColor: tokens.colors.text.highEmphasis,
+          label: messages.relationshipDueSince(
+            relationshipWeekdayLabelOf(
+              context,
+              peopleDueDateOf(item)!,
+            ),
+            pill.daysOver,
+          ),
+        ),
+      );
+    case PeopleCadencePillKind.dueSoon || PeopleCadencePillKind.onTrack:
+      pills.add(
+        DsPill(
+          key: const ValueKey('person-pill-cadence'),
+          variant: DsPillVariant.filled,
+          shape: DsPillShape.tag,
+          leading: Icon(LottiIcons.confirm, size: IconSizes.s, color: quiet),
+          labelColor: quiet,
+          // The effective cadence, not the stored one: an enrolled person
+          // with no cadence set is on the runtime's default, and the pill
+          // says which rhythm actually governs the due date.
+          label: messages.relationshipOnTrackCadence(
+            relationshipCadenceLabel(
+              context,
+              effectiveCadenceDaysOf(item.relationship),
+            ),
+          ),
+        ),
+      );
+    case PeopleCadencePillKind.notEnrolled ||
+        PeopleCadencePillKind.dormant ||
+        PeopleCadencePillKind.archived:
+      pills.add(
+        DsPill(
+          key: const ValueKey('person-pill-status'),
+          variant: DsPillVariant.filled,
+          shape: DsPillShape.tag,
+          labelColor: quiet,
+          label: switch (pill.kind) {
+            PeopleCadencePillKind.dormant => messages.relationshipStatusDormant,
+            PeopleCadencePillKind.archived =>
+              messages.relationshipStatusArchived,
+            _ => messages.relationshipNotEnrolled,
+          },
+        ),
+      );
+  }
+
+  if (healthBand != null) {
+    pills.add(
+      DsPill(
+        key: const ValueKey('person-pill-health'),
+        variant: DsPillVariant.tinted,
+        shape: DsPillShape.tag,
+        color: relationshipHealthBandColor(tokens, healthBand),
+        labelColor: tokens.colors.text.highEmphasis,
+        label: relationshipHealthBandLabel(context, healthBand),
+      ),
+    );
+  }
+
+  final due = peopleDueDateOf(item);
+  if (due != null &&
+      (pill.kind == PeopleCadencePillKind.dueSoon ||
+          pill.kind == PeopleCadencePillKind.onTrack)) {
+    pills.add(
+      DsPill(
+        key: const ValueKey('person-pill-next-due'),
+        variant: DsPillVariant.filled,
+        shape: DsPillShape.tag,
+        leading: Icon(LottiIcons.today, size: IconSizes.s, color: quiet),
+        labelColor: quiet,
+        label: messages.relationshipNextDueOn(
+          relationshipDayLabelOf(context, due),
+        ),
+      ),
+    );
+  }
+  return pills;
+}

--- a/lib/features/relationships/ui/widgets/person_page_cards.dart
+++ b/lib/features/relationships/ui/widgets/person_page_cards.dart
@@ -1,0 +1,245 @@
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/relationship_data.dart';
+import 'package:lotti/features/design_system/components/cards/design_system_section_card.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/relationships/ui/shared/relationship_timestamps.dart';
+import 'package:lotti/features/relationships/ui/widgets/contact_quick_actions.dart';
+import 'package:lotti/features/relationships/ui/widgets/relationship_form_modal.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:material_ui/material_ui.dart';
+
+/// A section card's title row: the heading, an optional count or caption
+/// beside it, and an optional trailing action — one shape for every card on
+/// the person page.
+class PersonCardHeader extends StatelessWidget {
+  const PersonCardHeader({
+    required this.title,
+    this.caption,
+    this.trailing,
+    super.key,
+  });
+
+  final String title;
+  final Widget? caption;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return Row(
+      children: [
+        Text(
+          title,
+          style: tokens.typography.styles.subtitle.subtitle2.copyWith(
+            color: tokens.colors.text.highEmphasis,
+          ),
+        ),
+        if (caption != null) ...[
+          SizedBox(width: tokens.spacing.step3),
+          caption!,
+        ],
+        const Spacer(),
+        ?trailing,
+      ],
+    );
+  }
+}
+
+/// The "Next time" card (design 2026-09-06 Q9): what the latest check-in
+/// asked to bring up, and what to leave alone — the one thing worth reading
+/// before the next call, sourced from the user's own words, never from the
+/// agent. Renders nothing when the latest check-in carries neither.
+class NextTimeCard extends StatelessWidget {
+  const NextTimeCard({required this.latest, super.key});
+
+  final CheckInEntry? latest;
+
+  static String? _attentionOf(CheckInEntry? latest) =>
+      _nonBlank(latest?.data.payAttentionTo);
+
+  static String? _avoidOf(CheckInEntry? latest) =>
+      _nonBlank(latest?.data.avoid);
+
+  static String? _nonBlank(String? text) {
+    final trimmed = text?.trim();
+    return trimmed == null || trimmed.isEmpty ? null : trimmed;
+  }
+
+  /// Whether the card would render anything for [latest] — exposed so the
+  /// page can decide on the gap after it with the same rule the card uses.
+  static bool hasContent(CheckInEntry? latest) =>
+      _attentionOf(latest) != null || _avoidOf(latest) != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    final attention = _attentionOf(latest);
+    final avoid = _avoidOf(latest);
+    if (attention == null && avoid == null) return const SizedBox.shrink();
+
+    Widget tile(String caption, String text, Key key) => Container(
+      key: key,
+      width: double.infinity,
+      padding: EdgeInsets.all(tokens.spacing.step4),
+      decoration: BoxDecoration(
+        color: tokens.colors.background.level03,
+        borderRadius: BorderRadius.circular(tokens.radii.m),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            caption,
+            style: tokens.typography.styles.others.caption.copyWith(
+              color: tokens.colors.text.lowEmphasis,
+            ),
+          ),
+          SizedBox(height: tokens.spacing.step1),
+          Text(
+            text,
+            style: tokens.typography.styles.body.bodyMedium.copyWith(
+              color: tokens.colors.text.highEmphasis,
+            ),
+          ),
+        ],
+      ),
+    );
+
+    return DesignSystemSectionCard(
+      key: const ValueKey('person-next-time-card'),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          PersonCardHeader(
+            title: messages.relationshipNextTimeTitle,
+            trailing: Text(
+              relationshipTimestampLabelOf(context, latest!.meta.dateFrom),
+              style: relationshipTimestampStyle(tokens),
+            ),
+          ),
+          SizedBox(height: tokens.spacing.step4),
+          if (attention != null)
+            tile(
+              messages.relationshipPayAttentionTo,
+              attention,
+              const ValueKey('person-next-time-attention'),
+            ),
+          if (attention != null && avoid != null)
+            SizedBox(height: tokens.spacing.step3),
+          if (avoid != null)
+            tile(
+              messages.checkInAvoidLabel,
+              avoid,
+              const ValueKey('person-next-time-avoid'),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The "Reach" card: the person's contact channels with the actions the
+/// device can service, under the privacy line the feature stands on — the
+/// channels stay on the device and never enter AI context (ADR 0041 §5).
+/// Renders nothing for a person without channels.
+class ReachCard extends StatelessWidget {
+  const ReachCard({
+    required this.relationshipId,
+    required this.channels,
+    super.key,
+  });
+
+  final String relationshipId;
+  final List<ContactChannel> channels;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    if (channels.isEmpty) return const SizedBox.shrink();
+
+    return DesignSystemSectionCard(
+      key: const ValueKey('person-reach-card'),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          PersonCardHeader(title: messages.relationshipReachTitle),
+          SizedBox(height: tokens.spacing.step1),
+          Text(
+            messages.relationshipReachPrivacy,
+            style: tokens.typography.styles.others.caption.copyWith(
+              color: tokens.colors.text.lowEmphasis,
+            ),
+          ),
+          SizedBox(height: tokens.spacing.step3),
+          for (final channel in channels)
+            _ReachRow(relationshipId: relationshipId, channel: channel),
+        ],
+      ),
+    );
+  }
+}
+
+class _ReachRow extends StatelessWidget {
+  const _ReachRow({required this.relationshipId, required this.channel});
+
+  final String relationshipId;
+  final ContactChannel channel;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final label = channel.label;
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: tokens.spacing.step2),
+      child: Row(
+        children: [
+          Container(
+            width: tokens.spacing.step8,
+            height: tokens.spacing.step8,
+            decoration: BoxDecoration(
+              color: tokens.colors.background.level03,
+              shape: BoxShape.circle,
+            ),
+            alignment: Alignment.center,
+            child: Icon(
+              contactChannelTypeIcon(channel.type),
+              size: IconSizes.m,
+              color: tokens.colors.text.mediumEmphasis,
+            ),
+          ),
+          SizedBox(width: tokens.spacing.step4),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  channel.value,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: tokens.typography.styles.body.bodyMedium.copyWith(
+                    color: tokens.colors.text.highEmphasis,
+                  ),
+                ),
+                Text(
+                  label == null || label.isEmpty
+                      ? contactChannelTypeLabel(context, channel.type)
+                      : label,
+                  style: tokens.typography.styles.body.bodySmall.copyWith(
+                    color: tokens.colors.text.lowEmphasis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SizedBox(width: tokens.spacing.step3),
+          // Renders nothing until the platform confirms it can service an
+          // action, and nothing at all for a channel with no launchable
+          // scheme (plan v2 phase 7 item 4).
+          ContactQuickActions(relationshipId: relationshipId, channel: channel),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/relationships/ui/widgets/post_interaction_prompt.dart
+++ b/lib/features/relationships/ui/widgets/post_interaction_prompt.dart
@@ -101,6 +101,10 @@ class _PostInteractionPromptState extends ConsumerState<PostInteractionPrompt>
   Future<void> _logCheckIn() async {
     final pending = _pending;
     if (pending == null) return;
+    // Read before the await below: the whole minutes the offer quoted are
+    // what the log must show, and clearing the marker can cross a minute
+    // boundary, which would hand the sheet a different reading.
+    final elapsed = clock.now().difference(pending.startedAt);
 
     // Cleared before the sheet opens, not after it closes: the offer has been
     // taken up either way, and a user who opens the form and then backs out
@@ -108,9 +112,6 @@ class _PostInteractionPromptState extends ConsumerState<PostInteractionPrompt>
     await _dismiss();
     if (!mounted) return;
 
-    // The whole minutes the offer quoted, so the log shows the duration the
-    // user was promised rather than a second, differently rounded reading.
-    final elapsed = clock.now().difference(pending.startedAt);
     await showCheckInCaptureSheet(
       context: context,
       relationshipId: pending.relationshipId,

--- a/lib/features/relationships/ui/widgets/post_interaction_prompt.dart
+++ b/lib/features/relationships/ui/widgets/post_interaction_prompt.dart
@@ -1,22 +1,29 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/classes/check_in_data.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
 import 'package:lotti/features/relationships/service/pending_interaction_store.dart';
+import 'package:lotti/features/relationships/ui/shared/relationship_timestamps.dart';
 import 'package:lotti/features/relationships/ui/widgets/check_in_capture_sheet.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:material_ui/material_ui.dart';
 
 /// Offers to log a check-in after the user comes back from a call or message
-/// they started in Lotti (plan v2 phase 7 item 5, ADR 0041 D4).
+/// they started in Lotti (plan v2 phase 7 item 5, ADR 0041 D4) — the
+/// highlighted state at the top of the Check-ins card (design 2026-09-06
+/// Q6): it names its evidence — the channel, how long ago, when it started
+/// and roughly how long it has been — so the offer reads as "log the call
+/// you just had", not as a generic nudge.
 ///
-/// Deliberately an inline card rather than a dialog. The user has just
-/// returned from a conversation and may want to do something else entirely;
-/// a modal would demand an answer before they can reach the rest of the app,
-/// while a card can simply be ignored. Declining leaves no trace — the marker
-/// is dropped and nothing is written anywhere.
+/// Deliberately inline rather than a dialog. The user has just returned
+/// from a conversation and may want to do something else entirely; a modal
+/// would demand an answer before they can reach the rest of the app, while
+/// a card can simply be ignored. Declining leaves no trace — the marker is
+/// dropped and nothing is written anywhere.
 ///
 /// Renders nothing when there is no marker, when it has expired, or when the
 /// person it names no longer resolves (deleted, or private while private
@@ -24,6 +31,13 @@ import 'package:material_ui/material_ui.dart';
 /// leak the fact that they exist.
 class PostInteractionPrompt extends ConsumerStatefulWidget {
   const PostInteractionPrompt({super.key});
+
+  /// The wash behind the offer: the interactive accent at the tint alpha
+  /// over the card surface, the recipe every tone-tinted fill uses.
+  static Color washColor(DsTokens tokens) => Color.alphaBlend(
+    tokens.colors.interactive.enabled.withValues(alpha: SurfaceAlphas.tint),
+    tokens.colors.background.level02,
+  );
 
   @override
   ConsumerState<PostInteractionPrompt> createState() =>
@@ -110,45 +124,92 @@ class _PostInteractionPromptState extends ConsumerState<PostInteractionPrompt>
 
     final tokens = context.designTokens;
     final messages = context.messages;
+    final accent = tokens.colors.interactive.enabled;
+    // Whole minutes since the user left for the call: what the sheet will
+    // prefill as the duration, so the offer and the form agree.
+    final minutes = clock.now().difference(pending.startedAt).inMinutes;
+    final title = switch (pending.interactionType) {
+      CheckInInteractionType.call => messages.relationshipPostCallOfferCall(
+        name,
+        minutes,
+      ),
+      _ => messages.relationshipPostCallOfferMessage(name, minutes),
+    };
 
-    return Card(
-      margin: EdgeInsets.only(bottom: tokens.spacing.sectionGap),
-      child: Padding(
-        padding: EdgeInsets.all(tokens.spacing.cardPadding),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              messages.relationshipPostCallTitle(name),
-              style: tokens.typography.styles.subtitle.subtitle2.copyWith(
-                color: tokens.colors.text.highEmphasis,
-              ),
-            ),
-            SizedBox(height: tokens.spacing.step2),
-            Text(
-              messages.relationshipPostCallBody,
-              style: tokens.typography.styles.body.bodyMedium.copyWith(
-                color: tokens.colors.text.mediumEmphasis,
-              ),
-            ),
-            SizedBox(height: tokens.spacing.cardItemSpacing),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              spacing: tokens.spacing.step2,
-              children: [
-                DesignSystemButton(
-                  label: messages.relationshipPostCallDismiss,
-                  variant: DesignSystemButtonVariant.tertiary,
-                  onPressed: () => unawaited(_dismiss()),
-                ),
-                DesignSystemButton(
-                  label: messages.relationshipPostCallConfirm,
-                  onPressed: () => unawaited(_logCheckIn()),
-                ),
-              ],
-            ),
-          ],
+    return Container(
+      key: const ValueKey('person-post-call-offer'),
+      decoration: BoxDecoration(
+        color: PostInteractionPrompt.washColor(tokens),
+        borderRadius: BorderRadius.circular(tokens.radii.l),
+        border: Border.all(
+          color: accent.withValues(alpha: SurfaceAlphas.washChip),
         ),
+      ),
+      padding: EdgeInsets.all(tokens.spacing.cardPadding),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: tokens.spacing.step8,
+                height: tokens.spacing.step8,
+                decoration: BoxDecoration(
+                  color: accent.withValues(alpha: SurfaceAlphas.washChip),
+                  shape: BoxShape.circle,
+                ),
+                alignment: Alignment.center,
+                child: Icon(
+                  checkInInteractionIcon(pending.interactionType),
+                  size: IconSizes.m,
+                  color: accent,
+                ),
+              ),
+              SizedBox(width: tokens.spacing.step4),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: tokens.typography.styles.subtitle.subtitle2
+                          .copyWith(color: tokens.colors.text.highEmphasis),
+                    ),
+                    SizedBox(height: tokens.spacing.step2),
+                    Text(
+                      messages.relationshipPostCallMeta(
+                        relationshipTimeLabel(pending.startedAt),
+                        minutes,
+                      ),
+                      key: const ValueKey('person-post-call-meta'),
+                      style: relationshipTimestampStyle(
+                        tokens,
+                        color: tokens.colors.text.lowEmphasis,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: tokens.spacing.cardItemSpacing),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            spacing: tokens.spacing.step2,
+            children: [
+              DesignSystemButton(
+                label: messages.relationshipPostCallDismiss,
+                variant: DesignSystemButtonVariant.tertiary,
+                onPressed: () => unawaited(_dismiss()),
+              ),
+              DesignSystemButton(
+                label: messages.relationshipPostCallConfirm,
+                onPressed: () => unawaited(_logCheckIn()),
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/relationships/ui/widgets/post_interaction_prompt.dart
+++ b/lib/features/relationships/ui/widgets/post_interaction_prompt.dart
@@ -108,11 +108,15 @@ class _PostInteractionPromptState extends ConsumerState<PostInteractionPrompt>
     await _dismiss();
     if (!mounted) return;
 
+    // The whole minutes the offer quoted, so the log shows the duration the
+    // user was promised rather than a second, differently rounded reading.
+    final elapsed = clock.now().difference(pending.startedAt);
     await showCheckInCaptureSheet(
       context: context,
       relationshipId: pending.relationshipId,
       prefilledInteractionType: pending.interactionType,
       prefilledTime: pending.startedAt,
+      prefilledDuration: Duration(minutes: elapsed.inMinutes),
     );
   }
 

--- a/lib/features/relationships/ui/widgets/relationship_action_bar.dart
+++ b/lib/features/relationships/ui/widgets/relationship_action_bar.dart
@@ -10,6 +10,7 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/relationships/service/contact_launcher.dart';
 import 'package:lotti/features/relationships/ui/widgets/contact_quick_actions.dart';
 import 'package:lotti/features/relationships/util/contact_channel_uri.dart';
+import 'package:lotti/l10n/app_localizations.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:material_ui/material_ui.dart';
 
@@ -49,6 +50,10 @@ class _RelationshipActionBarState extends ConsumerState<RelationshipActionBar> {
   /// launchable, which renders the bar with two controls.
   ReachableChannel? _reachable;
 
+  /// Bumped per resolution so one that started before the channels changed
+  /// cannot land after the newer one and offer a channel that is gone.
+  int _resolution = 0;
+
   @override
   void initState() {
     super.initState();
@@ -65,6 +70,7 @@ class _RelationshipActionBarState extends ConsumerState<RelationshipActionBar> {
   }
 
   Future<void> _resolveReachable() async {
+    final generation = ++_resolution;
     final launcher = ref.read(contactLauncherProvider);
     ReachableChannel? found;
     for (final channel in widget.relationship.data.contactChannels) {
@@ -76,7 +82,7 @@ class _RelationshipActionBarState extends ConsumerState<RelationshipActionBar> {
       }
       if (found != null) break;
     }
-    if (!mounted) return;
+    if (!mounted || generation != _resolution) return;
     setState(() => _reachable = found);
   }
 
@@ -90,56 +96,73 @@ class _RelationshipActionBarState extends ConsumerState<RelationshipActionBar> {
     // controls sit above it (the task bar's rule) and on the page's reading
     // column, so a desktop window does not stretch the pill across it.
     final safeBottomInset = MediaQuery.paddingOf(context).bottom;
-    final column = detailContentInsets(context);
 
     return DesignSystemGlassStrip(
-      child: Padding(
-        padding: EdgeInsets.fromLTRB(
-          column.left,
-          spacing.step4,
-          column.right,
-          spacing.step4 + safeBottomInset,
-        ),
-        child: Row(
-          children: [
-            Expanded(
-              child: DsGlassPill(
-                key: const ValueKey('person-action-log-check-in'),
-                label: messages.relationshipLogCheckIn,
-                icon: LottiIcons.greeting,
-                expand: true,
-                fillColor: tokens.colors.interactive.enabled,
-                foregroundColor: tokens.colors.text.onInteractiveAlert,
-                onTap: widget.onLogCheckIn,
-              ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final column = detailContentInsets(
+            context,
+            availableWidth: constraints.maxWidth,
+          );
+          return Padding(
+            padding: EdgeInsets.fromLTRB(
+              column.left,
+              spacing.step4,
+              column.right,
+              spacing.step4 + safeBottomInset,
             ),
-            SizedBox(width: spacing.step4),
-            DsGlassRoundButton(
-              key: const ValueKey('person-action-speak'),
-              icon: LottiIcons.mic,
-              semanticLabel: messages.checkInSpeakButton,
-              onPressed: widget.onSpeak,
-            ),
-            if (reachable != null) ...[
-              SizedBox(width: spacing.step4),
-              DsGlassRoundButton(
-                key: const ValueKey('person-action-channel'),
-                icon: contactActionIcon(reachable.action),
-                semanticLabel: contactActionLabel(context, reachable.action),
-                onPressed: () => unawaited(
-                  launchContactAction(
-                    context,
-                    ref,
-                    relationshipId: widget.relationship.id,
-                    channel: reachable.channel,
-                    action: reachable.action,
-                  ),
-                ),
-              ),
-            ],
-          ],
-        ),
+            child: _controls(context, tokens, messages, reachable),
+          );
+        },
       ),
+    );
+  }
+
+  Widget _controls(
+    BuildContext context,
+    DsTokens tokens,
+    AppLocalizations messages,
+    ReachableChannel? reachable,
+  ) {
+    final spacing = tokens.spacing;
+    return Row(
+      children: [
+        Expanded(
+          child: DsGlassPill(
+            key: const ValueKey('person-action-log-check-in'),
+            label: messages.relationshipLogCheckIn,
+            icon: LottiIcons.greeting,
+            expand: true,
+            fillColor: tokens.colors.interactive.enabled,
+            foregroundColor: tokens.colors.text.onInteractiveAlert,
+            onTap: widget.onLogCheckIn,
+          ),
+        ),
+        SizedBox(width: spacing.step4),
+        DsGlassRoundButton(
+          key: const ValueKey('person-action-speak'),
+          icon: LottiIcons.mic,
+          semanticLabel: messages.checkInSpeakButton,
+          onPressed: widget.onSpeak,
+        ),
+        if (reachable != null) ...[
+          SizedBox(width: spacing.step4),
+          DsGlassRoundButton(
+            key: const ValueKey('person-action-channel'),
+            icon: contactActionIcon(reachable.action),
+            semanticLabel: contactActionLabel(context, reachable.action),
+            onPressed: () => unawaited(
+              launchContactAction(
+                context,
+                ref,
+                relationshipId: widget.relationship.id,
+                channel: reachable.channel,
+                action: reachable.action,
+              ),
+            ),
+          ),
+        ],
+      ],
     );
   }
 }

--- a/lib/features/relationships/ui/widgets/relationship_action_bar.dart
+++ b/lib/features/relationships/ui/widgets/relationship_action_bar.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/relationship_data.dart';
@@ -63,8 +64,12 @@ class _RelationshipActionBarState extends ConsumerState<RelationshipActionBar> {
   @override
   void didUpdateWidget(RelationshipActionBar oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.relationship.data.contactChannels !=
-        widget.relationship.data.contactChannels) {
+    // By value: a rebuilt entity with the same channels must not re-probe
+    // the platform, and a changed list must, whatever its identity.
+    if (!listEquals(
+      oldWidget.relationship.data.contactChannels,
+      widget.relationship.data.contactChannels,
+    )) {
       unawaited(_resolveReachable());
     }
   }

--- a/lib/features/relationships/ui/widgets/relationship_action_bar.dart
+++ b/lib/features/relationships/ui/widgets/relationship_action_bar.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/relationship_data.dart';
+import 'package:lotti/features/design_system/components/glass_action_bar.dart';
+import 'package:lotti/features/design_system/components/glass_strip.dart';
+import 'package:lotti/features/design_system/components/layout/detail_content_width.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/relationships/service/contact_launcher.dart';
+import 'package:lotti/features/relationships/ui/widgets/contact_quick_actions.dart';
+import 'package:lotti/features/relationships/util/contact_channel_uri.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:material_ui/material_ui.dart';
+
+/// A contact channel paired with the one action the platform will service
+/// for it — what the action bar's third control launches.
+typedef ReachableChannel = ({ContactChannel channel, ContactAction action});
+
+/// The person page's sticky bottom bar (design 2026-09-06 §2–3), replacing
+/// the floating button: *Log check-in* · mic · the platform's actionable
+/// channel. The same glass strip the task page docks, so the two pages
+/// end the same way.
+///
+/// The channel control is the first channel, in the person's own order,
+/// that the platform can actually open — a call on a phone, email on a
+/// desktop with a mail client, nothing at all where neither exists. The
+/// check runs once when the bar is built, like the channel row's buttons,
+/// so the user never taps a control that turns out to do nothing.
+class RelationshipActionBar extends ConsumerStatefulWidget {
+  const RelationshipActionBar({
+    required this.relationship,
+    required this.onLogCheckIn,
+    required this.onSpeak,
+    super.key,
+  });
+
+  final RelationshipEntry relationship;
+  final VoidCallback onLogCheckIn;
+  final VoidCallback onSpeak;
+
+  @override
+  ConsumerState<RelationshipActionBar> createState() =>
+      _RelationshipActionBarState();
+}
+
+class _RelationshipActionBarState extends ConsumerState<RelationshipActionBar> {
+  /// Null until the platform has been asked; stays null when no channel is
+  /// launchable, which renders the bar with two controls.
+  ReachableChannel? _reachable;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_resolveReachable());
+  }
+
+  @override
+  void didUpdateWidget(RelationshipActionBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.relationship.data.contactChannels !=
+        widget.relationship.data.contactChannels) {
+      unawaited(_resolveReachable());
+    }
+  }
+
+  Future<void> _resolveReachable() async {
+    final launcher = ref.read(contactLauncherProvider);
+    ReachableChannel? found;
+    for (final channel in widget.relationship.data.contactChannels) {
+      for (final action in contactActionsFor(channel.type)) {
+        if (await launcher.canLaunch(channel, action)) {
+          found = (channel: channel, action: action);
+          break;
+        }
+      }
+      if (found != null) break;
+    }
+    if (!mounted) return;
+    setState(() => _reachable = found);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final spacing = tokens.spacing;
+    final messages = context.messages;
+    final reachable = _reachable;
+    // The glass extends edge to edge and into the home-indicator inset; the
+    // controls sit above it (the task bar's rule) and on the page's reading
+    // column, so a desktop window does not stretch the pill across it.
+    final safeBottomInset = MediaQuery.paddingOf(context).bottom;
+    final column = detailContentInsets(context);
+
+    return DesignSystemGlassStrip(
+      child: Padding(
+        padding: EdgeInsets.fromLTRB(
+          column.left,
+          spacing.step4,
+          column.right,
+          spacing.step4 + safeBottomInset,
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: DsGlassPill(
+                key: const ValueKey('person-action-log-check-in'),
+                label: messages.relationshipLogCheckIn,
+                icon: LottiIcons.greeting,
+                expand: true,
+                fillColor: tokens.colors.interactive.enabled,
+                foregroundColor: tokens.colors.text.onInteractiveAlert,
+                onTap: widget.onLogCheckIn,
+              ),
+            ),
+            SizedBox(width: spacing.step4),
+            DsGlassRoundButton(
+              key: const ValueKey('person-action-speak'),
+              icon: LottiIcons.mic,
+              semanticLabel: messages.checkInSpeakButton,
+              onPressed: widget.onSpeak,
+            ),
+            if (reachable != null) ...[
+              SizedBox(width: spacing.step4),
+              DsGlassRoundButton(
+                key: const ValueKey('person-action-channel'),
+                icon: contactActionIcon(reachable.action),
+                semanticLabel: contactActionLabel(context, reachable.action),
+                onPressed: () => unawaited(
+                  launchContactAction(
+                    context,
+                    ref,
+                    relationshipId: widget.relationship.id,
+                    channel: reachable.channel,
+                    action: reachable.action,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/relationships/ui/widgets/relationship_briefing_card.dart
+++ b/lib/features/relationships/ui/widgets/relationship_briefing_card.dart
@@ -34,6 +34,33 @@ String relationshipHealthBandLabel(
     context.messages.relationshipHealthStrained,
 };
 
+/// The accent a health band wears wherever it is shown as a tinted pill —
+/// the briefing card's chip and the person header's band pill alike. The
+/// band accent as text on its own tint is a contrast failure, so callers
+/// paint the label in high-emphasis ink and let the colour ride the tint.
+Color relationshipHealthBandColor(
+  DsTokens tokens,
+  RelationshipHealthBand band,
+) => switch (band) {
+  RelationshipHealthBand.thriving => tokens.colors.alert.success.defaultColor,
+  RelationshipHealthBand.steady => tokens.colors.aiCard.accent,
+  RelationshipHealthBand.needsAttention =>
+    tokens.colors.alert.warning.defaultColor,
+  RelationshipHealthBand.strained => tokens.colors.alert.error.defaultColor,
+};
+
+/// The agent's standing briefing, if [report] is one: the `current`-scope
+/// report entity that has not been deleted. Anything else — no report yet,
+/// a historical scope, a tombstone — is `null`, and the surfaces that read
+/// the briefing (the card, the header's band pill) treat that as "no
+/// briefing" together rather than each deciding differently.
+AgentReportEntity? currentRelationshipReport(Object? report) =>
+    report is AgentReportEntity &&
+        report.scope == AgentReportScopes.current &&
+        report.deletedAt == null
+    ? report
+    : null;
+
 /// The executive briefing on the person's detail page (plan v2 phase 5
 /// item 5): the latest report's health chip and TLDR, the expandable full
 /// briefing, the explicit "Brief me" trigger — with provider disclosure
@@ -149,14 +176,9 @@ class _RelationshipBriefingCardState
     final tokens = context.designTokens;
     final ai = tokens.colors.aiCard;
     final messages = context.messages;
-    final reportAsync = ref.watch(agentReportProvider(_agentId));
-    final report = reportAsync.value;
-    final current =
-        report is AgentReportEntity &&
-            report.scope == AgentReportScopes.current &&
-            report.deletedAt == null
-        ? report
-        : null;
+    final current = currentRelationshipReport(
+      ref.watch(agentReportProvider(_agentId)).value,
+    );
     final health = current == null
         ? null
         : relationshipHealthMetricsFromReport(current);
@@ -177,16 +199,6 @@ class _RelationshipBriefingCardState
     final agentName = rawAgentName == widget.relationship.data.title.trim()
         ? null
         : rawAgentName;
-
-    final bandColor = switch (health?.band) {
-      RelationshipHealthBand.thriving =>
-        tokens.colors.alert.success.defaultColor,
-      RelationshipHealthBand.steady => ai.accent,
-      RelationshipHealthBand.needsAttention =>
-        tokens.colors.alert.warning.defaultColor,
-      RelationshipHealthBand.strained => tokens.colors.alert.error.defaultColor,
-      null => tokens.colors.background.level03,
-    };
 
     return DecoratedBox(
       key: const ValueKey('relationship-briefing-card'),
@@ -226,7 +238,7 @@ class _RelationshipBriefingCardState
                       key: const ValueKey('relationship-health-chip'),
                       variant: DsPillVariant.tinted,
                       shape: DsPillShape.tag,
-                      color: bandColor,
+                      color: relationshipHealthBandColor(tokens, health.band),
                       // The band accent as text on its own tint is a
                       // contrast failure; the colour identity rides the
                       // tint, as it does on the task status tag.

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4475,7 +4475,7 @@
   "relationshipPayAttentionTo": "Dávej pozor na",
   "relationshipPostCallConfirm": "Zapsat check-in",
   "relationshipPostCallDismiss": "Teď ne",
-  "relationshipPostCallMeta": "začátek {time} · asi {minutes} min",
+  "relationshipPostCallMeta": "začátek v {time} · asi {minutes} min",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {
@@ -4486,7 +4486,7 @@
       }
     }
   },
-  "relationshipPostCallOfferCall": "Hovor s {name} před {minutes, plural, =1{1 minutou} other{{minutes} minutami}} — zapíšeme to, dokud je to čerstvé?",
+  "relationshipPostCallOfferCall": "Hovor s {name} před {minutes, plural, =0{necelou minutou} =1{1 minutou} other{{minutes} minutami}} — zapíšeme to, dokud je to čerstvé?",
   "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
@@ -4497,7 +4497,7 @@
       }
     }
   },
-  "relationshipPostCallOfferMessage": "Zpráva pro {name} před {minutes, plural, =1{1 minutou} other{{minutes} minutami}} — zapíšeme to, dokud je to čerstvé?",
+  "relationshipPostCallOfferMessage": "Zpráva pro {name} před {minutes, plural, =0{necelou minutou} =1{1 minutou} other{{minutes} minutami}} — zapíšeme to, dokud je to čerstvé?",
   "@relationshipPostCallOfferMessage": {
     "placeholders": {
       "name": {

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4475,7 +4475,7 @@
   "relationshipPayAttentionTo": "Dávej pozor na",
   "relationshipPostCallConfirm": "Zapsat check-in",
   "relationshipPostCallDismiss": "Teď ne",
-  "relationshipPostCallMeta": "začátek v {time} · asi {minutes} min",
+  "relationshipPostCallMeta": "začátek v {time} · {minutes, plural, =0{necelá minuta} =1{asi 1 min} other{asi {minutes} min}}",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4340,7 +4340,45 @@
       }
     }
   },
+  "relationshipDueSince": "Po termínu od {day} · {count, plural, =1{1 den po termínu} few{{count} dny po termínu} other{{count} dní po termínu}}",
+  "@relationshipDueSince": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDueToday": "Dnes na řadě",
+  "relationshipDurationHours": "{hours} h",
+  "@relationshipDurationHours": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipDurationHoursMinutes": "{hours} h {minutes}",
+  "@relationshipDurationHoursMinutes": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipDurationMinutes": "{count} min",
+  "@relationshipDurationMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipEditTitle": "Upravit osobu",
   "relationshipErrorCreateFailed": "Osobu se nepodařilo uložit. Zkus to prosím znovu.",
   "relationshipErrorDeleteFailed": "Osobu se nepodařilo smazat. Zkus to prosím znovu.",
@@ -4373,6 +4411,14 @@
     "description": "Relationships redesign label."
   },
   "relationshipLastCheckInLabel": "Poslední záznam {date}",
+  "relationshipLastSpoke": "naposledy mluvili {time}",
+  "@relationshipLastSpoke": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipLinkContact": "Propojit kontakt",
   "relationshipLinkedTasksLabel": "Úkoly",
   "relationshipLinkTaskButton": "Propojit úkol",
@@ -4389,6 +4435,7 @@
       }
     }
   },
+  "relationshipMoreActions": "Další akce",
   "relationshipNameLabel": "Jméno",
   "relationshipNameRequired": "Jméno je povinné",
   "relationshipNextByDay": "příští do {day}",
@@ -4399,6 +4446,15 @@
       }
     }
   },
+  "relationshipNextDueOn": "Příště {day}",
+  "@relationshipNextDueOn": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipNextTimeTitle": "Příště",
   "relationshipNicknameLabel": "Přezdívka",
   "relationshipNoCheckIns": "Zatím žádné záznamy — přidej první po dalším rozhovoru.",
   "relationshipNoLinkedTasks": "Zatím žádné propojené úkoly.",
@@ -4408,15 +4464,47 @@
   "@relationshipNudgesOn": {
     "description": "Relationships redesign label."
   },
-  "relationshipPostCallBody": "Právě jsi se ozval. Chceš si zapsat check-in, dokud je to čerstvé?",
+  "relationshipOnTrackCadence": "V rytmu · {cadence}",
+  "@relationshipOnTrackCadence": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipPayAttentionTo": "Dávej pozor na",
   "relationshipPostCallConfirm": "Zapsat check-in",
   "relationshipPostCallDismiss": "Teď ne",
-  "relationshipPostCallTitle": "Jak to šlo s {name}?",
-  "@relationshipPostCallTitle": {
+  "relationshipPostCallMeta": "začátek {time} · asi {minutes} min",
+  "@relationshipPostCallMeta": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferCall": "Hovor s {name} před {minutes, plural, =1{1 minutou} other{{minutes} minutami}} — zapíšeme to, dokud je to čerstvé?",
+  "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
-        "type": "String",
-        "example": "Anna"
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferMessage": "Zpráva pro {name} před {minutes, plural, =1{1 minutou} other{{minutes} minutami}} — zapíšeme to, dokud je to čerstvé?",
+  "@relationshipPostCallOfferMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
       }
     }
   },
@@ -4428,6 +4516,8 @@
       }
     }
   },
+  "relationshipReachPrivacy": "Zůstává v tomto zařízení · nikdy se nesdílí s AI",
+  "relationshipReachTitle": "Kontakt",
   "relationshipRelinkContact": "Propojit jiný kontakt",
   "relationshipSeeAllCheckIns": "Zobrazit všechny záznamy",
   "@relationshipSeeAllCheckIns": {
@@ -4510,6 +4600,14 @@
   "relationshipStayInTouch": "Udržovat kontakt",
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
+  },
+  "relationshipTasksLinkedCount": "{count, plural, =1{1 propojený} few{{count} propojené} other{{count} propojených}}",
+  "@relationshipTasksLinkedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   },
   "relationshipTimestampToday": "Dnes",
   "relationshipTimestampYesterday": "Včera",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4971,7 +4971,7 @@
   "relationshipPayAttentionTo": "Vær opmærksom på",
   "relationshipPostCallConfirm": "Log tjek-ind",
   "relationshipPostCallDismiss": "Ikke nu",
-  "relationshipPostCallMeta": "startede kl. {time} · cirka {minutes} min",
+  "relationshipPostCallMeta": "startede kl. {time} · {minutes, plural, =0{under et minut} =1{cirka 1 min} other{cirka {minutes} min}}",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4836,7 +4836,45 @@
       }
     }
   },
+  "relationshipDueSince": "Forfaldet siden {day} · {count, plural, =1{1 dag over tid} other{{count} dage over tid}}",
+  "@relationshipDueSince": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDueToday": "Skal kontaktes i dag",
+  "relationshipDurationHours": "{hours} t",
+  "@relationshipDurationHours": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipDurationHoursMinutes": "{hours} t {minutes}",
+  "@relationshipDurationHoursMinutes": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipDurationMinutes": "{count} min",
+  "@relationshipDurationMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipEditTitle": "Redigér person",
   "relationshipErrorCreateFailed": "Personen kunne ikke gemmes. Prøv igen.",
   "relationshipErrorDeleteFailed": "Personen kunne ikke slettes. Prøv igen.",
@@ -4869,6 +4907,14 @@
     "description": "Relationships redesign label."
   },
   "relationshipLastCheckInLabel": "Seneste check-in {date}",
+  "relationshipLastSpoke": "sidst talt {time}",
+  "@relationshipLastSpoke": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipLinkContact": "Tilknyt kontakt",
   "relationshipLinkedTasksLabel": "Opgaver",
   "relationshipLinkTaskButton": "Link opgave",
@@ -4885,6 +4931,7 @@
       }
     }
   },
+  "relationshipMoreActions": "Flere handlinger",
   "relationshipNameLabel": "Navn",
   "relationshipNameRequired": "Navn er påkrævet",
   "relationshipNextByDay": "næste senest {day}",
@@ -4895,6 +4942,15 @@
       }
     }
   },
+  "relationshipNextDueOn": "Næste gang {day}",
+  "@relationshipNextDueOn": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipNextTimeTitle": "Næste gang",
   "relationshipNicknameLabel": "Kaldenavn",
   "relationshipNoCheckIns": "Ingen check-ins endnu — registrér et efter jeres næste snak.",
   "relationshipNoLinkedTasks": "Ingen opgaver linket endnu.",
@@ -4904,15 +4960,47 @@
   "@relationshipNudgesOn": {
     "description": "Relationships redesign label."
   },
-  "relationshipPostCallBody": "Du tog lige kontakt. Vil du logge et tjek-ind, mens det er friskt?",
+  "relationshipOnTrackCadence": "På sporet · {cadence}",
+  "@relationshipOnTrackCadence": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipPayAttentionTo": "Vær opmærksom på",
   "relationshipPostCallConfirm": "Log tjek-ind",
   "relationshipPostCallDismiss": "Ikke nu",
-  "relationshipPostCallTitle": "Hvordan gik det med {name}?",
-  "@relationshipPostCallTitle": {
+  "relationshipPostCallMeta": "startede {time} · cirka {minutes} min",
+  "@relationshipPostCallMeta": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferCall": "Du ringede til {name} for {minutes, plural, =1{1 minut} other{{minutes} minutter}} siden — skal vi notere det, mens det er frisk?",
+  "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
-        "type": "String",
-        "example": "Anna"
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferMessage": "Du skrev til {name} for {minutes, plural, =1{1 minut} other{{minutes} minutter}} siden — skal vi notere det, mens det er frisk?",
+  "@relationshipPostCallOfferMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
       }
     }
   },
@@ -4924,6 +5012,8 @@
       }
     }
   },
+  "relationshipReachPrivacy": "Bliver på denne enhed · deles aldrig med AI'en",
+  "relationshipReachTitle": "Kontakt",
   "relationshipRelinkContact": "Tilknyt en anden kontakt",
   "relationshipSeeAllCheckIns": "Se alle check-ins",
   "@relationshipSeeAllCheckIns": {
@@ -5006,6 +5096,14 @@
   "relationshipStayInTouch": "Hold kontakten",
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
+  },
+  "relationshipTasksLinkedCount": "{count, plural, =1{1 tilknyttet} other{{count} tilknyttede}}",
+  "@relationshipTasksLinkedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   },
   "relationshipTimestampToday": "I dag",
   "relationshipTimestampYesterday": "I går",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4836,7 +4836,7 @@
       }
     }
   },
-  "relationshipDueSince": "Forfaldet siden {day} · {count, plural, =1{1 dag over tid} other{{count} dage over tid}}",
+  "relationshipDueSince": "Forfalden siden {day} · {count, plural, =1{1 dag forsinket} other{{count} dage forsinket}}",
   "@relationshipDueSince": {
     "placeholders": {
       "day": {
@@ -4971,7 +4971,7 @@
   "relationshipPayAttentionTo": "Vær opmærksom på",
   "relationshipPostCallConfirm": "Log tjek-ind",
   "relationshipPostCallDismiss": "Ikke nu",
-  "relationshipPostCallMeta": "startede {time} · cirka {minutes} min",
+  "relationshipPostCallMeta": "startede kl. {time} · cirka {minutes} min",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {
@@ -4982,7 +4982,7 @@
       }
     }
   },
-  "relationshipPostCallOfferCall": "Du ringede til {name} for {minutes, plural, =1{1 minut} other{{minutes} minutter}} siden — skal vi notere det, mens det er frisk?",
+  "relationshipPostCallOfferCall": "Du ringede til {name} for {minutes, plural, =0{under et minut} =1{1 minut} other{{minutes} minutter}} siden — skal vi notere det, mens det er frisk?",
   "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
@@ -4993,7 +4993,7 @@
       }
     }
   },
-  "relationshipPostCallOfferMessage": "Du skrev til {name} for {minutes, plural, =1{1 minut} other{{minutes} minutter}} siden — skal vi notere det, mens det er frisk?",
+  "relationshipPostCallOfferMessage": "Du skrev til {name} for {minutes, plural, =0{under et minut} =1{1 minut} other{{minutes} minutter}} siden — skal vi notere det, mens det er frisk?",
   "@relationshipPostCallOfferMessage": {
     "placeholders": {
       "name": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -4333,7 +4333,45 @@
       }
     }
   },
+  "relationshipDueSince": "Fällig seit {day} · {count, plural, =1{1 Tag drüber} other{{count} Tage drüber}}",
+  "@relationshipDueSince": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDueToday": "Heute fällig",
+  "relationshipDurationHours": "{hours} Std.",
+  "@relationshipDurationHours": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipDurationHoursMinutes": "{hours} Std. {minutes}",
+  "@relationshipDurationHoursMinutes": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipDurationMinutes": "{count} Min.",
+  "@relationshipDurationMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipEditTitle": "Person bearbeiten",
   "relationshipErrorCreateFailed": "Person konnte nicht gespeichert werden. Bitte versuch es erneut.",
   "relationshipErrorDeleteFailed": "Person konnte nicht gelöscht werden. Bitte versuch es erneut.",
@@ -4366,6 +4404,14 @@
     "description": "Relationships redesign label."
   },
   "relationshipLastCheckInLabel": "Letzter Check-in {date}",
+  "relationshipLastSpoke": "zuletzt gesprochen {time}",
+  "@relationshipLastSpoke": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipLinkContact": "Kontakt verknüpfen",
   "relationshipLinkedTasksLabel": "Aufgaben",
   "relationshipLinkTaskButton": "Aufgabe verknüpfen",
@@ -4382,6 +4428,7 @@
       }
     }
   },
+  "relationshipMoreActions": "Weitere Aktionen",
   "relationshipNameLabel": "Name",
   "relationshipNameRequired": "Ein Name ist erforderlich",
   "relationshipNextByDay": "nächstens bis {day}",
@@ -4392,6 +4439,15 @@
       }
     }
   },
+  "relationshipNextDueOn": "Nächste Fälligkeit {day}",
+  "@relationshipNextDueOn": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipNextTimeTitle": "Nächstes Mal",
   "relationshipNicknameLabel": "Spitzname",
   "relationshipNoCheckIns": "Noch keine Check-ins — erfasse einen nach eurem nächsten Gespräch.",
   "relationshipNoLinkedTasks": "Noch keine Aufgaben verknüpft.",
@@ -4401,15 +4457,47 @@
   "@relationshipNudgesOn": {
     "description": "Relationships redesign label."
   },
-  "relationshipPostCallBody": "Du hast dich gerade gemeldet. Willst du gleich einen Check-in festhalten?",
+  "relationshipOnTrackCadence": "Im Rhythmus · {cadence}",
+  "@relationshipOnTrackCadence": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipPayAttentionTo": "Darauf achten",
   "relationshipPostCallConfirm": "Check-in festhalten",
   "relationshipPostCallDismiss": "Jetzt nicht",
-  "relationshipPostCallTitle": "Wie ist es mit {name} gelaufen?",
-  "@relationshipPostCallTitle": {
+  "relationshipPostCallMeta": "begonnen {time} · etwa {minutes} Min.",
+  "@relationshipPostCallMeta": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferCall": "Du hast {name} vor {minutes, plural, =1{1 Minute} other{{minutes} Minuten}} angerufen — jetzt festhalten, solange es frisch ist?",
+  "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
-        "type": "String",
-        "example": "Anna"
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferMessage": "Du hast {name} vor {minutes, plural, =1{1 Minute} other{{minutes} Minuten}} geschrieben — jetzt festhalten, solange es frisch ist?",
+  "@relationshipPostCallOfferMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
       }
     }
   },
@@ -4421,6 +4509,8 @@
       }
     }
   },
+  "relationshipReachPrivacy": "Bleibt auf diesem Gerät · nie mit der KI geteilt",
+  "relationshipReachTitle": "Erreichen",
   "relationshipRelinkContact": "Anderen Kontakt verknüpfen",
   "relationshipSeeAllCheckIns": "Alle Check-ins ansehen",
   "@relationshipSeeAllCheckIns": {
@@ -4503,6 +4593,14 @@
   "relationshipStayInTouch": "Kontakt halten",
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
+  },
+  "relationshipTasksLinkedCount": "{count, plural, =1{1 verknüpft} other{{count} verknüpft}}",
+  "@relationshipTasksLinkedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   },
   "relationshipTimestampToday": "Heute",
   "relationshipTimestampYesterday": "Gestern",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -4468,7 +4468,7 @@
   "relationshipPayAttentionTo": "Darauf achten",
   "relationshipPostCallConfirm": "Check-in festhalten",
   "relationshipPostCallDismiss": "Jetzt nicht",
-  "relationshipPostCallMeta": "begonnen um {time} · etwa {minutes} Min.",
+  "relationshipPostCallMeta": "begonnen um {time} · {minutes, plural, =0{unter einer Minute} =1{etwa 1 Min.} other{etwa {minutes} Min.}}",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -4333,7 +4333,7 @@
       }
     }
   },
-  "relationshipDueSince": "Fällig seit {day} · {count, plural, =1{1 Tag drüber} other{{count} Tage drüber}}",
+  "relationshipDueSince": "Fällig seit {day} · {count, plural, =1{1 Tag überfällig} other{{count} Tage überfällig}}",
   "@relationshipDueSince": {
     "placeholders": {
       "day": {
@@ -4468,7 +4468,7 @@
   "relationshipPayAttentionTo": "Darauf achten",
   "relationshipPostCallConfirm": "Check-in festhalten",
   "relationshipPostCallDismiss": "Jetzt nicht",
-  "relationshipPostCallMeta": "begonnen {time} · etwa {minutes} Min.",
+  "relationshipPostCallMeta": "begonnen um {time} · etwa {minutes} Min.",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {
@@ -4479,7 +4479,7 @@
       }
     }
   },
-  "relationshipPostCallOfferCall": "Du hast {name} vor {minutes, plural, =1{1 Minute} other{{minutes} Minuten}} angerufen — jetzt festhalten, solange es frisch ist?",
+  "relationshipPostCallOfferCall": "Du hast {name} vor {minutes, plural, =0{weniger als einer Minute} =1{1 Minute} other{{minutes} Minuten}} angerufen — jetzt festhalten, solange es frisch ist?",
   "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
@@ -4490,7 +4490,7 @@
       }
     }
   },
-  "relationshipPostCallOfferMessage": "Du hast {name} vor {minutes, plural, =1{1 Minute} other{{minutes} Minuten}} geschrieben — jetzt festhalten, solange es frisch ist?",
+  "relationshipPostCallOfferMessage": "Du hast {name} vor {minutes, plural, =0{weniger als einer Minute} =1{1 Minute} other{{minutes} Minuten}} geschrieben — jetzt festhalten, solange es frisch ist?",
   "@relationshipPostCallOfferMessage": {
     "placeholders": {
       "name": {
@@ -4594,7 +4594,7 @@
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
   },
-  "relationshipTasksLinkedCount": "{count, plural, =1{1 verknüpft} other{{count} verknüpft}}",
+  "relationshipTasksLinkedCount": "{count, plural, =1{1 verknüpfte Aufgabe} other{{count} verknüpfte Aufgaben}}",
   "@relationshipTasksLinkedCount": {
     "placeholders": {
       "count": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6601,7 +6601,7 @@
       }
     }
   },
-  "relationshipPostCallOfferCall": "You called {name} {minutes, plural, =1{1 minute} other{{minutes} minutes}} ago — log it while it is fresh?",
+  "relationshipPostCallOfferCall": "You called {name} {minutes, plural, =0{less than a minute} =1{1 minute} other{{minutes} minutes}} ago — log it while it is fresh?",
   "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
@@ -6612,7 +6612,7 @@
       }
     }
   },
-  "relationshipPostCallOfferMessage": "You wrote to {name} {minutes, plural, =1{1 minute} other{{minutes} minutes}} ago — log it while it is fresh?",
+  "relationshipPostCallOfferMessage": "You wrote to {name} {minutes, plural, =0{less than a minute} =1{1 minute} other{{minutes} minutes}} ago — log it while it is fresh?",
   "@relationshipPostCallOfferMessage": {
     "placeholders": {
       "name": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6373,7 +6373,45 @@
       }
     }
   },
+  "relationshipDueSince": "Due since {day} · {count, plural, =1{1 day over} other{{count} days over}}",
+  "@relationshipDueSince": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDueToday": "Due today",
+  "relationshipDurationHours": "{hours} h",
+  "@relationshipDurationHours": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipDurationHoursMinutes": "{hours} h {minutes}",
+  "@relationshipDurationHoursMinutes": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipDurationMinutes": "{count} min",
+  "@relationshipDurationMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipEditTitle": "Edit person",
   "relationshipErrorCreateFailed": "Could not save this person. Please try again.",
   "relationshipErrorDeleteFailed": "Could not delete this person. Please try again.",
@@ -6476,6 +6514,14 @@
       }
     }
   },
+  "relationshipLastSpoke": "last spoke {time}",
+  "@relationshipLastSpoke": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipLinkContact": "Link contact",
   "@relationshipLinkContact": {
     "description": "Action that opens the OS contact picker to copy channels onto a person"
@@ -6495,6 +6541,10 @@
       }
     }
   },
+  "relationshipMoreActions": "More actions",
+  "@relationshipMoreActions": {
+    "description": "Tooltip of the person page's overflow menu (link contact, delete)"
+  },
   "relationshipNameLabel": "Name",
   "relationshipNameRequired": "A name is required",
   "relationshipNextByDay": "next by {day}",
@@ -6505,6 +6555,15 @@
       }
     }
   },
+  "relationshipNextDueOn": "Next due {day}",
+  "@relationshipNextDueOn": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipNextTimeTitle": "Next time",
   "relationshipNicknameLabel": "Nickname",
   "relationshipNoCheckIns": "No check-ins yet — log one after you next talk.",
   "relationshipNoLinkedTasks": "No tasks linked yet.",
@@ -6514,10 +6573,15 @@
   "@relationshipNudgesOn": {
     "description": "Relationships redesign label."
   },
-  "relationshipPostCallBody": "You reached out a moment ago. Log a check-in while it is fresh?",
-  "@relationshipPostCallBody": {
-    "description": "Body of the prompt offered after returning from a call or message"
+  "relationshipOnTrackCadence": "On track · {cadence}",
+  "@relationshipOnTrackCadence": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
   },
+  "relationshipPayAttentionTo": "Pay attention to",
   "relationshipPostCallConfirm": "Log check-in",
   "@relationshipPostCallConfirm": {
     "description": "Button that opens a pre-filled check-in from the post-call prompt"
@@ -6526,13 +6590,36 @@
   "@relationshipPostCallDismiss": {
     "description": "Button that dismisses the post-call prompt without a trace"
   },
-  "relationshipPostCallTitle": "How did it go with {name}?",
-  "@relationshipPostCallTitle": {
-    "description": "Title of the prompt offered after returning from a call or message",
+  "relationshipPostCallMeta": "started {time} · about {minutes} min",
+  "@relationshipPostCallMeta": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferCall": "You called {name} {minutes, plural, =1{1 minute} other{{minutes} minutes}} ago — log it while it is fresh?",
+  "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
-        "type": "String",
-        "example": "Anna"
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferMessage": "You wrote to {name} {minutes, plural, =1{1 minute} other{{minutes} minutes}} ago — log it while it is fresh?",
+  "@relationshipPostCallOfferMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
       }
     }
   },
@@ -6544,6 +6631,8 @@
       }
     }
   },
+  "relationshipReachPrivacy": "Stays on this device · never shared with the AI",
+  "relationshipReachTitle": "Reach",
   "relationshipRelinkContact": "Link a different contact",
   "@relationshipRelinkContact": {
     "description": "Menu action that replaces the OS contact a person is linked to"
@@ -6629,6 +6718,14 @@
   "relationshipStayInTouch": "Stay in touch",
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
+  },
+  "relationshipTasksLinkedCount": "{count, plural, =1{1 linked} other{{count} linked}}",
+  "@relationshipTasksLinkedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   },
   "relationshipTimestampToday": "Today",
   "@relationshipTimestampToday": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6590,7 +6590,7 @@
   "@relationshipPostCallDismiss": {
     "description": "Button that dismisses the post-call prompt without a trace"
   },
-  "relationshipPostCallMeta": "started {time} · about {minutes} min",
+  "relationshipPostCallMeta": "started {time} · {minutes, plural, =0{under a minute} =1{about 1 min} other{about {minutes} min}}",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4333,7 +4333,45 @@
       }
     }
   },
+  "relationshipDueSince": "Pendiente desde {day} · {count, plural, =1{1 día de retraso} other{{count} días de retraso}}",
+  "@relationshipDueSince": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDueToday": "Pendiente hoy",
+  "relationshipDurationHours": "{hours} h",
+  "@relationshipDurationHours": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipDurationHoursMinutes": "{hours} h {minutes}",
+  "@relationshipDurationHoursMinutes": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipDurationMinutes": "{count} min",
+  "@relationshipDurationMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipEditTitle": "Editar persona",
   "relationshipErrorCreateFailed": "No se pudo guardar la persona. Inténtalo de nuevo.",
   "relationshipErrorDeleteFailed": "No se pudo eliminar la persona. Inténtalo de nuevo.",
@@ -4366,6 +4404,14 @@
     "description": "Relationships redesign label."
   },
   "relationshipLastCheckInLabel": "Último registro {date}",
+  "relationshipLastSpoke": "última charla {time}",
+  "@relationshipLastSpoke": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipLinkContact": "Vincular contacto",
   "relationshipLinkedTasksLabel": "Tareas",
   "relationshipLinkTaskButton": "Vincular tarea",
@@ -4382,6 +4428,7 @@
       }
     }
   },
+  "relationshipMoreActions": "Más acciones",
   "relationshipNameLabel": "Nombre",
   "relationshipNameRequired": "El nombre es obligatorio",
   "relationshipNextByDay": "próximo antes de {day}",
@@ -4392,6 +4439,15 @@
       }
     }
   },
+  "relationshipNextDueOn": "Próximo plazo {day}",
+  "@relationshipNextDueOn": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipNextTimeTitle": "La próxima vez",
   "relationshipNicknameLabel": "Apodo",
   "relationshipNoCheckIns": "Aún no hay registros: añade uno tras vuestra próxima conversación.",
   "relationshipNoLinkedTasks": "Aún no hay tareas vinculadas.",
@@ -4401,15 +4457,47 @@
   "@relationshipNudgesOn": {
     "description": "Relationships redesign label."
   },
-  "relationshipPostCallBody": "Acabas de contactar. ¿Anotas un check-in mientras lo recuerdas?",
+  "relationshipOnTrackCadence": "Al día · {cadence}",
+  "@relationshipOnTrackCadence": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipPayAttentionTo": "Prestar atención a",
   "relationshipPostCallConfirm": "Anotar check-in",
   "relationshipPostCallDismiss": "Ahora no",
-  "relationshipPostCallTitle": "¿Qué tal fue con {name}?",
-  "@relationshipPostCallTitle": {
+  "relationshipPostCallMeta": "empezó {time} · unos {minutes} min",
+  "@relationshipPostCallMeta": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferCall": "Llamaste a {name} hace {minutes, plural, =1{1 minuto} other{{minutes} minutos}}. ¿Lo anotamos mientras está fresco?",
+  "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
-        "type": "String",
-        "example": "Anna"
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferMessage": "Escribiste a {name} hace {minutes, plural, =1{1 minuto} other{{minutes} minutos}}. ¿Lo anotamos mientras está fresco?",
+  "@relationshipPostCallOfferMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
       }
     }
   },
@@ -4421,6 +4509,8 @@
       }
     }
   },
+  "relationshipReachPrivacy": "Se queda en este dispositivo · nunca se comparte con la IA",
+  "relationshipReachTitle": "Contacto",
   "relationshipRelinkContact": "Vincular otro contacto",
   "relationshipSeeAllCheckIns": "Ver todos los registros",
   "@relationshipSeeAllCheckIns": {
@@ -4503,6 +4593,14 @@
   "relationshipStayInTouch": "Mantener el contacto",
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
+  },
+  "relationshipTasksLinkedCount": "{count, plural, =1{1 vinculada} other{{count} vinculadas}}",
+  "@relationshipTasksLinkedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   },
   "relationshipTimestampToday": "Hoy",
   "relationshipTimestampYesterday": "Ayer",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4468,7 +4468,7 @@
   "relationshipPayAttentionTo": "Prestar atención a",
   "relationshipPostCallConfirm": "Anotar check-in",
   "relationshipPostCallDismiss": "Ahora no",
-  "relationshipPostCallMeta": "empezó a las {time} · unos {minutes} min",
+  "relationshipPostCallMeta": "empezó a las {time} · {minutes, plural, =0{menos de un minuto} =1{alrededor de 1 min} other{unos {minutes} min}}",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4468,7 +4468,7 @@
   "relationshipPayAttentionTo": "Prestar atención a",
   "relationshipPostCallConfirm": "Anotar check-in",
   "relationshipPostCallDismiss": "Ahora no",
-  "relationshipPostCallMeta": "empezó {time} · unos {minutes} min",
+  "relationshipPostCallMeta": "empezó a las {time} · unos {minutes} min",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {
@@ -4479,7 +4479,7 @@
       }
     }
   },
-  "relationshipPostCallOfferCall": "Llamaste a {name} hace {minutes, plural, =1{1 minuto} other{{minutes} minutos}}. ¿Lo anotamos mientras está fresco?",
+  "relationshipPostCallOfferCall": "Llamaste a {name} hace {minutes, plural, =0{menos de un minuto} =1{1 minuto} other{{minutes} minutos}}. ¿Lo anotamos mientras está fresco?",
   "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
@@ -4490,7 +4490,7 @@
       }
     }
   },
-  "relationshipPostCallOfferMessage": "Escribiste a {name} hace {minutes, plural, =1{1 minuto} other{{minutes} minutos}}. ¿Lo anotamos mientras está fresco?",
+  "relationshipPostCallOfferMessage": "Escribiste a {name} hace {minutes, plural, =0{menos de un minuto} =1{1 minuto} other{{minutes} minutos}}. ¿Lo anotamos mientras está fresco?",
   "@relationshipPostCallOfferMessage": {
     "placeholders": {
       "name": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4333,7 +4333,45 @@
       }
     }
   },
+  "relationshipDueSince": "En retard depuis {day} · {count, plural, =1{1 jour de retard} other{{count} jours de retard}}",
+  "@relationshipDueSince": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDueToday": "À relancer aujourd'hui",
+  "relationshipDurationHours": "{hours} h",
+  "@relationshipDurationHours": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipDurationHoursMinutes": "{hours} h {minutes}",
+  "@relationshipDurationHoursMinutes": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipDurationMinutes": "{count} min",
+  "@relationshipDurationMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipEditTitle": "Modifier la personne",
   "relationshipErrorCreateFailed": "Impossible d'enregistrer la personne. Réessaie.",
   "relationshipErrorDeleteFailed": "Impossible de supprimer la personne. Réessaie.",
@@ -4366,6 +4404,14 @@
     "description": "Relationships redesign label."
   },
   "relationshipLastCheckInLabel": "Dernier échange {date}",
+  "relationshipLastSpoke": "dernier échange {time}",
+  "@relationshipLastSpoke": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipLinkContact": "Associer un contact",
   "relationshipLinkedTasksLabel": "Tâches",
   "relationshipLinkTaskButton": "Lier une tâche",
@@ -4382,6 +4428,7 @@
       }
     }
   },
+  "relationshipMoreActions": "Plus d'actions",
   "relationshipNameLabel": "Nom",
   "relationshipNameRequired": "Le nom est obligatoire",
   "relationshipNextByDay": "prochain avant {day}",
@@ -4392,6 +4439,15 @@
       }
     }
   },
+  "relationshipNextDueOn": "Prochaine échéance {day}",
+  "@relationshipNextDueOn": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipNextTimeTitle": "La prochaine fois",
   "relationshipNicknameLabel": "Surnom",
   "relationshipNoCheckIns": "Aucun échange noté — ajoute le premier après votre prochaine conversation.",
   "relationshipNoLinkedTasks": "Aucune tâche liée pour l'instant.",
@@ -4401,15 +4457,47 @@
   "@relationshipNudgesOn": {
     "description": "Relationships redesign label."
   },
-  "relationshipPostCallBody": "Tu viens de le/la contacter. Tu notes un point tant que c’est frais ?",
+  "relationshipOnTrackCadence": "Dans le rythme · {cadence}",
+  "@relationshipOnTrackCadence": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipPayAttentionTo": "Faire attention à",
   "relationshipPostCallConfirm": "Noter un point",
   "relationshipPostCallDismiss": "Pas maintenant",
-  "relationshipPostCallTitle": "Comment ça s’est passé avec {name} ?",
-  "@relationshipPostCallTitle": {
+  "relationshipPostCallMeta": "commencé {time} · environ {minutes} min",
+  "@relationshipPostCallMeta": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferCall": "Tu as appelé {name} il y a {minutes, plural, =1{1 minute} other{{minutes} minutes}} — on note ça tant que c'est frais ?",
+  "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
-        "type": "String",
-        "example": "Anna"
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferMessage": "Tu as écrit à {name} il y a {minutes, plural, =1{1 minute} other{{minutes} minutes}} — on note ça tant que c'est frais ?",
+  "@relationshipPostCallOfferMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
       }
     }
   },
@@ -4421,6 +4509,8 @@
       }
     }
   },
+  "relationshipReachPrivacy": "Reste sur cet appareil · jamais partagé avec l'IA",
+  "relationshipReachTitle": "Contacter",
   "relationshipRelinkContact": "Associer un autre contact",
   "relationshipSeeAllCheckIns": "Voir tous les échanges",
   "@relationshipSeeAllCheckIns": {
@@ -4503,6 +4593,14 @@
   "relationshipStayInTouch": "Rester en contact",
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
+  },
+  "relationshipTasksLinkedCount": "{count, plural, =1{1 liée} other{{count} liées}}",
+  "@relationshipTasksLinkedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   },
   "relationshipTimestampToday": "Aujourd'hui",
   "relationshipTimestampYesterday": "Hier",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4468,7 +4468,7 @@
   "relationshipPayAttentionTo": "Faire attention à",
   "relationshipPostCallConfirm": "Noter un point",
   "relationshipPostCallDismiss": "Pas maintenant",
-  "relationshipPostCallMeta": "commencé à {time} · environ {minutes} min",
+  "relationshipPostCallMeta": "commencé à {time} · {minutes, plural, =0{moins d'une minute} =1{environ 1 min} other{environ {minutes} min}}",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4468,7 +4468,7 @@
   "relationshipPayAttentionTo": "Faire attention à",
   "relationshipPostCallConfirm": "Noter un point",
   "relationshipPostCallDismiss": "Pas maintenant",
-  "relationshipPostCallMeta": "commencé {time} · environ {minutes} min",
+  "relationshipPostCallMeta": "commencé à {time} · environ {minutes} min",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {
@@ -4479,7 +4479,7 @@
       }
     }
   },
-  "relationshipPostCallOfferCall": "Tu as appelé {name} il y a {minutes, plural, =1{1 minute} other{{minutes} minutes}} — on note ça tant que c'est frais ?",
+  "relationshipPostCallOfferCall": "Tu as appelé {name} il y a {minutes, plural, =0{moins d'une minute} =1{1 minute} other{{minutes} minutes}} — on note ça tant que c'est frais ?",
   "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
@@ -4490,7 +4490,7 @@
       }
     }
   },
-  "relationshipPostCallOfferMessage": "Tu as écrit à {name} il y a {minutes, plural, =1{1 minute} other{{minutes} minutes}} — on note ça tant que c'est frais ?",
+  "relationshipPostCallOfferMessage": "Tu as écrit à {name} il y a {minutes, plural, =0{moins d'une minute} =1{1 minute} other{{minutes} minutes}} — on note ça tant que c'est frais ?",
   "@relationshipPostCallOfferMessage": {
     "placeholders": {
       "name": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4836,7 +4836,7 @@
       }
     }
   },
-  "relationshipDueSince": "In scadenza da {day} · {count, plural, =1{1 giorno di ritardo} other{{count} giorni di ritardo}}",
+  "relationshipDueSince": "In ritardo da {day} · {count, plural, =1{1 giorno di ritardo} other{{count} giorni di ritardo}}",
   "@relationshipDueSince": {
     "placeholders": {
       "day": {
@@ -4971,7 +4971,7 @@
   "relationshipPayAttentionTo": "Fai attenzione a",
   "relationshipPostCallConfirm": "Annota check-in",
   "relationshipPostCallDismiss": "Non ora",
-  "relationshipPostCallMeta": "iniziata {time} · circa {minutes} min",
+  "relationshipPostCallMeta": "Inizio: {time} · circa {minutes} min",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {
@@ -4982,7 +4982,7 @@
       }
     }
   },
-  "relationshipPostCallOfferCall": "Hai chiamato {name} {minutes, plural, =1{1 minuto} other{{minutes} minuti}} fa — lo annotiamo finché è fresco?",
+  "relationshipPostCallOfferCall": "Hai chiamato {name} {minutes, plural, =0{meno di un minuto} =1{1 minuto} other{{minutes} minuti}} fa — lo annotiamo finché è fresco?",
   "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
@@ -4993,7 +4993,7 @@
       }
     }
   },
-  "relationshipPostCallOfferMessage": "Hai scritto a {name} {minutes, plural, =1{1 minuto} other{{minutes} minuti}} fa — lo annotiamo finché è fresco?",
+  "relationshipPostCallOfferMessage": "Hai scritto a {name} {minutes, plural, =0{meno di un minuto} =1{1 minuto} other{{minutes} minuti}} fa — lo annotiamo finché è fresco?",
   "@relationshipPostCallOfferMessage": {
     "placeholders": {
       "name": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4836,7 +4836,45 @@
       }
     }
   },
+  "relationshipDueSince": "In scadenza da {day} · {count, plural, =1{1 giorno di ritardo} other{{count} giorni di ritardo}}",
+  "@relationshipDueSince": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDueToday": "In scadenza oggi",
+  "relationshipDurationHours": "{hours} h",
+  "@relationshipDurationHours": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipDurationHoursMinutes": "{hours} h {minutes}",
+  "@relationshipDurationHoursMinutes": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipDurationMinutes": "{count} min",
+  "@relationshipDurationMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipEditTitle": "Modifica persona",
   "relationshipErrorCreateFailed": "Impossibile salvare la persona. Riprova.",
   "relationshipErrorDeleteFailed": "Impossibile eliminare la persona. Riprova.",
@@ -4869,6 +4907,14 @@
     "description": "Relationships redesign label."
   },
   "relationshipLastCheckInLabel": "Ultimo contatto {date}",
+  "relationshipLastSpoke": "ultimo contatto {time}",
+  "@relationshipLastSpoke": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipLinkContact": "Collega contatto",
   "relationshipLinkedTasksLabel": "Attività",
   "relationshipLinkTaskButton": "Collega attività",
@@ -4885,6 +4931,7 @@
       }
     }
   },
+  "relationshipMoreActions": "Altre azioni",
   "relationshipNameLabel": "Nome",
   "relationshipNameRequired": "Il nome è obbligatorio",
   "relationshipNextByDay": "prossimo entro {day}",
@@ -4895,6 +4942,15 @@
       }
     }
   },
+  "relationshipNextDueOn": "Prossima scadenza {day}",
+  "@relationshipNextDueOn": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipNextTimeTitle": "La prossima volta",
   "relationshipNicknameLabel": "Soprannome",
   "relationshipNoCheckIns": "Nessun contatto registrato — aggiungine uno dopo la prossima conversazione.",
   "relationshipNoLinkedTasks": "Nessuna attività collegata.",
@@ -4904,15 +4960,47 @@
   "@relationshipNudgesOn": {
     "description": "Relationships redesign label."
   },
-  "relationshipPostCallBody": "Hai appena scritto o chiamato. Vuoi annotare un check-in finché è fresco?",
+  "relationshipOnTrackCadence": "In linea · {cadence}",
+  "@relationshipOnTrackCadence": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipPayAttentionTo": "Fai attenzione a",
   "relationshipPostCallConfirm": "Annota check-in",
   "relationshipPostCallDismiss": "Non ora",
-  "relationshipPostCallTitle": "Com’è andata con {name}?",
-  "@relationshipPostCallTitle": {
+  "relationshipPostCallMeta": "iniziata {time} · circa {minutes} min",
+  "@relationshipPostCallMeta": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferCall": "Hai chiamato {name} {minutes, plural, =1{1 minuto} other{{minutes} minuti}} fa — lo annotiamo finché è fresco?",
+  "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
-        "type": "String",
-        "example": "Anna"
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferMessage": "Hai scritto a {name} {minutes, plural, =1{1 minuto} other{{minutes} minuti}} fa — lo annotiamo finché è fresco?",
+  "@relationshipPostCallOfferMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
       }
     }
   },
@@ -4924,6 +5012,8 @@
       }
     }
   },
+  "relationshipReachPrivacy": "Resta su questo dispositivo · mai condiviso con l'IA",
+  "relationshipReachTitle": "Contatti",
   "relationshipRelinkContact": "Collega un altro contatto",
   "relationshipSeeAllCheckIns": "Vedi tutti i contatti",
   "@relationshipSeeAllCheckIns": {
@@ -5006,6 +5096,14 @@
   "relationshipStayInTouch": "Restare in contatto",
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
+  },
+  "relationshipTasksLinkedCount": "{count, plural, =1{1 collegata} other{{count} collegate}}",
+  "@relationshipTasksLinkedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   },
   "relationshipTimestampToday": "Oggi",
   "relationshipTimestampYesterday": "Ieri",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4971,7 +4971,7 @@
   "relationshipPayAttentionTo": "Fai attenzione a",
   "relationshipPostCallConfirm": "Annota check-in",
   "relationshipPostCallDismiss": "Non ora",
-  "relationshipPostCallMeta": "Inizio: {time} · circa {minutes} min",
+  "relationshipPostCallMeta": "Inizio: {time} · {minutes, plural, =0{meno di un minuto} =1{circa 1 min} other{circa {minutes} min}}",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -18493,11 +18493,35 @@ abstract class AppLocalizations {
   /// **'Due {day}'**
   String relationshipDueDay(String day);
 
+  /// No description provided for @relationshipDueSince.
+  ///
+  /// In en, this message translates to:
+  /// **'Due since {day} · {count, plural, =1{1 day over} other{{count} days over}}'**
+  String relationshipDueSince(String day, int count);
+
   /// No description provided for @relationshipDueToday.
   ///
   /// In en, this message translates to:
   /// **'Due today'**
   String get relationshipDueToday;
+
+  /// No description provided for @relationshipDurationHours.
+  ///
+  /// In en, this message translates to:
+  /// **'{hours} h'**
+  String relationshipDurationHours(int hours);
+
+  /// No description provided for @relationshipDurationHoursMinutes.
+  ///
+  /// In en, this message translates to:
+  /// **'{hours} h {minutes}'**
+  String relationshipDurationHoursMinutes(int hours, String minutes);
+
+  /// No description provided for @relationshipDurationMinutes.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} min'**
+  String relationshipDurationMinutes(int count);
 
   /// No description provided for @relationshipEditTitle.
   ///
@@ -18673,6 +18697,12 @@ abstract class AppLocalizations {
   /// **'Last check-in {date}'**
   String relationshipLastCheckInLabel(String date);
 
+  /// No description provided for @relationshipLastSpoke.
+  ///
+  /// In en, this message translates to:
+  /// **'last spoke {time}'**
+  String relationshipLastSpoke(String time);
+
   /// Action that opens the OS contact picker to copy channels onto a person
   ///
   /// In en, this message translates to:
@@ -18709,6 +18739,12 @@ abstract class AppLocalizations {
   /// **'as of {time}'**
   String relationshipLottisReadAsOf(String time);
 
+  /// Tooltip of the person page's overflow menu (link contact, delete)
+  ///
+  /// In en, this message translates to:
+  /// **'More actions'**
+  String get relationshipMoreActions;
+
   /// No description provided for @relationshipNameLabel.
   ///
   /// In en, this message translates to:
@@ -18726,6 +18762,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'next by {day}'**
   String relationshipNextByDay(String day);
+
+  /// No description provided for @relationshipNextDueOn.
+  ///
+  /// In en, this message translates to:
+  /// **'Next due {day}'**
+  String relationshipNextDueOn(String day);
+
+  /// No description provided for @relationshipNextTimeTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Next time'**
+  String get relationshipNextTimeTitle;
 
   /// No description provided for @relationshipNicknameLabel.
   ///
@@ -18763,11 +18811,17 @@ abstract class AppLocalizations {
   /// **'nudges on'**
   String get relationshipNudgesOn;
 
-  /// Body of the prompt offered after returning from a call or message
+  /// No description provided for @relationshipOnTrackCadence.
   ///
   /// In en, this message translates to:
-  /// **'You reached out a moment ago. Log a check-in while it is fresh?'**
-  String get relationshipPostCallBody;
+  /// **'On track · {cadence}'**
+  String relationshipOnTrackCadence(String cadence);
+
+  /// No description provided for @relationshipPayAttentionTo.
+  ///
+  /// In en, this message translates to:
+  /// **'Pay attention to'**
+  String get relationshipPayAttentionTo;
 
   /// Button that opens a pre-filled check-in from the post-call prompt
   ///
@@ -18781,17 +18835,41 @@ abstract class AppLocalizations {
   /// **'Not now'**
   String get relationshipPostCallDismiss;
 
-  /// Title of the prompt offered after returning from a call or message
+  /// No description provided for @relationshipPostCallMeta.
   ///
   /// In en, this message translates to:
-  /// **'How did it go with {name}?'**
-  String relationshipPostCallTitle(String name);
+  /// **'started {time} · about {minutes} min'**
+  String relationshipPostCallMeta(String time, int minutes);
+
+  /// No description provided for @relationshipPostCallOfferCall.
+  ///
+  /// In en, this message translates to:
+  /// **'You called {name} {minutes, plural, =1{1 minute} other{{minutes} minutes}} ago — log it while it is fresh?'**
+  String relationshipPostCallOfferCall(String name, int minutes);
+
+  /// No description provided for @relationshipPostCallOfferMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'You wrote to {name} {minutes, plural, =1{1 minute} other{{minutes} minutes}} ago — log it while it is fresh?'**
+  String relationshipPostCallOfferMessage(String name, int minutes);
 
   /// No description provided for @relationshipQuietForDays.
   ///
   /// In en, this message translates to:
   /// **'Quiet for {count, plural, =1{1 day} other{{count} days}}'**
   String relationshipQuietForDays(int count);
+
+  /// No description provided for @relationshipReachPrivacy.
+  ///
+  /// In en, this message translates to:
+  /// **'Stays on this device · never shared with the AI'**
+  String get relationshipReachPrivacy;
+
+  /// No description provided for @relationshipReachTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Reach'**
+  String get relationshipReachTitle;
 
   /// Menu action that replaces the OS contact a person is linked to
   ///
@@ -18916,6 +18994,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Stay in touch'**
   String get relationshipStayInTouch;
+
+  /// No description provided for @relationshipTasksLinkedCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 linked} other{{count} linked}}'**
+  String relationshipTasksLinkedCount(int count);
 
   /// The relative day word in a relationship timestamp, e.g. "Today 14:20".
   ///

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -18844,13 +18844,13 @@ abstract class AppLocalizations {
   /// No description provided for @relationshipPostCallOfferCall.
   ///
   /// In en, this message translates to:
-  /// **'You called {name} {minutes, plural, =1{1 minute} other{{minutes} minutes}} ago — log it while it is fresh?'**
+  /// **'You called {name} {minutes, plural, =0{less than a minute} =1{1 minute} other{{minutes} minutes}} ago — log it while it is fresh?'**
   String relationshipPostCallOfferCall(String name, int minutes);
 
   /// No description provided for @relationshipPostCallOfferMessage.
   ///
   /// In en, this message translates to:
-  /// **'You wrote to {name} {minutes, plural, =1{1 minute} other{{minutes} minutes}} ago — log it while it is fresh?'**
+  /// **'You wrote to {name} {minutes, plural, =0{less than a minute} =1{1 minute} other{{minutes} minutes}} ago — log it while it is fresh?'**
   String relationshipPostCallOfferMessage(String name, int minutes);
 
   /// No description provided for @relationshipQuietForDays.

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -18838,7 +18838,7 @@ abstract class AppLocalizations {
   /// No description provided for @relationshipPostCallMeta.
   ///
   /// In en, this message translates to:
-  /// **'started {time} · about {minutes} min'**
+  /// **'started {time} · {minutes, plural, =0{under a minute} =1{about 1 min} other{about {minutes} min}}'**
   String relationshipPostCallMeta(String time, int minutes);
 
   /// No description provided for @relationshipPostCallOfferCall.

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -11432,7 +11432,14 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'začátek v $time · asi $minutes min';
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: 'asi $minutes min',
+      one: 'asi 1 min',
+      zero: 'necelá minuta',
+    );
+    return 'začátek v $time · $_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -11196,7 +11196,34 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String relationshipDueSince(String day, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dní po termínu',
+      few: '$count dny po termínu',
+      one: '1 den po termínu',
+    );
+    return 'Po termínu od $day · $_temp0';
+  }
+
+  @override
   String get relationshipDueToday => 'Dnes na řadě';
+
+  @override
+  String relationshipDurationHours(int hours) {
+    return '$hours h';
+  }
+
+  @override
+  String relationshipDurationHoursMinutes(int hours, String minutes) {
+    return '$hours h $minutes';
+  }
+
+  @override
+  String relationshipDurationMinutes(int count) {
+    return '$count min';
+  }
 
   @override
   String get relationshipEditTitle => 'Upravit osobu';
@@ -11324,6 +11351,11 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String relationshipLastSpoke(String time) {
+    return 'naposledy mluvili $time';
+  }
+
+  @override
   String get relationshipLinkContact => 'Propojit kontakt';
 
   @override
@@ -11344,6 +11376,9 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get relationshipMoreActions => 'Další akce';
+
+  @override
   String get relationshipNameLabel => 'Jméno';
 
   @override
@@ -11353,6 +11388,14 @@ class AppLocalizationsCs extends AppLocalizations {
   String relationshipNextByDay(String day) {
     return 'příští do $day';
   }
+
+  @override
+  String relationshipNextDueOn(String day) {
+    return 'Příště $day';
+  }
+
+  @override
+  String get relationshipNextTimeTitle => 'Příště';
 
   @override
   String get relationshipNicknameLabel => 'Přezdívka';
@@ -11374,8 +11417,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get relationshipNudgesOn => 'připomínky zapnuty';
 
   @override
-  String get relationshipPostCallBody =>
-      'Právě jsi se ozval. Chceš si zapsat check-in, dokud je to čerstvé?';
+  String relationshipOnTrackCadence(String cadence) {
+    return 'V rytmu · $cadence';
+  }
+
+  @override
+  String get relationshipPayAttentionTo => 'Dávej pozor na';
 
   @override
   String get relationshipPostCallConfirm => 'Zapsat check-in';
@@ -11384,8 +11431,30 @@ class AppLocalizationsCs extends AppLocalizations {
   String get relationshipPostCallDismiss => 'Teď ne';
 
   @override
-  String relationshipPostCallTitle(String name) {
-    return 'Jak to šlo s $name?';
+  String relationshipPostCallMeta(String time, int minutes) {
+    return 'začátek $time · asi $minutes min';
+  }
+
+  @override
+  String relationshipPostCallOfferCall(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minutami',
+      one: '1 minutou',
+    );
+    return 'Hovor s $name před $_temp0 — zapíšeme to, dokud je to čerstvé?';
+  }
+
+  @override
+  String relationshipPostCallOfferMessage(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minutami',
+      one: '1 minutou',
+    );
+    return 'Zpráva pro $name před $_temp0 — zapíšeme to, dokud je to čerstvé?';
   }
 
   @override
@@ -11399,6 +11468,13 @@ class AppLocalizationsCs extends AppLocalizations {
     );
     return '$_temp0 bez kontaktu';
   }
+
+  @override
+  String get relationshipReachPrivacy =>
+      'Zůstává v tomto zařízení · nikdy se nesdílí s AI';
+
+  @override
+  String get relationshipReachTitle => 'Kontakt';
 
   @override
   String get relationshipRelinkContact => 'Propojit jiný kontakt';
@@ -11491,6 +11567,18 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get relationshipStayInTouch => 'Udržovat kontakt';
+
+  @override
+  String relationshipTasksLinkedCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count propojených',
+      few: '$count propojené',
+      one: '1 propojený',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipTimestampToday => 'Dnes';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -11432,7 +11432,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'začátek $time · asi $minutes min';
+    return 'začátek v $time · asi $minutes min';
   }
 
   @override
@@ -11442,6 +11442,7 @@ class AppLocalizationsCs extends AppLocalizations {
       locale: localeName,
       other: '$minutes minutami',
       one: '1 minutou',
+      zero: 'necelou minutou',
     );
     return 'Hovor s $name před $_temp0 — zapíšeme to, dokud je to čerstvé?';
   }
@@ -11453,6 +11454,7 @@ class AppLocalizationsCs extends AppLocalizations {
       locale: localeName,
       other: '$minutes minutami',
       one: '1 minutou',
+      zero: 'necelou minutou',
     );
     return 'Zpráva pro $name před $_temp0 — zapíšeme to, dokud je to čerstvé?';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -11263,7 +11263,14 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'startede kl. $time · cirka $minutes min';
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: 'cirka $minutes min',
+      one: 'cirka 1 min',
+      zero: 'under et minut',
+    );
+    return 'startede kl. $time · $_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -11035,10 +11035,10 @@ class AppLocalizationsDa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count dage over tid',
-      one: '1 dag over tid',
+      other: '$count dage forsinket',
+      one: '1 dag forsinket',
     );
-    return 'Forfaldet siden $day · $_temp0';
+    return 'Forfalden siden $day · $_temp0';
   }
 
   @override
@@ -11263,7 +11263,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'startede $time · cirka $minutes min';
+    return 'startede kl. $time · cirka $minutes min';
   }
 
   @override
@@ -11273,6 +11273,7 @@ class AppLocalizationsDa extends AppLocalizations {
       locale: localeName,
       other: '$minutes minutter',
       one: '1 minut',
+      zero: 'under et minut',
     );
     return 'Du ringede til $name for $_temp0 siden — skal vi notere det, mens det er frisk?';
   }
@@ -11284,6 +11285,7 @@ class AppLocalizationsDa extends AppLocalizations {
       locale: localeName,
       other: '$minutes minutter',
       one: '1 minut',
+      zero: 'under et minut',
     );
     return 'Du skrev til $name for $_temp0 siden — skal vi notere det, mens det er frisk?';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -11031,7 +11031,33 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String relationshipDueSince(String day, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dage over tid',
+      one: '1 dag over tid',
+    );
+    return 'Forfaldet siden $day · $_temp0';
+  }
+
+  @override
   String get relationshipDueToday => 'Skal kontaktes i dag';
+
+  @override
+  String relationshipDurationHours(int hours) {
+    return '$hours t';
+  }
+
+  @override
+  String relationshipDurationHoursMinutes(int hours, String minutes) {
+    return '$hours t $minutes';
+  }
+
+  @override
+  String relationshipDurationMinutes(int count) {
+    return '$count min';
+  }
 
   @override
   String get relationshipEditTitle => 'Redigér person';
@@ -11156,6 +11182,11 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String relationshipLastSpoke(String time) {
+    return 'sidst talt $time';
+  }
+
+  @override
   String get relationshipLinkContact => 'Tilknyt kontakt';
 
   @override
@@ -11176,6 +11207,9 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get relationshipMoreActions => 'Flere handlinger';
+
+  @override
   String get relationshipNameLabel => 'Navn';
 
   @override
@@ -11185,6 +11219,14 @@ class AppLocalizationsDa extends AppLocalizations {
   String relationshipNextByDay(String day) {
     return 'næste senest $day';
   }
+
+  @override
+  String relationshipNextDueOn(String day) {
+    return 'Næste gang $day';
+  }
+
+  @override
+  String get relationshipNextTimeTitle => 'Næste gang';
 
   @override
   String get relationshipNicknameLabel => 'Kaldenavn';
@@ -11206,8 +11248,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get relationshipNudgesOn => 'påmindelser til';
 
   @override
-  String get relationshipPostCallBody =>
-      'Du tog lige kontakt. Vil du logge et tjek-ind, mens det er friskt?';
+  String relationshipOnTrackCadence(String cadence) {
+    return 'På sporet · $cadence';
+  }
+
+  @override
+  String get relationshipPayAttentionTo => 'Vær opmærksom på';
 
   @override
   String get relationshipPostCallConfirm => 'Log tjek-ind';
@@ -11216,8 +11262,30 @@ class AppLocalizationsDa extends AppLocalizations {
   String get relationshipPostCallDismiss => 'Ikke nu';
 
   @override
-  String relationshipPostCallTitle(String name) {
-    return 'Hvordan gik det med $name?';
+  String relationshipPostCallMeta(String time, int minutes) {
+    return 'startede $time · cirka $minutes min';
+  }
+
+  @override
+  String relationshipPostCallOfferCall(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minutter',
+      one: '1 minut',
+    );
+    return 'Du ringede til $name for $_temp0 siden — skal vi notere det, mens det er frisk?';
+  }
+
+  @override
+  String relationshipPostCallOfferMessage(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minutter',
+      one: '1 minut',
+    );
+    return 'Du skrev til $name for $_temp0 siden — skal vi notere det, mens det er frisk?';
   }
 
   @override
@@ -11230,6 +11298,13 @@ class AppLocalizationsDa extends AppLocalizations {
     );
     return 'Ingen kontakt $_temp0';
   }
+
+  @override
+  String get relationshipReachPrivacy =>
+      'Bliver på denne enhed · deles aldrig med AI\'en';
+
+  @override
+  String get relationshipReachTitle => 'Kontakt';
 
   @override
   String get relationshipRelinkContact => 'Tilknyt en anden kontakt';
@@ -11314,6 +11389,17 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get relationshipStayInTouch => 'Hold kontakten';
+
+  @override
+  String relationshipTasksLinkedCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count tilknyttede',
+      one: '1 tilknyttet',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipTimestampToday => 'I dag';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -11099,7 +11099,33 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String relationshipDueSince(String day, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Tage drüber',
+      one: '1 Tag drüber',
+    );
+    return 'Fällig seit $day · $_temp0';
+  }
+
+  @override
   String get relationshipDueToday => 'Heute fällig';
+
+  @override
+  String relationshipDurationHours(int hours) {
+    return '$hours Std.';
+  }
+
+  @override
+  String relationshipDurationHoursMinutes(int hours, String minutes) {
+    return '$hours Std. $minutes';
+  }
+
+  @override
+  String relationshipDurationMinutes(int count) {
+    return '$count Min.';
+  }
 
   @override
   String get relationshipEditTitle => 'Person bearbeiten';
@@ -11224,6 +11250,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String relationshipLastSpoke(String time) {
+    return 'zuletzt gesprochen $time';
+  }
+
+  @override
   String get relationshipLinkContact => 'Kontakt verknüpfen';
 
   @override
@@ -11244,6 +11275,9 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get relationshipMoreActions => 'Weitere Aktionen';
+
+  @override
   String get relationshipNameLabel => 'Name';
 
   @override
@@ -11253,6 +11287,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String relationshipNextByDay(String day) {
     return 'nächstens bis $day';
   }
+
+  @override
+  String relationshipNextDueOn(String day) {
+    return 'Nächste Fälligkeit $day';
+  }
+
+  @override
+  String get relationshipNextTimeTitle => 'Nächstes Mal';
 
   @override
   String get relationshipNicknameLabel => 'Spitzname';
@@ -11275,8 +11317,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get relationshipNudgesOn => 'Erinnerungen an';
 
   @override
-  String get relationshipPostCallBody =>
-      'Du hast dich gerade gemeldet. Willst du gleich einen Check-in festhalten?';
+  String relationshipOnTrackCadence(String cadence) {
+    return 'Im Rhythmus · $cadence';
+  }
+
+  @override
+  String get relationshipPayAttentionTo => 'Darauf achten';
 
   @override
   String get relationshipPostCallConfirm => 'Check-in festhalten';
@@ -11285,8 +11331,30 @@ class AppLocalizationsDe extends AppLocalizations {
   String get relationshipPostCallDismiss => 'Jetzt nicht';
 
   @override
-  String relationshipPostCallTitle(String name) {
-    return 'Wie ist es mit $name gelaufen?';
+  String relationshipPostCallMeta(String time, int minutes) {
+    return 'begonnen $time · etwa $minutes Min.';
+  }
+
+  @override
+  String relationshipPostCallOfferCall(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes Minuten',
+      one: '1 Minute',
+    );
+    return 'Du hast $name vor $_temp0 angerufen — jetzt festhalten, solange es frisch ist?';
+  }
+
+  @override
+  String relationshipPostCallOfferMessage(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes Minuten',
+      one: '1 Minute',
+    );
+    return 'Du hast $name vor $_temp0 geschrieben — jetzt festhalten, solange es frisch ist?';
   }
 
   @override
@@ -11299,6 +11367,13 @@ class AppLocalizationsDe extends AppLocalizations {
     );
     return 'Seit $_temp0 keine Nachricht';
   }
+
+  @override
+  String get relationshipReachPrivacy =>
+      'Bleibt auf diesem Gerät · nie mit der KI geteilt';
+
+  @override
+  String get relationshipReachTitle => 'Erreichen';
 
   @override
   String get relationshipRelinkContact => 'Anderen Kontakt verknüpfen';
@@ -11383,6 +11458,17 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get relationshipStayInTouch => 'Kontakt halten';
+
+  @override
+  String relationshipTasksLinkedCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count verknüpft',
+      one: '1 verknüpft',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipTimestampToday => 'Heute';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -11332,7 +11332,14 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'begonnen um $time · etwa $minutes Min.';
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: 'etwa $minutes Min.',
+      one: 'etwa 1 Min.',
+      zero: 'unter einer Minute',
+    );
+    return 'begonnen um $time · $_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -11103,8 +11103,8 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Tage drüber',
-      one: '1 Tag drüber',
+      other: '$count Tage überfällig',
+      one: '1 Tag überfällig',
     );
     return 'Fällig seit $day · $_temp0';
   }
@@ -11332,7 +11332,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'begonnen $time · etwa $minutes Min.';
+    return 'begonnen um $time · etwa $minutes Min.';
   }
 
   @override
@@ -11342,6 +11342,7 @@ class AppLocalizationsDe extends AppLocalizations {
       locale: localeName,
       other: '$minutes Minuten',
       one: '1 Minute',
+      zero: 'weniger als einer Minute',
     );
     return 'Du hast $name vor $_temp0 angerufen — jetzt festhalten, solange es frisch ist?';
   }
@@ -11353,6 +11354,7 @@ class AppLocalizationsDe extends AppLocalizations {
       locale: localeName,
       other: '$minutes Minuten',
       one: '1 Minute',
+      zero: 'weniger als einer Minute',
     );
     return 'Du hast $name vor $_temp0 geschrieben — jetzt festhalten, solange es frisch ist?';
   }
@@ -11464,8 +11466,8 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count verknüpft',
-      one: '1 verknüpft',
+      other: '$count verknüpfte Aufgaben',
+      one: '1 verknüpfte Aufgabe',
     );
     return '$_temp0';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -11217,6 +11217,7 @@ class AppLocalizationsEn extends AppLocalizations {
       locale: localeName,
       other: '$minutes minutes',
       one: '1 minute',
+      zero: 'less than a minute',
     );
     return 'You called $name $_temp0 ago — log it while it is fresh?';
   }
@@ -11228,6 +11229,7 @@ class AppLocalizationsEn extends AppLocalizations {
       locale: localeName,
       other: '$minutes minutes',
       one: '1 minute',
+      zero: 'less than a minute',
     );
     return 'You wrote to $name $_temp0 ago — log it while it is fresh?';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -10977,7 +10977,33 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String relationshipDueSince(String day, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count days over',
+      one: '1 day over',
+    );
+    return 'Due since $day · $_temp0';
+  }
+
+  @override
   String get relationshipDueToday => 'Due today';
+
+  @override
+  String relationshipDurationHours(int hours) {
+    return '$hours h';
+  }
+
+  @override
+  String relationshipDurationHoursMinutes(int hours, String minutes) {
+    return '$hours h $minutes';
+  }
+
+  @override
+  String relationshipDurationMinutes(int count) {
+    return '$count min';
+  }
 
   @override
   String get relationshipEditTitle => 'Edit person';
@@ -11100,6 +11126,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String relationshipLastSpoke(String time) {
+    return 'last spoke $time';
+  }
+
+  @override
   String get relationshipLinkContact => 'Link contact';
 
   @override
@@ -11120,6 +11151,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get relationshipMoreActions => 'More actions';
+
+  @override
   String get relationshipNameLabel => 'Name';
 
   @override
@@ -11129,6 +11163,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String relationshipNextByDay(String day) {
     return 'next by $day';
   }
+
+  @override
+  String relationshipNextDueOn(String day) {
+    return 'Next due $day';
+  }
+
+  @override
+  String get relationshipNextTimeTitle => 'Next time';
 
   @override
   String get relationshipNicknameLabel => 'Nickname';
@@ -11150,8 +11192,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get relationshipNudgesOn => 'nudges on';
 
   @override
-  String get relationshipPostCallBody =>
-      'You reached out a moment ago. Log a check-in while it is fresh?';
+  String relationshipOnTrackCadence(String cadence) {
+    return 'On track · $cadence';
+  }
+
+  @override
+  String get relationshipPayAttentionTo => 'Pay attention to';
 
   @override
   String get relationshipPostCallConfirm => 'Log check-in';
@@ -11160,8 +11206,30 @@ class AppLocalizationsEn extends AppLocalizations {
   String get relationshipPostCallDismiss => 'Not now';
 
   @override
-  String relationshipPostCallTitle(String name) {
-    return 'How did it go with $name?';
+  String relationshipPostCallMeta(String time, int minutes) {
+    return 'started $time · about $minutes min';
+  }
+
+  @override
+  String relationshipPostCallOfferCall(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minutes',
+      one: '1 minute',
+    );
+    return 'You called $name $_temp0 ago — log it while it is fresh?';
+  }
+
+  @override
+  String relationshipPostCallOfferMessage(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minutes',
+      one: '1 minute',
+    );
+    return 'You wrote to $name $_temp0 ago — log it while it is fresh?';
   }
 
   @override
@@ -11174,6 +11242,13 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return 'Quiet for $_temp0';
   }
+
+  @override
+  String get relationshipReachPrivacy =>
+      'Stays on this device · never shared with the AI';
+
+  @override
+  String get relationshipReachTitle => 'Reach';
 
   @override
   String get relationshipRelinkContact => 'Link a different contact';
@@ -11258,6 +11333,17 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get relationshipStayInTouch => 'Stay in touch';
+
+  @override
+  String relationshipTasksLinkedCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count linked',
+      one: '1 linked',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipTimestampToday => 'Today';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -11207,7 +11207,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'started $time · about $minutes min';
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: 'about $minutes min',
+      one: 'about 1 min',
+      zero: 'under a minute',
+    );
+    return 'started $time · $_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -11195,7 +11195,33 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String relationshipDueSince(String day, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count días de retraso',
+      one: '1 día de retraso',
+    );
+    return 'Pendiente desde $day · $_temp0';
+  }
+
+  @override
   String get relationshipDueToday => 'Pendiente hoy';
+
+  @override
+  String relationshipDurationHours(int hours) {
+    return '$hours h';
+  }
+
+  @override
+  String relationshipDurationHoursMinutes(int hours, String minutes) {
+    return '$hours h $minutes';
+  }
+
+  @override
+  String relationshipDurationMinutes(int count) {
+    return '$count min';
+  }
 
   @override
   String get relationshipEditTitle => 'Editar persona';
@@ -11320,6 +11346,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String relationshipLastSpoke(String time) {
+    return 'última charla $time';
+  }
+
+  @override
   String get relationshipLinkContact => 'Vincular contacto';
 
   @override
@@ -11340,6 +11371,9 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get relationshipMoreActions => 'Más acciones';
+
+  @override
   String get relationshipNameLabel => 'Nombre';
 
   @override
@@ -11349,6 +11383,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String relationshipNextByDay(String day) {
     return 'próximo antes de $day';
   }
+
+  @override
+  String relationshipNextDueOn(String day) {
+    return 'Próximo plazo $day';
+  }
+
+  @override
+  String get relationshipNextTimeTitle => 'La próxima vez';
 
   @override
   String get relationshipNicknameLabel => 'Apodo';
@@ -11370,8 +11412,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get relationshipNudgesOn => 'avisos activos';
 
   @override
-  String get relationshipPostCallBody =>
-      'Acabas de contactar. ¿Anotas un check-in mientras lo recuerdas?';
+  String relationshipOnTrackCadence(String cadence) {
+    return 'Al día · $cadence';
+  }
+
+  @override
+  String get relationshipPayAttentionTo => 'Prestar atención a';
 
   @override
   String get relationshipPostCallConfirm => 'Anotar check-in';
@@ -11380,8 +11426,30 @@ class AppLocalizationsEs extends AppLocalizations {
   String get relationshipPostCallDismiss => 'Ahora no';
 
   @override
-  String relationshipPostCallTitle(String name) {
-    return '¿Qué tal fue con $name?';
+  String relationshipPostCallMeta(String time, int minutes) {
+    return 'empezó $time · unos $minutes min';
+  }
+
+  @override
+  String relationshipPostCallOfferCall(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minutos',
+      one: '1 minuto',
+    );
+    return 'Llamaste a $name hace $_temp0. ¿Lo anotamos mientras está fresco?';
+  }
+
+  @override
+  String relationshipPostCallOfferMessage(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minutos',
+      one: '1 minuto',
+    );
+    return 'Escribiste a $name hace $_temp0. ¿Lo anotamos mientras está fresco?';
   }
 
   @override
@@ -11394,6 +11462,13 @@ class AppLocalizationsEs extends AppLocalizations {
     );
     return 'Sin contacto $_temp0';
   }
+
+  @override
+  String get relationshipReachPrivacy =>
+      'Se queda en este dispositivo · nunca se comparte con la IA';
+
+  @override
+  String get relationshipReachTitle => 'Contacto';
 
   @override
   String get relationshipRelinkContact => 'Vincular otro contacto';
@@ -11478,6 +11553,17 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get relationshipStayInTouch => 'Mantener el contacto';
+
+  @override
+  String relationshipTasksLinkedCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count vinculadas',
+      one: '1 vinculada',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipTimestampToday => 'Hoy';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -11427,7 +11427,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'empezó $time · unos $minutes min';
+    return 'empezó a las $time · unos $minutes min';
   }
 
   @override
@@ -11437,6 +11437,7 @@ class AppLocalizationsEs extends AppLocalizations {
       locale: localeName,
       other: '$minutes minutos',
       one: '1 minuto',
+      zero: 'menos de un minuto',
     );
     return 'Llamaste a $name hace $_temp0. ¿Lo anotamos mientras está fresco?';
   }
@@ -11448,6 +11449,7 @@ class AppLocalizationsEs extends AppLocalizations {
       locale: localeName,
       other: '$minutes minutos',
       one: '1 minuto',
+      zero: 'menos de un minuto',
     );
     return 'Escribiste a $name hace $_temp0. ¿Lo anotamos mientras está fresco?';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -11427,7 +11427,14 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'empezó a las $time · unos $minutes min';
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: 'unos $minutes min',
+      one: 'alrededor de 1 min',
+      zero: 'menos de un minuto',
+    );
+    return 'empezó a las $time · $_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -11460,7 +11460,14 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'commencé à $time · environ $minutes min';
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: 'environ $minutes min',
+      one: 'environ 1 min',
+      zero: 'moins d\'une minute',
+    );
+    return 'commencé à $time · $_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -11460,7 +11460,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'commencé $time · environ $minutes min';
+    return 'commencé à $time · environ $minutes min';
   }
 
   @override
@@ -11470,6 +11470,7 @@ class AppLocalizationsFr extends AppLocalizations {
       locale: localeName,
       other: '$minutes minutes',
       one: '1 minute',
+      zero: 'moins d\'une minute',
     );
     return 'Tu as appelé $name il y a $_temp0 — on note ça tant que c\'est frais ?';
   }
@@ -11481,6 +11482,7 @@ class AppLocalizationsFr extends AppLocalizations {
       locale: localeName,
       other: '$minutes minutes',
       one: '1 minute',
+      zero: 'moins d\'une minute',
     );
     return 'Tu as écrit à $name il y a $_temp0 — on note ça tant que c\'est frais ?';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -11227,7 +11227,33 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String relationshipDueSince(String day, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count jours de retard',
+      one: '1 jour de retard',
+    );
+    return 'En retard depuis $day · $_temp0';
+  }
+
+  @override
   String get relationshipDueToday => 'À relancer aujourd\'hui';
+
+  @override
+  String relationshipDurationHours(int hours) {
+    return '$hours h';
+  }
+
+  @override
+  String relationshipDurationHoursMinutes(int hours, String minutes) {
+    return '$hours h $minutes';
+  }
+
+  @override
+  String relationshipDurationMinutes(int count) {
+    return '$count min';
+  }
 
   @override
   String get relationshipEditTitle => 'Modifier la personne';
@@ -11352,6 +11378,11 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String relationshipLastSpoke(String time) {
+    return 'dernier échange $time';
+  }
+
+  @override
   String get relationshipLinkContact => 'Associer un contact';
 
   @override
@@ -11372,6 +11403,9 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get relationshipMoreActions => 'Plus d\'actions';
+
+  @override
   String get relationshipNameLabel => 'Nom';
 
   @override
@@ -11381,6 +11415,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String relationshipNextByDay(String day) {
     return 'prochain avant $day';
   }
+
+  @override
+  String relationshipNextDueOn(String day) {
+    return 'Prochaine échéance $day';
+  }
+
+  @override
+  String get relationshipNextTimeTitle => 'La prochaine fois';
 
   @override
   String get relationshipNicknameLabel => 'Surnom';
@@ -11403,8 +11445,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get relationshipNudgesOn => 'rappels activés';
 
   @override
-  String get relationshipPostCallBody =>
-      'Tu viens de le/la contacter. Tu notes un point tant que c’est frais ?';
+  String relationshipOnTrackCadence(String cadence) {
+    return 'Dans le rythme · $cadence';
+  }
+
+  @override
+  String get relationshipPayAttentionTo => 'Faire attention à';
 
   @override
   String get relationshipPostCallConfirm => 'Noter un point';
@@ -11413,8 +11459,30 @@ class AppLocalizationsFr extends AppLocalizations {
   String get relationshipPostCallDismiss => 'Pas maintenant';
 
   @override
-  String relationshipPostCallTitle(String name) {
-    return 'Comment ça s’est passé avec $name ?';
+  String relationshipPostCallMeta(String time, int minutes) {
+    return 'commencé $time · environ $minutes min';
+  }
+
+  @override
+  String relationshipPostCallOfferCall(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minutes',
+      one: '1 minute',
+    );
+    return 'Tu as appelé $name il y a $_temp0 — on note ça tant que c\'est frais ?';
+  }
+
+  @override
+  String relationshipPostCallOfferMessage(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minutes',
+      one: '1 minute',
+    );
+    return 'Tu as écrit à $name il y a $_temp0 — on note ça tant que c\'est frais ?';
   }
 
   @override
@@ -11427,6 +11495,13 @@ class AppLocalizationsFr extends AppLocalizations {
     );
     return 'Aucun échange $_temp0';
   }
+
+  @override
+  String get relationshipReachPrivacy =>
+      'Reste sur cet appareil · jamais partagé avec l\'IA';
+
+  @override
+  String get relationshipReachTitle => 'Contacter';
 
   @override
   String get relationshipRelinkContact => 'Associer un autre contact';
@@ -11511,6 +11586,17 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get relationshipStayInTouch => 'Rester en contact';
+
+  @override
+  String relationshipTasksLinkedCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count liées',
+      one: '1 liée',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipTimestampToday => 'Aujourd\'hui';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -11179,7 +11179,7 @@ class AppLocalizationsIt extends AppLocalizations {
       other: '$count giorni di ritardo',
       one: '1 giorno di ritardo',
     );
-    return 'In scadenza da $day · $_temp0';
+    return 'In ritardo da $day · $_temp0';
   }
 
   @override
@@ -11406,7 +11406,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'iniziata $time · circa $minutes min';
+    return 'Inizio: $time · circa $minutes min';
   }
 
   @override
@@ -11416,6 +11416,7 @@ class AppLocalizationsIt extends AppLocalizations {
       locale: localeName,
       other: '$minutes minuti',
       one: '1 minuto',
+      zero: 'meno di un minuto',
     );
     return 'Hai chiamato $name $_temp0 fa — lo annotiamo finché è fresco?';
   }
@@ -11427,6 +11428,7 @@ class AppLocalizationsIt extends AppLocalizations {
       locale: localeName,
       other: '$minutes minuti',
       one: '1 minuto',
+      zero: 'meno di un minuto',
     );
     return 'Hai scritto a $name $_temp0 fa — lo annotiamo finché è fresco?';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -11406,7 +11406,14 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'Inizio: $time · circa $minutes min';
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: 'circa $minutes min',
+      one: 'circa 1 min',
+      zero: 'meno di un minuto',
+    );
+    return 'Inizio: $time · $_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -11172,7 +11172,33 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String relationshipDueSince(String day, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count giorni di ritardo',
+      one: '1 giorno di ritardo',
+    );
+    return 'In scadenza da $day · $_temp0';
+  }
+
+  @override
   String get relationshipDueToday => 'In scadenza oggi';
+
+  @override
+  String relationshipDurationHours(int hours) {
+    return '$hours h';
+  }
+
+  @override
+  String relationshipDurationHoursMinutes(int hours, String minutes) {
+    return '$hours h $minutes';
+  }
+
+  @override
+  String relationshipDurationMinutes(int count) {
+    return '$count min';
+  }
 
   @override
   String get relationshipEditTitle => 'Modifica persona';
@@ -11298,6 +11324,11 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String relationshipLastSpoke(String time) {
+    return 'ultimo contatto $time';
+  }
+
+  @override
   String get relationshipLinkContact => 'Collega contatto';
 
   @override
@@ -11318,6 +11349,9 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get relationshipMoreActions => 'Altre azioni';
+
+  @override
   String get relationshipNameLabel => 'Nome';
 
   @override
@@ -11327,6 +11361,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String relationshipNextByDay(String day) {
     return 'prossimo entro $day';
   }
+
+  @override
+  String relationshipNextDueOn(String day) {
+    return 'Prossima scadenza $day';
+  }
+
+  @override
+  String get relationshipNextTimeTitle => 'La prossima volta';
 
   @override
   String get relationshipNicknameLabel => 'Soprannome';
@@ -11349,8 +11391,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get relationshipNudgesOn => 'promemoria attivi';
 
   @override
-  String get relationshipPostCallBody =>
-      'Hai appena scritto o chiamato. Vuoi annotare un check-in finché è fresco?';
+  String relationshipOnTrackCadence(String cadence) {
+    return 'In linea · $cadence';
+  }
+
+  @override
+  String get relationshipPayAttentionTo => 'Fai attenzione a';
 
   @override
   String get relationshipPostCallConfirm => 'Annota check-in';
@@ -11359,8 +11405,30 @@ class AppLocalizationsIt extends AppLocalizations {
   String get relationshipPostCallDismiss => 'Non ora';
 
   @override
-  String relationshipPostCallTitle(String name) {
-    return 'Com’è andata con $name?';
+  String relationshipPostCallMeta(String time, int minutes) {
+    return 'iniziata $time · circa $minutes min';
+  }
+
+  @override
+  String relationshipPostCallOfferCall(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minuti',
+      one: '1 minuto',
+    );
+    return 'Hai chiamato $name $_temp0 fa — lo annotiamo finché è fresco?';
+  }
+
+  @override
+  String relationshipPostCallOfferMessage(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minuti',
+      one: '1 minuto',
+    );
+    return 'Hai scritto a $name $_temp0 fa — lo annotiamo finché è fresco?';
   }
 
   @override
@@ -11373,6 +11441,13 @@ class AppLocalizationsIt extends AppLocalizations {
     );
     return 'Nessun contatto $_temp0';
   }
+
+  @override
+  String get relationshipReachPrivacy =>
+      'Resta su questo dispositivo · mai condiviso con l\'IA';
+
+  @override
+  String get relationshipReachTitle => 'Contatti';
 
   @override
   String get relationshipRelinkContact => 'Collega un altro contatto';
@@ -11463,6 +11538,17 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get relationshipStayInTouch => 'Restare in contatto';
+
+  @override
+  String relationshipTasksLinkedCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count collegate',
+      one: '1 collegata',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipTimestampToday => 'Oggi';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -11283,7 +11283,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'begonnen $time · ongeveer $minutes min';
+    return 'begonnen om $time · ongeveer $minutes min';
   }
 
   @override
@@ -11293,6 +11293,7 @@ class AppLocalizationsNl extends AppLocalizations {
       locale: localeName,
       other: '$minutes minuten',
       one: '1 minuut',
+      zero: 'minder dan een minuut',
     );
     return 'Je hebt $name $_temp0 geleden gebeld — nu vastleggen zolang het vers is?';
   }
@@ -11304,6 +11305,7 @@ class AppLocalizationsNl extends AppLocalizations {
       locale: localeName,
       other: '$minutes minuten',
       one: '1 minuut',
+      zero: 'minder dan een minuut',
     );
     return 'Je hebt $name $_temp0 geleden geschreven — nu vastleggen zolang het vers is?';
   }
@@ -11324,7 +11326,7 @@ class AppLocalizationsNl extends AppLocalizations {
       'Blijft op dit apparaat · nooit gedeeld met de AI';
 
   @override
-  String get relationshipReachTitle => 'Bereiken';
+  String get relationshipReachTitle => 'Contact';
 
   @override
   String get relationshipRelinkContact => 'Ander contact koppelen';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -11050,7 +11050,33 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String relationshipDueSince(String day, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dagen te laat',
+      one: '1 dag te laat',
+    );
+    return 'Te laat sinds $day · $_temp0';
+  }
+
+  @override
   String get relationshipDueToday => 'Vandaag aan de beurt';
+
+  @override
+  String relationshipDurationHours(int hours) {
+    return '$hours u';
+  }
+
+  @override
+  String relationshipDurationHoursMinutes(int hours, String minutes) {
+    return '$hours u $minutes';
+  }
+
+  @override
+  String relationshipDurationMinutes(int count) {
+    return '$count min';
+  }
 
   @override
   String get relationshipEditTitle => 'Persoon bewerken';
@@ -11175,6 +11201,11 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String relationshipLastSpoke(String time) {
+    return 'laatst gesproken $time';
+  }
+
+  @override
   String get relationshipLinkContact => 'Contact koppelen';
 
   @override
@@ -11195,6 +11226,9 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get relationshipMoreActions => 'Meer acties';
+
+  @override
   String get relationshipNameLabel => 'Naam';
 
   @override
@@ -11204,6 +11238,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String relationshipNextByDay(String day) {
     return 'volgende voor $day';
   }
+
+  @override
+  String relationshipNextDueOn(String day) {
+    return 'Volgende keer $day';
+  }
+
+  @override
+  String get relationshipNextTimeTitle => 'Volgende keer';
 
   @override
   String get relationshipNicknameLabel => 'Bijnaam';
@@ -11226,8 +11268,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get relationshipNudgesOn => 'herinneringen aan';
 
   @override
-  String get relationshipPostCallBody =>
-      'Je hebt net contact gehad. Wil je een check-in vastleggen nu het nog vers is?';
+  String relationshipOnTrackCadence(String cadence) {
+    return 'Op schema · $cadence';
+  }
+
+  @override
+  String get relationshipPayAttentionTo => 'Let op';
 
   @override
   String get relationshipPostCallConfirm => 'Check-in vastleggen';
@@ -11236,8 +11282,30 @@ class AppLocalizationsNl extends AppLocalizations {
   String get relationshipPostCallDismiss => 'Niet nu';
 
   @override
-  String relationshipPostCallTitle(String name) {
-    return 'Hoe ging het met $name?';
+  String relationshipPostCallMeta(String time, int minutes) {
+    return 'begonnen $time · ongeveer $minutes min';
+  }
+
+  @override
+  String relationshipPostCallOfferCall(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minuten',
+      one: '1 minuut',
+    );
+    return 'Je hebt $name $_temp0 geleden gebeld — nu vastleggen zolang het vers is?';
+  }
+
+  @override
+  String relationshipPostCallOfferMessage(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minuten',
+      one: '1 minuut',
+    );
+    return 'Je hebt $name $_temp0 geleden geschreven — nu vastleggen zolang het vers is?';
   }
 
   @override
@@ -11250,6 +11318,13 @@ class AppLocalizationsNl extends AppLocalizations {
     );
     return '$_temp0 geen contact';
   }
+
+  @override
+  String get relationshipReachPrivacy =>
+      'Blijft op dit apparaat · nooit gedeeld met de AI';
+
+  @override
+  String get relationshipReachTitle => 'Bereiken';
 
   @override
   String get relationshipRelinkContact => 'Ander contact koppelen';
@@ -11334,6 +11409,17 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get relationshipStayInTouch => 'Contact houden';
+
+  @override
+  String relationshipTasksLinkedCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count gekoppeld',
+      one: '1 gekoppeld',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipTimestampToday => 'Vandaag';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -11283,7 +11283,14 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'begonnen om $time · ongeveer $minutes min';
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: 'ongeveer $minutes min',
+      one: 'ongeveer 1 min',
+      zero: 'minder dan een minuut',
+    );
+    return 'begonnen om $time · $_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -11367,7 +11367,14 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'começou às $time · cerca de $minutes min';
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: 'cerca de $minutes min',
+      one: 'cerca de 1 min',
+      zero: 'menos de um minuto',
+    );
+    return 'começou às $time · $_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -11367,7 +11367,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'começou $time · cerca de $minutes min';
+    return 'começou às $time · cerca de $minutes min';
   }
 
   @override
@@ -11377,6 +11377,7 @@ class AppLocalizationsPt extends AppLocalizations {
       locale: localeName,
       other: '$minutes minutos',
       one: '1 minuto',
+      zero: 'menos de um minuto',
     );
     return 'Ligaste a $name há $_temp0 — registamos enquanto está fresco?';
   }
@@ -11388,6 +11389,7 @@ class AppLocalizationsPt extends AppLocalizations {
       locale: localeName,
       other: '$minutes minutos',
       one: '1 minuto',
+      zero: 'menos de um minuto',
     );
     return 'Escreveste a $name há $_temp0 — registamos enquanto está fresco?';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -11136,7 +11136,33 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String relationshipDueSince(String day, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dias de atraso',
+      one: '1 dia de atraso',
+    );
+    return 'Pendente desde $day · $_temp0';
+  }
+
+  @override
   String get relationshipDueToday => 'Pendente hoje';
+
+  @override
+  String relationshipDurationHours(int hours) {
+    return '$hours h';
+  }
+
+  @override
+  String relationshipDurationHoursMinutes(int hours, String minutes) {
+    return '$hours h $minutes';
+  }
+
+  @override
+  String relationshipDurationMinutes(int count) {
+    return '$count min';
+  }
 
   @override
   String get relationshipEditTitle => 'Editar pessoa';
@@ -11260,6 +11286,11 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String relationshipLastSpoke(String time) {
+    return 'última conversa $time';
+  }
+
+  @override
   String get relationshipLinkContact => 'Associar contacto';
 
   @override
@@ -11280,6 +11311,9 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get relationshipMoreActions => 'Mais ações';
+
+  @override
   String get relationshipNameLabel => 'Nome';
 
   @override
@@ -11289,6 +11323,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String relationshipNextByDay(String day) {
     return 'próximo até $day';
   }
+
+  @override
+  String relationshipNextDueOn(String day) {
+    return 'Próximo prazo $day';
+  }
+
+  @override
+  String get relationshipNextTimeTitle => 'Da próxima vez';
 
   @override
   String get relationshipNicknameLabel => 'Apelido';
@@ -11310,8 +11352,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get relationshipNudgesOn => 'lembretes ativos';
 
   @override
-  String get relationshipPostCallBody =>
-      'Acabaste de entrar em contacto. Queres registar um check-in enquanto está fresco?';
+  String relationshipOnTrackCadence(String cadence) {
+    return 'Em dia · $cadence';
+  }
+
+  @override
+  String get relationshipPayAttentionTo => 'Prestar atenção a';
 
   @override
   String get relationshipPostCallConfirm => 'Registar check-in';
@@ -11320,8 +11366,30 @@ class AppLocalizationsPt extends AppLocalizations {
   String get relationshipPostCallDismiss => 'Agora não';
 
   @override
-  String relationshipPostCallTitle(String name) {
-    return 'Como foi com $name?';
+  String relationshipPostCallMeta(String time, int minutes) {
+    return 'começou $time · cerca de $minutes min';
+  }
+
+  @override
+  String relationshipPostCallOfferCall(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minutos',
+      one: '1 minuto',
+    );
+    return 'Ligaste a $name há $_temp0 — registamos enquanto está fresco?';
+  }
+
+  @override
+  String relationshipPostCallOfferMessage(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minutos',
+      one: '1 minuto',
+    );
+    return 'Escreveste a $name há $_temp0 — registamos enquanto está fresco?';
   }
 
   @override
@@ -11334,6 +11402,13 @@ class AppLocalizationsPt extends AppLocalizations {
     );
     return 'Sem contato $_temp0';
   }
+
+  @override
+  String get relationshipReachPrivacy =>
+      'Fica neste dispositivo · nunca partilhado com a IA';
+
+  @override
+  String get relationshipReachTitle => 'Contactar';
 
   @override
   String get relationshipRelinkContact => 'Associar outro contacto';
@@ -11418,6 +11493,17 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get relationshipStayInTouch => 'Manter contato';
+
+  @override
+  String relationshipTasksLinkedCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ligadas',
+      one: '1 ligada',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipTimestampToday => 'Hoje';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -11256,7 +11256,34 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String relationshipDueSince(String day, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count de zile întârziere',
+      few: '$count zile întârziere',
+      one: '1 zi întârziere',
+    );
+    return 'Scadent din $day · $_temp0';
+  }
+
+  @override
   String get relationshipDueToday => 'Scadent astăzi';
+
+  @override
+  String relationshipDurationHours(int hours) {
+    return '$hours h';
+  }
+
+  @override
+  String relationshipDurationHoursMinutes(int hours, String minutes) {
+    return '$hours h $minutes';
+  }
+
+  @override
+  String relationshipDurationMinutes(int count) {
+    return '$count min';
+  }
 
   @override
   String get relationshipEditTitle => 'Editați persoana';
@@ -11385,6 +11412,11 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String relationshipLastSpoke(String time) {
+    return 'ultima discuție $time';
+  }
+
+  @override
   String get relationshipLinkContact => 'Asociați un contact';
 
   @override
@@ -11405,6 +11437,9 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get relationshipMoreActions => 'Mai multe acțiuni';
+
+  @override
   String get relationshipNameLabel => 'Nume';
 
   @override
@@ -11414,6 +11449,14 @@ class AppLocalizationsRo extends AppLocalizations {
   String relationshipNextByDay(String day) {
     return 'următorul până $day';
   }
+
+  @override
+  String relationshipNextDueOn(String day) {
+    return 'Următoarea scadență $day';
+  }
+
+  @override
+  String get relationshipNextTimeTitle => 'Data viitoare';
 
   @override
   String get relationshipNicknameLabel => 'Poreclă';
@@ -11435,8 +11478,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get relationshipNudgesOn => 'memento-uri active';
 
   @override
-  String get relationshipPostCallBody =>
-      'Tocmai ați luat legătura. Doriți să notați un check-in cât este proaspăt?';
+  String relationshipOnTrackCadence(String cadence) {
+    return 'În ritm · $cadence';
+  }
+
+  @override
+  String get relationshipPayAttentionTo => 'Fiți atent la';
 
   @override
   String get relationshipPostCallConfirm => 'Notați check-in';
@@ -11445,8 +11492,32 @@ class AppLocalizationsRo extends AppLocalizations {
   String get relationshipPostCallDismiss => 'Nu acum';
 
   @override
-  String relationshipPostCallTitle(String name) {
-    return 'Cum a fost cu $name?';
+  String relationshipPostCallMeta(String time, int minutes) {
+    return 'început $time · circa $minutes min';
+  }
+
+  @override
+  String relationshipPostCallOfferCall(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes de minute',
+      few: '$minutes minute',
+      one: '1 minut',
+    );
+    return 'Ați sunat pe $name acum $_temp0 — notați cât este proaspăt?';
+  }
+
+  @override
+  String relationshipPostCallOfferMessage(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes de minute',
+      few: '$minutes minute',
+      one: '1 minut',
+    );
+    return 'I-ați scris lui $name acum $_temp0 — notați cât este proaspăt?';
   }
 
   @override
@@ -11459,6 +11530,13 @@ class AppLocalizationsRo extends AppLocalizations {
     );
     return 'Fără contact $_temp0';
   }
+
+  @override
+  String get relationshipReachPrivacy =>
+      'Rămâne pe acest dispozitiv · niciodată partajat cu AI-ul';
+
+  @override
+  String get relationshipReachTitle => 'Contact';
 
   @override
   String get relationshipRelinkContact => 'Asociați alt contact';
@@ -11551,6 +11629,18 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get relationshipStayInTouch => 'Menține contactul';
+
+  @override
+  String relationshipTasksLinkedCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count de asociate',
+      few: '$count asociate',
+      one: '1 asociată',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipTimestampToday => 'Azi';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -11493,7 +11493,14 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'început la $time · circa $minutes min';
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: 'circa $minutes min',
+      one: 'circa 1 min',
+      zero: 'sub un minut',
+    );
+    return 'început la $time · $_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -11260,9 +11260,9 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count de zile întârziere',
-      few: '$count zile întârziere',
-      one: '1 zi întârziere',
+      other: '$count de zile de întârziere',
+      few: '$count zile de întârziere',
+      one: '1 zi de întârziere',
     );
     return 'Scadent din $day · $_temp0';
   }
@@ -11493,7 +11493,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'început $time · circa $minutes min';
+    return 'început la $time · circa $minutes min';
   }
 
   @override
@@ -11504,6 +11504,7 @@ class AppLocalizationsRo extends AppLocalizations {
       other: '$minutes de minute',
       few: '$minutes minute',
       one: '1 minut',
+      zero: 'mai puțin de un minut',
     );
     return 'Ați sunat pe $name acum $_temp0 — notați cât este proaspăt?';
   }
@@ -11516,6 +11517,7 @@ class AppLocalizationsRo extends AppLocalizations {
       other: '$minutes de minute',
       few: '$minutes minute',
       one: '1 minut',
+      zero: 'mai puțin de un minut',
     );
     return 'I-ați scris lui $name acum $_temp0 — notați cât este proaspăt?';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -11043,7 +11043,33 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String relationshipDueSince(String day, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dagar försenade',
+      one: '1 dag försenad',
+    );
+    return 'Försenad sedan $day · $_temp0';
+  }
+
+  @override
   String get relationshipDueToday => 'Dags i dag';
+
+  @override
+  String relationshipDurationHours(int hours) {
+    return '$hours h';
+  }
+
+  @override
+  String relationshipDurationHoursMinutes(int hours, String minutes) {
+    return '$hours h $minutes';
+  }
+
+  @override
+  String relationshipDurationMinutes(int count) {
+    return '$count min';
+  }
 
   @override
   String get relationshipEditTitle => 'Redigera person';
@@ -11168,6 +11194,11 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String relationshipLastSpoke(String time) {
+    return 'pratade senast $time';
+  }
+
+  @override
   String get relationshipLinkContact => 'Länka kontakt';
 
   @override
@@ -11188,6 +11219,9 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get relationshipMoreActions => 'Fler åtgärder';
+
+  @override
   String get relationshipNameLabel => 'Namn';
 
   @override
@@ -11197,6 +11231,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String relationshipNextByDay(String day) {
     return 'nästa senast $day';
   }
+
+  @override
+  String relationshipNextDueOn(String day) {
+    return 'Nästa gång $day';
+  }
+
+  @override
+  String get relationshipNextTimeTitle => 'Nästa gång';
 
   @override
   String get relationshipNicknameLabel => 'Smeknamn';
@@ -11218,8 +11260,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get relationshipNudgesOn => 'påminnelser på';
 
   @override
-  String get relationshipPostCallBody =>
-      'Du hörde precis av dig. Vill du logga en avstämning medan det är färskt?';
+  String relationshipOnTrackCadence(String cadence) {
+    return 'I fas · $cadence';
+  }
+
+  @override
+  String get relationshipPayAttentionTo => 'Var uppmärksam på';
 
   @override
   String get relationshipPostCallConfirm => 'Logga avstämning';
@@ -11228,8 +11274,30 @@ class AppLocalizationsSv extends AppLocalizations {
   String get relationshipPostCallDismiss => 'Inte nu';
 
   @override
-  String relationshipPostCallTitle(String name) {
-    return 'Hur gick det med $name?';
+  String relationshipPostCallMeta(String time, int minutes) {
+    return 'började $time · cirka $minutes min';
+  }
+
+  @override
+  String relationshipPostCallOfferCall(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minuter',
+      one: '1 minut',
+    );
+    return 'Du ringde $name för $_temp0 sedan — anteckna medan det är färskt?';
+  }
+
+  @override
+  String relationshipPostCallOfferMessage(String name, int minutes) {
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: '$minutes minuter',
+      one: '1 minut',
+    );
+    return 'Du skrev till $name för $_temp0 sedan — anteckna medan det är färskt?';
   }
 
   @override
@@ -11242,6 +11310,13 @@ class AppLocalizationsSv extends AppLocalizations {
     );
     return 'Ingen kontakt $_temp0';
   }
+
+  @override
+  String get relationshipReachPrivacy =>
+      'Stannar på den här enheten · delas aldrig med AI:n';
+
+  @override
+  String get relationshipReachTitle => 'Kontakt';
 
   @override
   String get relationshipRelinkContact => 'Länka en annan kontakt';
@@ -11332,6 +11407,17 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get relationshipStayInTouch => 'Håll kontakten';
+
+  @override
+  String relationshipTasksLinkedCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count kopplade',
+      one: '1 kopplad',
+    );
+    return '$_temp0';
+  }
 
   @override
   String get relationshipTimestampToday => 'Idag';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -11047,7 +11047,7 @@ class AppLocalizationsSv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count dagar försenade',
+      other: '$count dagar försenad',
       one: '1 dag försenad',
     );
     return 'Försenad sedan $day · $_temp0';
@@ -11275,7 +11275,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'började $time · cirka $minutes min';
+    return 'började kl. $time · cirka $minutes min';
   }
 
   @override
@@ -11285,6 +11285,7 @@ class AppLocalizationsSv extends AppLocalizations {
       locale: localeName,
       other: '$minutes minuter',
       one: '1 minut',
+      zero: 'mindre än en minut',
     );
     return 'Du ringde $name för $_temp0 sedan — anteckna medan det är färskt?';
   }
@@ -11296,6 +11297,7 @@ class AppLocalizationsSv extends AppLocalizations {
       locale: localeName,
       other: '$minutes minuter',
       one: '1 minut',
+      zero: 'mindre än en minut',
     );
     return 'Du skrev till $name för $_temp0 sedan — anteckna medan det är färskt?';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -11275,7 +11275,14 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String relationshipPostCallMeta(String time, int minutes) {
-    return 'började kl. $time · cirka $minutes min';
+    String _temp0 = intl.Intl.pluralLogic(
+      minutes,
+      locale: localeName,
+      other: 'cirka $minutes min',
+      one: 'cirka 1 min',
+      zero: 'under en minut',
+    );
+    return 'började kl. $time · $_temp0';
   }
 
   @override

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4970,7 +4970,7 @@
   "relationshipPayAttentionTo": "Let op",
   "relationshipPostCallConfirm": "Check-in vastleggen",
   "relationshipPostCallDismiss": "Niet nu",
-  "relationshipPostCallMeta": "begonnen om {time} · ongeveer {minutes} min",
+  "relationshipPostCallMeta": "begonnen om {time} · {minutes, plural, =0{minder dan een minuut} =1{ongeveer 1 min} other{ongeveer {minutes} min}}",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4970,7 +4970,7 @@
   "relationshipPayAttentionTo": "Let op",
   "relationshipPostCallConfirm": "Check-in vastleggen",
   "relationshipPostCallDismiss": "Niet nu",
-  "relationshipPostCallMeta": "begonnen {time} · ongeveer {minutes} min",
+  "relationshipPostCallMeta": "begonnen om {time} · ongeveer {minutes} min",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {
@@ -4981,7 +4981,7 @@
       }
     }
   },
-  "relationshipPostCallOfferCall": "Je hebt {name} {minutes, plural, =1{1 minuut} other{{minutes} minuten}} geleden gebeld — nu vastleggen zolang het vers is?",
+  "relationshipPostCallOfferCall": "Je hebt {name} {minutes, plural, =0{minder dan een minuut} =1{1 minuut} other{{minutes} minuten}} geleden gebeld — nu vastleggen zolang het vers is?",
   "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
@@ -4992,7 +4992,7 @@
       }
     }
   },
-  "relationshipPostCallOfferMessage": "Je hebt {name} {minutes, plural, =1{1 minuut} other{{minutes} minuten}} geleden geschreven — nu vastleggen zolang het vers is?",
+  "relationshipPostCallOfferMessage": "Je hebt {name} {minutes, plural, =0{minder dan een minuut} =1{1 minuut} other{{minutes} minuten}} geleden geschreven — nu vastleggen zolang het vers is?",
   "@relationshipPostCallOfferMessage": {
     "placeholders": {
       "name": {
@@ -5012,7 +5012,7 @@
     }
   },
   "relationshipReachPrivacy": "Blijft op dit apparaat · nooit gedeeld met de AI",
-  "relationshipReachTitle": "Bereiken",
+  "relationshipReachTitle": "Contact",
   "relationshipRelinkContact": "Ander contact koppelen",
   "relationshipSeeAllCheckIns": "Alle check-ins bekijken",
   "@relationshipSeeAllCheckIns": {

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4835,7 +4835,45 @@
       }
     }
   },
+  "relationshipDueSince": "Te laat sinds {day} · {count, plural, =1{1 dag te laat} other{{count} dagen te laat}}",
+  "@relationshipDueSince": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDueToday": "Vandaag aan de beurt",
+  "relationshipDurationHours": "{hours} u",
+  "@relationshipDurationHours": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipDurationHoursMinutes": "{hours} u {minutes}",
+  "@relationshipDurationHoursMinutes": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipDurationMinutes": "{count} min",
+  "@relationshipDurationMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipEditTitle": "Persoon bewerken",
   "relationshipErrorCreateFailed": "Kon de persoon niet opslaan. Probeer het opnieuw.",
   "relationshipErrorDeleteFailed": "Kon de persoon niet verwijderen. Probeer het opnieuw.",
@@ -4868,6 +4906,14 @@
     "description": "Relationships redesign label."
   },
   "relationshipLastCheckInLabel": "Laatste check-in {date}",
+  "relationshipLastSpoke": "laatst gesproken {time}",
+  "@relationshipLastSpoke": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipLinkContact": "Contact koppelen",
   "relationshipLinkedTasksLabel": "Taken",
   "relationshipLinkTaskButton": "Taak koppelen",
@@ -4884,6 +4930,7 @@
       }
     }
   },
+  "relationshipMoreActions": "Meer acties",
   "relationshipNameLabel": "Naam",
   "relationshipNameRequired": "Een naam is verplicht",
   "relationshipNextByDay": "volgende voor {day}",
@@ -4894,6 +4941,15 @@
       }
     }
   },
+  "relationshipNextDueOn": "Volgende keer {day}",
+  "@relationshipNextDueOn": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipNextTimeTitle": "Volgende keer",
   "relationshipNicknameLabel": "Bijnaam",
   "relationshipNoCheckIns": "Nog geen check-ins — leg er een vast na jullie volgende gesprek.",
   "relationshipNoLinkedTasks": "Nog geen gekoppelde taken.",
@@ -4903,15 +4959,47 @@
   "@relationshipNudgesOn": {
     "description": "Relationships redesign label."
   },
-  "relationshipPostCallBody": "Je hebt net contact gehad. Wil je een check-in vastleggen nu het nog vers is?",
+  "relationshipOnTrackCadence": "Op schema · {cadence}",
+  "@relationshipOnTrackCadence": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipPayAttentionTo": "Let op",
   "relationshipPostCallConfirm": "Check-in vastleggen",
   "relationshipPostCallDismiss": "Niet nu",
-  "relationshipPostCallTitle": "Hoe ging het met {name}?",
-  "@relationshipPostCallTitle": {
+  "relationshipPostCallMeta": "begonnen {time} · ongeveer {minutes} min",
+  "@relationshipPostCallMeta": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferCall": "Je hebt {name} {minutes, plural, =1{1 minuut} other{{minutes} minuten}} geleden gebeld — nu vastleggen zolang het vers is?",
+  "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
-        "type": "String",
-        "example": "Anna"
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferMessage": "Je hebt {name} {minutes, plural, =1{1 minuut} other{{minutes} minuten}} geleden geschreven — nu vastleggen zolang het vers is?",
+  "@relationshipPostCallOfferMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
       }
     }
   },
@@ -4923,6 +5011,8 @@
       }
     }
   },
+  "relationshipReachPrivacy": "Blijft op dit apparaat · nooit gedeeld met de AI",
+  "relationshipReachTitle": "Bereiken",
   "relationshipRelinkContact": "Ander contact koppelen",
   "relationshipSeeAllCheckIns": "Alle check-ins bekijken",
   "@relationshipSeeAllCheckIns": {
@@ -5005,6 +5095,14 @@
   "relationshipStayInTouch": "Contact houden",
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
+  },
+  "relationshipTasksLinkedCount": "{count, plural, =1{1 gekoppeld} other{{count} gekoppeld}}",
+  "@relationshipTasksLinkedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   },
   "relationshipTimestampToday": "Vandaag",
   "relationshipTimestampYesterday": "Gisteren",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4835,7 +4835,45 @@
       }
     }
   },
+  "relationshipDueSince": "Pendente desde {day} · {count, plural, =1{1 dia de atraso} other{{count} dias de atraso}}",
+  "@relationshipDueSince": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDueToday": "Pendente hoje",
+  "relationshipDurationHours": "{hours} h",
+  "@relationshipDurationHours": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipDurationHoursMinutes": "{hours} h {minutes}",
+  "@relationshipDurationHoursMinutes": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipDurationMinutes": "{count} min",
+  "@relationshipDurationMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipEditTitle": "Editar pessoa",
   "relationshipErrorCreateFailed": "Não foi possível salvar a pessoa. Tente novamente.",
   "relationshipErrorDeleteFailed": "Não foi possível excluir a pessoa. Tente novamente.",
@@ -4868,6 +4906,14 @@
     "description": "Relationships redesign label."
   },
   "relationshipLastCheckInLabel": "Último registro {date}",
+  "relationshipLastSpoke": "última conversa {time}",
+  "@relationshipLastSpoke": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipLinkContact": "Associar contacto",
   "relationshipLinkedTasksLabel": "Tarefas",
   "relationshipLinkTaskButton": "Vincular tarefa",
@@ -4884,6 +4930,7 @@
       }
     }
   },
+  "relationshipMoreActions": "Mais ações",
   "relationshipNameLabel": "Nome",
   "relationshipNameRequired": "O nome é obrigatório",
   "relationshipNextByDay": "próximo até {day}",
@@ -4894,6 +4941,15 @@
       }
     }
   },
+  "relationshipNextDueOn": "Próximo prazo {day}",
+  "@relationshipNextDueOn": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipNextTimeTitle": "Da próxima vez",
   "relationshipNicknameLabel": "Apelido",
   "relationshipNoCheckIns": "Nenhum registro ainda — adicione um após a próxima conversa.",
   "relationshipNoLinkedTasks": "Nenhuma tarefa vinculada ainda.",
@@ -4903,15 +4959,47 @@
   "@relationshipNudgesOn": {
     "description": "Relationships redesign label."
   },
-  "relationshipPostCallBody": "Acabaste de entrar em contacto. Queres registar um check-in enquanto está fresco?",
+  "relationshipOnTrackCadence": "Em dia · {cadence}",
+  "@relationshipOnTrackCadence": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipPayAttentionTo": "Prestar atenção a",
   "relationshipPostCallConfirm": "Registar check-in",
   "relationshipPostCallDismiss": "Agora não",
-  "relationshipPostCallTitle": "Como foi com {name}?",
-  "@relationshipPostCallTitle": {
+  "relationshipPostCallMeta": "começou {time} · cerca de {minutes} min",
+  "@relationshipPostCallMeta": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferCall": "Ligaste a {name} há {minutes, plural, =1{1 minuto} other{{minutes} minutos}} — registamos enquanto está fresco?",
+  "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
-        "type": "String",
-        "example": "Anna"
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferMessage": "Escreveste a {name} há {minutes, plural, =1{1 minuto} other{{minutes} minutos}} — registamos enquanto está fresco?",
+  "@relationshipPostCallOfferMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
       }
     }
   },
@@ -4923,6 +5011,8 @@
       }
     }
   },
+  "relationshipReachPrivacy": "Fica neste dispositivo · nunca partilhado com a IA",
+  "relationshipReachTitle": "Contactar",
   "relationshipRelinkContact": "Associar outro contacto",
   "relationshipSeeAllCheckIns": "Ver todos os registros",
   "@relationshipSeeAllCheckIns": {
@@ -5005,6 +5095,14 @@
   "relationshipStayInTouch": "Manter contato",
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
+  },
+  "relationshipTasksLinkedCount": "{count, plural, =1{1 ligada} other{{count} ligadas}}",
+  "@relationshipTasksLinkedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   },
   "relationshipTimestampToday": "Hoje",
   "relationshipTimestampYesterday": "Ontem",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4970,7 +4970,7 @@
   "relationshipPayAttentionTo": "Prestar atenção a",
   "relationshipPostCallConfirm": "Registar check-in",
   "relationshipPostCallDismiss": "Agora não",
-  "relationshipPostCallMeta": "começou {time} · cerca de {minutes} min",
+  "relationshipPostCallMeta": "começou às {time} · cerca de {minutes} min",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {
@@ -4981,7 +4981,7 @@
       }
     }
   },
-  "relationshipPostCallOfferCall": "Ligaste a {name} há {minutes, plural, =1{1 minuto} other{{minutes} minutos}} — registamos enquanto está fresco?",
+  "relationshipPostCallOfferCall": "Ligaste a {name} há {minutes, plural, =0{menos de um minuto} =1{1 minuto} other{{minutes} minutos}} — registamos enquanto está fresco?",
   "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
@@ -4992,7 +4992,7 @@
       }
     }
   },
-  "relationshipPostCallOfferMessage": "Escreveste a {name} há {minutes, plural, =1{1 minuto} other{{minutes} minutos}} — registamos enquanto está fresco?",
+  "relationshipPostCallOfferMessage": "Escreveste a {name} há {minutes, plural, =0{menos de um minuto} =1{1 minuto} other{{minutes} minutos}} — registamos enquanto está fresco?",
   "@relationshipPostCallOfferMessage": {
     "placeholders": {
       "name": {

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4970,7 +4970,7 @@
   "relationshipPayAttentionTo": "Prestar atenção a",
   "relationshipPostCallConfirm": "Registar check-in",
   "relationshipPostCallDismiss": "Agora não",
-  "relationshipPostCallMeta": "começou às {time} · cerca de {minutes} min",
+  "relationshipPostCallMeta": "começou às {time} · {minutes, plural, =0{menos de um minuto} =1{cerca de 1 min} other{cerca de {minutes} min}}",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4333,7 +4333,7 @@
       }
     }
   },
-  "relationshipDueSince": "Scadent din {day} · {count, plural, =1{1 zi întârziere} few{{count} zile întârziere} other{{count} de zile întârziere}}",
+  "relationshipDueSince": "Scadent din {day} · {count, plural, =1{1 zi de întârziere} few{{count} zile de întârziere} other{{count} de zile de întârziere}}",
   "@relationshipDueSince": {
     "placeholders": {
       "day": {
@@ -4468,7 +4468,7 @@
   "relationshipPayAttentionTo": "Fiți atent la",
   "relationshipPostCallConfirm": "Notați check-in",
   "relationshipPostCallDismiss": "Nu acum",
-  "relationshipPostCallMeta": "început {time} · circa {minutes} min",
+  "relationshipPostCallMeta": "început la {time} · circa {minutes} min",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {
@@ -4479,7 +4479,7 @@
       }
     }
   },
-  "relationshipPostCallOfferCall": "Ați sunat pe {name} acum {minutes, plural, =1{1 minut} few{{minutes} minute} other{{minutes} de minute}} — notați cât este proaspăt?",
+  "relationshipPostCallOfferCall": "Ați sunat pe {name} acum {minutes, plural, =0{mai puțin de un minut} =1{1 minut} few{{minutes} minute} other{{minutes} de minute}} — notați cât este proaspăt?",
   "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
@@ -4490,7 +4490,7 @@
       }
     }
   },
-  "relationshipPostCallOfferMessage": "I-ați scris lui {name} acum {minutes, plural, =1{1 minut} few{{minutes} minute} other{{minutes} de minute}} — notați cât este proaspăt?",
+  "relationshipPostCallOfferMessage": "I-ați scris lui {name} acum {minutes, plural, =0{mai puțin de un minut} =1{1 minut} few{{minutes} minute} other{{minutes} de minute}} — notați cât este proaspăt?",
   "@relationshipPostCallOfferMessage": {
     "placeholders": {
       "name": {

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4468,7 +4468,7 @@
   "relationshipPayAttentionTo": "Fiți atent la",
   "relationshipPostCallConfirm": "Notați check-in",
   "relationshipPostCallDismiss": "Nu acum",
-  "relationshipPostCallMeta": "început la {time} · circa {minutes} min",
+  "relationshipPostCallMeta": "început la {time} · {minutes, plural, =0{sub un minut} =1{circa 1 min} other{circa {minutes} min}}",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4333,7 +4333,45 @@
       }
     }
   },
+  "relationshipDueSince": "Scadent din {day} · {count, plural, =1{1 zi întârziere} few{{count} zile întârziere} other{{count} de zile întârziere}}",
+  "@relationshipDueSince": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDueToday": "Scadent astăzi",
+  "relationshipDurationHours": "{hours} h",
+  "@relationshipDurationHours": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipDurationHoursMinutes": "{hours} h {minutes}",
+  "@relationshipDurationHoursMinutes": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipDurationMinutes": "{count} min",
+  "@relationshipDurationMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipEditTitle": "Editați persoana",
   "relationshipErrorCreateFailed": "Persoana nu a putut fi salvată. Încercați din nou.",
   "relationshipErrorDeleteFailed": "Persoana nu a putut fi ștearsă. Încercați din nou.",
@@ -4366,6 +4404,14 @@
     "description": "Relationships redesign label."
   },
   "relationshipLastCheckInLabel": "Ultima înregistrare {date}",
+  "relationshipLastSpoke": "ultima discuție {time}",
+  "@relationshipLastSpoke": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipLinkContact": "Asociați un contact",
   "relationshipLinkedTasksLabel": "Sarcini",
   "relationshipLinkTaskButton": "Asociați o sarcină",
@@ -4382,6 +4428,7 @@
       }
     }
   },
+  "relationshipMoreActions": "Mai multe acțiuni",
   "relationshipNameLabel": "Nume",
   "relationshipNameRequired": "Numele este obligatoriu",
   "relationshipNextByDay": "următorul până {day}",
@@ -4392,6 +4439,15 @@
       }
     }
   },
+  "relationshipNextDueOn": "Următoarea scadență {day}",
+  "@relationshipNextDueOn": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipNextTimeTitle": "Data viitoare",
   "relationshipNicknameLabel": "Poreclă",
   "relationshipNoCheckIns": "Nicio înregistrare încă — adăugați una după următoarea conversație.",
   "relationshipNoLinkedTasks": "Nicio sarcină asociată încă.",
@@ -4401,15 +4457,47 @@
   "@relationshipNudgesOn": {
     "description": "Relationships redesign label."
   },
-  "relationshipPostCallBody": "Tocmai ați luat legătura. Doriți să notați un check-in cât este proaspăt?",
+  "relationshipOnTrackCadence": "În ritm · {cadence}",
+  "@relationshipOnTrackCadence": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipPayAttentionTo": "Fiți atent la",
   "relationshipPostCallConfirm": "Notați check-in",
   "relationshipPostCallDismiss": "Nu acum",
-  "relationshipPostCallTitle": "Cum a fost cu {name}?",
-  "@relationshipPostCallTitle": {
+  "relationshipPostCallMeta": "început {time} · circa {minutes} min",
+  "@relationshipPostCallMeta": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferCall": "Ați sunat pe {name} acum {minutes, plural, =1{1 minut} few{{minutes} minute} other{{minutes} de minute}} — notați cât este proaspăt?",
+  "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
-        "type": "String",
-        "example": "Anna"
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferMessage": "I-ați scris lui {name} acum {minutes, plural, =1{1 minut} few{{minutes} minute} other{{minutes} de minute}} — notați cât este proaspăt?",
+  "@relationshipPostCallOfferMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
       }
     }
   },
@@ -4421,6 +4509,8 @@
       }
     }
   },
+  "relationshipReachPrivacy": "Rămâne pe acest dispozitiv · niciodată partajat cu AI-ul",
+  "relationshipReachTitle": "Contact",
   "relationshipRelinkContact": "Asociați alt contact",
   "relationshipSeeAllCheckIns": "Vezi toate înregistrările",
   "@relationshipSeeAllCheckIns": {
@@ -4503,6 +4593,14 @@
   "relationshipStayInTouch": "Menține contactul",
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
+  },
+  "relationshipTasksLinkedCount": "{count, plural, =1{1 asociată} few{{count} asociate} other{{count} de asociate}}",
+  "@relationshipTasksLinkedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   },
   "relationshipTimestampToday": "Azi",
   "relationshipTimestampYesterday": "Ieri",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4836,7 +4836,45 @@
       }
     }
   },
+  "relationshipDueSince": "Försenad sedan {day} · {count, plural, =1{1 dag försenad} other{{count} dagar försenade}}",
+  "@relationshipDueSince": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipDueToday": "Dags i dag",
+  "relationshipDurationHours": "{hours} h",
+  "@relationshipDurationHours": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipDurationHoursMinutes": "{hours} h {minutes}",
+  "@relationshipDurationHoursMinutes": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipDurationMinutes": "{count} min",
+  "@relationshipDurationMinutes": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "relationshipEditTitle": "Redigera person",
   "relationshipErrorCreateFailed": "Personen kunde inte sparas. Försök igen.",
   "relationshipErrorDeleteFailed": "Personen kunde inte tas bort. Försök igen.",
@@ -4869,6 +4907,14 @@
     "description": "Relationships redesign label."
   },
   "relationshipLastCheckInLabel": "Senaste avstämning {date}",
+  "relationshipLastSpoke": "pratade senast {time}",
+  "@relationshipLastSpoke": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "relationshipLinkContact": "Länka kontakt",
   "relationshipLinkedTasksLabel": "Uppgifter",
   "relationshipLinkTaskButton": "Länka uppgift",
@@ -4885,6 +4931,7 @@
       }
     }
   },
+  "relationshipMoreActions": "Fler åtgärder",
   "relationshipNameLabel": "Namn",
   "relationshipNameRequired": "Namn krävs",
   "relationshipNextByDay": "nästa senast {day}",
@@ -4895,6 +4942,15 @@
       }
     }
   },
+  "relationshipNextDueOn": "Nästa gång {day}",
+  "@relationshipNextDueOn": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipNextTimeTitle": "Nästa gång",
   "relationshipNicknameLabel": "Smeknamn",
   "relationshipNoCheckIns": "Inga avstämningar än — logga en efter ert nästa samtal.",
   "relationshipNoLinkedTasks": "Inga uppgifter länkade än.",
@@ -4904,15 +4960,47 @@
   "@relationshipNudgesOn": {
     "description": "Relationships redesign label."
   },
-  "relationshipPostCallBody": "Du hörde precis av dig. Vill du logga en avstämning medan det är färskt?",
+  "relationshipOnTrackCadence": "I fas · {cadence}",
+  "@relationshipOnTrackCadence": {
+    "placeholders": {
+      "cadence": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipPayAttentionTo": "Var uppmärksam på",
   "relationshipPostCallConfirm": "Logga avstämning",
   "relationshipPostCallDismiss": "Inte nu",
-  "relationshipPostCallTitle": "Hur gick det med {name}?",
-  "@relationshipPostCallTitle": {
+  "relationshipPostCallMeta": "började {time} · cirka {minutes} min",
+  "@relationshipPostCallMeta": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferCall": "Du ringde {name} för {minutes, plural, =1{1 minut} other{{minutes} minuter}} sedan — anteckna medan det är färskt?",
+  "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
-        "type": "String",
-        "example": "Anna"
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "relationshipPostCallOfferMessage": "Du skrev till {name} för {minutes, plural, =1{1 minut} other{{minutes} minuter}} sedan — anteckna medan det är färskt?",
+  "@relationshipPostCallOfferMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "minutes": {
+        "type": "int"
       }
     }
   },
@@ -4924,6 +5012,8 @@
       }
     }
   },
+  "relationshipReachPrivacy": "Stannar på den här enheten · delas aldrig med AI:n",
+  "relationshipReachTitle": "Kontakt",
   "relationshipRelinkContact": "Länka en annan kontakt",
   "relationshipSeeAllCheckIns": "Se alla avstämningar",
   "@relationshipSeeAllCheckIns": {
@@ -5006,6 +5096,14 @@
   "relationshipStayInTouch": "Håll kontakten",
   "@relationshipStayInTouch": {
     "description": "Relationships redesign label."
+  },
+  "relationshipTasksLinkedCount": "{count, plural, =1{1 kopplad} other{{count} kopplade}}",
+  "@relationshipTasksLinkedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   },
   "relationshipTimestampToday": "Idag",
   "relationshipTimestampYesterday": "Igår",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4971,7 +4971,7 @@
   "relationshipPayAttentionTo": "Var uppmärksam på",
   "relationshipPostCallConfirm": "Logga avstämning",
   "relationshipPostCallDismiss": "Inte nu",
-  "relationshipPostCallMeta": "började kl. {time} · cirka {minutes} min",
+  "relationshipPostCallMeta": "började kl. {time} · {minutes, plural, =0{under en minut} =1{cirka 1 min} other{cirka {minutes} min}}",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4836,7 +4836,7 @@
       }
     }
   },
-  "relationshipDueSince": "Försenad sedan {day} · {count, plural, =1{1 dag försenad} other{{count} dagar försenade}}",
+  "relationshipDueSince": "Försenad sedan {day} · {count, plural, =1{1 dag försenad} other{{count} dagar försenad}}",
   "@relationshipDueSince": {
     "placeholders": {
       "day": {
@@ -4971,7 +4971,7 @@
   "relationshipPayAttentionTo": "Var uppmärksam på",
   "relationshipPostCallConfirm": "Logga avstämning",
   "relationshipPostCallDismiss": "Inte nu",
-  "relationshipPostCallMeta": "började {time} · cirka {minutes} min",
+  "relationshipPostCallMeta": "började kl. {time} · cirka {minutes} min",
   "@relationshipPostCallMeta": {
     "placeholders": {
       "time": {
@@ -4982,7 +4982,7 @@
       }
     }
   },
-  "relationshipPostCallOfferCall": "Du ringde {name} för {minutes, plural, =1{1 minut} other{{minutes} minuter}} sedan — anteckna medan det är färskt?",
+  "relationshipPostCallOfferCall": "Du ringde {name} för {minutes, plural, =0{mindre än en minut} =1{1 minut} other{{minutes} minuter}} sedan — anteckna medan det är färskt?",
   "@relationshipPostCallOfferCall": {
     "placeholders": {
       "name": {
@@ -4993,7 +4993,7 @@
       }
     }
   },
-  "relationshipPostCallOfferMessage": "Du skrev till {name} för {minutes, plural, =1{1 minut} other{{minutes} minuter}} sedan — anteckna medan det är färskt?",
+  "relationshipPostCallOfferMessage": "Du skrev till {name} för {minutes, plural, =0{mindre än en minut} =1{1 minut} other{{minutes} minuter}} sedan — anteckna medan det är färskt?",
   "@relationshipPostCallOfferMessage": {
     "placeholders": {
       "name": {

--- a/lib/widgets/app_bar/glass_action_button.dart
+++ b/lib/widgets/app_bar/glass_action_button.dart
@@ -9,7 +9,7 @@ class GlassActionButton extends StatelessWidget {
   const GlassActionButton({
     required this.child,
     required this.onTap,
-    this.size = 40,
+    this.size = defaultSize,
     this.semanticLabel,
     this.tooltip,
     super.key,
@@ -21,7 +21,11 @@ class GlassActionButton extends StatelessWidget {
   /// Callback when button is tapped.
   final VoidCallback onTap;
 
-  /// Size of the glass container. Defaults to 40.
+  /// The default [size]: the touch target every glass action in an app bar
+  /// shares, so a row of them lines up.
+  static const double defaultSize = 40;
+
+  /// Size of the glass container. Defaults to [defaultSize].
   final double size;
 
   /// Accessible label for icon-only glass actions.

--- a/test/features/design_system/components/cards/design_system_section_card_test.dart
+++ b/test/features/design_system/components/cards/design_system_section_card_test.dart
@@ -127,4 +127,14 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200));
     expect(tapped, 1);
   });
+
+  testWidgets('decoration() is exactly what the card paints, so a sliver host '
+      'is indistinguishable from the boxed card', (tester) async {
+    final context = await pumpCard(tester);
+
+    expect(
+      decorationOf(tester),
+      DesignSystemSectionCard.decoration(context.designTokens),
+    );
+  });
 }

--- a/test/features/design_system/components/layout/detail_content_width_test.dart
+++ b/test/features/design_system/components/layout/detail_content_width_test.dart
@@ -25,8 +25,14 @@ void main() {
             child: Builder(
               builder: (context) {
                 captured = context;
+                // Loose constraints inside the column: the child says how
+                // wide it wants to be, and this one wants the whole measure.
                 return const DetailContentWidth(
-                  child: SizedBox(key: ValueKey('content'), height: 10),
+                  child: SizedBox(
+                    key: ValueKey('content'),
+                    width: double.infinity,
+                    height: 10,
+                  ),
                 );
               },
             ),

--- a/test/features/design_system/components/layout/detail_content_width_test.dart
+++ b/test/features/design_system/components/layout/detail_content_width_test.dart
@@ -7,18 +7,30 @@ import 'package:material_ui/material_ui.dart';
 import '../../../../widget_test_utils.dart';
 
 void main() {
-  Future<BuildContext> pump(WidgetTester tester, Size size) async {
+  /// Pumps the widget on a [size] window; [paneWidth] narrows the parent the
+  /// way a list/detail split's detail pane does.
+  Future<BuildContext> pump(
+    WidgetTester tester,
+    Size size, {
+    double? paneWidth,
+  }) async {
     setTestSurfaceSize(tester, size);
     late BuildContext captured;
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
-        Builder(
-          builder: (context) {
-            captured = context;
-            return const DetailContentWidth(
-              child: SizedBox(key: ValueKey('content'), height: 10),
-            );
-          },
+        Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: paneWidth ?? size.width,
+            child: Builder(
+              builder: (context) {
+                captured = context;
+                return const DetailContentWidth(
+                  child: SizedBox(key: ValueKey('content'), height: 10),
+                );
+              },
+            ),
+          ),
         ),
         mediaQueryData: MediaQueryData(size: size),
       ),
@@ -33,7 +45,7 @@ void main() {
 
       final gutter = context.designTokens.spacing.step5;
       expect(
-        detailContentInsets(context),
+        detailContentInsets(context, availableWidth: 400),
         EdgeInsets.symmetric(horizontal: gutter),
       );
     });
@@ -44,23 +56,52 @@ void main() {
 
       final gutter = context.designTokens.spacing.step5;
       expect(
-        detailContentInsets(context),
+        detailContentInsets(context, availableWidth: 1280),
         EdgeInsets.symmetric(
           horizontal: gutter + (1280 - kDetailContentMaxWidth) / 2,
         ),
       );
     });
 
-    testWidgets('a desktop window narrower than the measure keeps the plain '
-        'gutter rather than a negative centring', (tester) async {
+    testWidgets('inside a pane narrower than the measure it centres on the '
+        'pane, not the window — the split must not over-inset its detail', (
+      tester,
+    ) async {
+      final context = await pump(tester, const Size(1280, 800));
+
+      final gutter = context.designTokens.spacing.step5;
+      expect(
+        detailContentInsets(context, availableWidth: 848),
+        EdgeInsets.symmetric(horizontal: gutter),
+      );
+      expect(
+        detailContentInsets(context, availableWidth: 1100),
+        EdgeInsets.symmetric(
+          horizontal: gutter + (1100 - kDetailContentMaxWidth) / 2,
+        ),
+      );
+    });
+
+    testWidgets('an unbounded parent gets the plain gutter', (tester) async {
+      final context = await pump(tester, const Size(1280, 800));
+
+      final gutter = context.designTokens.spacing.step5;
+      expect(
+        detailContentInsets(context, availableWidth: double.infinity),
+        EdgeInsets.symmetric(horizontal: gutter),
+      );
+    });
+
+    testWidgets('a window narrower than the breakpoint keeps the plain gutter '
+        'whatever width is available', (tester) async {
       final context = await pump(
         tester,
-        const Size(kDesktopBreakpoint, 800),
+        const Size(kDesktopBreakpoint - 1, 800),
       );
 
       final gutter = context.designTokens.spacing.step5;
       expect(
-        detailContentInsets(context),
+        detailContentInsets(context, availableWidth: 2000),
         EdgeInsets.symmetric(horizontal: gutter),
       );
     });
@@ -80,7 +121,7 @@ void main() {
         'geometry detailContentInsets describes', (tester) async {
       final context = await pump(tester, const Size(1280, 800));
 
-      final insets = detailContentInsets(context);
+      final insets = detailContentInsets(context, availableWidth: 1280);
       final content = find.byKey(const ValueKey('content'));
       expect(tester.getSize(content).width, 1280 - insets.horizontal);
       expect(tester.getTopLeft(content).dx, insets.left);
@@ -88,6 +129,20 @@ void main() {
         tester.getSize(content).width,
         kDetailContentMaxWidth - 2 * context.designTokens.spacing.step5,
       );
+    });
+
+    testWidgets("in a detail pane narrower than the measure it uses the pane's "
+        'width inside the gutter', (tester) async {
+      final context = await pump(
+        tester,
+        const Size(1280, 800),
+        paneWidth: 848,
+      );
+
+      final gutter = context.designTokens.spacing.step5;
+      final content = find.byKey(const ValueKey('content'));
+      expect(tester.getSize(content).width, 848 - 2 * gutter);
+      expect(tester.getTopLeft(content).dx, gutter);
     });
   });
 }

--- a/test/features/design_system/components/layout/detail_content_width_test.dart
+++ b/test/features/design_system/components/layout/detail_content_width_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/layout/detail_content_width.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:material_ui/material_ui.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  Future<BuildContext> pump(WidgetTester tester, Size size) async {
+    setTestSurfaceSize(tester, size);
+    late BuildContext captured;
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Builder(
+          builder: (context) {
+            captured = context;
+            return const DetailContentWidth(
+              child: SizedBox(key: ValueKey('content'), height: 10),
+            );
+          },
+        ),
+        mediaQueryData: MediaQueryData(size: size),
+      ),
+    );
+    await tester.pump();
+    return captured;
+  }
+
+  group('detailContentInsets', () {
+    testWidgets('on a phone it is the plain content gutter', (tester) async {
+      final context = await pump(tester, const Size(400, 800));
+
+      final gutter = context.designTokens.spacing.step5;
+      expect(
+        detailContentInsets(context),
+        EdgeInsets.symmetric(horizontal: gutter),
+      );
+    });
+
+    testWidgets('on a desktop-wide window it centres a column capped at the '
+        'reading measure', (tester) async {
+      final context = await pump(tester, const Size(1280, 800));
+
+      final gutter = context.designTokens.spacing.step5;
+      expect(
+        detailContentInsets(context),
+        EdgeInsets.symmetric(
+          horizontal: gutter + (1280 - kDetailContentMaxWidth) / 2,
+        ),
+      );
+    });
+
+    testWidgets('a desktop window narrower than the measure keeps the plain '
+        'gutter rather than a negative centring', (tester) async {
+      final context = await pump(
+        tester,
+        const Size(kDesktopBreakpoint, 800),
+      );
+
+      final gutter = context.designTokens.spacing.step5;
+      expect(
+        detailContentInsets(context),
+        EdgeInsets.symmetric(horizontal: gutter),
+      );
+    });
+  });
+
+  group('DetailContentWidth', () {
+    testWidgets('spans the phone width inside the gutter', (tester) async {
+      final context = await pump(tester, const Size(400, 800));
+
+      final gutter = context.designTokens.spacing.step5;
+      final content = find.byKey(const ValueKey('content'));
+      expect(tester.getSize(content).width, 400 - 2 * gutter);
+      expect(tester.getTopLeft(content).dx, gutter);
+    });
+
+    testWidgets('caps and centres the content on a wide window — the same '
+        'geometry detailContentInsets describes', (tester) async {
+      final context = await pump(tester, const Size(1280, 800));
+
+      final insets = detailContentInsets(context);
+      final content = find.byKey(const ValueKey('content'));
+      expect(tester.getSize(content).width, 1280 - insets.horizontal);
+      expect(tester.getTopLeft(content).dx, insets.left);
+      expect(
+        tester.getSize(content).width,
+        kDetailContentMaxWidth - 2 * context.designTokens.spacing.step5,
+      );
+    });
+  });
+}

--- a/test/features/relationships/ui/pages/relationship_details_page_test.dart
+++ b/test/features/relationships/ui/pages/relationship_details_page_test.dart
@@ -849,6 +849,7 @@ void main() {
         data: any(named: 'data'),
         entryText: any(named: 'entryText'),
         dateFrom: any(named: 'dateFrom'),
+        dateTo: any(named: 'dateTo'),
       ),
     ).thenAnswer((_) async => checkIn('check-new'));
 
@@ -877,6 +878,7 @@ void main() {
                 data: captureAny(named: 'data'),
                 entryText: any(named: 'entryText'),
                 dateFrom: any(named: 'dateFrom'),
+                dateTo: any(named: 'dateTo'),
               ),
             ).captured.single
             as CheckInData;

--- a/test/features/relationships/ui/pages/relationship_details_page_test.dart
+++ b/test/features/relationships/ui/pages/relationship_details_page_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/check_in_data.dart';
@@ -10,15 +11,23 @@ import 'package:lotti/classes/task.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/task_agent_providers.dart';
-import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
 import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/projects/repository/project_repository.dart';
+import 'package:lotti/features/relationships/model/relationship_health_metrics.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
+import 'package:lotti/features/relationships/service/check_in_transcription_service.dart';
 import 'package:lotti/features/relationships/state/relationship_agent_providers.dart';
 import 'package:lotti/features/relationships/ui/pages/relationship_details_page.dart';
+import 'package:lotti/features/relationships/ui/widgets/check_in_capture_sheet.dart';
+import 'package:lotti/features/relationships/ui/widgets/check_ins_card.dart';
+import 'package:lotti/features/relationships/ui/widgets/relationship_action_bar.dart';
+import 'package:lotti/features/relationships/ui/widgets/relationship_briefing_card.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
@@ -33,13 +42,31 @@ import '../../../../mocks/mocks.dart';
 import '../../../../widget_test_utils.dart';
 import '../../../categories/test_utils.dart';
 
+/// Answers the speak flow's pre-flight probe with "no", so the mic test can
+/// prove the form opened in speaking mode without a recorder on screen.
+class _NoTranscription implements CheckInTranscriptionService {
+  @override
+  Future<bool> canTranscribe(String subjectId) async => false;
+
+  @override
+  CheckInTranscriptWait transcribe({
+    required String audioEntryId,
+    required String subjectId,
+    Duration timeout = checkInTranscriptTimeout,
+  }) => throw UnimplementedError();
+}
+
 void main() {
   final testDate = DateTime(2026, 8, 13, 10, 30);
+  // The morning after the fixture's date: the cadence pills are computed
+  // against the clock, so every header assertion pumps under this one.
+  final now = DateTime(2026, 8, 14, 10, 30);
 
   late MockRelationshipRepository mockRepository;
   late MockRelationshipAgentService mockAgentService;
   late MockRelationshipReminderService mockReminders;
   late MockUpdateNotifications mockNotifications;
+  late MockEntitiesCacheService mockCache;
   // The post-interaction prompt mounted on this page reads the device-local
   // marker, which lives in settings. A real in-memory db is simpler than a
   // mock here and keeps the prompt's "no marker → renders nothing" default.
@@ -106,13 +133,16 @@ void main() {
     CheckInSentiment? sentiment,
     List<String> topics = const [],
     String? narrative,
+    String? attention,
+    Duration length = Duration.zero,
   }) => CheckInEntry(
-    meta: meta(id),
+    meta: meta(id).copyWith(dateTo: testDate.add(length)),
     data: CheckInData(
       relationshipId: 'rel-1',
       interactionType: CheckInInteractionType.call,
       sentiment: sentiment,
       topics: topics,
+      payAttentionTo: attention,
     ),
     entryText: narrative == null ? null : EntryText(plainText: narrative),
   );
@@ -120,12 +150,25 @@ void main() {
   setUpAll(registerAllFallbackValues);
 
   setUp(() {
+    // The page is a full scroll — hero, header, cards, then the log — and
+    // the default 800x600 surface leaves the Tasks card and most check-in
+    // rows unbuilt, where a tap lands on nothing. Tall enough for every
+    // section to be on screen at once; desktop tests set their own size.
+    TestWidgetsFlutterBinding.instance.platformDispatcher.views.single
+      ..physicalSize = const Size(1000, 2400)
+      ..devicePixelRatio = 1;
     mockRepository = MockRelationshipRepository();
     mockNotifications = MockUpdateNotifications();
     settingsDb = SettingsDb(inMemoryDatabase: true);
+    // The header's eyebrow and the form's CategoryField resolve the category
+    // name through the cache; the picker reads its sorted categories.
+    mockCache = MockEntitiesCacheService();
+    when(() => mockCache.getCategoryById(any())).thenReturn(null);
+    when(() => mockCache.sortedCategories).thenReturn([]);
     getIt
       ..registerSingleton<UpdateNotifications>(mockNotifications)
-      ..registerSingleton<SettingsDb>(settingsDb);
+      ..registerSingleton<SettingsDb>(settingsDb)
+      ..registerSingleton<EntitiesCacheService>(mockCache);
     // Most tests exercise other sections; linked tasks default to empty.
     when(
       () => mockRepository.getLinkedTasks('rel-1'),
@@ -139,24 +182,53 @@ void main() {
   });
 
   tearDown(() async {
+    TestWidgetsFlutterBinding.instance.platformDispatcher.views.single.reset();
     await getIt.unregister<UpdateNotifications>();
     await getIt.unregister<SettingsDb>();
+    await getIt.unregister<EntitiesCacheService>();
     await settingsDb.close();
   });
 
-  Widget buildPage({List<Override> overrides = const []}) =>
-      makeTestableWidgetNoScroll(
-        const RelationshipDetailsPage(relationshipId: 'rel-1'),
-        overrides: [
-          relationshipRepositoryProvider.overrideWithValue(mockRepository),
-          relationshipAgentServiceProvider.overrideWithValue(mockAgentService),
-          relationshipReminderServiceProvider.overrideWithValue(mockReminders),
-          ...overrides,
-        ],
-      );
+  Widget buildPage({
+    List<Override> overrides = const [],
+    MediaQueryData? mediaQueryData,
+  }) => makeTestableWidgetNoScroll(
+    const RelationshipDetailsPage(relationshipId: 'rel-1'),
+    mediaQueryData: mediaQueryData,
+    overrides: [
+      relationshipRepositoryProvider.overrideWithValue(mockRepository),
+      relationshipAgentServiceProvider.overrideWithValue(mockAgentService),
+      relationshipReminderServiceProvider.overrideWithValue(mockReminders),
+      ...overrides,
+    ],
+  );
+
+  /// Pumps the page under the fixed clock the header pills are read against.
+  Future<void> pumpPage(
+    WidgetTester tester, {
+    List<Override> overrides = const [],
+    MediaQueryData? mediaQueryData,
+  }) => withClock(Clock.fixed(now), () async {
+    await tester.pumpWidget(
+      buildPage(overrides: overrides, mediaQueryData: mediaQueryData),
+    );
+    await tester.pumpAndSettle();
+  });
+
+  /// Delete lives in the hero's overflow menu.
+  Future<void> openDelete(WidgetTester tester) async {
+    await tester.tap(find.byKey(const ValueKey('person-menu')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(LottiIcons.delete));
+    await tester.pumpAndSettle();
+  }
+
+  DsPill pill(WidgetTester tester, String key) =>
+      tester.widget<DsPill>(find.byKey(ValueKey(key)));
 
   testWidgets(
-    'renders header chips (status, cadence, nickname) and check-in rows',
+    'renders the header block (eyebrow, name, one-liner, pills) and the '
+    'check-in rows',
     (tester) async {
       when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
         (_) async => relationship(important: true, cadenceDays: 14),
@@ -170,52 +242,150 @@ void main() {
             sentiment: CheckInSentiment.good,
             topics: ['travel'],
             narrative: 'Planned the summer trip.',
+            length: const Duration(minutes: 11),
           ),
         ],
       );
 
-      await tester.pumpWidget(buildPage());
-      await tester.pumpAndSettle();
+      await pumpPage(tester);
 
       expect(find.text('Anna'), findsOneWidget);
-      expect(find.text('Active'), findsOneWidget);
-      expect(find.text('Every two weeks'), findsOneWidget);
-      expect(find.text('Sis'), findsOneWidget);
-      expect(find.byIcon(LottiIcons.star), findsOneWidget);
+      expect(
+        tester.widget<Text>(find.byKey(const ValueKey('person-eyebrow'))).data,
+        'Important',
+      );
+      expect(
+        tester
+            .widget<Text>(find.byKey(const ValueKey('person-one-liner')))
+            .data,
+        '"Sis" · last spoke Yesterday 10:30',
+      );
+      expect(
+        pill(tester, 'person-pill-cadence').label,
+        'On track · Every two weeks',
+      );
+      expect(pill(tester, 'person-pill-next-due').label, 'Next due Thu 27 Aug');
+      // The star is gone: importance lives in the eyebrow.
+      expect(find.byIcon(LottiIcons.star), findsNothing);
 
-      expect(find.text('Call'), findsOneWidget);
+      expect(
+        tester
+            .widget<Text>(find.byKey(const ValueKey('check-in-row-meta')))
+            .data,
+        'Yesterday 10:30 · Call · 11 min',
+      );
       expect(find.text('Good'), findsOneWidget);
       expect(find.text('travel'), findsOneWidget);
       expect(find.text('Planned the summer trip.'), findsOneWidget);
     },
   );
 
+  testWidgets('the eyebrow names the category the person is filed under', (
+    tester,
+  ) async {
+    when(() => mockCache.getCategoryById('cat-1')).thenReturn(
+      CategoryTestUtils.createTestCategory(
+        id: 'cat-1',
+        name: 'Penguin Operations',
+      ),
+    );
+    when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
+      (_) async => relationship(important: true, categoryId: 'cat-1'),
+    );
+    when(
+      () => mockRepository.getCheckInsForRelationship('rel-1'),
+    ).thenAnswer((_) async => []);
+
+    await pumpPage(tester);
+
+    expect(
+      tester.widget<Text>(find.byKey(const ValueKey('person-eyebrow'))).data,
+      'Penguin Operations · Important',
+    );
+  });
+
+  testWidgets('a standing briefing puts the health band on the header as a '
+      'pill, beside the briefing card', (tester) async {
+    final agentId = relationshipAgentIdFor('rel-1');
+    final report =
+        AgentDomainEntity.agentReport(
+              id: 'report-1',
+              agentId: agentId,
+              scope: AgentReportScopes.current,
+              createdAt: testDate,
+              vectorClock: null,
+              content: 'Anna is in good spirits.',
+              provenance: {
+                RelationshipReportProvenanceKeys.healthBand: 'thriving',
+                RelationshipReportProvenanceKeys.healthRationale: 'Two calls.',
+              },
+            )
+            as AgentReportEntity;
+    when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
+      (_) async => relationship(important: true),
+    );
+    when(
+      () => mockRepository.getCheckInsForRelationship('rel-1'),
+    ).thenAnswer((_) async => []);
+
+    await pumpPage(
+      tester,
+      overrides: [
+        agentReportProvider(agentId).overrideWith((ref) async => report),
+        agentIdentityProvider(agentId).overrideWith((ref) async => null),
+      ],
+    );
+
+    expect(pill(tester, 'person-pill-health').label, 'Thriving');
+    expect(find.byType(RelationshipBriefingCard), findsOneWidget);
+    expect(find.text('Anna is in good spirits.'), findsOneWidget);
+  });
+
+  testWidgets('the Next time card appears only when the latest check-in '
+      'carries guidance', (tester) async {
+    when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
+      (_) async => relationship(),
+    );
+    when(
+      () => mockRepository.getCheckInsForRelationship('rel-1'),
+    ).thenAnswer(
+      (_) async => [
+        checkIn('check-2', attention: 'Ask how the move went.'),
+        checkIn('check-1', attention: 'Older guidance.'),
+      ],
+    );
+
+    await pumpPage(tester);
+
+    expect(find.byKey(const ValueKey('person-next-time-card')), findsOne);
+    expect(find.text('Ask how the move went.'), findsOneWidget);
+    expect(find.text('Older guidance.'), findsNothing);
+  });
+
   testWidgets(
     'a synced cadence outside the presets reads as "every N days" rather '
     'than being rounded into one',
     (tester) async {
       when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
-        (_) async => relationship(cadenceDays: 3),
+        (_) async => relationship(important: true, cadenceDays: 3),
       );
       when(
         () => mockRepository.getCheckInsForRelationship('rel-1'),
       ).thenAnswer((_) async => []);
 
-      await tester.pumpWidget(buildPage());
-      await tester.pumpAndSettle();
+      await pumpPage(tester);
 
-      expect(find.text('Every 3 days'), findsOneWidget);
-      expect(find.text('Weekly'), findsNothing);
+      expect(
+        pill(tester, 'person-pill-cadence').label,
+        'On track · Every 3 days',
+      );
+      expect(find.textContaining('Weekly'), findsNothing);
     },
   );
 
-  testWidgets('the status chip names every status kind', (tester) async {
+  testWidgets('a dormant or archived person wears the status pill; an active '
+      'one wears the cadence fact instead', (tester) async {
     final statuses = <String, RelationshipStatus>{
-      'Active': RelationshipStatus.active(
-        id: 'st-a',
-        createdAt: testDate,
-        utcOffset: 0,
-      ),
       'Dormant': RelationshipStatus.dormant(
         id: 'st-d',
         createdAt: testDate,
@@ -233,24 +403,26 @@ void main() {
 
     for (final entry in statuses.entries) {
       when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
-        (_) async => relationship(status: entry.value),
+        (_) async => relationship(important: true, status: entry.value),
       );
 
-      await tester.pumpWidget(buildPage());
-      await tester.pumpAndSettle();
+      await pumpPage(tester);
 
-      expect(find.text(entry.key), findsOneWidget, reason: entry.key);
-      for (final other in statuses.keys.where((k) => k != entry.key)) {
-        expect(
-          find.text(other),
-          findsNothing,
-          reason: '$other vs ${entry.key}',
-        );
-      }
+      expect(pill(tester, 'person-pill-status').label, entry.key);
+      expect(find.byKey(const ValueKey('person-pill-cadence')), findsNothing);
 
       await tester.pumpWidget(const SizedBox.shrink());
       await tester.pumpAndSettle();
     }
+
+    when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
+      (_) async => relationship(important: true, cadenceDays: 7),
+    );
+    await pumpPage(tester);
+
+    expect(find.byKey(const ValueKey('person-pill-status')), findsNothing);
+    expect(find.text('Active'), findsNothing);
+    expect(pill(tester, 'person-pill-cadence').label, 'On track · Weekly');
   });
 
   testWidgets('renders the no-check-ins hint when the log is empty', (
@@ -270,8 +442,9 @@ void main() {
       find.text('No check-ins yet — log one after you next talk.'),
       findsOneWidget,
     );
-    // No star in the app bar for an unimportant relationship.
-    expect(find.byIcon(LottiIcons.star), findsNothing);
+    // An unimportant person in no category has no eyebrow at all.
+    expect(find.byKey(const ValueKey('person-eyebrow')), findsNothing);
+    expect(pill(tester, 'person-pill-status').label, 'Not enrolled');
   });
 
   testWidgets('says the person is no longer tracked when the id is gone — '
@@ -303,11 +476,6 @@ void main() {
   testWidgets('edit action opens the form prefilled with the person', (
     tester,
   ) async {
-    // The form's CategoryField resolves the category name through getIt.
-    final cache = MockEntitiesCacheService();
-    when(() => cache.getCategoryById(any())).thenReturn(null);
-    getIt.registerSingleton<EntitiesCacheService>(cache);
-    addTearDown(() => getIt.unregister<EntitiesCacheService>());
     when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
       (_) async => relationship(cadenceDays: 14),
     );
@@ -318,7 +486,7 @@ void main() {
     await tester.pumpWidget(buildPage());
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byIcon(LottiIcons.edit));
+    await tester.tap(find.byKey(const ValueKey('person-edit')));
     await tester.pumpAndSettle();
 
     // Prefilled name and nickname fields, and the edit-only status picker.
@@ -354,8 +522,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byIcon(LottiIcons.delete));
-      await tester.pumpAndSettle();
+      await openDelete(tester);
 
       // Confirmation modal names the person; nothing deleted before consent.
       expect(find.text('Delete Anna?'), findsOneWidget);
@@ -401,8 +568,7 @@ void main() {
 
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
-      await tester.tap(find.byIcon(LottiIcons.delete));
-      await tester.pumpAndSettle();
+      await openDelete(tester);
       await tester.tap(find.text('Delete'));
       await tester.pumpAndSettle();
 
@@ -430,8 +596,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byIcon(LottiIcons.delete));
-      await tester.pumpAndSettle();
+      await openDelete(tester);
       await tester.tap(find.text('Delete'));
       await tester.pumpAndSettle();
 
@@ -461,8 +626,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byIcon(LottiIcons.delete));
-      await tester.pumpAndSettle();
+      await openDelete(tester);
       await tester.tap(find.text('Delete'));
       await tester.pumpAndSettle();
 
@@ -474,8 +638,8 @@ void main() {
   );
 
   testWidgets(
-    'the log-check-in FAB is the design-system primary action, labelled and '
-    'painted in the interactive accent — not a neutral Material pill',
+    'the page ends in the sticky action bar — Log check-in and the mic — and '
+    'no floating button',
     (tester) async {
       when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
         (_) async => relationship(),
@@ -484,34 +648,155 @@ void main() {
         () => mockRepository.getCheckInsForRelationship('rel-1'),
       ).thenAnswer((_) async => []);
 
-      await tester.pumpWidget(buildPage());
-      await tester.pumpAndSettle();
+      await pumpPage(tester);
 
-      final fab = find.byKey(
-        const ValueKey('relationship-log-check-in-fab'),
-      );
-      expect(fab, findsOneWidget);
+      expect(find.byType(RelationshipActionBar), findsOneWidget);
       expect(
-        find.byType(FloatingActionButton),
-        findsNothing,
-        reason: 'the Material default carried the wrong colour',
+        find.byKey(const ValueKey('person-action-log-check-in')),
+        findsOneWidget,
       );
-
-      final button = tester.widget<DesignSystemFloatingActionButton>(fab);
-      expect(button.label, 'Log check-in');
-      expect(button.icon, LottiIcons.greeting);
-
-      final tokens = tester.element(fab).designTokens;
-      final ink = tester.widget<Ink>(
-        find.descendant(of: fab, matching: find.byType(Ink)),
-      );
+      expect(find.byKey(const ValueKey('person-action-speak')), findsOne);
+      expect(find.byType(FloatingActionButton), findsNothing);
       expect(
-        (ink.decoration! as BoxDecoration).color,
-        tokens.colors.interactive.enabled,
-        reason: 'same accent as Link task and every other primary action',
+        tester.widget<Scaffold>(find.byType(Scaffold).first).extendBody,
+        isTrue,
+        reason: 'the glass strip blurs the body scrolling under it',
       );
     },
   );
+
+  testWidgets('the mic opens the capture sheet in speaking mode', (
+    tester,
+  ) async {
+    when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
+      (_) async => relationship(),
+    );
+    when(
+      () => mockRepository.getCheckInsForRelationship('rel-1'),
+    ).thenAnswer((_) async => []);
+
+    await pumpPage(
+      tester,
+      overrides: [
+        checkInTranscriptionServiceProvider.overrideWithValue(
+          _NoTranscription(),
+        ),
+      ],
+    );
+    await tester.tap(find.byKey(const ValueKey('person-action-speak')));
+    await tester.pumpAndSettle();
+
+    final form = tester.widget<CheckInCaptureForm>(
+      find.byType(CheckInCaptureForm),
+    );
+    expect(form.startSpeaking, isTrue);
+    expect(form.relationshipId, 'rel-1');
+  });
+
+  testWidgets("Talk to agent beams to the person's chat", (tester) async {
+    when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
+      (_) async => relationship(),
+    );
+    when(
+      () => mockRepository.getCheckInsForRelationship('rel-1'),
+    ).thenAnswer((_) async => []);
+    final beamedTo = <String>[];
+    beamToNamedOverride = beamedTo.add;
+    addTearDown(() => beamToNamedOverride = null);
+
+    await pumpPage(tester);
+    await tester.tap(find.byKey(const ValueKey('person-talk-to-agent')));
+    await tester.pump();
+
+    expect(beamedTo, ['/people/rel-1/chat']);
+  });
+
+  testWidgets('on a phone, back pops the page', (tester) async {
+    when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
+      (_) async => relationship(),
+    );
+    when(
+      () => mockRepository.getCheckInsForRelationship('rel-1'),
+    ).thenAnswer((_) async => []);
+
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        Scaffold(
+          body: Builder(
+            builder: (context) => TextButton(
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) =>
+                      const RelationshipDetailsPage(relationshipId: 'rel-1'),
+                ),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+        overrides: [
+          relationshipRepositoryProvider.overrideWithValue(mockRepository),
+          relationshipAgentServiceProvider.overrideWithValue(mockAgentService),
+          relationshipReminderServiceProvider.overrideWithValue(mockReminders),
+        ],
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.byType(RelationshipDetailsPage), findsOneWidget);
+
+    await tester.tap(find.byIcon(LottiIcons.chevronLeft));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RelationshipDetailsPage), findsNothing);
+    expect(find.text('open'), findsOneWidget);
+  });
+
+  testWidgets('on the desktop split, back clears the selection by beaming '
+      'to the list', (tester) async {
+    when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
+      (_) async => relationship(),
+    );
+    when(
+      () => mockRepository.getCheckInsForRelationship('rel-1'),
+    ).thenAnswer((_) async => []);
+    final beamedTo = <String>[];
+    beamToNamedOverride = beamedTo.add;
+    addTearDown(() => beamToNamedOverride = null);
+    setTestSurfaceSize(tester, const Size(1280, 800));
+
+    await pumpPage(
+      tester,
+      mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+    );
+    await tester.tap(find.byIcon(LottiIcons.chevronLeft));
+    await tester.pump();
+
+    expect(beamedTo, ['/people']);
+  });
+
+  testWidgets('on a desktop-wide window every section sits on the centred '
+      'reading column', (tester) async {
+    when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
+      (_) async => relationship(),
+    );
+    when(
+      () => mockRepository.getCheckInsForRelationship('rel-1'),
+    ).thenAnswer((_) async => []);
+    setTestSurfaceSize(tester, const Size(1280, 800));
+
+    await pumpPage(
+      tester,
+      mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+    );
+
+    final card = find.byKey(const ValueKey('person-tasks-card'));
+    final width = tester.getSize(card).width;
+    final left = tester.getTopLeft(card).dx;
+    // 960 reading measure less the two step5 gutters, centred in 1280.
+    expect(width, 960 - 2 * 16);
+    expect(left, (1280 - 960) / 2 + 16);
+  });
 
   testWidgets(
     'check-in topics render as the design-system tag pill, the same read-out '
@@ -531,28 +816,26 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
+      // The header's own pills are tags too; the hairline is what separates
+      // a topic tag from them and from bare text.
       final pills = tester
           .widgetList<DsPill>(find.byType(DsPill))
-          .where((pill) => pill.shape == DsPillShape.tag)
+          .where((pill) => pill.bordered)
           .toList();
       expect(pills.map((pill) => pill.label), ['design tokens', 'Figma']);
       for (final pill in pills) {
+        expect(pill.shape, DsPillShape.tag);
         expect(pill.variant, DsPillVariant.filled);
-        expect(
-          pill.bordered,
-          isTrue,
-          reason: 'the hairline is what separates a tag from bare text',
-        );
       }
       expect(
-        find.descendant(of: find.byType(Card), matching: find.byType(Chip)),
+        find.byType(Chip),
         findsNothing,
         reason: 'topics were the last Material Chip on the check-in row',
       );
     },
   );
 
-  testWidgets('the FAB opens the check-in capture sheet for this person', (
+  testWidgets('Log check-in opens the capture sheet for this person', (
     tester,
   ) async {
     when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
@@ -634,8 +917,12 @@ void main() {
     await tester.pumpAndSettle();
 
     for (final entry in glyphs.entries) {
+      // Scoped to the rows: the hero's Talk to agent wears the chat glyph too.
       expect(
-        find.byIcon(entry.value),
+        find.descendant(
+          of: find.byType(CheckInRow),
+          matching: find.byIcon(entry.value),
+        ),
         findsOneWidget,
         reason: '${entry.key} row glyph',
       );
@@ -669,10 +956,9 @@ void main() {
       find.widgetWithText(TextField, 'Planned the summer trip.'),
       findsOneWidget,
     );
-    // Exactly two: the page's own app-bar action, which was already there
-    // before the sheet opened, plus the sheet's edit-only one. `findsWidgets`
-    // here would pass on the app-bar icon alone and prove nothing.
-    expect(find.byIcon(LottiIcons.delete), findsNWidgets(2));
+    // Exactly one: the page's own delete sits inside its closed menu, so
+    // the icon on screen is the sheet's edit-only one.
+    expect(find.byIcon(LottiIcons.delete), findsOneWidget);
   });
 
   testWidgets('renders contact channels with value and label', (tester) async {
@@ -698,7 +984,11 @@ void main() {
     await tester.pumpWidget(buildPage());
     await tester.pumpAndSettle();
 
-    expect(find.text('Contact channels'), findsOneWidget);
+    expect(find.text('Reach'), findsOneWidget);
+    expect(
+      find.text('Stays on this device · never shared with the AI'),
+      findsOneWidget,
+    );
     expect(find.text('anna@example.com'), findsOneWidget);
     expect(find.text('Personal'), findsOneWidget);
     expect(find.text('+49 151 1234567'), findsOneWidget);
@@ -907,13 +1197,10 @@ void main() {
   group('link task picker -', () {
     late MockJournalDb mockDb;
     late MockFts5Db mockFts5Db;
-    late MockEntitiesCacheService mockCache;
 
     setUp(() {
       mockDb = MockJournalDb();
       mockFts5Db = MockFts5Db();
-      mockCache = MockEntitiesCacheService();
-      when(() => mockCache.sortedCategories).thenReturn([]);
       when(
         () => mockDb.getTasks(
           starredStatuses: any(named: 'starredStatuses'),
@@ -928,8 +1215,7 @@ void main() {
 
       getIt
         ..registerSingleton<JournalDb>(mockDb)
-        ..registerSingleton<Fts5Db>(mockFts5Db)
-        ..registerSingleton<EntitiesCacheService>(mockCache);
+        ..registerSingleton<Fts5Db>(mockFts5Db);
 
       when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
         (_) async => relationship(),
@@ -942,7 +1228,6 @@ void main() {
     tearDown(() async {
       await getIt.unregister<JournalDb>();
       await getIt.unregister<Fts5Db>();
-      await getIt.unregister<EntitiesCacheService>();
     });
 
     Future<void> pickTask(WidgetTester tester) async {

--- a/test/features/relationships/ui/shared/relationship_timestamps_test.dart
+++ b/test/features/relationships/ui/shared/relationship_timestamps_test.dart
@@ -404,4 +404,63 @@ void main() {
       expect(rendered, 'Do');
     });
   });
+
+  group('relationshipDurationLabelOf', () {
+    Future<String?> labelFor(WidgetTester tester, Duration duration) async {
+      late String? rendered;
+      await tester.pumpWidget(
+        MaterialApp(
+          builder: LegacyMaterialBridge.builder,
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            ...GlobalMaterialLocalizations.delegates,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) {
+              rendered = relationshipDurationLabelOf(context, duration);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return rendered;
+    }
+
+    testWidgets('nothing for a zero or negative duration — a check-in with '
+        'no length shows no duration at all', (tester) async {
+      expect(await labelFor(tester, Duration.zero), isNull);
+      expect(await labelFor(tester, const Duration(minutes: -5)), isNull);
+    });
+
+    testWidgets('minutes under an hour', (tester) async {
+      expect(await labelFor(tester, const Duration(minutes: 11)), '11 min');
+      expect(await labelFor(tester, const Duration(minutes: 59)), '59 min');
+    });
+
+    testWidgets('whole hours', (tester) async {
+      expect(await labelFor(tester, const Duration(hours: 1)), '1 h');
+      expect(await labelFor(tester, const Duration(hours: 3)), '3 h');
+    });
+
+    testWidgets('hours and minutes, minutes zero-padded', (tester) async {
+      expect(
+        await labelFor(tester, const Duration(hours: 1, minutes: 5)),
+        '1 h 05',
+      );
+      expect(
+        await labelFor(tester, const Duration(hours: 2, minutes: 30)),
+        '2 h 30',
+      );
+    });
+
+    testWidgets('seconds do not round up', (tester) async {
+      expect(await labelFor(tester, const Duration(seconds: 59)), isNull);
+      expect(
+        await labelFor(tester, const Duration(minutes: 10, seconds: 59)),
+        '10 min',
+      );
+    });
+  });
 }

--- a/test/features/relationships/ui/widgets/check_in_capture_sheet_test.dart
+++ b/test/features/relationships/ui/widgets/check_in_capture_sheet_test.dart
@@ -1350,6 +1350,43 @@ void main() {
       expect(find.text('How did you connect?'), findsOneWidget);
     });
 
+    testWidgets("a Speak press during the automatic launch's pre-flight does "
+        'not open a second recorder', (tester) async {
+      final launches = <String?>[];
+      // Hold the pre-flight open: the automatic launch is mid-await when the
+      // user presses Speak.
+      final gate = Completer<RelationshipEntry?>();
+      when(
+        () => mockRepository.getRelationshipById(any()),
+      ).thenAnswer((_) => gate.future);
+      await tester.pumpWidget(
+        buildSpeakableForm(
+          recordedEntryId: null,
+          transcript: null,
+          onLaunch: launches.add,
+          startSpeaking: true,
+        ),
+      );
+      await tester.pump();
+
+      final speak = find.widgetWithText(DesignSystemButton, 'Speak check-in');
+      expect(
+        tester.widget<DesignSystemButton>(speak).onPressed,
+        isNull,
+        reason: 'the button is out while a spoken check-in is in flight',
+      );
+      await tester.tap(speak, warnIfMissed: false);
+      gate.complete(testRelationship);
+      await tester.pumpAndSettle();
+
+      expect(launches, hasLength(1));
+      expect(
+        tester.widget<DesignSystemButton>(speak).onPressed,
+        isNotNull,
+        reason: 'a cancelled recording hands the button back',
+      );
+    });
+
     testWidgets('a form opened the ordinary way launches nothing on its own', (
       tester,
     ) async {

--- a/test/features/relationships/ui/widgets/check_in_capture_sheet_test.dart
+++ b/test/features/relationships/ui/widgets/check_in_capture_sheet_test.dart
@@ -191,8 +191,9 @@ void main() {
     void Function(String? categoryId)? onLaunch,
     bool canTranscribe = true,
     bool? enableSpeechRecognition,
+    bool startSpeaking = false,
   }) => makeTestableWidgetWithScaffold(
-    const CheckInCaptureForm(relationshipId: 'rel-001'),
+    CheckInCaptureForm(relationshipId: 'rel-001', startSpeaking: startSpeaking),
     overrides: [
       relationshipRepositoryProvider.overrideWithValue(mockRepository),
 
@@ -1319,6 +1320,42 @@ void main() {
       );
       expect(content.linkedId, 'rel-001');
       expect(content.categoryId, 'category-7');
+    });
+  });
+
+  group('startSpeaking', () {
+    testWidgets('opens the recorder after the first frame without a tap — '
+        'the page mic means "say it", not "show me the form"', (tester) async {
+      final launches = <String?>[];
+      await tester.pumpWidget(
+        buildSpeakableForm(
+          recordedEntryId: null,
+          transcript: null,
+          onLaunch: launches.add,
+          startSpeaking: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(launches, hasLength(1));
+      // A cancelled recording leaves the form as it was.
+      expect(find.text('How did you connect?'), findsOneWidget);
+    });
+
+    testWidgets('a form opened the ordinary way launches nothing on its own', (
+      tester,
+    ) async {
+      final launches = <String?>[];
+      await tester.pumpWidget(
+        buildSpeakableForm(
+          recordedEntryId: null,
+          transcript: null,
+          onLaunch: launches.add,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(launches, isEmpty);
     });
   });
 }

--- a/test/features/relationships/ui/widgets/check_in_capture_sheet_test.dart
+++ b/test/features/relationships/ui/widgets/check_in_capture_sheet_test.dart
@@ -160,6 +160,7 @@ void main() {
         data: any(named: 'data'),
         entryText: any(named: 'entryText'),
         dateFrom: any(named: 'dateFrom'),
+        dateTo: any(named: 'dateTo'),
       ),
     ).thenAnswer(
       (invocation) async => createdEntry(
@@ -259,6 +260,7 @@ void main() {
         data: captureAny(named: 'data'),
         entryText: captureAny(named: 'entryText'),
         dateFrom: captureAny(named: 'dateFrom'),
+        dateTo: any(named: 'dateTo'),
       ),
     ).captured;
     return (
@@ -368,6 +370,7 @@ void main() {
         data: any(named: 'data'),
         entryText: any(named: 'entryText'),
         dateFrom: any(named: 'dateFrom'),
+        dateTo: any(named: 'dateTo'),
       ),
     ).thenAnswer((_) async => null);
 
@@ -400,6 +403,7 @@ void main() {
         data: any(named: 'data'),
         entryText: any(named: 'entryText'),
         dateFrom: any(named: 'dateFrom'),
+        dateTo: any(named: 'dateTo'),
       ),
     ).thenThrow(Exception('db gone'));
 
@@ -430,6 +434,7 @@ void main() {
         data: any(named: 'data'),
         entryText: any(named: 'entryText'),
         dateFrom: any(named: 'dateFrom'),
+        dateTo: any(named: 'dateTo'),
       ),
     );
   });
@@ -645,6 +650,7 @@ void main() {
           data: any(named: 'data'),
           entryText: any(named: 'entryText'),
           dateFrom: any(named: 'dateFrom'),
+          dateTo: any(named: 'dateTo'),
         ),
       ).thenAnswer((_) async => null);
 
@@ -667,6 +673,7 @@ void main() {
           data: any(named: 'data'),
           entryText: any(named: 'entryText'),
           dateFrom: any(named: 'dateFrom'),
+          dateTo: any(named: 'dateTo'),
         ),
       ).thenThrow(Exception('db locked'));
 
@@ -1243,6 +1250,7 @@ void main() {
           data: any(named: 'data'),
           entryText: any(named: 'entryText'),
           dateFrom: any(named: 'dateFrom'),
+          dateTo: any(named: 'dateTo'),
         ),
       ).called(1);
     });
@@ -1356,6 +1364,104 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(launches, isEmpty);
+    });
+  });
+
+  group('duration', () {
+    testWidgets('a prefilled duration is persisted as the end time, so the '
+        'log shows what the post-call offer promised', (tester) async {
+      setTestSurfaceSize(tester, const Size(1000, 1400));
+      final startedAt = DateTime(2026, 8, 13, 12, 33);
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          CheckInCaptureForm(
+            relationshipId: 'rel-001',
+            prefilledTime: startedAt,
+            prefilledDuration: const Duration(minutes: 11),
+          ),
+          overrides: [
+            relationshipRepositoryProvider.overrideWithValue(mockRepository),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(find.text('Save'));
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      final captured = verify(
+        () => mockRepository.createCheckIn(
+          data: any(named: 'data'),
+          entryText: any(named: 'entryText'),
+          dateFrom: captureAny(named: 'dateFrom'),
+          dateTo: captureAny(named: 'dateTo'),
+        ),
+      ).captured;
+      expect(captured[0], startedAt);
+      expect(captured[1], startedAt.add(const Duration(minutes: 11)));
+    });
+
+    testWidgets('a check-in with no known duration saves a zero-length one', (
+      tester,
+    ) async {
+      setTestSurfaceSize(tester, const Size(1000, 1400));
+      await tester.pumpWidget(buildForm());
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(find.text('Save'));
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      final captured = verify(
+        () => mockRepository.createCheckIn(
+          data: any(named: 'data'),
+          entryText: any(named: 'entryText'),
+          dateFrom: captureAny(named: 'dateFrom'),
+          dateTo: captureAny(named: 'dateTo'),
+        ),
+      ).captured;
+      expect(captured[1], captured[0]);
+    });
+
+    testWidgets('editing keeps the existing length when nothing about the '
+        'time changes', (tester) async {
+      setTestSurfaceSize(tester, const Size(1000, 1400));
+      final from = DateTime(2026, 8, 13, 12, 33);
+      final existing = CheckInEntry(
+        meta: Metadata(
+          id: 'check-1',
+          createdAt: from,
+          updatedAt: from,
+          dateFrom: from,
+          dateTo: from.add(const Duration(minutes: 35)),
+        ),
+        data: const CheckInData(
+          relationshipId: 'rel-001',
+          interactionType: CheckInInteractionType.videoCall,
+        ),
+      );
+      when(
+        () => mockRepository.updateCheckIn(any()),
+      ).thenAnswer((_) async => true);
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          CheckInCaptureForm(relationshipId: 'rel-001', initial: existing),
+          overrides: [
+            relationshipRepositoryProvider.overrideWithValue(mockRepository),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(find.text('Save'));
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      final updated =
+          verify(
+                () => mockRepository.updateCheckIn(captureAny()),
+              ).captured.single
+              as CheckInEntry;
+      expect(updated.meta.dateFrom, from);
+      expect(updated.meta.dateTo, from.add(const Duration(minutes: 35)));
     });
   });
 }

--- a/test/features/relationships/ui/widgets/check_ins_card_test.dart
+++ b/test/features/relationships/ui/widgets/check_ins_card_test.dart
@@ -1,0 +1,220 @@
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/check_in_data.dart';
+import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/design_system/components/cards/design_system_section_card.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/relationships/ui/shared/sentiment.dart';
+import 'package:lotti/features/relationships/ui/widgets/check_ins_card.dart';
+import 'package:material_ui/material_ui.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  final now = DateTime(2026, 8, 13, 14);
+
+  CheckInEntry checkIn(
+    String id, {
+    DateTime? at,
+    Duration length = Duration.zero,
+    CheckInInteractionType type = CheckInInteractionType.call,
+    CheckInSentiment? sentiment,
+    List<String> topics = const [],
+    String? narrative,
+  }) {
+    final from = at ?? now.subtract(const Duration(hours: 2));
+    return CheckInEntry(
+      meta: Metadata(
+        id: id,
+        createdAt: from,
+        updatedAt: from,
+        dateFrom: from,
+        dateTo: from.add(length),
+      ),
+      data: CheckInData(
+        relationshipId: 'rel-1',
+        interactionType: type,
+        sentiment: sentiment,
+        topics: topics,
+      ),
+      entryText: narrative == null ? null : EntryText(plainText: narrative),
+    );
+  }
+
+  Future<List<CheckInEntry>> pump(
+    WidgetTester tester,
+    List<CheckInEntry> checkIns,
+  ) async {
+    final opened = <CheckInEntry>[];
+    await withClock(Clock.fixed(now), () async {
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          CustomScrollView(
+            slivers: [
+              CheckInsCardSliver(checkIns: checkIns, onOpen: opened.add),
+            ],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    });
+    return opened;
+  }
+
+  group('the card', () {
+    testWidgets('wears the section card surface, so it matches the boxed '
+        'cards around it', (tester) async {
+      await pump(tester, [checkIn('c1')]);
+
+      final sliver = tester.widget<DecoratedSliver>(
+        find.byKey(const ValueKey('person-check-ins-card')),
+      );
+      final tokens = tester
+          .element(find.byKey(const ValueKey('person-check-ins-card')))
+          .designTokens;
+      expect(sliver.decoration, DesignSystemSectionCard.decoration(tokens));
+    });
+
+    testWidgets('counts the check-ins beside the title', (tester) async {
+      await pump(tester, [checkIn('c1'), checkIn('c2'), checkIn('c3')]);
+
+      expect(find.text('Check-ins'), findsOneWidget);
+      final pill = tester.widget<DsPill>(
+        find.byKey(const ValueKey('person-check-ins-count')),
+      );
+      expect(pill.label, '3');
+    });
+
+    testWidgets('an empty log shows the hint and no count', (tester) async {
+      await pump(tester, const []);
+
+      expect(
+        find.text('No check-ins yet — log one after you next talk.'),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('person-check-ins-count')),
+        findsNothing,
+      );
+      expect(find.byType(CheckInRow), findsNothing);
+    });
+
+    testWidgets('tapping a row hands that check-in back', (tester) async {
+      final opened = await pump(tester, [
+        checkIn('c1', narrative: 'First.'),
+        checkIn('c2', narrative: 'Second.'),
+      ]);
+
+      await tester.tap(find.text('Second.'));
+      await tester.pump();
+
+      expect(opened.map((c) => c.meta.id), ['c2']);
+    });
+  });
+
+  group('the row', () {
+    testWidgets('meta line reads timestamp · type · duration in mono', (
+      tester,
+    ) async {
+      await pump(tester, [
+        checkIn(
+          'c1',
+          at: DateTime(2026, 8, 13, 12, 44),
+          length: const Duration(minutes: 11),
+        ),
+      ]);
+
+      final meta = tester.widget<Text>(
+        find.byKey(const ValueKey('check-in-row-meta')),
+      );
+      expect(meta.data, 'Today 12:44 · Call · 11 min');
+      expect(meta.style?.fontFamily, 'Inconsolata');
+    });
+
+    testWidgets('a check-in with no duration leaves the duration out', (
+      tester,
+    ) async {
+      await pump(tester, [
+        checkIn(
+          'c1',
+          at: DateTime(2026, 8, 12, 19, 5),
+          type: CheckInInteractionType.videoCall,
+        ),
+      ]);
+
+      final meta = tester.widget<Text>(
+        find.byKey(const ValueKey('check-in-row-meta')),
+      );
+      expect(meta.data, 'Yesterday 19:05 · Video call');
+    });
+
+    testWidgets('the sentiment pill is tinted with the sentiment colour and '
+        'absent when unset', (tester) async {
+      await pump(tester, [
+        checkIn('c1', sentiment: CheckInSentiment.delightful),
+        checkIn('c2'),
+      ]);
+
+      final pills = tester
+          .widgetList<DsPill>(
+            find.byKey(const ValueKey('check-in-row-sentiment')),
+          )
+          .toList();
+      expect(pills, hasLength(1));
+      final tokens = tester.element(find.byType(CheckInRow).first).designTokens;
+      expect(pills.single.label, 'Delightful');
+      expect(pills.single.variant, DsPillVariant.tinted);
+      expect(
+        pills.single.color,
+        sentimentColor(tokens, CheckInSentiment.delightful),
+      );
+    });
+
+    testWidgets('each interaction type gets its own glyph', (tester) async {
+      const glyphs = {
+        CheckInInteractionType.inPerson: LottiIcons.people,
+        CheckInInteractionType.call: LottiIcons.call,
+        CheckInInteractionType.videoCall: LottiIcons.video,
+        CheckInInteractionType.message: LottiIcons.chat,
+        CheckInInteractionType.other: LottiIcons.forum,
+      };
+      setTestSurfaceSize(tester, const Size(1000, 1400));
+      await pump(tester, [
+        for (final type in glyphs.keys) checkIn('c-${type.name}', type: type),
+      ]);
+
+      for (final entry in glyphs.entries) {
+        expect(
+          find.byIcon(entry.value),
+          findsOneWidget,
+          reason: '${entry.key} row glyph',
+        );
+      }
+    });
+
+    testWidgets('narrative and topic tags render under the meta line', (
+      tester,
+    ) async {
+      await pump(tester, [
+        checkIn(
+          'c1',
+          narrative: 'Planned the summer trip.',
+          topics: ['travel', 'Figma'],
+        ),
+      ]);
+
+      expect(find.text('Planned the summer trip.'), findsOneWidget);
+      final tags = tester
+          .widgetList<DsPill>(find.byType(DsPill))
+          .where((pill) => pill.bordered)
+          .toList();
+      expect(tags.map((pill) => pill.label), ['travel', 'Figma']);
+      for (final tag in tags) {
+        expect(tag.shape, DsPillShape.tag);
+        expect(tag.variant, DsPillVariant.filled);
+      }
+    });
+  });
+}

--- a/test/features/relationships/ui/widgets/contact_link_action_test.dart
+++ b/test/features/relationships/ui/widgets/contact_link_action_test.dart
@@ -1,44 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/relationship_data.dart';
-import 'package:lotti/features/design_system/theme/design_tokens.dart';
-import 'package:lotti/features/relationships/model/imported_contact.dart';
-import 'package:lotti/features/relationships/service/contacts_service.dart';
-import 'package:lotti/features/relationships/state/contact_import_controller.dart';
 import 'package:lotti/features/relationships/state/contact_link_controller.dart';
 import 'package:lotti/features/relationships/ui/widgets/contact_link_action.dart';
 import 'package:material_ui/material_ui.dart';
 
 import '../../../../widget_test_utils.dart';
 
-/// Only [isSupported] matters to the widget; the rest of the interface is
-/// satisfied so the real provider type can be overridden.
-class _FakeContactsService implements ContactsService {
-  _FakeContactsService({this.supported = true});
-
-  final bool supported;
-
-  @override
-  bool get isSupported => supported;
-
-  @override
-  Future<ContactsAccess> requestReadAccess() async => ContactsAccess.granted;
-
-  @override
-  Future<ImportedContact?> pickSingle() async => null;
-
-  @override
-  Future<List<ImportedContact>> readAll() async => const [];
-
-  @override
-  Future<ImportedContact?> readById(String id) async => null;
-
-  @override
-  Future<void> openSystemSettings() async {}
-}
-
-/// Records which controller method the widget invoked, and answers with a
-/// scripted outcome so every toast branch is reachable.
+/// Records which controller method was invoked, and answers with a scripted
+/// outcome so every toast branch is reachable.
 class _FakeContactLinkController implements ContactLinkController {
   _FakeContactLinkController(this.outcome);
 
@@ -85,140 +56,97 @@ void main() {
         ),
       );
 
-  Future<_FakeContactLinkController> pump(
-    WidgetTester tester, {
-    required RelationshipEntry relationship,
-    bool supported = true,
-    ContactLinkOutcome outcome = ContactLinkOutcome.linked,
-  }) async {
-    final controller = _FakeContactLinkController(outcome);
-    await tester.pumpWidget(
-      makeTestableWidgetWithScaffold(
-        ContactLinkAction(relationship: relationship),
-        overrides: [
-          contactsServiceProvider.overrideWithValue(
-            _FakeContactsService(supported: supported),
-          ),
-          contactLinkControllerProvider.overrideWithValue(controller),
-          contactRefKeyProvider.overrideWith((ref) async => deviceKey),
-        ],
-      ),
-    );
-    await tester.pumpAndSettle();
-    return controller;
-  }
-
-  group('what is offered', () {
-    testWidgets('an unlinked person gets a single link button', (tester) async {
-      await pump(tester, relationship: person());
-
-      expect(find.byIcon(LottiIcons.findPerson), findsOneWidget);
-      expect(find.byIcon(LottiIcons.contactCard), findsNothing);
-    });
-
-    testWidgets('a linked person gets the menu instead', (tester) async {
-      await pump(tester, relationship: person(refs: {deviceKey: 'os-1'}));
-
-      expect(find.byIcon(LottiIcons.contactCard), findsOneWidget);
-      expect(find.byIcon(LottiIcons.findPerson), findsNothing);
-    });
-
-    testWidgets('an empty ref counts as unlinked', (tester) async {
-      await pump(tester, relationship: person(refs: {deviceKey: ''}));
-
-      expect(find.byIcon(LottiIcons.findPerson), findsOneWidget);
-    });
-
-    testWidgets('a ref another device wrote counts as unlinked — even one '
-        'from a device on the same platform', (tester) async {
-      await pump(
-        tester,
-        relationship: person(
-          refs: {'android:host-b': 'os-1', 'ios:host-c': 'os-2'},
-        ),
-      );
-
+  group('contactIsLinkedOnThisDevice', () {
+    test("a ref under this device's key counts as linked", () {
       expect(
-        find.byIcon(LottiIcons.findPerson),
-        findsOneWidget,
+        contactIsLinkedOnThisDevice(
+          person(refs: {deviceKey: 'os-1'}),
+          deviceKey,
+        ),
+        isTrue,
+      );
+    });
+
+    test('no ref at all is unlinked', () {
+      expect(contactIsLinkedOnThisDevice(person(), deviceKey), isFalse);
+    });
+
+    test('an empty ref counts as unlinked', () {
+      expect(
+        contactIsLinkedOnThisDevice(person(refs: {deviceKey: ''}), deviceKey),
+        isFalse,
+      );
+    });
+
+    test('a ref another device wrote counts as unlinked — even one from a '
+        'device on the same platform', () {
+      expect(
+        contactIsLinkedOnThisDevice(
+          person(refs: {'android:host-b': 'os-1', 'ios:host-c': 'os-2'}),
+          deviceKey,
+        ),
+        isFalse,
         reason:
             'offering "update from contact" here would resolve another '
             "device's contact id against this device's address book",
       );
     });
 
-    testWidgets('renders nothing where there is no address book', (
-      tester,
-    ) async {
-      await pump(tester, relationship: person(), supported: false);
-
-      expect(find.byType(IconButton), findsNothing);
-      expect(find.byType(PopupMenuButton<dynamic>), findsNothing);
+    test('no key yet (host id unknown) is unlinked whatever the refs say', () {
+      expect(
+        contactIsLinkedOnThisDevice(person(refs: {deviceKey: 'os-1'}), null),
+        isFalse,
+      );
     });
   });
 
-  group('the menu on a linked person', () {
-    testWidgets('offers refreshing and re-linking as separate intents', (
-      tester,
-    ) async {
-      await pump(tester, relationship: person(refs: {deviceKey: 'os-1'}));
-
-      await tester.tap(find.byIcon(LottiIcons.contactCard));
+  group('runContactLinkAction', () {
+    /// A button that runs the link intent through the shared helper, so the
+    /// toast the user sees is the helper's — not a page's.
+    Future<_FakeContactLinkController> pump(
+      WidgetTester tester, {
+      required ContactLinkOutcome outcome,
+    }) async {
+      final controller = _FakeContactLinkController(outcome);
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          Consumer(
+            builder: (context, ref, _) => TextButton(
+              onPressed: () => runContactLinkAction(
+                context,
+                ref,
+                (c) => c.linkContact(person()),
+              ),
+              child: const Text('Link'),
+            ),
+          ),
+          overrides: [
+            contactLinkControllerProvider.overrideWithValue(controller),
+          ],
+        ),
+      );
+      await tester.tap(find.text('Link'));
       await tester.pumpAndSettle();
+      return controller;
+    }
 
-      expect(find.text('Update from contact'), findsOneWidget);
-      expect(find.text('Link a different contact'), findsOneWidget);
-    });
-
-    testWidgets('refreshing re-reads the linked contact', (tester) async {
+    testWidgets('runs the intent it was handed', (tester) async {
       final controller = await pump(
         tester,
-        relationship: person(refs: {deviceKey: 'os-1'}),
+        outcome: ContactLinkOutcome.linked,
       );
-
-      await tester.tap(find.byIcon(LottiIcons.contactCard));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('Update from contact'));
-      await tester.pumpAndSettle();
-
-      expect(controller.calls, ['refresh']);
-    });
-
-    testWidgets('re-linking opens the picker instead', (tester) async {
-      final controller = await pump(
-        tester,
-        relationship: person(refs: {deviceKey: 'os-1'}),
-      );
-
-      await tester.tap(find.byIcon(LottiIcons.contactCard));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('Link a different contact'));
-      await tester.pumpAndSettle();
 
       expect(controller.calls, ['link']);
     });
-  });
-
-  group('what the user is told', () {
-    Future<void> tapLink(WidgetTester tester) async {
-      await tester.tap(find.byIcon(LottiIcons.findPerson));
-      await tester.pumpAndSettle();
-    }
 
     testWidgets('confirms when details were copied', (tester) async {
-      await pump(tester, relationship: person());
-      await tapLink(tester);
+      await pump(tester, outcome: ContactLinkOutcome.linked);
 
       expect(find.text('Contact details copied'), findsOneWidget);
     });
 
     testWidgets('says so when the contact held nothing new', (tester) async {
-      await pump(
-        tester,
-        relationship: person(),
-        outcome: ContactLinkOutcome.noChanges,
-      );
-      await tapLink(tester);
+      await pump(tester, outcome: ContactLinkOutcome.noChanges);
 
       expect(find.text('Nothing new to copy'), findsOneWidget);
     });
@@ -226,39 +154,32 @@ void main() {
     testWidgets('says so when the contact is not on this device', (
       tester,
     ) async {
-      await pump(
-        tester,
-        relationship: person(),
-        outcome: ContactLinkOutcome.contactMissing,
-      );
-      await tapLink(tester);
+      await pump(tester, outcome: ContactLinkOutcome.contactMissing);
 
       expect(find.text("That contact isn't on this device"), findsOneWidget);
     });
 
     testWidgets('reports a rejected save', (tester) async {
-      await pump(
-        tester,
-        relationship: person(),
-        outcome: ContactLinkOutcome.saveFailed,
-      );
-      await tapLink(tester);
+      await pump(tester, outcome: ContactLinkOutcome.saveFailed);
 
       expect(find.text('Could not save the contact details'), findsOneWidget);
     });
 
     testWidgets('says nothing when the user backs out of the picker — '
         'cancelling is an answer, not a failure', (tester) async {
-      await pump(
-        tester,
-        relationship: person(),
-        outcome: ContactLinkOutcome.cancelled,
-      );
-      await tapLink(tester);
+      await pump(tester, outcome: ContactLinkOutcome.cancelled);
 
       expect(find.byType(SnackBar), findsNothing);
       expect(find.text('Contact details copied'), findsNothing);
       expect(find.text('Could not save the contact details'), findsNothing);
+    });
+
+    testWidgets('says nothing for the unsupported outcome either', (
+      tester,
+    ) async {
+      await pump(tester, outcome: ContactLinkOutcome.unsupported);
+
+      expect(find.byType(SnackBar), findsNothing);
     });
   });
 }

--- a/test/features/relationships/ui/widgets/linked_tasks_card_test.dart
+++ b/test/features/relationships/ui/widgets/linked_tasks_card_test.dart
@@ -1,0 +1,168 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/task.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/database/fts5_db.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/relationships/repository/relationship_repository.dart';
+import 'package:lotti/features/relationships/ui/widgets/linked_tasks_card.dart';
+import 'package:lotti/features/tasks/ui/linked_tasks/linked_task_row.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/services/nav_service.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../helpers/fallbacks.dart';
+import '../../../../mocks/mocks.dart';
+import '../../../../widget_test_utils.dart';
+
+/// The card's rendering contract. The link/create/unlink flows run through
+/// the person page and are exercised end to end in its test, where the
+/// repository, picker and toasts are all wired.
+void main() {
+  final testDate = DateTime(2026, 8, 13, 10, 30);
+  late MockRelationshipRepository repository;
+
+  setUpAll(registerAllFallbackValues);
+
+  setUp(() {
+    repository = MockRelationshipRepository();
+  });
+
+  Task task(
+    String id, {
+    String title = 'Prepare the call',
+    TaskStatus? status,
+  }) =>
+      JournalEntity.task(
+            meta: Metadata(
+              id: id,
+              createdAt: testDate,
+              updatedAt: testDate,
+              dateFrom: testDate,
+              dateTo: testDate,
+            ),
+            data: TaskData(
+              status:
+                  status ??
+                  TaskStatus.open(
+                    id: 'ts-$id',
+                    createdAt: testDate,
+                    utcOffset: 0,
+                  ),
+              dateFrom: testDate,
+              dateTo: testDate,
+              statusHistory: const [],
+              title: title,
+            ),
+          )
+          as Task;
+
+  Future<void> pump(WidgetTester tester, List<Task> tasks) async {
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        LinkedTasksCard(relationshipId: 'rel-1', tasks: tasks),
+        overrides: [
+          relationshipRepositoryProvider.overrideWithValue(repository),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('the empty state names the section, offers Link task and says '
+      'nothing is linked', (tester) async {
+    await pump(tester, const []);
+
+    expect(find.text('Tasks'), findsOneWidget);
+    expect(find.byKey(const ValueKey('person-link-task')), findsOneWidget);
+    expect(find.text('No tasks linked yet.'), findsOneWidget);
+    expect(find.byKey(const ValueKey('person-tasks-count')), findsNothing);
+    expect(find.byType(DesignSystemListItem), findsNothing);
+  });
+
+  testWidgets('rows carry the title, the localized status, the status glyph '
+      'and an unlink action; the header counts them', (tester) async {
+    await pump(tester, [
+      task('t1'),
+      task(
+        't2',
+        title: 'Draft the comms plan',
+        status: TaskStatus.groomed(
+          id: 'ts-t2',
+          createdAt: testDate,
+          utcOffset: 0,
+        ),
+      ),
+    ]);
+
+    final count = tester
+        .widgetList<DsPill>(find.byType(DsPill))
+        .firstWhere((pill) => pill.label == '2 linked');
+    expect(count.shape, DsPillShape.tag);
+    expect(find.text('Prepare the call'), findsOneWidget);
+    expect(find.text('Draft the comms plan'), findsOneWidget);
+    expect(find.text('Open'), findsOneWidget);
+    expect(find.text('Groomed'), findsOneWidget);
+    expect(find.byType(StatusGlyph), findsNWidgets(2));
+    expect(find.byIcon(LottiIcons.linkOff), findsNWidgets(2));
+    expect(find.text('No tasks linked yet.'), findsNothing);
+  });
+
+  testWidgets('an untitled task uses the localized fallback', (tester) async {
+    await pump(tester, [task('t1', title: '')]);
+
+    expect(find.text('(untitled)'), findsOneWidget);
+  });
+
+  testWidgets('tapping a row beams to the task', (tester) async {
+    await pump(tester, [task('t1')]);
+    final beamedTo = <String>[];
+    beamToNamedOverride = beamedTo.add;
+    addTearDown(() => beamToNamedOverride = null);
+
+    await tester.tap(find.text('Prepare the call'));
+    await tester.pump();
+
+    expect(beamedTo, ['/tasks/t1']);
+  });
+
+  testWidgets('Link task opens the picker, excluding the tasks already '
+      'linked', (tester) async {
+    final db = MockJournalDb();
+    final fts = MockFts5Db();
+    final cache = MockEntitiesCacheService();
+    when(() => cache.sortedCategories).thenReturn([]);
+    when(
+      () => db.getTasks(
+        starredStatuses: any(named: 'starredStatuses'),
+        taskStatuses: any(named: 'taskStatuses'),
+        categoryIds: any(named: 'categoryIds'),
+        limit: any(named: 'limit'),
+      ),
+    ).thenAnswer((_) async => [task('t1'), task('t9', title: 'Send photos')]);
+    when(
+      () => fts.watchFullTextMatches(any()),
+    ).thenAnswer((_) => Stream.value(const <String>[]));
+    getIt
+      ..registerSingleton<JournalDb>(db)
+      ..registerSingleton<Fts5Db>(fts)
+      ..registerSingleton<EntitiesCacheService>(cache);
+    addTearDown(() async {
+      await getIt.unregister<JournalDb>();
+      await getIt.unregister<Fts5Db>();
+      await getIt.unregister<EntitiesCacheService>();
+    });
+
+    await pump(tester, [task('t1')]);
+    await tester.tap(find.byKey(const ValueKey('person-link-task')));
+    await tester.pumpAndSettle();
+
+    // The picker lists the other task and not the one already linked.
+    expect(find.text('Send photos'), findsOneWidget);
+    expect(find.text('Prepare the call'), findsOneWidget);
+  });
+}

--- a/test/features/relationships/ui/widgets/person_header_test.dart
+++ b/test/features/relationships/ui/widgets/person_header_test.dart
@@ -250,6 +250,14 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text('Delete'), findsOneWidget);
       expect(find.text('Link contact'), findsNothing);
+      // Destructive ink on the body token — not an ad hoc TextStyle.
+      final tokens = tester.element(find.text('Delete')).designTokens;
+      final style = tester.widget<Text>(find.text('Delete')).style!;
+      expect(style.color, tokens.colors.alert.error.ink);
+      expect(
+        style.fontSize,
+        tokens.typography.styles.body.bodyMedium.fontSize,
+      );
 
       await tester.tap(find.text('Delete'));
       await tester.pumpAndSettle();

--- a/test/features/relationships/ui/widgets/person_header_test.dart
+++ b/test/features/relationships/ui/widgets/person_header_test.dart
@@ -1,0 +1,503 @@
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/check_in_data.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/relationship_data.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/keyboard/ui/list_detail_focus_traversal.dart';
+import 'package:lotti/features/relationships/model/imported_contact.dart';
+import 'package:lotti/features/relationships/model/relationship_health_metrics.dart';
+import 'package:lotti/features/relationships/service/contacts_service.dart';
+import 'package:lotti/features/relationships/state/contact_import_controller.dart';
+import 'package:lotti/features/relationships/state/contact_link_controller.dart';
+import 'package:lotti/features/relationships/ui/shared/persona_avatar.dart';
+import 'package:lotti/features/relationships/ui/widgets/person_header.dart';
+import 'package:lotti/features/relationships/ui/widgets/relationship_briefing_card.dart';
+import 'package:lotti/widgets/app_bar/glass_action_button.dart';
+import 'package:material_ui/material_ui.dart';
+
+import '../../../../widget_test_utils.dart';
+
+class _FakeContactsService implements ContactsService {
+  _FakeContactsService({this.supported = true});
+
+  final bool supported;
+
+  @override
+  bool get isSupported => supported;
+
+  @override
+  Future<ContactsAccess> requestReadAccess() async => ContactsAccess.granted;
+
+  @override
+  Future<ImportedContact?> pickSingle() async => null;
+
+  @override
+  Future<List<ImportedContact>> readAll() async => const [];
+
+  @override
+  Future<ImportedContact?> readById(String id) async => null;
+
+  @override
+  Future<void> openSystemSettings() async {}
+}
+
+class _FakeContactLinkController implements ContactLinkController {
+  final List<String> calls = [];
+
+  @override
+  Future<ContactLinkOutcome> linkContact(RelationshipEntry relationship) async {
+    calls.add('link');
+    return ContactLinkOutcome.linked;
+  }
+
+  @override
+  Future<ContactLinkOutcome> refreshFromContact(
+    RelationshipEntry relationship,
+  ) async {
+    calls.add('refresh');
+    return ContactLinkOutcome.linked;
+  }
+}
+
+void main() {
+  // A Thursday; the crew's dates are chosen around it.
+  final now = DateTime(2026, 8, 13, 14);
+  const deviceKey = 'android:host-a';
+
+  RelationshipEntry person({
+    bool important = false,
+    int? cadenceDays,
+    String? nickname,
+    RelationshipStatus? status,
+    Map<String, String> refs = const {},
+  }) => RelationshipEntry(
+    meta: Metadata(
+      id: 'rel-1',
+      createdAt: DateTime(2026, 7),
+      updatedAt: DateTime(2026, 7),
+      dateFrom: DateTime(2026, 7),
+      dateTo: DateTime(2026, 7),
+    ),
+    data: RelationshipData(
+      title: 'Commander Pip Frostbeak',
+      nickname: nickname,
+      important: important,
+      checkInCadenceDays: cadenceDays,
+      contactRefs: refs,
+      status:
+          status ??
+          RelationshipStatus.active(
+            id: 'status-1',
+            createdAt: DateTime(2026, 7),
+            utcOffset: 0,
+          ),
+    ),
+  );
+
+  CheckInEntry checkIn(DateTime at) => CheckInEntry(
+    meta: Metadata(
+      id: 'check-1',
+      createdAt: at,
+      updatedAt: at,
+      dateFrom: at,
+      dateTo: at,
+    ),
+    data: const CheckInData(
+      relationshipId: 'rel-1',
+      interactionType: CheckInInteractionType.call,
+    ),
+  );
+
+  group('PersonHeroAppBar', () {
+    var backs = 0;
+    var chats = 0;
+    var deletes = 0;
+    late _FakeContactLinkController linkController;
+
+    setUp(() {
+      backs = 0;
+      chats = 0;
+      deletes = 0;
+      linkController = _FakeContactLinkController();
+    });
+
+    Future<void> pump(
+      WidgetTester tester, {
+      RelationshipEntry? relationship,
+      bool contactsSupported = false,
+      Size size = const Size(400, 800),
+      bool tall = false,
+    }) async {
+      setTestSurfaceSize(tester, size);
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          // A Scaffold, because the menu's link intents report in toasts.
+          Scaffold(
+            body: CustomScrollView(
+              slivers: [
+                PersonHeroAppBar(
+                  relationship: relationship ?? person(),
+                  onBack: () => backs++,
+                  onTalkToAgent: () => chats++,
+                  onDelete: () async => deletes++,
+                ),
+                SliverToBoxAdapter(
+                  child: SizedBox(height: tall ? 3000 : 100),
+                ),
+              ],
+            ),
+          ),
+          mediaQueryData: MediaQueryData(size: size),
+          overrides: [
+            contactsServiceProvider.overrideWithValue(
+              _FakeContactsService(supported: contactsSupported),
+            ),
+            contactLinkControllerProvider.overrideWithValue(linkController),
+            contactRefKeyProvider.overrideWith((ref) async => deviceKey),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('carries back, talk to agent, edit and the menu; the wash is '
+        'the interactive tint over the page surface', (tester) async {
+      await pump(tester);
+
+      final bar = tester.widget<SliverPersistentHeader>(
+        find.byKey(const ValueKey('person-hero')),
+      );
+      final tokens = tester
+          .element(find.byKey(const ValueKey('person-hero')))
+          .designTokens;
+      expect(bar.pinned, isTrue);
+      expect(
+        tester
+            .widget<ColoredBox>(find.byKey(const ValueKey('person-hero-wash')))
+            .color,
+        PersonHeroAppBar.washColor(tokens),
+      );
+      expect(find.byKey(const ValueKey('person-talk-to-agent')), findsOne);
+      expect(find.byKey(const ValueKey('person-edit')), findsOneWidget);
+      expect(find.byKey(const ValueKey('person-menu')), findsOneWidget);
+      // The name belongs to the header block; the open hero shows none.
+      expect(find.text('Commander Pip Frostbeak'), findsNothing);
+    });
+
+    testWidgets('back and talk-to-agent call back', (tester) async {
+      await pump(tester);
+
+      await tester.tap(find.byIcon(LottiIcons.chevronLeft));
+      await tester.tap(find.byKey(const ValueKey('person-talk-to-agent')));
+      await tester.pump();
+
+      expect(backs, 1);
+      expect(chats, 1);
+    });
+
+    testWidgets('on desktop Talk to agent is a labelled button', (
+      tester,
+    ) async {
+      await pump(tester, size: const Size(1280, 800));
+
+      final button = tester.widget<DesignSystemButton>(
+        find.byKey(const ValueKey('person-talk-to-agent')),
+      );
+      expect(button.label, 'Talk to agent');
+      expect(button.variant, DesignSystemButtonVariant.secondary);
+    });
+
+    testWidgets('names the person in the bar only once the band has folded, '
+        'and fades the avatar with the band', (tester) async {
+      await pump(tester, tall: true);
+      expect(find.byKey(const ValueKey('person-hero-title')), findsNothing);
+      Opacity avatar() => tester.widget<Opacity>(
+        find.byKey(const ValueKey('person-hero-avatar')),
+      );
+      expect(avatar().opacity, 1);
+
+      await tester.drag(find.byType(CustomScrollView), const Offset(0, -600));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('person-hero-title')), findsOneWidget);
+      expect(find.text('Commander Pip Frostbeak'), findsOneWidget);
+      expect(avatar().opacity, 0);
+    });
+
+    testWidgets('the avatar hangs half its diameter below the hero, on the '
+        'content inset', (tester) async {
+      await pump(tester);
+
+      final hero = find.byKey(const ValueKey('person-hero-wash'));
+      final avatar = find.byType(PersonaAvatar);
+      final tokens = tester.element(hero).designTokens;
+      expect(
+        tester.getBottomLeft(avatar).dy,
+        tester.getBottomLeft(hero).dy + PersonHeroAppBar.avatarSize(tokens) / 2,
+      );
+      expect(tester.getTopLeft(avatar).dx, 0);
+    });
+
+    testWidgets('the menu offers delete, and delete calls back', (
+      tester,
+    ) async {
+      await pump(tester);
+
+      await tester.tap(find.byKey(const ValueKey('person-menu')));
+      await tester.pumpAndSettle();
+      expect(find.text('Delete'), findsOneWidget);
+      expect(find.text('Link contact'), findsNothing);
+
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      expect(deletes, 1);
+    });
+
+    testWidgets('with an address book, an unlinked person gets Link contact', (
+      tester,
+    ) async {
+      await pump(tester, contactsSupported: true);
+
+      await tester.tap(find.byKey(const ValueKey('person-menu')));
+      await tester.pumpAndSettle();
+      expect(find.text('Link contact'), findsOneWidget);
+      expect(find.text('Update from contact'), findsNothing);
+
+      await tester.tap(find.text('Link contact'));
+      await tester.pumpAndSettle();
+
+      expect(linkController.calls, ['link']);
+    });
+
+    testWidgets('a linked person gets refresh and re-link as separate '
+        'intents', (tester) async {
+      await pump(
+        tester,
+        contactsSupported: true,
+        relationship: person(refs: {deviceKey: 'os-1'}),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('person-menu')));
+      await tester.pumpAndSettle();
+      expect(find.text('Link contact'), findsNothing);
+      expect(find.text('Update from contact'), findsOneWidget);
+      expect(find.text('Link a different contact'), findsOneWidget);
+
+      await tester.tap(find.text('Update from contact'));
+      await tester.pumpAndSettle();
+      expect(linkController.calls, ['refresh']);
+
+      await tester.tap(find.byKey(const ValueKey('person-menu')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Link a different contact'));
+      await tester.pumpAndSettle();
+      expect(linkController.calls, ['refresh', 'link']);
+    });
+
+    testWidgets('shows the show-list-pane control only while the desktop '
+        'list pane is folded away', (tester) async {
+      var visible = true;
+      Widget host({required bool listVisible}) => makeTestableWidgetNoScroll(
+        ListDetailFocusTraversal(
+          debugLabel: 'test',
+          listPaneVisible: listVisible,
+          canHideListPane: true,
+          onListPaneVisibilityChanged: (v) => visible = v,
+          listPane: const SizedBox(width: 200),
+          divider: const SizedBox(width: 1),
+          detailPane: CustomScrollView(
+            slivers: [
+              PersonHeroAppBar(
+                relationship: person(),
+                onBack: () {},
+                onTalkToAgent: () {},
+                onDelete: () async {},
+              ),
+            ],
+          ),
+        ),
+        mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+        overrides: [
+          contactsServiceProvider.overrideWithValue(_FakeContactsService()),
+        ],
+      );
+      setTestSurfaceSize(tester, const Size(1280, 800));
+
+      await tester.pumpWidget(host(listVisible: true));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('people-show-list-pane')), findsNothing);
+
+      await tester.pumpWidget(host(listVisible: false));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('people-show-list-pane')), findsOne);
+      expect(find.byType(GlassActionButton), findsWidgets);
+
+      await tester.tap(find.byKey(const ValueKey('people-show-list-pane')));
+      await tester.pump();
+      expect(visible, isTrue);
+    });
+  });
+
+  group('PersonHeaderBlock', () {
+    Future<void> pump(
+      WidgetTester tester, {
+      required RelationshipEntry relationship,
+      CheckInEntry? lastCheckIn,
+      String? categoryName,
+      RelationshipHealthBand? healthBand,
+    }) async {
+      await withClock(Clock.fixed(now), () async {
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            PersonHeaderBlock(
+              item: (relationship: relationship, lastCheckIn: lastCheckIn),
+              categoryName: categoryName,
+              healthBand: healthBand,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+      });
+    }
+
+    DsPill pill(WidgetTester tester, String key) =>
+        tester.widget<DsPill>(find.byKey(ValueKey(key)));
+
+    testWidgets('eyebrow joins category and Important; the one-liner joins '
+        'the nickname and the last contact', (tester) async {
+      await pump(
+        tester,
+        relationship: person(important: true, nickname: 'Pip'),
+        lastCheckIn: checkIn(DateTime(2026, 8, 13, 12, 44)),
+        categoryName: 'Penguin Operations',
+      );
+
+      expect(
+        tester.widget<Text>(find.byKey(const ValueKey('person-eyebrow'))).data,
+        'Penguin Operations · Important',
+      );
+      expect(find.text('Commander Pip Frostbeak'), findsOneWidget);
+      expect(
+        tester
+            .widget<Text>(find.byKey(const ValueKey('person-one-liner')))
+            .data,
+        '"Pip" · last spoke Today 12:44',
+      );
+    });
+
+    testWidgets('no category and not important leaves the eyebrow out; no '
+        'check-in reads as just added', (tester) async {
+      await pump(tester, relationship: person());
+
+      expect(find.byKey(const ValueKey('person-eyebrow')), findsNothing);
+      expect(
+        tester
+            .widget<Text>(find.byKey(const ValueKey('person-one-liner')))
+            .data,
+        'Just added',
+      );
+    });
+
+    testWidgets('on track: the cadence pill names the effective rhythm and '
+        'the next-due pill the day', (tester) async {
+      await pump(
+        tester,
+        relationship: person(important: true, cadenceDays: 7),
+        lastCheckIn: checkIn(DateTime(2026, 8, 12, 19, 5)),
+      );
+
+      expect(pill(tester, 'person-pill-cadence').label, 'On track · Weekly');
+      expect(pill(tester, 'person-pill-next-due').label, 'Next due Wed 19 Aug');
+      expect(find.byKey(const ValueKey('person-pill-due')), findsNothing);
+      expect(find.byKey(const ValueKey('person-pill-status')), findsNothing);
+    });
+
+    testWidgets('an enrolled person with no cadence set is on the default '
+        'rhythm, and the pill says so', (tester) async {
+      await pump(
+        tester,
+        relationship: person(important: true),
+        lastCheckIn: checkIn(DateTime(2026, 8, 12)),
+      );
+
+      expect(pill(tester, 'person-pill-cadence').label, 'On track · Monthly');
+    });
+
+    testWidgets('overdue: one warning-tinted pill saying since when and how '
+        'far over, and no next-due pill', (tester) async {
+      await pump(
+        tester,
+        relationship: person(important: true, cadenceDays: 7),
+        lastCheckIn: checkIn(DateTime(2026, 8)),
+      );
+
+      final due = pill(tester, 'person-pill-due');
+      final tokens = tester
+          .element(find.byType(PersonHeaderBlock))
+          .designTokens;
+      expect(due.label, 'Due since Sat · 5 days over');
+      expect(due.variant, DsPillVariant.tinted);
+      expect(due.color, tokens.colors.alert.warning.defaultColor);
+      expect(find.byKey(const ValueKey('person-pill-next-due')), findsNothing);
+      expect(find.byKey(const ValueKey('person-pill-cadence')), findsNothing);
+    });
+
+    testWidgets('not enrolled, dormant and archived each get the status pill', (
+      tester,
+    ) async {
+      await pump(tester, relationship: person(cadenceDays: 7));
+      expect(pill(tester, 'person-pill-status').label, 'Not enrolled');
+
+      await pump(
+        tester,
+        relationship: person(
+          important: true,
+          status: RelationshipStatus.dormant(
+            id: 's',
+            createdAt: now,
+            utcOffset: 0,
+          ),
+        ),
+      );
+      expect(pill(tester, 'person-pill-status').label, 'Dormant');
+
+      await pump(
+        tester,
+        relationship: person(
+          important: true,
+          status: RelationshipStatus.archived(
+            id: 's',
+            createdAt: now,
+            utcOffset: 0,
+          ),
+        ),
+      );
+      expect(pill(tester, 'person-pill-status').label, 'Archived');
+    });
+
+    testWidgets('the health band pill appears only with a briefing, tinted '
+        'with the band colour', (tester) async {
+      await pump(tester, relationship: person(important: true));
+      expect(find.byKey(const ValueKey('person-pill-health')), findsNothing);
+
+      await pump(
+        tester,
+        relationship: person(important: true),
+        healthBand: RelationshipHealthBand.thriving,
+      );
+      final health = pill(tester, 'person-pill-health');
+      final tokens = tester
+          .element(find.byType(PersonHeaderBlock))
+          .designTokens;
+      expect(health.label, 'Thriving');
+      expect(
+        health.color,
+        relationshipHealthBandColor(tokens, RelationshipHealthBand.thriving),
+      );
+    });
+  });
+}

--- a/test/features/relationships/ui/widgets/person_page_cards_test.dart
+++ b/test/features/relationships/ui/widgets/person_page_cards_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/check_in_data.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/relationship_data.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/relationships/service/contact_launcher.dart';
+import 'package:lotti/features/relationships/ui/widgets/contact_quick_actions.dart';
+import 'package:lotti/features/relationships/ui/widgets/person_page_cards.dart';
+import 'package:lotti/features/relationships/util/contact_channel_uri.dart';
+import 'package:material_ui/material_ui.dart';
+
+import '../../../../widget_test_utils.dart';
+
+/// Nothing is launchable: the channel rows render, the action buttons do
+/// not, and the card's own content is what the tests see.
+class _NoLauncher implements ContactLauncher {
+  @override
+  Future<bool> canLaunch(ContactChannel channel, ContactAction action) async =>
+      false;
+
+  @override
+  Future<bool> launch(ContactChannel channel, ContactAction action) async =>
+      false;
+}
+
+void main() {
+  final at = DateTime(2026, 8, 13, 10, 30);
+
+  CheckInEntry checkIn({String? attention, String? avoid}) => CheckInEntry(
+    meta: Metadata(
+      id: 'check-1',
+      createdAt: at,
+      updatedAt: at,
+      dateFrom: at,
+      dateTo: at,
+    ),
+    data: CheckInData(
+      relationshipId: 'rel-1',
+      interactionType: CheckInInteractionType.call,
+      payAttentionTo: attention,
+      avoid: avoid,
+    ),
+  );
+
+  group('PersonCardHeader', () {
+    testWidgets('lays out title, caption and trailing action', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const PersonCardHeader(
+            title: 'Tasks',
+            caption: Text('2 linked'),
+            trailing: Text('Link task'),
+          ),
+        ),
+      );
+
+      expect(find.text('Tasks'), findsOneWidget);
+      expect(find.text('2 linked'), findsOneWidget);
+      expect(find.text('Link task'), findsOneWidget);
+      // The action is pushed to the far edge; the caption stays by the title.
+      expect(
+        tester.getTopLeft(find.text('Link task')).dx,
+        greaterThan(tester.getTopRight(find.text('2 linked')).dx),
+      );
+    });
+  });
+
+  group('NextTimeCard', () {
+    test('hasContent is false for no check-in or blank guidance', () {
+      expect(NextTimeCard.hasContent(null), isFalse);
+      expect(NextTimeCard.hasContent(checkIn()), isFalse);
+      expect(NextTimeCard.hasContent(checkIn(attention: '  ')), isFalse);
+      expect(NextTimeCard.hasContent(checkIn(attention: 'The move')), isTrue);
+      expect(NextTimeCard.hasContent(checkIn(avoid: 'The coffee')), isTrue);
+    });
+
+    testWidgets('renders nothing when the latest check-in carries no '
+        'guidance — the page skips the gap on the same rule', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(NextTimeCard(latest: checkIn())),
+      );
+
+      expect(find.byKey(const ValueKey('person-next-time-card')), findsNothing);
+    });
+
+    testWidgets('shows both tiles with their captions and the check-in time', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          NextTimeCard(
+            latest: checkIn(
+              attention: 'Ask how the fitting went.',
+              avoid: 'The coffee incident.',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Next time'), findsOneWidget);
+      expect(find.text('Pay attention to'), findsOneWidget);
+      expect(find.text('Ask how the fitting went.'), findsOneWidget);
+      expect(find.text('Better to avoid'), findsOneWidget);
+      expect(find.text('The coffee incident.'), findsOneWidget);
+      // The trailing stamp is the check-in's own day and time.
+      expect(find.textContaining('10:30'), findsOneWidget);
+    });
+
+    testWidgets('a single field renders alone, untrimmed content trimmed', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          NextTimeCard(latest: checkIn(avoid: '  Politics.  ')),
+        ),
+      );
+
+      expect(
+        find.byKey(const ValueKey('person-next-time-attention')),
+        findsNothing,
+      );
+      expect(find.byKey(const ValueKey('person-next-time-avoid')), findsOne);
+      expect(find.text('Politics.'), findsOneWidget);
+    });
+  });
+
+  group('ReachCard', () {
+    Future<void> pump(WidgetTester tester, List<ContactChannel> channels) =>
+        tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            ReachCard(relationshipId: 'rel-1', channels: channels),
+            overrides: [
+              contactLauncherProvider.overrideWithValue(_NoLauncher()),
+            ],
+          ),
+        );
+
+    testWidgets('renders nothing for a person without channels', (
+      tester,
+    ) async {
+      await pump(tester, const []);
+
+      expect(find.byKey(const ValueKey('person-reach-card')), findsNothing);
+    });
+
+    testWidgets('names the section, states the privacy line and lists every '
+        'channel with value and label', (tester) async {
+      await pump(tester, const [
+        ContactChannel(
+          type: ContactChannelType.email,
+          value: 'anna@example.com',
+          label: 'Personal',
+        ),
+        ContactChannel(type: ContactChannelType.mobile, value: '+49 151 1'),
+      ]);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Reach'), findsOneWidget);
+      expect(
+        find.text('Stays on this device · never shared with the AI'),
+        findsOneWidget,
+      );
+      expect(find.text('anna@example.com'), findsOneWidget);
+      expect(find.text('Personal'), findsOneWidget);
+      expect(find.text('+49 151 1'), findsOneWidget);
+      // A channel without a label falls back to its localized type name.
+      expect(find.text('Mobile'), findsOneWidget);
+      expect(find.byIcon(LottiIcons.mail), findsOneWidget);
+      expect(find.byIcon(LottiIcons.phone), findsOneWidget);
+      // Every row carries the quick actions, which decide for themselves.
+      expect(find.byType(ContactQuickActions), findsNWidgets(2));
+    });
+  });
+}

--- a/test/features/relationships/ui/widgets/post_interaction_prompt_test.dart
+++ b/test/features/relationships/ui/widgets/post_interaction_prompt_test.dart
@@ -178,6 +178,19 @@ void main() {
         ),
         findsOneWidget,
       );
+      expect(find.text('started 11:40 · under a minute'), findsOneWidget);
+    });
+
+    testWidgets('a single minute reads in the singular on the meta line too', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        pending: marker(startedAt: DateTime(2026, 8, 17, 11, 40)),
+        resolves: person(),
+      );
+
+      expect(find.text('started 11:40 · about 1 min'), findsOneWidget);
     });
 
     testWidgets('a message reads as writing, not calling', (tester) async {

--- a/test/features/relationships/ui/widgets/post_interaction_prompt_test.dart
+++ b/test/features/relationships/ui/widgets/post_interaction_prompt_test.dart
@@ -155,6 +155,24 @@ void main() {
       );
     });
 
+    testWidgets('under a minute reads as such, never as "0 minutes"', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        pending: marker(startedAt: DateTime(2026, 8, 17, 11, 40, 30)),
+        resolves: person(),
+      );
+
+      expect(
+        find.text(
+          'You called Anna Schmidt less than a minute ago — log it while it '
+          'is fresh?',
+        ),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('a message reads as writing, not calling', (tester) async {
       await pump(
         tester,

--- a/test/features/relationships/ui/widgets/post_interaction_prompt_test.dart
+++ b/test/features/relationships/ui/widgets/post_interaction_prompt_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/check_in_data.dart';
@@ -23,6 +25,10 @@ class _FakePendingInteractionStore implements PendingInteractionStore {
   PendingInteraction? _pending;
   int clearCount = 0;
 
+  /// When set, [clear] waits on it — so a test can let the clock move while
+  /// the marker is being cleared.
+  Completer<void>? clearGate;
+
   @override
   Future<void> remember({
     required String relationshipId,
@@ -40,6 +46,7 @@ class _FakePendingInteractionStore implements PendingInteractionStore {
 
   @override
   Future<void> clear() async {
+    if (clearGate case final gate?) await gate.future;
     clearCount++;
     _pending = null;
   }
@@ -330,6 +337,44 @@ void main() {
         find.byType(CheckInCaptureForm),
       );
       expect(form.prefilledTime, DateTime(2026, 8, 17, 11, 30));
+      expect(form.prefilledDuration, const Duration(minutes: 11));
+    });
+
+    testWidgets('the minutes handed to the sheet are the ones the offer '
+        'quoted, even when clearing the marker crosses a minute boundary', (
+      tester,
+    ) async {
+      var current = now;
+      final store = _FakePendingInteractionStore(marker());
+      when(
+        () => repository.getRelationshipById(any()),
+      ).thenAnswer((_) async => person());
+      await withClock(Clock(() => current), () async {
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            const PostInteractionPrompt(),
+            overrides: [
+              pendingInteractionStoreProvider.overrideWithValue(store),
+              relationshipRepositoryProvider.overrideWithValue(repository),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.textContaining('11 minutes ago'), findsOneWidget);
+
+        // Accepting clears the marker first; the clock moves on while that
+        // is in flight.
+        final gate = store.clearGate = Completer<void>();
+        await tester.tap(find.text('Log check-in'));
+        await tester.pump();
+        current = now.add(const Duration(minutes: 5));
+        gate.complete();
+        await tester.pumpAndSettle();
+      });
+
+      final form = tester.widget<CheckInCaptureForm>(
+        find.byType(CheckInCaptureForm),
+      );
       expect(form.prefilledDuration, const Duration(minutes: 11));
     });
 

--- a/test/features/relationships/ui/widgets/post_interaction_prompt_test.dart
+++ b/test/features/relationships/ui/widgets/post_interaction_prompt_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/classes/relationship_data.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
 import 'package:lotti/features/relationships/service/pending_interaction_store.dart';
+import 'package:lotti/features/relationships/ui/widgets/check_in_capture_sheet.dart';
 import 'package:lotti/features/relationships/ui/widgets/post_interaction_prompt.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:mocktail/mocktail.dart';
@@ -296,6 +297,22 @@ void main() {
             'the sheet must open on what actually happened, not on the '
             'in-person default',
       );
+    });
+
+    testWidgets('hands the elapsed minutes to the sheet as the duration, so '
+        'the saved check-in shows what the offer promised', (tester) async {
+      await pump(tester, pending: marker(), resolves: person());
+
+      await withClock(Clock.fixed(now), () async {
+        await tester.tap(find.text('Log check-in'));
+        await tester.pumpAndSettle();
+      });
+
+      final form = tester.widget<CheckInCaptureForm>(
+        find.byType(CheckInCaptureForm),
+      );
+      expect(form.prefilledTime, DateTime(2026, 8, 17, 11, 30));
+      expect(form.prefilledDuration, const Duration(minutes: 11));
     });
 
     testWidgets('carries a message interaction through instead of a call', (

--- a/test/features/relationships/ui/widgets/post_interaction_prompt_test.dart
+++ b/test/features/relationships/ui/widgets/post_interaction_prompt_test.dart
@@ -1,7 +1,9 @@
+import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/check_in_data.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/relationship_data.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
 import 'package:lotti/features/relationships/service/pending_interaction_store.dart';
 import 'package:lotti/features/relationships/ui/widgets/post_interaction_prompt.dart';
@@ -44,6 +46,8 @@ class _FakePendingInteractionStore implements PendingInteractionStore {
 
 void main() {
   final startedAt = DateTime(2026, 8, 17, 11, 30);
+  // The user comes back eleven minutes after leaving for the call.
+  final now = DateTime(2026, 8, 17, 11, 41);
 
   late MockRelationshipRepository repository;
 
@@ -75,10 +79,11 @@ void main() {
   PendingInteraction marker({
     String relationshipId = 'rel-1',
     CheckInInteractionType type = CheckInInteractionType.call,
+    DateTime? startedAt,
   }) => (
     relationshipId: relationshipId,
     interactionType: type,
-    startedAt: startedAt,
+    startedAt: startedAt ?? DateTime(2026, 8, 17, 11, 30),
   );
 
   Future<_FakePendingInteractionStore> pump(
@@ -91,24 +96,91 @@ void main() {
       () => repository.getRelationshipById(any()),
     ).thenAnswer((_) async => resolves);
 
-    await tester.pumpWidget(
-      makeTestableWidgetWithScaffold(
-        const PostInteractionPrompt(),
-        overrides: [
-          pendingInteractionStoreProvider.overrideWithValue(store),
-          relationshipRepositoryProvider.overrideWithValue(repository),
-        ],
-      ),
-    );
-    await tester.pumpAndSettle();
+    await withClock(Clock.fixed(now), () async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const PostInteractionPrompt(),
+          overrides: [
+            pendingInteractionStoreProvider.overrideWithValue(store),
+            relationshipRepositoryProvider.overrideWithValue(repository),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+    });
     return store;
   }
 
+  final offer = find.byKey(const ValueKey('person-post-call-offer'));
+
   group('when the prompt appears', () {
-    testWidgets('names the person the user just contacted', (tester) async {
+    testWidgets('names the person, the channel and how long ago', (
+      tester,
+    ) async {
       await pump(tester, pending: marker(), resolves: person());
 
-      expect(find.text('How did it go with Anna Schmidt?'), findsOneWidget);
+      expect(
+        find.text(
+          'You called Anna Schmidt 11 minutes ago — log it while it is fresh?',
+        ),
+        findsOneWidget,
+      );
+      expect(find.byIcon(LottiIcons.call), findsOneWidget);
+    });
+
+    testWidgets('states when it started and about how long it has been, in '
+        'the mono meta style', (tester) async {
+      await pump(tester, pending: marker(), resolves: person());
+
+      final meta = tester.widget<Text>(
+        find.byKey(const ValueKey('person-post-call-meta')),
+      );
+      expect(meta.data, 'started 11:30 · about 11 min');
+      expect(meta.style?.fontFamily, 'Inconsolata');
+    });
+
+    testWidgets('a single minute reads in the singular', (tester) async {
+      await pump(
+        tester,
+        pending: marker(startedAt: DateTime(2026, 8, 17, 11, 40)),
+        resolves: person(),
+      );
+
+      expect(
+        find.text(
+          'You called Anna Schmidt 1 minute ago — log it while it is fresh?',
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('a message reads as writing, not calling', (tester) async {
+      await pump(
+        tester,
+        pending: marker(type: CheckInInteractionType.message),
+        resolves: person(),
+      );
+
+      expect(
+        find.text(
+          'You wrote to Anna Schmidt 11 minutes ago — log it while it is '
+          'fresh?',
+        ),
+        findsOneWidget,
+      );
+      expect(find.byIcon(LottiIcons.chat), findsOneWidget);
+    });
+
+    testWidgets('wears the interactive wash, not a plain card', (
+      tester,
+    ) async {
+      await pump(tester, pending: marker(), resolves: person());
+
+      final tokens = tester.element(offer).designTokens;
+      final decoration =
+          tester.widget<Container>(offer).decoration! as BoxDecoration;
+      expect(decoration.color, PostInteractionPrompt.washColor(tokens));
+      expect(find.byType(Card), findsNothing);
     });
 
     testWidgets('offers both logging and declining', (tester) async {
@@ -123,7 +195,7 @@ void main() {
     testWidgets('renders nothing when no call was placed', (tester) async {
       await pump(tester, resolves: person());
 
-      expect(find.text('Log check-in'), findsNothing);
+      expect(offer, findsNothing);
     });
 
     testWidgets('renders nothing when the person has since been deleted', (
@@ -132,7 +204,7 @@ void main() {
       await pump(tester, pending: marker());
 
       expect(
-        find.text('Log check-in'),
+        offer,
         findsNothing,
         reason:
             'the marker holds an id written before the user left; the '
@@ -155,7 +227,7 @@ void main() {
       await tester.tap(find.text('Not now'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Log check-in'), findsNothing);
+      expect(offer, findsNothing);
     });
 
     testWidgets('clears the marker, so declining leaves no trace', (
@@ -183,7 +255,7 @@ void main() {
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
       await tester.pumpAndSettle();
 
-      expect(find.text('Log check-in'), findsNothing);
+      expect(offer, findsNothing);
     });
   });
 
@@ -206,11 +278,7 @@ void main() {
     testWidgets('opens the form already describing the call that happened', (
       tester,
     ) async {
-      await pump(
-        tester,
-        pending: marker(),
-        resolves: person(),
-      );
+      await pump(tester, pending: marker(), resolves: person());
 
       await tester.tap(find.text('Log check-in'));
       await tester.pumpAndSettle();
@@ -290,7 +358,7 @@ void main() {
       tester,
     ) async {
       final store = await pump(tester, resolves: person());
-      expect(find.text('Log check-in'), findsNothing);
+      expect(offer, findsNothing);
 
       await store.remember(
         relationshipId: 'rel-1',
@@ -299,7 +367,8 @@ void main() {
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
       await tester.pumpAndSettle();
 
-      expect(find.text('How did it go with Anna Schmidt?'), findsOneWidget);
+      expect(offer, findsOneWidget);
+      expect(find.textContaining('You called Anna Schmidt'), findsOneWidget);
     });
 
     testWidgets('ignores lifecycle states other than resumed', (tester) async {
@@ -313,7 +382,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(
-        find.text('Log check-in'),
+        offer,
         findsNothing,
         reason:
             'going to the background is when the call starts, not when '

--- a/test/features/relationships/ui/widgets/relationship_action_bar_test.dart
+++ b/test/features/relationships/ui/widgets/relationship_action_bar_test.dart
@@ -24,6 +24,7 @@ class _FakeContactLauncher implements ContactLauncher {
   final Set<ContactAction> launchable;
   final bool launchSucceeds;
   final List<(ContactChannel, ContactAction)> launched = [];
+  int probes = 0;
 
   /// When set, every availability answer waits on it — so a test can hold a
   /// resolution open while the widget's channels change under it.
@@ -31,6 +32,7 @@ class _FakeContactLauncher implements ContactLauncher {
 
   @override
   Future<bool> canLaunch(ContactChannel channel, ContactAction action) async {
+    probes++;
     if (gate case final gate?) await gate.future;
     return launchable.contains(action) &&
         contactChannelUri(channel, action) != null;
@@ -270,6 +272,36 @@ void main() {
 
       expect(channelButton, findsNothing);
       expect(find.byIcon(LottiIcons.call), findsNothing);
+    });
+
+    testWidgets('a rebuilt person with the same channels does not probe the '
+        'platform again — channels compare by value', (tester) async {
+      final launcher = _FakeContactLauncher(
+        launchable: const {ContactAction.call},
+      );
+      Widget bar() => makeTestableWidgetWithScaffold(
+        RelationshipActionBar(
+          // A fresh entity and a fresh list each build.
+          relationship: person([mobile]),
+          onLogCheckIn: () {},
+          onSpeak: () {},
+        ),
+        overrides: [
+          contactLauncherProvider.overrideWithValue(launcher),
+          pendingInteractionStoreProvider.overrideWithValue(store),
+        ],
+      );
+
+      await tester.pumpWidget(bar());
+      await tester.pumpAndSettle();
+      final probesAfterFirstBuild = launcher.probes;
+      expect(probesAfterFirstBuild, greaterThan(0));
+
+      await tester.pumpWidget(bar());
+      await tester.pumpAndSettle();
+
+      expect(launcher.probes, probesAfterFirstBuild);
+      expect(channelButton, findsOneWidget);
     });
 
     testWidgets('re-resolves when the channels change under it', (

--- a/test/features/relationships/ui/widgets/relationship_action_bar_test.dart
+++ b/test/features/relationships/ui/widgets/relationship_action_bar_test.dart
@@ -1,0 +1,253 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/check_in_data.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/relationship_data.dart';
+import 'package:lotti/features/design_system/components/glass_action_bar.dart';
+import 'package:lotti/features/design_system/components/glass_strip.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/relationships/service/contact_launcher.dart';
+import 'package:lotti/features/relationships/service/pending_interaction_store.dart';
+import 'package:lotti/features/relationships/ui/widgets/relationship_action_bar.dart';
+import 'package:lotti/features/relationships/util/contact_channel_uri.dart';
+import 'package:material_ui/material_ui.dart';
+
+import '../../../../widget_test_utils.dart';
+
+/// A launcher whose answers are scripted per action and whose calls are
+/// recorded — the bar's two decisions, which channel to offer and what a
+/// press does, are both observable.
+class _FakeContactLauncher implements ContactLauncher {
+  _FakeContactLauncher({required this.launchable, this.launchSucceeds = true});
+
+  final Set<ContactAction> launchable;
+  final bool launchSucceeds;
+  final List<(ContactChannel, ContactAction)> launched = [];
+
+  @override
+  Future<bool> canLaunch(ContactChannel channel, ContactAction action) async =>
+      launchable.contains(action) && contactChannelUri(channel, action) != null;
+
+  @override
+  Future<bool> launch(ContactChannel channel, ContactAction action) async {
+    launched.add((channel, action));
+    return launchSucceeds;
+  }
+}
+
+class _FakePendingInteractionStore implements PendingInteractionStore {
+  PendingInteraction? remembered;
+
+  @override
+  Future<void> remember({
+    required String relationshipId,
+    required CheckInInteractionType interactionType,
+  }) async {
+    remembered = (
+      relationshipId: relationshipId,
+      interactionType: interactionType,
+      startedAt: DateTime(2026, 8, 17),
+    );
+  }
+
+  @override
+  Future<PendingInteraction?> read() async => remembered;
+
+  @override
+  Future<void> clear() async => remembered = null;
+}
+
+void main() {
+  final testDate = DateTime(2026, 8, 17, 12);
+  const email = ContactChannel(
+    type: ContactChannelType.email,
+    value: 'pip@example.com',
+  );
+  const mobile = ContactChannel(
+    type: ContactChannelType.mobile,
+    value: '+15550109999',
+  );
+
+  RelationshipEntry person(List<ContactChannel> channels) => RelationshipEntry(
+    meta: Metadata(
+      id: 'rel-1',
+      createdAt: testDate,
+      updatedAt: testDate,
+      dateFrom: testDate,
+      dateTo: testDate,
+    ),
+    data: RelationshipData(
+      title: 'Pip',
+      contactChannels: channels,
+      status: RelationshipStatus.active(
+        id: 'status-1',
+        createdAt: testDate,
+        utcOffset: 0,
+      ),
+    ),
+  );
+
+  late _FakePendingInteractionStore store;
+  var logged = 0;
+  var spoke = 0;
+
+  setUp(() {
+    store = _FakePendingInteractionStore();
+    logged = 0;
+    spoke = 0;
+  });
+
+  Future<_FakeContactLauncher> pump(
+    WidgetTester tester, {
+    List<ContactChannel> channels = const [],
+    Set<ContactAction> launchable = const {
+      ContactAction.call,
+      ContactAction.message,
+      ContactAction.email,
+    },
+    bool launchSucceeds = true,
+  }) async {
+    final launcher = _FakeContactLauncher(
+      launchable: launchable,
+      launchSucceeds: launchSucceeds,
+    );
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        RelationshipActionBar(
+          relationship: person(channels),
+          onLogCheckIn: () => logged++,
+          onSpeak: () => spoke++,
+        ),
+        overrides: [
+          contactLauncherProvider.overrideWithValue(launcher),
+          pendingInteractionStoreProvider.overrideWithValue(store),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+    return launcher;
+  }
+
+  final channelButton = find.byKey(const ValueKey('person-action-channel'));
+
+  testWidgets('sits on the glass strip with the labelled primary pill and the '
+      'mic, in the interactive accent', (tester) async {
+    await pump(tester);
+
+    expect(find.byType(DesignSystemGlassStrip), findsOneWidget);
+    final pill = tester.widget<DsGlassPill>(
+      find.byKey(const ValueKey('person-action-log-check-in')),
+    );
+    final tokens = tester.element(find.byType(DsGlassPill)).designTokens;
+    expect(pill.label, 'Log check-in');
+    expect(pill.fillColor, tokens.colors.interactive.enabled);
+    expect(pill.expand, isTrue);
+    expect(find.byKey(const ValueKey('person-action-speak')), findsOneWidget);
+  });
+
+  testWidgets('the pill and the mic call back', (tester) async {
+    await pump(tester);
+
+    await tester.tap(find.byKey(const ValueKey('person-action-log-check-in')));
+    await tester.tap(find.byKey(const ValueKey('person-action-speak')));
+    await tester.pump();
+
+    expect(logged, 1);
+    expect(spoke, 1);
+  });
+
+  group('the channel control', () {
+    testWidgets('is absent for a person without channels', (tester) async {
+      await pump(tester);
+
+      expect(channelButton, findsNothing);
+    });
+
+    testWidgets('is absent when nothing is launchable, so the user never taps '
+        'a control that does nothing', (tester) async {
+      await pump(tester, channels: const [mobile, email], launchable: const {});
+
+      expect(channelButton, findsNothing);
+    });
+
+    testWidgets('offers the first channel the platform can open, in the '
+        "person's own order — a call on a phone", (tester) async {
+      await pump(tester, channels: const [mobile, email]);
+
+      expect(channelButton, findsOneWidget);
+      expect(find.byIcon(LottiIcons.call), findsOneWidget);
+      expect(find.byIcon(LottiIcons.mail), findsNothing);
+    });
+
+    testWidgets('skips to email where there is no dialer — a desktop', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        channels: const [mobile, email],
+        launchable: const {ContactAction.email},
+      );
+
+      expect(find.byIcon(LottiIcons.mail), findsOneWidget);
+      expect(find.byIcon(LottiIcons.call), findsNothing);
+      expect(
+        tester.widget<DsGlassRoundButton>(channelButton).semanticLabel,
+        'Email',
+      );
+    });
+
+    testWidgets('a press launches the channel and remembers the interaction '
+        'for the post-call offer', (tester) async {
+      final launcher = await pump(tester, channels: const [mobile]);
+
+      await tester.tap(channelButton);
+      await tester.pumpAndSettle();
+
+      expect(launcher.launched, [(mobile, ContactAction.call)]);
+      expect(store.remembered?.relationshipId, 'rel-1');
+      expect(store.remembered?.interactionType, CheckInInteractionType.call);
+    });
+
+    testWidgets('a launch the platform refuses remembers nothing and says so', (
+      tester,
+    ) async {
+      await pump(tester, channels: const [mobile], launchSucceeds: false);
+
+      await tester.tap(channelButton);
+      await tester.pumpAndSettle();
+
+      expect(store.remembered, isNull);
+      expect(
+        find.text('Nothing on this device can open that'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('re-resolves when the channels change under it', (
+      tester,
+    ) async {
+      final launcher = _FakeContactLauncher(
+        launchable: const {ContactAction.call, ContactAction.email},
+      );
+      Widget bar(List<ContactChannel> channels) =>
+          makeTestableWidgetWithScaffold(
+            RelationshipActionBar(
+              relationship: person(channels),
+              onLogCheckIn: () {},
+              onSpeak: () {},
+            ),
+            overrides: [
+              contactLauncherProvider.overrideWithValue(launcher),
+              pendingInteractionStoreProvider.overrideWithValue(store),
+            ],
+          );
+
+      await tester.pumpWidget(bar(const []));
+      await tester.pumpAndSettle();
+      expect(channelButton, findsNothing);
+
+      await tester.pumpWidget(bar(const [email]));
+      await tester.pumpAndSettle();
+      expect(find.byIcon(LottiIcons.mail), findsOneWidget);
+    });
+  });
+}

--- a/test/features/relationships/ui/widgets/relationship_action_bar_test.dart
+++ b/test/features/relationships/ui/widgets/relationship_action_bar_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/check_in_data.dart';
 import 'package:lotti/classes/journal_entities.dart';
@@ -23,9 +25,16 @@ class _FakeContactLauncher implements ContactLauncher {
   final bool launchSucceeds;
   final List<(ContactChannel, ContactAction)> launched = [];
 
+  /// When set, every availability answer waits on it — so a test can hold a
+  /// resolution open while the widget's channels change under it.
+  Completer<void>? gate;
+
   @override
-  Future<bool> canLaunch(ContactChannel channel, ContactAction action) async =>
-      launchable.contains(action) && contactChannelUri(channel, action) != null;
+  Future<bool> canLaunch(ContactChannel channel, ContactAction action) async {
+    if (gate case final gate?) await gate.future;
+    return launchable.contains(action) &&
+        contactChannelUri(channel, action) != null;
+  }
 
   @override
   Future<bool> launch(ContactChannel channel, ContactAction action) async {
@@ -220,6 +229,47 @@ void main() {
         find.text('Nothing on this device can open that'),
         findsOneWidget,
       );
+    });
+
+    testWidgets('a resolution that started before the channels changed is '
+        'discarded, so a removed channel can never be offered', (
+      tester,
+    ) async {
+      final launcher = _FakeContactLauncher(
+        launchable: const {ContactAction.call, ContactAction.email},
+      );
+      Widget bar(List<ContactChannel> channels) =>
+          makeTestableWidgetWithScaffold(
+            RelationshipActionBar(
+              relationship: person(channels),
+              onLogCheckIn: () {},
+              onSpeak: () {},
+            ),
+            overrides: [
+              contactLauncherProvider.overrideWithValue(launcher),
+              pendingInteractionStoreProvider.overrideWithValue(store),
+            ],
+          );
+
+      // The first resolution (mobile → call) is held open...
+      final first = Completer<void>();
+      launcher.gate = first;
+      await tester.pumpWidget(bar(const [mobile]));
+      await tester.pump();
+
+      // ...while the person loses the number; the second resolution runs
+      // unhindered and lands first.
+      launcher.gate = null;
+      await tester.pumpWidget(bar(const []));
+      await tester.pumpAndSettle();
+      expect(channelButton, findsNothing);
+
+      // The stale answer arrives last and must be ignored.
+      first.complete();
+      await tester.pumpAndSettle();
+
+      expect(channelButton, findsNothing);
+      expect(find.byIcon(LottiIcons.call), findsNothing);
     });
 
     testWidgets('re-resolves when the channels change under it', (


### PR DESCRIPTION
Increment B of the People redesign (design handover 2026-09-06, plan in `docs/implementation_plans/2026-09-06_people_redesign.md`). Follows #4178 (the list and the desktop split).

## What changes

The person page becomes a sibling of the task page:

- **Hero.** A pinned cover-style header on the interactive wash carrying back · Talk to agent · edit · a menu (link contact, refresh, re-link where there is an address book; delete). The persona avatar hangs half its diameter off the header's lower edge, over the header block. It is a `SliverPersistentHeader` of its own rather than a `SliverAppBar`: every layer of an app bar clips that overhang, while slivers paint back to front so the earlier header paints its avatar over the content scrolling under it. The name appears in the bar only once the wash band has folded away, swapped in rather than faded so it never exists twice on the page.
- **Header block.** Eyebrow (`Penguin Operations · Important`), the full wrapping name, the teal one-liner (`"Pip" · last spoke Today 12:44`), then pills from the list model's own rules, so the page and the list never disagree about *due*: `On track · Weekly` (the **effective** cadence, i.e. the runtime default when none is set), `Due since Sat · 5 days over` (warning tint), the health band once a briefing exists, `Next due Fri 24 Jul`. The star is gone; *Important* lives in the eyebrow.
- **Section cards in the design's order.** Briefing (unchanged card; the page reads the same `currentRelationshipReport` rule, so the band pill and the chip agree) · **Next time** (what the latest check-in asked to bring up or avoid) · **Check-ins** as a `DecoratedSliver` wearing `DesignSystemSectionCard.decoration`, so the unbounded log stays lazy inside a card indistinguishable from the boxed ones; rows read `Today 12:44 · Call · 11 min` in mono with the sentiment as a tinted pill and topics as tags · **Reach** (channels with the actions the device can service, under the privacy line) · **Tasks** (`RelationshipLink` both ways, the picker that also creates, per-row unlink — extracted to `LinkedTasksCard`).
- **Action bar.** The task page's glass strip replaces the floating button: *Log check-in* · a mic that opens the capture sheet already recording (`startSpeaking`) · the first channel, in the person's own order, that `ContactLauncher.canLaunch` will open — a call on a phone, email on a desktop, nothing where neither exists. It launches through the same `launchContactAction` the Reach rows use, so the post-call marker is written the same way from both.
- **Post-call offer** now names its evidence: `You called Pip 11 minutes ago — log it while it is fresh?` · `started 12:33 · about 11 min`, in the interactive wash directly above the check-ins.
- **Desktop.** Every section sits on the centred reading column (`kDetailContentMaxWidth`, the same measure `DetailContentWidth` gives boxed content, computed by hand because a sliver cannot sit inside it). Back clears the selection; while the list pane is folded away the hero carries the show-list-pane control, so nothing is overlaid on the page's chrome.

Also: check-in durations (`dateTo − dateFrom`) get a label (`11 min`, `1 h`, `1 h 05`; nothing under a minute), `latestCheckIns` is unchanged, and the four dead post-call/short labels leave every catalog; `relationshipMoreActions` joins them.

## Tests

One test file per new widget (`person_header`, `person_page_cards`, `check_ins_card`, `relationship_action_bar`, `linked_tasks_card`), the page test adapted to the new structure (tall surface, hero menu, action bar, desktop column geometry, back on phone vs desktop, mic → speaking mode, band pill from a report, category eyebrow), the post-call offer test rewritten around a fixed clock, `contact_link_action_test` reduced to the pure check and the shared runner, `startSpeaking` covered on the capture form, the duration label and the shared card decoration covered.

## Screenshots

Phone and desktop, dark and light, penguin crew fixture. Before is the merged main (#4178), after is this branch.

| Surface | Before | After |
|---|---|---|
| Person page · phone · dark | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_mobile_dark.png" width="300"> | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_mobile_dark.png" width="300"> |
| Person page · desktop · dark | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_desktop_dark.png" width="300"> | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_desktop_dark.png" width="300"> |
| Lapsed cadence · phone · dark | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_due_mobile_dark.png" width="300"> | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_due_mobile_dark.png" width="300"> |
| With a briefing · phone · dark | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_mobile_dark.png" width="300"> | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_mobile_dark.png" width="300"> |
| Post-call offer · phone · dark | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_post_call_mobile_dark.png" width="300"> | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_post_call_mobile_dark.png" width="300"> |
| Post-call offer · desktop · dark | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_post_call_desktop_dark.png" width="300"> | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_post_call_desktop_dark.png" width="300"> |
| Check-ins · phone · dark | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_checkins_mobile_dark.png" width="300"> | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_checkins_mobile_dark.png" width="300"> |

<details><summary>All 80 frames (phone and desktop, light and dark, before and after)</summary>

- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/check_in_capture_prefilled_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/check_in_capture_prefilled_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/check_in_capture_prefilled_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/check_in_capture_prefilled_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/check_in_edit_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/check_in_edit_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/check_in_edit_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/check_in_edit_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_disclosure_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_disclosure_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_disclosure_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_disclosure_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_error_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_error_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_error_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_error_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_expanded_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_expanded_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_expanded_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_expanded_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_briefing_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_checkins_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_checkins_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_checkins_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_checkins_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_due_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_due_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_due_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_due_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_post_call_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_post_call_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_post_call_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/after/person_detail_post_call_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/check_in_capture_prefilled_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/check_in_capture_prefilled_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/check_in_capture_prefilled_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/check_in_capture_prefilled_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/check_in_edit_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/check_in_edit_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/check_in_edit_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/check_in_edit_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_disclosure_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_disclosure_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_disclosure_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_disclosure_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_error_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_error_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_error_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_error_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_expanded_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_expanded_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_expanded_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_expanded_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_briefing_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_checkins_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_checkins_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_checkins_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_checkins_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_due_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_due_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_due_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_due_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_mobile_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_post_call_desktop_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_post_call_desktop_light.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_post_call_mobile_dark.png
- https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/people-person-page-redesign/1a9db9d571b2db79169690bbbb09ddc1d4b9ca8a/before/person_detail_post_call_mobile_light.png

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned person pages with a cover-style header, status details, organized sections, and sticky actions.
  * Added dedicated views for check-ins, next-time guidance, contact reachability, and linked tasks.
  * Added one-tap logging, voice check-ins, and quick access to the first available contact method.
  * Post-call prompts now show the contact method, elapsed time, and duration before offering to log the interaction.
* **Bug Fixes**
  * Improved content alignment within split-screen detail panes.
  * Preserved interaction duration when editing check-ins.
* **Documentation**
  * Updated relationship documentation and localized text across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->