### PR TITLE
feat: add searchable multilingual on-device speech catalog

### DIFF
--- a/changelog.d/2026-09-06-sherpa-model-catalog.md
+++ b/changelog.d/2026-09-06-sherpa-model-catalog.md
@@ -1,0 +1,10 @@
+### Added
+- **Searchable on-device speech model catalog with 22 multilingual models.**
+  Choose from Whisper Medium and Turbo, Parakeet, SenseVoice, Dolphin,
+  Omnilingual, FireRed, Paraformer, WeNet, Qwen3 ASR, and FunASR Nano. Filter
+  by model family and download the models you want.
+
+### Fixed
+- **Installed speech models now reflect verified downloads on this device.**
+  Models become selectable only after installation. Reuse existing downloads
+  when adding a model to another provider.

--- a/knowledge/features/ai/embedded-speech.md
+++ b/knowledge/features/ai/embedded-speech.md
@@ -1,7 +1,7 @@
 ---
 type: Feature Module
 title: Embedded speech recognition
-description: Device-local sherpa-onnx model installation, background Whisper decoding, cancellation, and shared native runtime packaging.
+description: Device-local sherpa-onnx model installation, background multilingual decoding, cancellation, and shared native runtime packaging.
 resource: ../../../lib/features/ai/speech
 tags: [ai, speech, asr, sherpa, onnx, offline]
 status: stable
@@ -11,6 +11,14 @@ sources:
   - id: models
     resource: ../../../lib/features/ai/speech/sherpa_model_repository.dart
     title: Pinned model artifacts and device-local installation
+    last_modified: 2026-09-06
+  - id: catalog
+    resource: ../../../lib/features/ai/speech/sherpa_model_catalog.dart
+    title: Multilingual export manifest and native artifact roles
+    last_modified: 2026-09-06
+  - id: availability
+    resource: ../../../lib/features/ai/speech/sherpa_installed_models_provider.dart
+    title: Verified device availability and selectable model projection
     last_modified: 2026-09-06
   - id: worker
     resource: ../../../lib/features/ai/speech/sherpa_worker.dart
@@ -33,12 +41,23 @@ sources:
 # Installation and configuration
 
 `InferenceProviderType.sherpa` is an embedded ASR provider. It requires neither
-an API key nor a server URL. Its curated catalog contains multilingual int8
-Whisper Large v3, Tiny and Base exports. Large v3 uses the full model with
-INT8 weights (about 1.78 GB of downloaded files). Model files are downloaded
-only after the user presses Download in the provider's model section. Model names are upstream
-product names; surrounding controls are localized. Sherpa appears in both the
-first-run and full provider pickers, without a desktop-only restriction.
+an API key nor a server URL. Its catalog contains 22 multilingual INT8 exports:
+eight Whisper variants (Large v3, Turbo, Medium, Small, Base, Tiny, Large v2 and
+Large v1), Parakeet TDT v3, SenseVoice, two Dolphin sizes, three Omnilingual
+variants, FireRed ASR2 and ASR2 CTC, bilingual and trilingual Paraformer, WeNet
+Cantonese/Chinese/English, Qwen3 ASR and FunASR Nano. Single-language exports are
+excluded. The catalog is the source for both download manifests and known model
+configurations; each entry identifies its publisher, recognizer architecture,
+artifact roles, pinned revision, sizes and SHA-256 checksums.
+
+Model files are downloaded only after the user presses Download. Search reuses
+`AiSettingsSearchBar`, also used by Melious, and matches model identity, family,
+publisher and declared language metadata. A single family dropdown narrows the
+catalog, with a result count and localized empty state. Filtering preserves row
+state; busy operations and errors remain visible even when the query excludes
+them. Short language sets are shown explicitly. Model and family names are
+upstream product metadata; surrounding controls are localized. Sherpa appears in
+both the first-run and full provider pickers without a desktop-only restriction.
 
 The model section groups compact download actions beside model identity and
 localized download size/language metadata. Actions wrap below the metadata on
@@ -92,8 +111,19 @@ Downloads stream into `.part` files, verify size and digest, then rename into
 place. Concurrent requests for the same model share one future. Partial files
 are deleted on failure; valid completed artifacts can be reused on retry.
 Removing files preserves synced model configurations and profile references.
-Provider cards and detail headers count verified local installations, refreshed
-after downloads and removals. Both operations also republish changed sync-node
+Provider creation and startup backfill never seed sherpa catalog rows. A model
+configuration is created after a verified download, preserving existing synced
+identities. Already-installed files without a configuration offer Add model,
+which restores the provider association without downloading again. Sherpa's
+installed section has no manual model-add or configuration-only delete action;
+local file removal remains in the catalog.
+
+Provider cards, detail headers, installed sections, the Models tab and model
+selection all use verified device availability. Provider identity must be
+resolved before admitting a saved row, including while streams load in either
+order. Raw configurations remain available for profile reference mapping and
+sync; a missing local assignment is displayed as unavailable without deleting
+its stored ID. Counts and candidates refresh after downloads and removals. Both operations also republish changed sync-node
 capabilities without requiring an app restart. A failed broadcast does not undo
 the successful local file operation. If model configuration persistence fails
 after installation, the row retains its downloaded state and shows a separate
@@ -114,7 +144,7 @@ flowchart TD
   Convert --> Scratch
   Scratch --> Worker[Worker isolate initializes sherpa bindings]
   Worker --> Window[Next window, at most 28 seconds]
-  Window --> Decode[Native Whisper recognition]
+  Window --> Decode[Native family-specific recognition]
   Decode --> Chunk[Chat-compatible text chunk, no invented token usage]
   Chunk --> More{Consumer requests more?}
   More -->|Yes| Window
@@ -135,10 +165,18 @@ the active segment finishes before native resources are freed. The caller waits
 for worker exit before deleting the WAV. Force-killing the isolate would leak
 native allocations. Empty results and worker failures propagate as errors.
 
-Whisper detects language automatically and transcribes rather than translates.
-This initial adapter does not feed task context or speech-dictionary hotwords
-to the model: the upstream Dart Whisper configuration has no prompt parameter.
-It emits text, with no fabricated token usage or cloud charges.
+The adapter transcribes rather than translates. The native configuration is
+built from the catalog's artifact roles. NeMo transducers declare their model
+type explicitly; Qwen3 ASR and FunASR Nano use tokenizer directories rather than
+a tokens file. Nested tokenizer artifacts retain their upstream relative paths.
+Qwen3 ASR allows up to 512 output tokens in a 1024-token total sequence per
+window. The adapter does not currently supply task context or speech-dictionary
+hotwords. It emits text with no fabricated token usage or cloud charges.
+
+Families that require an explicitly selected spoken language (Canary and Cohere
+Transcribe) are not in this automatic-recognition catalog. Adding them requires
+a persisted language control and propagation to each recognition request; an
+English default must not masquerade as multilingual automatic detection.
 
 # Selection and sync
 

--- a/lib/features/ai/speech/sherpa_installed_models_provider.dart
+++ b/lib/features/ai/speech/sherpa_installed_models_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/speech/sherpa_model_repository.dart';
 
 /// Device-local readiness, refreshed after explicit model changes. Synced
@@ -13,3 +14,24 @@ final sherpaInstalledModelIdsProvider = FutureProvider<Set<String>>((
   }
   return installed;
 });
+
+/// Models usable on this device. Synced configurations preserve profile
+/// references, but only verified local files make an embedded model available.
+/// Wait for provider identity before admitting a configuration: the provider
+/// and model streams can resolve in either order.
+List<AiConfigModel> modelsAvailableOnDevice({
+  required Iterable<AiConfigModel> models,
+  required Iterable<AiConfigInferenceProvider> providers,
+  required Set<String> installedSherpaModelIds,
+}) {
+  final providerTypes = {
+    for (final provider in providers)
+      provider.id: provider.inferenceProviderType,
+  };
+  return models.where((model) {
+    final type = providerTypes[model.inferenceProviderId];
+    return type != null &&
+        (type != InferenceProviderType.sherpa ||
+            installedSherpaModelIds.contains(model.providerModelId));
+  }).toList();
+}

--- a/lib/features/ai/speech/sherpa_model_catalog.dart
+++ b/lib/features/ai/speech/sherpa_model_catalog.dart
@@ -1,0 +1,691 @@
+/// The recognizer configuration key used by the pinned sherpa runtime.
+enum SherpaModelArchitecture {
+  whisper,
+  nemoTransducer,
+  senseVoice,
+  dolphin,
+  omnilingual,
+  fireRedAsr,
+  fireRedAsrCtc,
+  paraformer,
+  wenetCtc,
+  qwen3Asr,
+  funasrNano;
+
+  String get configurationKey => this == nemoTransducer ? 'transducer' : name;
+}
+
+/// One immutable, checksum-pinned artifact in an embedded speech model.
+class SherpaModelFile {
+  const SherpaModelFile(this.name, this.bytes, this.sha256);
+
+  final String name;
+  final int bytes;
+  final String sha256;
+}
+
+/// A multilingual export supported by the embedded recognizer.
+class SherpaModel {
+  const SherpaModel({
+    required this.id,
+    required this.name,
+    required this.revision,
+    required this.files,
+    this.repository,
+    this.architecture = SherpaModelArchitecture.whisper,
+    this.family = 'Whisper',
+    this.publisher = 'OpenAI',
+    this.languageCodes = const [],
+    this.fileRoles = const {},
+  });
+
+  final String? repository;
+  final SherpaModelArchitecture architecture;
+  final String family;
+  final String publisher;
+  final List<String> languageCodes;
+  final Map<String, String> fileRoles;
+
+  /// Native artifact roles, independent of each upstream export's filenames.
+  Map<String, String> get recognizerFiles =>
+      architecture == SherpaModelArchitecture.whisper
+      ? {'encoder': '$id-encoder.int8.onnx', 'decoder': '$id-decoder.int8.onnx'}
+      : fileRoles;
+
+  String get tokensFile => architecture == SherpaModelArchitecture.whisper
+      ? '$id-tokens.txt'
+      : 'tokens.txt';
+
+  final String id;
+  final String name;
+  final String revision;
+  final List<SherpaModelFile> files;
+
+  int get bytes => files.fold(0, (total, file) => total + file.bytes);
+
+  Uri uri(SherpaModelFile file) => Uri.parse(
+    'https://huggingface.co/${repository ?? 'csukuangfj/sherpa-onnx-whisper-$id'}/'
+    'resolve/$revision/${file.name}',
+  );
+}
+
+/// Fixed upstream revisions prevent model downloads changing beneath a build.
+const sherpaModels = [
+  SherpaModel(
+    id: 'large-v3',
+    name: 'Whisper Large v3',
+    revision: '2a6507094dd6020d939d78e3f1834a1d06267fca',
+    files: [
+      SherpaModelFile(
+        'large-v3-encoder.int8.onnx',
+        766671985,
+        'd531cf17248acc43e8c09b472a0877055e770877857a5332fc1304b36534ec85',
+      ),
+      SherpaModelFile(
+        'large-v3-decoder.int8.onnx',
+        1008265203,
+        'ebc6bfd88e162a46cb3edee8a7e727e1dcbc65cabecb19e2573695e4d495e1af',
+      ),
+      SherpaModelFile(
+        'large-v3-tokens.txt',
+        816730,
+        'b34b360dbb493e781e479794586d661700670d65564001f23024971d1f2fa126',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'turbo',
+    name: 'Whisper Large v3 Turbo',
+    revision: '2ca6ff69fc878651b770880507669577ac41c2ff',
+    files: [
+      SherpaModelFile(
+        'turbo-encoder.int8.onnx',
+        674716297,
+        'b02dcdf54f348741e93fe732b67d933c8dcb6735655f710640143081db38878b',
+      ),
+      SherpaModelFile(
+        'turbo-decoder.int8.onnx',
+        361080764,
+        '20accd02388482eb3a46bd615631adfdc85e1eb2c7db9ea3f02a40ffe6b81547',
+      ),
+      SherpaModelFile(
+        'turbo-tokens.txt',
+        816730,
+        'b34b360dbb493e781e479794586d661700670d65564001f23024971d1f2fa126',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'medium',
+    name: 'Whisper Medium',
+    revision: '8c31d28503847560985df21f90e14f0c736e075e',
+    files: [
+      SherpaModelFile(
+        'medium-encoder.int8.onnx',
+        374196283,
+        '1c54582b4d829de0089f6cb63bbbdb3bf7555398bacaf855fbecf1a84dfd193e',
+      ),
+      SherpaModelFile(
+        'medium-decoder.int8.onnx',
+        571059257,
+        '595d00a338a365a7bfa0ca7f296cabc639583bef770ab6130df90f49a6412747',
+      ),
+      SherpaModelFile(
+        'medium-tokens.txt',
+        816730,
+        'b34b360dbb493e781e479794586d661700670d65564001f23024971d1f2fa126',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'small',
+    name: 'Whisper Small',
+    revision: '8f3c18b358db4d1f2fc1eae49d75cd20989e4309',
+    files: [
+      SherpaModelFile(
+        'small-encoder.int8.onnx',
+        112442483,
+        '4cbe7b22fa9026b843b60a68640c747de05bafb1a11b57edc0e66c232d9f33a9',
+      ),
+      SherpaModelFile(
+        'small-decoder.int8.onnx',
+        262226114,
+        'acad50b5c782696e91b55914cc5ab4f756f1532f76e22aa6fc615f39fb69a8ee',
+      ),
+      SherpaModelFile(
+        'small-tokens.txt',
+        816730,
+        'b34b360dbb493e781e479794586d661700670d65564001f23024971d1f2fa126',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'base',
+    name: 'Whisper Base',
+    revision: 'bb53ee204431c90d314c1cc08d28d23e5b7927cc',
+    files: [
+      SherpaModelFile(
+        'base-encoder.int8.onnx',
+        29120534,
+        '0b8fb1304b6109976038efff5ace81720e00386f3ff6b54ee8c75291ca0a1e11',
+      ),
+      SherpaModelFile(
+        'base-decoder.int8.onnx',
+        130672026,
+        '9759d217388a01b3a4c7c15533201067b48ae819c4daafc8624e64b9409dc02d',
+      ),
+      SherpaModelFile(
+        'base-tokens.txt',
+        816730,
+        'b34b360dbb493e781e479794586d661700670d65564001f23024971d1f2fa126',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'tiny',
+    name: 'Whisper Tiny',
+    revision: '65176e2deb88badc814a94058666cadccc29b61c',
+    files: [
+      SherpaModelFile(
+        'tiny-encoder.int8.onnx',
+        12937772,
+        'd24fb083ae3b1041fc24e97971d60e280c9342201fbb67b0ab428a8b4a51a434',
+      ),
+      SherpaModelFile(
+        'tiny-decoder.int8.onnx',
+        89855401,
+        'd2fece8dd42771f1df975c6c0445770d0c292bf7547c2cae04a6c0cc57540925',
+      ),
+      SherpaModelFile(
+        'tiny-tokens.txt',
+        816730,
+        'b34b360dbb493e781e479794586d661700670d65564001f23024971d1f2fa126',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'large-v2',
+    name: 'Whisper Large v2',
+    revision: '1dce177ee978f227f39538443ae7c3bc611e9be4',
+    files: [
+      SherpaModelFile(
+        'large-v2-encoder.int8.onnx',
+        765934692,
+        'f055f8397a69895818c1763fd001e47fb9ca51ea7efaccfafc1b635d121203a3',
+      ),
+      SherpaModelFile(
+        'large-v2-decoder.int8.onnx',
+        1008260083,
+        'ea513c5bfcbdc422b025da8fc93065ab8706994ba90053af442145b9aa7c2ee8',
+      ),
+      SherpaModelFile(
+        'large-v2-tokens.txt',
+        816730,
+        'b34b360dbb493e781e479794586d661700670d65564001f23024971d1f2fa126',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'large-v1',
+    name: 'Whisper Large v1',
+    revision: '5ec7cc1eddcc63ec78aaae738f7023e8c6e048a1',
+    files: [
+      SherpaModelFile(
+        'large-v1-encoder.int8.onnx',
+        765934692,
+        '1643928022a8fe0a40afff5935703751a6486aee65b99717daa14728fec273f6',
+      ),
+      SherpaModelFile(
+        'large-v1-decoder.int8.onnx',
+        1008260083,
+        '1b43c7ae36ef8c4eed9d2e07eca6c96e51edb83ceda275146c5282e93a8c68b1',
+      ),
+      SherpaModelFile(
+        'large-v1-tokens.txt',
+        816730,
+        'b34b360dbb493e781e479794586d661700670d65564001f23024971d1f2fa126',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'parakeet-v3',
+    name: 'Parakeet TDT 0.6B v3',
+    revision: '2bda32ec70b097a55adaa07d9a7173915b43cc78',
+    repository: 'csukuangfj/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8',
+    publisher: 'NVIDIA',
+    architecture: SherpaModelArchitecture.nemoTransducer,
+    family: 'Parakeet',
+    languageCodes: [
+      'bg',
+      'hr',
+      'cs',
+      'da',
+      'nl',
+      'en',
+      'et',
+      'fi',
+      'fr',
+      'de',
+      'el',
+      'hu',
+      'it',
+      'lv',
+      'lt',
+      'mt',
+      'pl',
+      'pt',
+      'ro',
+      'sk',
+      'sl',
+      'es',
+      'sv',
+      'ru',
+      'uk',
+    ],
+    fileRoles: {
+      'encoder': 'encoder.int8.onnx',
+      'decoder': 'decoder.int8.onnx',
+      'joiner': 'joiner.int8.onnx',
+    },
+    files: [
+      SherpaModelFile(
+        'encoder.int8.onnx',
+        652184281,
+        'acfc2b4456377e15d04f0243af540b7fe7c992f8d898d751cf134c3a55fd2247',
+      ),
+      SherpaModelFile(
+        'decoder.int8.onnx',
+        11845275,
+        '179e50c43d1a9de79c8a24149a2f9bac6eb5981823f2a2ed88d655b24248db4e',
+      ),
+      SherpaModelFile(
+        'joiner.int8.onnx',
+        6355277,
+        '3164c13fc2821009440d20fcb5fdc78bff28b4db2f8d0f0b329101719c0948b3',
+      ),
+      SherpaModelFile(
+        'tokens.txt',
+        93939,
+        'd58544679ea4bc6ac563d1f545eb7d474bd6cfa467f0a6e2c1dc1c7d37e3c35d',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'sensevoice',
+    name: 'SenseVoice Small',
+    revision: '2365baeacb507f821a0c8120fcee3d484dba7a07',
+    repository: 'csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17',
+    publisher: 'FunAudioLLM',
+    architecture: SherpaModelArchitecture.senseVoice,
+    family: 'SenseVoice',
+    languageCodes: ['zh', 'en', 'ja', 'ko', 'yue'],
+    fileRoles: {
+      'model': 'model.int8.onnx',
+    },
+    files: [
+      SherpaModelFile(
+        'model.int8.onnx',
+        239233841,
+        'c71f0ce00bec95b07744e116345e33d8cbbe08cef896382cf907bf4b51a2cd51',
+      ),
+      SherpaModelFile(
+        'tokens.txt',
+        315894,
+        'f449eb28dc567533d7fa59be34e2abca8784f771850c78a47fb731a31429a1dc',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'dolphin-base',
+    name: 'Dolphin Base',
+    revision: '1f3a53d0ecf658f8b0974e2cfde368eee40732fa',
+    repository:
+        'csukuangfj/sherpa-onnx-dolphin-base-ctc-multi-lang-int8-2025-04-02',
+    publisher: 'Dataocean AI',
+    architecture: SherpaModelArchitecture.dolphin,
+    family: 'Dolphin',
+    fileRoles: {
+      'model': 'model.int8.onnx',
+    },
+    files: [
+      SherpaModelFile(
+        'model.int8.onnx',
+        103729802,
+        'a3aa46c97f3f60f135ff949793cb05fabe7a0b3c484dc2e3cc699d354ee11b76',
+      ),
+      SherpaModelFile(
+        'tokens.txt',
+        504662,
+        'c3788261a51df1899ea4b210b552cd42139204de72c0ad60f6cebb199078872e',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'dolphin-small',
+    name: 'Dolphin Small',
+    revision: 'c8b6689509acfcd744c04e5e169164f9ac4cae32',
+    repository:
+        'csukuangfj/sherpa-onnx-dolphin-small-ctc-multi-lang-int8-2025-04-02',
+    publisher: 'Dataocean AI',
+    architecture: SherpaModelArchitecture.dolphin,
+    family: 'Dolphin',
+    fileRoles: {
+      'model': 'model.int8.onnx',
+    },
+    files: [
+      SherpaModelFile(
+        'model.int8.onnx',
+        249658954,
+        'c1afcb9265de0ebd853eb8f570b371f399a6f9b2b9af9a3cb17c2e509171e697',
+      ),
+      SherpaModelFile(
+        'tokens.txt',
+        504662,
+        'c3788261a51df1899ea4b210b552cd42139204de72c0ad60f6cebb199078872e',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'omnilingual-300m',
+    name: 'Omnilingual 300M',
+    revision: '6fc542a3b0661c8278cca1230c34deb989f31202',
+    repository:
+        'csukuangfj2/sherpa-onnx-omnilingual-asr-1600-languages-300M-ctc-int8-2025-11-12',
+    publisher: 'Meta',
+    architecture: SherpaModelArchitecture.omnilingual,
+    family: 'Omnilingual',
+    fileRoles: {
+      'model': 'model.int8.onnx',
+    },
+    files: [
+      SherpaModelFile(
+        'model.int8.onnx',
+        365352120,
+        'e7c4e54ee4c4c47829cc6667d5d00ed8ea7bef1dcfeef0fce766f77752a2726c',
+      ),
+      SherpaModelFile(
+        'tokens.txt',
+        86423,
+        'a7a044c52cb29cbe8b0dc1953e92cefd4ca16b0ed968177b6beab21f9a7d0b31',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'omnilingual-1b',
+    name: 'Omnilingual 1B',
+    revision: 'c765c919b1e7dfb03f55f7318eb0649f47015cb4',
+    repository:
+        'csukuangfj2/sherpa-onnx-omnilingual-asr-1600-languages-1B-ctc-int8-2025-11-12',
+    publisher: 'Meta',
+    architecture: SherpaModelArchitecture.omnilingual,
+    family: 'Omnilingual',
+    fileRoles: {
+      'model': 'model.int8.onnx',
+    },
+    files: [
+      SherpaModelFile(
+        'model.int8.onnx',
+        1031628252,
+        'f7b74c964039162423b83e3fa950ce24810c9a635d9ff8468b5f4d142b7c1e8c',
+      ),
+      SherpaModelFile(
+        'tokens.txt',
+        86423,
+        'a7a044c52cb29cbe8b0dc1953e92cefd4ca16b0ed968177b6beab21f9a7d0b31',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'omnilingual-1b-v2',
+    name: 'Omnilingual 1B v2',
+    revision: '5243e02858d1428b8fbeeb5f7f1cc6fccf4d9433',
+    repository:
+        'csukuangfj2/sherpa-onnx-omnilingual-asr-1600-languages-1B-ctc-v2-int8-2026-02-05',
+    publisher: 'Meta',
+    architecture: SherpaModelArchitecture.omnilingual,
+    family: 'Omnilingual',
+    fileRoles: {
+      'model': 'model.int8.onnx',
+    },
+    files: [
+      SherpaModelFile(
+        'model.int8.onnx',
+        1032239439,
+        '8af72da192fc2c8567c328d4f8059bdf47f182a0369077893c295ef39740c637',
+      ),
+      SherpaModelFile(
+        'tokens.txt',
+        90630,
+        '7d99997ef207ff14c2cfe825f2aa037528ea250113cc3c6392bfe49326884ba6',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'firered-asr2',
+    name: 'FireRed ASR2',
+    revision: '374cff185e952c40fcf2f6da972a3b6cf340608d',
+    repository: 'csukuangfj2/sherpa-onnx-fire-red-asr2-zh_en-int8-2026-02-26',
+    publisher: 'FireRedTeam',
+    architecture: SherpaModelArchitecture.fireRedAsr,
+    family: 'FireRed',
+    languageCodes: ['zh', 'en'],
+    fileRoles: {
+      'encoder': 'encoder.int8.onnx',
+      'decoder': 'decoder.int8.onnx',
+    },
+    files: [
+      SherpaModelFile(
+        'encoder.int8.onnx',
+        817286833,
+        '54048d66b6e8f3c80ea7ce95efe794587b0fd81d7271651d0decd3803852ae82',
+      ),
+      SherpaModelFile(
+        'decoder.int8.onnx',
+        417291928,
+        'b840ce7196ae4a14d05ae84bbf56082b6b61ccec5610fda907dddbcea37354ff',
+      ),
+      SherpaModelFile(
+        'tokens.txt',
+        79172,
+        '1bc613de2112d257e61a349c3e72d1b1a9cf19c33d3ca954197ad2171e5ea07b',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'firered-asr2-ctc',
+    name: 'FireRed ASR2 CTC',
+    revision: '423be1acfdc5d8aaa5a485fb6263fe4ea8570b06',
+    repository:
+        'csukuangfj2/sherpa-onnx-fire-red-asr2-ctc-zh_en-int8-2026-02-25',
+    publisher: 'FireRedTeam',
+    architecture: SherpaModelArchitecture.fireRedAsrCtc,
+    family: 'FireRed',
+    languageCodes: ['zh', 'en'],
+    fileRoles: {
+      'model': 'model.int8.onnx',
+    },
+    files: [
+      SherpaModelFile(
+        'model.int8.onnx',
+        775861420,
+        'ca3dbabd82170110cc0b343c2890866d449984bc9cd92b9a18371ff80a81bb99',
+      ),
+      SherpaModelFile(
+        'tokens.txt',
+        79172,
+        '1bc613de2112d257e61a349c3e72d1b1a9cf19c33d3ca954197ad2171e5ea07b',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'paraformer-bilingual',
+    name: 'Paraformer Chinese / English',
+    revision: '4b891f7b5c73d874e607797a4b0578fd4c35dd4b',
+    repository: 'csukuangfj/sherpa-onnx-paraformer-bilingual-zh-en',
+    publisher: 'Alibaba',
+    architecture: SherpaModelArchitecture.paraformer,
+    family: 'Paraformer',
+    languageCodes: ['zh', 'en'],
+    fileRoles: {
+      'model': 'model.int8.onnx',
+    },
+    files: [
+      SherpaModelFile(
+        'model.int8.onnx',
+        223385835,
+        '9ada9127ca5b82320385ac12340eb8b05dee64fd45cf8cf593ec693826ec2fd7',
+      ),
+      SherpaModelFile(
+        'tokens.txt',
+        75756,
+        '59aba8873a2ed1e122c25fee421e25f283b63290efbde85c1f01a853d83cb6e6',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'paraformer-trilingual',
+    name: 'Paraformer Chinese / Cantonese / English',
+    revision: '8d90151338178bb433354c9fb677bd3acb8023cd',
+    repository: 'csukuangfj/sherpa-onnx-paraformer-trilingual-zh-cantonese-en',
+    publisher: 'Alibaba',
+    architecture: SherpaModelArchitecture.paraformer,
+    family: 'Paraformer',
+    languageCodes: ['zh', 'yue', 'en'],
+    fileRoles: {
+      'model': 'model.int8.onnx',
+    },
+    files: [
+      SherpaModelFile(
+        'model.int8.onnx',
+        244684152,
+        'eb3cdd288f535cf73258f491cdd7d68ad5a00aee135c0bba4c0884ea8d926144',
+      ),
+      SherpaModelFile(
+        'tokens.txt',
+        118931,
+        '8e4593d7a2eb2404ff82976b5494265e9a06283ca4d5e8605bf7b4fed557a492',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'wenet-yue',
+    name: 'WeNet Cantonese / Chinese / English',
+    revision: 'c911764e8227cf372ee60adc75f7f407e5b8c905',
+    repository:
+        'csukuangfj/sherpa-onnx-wenetspeech-yue-u2pp-conformer-ctc-zh-en-cantonese-int8-2025-09-10',
+    publisher: 'WeNet',
+    architecture: SherpaModelArchitecture.wenetCtc,
+    family: 'WeNet',
+    languageCodes: ['yue', 'zh', 'en'],
+    fileRoles: {
+      'model': 'model.int8.onnx',
+    },
+    files: [
+      SherpaModelFile(
+        'model.int8.onnx',
+        134698500,
+        '201bfd9e12ec4ac9ee3b23c5e071d9fa2381a8b21df317e2e08a170d6f1f55d3',
+      ),
+      SherpaModelFile(
+        'tokens.txt',
+        85361,
+        'c7750677a1183606d2fd6f16d792e06e70d9843dba8a0c6e23a9dec78e06977a',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'qwen3-asr',
+    name: 'Qwen3 ASR 0.6B',
+    revision: '68818b2313fe77bd06f6a7c5068ff3ef59d02b8a',
+    repository: 'csukuangfj2/sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25',
+    publisher: 'Alibaba',
+    architecture: SherpaModelArchitecture.qwen3Asr,
+    family: 'Qwen3 ASR',
+    fileRoles: {
+      'convFrontend': 'conv_frontend.onnx',
+      'encoder': 'encoder.int8.onnx',
+      'decoder': 'decoder.int8.onnx',
+      'tokenizer': 'tokenizer',
+    },
+    files: [
+      SherpaModelFile(
+        'conv_frontend.onnx',
+        44148281,
+        'd22dc4423e0940e49884e903d2ea2f7e5567c14fc1aed97e4e26d6b8f208ef9e',
+      ),
+      SherpaModelFile(
+        'encoder.int8.onnx',
+        182491662,
+        '60748d3e6744a57c9c91e1b17424a6c2990567e8adceb0783940c03ed98fa9d9',
+      ),
+      SherpaModelFile(
+        'decoder.int8.onnx',
+        755914231,
+        '4f6885be5959ae26af3089d38ee7972c5fafbeeb1cf8d5e76eab6d8b61ca5771',
+      ),
+      SherpaModelFile(
+        'tokenizer/vocab.json',
+        2776833,
+        'ca10d7e9fb3ed18575dd1e277a2579c16d108e32f27439684afa0e10b1440910',
+      ),
+      SherpaModelFile(
+        'tokenizer/merges.txt',
+        1671853,
+        '8831e4f1a044471340f7c0a83d7bd71306a5b867e95fd870f74d0c5308a904d5',
+      ),
+      SherpaModelFile(
+        'tokenizer/tokenizer_config.json',
+        12487,
+        '4942d005604266809309cabc9f4e9cb89ce855d59b14681fdc0e1cc62ea26c4c',
+      ),
+    ],
+  ),
+  SherpaModel(
+    id: 'funasr-nano',
+    name: 'FunASR Nano',
+    revision: '6f16bd378457e13f36ccf3910df9017f96c346fb',
+    repository: 'csukuangfj/sherpa-onnx-funasr-nano-int8-2025-12-30',
+    publisher: 'FunAudioLLM',
+    architecture: SherpaModelArchitecture.funasrNano,
+    family: 'FunASR Nano',
+    languageCodes: ['zh', 'en', 'ja'],
+    fileRoles: {
+      'encoderAdaptor': 'encoder_adaptor.int8.onnx',
+      'llm': 'llm.int8.onnx',
+      'embedding': 'embedding.int8.onnx',
+      'tokenizer': 'Qwen3-0.6B',
+    },
+    files: [
+      SherpaModelFile(
+        'encoder_adaptor.int8.onnx',
+        237792748,
+        'f36dea2e30fbc33b5db1d7a7265cc976c5e5586c77b042d5adb1ad27c72db422',
+      ),
+      SherpaModelFile(
+        'llm.int8.onnx',
+        600356593,
+        'dfbf9aa3be41bccc257587f151e15c63fbe1b549f2b517f5ccd5bdce3bf4322a',
+      ),
+      SherpaModelFile(
+        'embedding.int8.onnx',
+        155584380,
+        '95e61cd0c9c3b9543339a4cf973c95c116815e745ccc1e0285cbd81f76d18644',
+      ),
+      SherpaModelFile(
+        'Qwen3-0.6B/vocab.json',
+        2776833,
+        'ca10d7e9fb3ed18575dd1e277a2579c16d108e32f27439684afa0e10b1440910',
+      ),
+      SherpaModelFile(
+        'Qwen3-0.6B/merges.txt',
+        1671853,
+        '8831e4f1a044471340f7c0a83d7bd71306a5b867e95fd870f74d0c5308a904d5',
+      ),
+      SherpaModelFile(
+        'Qwen3-0.6B/tokenizer.json',
+        11422654,
+        'aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4',
+      ),
+    ],
+  ),
+];

--- a/lib/features/ai/speech/sherpa_model_repository.dart
+++ b/lib/features/ai/speech/sherpa_model_repository.dart
@@ -4,109 +4,11 @@ import 'dart:io';
 import 'package:crypto/crypto.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
+import 'package:lotti/features/ai/speech/sherpa_model_catalog.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
-/// One immutable, checksum-pinned artifact in an embedded speech model.
-class SherpaModelFile {
-  const SherpaModelFile(this.name, this.bytes, this.sha256);
-
-  final String name;
-  final int bytes;
-  final String sha256;
-}
-
-/// A multilingual Whisper export supported by the embedded recognizer.
-class SherpaModel {
-  const SherpaModel({
-    required this.id,
-    required this.name,
-    required this.revision,
-    required this.files,
-  });
-
-  final String id;
-  final String name;
-  final String revision;
-  final List<SherpaModelFile> files;
-
-  int get bytes => files.fold(0, (total, file) => total + file.bytes);
-
-  Uri uri(SherpaModelFile file) => Uri.parse(
-    'https://huggingface.co/csukuangfj/sherpa-onnx-whisper-$id/'
-    'resolve/$revision/${file.name}',
-  );
-}
-
-/// Fixed upstream revisions prevent model downloads changing beneath a build.
-const sherpaModels = [
-  SherpaModel(
-    id: 'large-v3',
-    name: 'Whisper Large v3',
-    revision: '2a6507094dd6020d939d78e3f1834a1d06267fca',
-    files: [
-      SherpaModelFile(
-        'large-v3-encoder.int8.onnx',
-        766671985,
-        'd531cf17248acc43e8c09b472a0877055e770877857a5332fc1304b36534ec85',
-      ),
-      SherpaModelFile(
-        'large-v3-decoder.int8.onnx',
-        1008265203,
-        'ebc6bfd88e162a46cb3edee8a7e727e1dcbc65cabecb19e2573695e4d495e1af',
-      ),
-      SherpaModelFile(
-        'large-v3-tokens.txt',
-        816730,
-        'b34b360dbb493e781e479794586d661700670d65564001f23024971d1f2fa126',
-      ),
-    ],
-  ),
-  SherpaModel(
-    id: 'tiny',
-    name: 'Whisper Tiny',
-    revision: '65176e2deb88badc814a94058666cadccc29b61c',
-    files: [
-      SherpaModelFile(
-        'tiny-encoder.int8.onnx',
-        12937772,
-        'd24fb083ae3b1041fc24e97971d60e280c9342201fbb67b0ab428a8b4a51a434',
-      ),
-      SherpaModelFile(
-        'tiny-decoder.int8.onnx',
-        89855401,
-        'd2fece8dd42771f1df975c6c0445770d0c292bf7547c2cae04a6c0cc57540925',
-      ),
-      SherpaModelFile(
-        'tiny-tokens.txt',
-        816730,
-        'b34b360dbb493e781e479794586d661700670d65564001f23024971d1f2fa126',
-      ),
-    ],
-  ),
-  SherpaModel(
-    id: 'base',
-    name: 'Whisper Base',
-    revision: 'bb53ee204431c90d314c1cc08d28d23e5b7927cc',
-    files: [
-      SherpaModelFile(
-        'base-encoder.int8.onnx',
-        29120534,
-        '0b8fb1304b6109976038efff5ace81720e00386f3ff6b54ee8c75291ca0a1e11',
-      ),
-      SherpaModelFile(
-        'base-decoder.int8.onnx',
-        130672026,
-        '9759d217388a01b3a4c7c15533201067b48ae819c4daafc8624e64b9409dc02d',
-      ),
-      SherpaModelFile(
-        'base-tokens.txt',
-        816730,
-        'b34b360dbb493e781e479794586d661700670d65564001f23024971d1f2fa126',
-      ),
-    ],
-  ),
-];
+export 'package:lotti/features/ai/speech/sherpa_model_catalog.dart';
 
 /// Device-local model files. Configuration sync never implies installation.
 /// Downloads are explicit, coalesced per model, and published atomically only
@@ -225,6 +127,7 @@ class SherpaModelRepository {
       await response.stream.drain<void>();
       throw HttpException('Model download failed: HTTP ${response.statusCode}');
     }
+    await destination.parent.create(recursive: true);
     final part = File('${destination.path}.part');
     try {
       final sink = part.openWrite();

--- a/lib/features/ai/speech/sherpa_worker.dart
+++ b/lib/features/ai/speech/sherpa_worker.dart
@@ -3,8 +3,43 @@ import 'dart:isolate';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
+import 'package:lotti/features/ai/speech/sherpa_model_catalog.dart';
 import 'package:path/path.dart' as p;
 import 'package:sherpa_onnx/sherpa_onnx.dart' as sherpa;
+
+/// Builds the native configuration from the same pinned manifest downloaded
+/// by settings. Tokenizer directories and external ONNX data remain siblings
+/// of their model files, as required by the upstream exports.
+sherpa.OfflineRecognizerConfig sherpaRecognizerConfig(
+  SherpaModel model,
+  String directory,
+) {
+  final architecture = model.architecture;
+  final options = <String, dynamic>{
+    for (final entry in model.recognizerFiles.entries)
+      entry.key: p.join(directory, entry.value),
+    if (architecture == SherpaModelArchitecture.whisper) 'task': 'transcribe',
+    if (architecture == SherpaModelArchitecture.senseVoice) 'language': 'auto',
+    if (architecture == SherpaModelArchitecture.qwen3Asr) ...{
+      'maxNewTokens': 512,
+      'maxTotalLen': 1024,
+    },
+  };
+  return sherpa.OfflineRecognizerConfig(
+    model: sherpa.OfflineModelConfig.fromJson({
+      architecture.configurationKey: options,
+      'tokens': model.recognizerFiles.containsKey('tokenizer')
+          ? ''
+          : p.join(directory, model.tokensFile),
+      if (architecture == SherpaModelArchitecture.whisper)
+        'modelType': 'whisper',
+      if (architecture == SherpaModelArchitecture.nemoTransducer)
+        'modelType': 'nemo_transducer',
+      'numThreads': 2,
+      'debug': false,
+    }),
+  );
+}
 
 /// File-only input sent to the worker; model pointers never cross isolates.
 class SherpaWorkerRequest {
@@ -83,22 +118,11 @@ Future<void> decodeSherpaSegments(
   sherpa.OfflineRecognizer? recognizer;
   try {
     initialize();
-    final directory = request.modelDirectory;
-    final id = request.modelId;
+    final model = sherpaModels.firstWhere(
+      (model) => model.id == request.modelId,
+    );
     recognizer = createRecognizer(
-      sherpa.OfflineRecognizerConfig(
-        model: sherpa.OfflineModelConfig(
-          whisper: sherpa.OfflineWhisperModelConfig(
-            encoder: p.join(directory, '$id-encoder.int8.onnx'),
-            decoder: p.join(directory, '$id-decoder.int8.onnx'),
-            task: 'transcribe',
-          ),
-          tokens: p.join(directory, '$id-tokens.txt'),
-          modelType: 'whisper',
-          numThreads: 2,
-          debug: false,
-        ),
-      ),
+      sherpaRecognizerConfig(model, request.modelDirectory),
     );
     final wave = readWave(request.wavPath);
     if (wave.sampleRate <= 0 || wave.samples.isEmpty) {

--- a/lib/features/ai/ui/inference_profile_slot_field.dart
+++ b/lib/features/ai/ui/inference_profile_slot_field.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/speech/sherpa_installed_models_provider.dart';
 import 'package:lotti/features/ai/state/settings/ai_config_by_type_controller.dart';
 import 'package:lotti/features/ai/ui/inference_profile_form.dart';
 import 'package:lotti/features/ai/ui/widgets/inference_provider_model_picker_modal.dart';
@@ -48,9 +49,20 @@ class ModelSlotField extends ConsumerWidget {
         .whereType<AiConfigInferenceProvider>()
         .toList();
 
-    final filteredModels = allModels.where(filter).toList();
+    final availableModels = modelsAvailableOnDevice(
+      models: allModels,
+      providers: providers,
+      installedSherpaModelIds:
+          providers.any(
+            (provider) =>
+                provider.inferenceProviderType == InferenceProviderType.sherpa,
+          )
+          ? ref.watch(sherpaInstalledModelIdsProvider).value ?? const {}
+          : const {},
+    );
+    final filteredModels = availableModels.where(filter).toList();
 
-    final selectedModel = resolveModelSlot(modelId, allModels);
+    final selectedModel = resolveModelSlot(modelId, availableModels);
 
     return SettingsPickerField(
       label: '$label${required ? ' *' : ''}',

--- a/lib/features/ai/ui/settings/ai_settings_page.dart
+++ b/lib/features/ai/ui/settings/ai_settings_page.dart
@@ -444,6 +444,17 @@ class _AiSettingsPageState extends ConsumerState<AiSettingsPage>
     final models =
         modelsAsync.value?.whereType<AiConfigModel>().toList() ??
         const <AiConfigModel>[];
+    final availableModels = modelsAvailableOnDevice(
+      models: models,
+      providers: providers ?? const [],
+      installedSherpaModelIds:
+          (providers ?? const <AiConfigInferenceProvider>[]).any(
+            (provider) =>
+                provider.inferenceProviderType == InferenceProviderType.sherpa,
+          )
+          ? ref.watch(sherpaInstalledModelIdsProvider).value ?? const {}
+          : const {},
+    );
     final profiles =
         profilesAsync.value?.whereType<AiConfigInferenceProfile>().toList() ??
         const <AiConfigInferenceProfile>[];
@@ -468,7 +479,7 @@ class _AiSettingsPageState extends ConsumerState<AiSettingsPage>
             child: AiSettingsTabBar(
               tabController: _tabController,
               providerCount: 0,
-              modelCount: models.length,
+              modelCount: availableModels.length,
               profileCount: profiles.length,
               onTabChanged: _handleTabChange,
             ),
@@ -493,12 +504,12 @@ class _AiSettingsPageState extends ConsumerState<AiSettingsPage>
           child: AiSettingsTabBar(
             tabController: _tabController,
             providerCount: providers!.length,
-            modelCount: models.length,
+            modelCount: availableModels.length,
             profileCount: profiles.length,
             onTabChanged: _handleTabChange,
           ),
         ),
-      ..._buildActiveTabBody(providers!, models, profiles),
+      ..._buildActiveTabBody(providers!, models, profiles, availableModels),
     ];
   }
 
@@ -506,6 +517,7 @@ class _AiSettingsPageState extends ConsumerState<AiSettingsPage>
     List<AiConfigInferenceProvider> providers,
     List<AiConfigModel> models,
     List<AiConfigInferenceProfile> profiles,
+    List<AiConfigModel> availableModels,
   ) {
     switch (_filterState.activeTab) {
       case AiSettingsTab.providers:
@@ -545,7 +557,7 @@ class _AiSettingsPageState extends ConsumerState<AiSettingsPage>
               },
             ),
           ),
-          _buildModelsList(models, providers),
+          _buildModelsList(availableModels, providers),
         ];
       case AiSettingsTab.profiles:
         return [_buildProfilesGrid(profiles, models, providers)];

--- a/lib/features/ai/ui/settings/provider/ai_provider_detail_widgets.dart
+++ b/lib/features/ai/ui/settings/provider/ai_provider_detail_widgets.dart
@@ -21,7 +21,7 @@ import 'package:material_ui/material_ui.dart';
 /// when a profile uses this provider, and a danger-zone delete action. Wires
 /// the page-level callbacks ([onAddModel], [onEdit], etc.) down to the
 /// individual sections.
-class DetailBody extends StatelessWidget {
+class DetailBody extends ConsumerWidget {
   const DetailBody({
     required this.provider,
     required this.models,
@@ -55,8 +55,16 @@ class DetailBody extends StatelessWidget {
   final VoidCallback onRemove;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final tokens = context.designTokens;
+    final installedModels = modelsAvailableOnDevice(
+      models: models,
+      providers: [provider],
+      installedSherpaModelIds:
+          provider.inferenceProviderType == InferenceProviderType.sherpa
+          ? ref.watch(sherpaInstalledModelIdsProvider).value ?? const {}
+          : const {},
+    );
     final showsModelCatalog =
         ProviderConfig.supportsDynamicCatalog(provider.inferenceProviderType) ||
         provider.inferenceProviderType == InferenceProviderType.sherpa;
@@ -83,7 +91,7 @@ class DetailBody extends StatelessWidget {
         // before scrolling on to the searchable catalog below.
         ModelsSection(
           provider: provider,
-          models: models,
+          models: installedModels,
           onAddModel: onAddModel,
           onModelTap: onModelTap,
           onDeleteModel: onDeleteModel,

--- a/lib/features/ai/ui/settings/provider/ai_provider_models_section.dart
+++ b/lib/features/ai/ui/settings/provider/ai_provider_models_section.dart
@@ -36,16 +36,23 @@ class ModelsSection extends StatelessWidget {
     final tokens = context.designTokens;
     final messages = context.messages;
     return Section(
-      title: messages.aiProviderDetailModelsTitle(models.length),
-      trailing: DesignSystemButton(
-        label: messages.aiProviderDetailAddModelButton,
-        variant: DesignSystemButtonVariant.secondary,
-        leadingIcon: LottiIcons.add,
-        onPressed: onAddModel,
-      ),
+      title: provider.inferenceProviderType == InferenceProviderType.sherpa
+          ? messages.sherpaInstalledModelsTitle
+          : messages.aiProviderDetailModelsTitle(models.length),
+      trailing: provider.inferenceProviderType == InferenceProviderType.sherpa
+          ? null
+          : DesignSystemButton(
+              label: messages.aiProviderDetailAddModelButton,
+              variant: DesignSystemButtonVariant.secondary,
+              leadingIcon: LottiIcons.add,
+              onPressed: onAddModel,
+            ),
       child: models.isEmpty
           ? EmptySectionCard(
-              message: messages.aiProviderDetailNoModelsMessage,
+              message:
+                  provider.inferenceProviderType == InferenceProviderType.sherpa
+                  ? messages.sherpaModelNotInstalled
+                  : messages.aiProviderDetailNoModelsMessage,
             )
           : Column(
               children: [
@@ -55,7 +62,11 @@ class ModelsSection extends StatelessWidget {
                     model: models[i],
                     providerType: provider.inferenceProviderType,
                     onTap: () => onModelTap(models[i]),
-                    onDelete: () => onDeleteModel(models[i]),
+                    onDelete:
+                        provider.inferenceProviderType ==
+                            InferenceProviderType.sherpa
+                        ? null
+                        : () => onDeleteModel(models[i]),
                   ),
                 ],
               ],

--- a/lib/features/ai/ui/settings/widgets/sherpa_models_section.dart
+++ b/lib/features/ai/ui/settings/widgets/sherpa_models_section.dart
@@ -2,13 +2,16 @@ import 'dart:developer' as developer;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:lotti/classes/supported_language.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/speech/sherpa_installed_models_provider.dart';
 import 'package:lotti/features/ai/speech/sherpa_model_repository.dart';
+import 'package:lotti/features/ai/ui/settings/widgets/ai_settings_search_bar.dart';
 import 'package:lotti/features/ai/util/known_models.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_icon_action.dart';
+import 'package:lotti/features/design_system/components/dropdowns/design_system_dropdown.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_grouped_list.dart';
 import 'package:lotti/features/design_system/components/progress_bars/design_system_progress_bar.dart';
 import 'package:lotti/features/design_system/components/spinners/design_system_spinner.dart';
@@ -19,19 +22,105 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:material_ui/material_ui.dart';
 
 /// Explicit device-local downloads, separate from synced model configurations.
-class SherpaModelsSection extends StatelessWidget {
+class SherpaModelsSection extends StatefulWidget {
   const SherpaModelsSection({required this.providerId, super.key});
 
   final String providerId;
 
   @override
+  State<SherpaModelsSection> createState() => _SherpaModelsSectionState();
+}
+
+class _SherpaModelsSectionState extends State<SherpaModelsSection> {
+  final _searchController = TextEditingController();
+  String _query = '';
+  String? _family;
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  bool _matches(SherpaModel model) {
+    if (_family != null && model.family != _family) return false;
+    final searchable = [
+      model.name,
+      model.id,
+      model.family,
+      model.publisher,
+      for (final code in model.languageCodes) ...[
+        code,
+        SupportedLanguage.fromCode(code)?.name ?? code,
+        _languageName(context, code),
+      ],
+    ].join(' ').toLowerCase();
+    return _query
+        .trim()
+        .toLowerCase()
+        .split(RegExp(r'\s+'))
+        .every(searchable.contains);
+  }
+
+  @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
+    final families = sherpaModels.map((model) => model.family).toSet().toList()
+      ..sort();
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        Text(
+          context.messages.sherpaModelCatalogTitle,
+          style: tokens.typography.styles.subtitle.subtitle1,
+        ),
+        SizedBox(height: tokens.spacing.step3),
         Text(context.messages.sherpaProviderDescription),
         SizedBox(height: tokens.spacing.step4),
+        AiSettingsSearchBar(
+          key: const ValueKey('sherpa-model-catalog-search'),
+          controller: _searchController,
+          hintText: context.messages.aiProfileModelPickerSearchHint,
+          isCompact: true,
+          onChanged: (value) => setState(() => _query = value),
+          onClear: () {
+            _searchController.clear();
+            setState(() => _query = '');
+          },
+        ),
+        SizedBox(height: tokens.spacing.step4),
+        DesignSystemDropdown(
+          key: const ValueKey('sherpa-model-family'),
+          label: context.messages.sherpaModelFamily,
+          inputLabel: _family ?? context.messages.sherpaAllFamilies,
+          size: DesignSystemDropdownSize.small,
+          items: [
+            DesignSystemDropdownItem(
+              id: '',
+              label: context.messages.sherpaAllFamilies,
+              selected: _family == null,
+            ),
+            for (final family in families)
+              DesignSystemDropdownItem(
+                id: family,
+                label: family,
+                selected: family == _family,
+              ),
+          ],
+          onItemPressed: (item) =>
+              setState(() => _family = item.id.isEmpty ? null : item.id),
+        ),
+        SizedBox(height: tokens.spacing.step3),
+        Text(
+          context.messages.sherpaCatalogMatches(
+            sherpaModels.where(_matches).length,
+            sherpaModels.length,
+          ),
+          style: tokens.typography.styles.body.bodySmall,
+        ),
+        SizedBox(height: tokens.spacing.step3),
+        if (!sherpaModels.any(_matches))
+          Text(context.messages.filterSelectionNoMatches),
         DesignSystemGroupedList(
           padding: EdgeInsets.zero,
           children: [
@@ -39,7 +128,8 @@ class SherpaModelsSection extends StatelessWidget {
               _ModelDownload(
                 key: ValueKey('sherpa-model-${model.id}'),
                 model: model,
-                providerId: providerId,
+                providerId: widget.providerId,
+                matchesQuery: _matches(model),
               ),
           ],
         ),
@@ -52,9 +142,11 @@ class _ModelDownload extends ConsumerStatefulWidget {
   const _ModelDownload({
     required this.model,
     required this.providerId,
+    required this.matchesQuery,
     super.key,
   });
 
+  final bool matchesQuery;
   final SherpaModel model;
   final String providerId;
 
@@ -71,13 +163,33 @@ class _ModelDownloadState extends ConsumerState<_ModelDownload> {
   bool get _busy => _operation != null;
   bool _failed = false;
   bool _configurationFailed = false;
+  bool _configurationMissing = false;
 
   @override
   void initState() {
     super.initState();
-    _installed = ref
-        .read(sherpaModelRepositoryProvider)
-        .isInstalled(widget.model.id);
+    _installed = _loadInstallation();
+  }
+
+  Future<bool> _loadInstallation() async {
+    final models = ref.read(sherpaModelRepositoryProvider);
+    final installed = await models.isInstalled(widget.model.id);
+    if (installed && mounted) {
+      final configs = ref.read(aiConfigRepositoryProvider);
+      try {
+        final existing = await configs.getConfigsByType(AiConfigType.model);
+        if (mounted) {
+          _configurationMissing = !existing.whereType<AiConfigModel>().any(
+            (model) =>
+                model.inferenceProviderId == widget.providerId &&
+                model.providerModelId == widget.model.id,
+          );
+        }
+      } catch (_) {
+        if (mounted) _configurationFailed = true;
+      }
+    }
+    return installed;
   }
 
   Future<void> _download() async {
@@ -152,7 +264,12 @@ class _ModelDownloadState extends ConsumerState<_ModelDownload> {
           ),
         );
       }
-      if (mounted) setState(() => _configurationFailed = false);
+      if (mounted) {
+        setState(() {
+          _configurationFailed = false;
+          _configurationMissing = false;
+        });
+      }
     } catch (_) {
       if (mounted) setState(() => _configurationFailed = true);
     }
@@ -188,6 +305,7 @@ class _ModelDownloadState extends ConsumerState<_ModelDownload> {
         setState(() {
           _installed = Future.value(false);
           _configurationFailed = false;
+          _configurationMissing = false;
         });
       }
     } catch (_) {
@@ -199,6 +317,17 @@ class _ModelDownloadState extends ConsumerState<_ModelDownload> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen(sherpaInstalledModelIdsProvider, (previous, next) {
+      final before = previous?.value;
+      final after = next.value;
+      if (before != null &&
+          after != null &&
+          before.contains(widget.model.id) != after.contains(widget.model.id)) {
+        setState(() {
+          _installed = _loadInstallation();
+        });
+      }
+    });
     final tokens = context.designTokens;
     final messages = context.messages;
     final numberFormat = NumberFormat.decimalPattern(messages.localeName);
@@ -212,116 +341,147 @@ class _ModelDownloadState extends ConsumerState<_ModelDownload> {
         : messages.sherpaModelSizeMB(
             numberFormat.format((widget.model.bytes / 1000000).ceil()),
           );
-    return FutureBuilder<bool>(
-      future: _installed,
-      builder: (context, snapshot) => Padding(
-        padding: EdgeInsets.all(tokens.spacing.step4),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Wrap(
-              alignment: WrapAlignment.spaceBetween,
-              crossAxisAlignment: WrapCrossAlignment.center,
-              spacing: tokens.spacing.step4,
-              runSpacing: tokens.spacing.step3,
-              children: [
-                Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      widget.model.name,
-                      style: tokens.typography.styles.subtitle.subtitle2,
-                    ),
-                    SizedBox(height: tokens.spacing.step2),
-                    Text(
-                      metadata,
-                      style: tokens.typography.styles.body.bodySmall.copyWith(
-                        color: tokens.colors.text.mediumEmphasis,
-                      ),
-                    ),
-                  ],
-                ),
-                if (_progress != null)
-                  const SizedBox.shrink()
-                else if (snapshot.connectionState == ConnectionState.waiting)
-                  const DesignSystemSpinner(
-                    size: IconSizes.s,
-                    strokeWidth: BorderWidths.emphasis,
-                  )
-                else if (snapshot.data ?? false)
-                  Wrap(
-                    crossAxisAlignment: WrapCrossAlignment.center,
-                    spacing: tokens.spacing.step2,
+    return Visibility(
+      visible: widget.matchesQuery || _busy || _failed || _configurationFailed,
+      maintainState: true,
+      child: FutureBuilder<bool>(
+        future: _installed,
+        builder: (context, snapshot) => Padding(
+          padding: EdgeInsets.all(tokens.spacing.step4),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Wrap(
+                alignment: WrapAlignment.spaceBetween,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                spacing: tokens.spacing.step4,
+                runSpacing: tokens.spacing.step3,
+                children: [
+                  Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        messages.sherpaModelInstalled,
+                        widget.model.name,
+                        style: tokens.typography.styles.subtitle.subtitle2,
+                      ),
+                      if (widget.model.languageCodes.isNotEmpty &&
+                          widget.model.languageCodes.length <= 5) ...[
+                        SizedBox(height: tokens.spacing.step2),
+                        Text(
+                          widget.model.languageCodes
+                              .map((code) => _languageName(context, code))
+                              .join(' · '),
+                          style: tokens.typography.styles.body.bodySmall,
+                        ),
+                      ],
+                      SizedBox(height: tokens.spacing.step2),
+                      Text(
+                        metadata,
                         style: tokens.typography.styles.body.bodySmall.copyWith(
                           color: tokens.colors.text.mediumEmphasis,
                         ),
                       ),
-                      DesignSystemIconAction(
-                        icon: LottiIcons.delete,
-                        tooltip: messages.sherpaDeleteModel(widget.model.name),
-                        isBusy: _operation == _ModelOperation.removing,
-                        onPressed: _busy ? null : _remove,
-                      ),
                     ],
-                  )
-                else
-                  DesignSystemButton(
-                    label: messages.sherpaDownloadAction,
-                    semanticsLabel: messages.sherpaDownloadModel(
-                      widget.model.name,
-                    ),
-                    leadingIcon: LottiIcons.download,
-                    variant: DesignSystemButtonVariant.outlined,
-                    tapTargetSize: MaterialTapTargetSize.padded,
-                    onPressed: _download,
                   ),
+                  if (_progress != null)
+                    const SizedBox.shrink()
+                  else if (snapshot.connectionState == ConnectionState.waiting)
+                    const DesignSystemSpinner(
+                      size: IconSizes.s,
+                      strokeWidth: BorderWidths.emphasis,
+                    )
+                  else if (snapshot.data ?? false)
+                    Wrap(
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      spacing: tokens.spacing.step2,
+                      children: [
+                        Text(
+                          messages.sherpaModelInstalled,
+                          style: tokens.typography.styles.body.bodySmall
+                              .copyWith(
+                                color: tokens.colors.text.mediumEmphasis,
+                              ),
+                        ),
+                        if (_configurationMissing && !_configurationFailed)
+                          DesignSystemButton(
+                            label: messages.aiProviderDetailAddModelButton,
+                            variant: DesignSystemButtonVariant.outlined,
+                            isLoading:
+                                _operation == _ModelOperation.configuring,
+                            onPressed: _busy ? null : _retryConfiguration,
+                          ),
+                        DesignSystemIconAction(
+                          icon: LottiIcons.delete,
+                          tooltip: messages.sherpaDeleteModel(
+                            widget.model.name,
+                          ),
+                          isBusy: _operation == _ModelOperation.removing,
+                          onPressed: _busy ? null : _remove,
+                        ),
+                      ],
+                    )
+                  else
+                    DesignSystemButton(
+                      label: messages.sherpaDownloadAction,
+                      semanticsLabel: messages.sherpaDownloadModel(
+                        widget.model.name,
+                      ),
+                      leadingIcon: LottiIcons.download,
+                      variant: DesignSystemButtonVariant.outlined,
+                      tapTargetSize: MaterialTapTargetSize.padded,
+                      onPressed: _download,
+                    ),
+                ],
+              ),
+              if (_progress != null) ...[
+                SizedBox(height: tokens.spacing.step3),
+                DesignSystemProgressBar(
+                  value: _progress!,
+                  label: messages.sherpaInstallingModel,
+                  semanticsLabel: messages.sherpaDownloadModel(
+                    widget.model.name,
+                  ),
+                  progressText: NumberFormat.percentPattern(
+                    messages.localeName,
+                  ).format(_progress!.clamp(0, 1)),
+                ),
               ],
-            ),
-            if (_progress != null) ...[
-              SizedBox(height: tokens.spacing.step3),
-              DesignSystemProgressBar(
-                value: _progress!,
-                label: messages.sherpaInstallingModel,
-                semanticsLabel: messages.sherpaDownloadModel(widget.model.name),
-                progressText: NumberFormat.percentPattern(
-                  messages.localeName,
-                ).format(_progress!.clamp(0, 1)),
-              ),
-            ],
-            if (_configurationFailed) ...[
-              SizedBox(height: tokens.spacing.step3),
-              Text(
-                messages.sherpaModelConfigurationError,
-                style: tokens.typography.styles.body.bodySmall.copyWith(
-                  color: tokens.colors.alert.error.ink,
+              if (_configurationFailed) ...[
+                SizedBox(height: tokens.spacing.step3),
+                Text(
+                  messages.sherpaModelConfigurationError,
+                  style: tokens.typography.styles.body.bodySmall.copyWith(
+                    color: tokens.colors.alert.error.ink,
+                  ),
                 ),
-              ),
-              Align(
-                alignment: AlignmentDirectional.centerStart,
-                child: DesignSystemButton(
-                  label: messages.aiProviderConnectionRetryButton,
-                  isLoading: _operation == _ModelOperation.configuring,
-                  variant: DesignSystemButtonVariant.tertiary,
-                  onPressed: _busy ? null : _retryConfiguration,
+                Align(
+                  alignment: AlignmentDirectional.centerStart,
+                  child: DesignSystemButton(
+                    label: messages.aiProviderConnectionRetryButton,
+                    isLoading: _operation == _ModelOperation.configuring,
+                    variant: DesignSystemButtonVariant.tertiary,
+                    onPressed: _busy ? null : _retryConfiguration,
+                  ),
                 ),
-              ),
-            ],
-            if (_failed || snapshot.hasError) ...[
-              SizedBox(height: tokens.spacing.step3),
-              Text(
-                messages.sherpaModelError,
-                style: tokens.typography.styles.body.bodySmall.copyWith(
-                  color: tokens.colors.alert.error.ink,
+              ],
+              if (_failed || snapshot.hasError) ...[
+                SizedBox(height: tokens.spacing.step3),
+                Text(
+                  messages.sherpaModelError,
+                  style: tokens.typography.styles.body.bodySmall.copyWith(
+                    color: tokens.colors.alert.error.ink,
+                  ),
                 ),
-              ),
+              ],
             ],
-          ],
+          ),
         ),
       ),
     );
   }
 }
+
+String _languageName(BuildContext context, String code) => code == 'yue'
+    ? context.messages.sherpaLanguageCantonese
+    : SupportedLanguage.fromCode(code)?.localizedName(context) ?? code;

--- a/lib/features/ai/ui/unified_ai_skills_modal.dart
+++ b/lib/features/ai/ui/unified_ai_skills_modal.dart
@@ -7,6 +7,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/resolved_profile.dart';
 import 'package:lotti/features/ai/repository/gemini_thinking_config.dart';
+import 'package:lotti/features/ai/speech/sherpa_installed_models_provider.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/state/profile_automation_providers.dart';
 import 'package:lotti/features/ai/state/skill_trigger_providers.dart';
@@ -361,8 +362,18 @@ class UnifiedAiModal {
           in providerConfigs.whereType<AiConfigInferenceProvider>())
         provider.id: provider,
     };
-    final modalityCapable = allConfigs
-        .whereType<AiConfigModel>()
+    final availableModels = modelsAvailableOnDevice(
+      models: allConfigs.whereType<AiConfigModel>(),
+      providers: providersById.values,
+      installedSherpaModelIds:
+          providersById.values.any(
+            (provider) =>
+                provider.inferenceProviderType == InferenceProviderType.sherpa,
+          )
+          ? await ref.read(sherpaInstalledModelIdsProvider.future)
+          : const {},
+    );
+    final modalityCapable = availableModels
         .where((model) => model.inputModalities.contains(config.modality))
         .where(
           (model) =>

--- a/lib/features/ai/util/known_models.dart
+++ b/lib/features/ai/util/known_models.dart
@@ -96,7 +96,7 @@ String? publisherForCuratedModel(String providerModelId) {
 }
 
 /// Known models for each inference provider type
-const Map<InferenceProviderType, List<KnownModel>> knownModelsByProvider = {
+final Map<InferenceProviderType, List<KnownModel>> knownModelsByProvider = {
   InferenceProviderType.sherpa: sherpaSpeechModels,
   InferenceProviderType.alibaba: alibabaModels,
   InferenceProviderType.gemini: geminiModels,

--- a/lib/features/ai/util/known_models_data.dart
+++ b/lib/features/ai/util/known_models_data.dart
@@ -1,4 +1,5 @@
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/speech/sherpa_model_catalog.dart';
 import 'package:lotti/features/ai/util/known_models.dart';
 
 /// Curated Melious.ai defaults.
@@ -776,32 +777,15 @@ const List<KnownModel> mistralModels = [
 ];
 
 /// Multilingual int8 Whisper exports for embedded, device-local transcription.
-const sherpaSpeechModels = [
-  KnownModel(
-    providerModelId: 'large-v3',
-    name: 'Whisper Large v3',
-    inputModalities: [Modality.audio],
-    outputModalities: [Modality.text],
-    isReasoningModel: false,
-    publisher: 'OpenAI',
-    description: 'OpenAI Whisper Large v3 · ONNX INT8',
-  ),
-  KnownModel(
-    providerModelId: 'tiny',
-    name: 'Whisper Tiny',
-    inputModalities: [Modality.audio],
-    outputModalities: [Modality.text],
-    isReasoningModel: false,
-    publisher: 'OpenAI',
-    description: 'OpenAI Whisper Tiny · ONNX INT8',
-  ),
-  KnownModel(
-    providerModelId: 'base',
-    name: 'Whisper Base',
-    inputModalities: [Modality.audio],
-    outputModalities: [Modality.text],
-    isReasoningModel: false,
-    publisher: 'OpenAI',
-    description: 'OpenAI Whisper Base · ONNX INT8',
-  ),
+final List<KnownModel> sherpaSpeechModels = [
+  for (final model in sherpaModels)
+    KnownModel(
+      providerModelId: model.id,
+      name: model.name,
+      inputModalities: const [Modality.audio],
+      outputModalities: const [Modality.text],
+      isReasoningModel: false,
+      publisher: model.publisher,
+      description: '${model.publisher} ${model.name} · ONNX INT8',
+    ),
 ];

--- a/lib/features/ai/util/model_prepopulation_service.dart
+++ b/lib/features/ai/util/model_prepopulation_service.dart
@@ -34,6 +34,11 @@ class ModelPrepopulationService {
   Future<int> prepopulateModelsForProvider(
     AiConfigInferenceProvider provider,
   ) async {
+    // Embedded models are configured only after an explicit, verified download.
+    if (provider.inferenceProviderType == InferenceProviderType.sherpa) {
+      return 0;
+    }
+
     // Get known models for this provider type
     final knownModels = knownModelsByProvider[provider.inferenceProviderType];
     if (knownModels == null || knownModels.isEmpty) {

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4989,6 +4989,8 @@
   "settingsV2UnimplementedTitle": "Panel zatím není k dispozici",
   "settingsWhatsNewSubtitle": "Podívej se na nejnovější aktualizace a funkce",
   "settingsWhatsNewTitle": "Co je nového",
+  "sherpaAllFamilies": "Všechny rodiny",
+  "sherpaCatalogMatches": "{count} z {total} modelů",
   "sherpaDeleteModel": "Odebrat {model} z tohoto zařízení",
   "@sherpaDeleteModel": {
     "placeholders": {
@@ -5006,9 +5008,13 @@
       }
     }
   },
+  "sherpaInstalledModelsTitle": "Nainstalované modely",
   "sherpaInstallingModel": "Instalace modelu",
+  "sherpaLanguageCantonese": "Kantonština",
+  "sherpaModelCatalogTitle": "Katalog modelů",
   "sherpaModelConfigurationError": "Model je stažený, ale jeho konfiguraci se nepodařilo uložit.",
   "sherpaModelError": "Operace s modelem se nezdařila. Zkus to znovu.",
+  "sherpaModelFamily": "Rodina modelů",
   "sherpaModelInstalled": "Staženo",
   "sherpaModelNotInstalled": "Stáhni si model do tohoto zařízení",
   "sherpaModelSizeGB": "{size} GB · Vícejazyčný",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -5518,6 +5518,8 @@
   "settingsV2UnimplementedTitle": "Panel endnu ikke implementeret",
   "settingsWhatsNewSubtitle": "Se de seneste opdateringer og funktioner",
   "settingsWhatsNewTitle": "Hvad er nyt",
+  "sherpaAllFamilies": "Alle familier",
+  "sherpaCatalogMatches": "{count} af {total} modeller",
   "sherpaDeleteModel": "Fjern {model} fra denne enhed",
   "@sherpaDeleteModel": {
     "placeholders": {
@@ -5535,9 +5537,13 @@
       }
     }
   },
+  "sherpaInstalledModelsTitle": "Installerede modeller",
   "sherpaInstallingModel": "Installerer model",
+  "sherpaLanguageCantonese": "Kantonesisk",
+  "sherpaModelCatalogTitle": "Modelkatalog",
   "sherpaModelConfigurationError": "Modellen er downloadet, men dens konfiguration kunne ikke gemmes.",
   "sherpaModelError": "Modelhandlingen mislykkedes. Prøv igen.",
+  "sherpaModelFamily": "Modelfamilie",
   "sherpaModelInstalled": "Downloadet",
   "sherpaModelNotInstalled": "Download en model på denne enhed",
   "sherpaModelSizeGB": "{size} GB · Flersproget",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -4982,6 +4982,8 @@
   "settingsV2UnimplementedTitle": "Bereich noch nicht verfügbar",
   "settingsWhatsNewSubtitle": "Sieh dir die neuesten Neuigkeiten und Funktionen an",
   "settingsWhatsNewTitle": "Was gibt's Neues",
+  "sherpaAllFamilies": "Alle Familien",
+  "sherpaCatalogMatches": "{count} von {total} Modellen",
   "sherpaDeleteModel": "{model} von diesem Gerät entfernen",
   "@sherpaDeleteModel": {
     "placeholders": {
@@ -4999,9 +5001,13 @@
       }
     }
   },
+  "sherpaInstalledModelsTitle": "Installierte Modelle",
   "sherpaInstallingModel": "Modell wird installiert",
+  "sherpaLanguageCantonese": "Kantonesisch",
+  "sherpaModelCatalogTitle": "Modellkatalog",
   "sherpaModelConfigurationError": "Das Modell wurde heruntergeladen, aber seine Konfiguration konnte nicht gespeichert werden.",
   "sherpaModelError": "Modellaktion fehlgeschlagen. Versuch es erneut.",
+  "sherpaModelFamily": "Modellfamilie",
   "sherpaModelInstalled": "Heruntergeladen",
   "sherpaModelNotInstalled": "Lade ein Modell auf dieses Gerät herunter",
   "sherpaModelSizeGB": "{size} GB · Mehrsprachig",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7157,6 +7157,19 @@
   "settingsV2UnimplementedTitle": "Panel not yet implemented",
   "settingsWhatsNewSubtitle": "See the latest updates and features",
   "settingsWhatsNewTitle": "What's New",
+  "sherpaAllFamilies": "All families",
+  "sherpaCatalogMatches": "{count} of {total} models",
+  "@sherpaCatalogMatches": {
+    "description": "Number of search matches in the downloadable model catalog.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "sherpaDeleteModel": "Remove {model} from this device",
   "@sherpaDeleteModel": {
     "placeholders": {
@@ -7174,9 +7187,13 @@
       }
     }
   },
+  "sherpaInstalledModelsTitle": "Installed models",
   "sherpaInstallingModel": "Installing model",
+  "sherpaLanguageCantonese": "Cantonese",
+  "sherpaModelCatalogTitle": "Model catalog",
   "sherpaModelConfigurationError": "Model downloaded, but its configuration could not be saved.",
   "sherpaModelError": "Model operation failed. Try again.",
+  "sherpaModelFamily": "Model family",
   "sherpaModelInstalled": "Downloaded",
   "sherpaModelNotInstalled": "Download a model on this device",
   "sherpaModelSizeGB": "{size} GB · Multilingual",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4982,6 +4982,8 @@
   "settingsV2UnimplementedTitle": "Panel aún no disponible",
   "settingsWhatsNewSubtitle": "Mira las últimas actualizaciones y funciones",
   "settingsWhatsNewTitle": "Novedades",
+  "sherpaAllFamilies": "Todas las familias",
+  "sherpaCatalogMatches": "{count} de {total} modelos",
   "sherpaDeleteModel": "Eliminar {model} de este dispositivo",
   "@sherpaDeleteModel": {
     "placeholders": {
@@ -4999,9 +5001,13 @@
       }
     }
   },
+  "sherpaInstalledModelsTitle": "Modelos instalados",
   "sherpaInstallingModel": "Instalando modelo",
+  "sherpaLanguageCantonese": "Cantonés",
+  "sherpaModelCatalogTitle": "Catálogo de modelos",
   "sherpaModelConfigurationError": "El modelo se ha descargado, pero no se ha podido guardar su configuración.",
   "sherpaModelError": "La operación del modelo falló. Inténtalo de nuevo.",
+  "sherpaModelFamily": "Familia de modelos",
   "sherpaModelInstalled": "Descargado",
   "sherpaModelNotInstalled": "Descarga un modelo en este dispositivo",
   "sherpaModelSizeGB": "{size} GB · Multilingüe",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4982,6 +4982,8 @@
   "settingsV2UnimplementedTitle": "Volet non encore disponible",
   "settingsWhatsNewSubtitle": "Découvre les dernières mises à jour et fonctionnalités",
   "settingsWhatsNewTitle": "Quoi de neuf",
+  "sherpaAllFamilies": "Toutes les familles",
+  "sherpaCatalogMatches": "{count} sur {total} modèles",
   "sherpaDeleteModel": "Supprimer {model} de cet appareil",
   "@sherpaDeleteModel": {
     "placeholders": {
@@ -4999,9 +5001,13 @@
       }
     }
   },
+  "sherpaInstalledModelsTitle": "Modèles installés",
   "sherpaInstallingModel": "Installation du modèle",
+  "sherpaLanguageCantonese": "Cantonais",
+  "sherpaModelCatalogTitle": "Catalogue de modèles",
   "sherpaModelConfigurationError": "Le modèle a été téléchargé, mais sa configuration n’a pas pu être enregistrée.",
   "sherpaModelError": "L’opération sur le modèle a échoué. Réessaie.",
+  "sherpaModelFamily": "Famille de modèles",
   "sherpaModelInstalled": "Téléchargé",
   "sherpaModelNotInstalled": "Télécharge un modèle sur cet appareil",
   "sherpaModelSizeGB": "{size} GB · Multilingue",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -5518,6 +5518,8 @@
   "settingsV2UnimplementedTitle": "Pannello non ancora implementato",
   "settingsWhatsNewSubtitle": "Visualizza gli ultimi aggiornamenti e le funzionalità",
   "settingsWhatsNewTitle": "Che cosa è nuovo",
+  "sherpaAllFamilies": "Tutte le famiglie",
+  "sherpaCatalogMatches": "{count} di {total} modelli",
   "sherpaDeleteModel": "Rimuovi {model} da questo dispositivo",
   "@sherpaDeleteModel": {
     "placeholders": {
@@ -5535,9 +5537,13 @@
       }
     }
   },
+  "sherpaInstalledModelsTitle": "Modelli installati",
   "sherpaInstallingModel": "Installazione del modello",
+  "sherpaLanguageCantonese": "Cantonese",
+  "sherpaModelCatalogTitle": "Catalogo dei modelli",
   "sherpaModelConfigurationError": "Il modello è stato scaricato, ma non è stato possibile salvare la sua configurazione.",
   "sherpaModelError": "Operazione sul modello non riuscita. Riprova.",
+  "sherpaModelFamily": "Famiglia di modelli",
   "sherpaModelInstalled": "Scaricato",
   "sherpaModelNotInstalled": "Scarica un modello su questo dispositivo",
   "sherpaModelSizeGB": "{size} GB · Multilingue",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -21281,6 +21281,18 @@ abstract class AppLocalizations {
   /// **'What\'s New'**
   String get settingsWhatsNewTitle;
 
+  /// No description provided for @sherpaAllFamilies.
+  ///
+  /// In en, this message translates to:
+  /// **'All families'**
+  String get sherpaAllFamilies;
+
+  /// Number of search matches in the downloadable model catalog.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} of {total} models'**
+  String sherpaCatalogMatches(int count, int total);
+
   /// No description provided for @sherpaDeleteModel.
   ///
   /// In en, this message translates to:
@@ -21299,11 +21311,29 @@ abstract class AppLocalizations {
   /// **'Download {model}'**
   String sherpaDownloadModel(String model);
 
+  /// No description provided for @sherpaInstalledModelsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Installed models'**
+  String get sherpaInstalledModelsTitle;
+
   /// No description provided for @sherpaInstallingModel.
   ///
   /// In en, this message translates to:
   /// **'Installing model'**
   String get sherpaInstallingModel;
+
+  /// No description provided for @sherpaLanguageCantonese.
+  ///
+  /// In en, this message translates to:
+  /// **'Cantonese'**
+  String get sherpaLanguageCantonese;
+
+  /// No description provided for @sherpaModelCatalogTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Model catalog'**
+  String get sherpaModelCatalogTitle;
 
   /// No description provided for @sherpaModelConfigurationError.
   ///
@@ -21316,6 +21346,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Model operation failed. Try again.'**
   String get sherpaModelError;
+
+  /// No description provided for @sherpaModelFamily.
+  ///
+  /// In en, this message translates to:
+  /// **'Model family'**
+  String get sherpaModelFamily;
 
   /// No description provided for @sherpaModelInstalled.
   ///

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -12838,6 +12838,14 @@ class AppLocalizationsCs extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Co je nového';
 
   @override
+  String get sherpaAllFamilies => 'Všechny rodiny';
+
+  @override
+  String sherpaCatalogMatches(int count, int total) {
+    return '$count z $total modelů';
+  }
+
+  @override
   String sherpaDeleteModel(String model) {
     return 'Odebrat $model z tohoto zařízení';
   }
@@ -12851,7 +12859,16 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get sherpaInstalledModelsTitle => 'Nainstalované modely';
+
+  @override
   String get sherpaInstallingModel => 'Instalace modelu';
+
+  @override
+  String get sherpaLanguageCantonese => 'Kantonština';
+
+  @override
+  String get sherpaModelCatalogTitle => 'Katalog modelů';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12860,6 +12877,9 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get sherpaModelError =>
       'Operace s modelem se nezdařila. Zkus to znovu.';
+
+  @override
+  String get sherpaModelFamily => 'Rodina modelů';
 
   @override
   String get sherpaModelInstalled => 'Staženo';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -12666,6 +12666,14 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Hvad er nyt';
 
   @override
+  String get sherpaAllFamilies => 'Alle familier';
+
+  @override
+  String sherpaCatalogMatches(int count, int total) {
+    return '$count af $total modeller';
+  }
+
+  @override
   String sherpaDeleteModel(String model) {
     return 'Fjern $model fra denne enhed';
   }
@@ -12679,7 +12687,16 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get sherpaInstalledModelsTitle => 'Installerede modeller';
+
+  @override
   String get sherpaInstallingModel => 'Installerer model';
+
+  @override
+  String get sherpaLanguageCantonese => 'Kantonesisk';
+
+  @override
+  String get sherpaModelCatalogTitle => 'Modelkatalog';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12687,6 +12704,9 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get sherpaModelError => 'Modelhandlingen mislykkedes. Prøv igen.';
+
+  @override
+  String get sherpaModelFamily => 'Modelfamilie';
 
   @override
   String get sherpaModelInstalled => 'Downloadet';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -12748,6 +12748,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Was gibt\'s Neues';
 
   @override
+  String get sherpaAllFamilies => 'Alle Familien';
+
+  @override
+  String sherpaCatalogMatches(int count, int total) {
+    return '$count von $total Modellen';
+  }
+
+  @override
   String sherpaDeleteModel(String model) {
     return '$model von diesem Gerät entfernen';
   }
@@ -12761,7 +12769,16 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get sherpaInstalledModelsTitle => 'Installierte Modelle';
+
+  @override
   String get sherpaInstallingModel => 'Modell wird installiert';
+
+  @override
+  String get sherpaLanguageCantonese => 'Kantonesisch';
+
+  @override
+  String get sherpaModelCatalogTitle => 'Modellkatalog';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12770,6 +12787,9 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get sherpaModelError =>
       'Modellaktion fehlgeschlagen. Versuch es erneut.';
+
+  @override
+  String get sherpaModelFamily => 'Modellfamilie';
 
   @override
   String get sherpaModelInstalled => 'Heruntergeladen';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -12591,6 +12591,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsWhatsNewTitle => 'What\'s New';
 
   @override
+  String get sherpaAllFamilies => 'All families';
+
+  @override
+  String sherpaCatalogMatches(int count, int total) {
+    return '$count of $total models';
+  }
+
+  @override
   String sherpaDeleteModel(String model) {
     return 'Remove $model from this device';
   }
@@ -12604,7 +12612,16 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get sherpaInstalledModelsTitle => 'Installed models';
+
+  @override
   String get sherpaInstallingModel => 'Installing model';
+
+  @override
+  String get sherpaLanguageCantonese => 'Cantonese';
+
+  @override
+  String get sherpaModelCatalogTitle => 'Model catalog';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12612,6 +12629,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get sherpaModelError => 'Model operation failed. Try again.';
+
+  @override
+  String get sherpaModelFamily => 'Model family';
 
   @override
   String get sherpaModelInstalled => 'Downloaded';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -12841,6 +12841,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Novedades';
 
   @override
+  String get sherpaAllFamilies => 'Todas las familias';
+
+  @override
+  String sherpaCatalogMatches(int count, int total) {
+    return '$count de $total modelos';
+  }
+
+  @override
   String sherpaDeleteModel(String model) {
     return 'Eliminar $model de este dispositivo';
   }
@@ -12854,7 +12862,16 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get sherpaInstalledModelsTitle => 'Modelos instalados';
+
+  @override
   String get sherpaInstallingModel => 'Instalando modelo';
+
+  @override
+  String get sherpaLanguageCantonese => 'Cantonés';
+
+  @override
+  String get sherpaModelCatalogTitle => 'Catálogo de modelos';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12863,6 +12880,9 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get sherpaModelError =>
       'La operación del modelo falló. Inténtalo de nuevo.';
+
+  @override
+  String get sherpaModelFamily => 'Familia de modelos';
 
   @override
   String get sherpaModelInstalled => 'Descargado';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -12886,6 +12886,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Quoi de neuf';
 
   @override
+  String get sherpaAllFamilies => 'Toutes les familles';
+
+  @override
+  String sherpaCatalogMatches(int count, int total) {
+    return '$count sur $total modèles';
+  }
+
+  @override
   String sherpaDeleteModel(String model) {
     return 'Supprimer $model de cet appareil';
   }
@@ -12899,7 +12907,16 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get sherpaInstalledModelsTitle => 'Modèles installés';
+
+  @override
   String get sherpaInstallingModel => 'Installation du modèle';
+
+  @override
+  String get sherpaLanguageCantonese => 'Cantonais';
+
+  @override
+  String get sherpaModelCatalogTitle => 'Catalogue de modèles';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12908,6 +12925,9 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get sherpaModelError =>
       'L’opération sur le modèle a échoué. Réessaie.';
+
+  @override
+  String get sherpaModelFamily => 'Famille de modèles';
 
   @override
   String get sherpaModelInstalled => 'Téléchargé';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -12838,6 +12838,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Che cosa è nuovo';
 
   @override
+  String get sherpaAllFamilies => 'Tutte le famiglie';
+
+  @override
+  String sherpaCatalogMatches(int count, int total) {
+    return '$count di $total modelli';
+  }
+
+  @override
   String sherpaDeleteModel(String model) {
     return 'Rimuovi $model da questo dispositivo';
   }
@@ -12851,7 +12859,16 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get sherpaInstalledModelsTitle => 'Modelli installati';
+
+  @override
   String get sherpaInstallingModel => 'Installazione del modello';
+
+  @override
+  String get sherpaLanguageCantonese => 'Cantonese';
+
+  @override
+  String get sherpaModelCatalogTitle => 'Catalogo dei modelli';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12860,6 +12877,9 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get sherpaModelError =>
       'Operazione sul modello non riuscita. Riprova.';
+
+  @override
+  String get sherpaModelFamily => 'Famiglia di modelli';
 
   @override
   String get sherpaModelInstalled => 'Scaricato';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -12691,6 +12691,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Wat is er nieuw?';
 
   @override
+  String get sherpaAllFamilies => 'Alle families';
+
+  @override
+  String sherpaCatalogMatches(int count, int total) {
+    return '$count van $total modellen';
+  }
+
+  @override
   String sherpaDeleteModel(String model) {
     return '$model van dit apparaat verwijderen';
   }
@@ -12704,7 +12712,16 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get sherpaInstalledModelsTitle => 'Geïnstalleerde modellen';
+
+  @override
   String get sherpaInstallingModel => 'Model installeren';
+
+  @override
+  String get sherpaLanguageCantonese => 'Kantonees';
+
+  @override
+  String get sherpaModelCatalogTitle => 'Modelcatalogus';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12712,6 +12729,9 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get sherpaModelError => 'Modelbewerking mislukt. Probeer het opnieuw.';
+
+  @override
+  String get sherpaModelFamily => 'Modelfamilie';
 
   @override
   String get sherpaModelInstalled => 'Gedownload';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -12785,6 +12785,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Novidades';
 
   @override
+  String get sherpaAllFamilies => 'Todas as famílias';
+
+  @override
+  String sherpaCatalogMatches(int count, int total) {
+    return '$count de $total modelos';
+  }
+
+  @override
   String sherpaDeleteModel(String model) {
     return 'Remover $model deste dispositivo';
   }
@@ -12798,7 +12806,16 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get sherpaInstalledModelsTitle => 'Modelos instalados';
+
+  @override
   String get sherpaInstallingModel => 'Instalando modelo';
+
+  @override
+  String get sherpaLanguageCantonese => 'Cantonês';
+
+  @override
+  String get sherpaModelCatalogTitle => 'Catálogo de modelos';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12807,6 +12824,9 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get sherpaModelError =>
       'A operação do modelo falhou. Tenta novamente.';
+
+  @override
+  String get sherpaModelFamily => 'Família de modelos';
 
   @override
   String get sherpaModelInstalled => 'Descarregado';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -12919,6 +12919,14 @@ class AppLocalizationsRo extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Ce este nou';
 
   @override
+  String get sherpaAllFamilies => 'Toate familiile';
+
+  @override
+  String sherpaCatalogMatches(int count, int total) {
+    return '$count din $total modele';
+  }
+
+  @override
   String sherpaDeleteModel(String model) {
     return 'Eliminați $model de pe acest dispozitiv';
   }
@@ -12932,7 +12940,16 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get sherpaInstalledModelsTitle => 'Modele instalate';
+
+  @override
   String get sherpaInstallingModel => 'Se instalează modelul';
+
+  @override
+  String get sherpaLanguageCantonese => 'Cantoneză';
+
+  @override
+  String get sherpaModelCatalogTitle => 'Catalog de modele';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12941,6 +12958,9 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get sherpaModelError =>
       'Operațiunea asupra modelului a eșuat. Încercați din nou.';
+
+  @override
+  String get sherpaModelFamily => 'Familie de modele';
 
   @override
   String get sherpaModelInstalled => 'Descărcat';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -12684,6 +12684,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String get settingsWhatsNewTitle => 'Vad är nytt';
 
   @override
+  String get sherpaAllFamilies => 'Alla familjer';
+
+  @override
+  String sherpaCatalogMatches(int count, int total) {
+    return '$count av $total modeller';
+  }
+
+  @override
   String sherpaDeleteModel(String model) {
     return 'Ta bort $model från den här enheten';
   }
@@ -12697,7 +12705,16 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get sherpaInstalledModelsTitle => 'Installerade modeller';
+
+  @override
   String get sherpaInstallingModel => 'Installerar modell';
+
+  @override
+  String get sherpaLanguageCantonese => 'Kantonesiska';
+
+  @override
+  String get sherpaModelCatalogTitle => 'Modellkatalog';
 
   @override
   String get sherpaModelConfigurationError =>
@@ -12705,6 +12722,9 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get sherpaModelError => 'Modellåtgärden misslyckades. Försök igen.';
+
+  @override
+  String get sherpaModelFamily => 'Modellfamilj';
 
   @override
   String get sherpaModelInstalled => 'Nedladdad';

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -5517,6 +5517,8 @@
   "settingsV2UnimplementedTitle": "Panel nog niet geïmplementeerd",
   "settingsWhatsNewSubtitle": "Zie de laatste updates en functies",
   "settingsWhatsNewTitle": "Wat is er nieuw?",
+  "sherpaAllFamilies": "Alle families",
+  "sherpaCatalogMatches": "{count} van {total} modellen",
   "sherpaDeleteModel": "{model} van dit apparaat verwijderen",
   "@sherpaDeleteModel": {
     "placeholders": {
@@ -5534,9 +5536,13 @@
       }
     }
   },
+  "sherpaInstalledModelsTitle": "Geïnstalleerde modellen",
   "sherpaInstallingModel": "Model installeren",
+  "sherpaLanguageCantonese": "Kantonees",
+  "sherpaModelCatalogTitle": "Modelcatalogus",
   "sherpaModelConfigurationError": "Het model is gedownload, maar de configuratie kon niet worden opgeslagen.",
   "sherpaModelError": "Modelbewerking mislukt. Probeer het opnieuw.",
+  "sherpaModelFamily": "Modelfamilie",
   "sherpaModelInstalled": "Gedownload",
   "sherpaModelNotInstalled": "Download een model op dit apparaat",
   "sherpaModelSizeGB": "{size} GB · Meertalig",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -5517,6 +5517,8 @@
   "settingsV2UnimplementedTitle": "Painel ainda não implementado",
   "settingsWhatsNewSubtitle": "Veja as últimas atualizações e recursos",
   "settingsWhatsNewTitle": "Novidades",
+  "sherpaAllFamilies": "Todas as famílias",
+  "sherpaCatalogMatches": "{count} de {total} modelos",
   "sherpaDeleteModel": "Remover {model} deste dispositivo",
   "@sherpaDeleteModel": {
     "placeholders": {
@@ -5534,9 +5536,13 @@
       }
     }
   },
+  "sherpaInstalledModelsTitle": "Modelos instalados",
   "sherpaInstallingModel": "Instalando modelo",
+  "sherpaLanguageCantonese": "Cantonês",
+  "sherpaModelCatalogTitle": "Catálogo de modelos",
   "sherpaModelConfigurationError": "O modelo foi descarregado, mas não foi possível guardar a sua configuração.",
   "sherpaModelError": "A operação do modelo falhou. Tenta novamente.",
+  "sherpaModelFamily": "Família de modelos",
   "sherpaModelInstalled": "Descarregado",
   "sherpaModelNotInstalled": "Transfere um modelo para este dispositivo",
   "sherpaModelSizeGB": "{size} GB · Multilíngue",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4982,6 +4982,8 @@
   "settingsV2UnimplementedTitle": "Panoul nu este încă implementat",
   "settingsWhatsNewSubtitle": "Vedeți cele mai recente actualizări și funcționalități",
   "settingsWhatsNewTitle": "Ce este nou",
+  "sherpaAllFamilies": "Toate familiile",
+  "sherpaCatalogMatches": "{count} din {total} modele",
   "sherpaDeleteModel": "Eliminați {model} de pe acest dispozitiv",
   "@sherpaDeleteModel": {
     "placeholders": {
@@ -4999,9 +5001,13 @@
       }
     }
   },
+  "sherpaInstalledModelsTitle": "Modele instalate",
   "sherpaInstallingModel": "Se instalează modelul",
+  "sherpaLanguageCantonese": "Cantoneză",
+  "sherpaModelCatalogTitle": "Catalog de modele",
   "sherpaModelConfigurationError": "Modelul a fost descărcat, dar configurația sa nu a putut fi salvată.",
   "sherpaModelError": "Operațiunea asupra modelului a eșuat. Încercați din nou.",
+  "sherpaModelFamily": "Familie de modele",
   "sherpaModelInstalled": "Descărcat",
   "sherpaModelNotInstalled": "Descărcați un model pe acest dispozitiv",
   "sherpaModelSizeGB": "{size} GB · Multilingv",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -5518,6 +5518,8 @@
   "settingsV2UnimplementedTitle": "Panelen har ännu inte implementerats",
   "settingsWhatsNewSubtitle": "Se de senaste uppdateringarna och funktionerna",
   "settingsWhatsNewTitle": "Vad är nytt",
+  "sherpaAllFamilies": "Alla familjer",
+  "sherpaCatalogMatches": "{count} av {total} modeller",
   "sherpaDeleteModel": "Ta bort {model} från den här enheten",
   "@sherpaDeleteModel": {
     "placeholders": {
@@ -5535,9 +5537,13 @@
       }
     }
   },
+  "sherpaInstalledModelsTitle": "Installerade modeller",
   "sherpaInstallingModel": "Installerar modell",
+  "sherpaLanguageCantonese": "Kantonesiska",
+  "sherpaModelCatalogTitle": "Modellkatalog",
   "sherpaModelConfigurationError": "Modellen har laddats ner, men dess konfiguration kunde inte sparas.",
   "sherpaModelError": "Modellåtgärden misslyckades. Försök igen.",
+  "sherpaModelFamily": "Modellfamilj",
   "sherpaModelInstalled": "Nedladdad",
   "sherpaModelNotInstalled": "Ladda ner en modell på den här enheten",
   "sherpaModelSizeGB": "{size} GB · Flerspråkig",

--- a/test/features/ai/speech/sherpa_installed_models_provider_test.dart
+++ b/test/features/ai/speech/sherpa_installed_models_provider_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/speech/sherpa_installed_models_provider.dart';
 import 'package:lotti/features/ai/speech/sherpa_model_repository.dart';
 import 'package:mocktail/mocktail.dart';
@@ -7,6 +8,59 @@ import 'package:mocktail/mocktail.dart';
 import '../../../mocks/mocks.dart';
 
 void main() {
+  test('saved rows become available only with verified device files', () {
+    final date = DateTime(2026, 3, 15);
+    final providers = [
+      AiConfigInferenceProvider(
+        id: 'embedded',
+        name: 'On device',
+        baseUrl: '',
+        apiKey: '',
+        createdAt: date,
+        inferenceProviderType: InferenceProviderType.sherpa,
+      ),
+      AiConfigInferenceProvider(
+        id: 'http',
+        name: 'Cloud',
+        baseUrl: 'https://example.com',
+        apiKey: '',
+        createdAt: date,
+        inferenceProviderType: InferenceProviderType.openAi,
+      ),
+    ];
+    final models = [
+      for (final (id, providerId, nativeId) in [
+        ('local-tiny', 'embedded', 'tiny'),
+        ('local-medium', 'embedded', 'medium'),
+        ('cloud', 'http', 'tiny'),
+        ('orphan', 'missing', 'tiny'),
+      ])
+        AiConfigModel(
+          id: id,
+          name: id,
+          providerModelId: nativeId,
+          inferenceProviderId: providerId,
+          createdAt: date,
+          inputModalities: [Modality.audio],
+          outputModalities: [Modality.text],
+          isReasoningModel: false,
+        ),
+    ];
+    List<String> available(Set<String> installed) => modelsAvailableOnDevice(
+      models: models,
+      providers: providers,
+      installedSherpaModelIds: installed,
+    ).map((model) => model.id).toList();
+    expect(available({}), ['cloud']);
+    expect(available({'tiny'}), ['local-tiny', 'cloud']);
+    expect(available({'medium'}), ['local-medium', 'cloud']);
+    expect(available({}), ['cloud']);
+    expect(
+      models.map((model) => model.id),
+      containsAll(['local-tiny', 'local-medium']),
+    );
+  });
+
   test(
     'readiness follows verified device files and refreshes after removal',
     () async {

--- a/test/features/ai/speech/sherpa_model_catalog_test.dart
+++ b/test/features/ai/speech/sherpa_model_catalog_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/speech/sherpa_model_catalog.dart';
+import 'package:lotti/features/ai/util/known_models.dart';
+
+void main() {
+  test(
+    'each native artifact role is covered by the pinned download manifest',
+    () {
+      expect(
+        sherpaModels.map((model) => model.id).toSet().length,
+        sherpaModels.length,
+      );
+      for (final model in sherpaModels) {
+        expect(model.revision, matches(RegExp(r'^[a-f0-9]{40}$')));
+        final files = model.files.map((file) => file.name).toSet();
+        expect(files.length, model.files.length);
+        for (final role in model.recognizerFiles.entries) {
+          if (role.key == 'tokenizer') {
+            final required =
+                model.architecture == SherpaModelArchitecture.qwen3Asr
+                ? ['vocab.json', 'merges.txt', 'tokenizer_config.json']
+                : ['vocab.json', 'merges.txt', 'tokenizer.json'];
+            expect(
+              files,
+              containsAll(required.map((name) => '${role.value}/$name')),
+            );
+          } else {
+            expect(
+              files,
+              contains(role.value),
+              reason: '${model.id}: ${role.key}',
+            );
+          }
+        }
+        if (!model.recognizerFiles.containsKey('tokenizer')) {
+          expect(files, contains(model.tokensFile));
+        }
+        for (final file in model.files) {
+          expect(file.bytes, greaterThan(0));
+          expect(file.sha256, matches(RegExp(r'^[a-f0-9]{64}$')));
+          expect(file.name.split('/'), isNot(contains('..')));
+          expect(file.name.startsWith('/'), isFalse);
+          expect(model.uri(file).host, 'huggingface.co');
+          expect(model.uri(file).path, contains('/resolve/${model.revision}/'));
+        }
+      }
+    },
+  );
+
+  test('configurations and downloads use the same catalog identities', () {
+    expect(
+      sherpaSpeechModels.map((model) => model.providerModelId),
+      sherpaModels.map((model) => model.id),
+    );
+    for (final (index, known) in sherpaSpeechModels.indexed) {
+      expect(known.name, sherpaModels[index].name);
+      expect(known.publisher, sherpaModels[index].publisher);
+      expect(known.inputModalities, [Modality.audio]);
+      expect(known.outputModalities, [Modality.text]);
+    }
+  });
+}

--- a/test/features/ai/speech/sherpa_model_repository_test.dart
+++ b/test/features/ai/speech/sherpa_model_repository_test.dart
@@ -59,6 +59,42 @@ void main() {
     return repo;
   }
 
+  test('installs and verifies nested tokenizer artifacts', () async {
+    final model = SherpaModel(
+      id: 'tokenizer-model',
+      name: 'Tokenizer model',
+      revision: 'pinned',
+      repository: 'exporter/model',
+      files: [
+        SherpaModelFile(
+          'tokenizer/vocab.json',
+          data.length,
+          sha256.convert(data).toString(),
+        ),
+      ],
+    );
+    final repo = SherpaModelRepository(
+      client: MockClient((request) async {
+        expect(
+          request.url.path,
+          '/exporter/model/resolve/pinned/tokenizer/vocab.json',
+        );
+        return http.Response.bytes(data, 200);
+      }),
+      supportDirectory: () async => directory,
+      models: [model],
+    );
+    addTearDown(repo.close);
+    final installed = await repo.install(model.id);
+    expect(
+      await File(p.join(installed, 'tokenizer/vocab.json')).readAsBytes(),
+      data,
+    );
+    expect(await repo.isInstalled(model.id), isTrue);
+    await repo.remove(model.id);
+    expect(await repo.isInstalled(model.id), isFalse);
+  });
+
   MockIoFile trackedFile(File file) {
     final tracked = MockIoFile();
     when(() => tracked.path).thenReturn(file.path);

--- a/test/features/ai/speech/sherpa_worker_test.dart
+++ b/test/features/ai/speech/sherpa_worker_test.dart
@@ -4,6 +4,7 @@ import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/speech/sherpa_model_catalog.dart';
 import 'package:lotti/features/ai/speech/sherpa_worker.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:sherpa_onnx/sherpa_onnx.dart' as sherpa;
@@ -31,6 +32,36 @@ Future<void> _failedWorker((SendPort, SherpaWorkerRequest) input) async {
 
 void main() {
   setUpAll(registerAllFallbackValues);
+  for (final model in sherpaModels) {
+    test(
+      '${model.name} wires its verified artifacts to the native recognizer',
+      () {
+        final config = sherpaRecognizerConfig(model, '/models/${model.id}');
+        final json = config.model.toJson();
+        final options =
+            json[model.architecture.configurationKey] as Map<String, dynamic>;
+        for (final role in model.recognizerFiles.entries) {
+          expect(options[role.key], '/models/${model.id}/${role.value}');
+        }
+        if (model.recognizerFiles.containsKey('tokenizer')) {
+          expect(config.model.tokens, isEmpty);
+        } else {
+          expect(
+            config.model.tokens,
+            '/models/${model.id}/${model.tokensFile}',
+          );
+        }
+        if (model.architecture == SherpaModelArchitecture.nemoTransducer) {
+          expect(config.model.modelType, 'nemo_transducer');
+        }
+        if (model.architecture == SherpaModelArchitecture.whisper) {
+          expect(config.model.whisper.task, 'transcribe');
+        }
+        expect(config.model.numThreads, 2);
+      },
+    );
+  }
+
   test(
     'segmentation covers all samples exactly once within the model limit',
     () {

--- a/test/features/ai/ui/inference_profile_form_test.dart
+++ b/test/features/ai/ui/inference_profile_form_test.dart
@@ -23,6 +23,7 @@ import 'package:mocktail/mocktail.dart';
 import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
 import '../../agents/test_utils.dart';
+import '../test_utils.dart' show AiTestDataFactory;
 
 DesignSystemToggle _toggleIn(WidgetTester tester, Finder rowFinder) =>
     tester.widget<DesignSystemToggle>(
@@ -58,9 +59,21 @@ void main() {
   Widget buildSubject({
     AiConfigInferenceProfile? existingProfile,
     List<AiConfig> models = const [],
-    List<AiConfig> providers = const [],
+    List<AiConfig>? providers,
     List<SyncNodeProfile> knownNodes = const [],
   }) {
+    // Normal model fixtures have an owning provider. Tests for missing or
+    // loading providers pass an explicit list instead.
+    final resolvedProviders =
+        providers ??
+        [
+          for (final id
+              in models
+                  .whereType<AiConfigModel>()
+                  .map((model) => model.inferenceProviderId)
+                  .toSet())
+            AiTestDataFactory.createTestProvider(id: id),
+        ];
     when(
       () => mockAiConfigRepository.getConfigsByType(AiConfigType.model),
     ).thenAnswer((_) async => models);
@@ -78,7 +91,7 @@ void main() {
         aiConfigByTypeControllerProvider(
           AiConfigType.inferenceProvider,
         ).overrideWith(() {
-          return _FakeAiConfigByTypeController(providers);
+          return _FakeAiConfigByTypeController(resolvedProviders);
         }),
         // Stub the pinning selector's data sources so the form's existing
         // tests don't need to register a real sync stack.

--- a/test/features/ai/ui/inference_profile_slot_field_test.dart
+++ b/test/features/ai/ui/inference_profile_slot_field_test.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/repository/ai_config_repository.dart';
+import 'package:lotti/features/ai/speech/sherpa_installed_models_provider.dart';
+import 'package:lotti/features/ai/ui/inference_profile_slot_field.dart';
+import 'package:lotti/widgets/settings/settings_picker_field.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../mocks/mocks.dart';
+import '../../../widget_test_utils.dart';
+import '../test_utils.dart' show AiTestDataFactory;
+
+void main() {
+  setUp(setUpTestGetIt);
+  tearDown(tearDownTestGetIt);
+
+  testWidgets(
+    'waits for provider identity and verified files before allowing selection',
+    (tester) async {
+      final configs = MockAiConfigRepository();
+      final providerLoaded = Completer<List<AiConfig>>();
+      final model = AiTestDataFactory.createTestModel(
+        id: 'saved-medium',
+        name: 'Whisper Medium',
+        providerModelId: 'medium',
+        inferenceProviderId: 'sherpa',
+        inputModalities: [Modality.audio],
+      );
+      when(
+        () => configs.watchConfigsByType(AiConfigType.model),
+      ).thenAnswer((_) => Stream.value([model]));
+      when(
+        () => configs.watchConfigsByType(AiConfigType.inferenceProvider),
+      ).thenAnswer((_) => Stream.fromFuture(providerLoaded.future));
+      var installed = <String>{};
+      final selections = <String?>[];
+      await tester.pumpWidget(
+        makeTestableWidget(
+          Material(
+            child: ModelSlotField(
+              label: 'Transcription',
+              modelId: model.id,
+              onModelSelected: selections.add,
+              filter: (model) => model.inputModalities.contains(Modality.audio),
+            ),
+          ),
+          overrides: [
+            aiConfigRepositoryProvider.overrideWithValue(configs),
+            sherpaInstalledModelIdsProvider.overrideWith(
+              (ref) async => installed,
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+      SettingsPickerField field() =>
+          tester.widget<SettingsPickerField>(find.byType(SettingsPickerField));
+      expect(field().valueText, isNot(model.name));
+      field().onTap();
+      await tester.pump();
+      expect(selections, isEmpty);
+      providerLoaded.complete([
+        AiTestDataFactory.createTestProvider(
+          id: 'sherpa',
+          type: InferenceProviderType.sherpa,
+        ),
+      ]);
+      await tester.pump();
+      await tester.pump();
+      expect(field().valueText, isNot(model.name));
+      field().onTap();
+      await tester.pump();
+      expect(selections, isEmpty);
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ModelSlotField)),
+      );
+      installed = {'medium'};
+      container.invalidate(sherpaInstalledModelIdsProvider);
+      await tester.pump();
+      await tester.pump();
+      expect(field().valueText, model.name);
+      field().onTap();
+      await tester.pump();
+      expect(selections, [model.id]);
+      installed = {};
+      container.invalidate(sherpaInstalledModelIdsProvider);
+      await tester.pump();
+      await tester.pump();
+      expect(field().valueText, isNot(model.name));
+      expect(
+        tester.widget<ModelSlotField>(find.byType(ModelSlotField)).modelId,
+        model.id,
+      );
+    },
+  );
+}

--- a/test/features/ai/ui/settings/ai_settings_page_test.dart
+++ b/test/features/ai/ui/settings/ai_settings_page_test.dart
@@ -295,6 +295,54 @@ void main() {
     },
   );
 
+  testWidgets('Models tab lists only sherpa models verified on this device', (
+    tester,
+  ) async {
+    var installed = <String>{};
+    await pumpWith(
+      tester: tester,
+      providers: [
+        buildProvider(
+          id: 'embedded',
+          type: InferenceProviderType.sherpa,
+          apiKey: '',
+          baseUrl: '',
+        ),
+      ],
+      models: [
+        buildModel(
+          id: 'medium-model',
+          providerId: 'embedded',
+          providerModelId: 'medium',
+        ),
+      ],
+      profiles: [],
+      initialTab: AiSettingsTab.models,
+      additionalOverrides: [
+        sherpaInstalledModelIdsProvider.overrideWith((ref) async => installed),
+      ],
+    );
+    await tester.pump();
+    expect(find.byType(AiModelCard), findsNothing);
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(AiSettingsPage)),
+    );
+    installed = {'medium'};
+    container.invalidate(sherpaInstalledModelIdsProvider);
+    await tester.pump();
+    await tester.pump();
+    expect(
+      tester.widget<AiModelCard>(find.byType(AiModelCard)).model.id,
+      'medium-model',
+    );
+    installed = {};
+    container.invalidate(sherpaInstalledModelIdsProvider);
+    await tester.pump();
+    await tester.pump();
+    expect(find.byType(AiModelCard), findsNothing);
+    await settleTimers(tester);
+  });
+
   group('AiSettingsPage — empty state', () {
     testWidgets(
       'renders the FTUE banner + the No-providers card with four quick-add '

--- a/test/features/ai/ui/settings/provider/ai_provider_detail_widgets_test.dart
+++ b/test/features/ai/ui/settings/provider/ai_provider_detail_widgets_test.dart
@@ -5,6 +5,8 @@ import 'package:lotti/features/ai/speech/sherpa_installed_models_provider.dart';
 import 'package:lotti/features/ai/speech/sherpa_model_repository.dart';
 import 'package:lotti/features/ai/ui/settings/provider/ai_provider_detail_widgets.dart';
 import 'package:lotti/features/ai/ui/settings/widgets/sherpa_models_section.dart';
+import 'package:lotti/features/ai/ui/settings/widgets/v2/ai_model_card.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../../mocks/mocks.dart';
@@ -40,17 +42,19 @@ void main() {
       );
       await tester.pumpWidget(
         makeTestableWidgetNoScroll(
-          DetailBody(
-            provider: provider,
-            models: [model],
-            allModels: [model],
-            profilesUsingProvider: const [],
-            onAddModel: () {},
-            onEdit: () {},
-            onModelTap: (_) {},
-            onDeleteModel: (_) {},
-            onProfileTap: (_) {},
-            onRemove: () {},
+          Material(
+            child: DetailBody(
+              provider: provider,
+              models: [model],
+              allModels: [model],
+              profilesUsingProvider: const [],
+              onAddModel: () {},
+              onEdit: () {},
+              onModelTap: (_) {},
+              onDeleteModel: (_) {},
+              onProfileTap: (_) {},
+              onRemove: () {},
+            ),
           ),
           overrides: [
             sherpaModelRepositoryProvider.overrideWithValue(models),
@@ -65,8 +69,9 @@ void main() {
         find.byType(SherpaModelsSection, skipOffstage: false),
         findsOneWidget,
       );
-      expect(find.text('Download a model on this device'), findsOneWidget);
+      expect(find.text('Download a model on this device'), findsNWidgets(2));
       expect(find.text('1 model'), findsNothing);
+      expect(find.byType(AiModelCard), findsNothing);
       final container = ProviderScope.containerOf(
         tester.element(find.byType(DetailBody)),
       );
@@ -74,11 +79,14 @@ void main() {
       container.invalidate(sherpaInstalledModelIdsProvider);
       await tester.pumpAndSettle();
       expect(find.text('1 model'), findsOneWidget);
+      final card = tester.widget<AiModelCard>(find.byType(AiModelCard));
+      expect(card.model.id, model.id);
+      expect(card.onDelete, isNull);
       expect(find.text('Download a model on this device'), findsNothing);
       installed = {};
       container.invalidate(sherpaInstalledModelIdsProvider);
       await tester.pumpAndSettle();
-      expect(find.text('Download a model on this device'), findsOneWidget);
+      expect(find.text('Download a model on this device'), findsNWidgets(2));
       expect(find.text('1 model'), findsNothing);
     },
   );

--- a/test/features/ai/ui/settings/widgets/sherpa_models_section_test.dart
+++ b/test/features/ai/ui/settings/widgets/sherpa_models_section_test.dart
@@ -1,12 +1,16 @@
 import 'dart:async';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
+import 'package:lotti/features/ai/speech/sherpa_installed_models_provider.dart';
 import 'package:lotti/features/ai/speech/sherpa_model_repository.dart';
+import 'package:lotti/features/ai/ui/settings/widgets/ai_settings_search_bar.dart';
 import 'package:lotti/features/ai/ui/settings/widgets/sherpa_models_section.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_icon_action.dart';
+import 'package:lotti/features/design_system/components/dropdowns/design_system_dropdown.dart';
 import 'package:lotti/features/design_system/components/progress_bars/design_system_progress_bar.dart';
 import 'package:lotti/features/sync/services/sync_node_profile_broadcaster.dart';
 import 'package:lotti/get_it.dart';
@@ -33,6 +37,10 @@ void main() {
     getIt.registerSingleton<SyncNodeProfileBroadcaster>(broadcaster);
     models = MockSherpaModelRepository();
     configs = MockAiConfigRepository();
+    when(() => models.models).thenReturn(sherpaModels);
+    when(() => models.isAvailable(any())).thenAnswer(
+      (call) => models.isInstalled(call.positionalArguments.single as String),
+    );
     when(() => models.isInstalled(any())).thenAnswer((_) async => false);
     when(
       () => configs.getConfigsByType(AiConfigType.model),
@@ -55,7 +63,9 @@ void main() {
       makeTestableWidget(
         MediaQuery(
           data: MediaQueryData(textScaler: TextScaler.linear(textScale)),
-          child: const SherpaModelsSection(providerId: 'sherpa-provider'),
+          child: const Material(
+            child: SherpaModelsSection(providerId: 'sherpa-provider'),
+          ),
         ),
         locale: locale,
         overrides: [
@@ -67,31 +77,196 @@ void main() {
     await tester.pump();
   }
 
+  testWidgets('searches catalog and clears a query with no matches', (
+    tester,
+  ) async {
+    await pump(tester);
+    final search = find.byType(AiSettingsSearchBar);
+    await tester.enterText(
+      find.descendant(of: search, matching: find.byType(TextField)),
+      '  MEDIUM  ',
+    );
+    await tester.pump();
+    expect(downloadFor('medium'), findsOneWidget);
+    expect(downloadFor('tiny'), findsNothing);
+    await tester.enterText(
+      find.descendant(of: search, matching: find.byType(TextField)),
+      'unmatched-model',
+    );
+    await tester.pump();
+    expect(downloadFor('medium'), findsNothing);
+    expect(find.text('No matches'), findsOneWidget);
+    tester.widget<AiSettingsSearchBar>(search).onClear!();
+    await tester.pump();
+    expect(downloadFor('tiny'), findsOneWidget);
+  });
+
   testWidgets(
-    'downloads Whisper Large v3 and saves a selectable speech model',
-    (
-      tester,
-    ) async {
-      when(
-        () => models.install('large-v3', onProgress: any(named: 'onProgress')),
-      ).thenAnswer((_) async => '/large-model');
+    'family filter and search narrow the multilingual catalog together',
+    (tester) async {
       await pump(tester);
-      final download = downloadFor('large-v3');
-      await tester.ensureVisible(download);
-      await tester.tap(download);
+      final dropdown = find.byKey(const ValueKey('sherpa-model-family'));
+      await tester.ensureVisible(dropdown);
+      await tester.tap(find.text('All families'));
+      await tester.pump();
+      final option = find.text('Paraformer');
+      await tester.ensureVisible(option);
+      await tester.tap(option);
+      await tester.pump();
+      expect(downloadFor('paraformer-bilingual'), findsOneWidget);
+      expect(downloadFor('paraformer-trilingual'), findsOneWidget);
+      expect(downloadFor('medium'), findsNothing);
+      final search = find.byType(AiSettingsSearchBar);
+      await tester.ensureVisible(search);
+      await tester.enterText(
+        find.descendant(of: search, matching: find.byType(TextField)),
+        'Cantonese',
+      );
+      await tester.pump();
+      expect(downloadFor('paraformer-bilingual'), findsNothing);
+      expect(downloadFor('paraformer-trilingual'), findsOneWidget);
+      tester.widget<AiSettingsSearchBar>(search).onClear!();
+      await tester.pump();
+      expect(downloadFor('paraformer-bilingual'), findsOneWidget);
+      tester.widget<DesignSystemDropdown>(dropdown).onItemPressed!(
+        const DesignSystemDropdownItem(id: '', label: 'All families'),
+      );
+      await tester.pump();
+      expect(downloadFor('medium'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'adds already installed files to a new provider without downloading',
+    (tester) async {
+      when(() => models.isInstalled('tiny')).thenAnswer((_) async => true);
+      await pump(tester);
+      final row = find.byKey(const ValueKey('sherpa-model-tiny'));
+      final add = find.descendant(
+        of: row,
+        matching: find.widgetWithText(DesignSystemButton, 'Add model'),
+      );
+      await tester.ensureVisible(add);
+      await tester.tap(add);
       await tester.pumpAndSettle();
       final saved =
           verify(() => configs.saveConfig(captureAny())).captured.single
               as AiConfigModel;
-      expect(saved.providerModelId, 'large-v3');
-      expect(saved.name, 'Whisper Large v3');
+      expect(saved.providerModelId, 'tiny');
       expect(saved.inferenceProviderId, 'sherpa-provider');
-      expect(saved.inputModalities, [Modality.audio]);
-      expect(saved.outputModalities, [Modality.text]);
-      expect(find.text('Downloaded'), findsOneWidget);
-      expect(download, findsNothing);
+      verifyNever(
+        () => models.install(any(), onProgress: any(named: 'onProgress')),
+      );
+      expect(add, findsNothing);
     },
   );
+
+  testWidgets('keeps an active download alive across catalog searches', (
+    tester,
+  ) async {
+    final finished = Completer<String>();
+    late void Function(double) progress;
+    when(
+      () => models.install('tiny', onProgress: any(named: 'onProgress')),
+    ).thenAnswer((call) {
+      progress = call.namedArguments[#onProgress] as void Function(double);
+      return finished.future;
+    });
+    await pump(tester);
+    await tester.ensureVisible(downloadFor('tiny'));
+    await tester.tap(downloadFor('tiny'));
+    await tester.pump();
+    final search = find.byType(AiSettingsSearchBar);
+    await tester.ensureVisible(search);
+    await tester.enterText(
+      find.descendant(of: search, matching: find.byType(TextField)),
+      'medium',
+    );
+    progress(0.6);
+    await tester.pump();
+    expect(find.text('60%'), findsOneWidget);
+    expect(downloadFor('base'), findsNothing);
+    finished.complete('/model');
+    await tester.pumpAndSettle();
+    tester.widget<AiSettingsSearchBar>(search).onClear!();
+    await tester.pump();
+    final row = find.byKey(const ValueKey('sherpa-model-tiny'));
+    expect(
+      find.descendant(of: row, matching: find.text('Downloaded')),
+      findsOneWidget,
+    );
+    expect(downloadFor('tiny'), findsNothing);
+    verify(
+      () => models.install('tiny', onProgress: any(named: 'onProgress')),
+    ).called(1);
+    final saved =
+        verify(() => configs.saveConfig(captureAny())).captured.single
+            as AiConfigModel;
+    expect(saved.providerModelId, 'tiny');
+  });
+
+  testWidgets('refreshes installed state after changes from another surface', (
+    tester,
+  ) async {
+    var installed = false;
+    when(() => models.isInstalled('tiny')).thenAnswer((_) async => installed);
+    await pump(tester);
+    await tester.pumpAndSettle();
+    expect(downloadFor('tiny'), findsOneWidget);
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(SherpaModelsSection)),
+    );
+    installed = true;
+    container.invalidate(sherpaInstalledModelIdsProvider);
+    await tester.pumpAndSettle();
+    expect(downloadFor('tiny'), findsNothing);
+    final row = find.byKey(const ValueKey('sherpa-model-tiny'));
+    expect(
+      find.descendant(of: row, matching: find.text('Downloaded')),
+      findsOneWidget,
+    );
+    installed = false;
+    container.invalidate(sherpaInstalledModelIdsProvider);
+    await tester.pumpAndSettle();
+    expect(downloadFor('tiny'), findsOneWidget);
+    expect(
+      find.descendant(of: row, matching: find.text('Downloaded')),
+      findsNothing,
+    );
+  });
+
+  for (final (id, name) in [
+    ('large-v3', 'Whisper Large v3'),
+    ('small', 'Whisper Small'),
+    ('medium', 'Whisper Medium'),
+    ('turbo', 'Whisper Large v3 Turbo'),
+  ]) {
+    testWidgets(
+      'downloads $name and saves a selectable speech model',
+      (
+        tester,
+      ) async {
+        when(
+          () => models.install(id, onProgress: any(named: 'onProgress')),
+        ).thenAnswer((_) async => '/large-model');
+        await pump(tester);
+        final download = downloadFor(id);
+        await tester.ensureVisible(download);
+        await tester.tap(download);
+        await tester.pumpAndSettle();
+        final saved =
+            verify(() => configs.saveConfig(captureAny())).captured.single
+                as AiConfigModel;
+        expect(saved.providerModelId, id);
+        expect(saved.name, name);
+        expect(saved.inferenceProviderId, 'sherpa-provider');
+        expect(saved.inputModalities, [Modality.audio]);
+        expect(saved.outputModalities, [Modality.text]);
+        expect(find.text('Downloaded'), findsOneWidget);
+        expect(download, findsNothing);
+      },
+    );
+  }
 
   testWidgets(
     'downloads only on request and creates a usable model row on success',
@@ -107,6 +282,7 @@ void main() {
       verifyNever(
         () => models.install(any(), onProgress: any(named: 'onProgress')),
       );
+      await tester.ensureVisible(downloadFor('tiny'));
       await tester.tap(downloadFor('tiny'));
       await tester.pump();
       verifyNever(() => configs.saveConfig(any()));
@@ -141,6 +317,7 @@ void main() {
         () => models.install('tiny', onProgress: any(named: 'onProgress')),
       ).thenThrow(StateError('failed'));
       await pump(tester);
+      await tester.ensureVisible(downloadFor('tiny'));
       await tester.tap(downloadFor('tiny'));
       await tester.pumpAndSettle();
       expect(find.text('Model operation failed. Try again.'), findsOneWidget);
@@ -155,6 +332,7 @@ void main() {
       when(() => models.isInstalled('tiny')).thenAnswer((_) async => true);
       when(() => models.remove('tiny')).thenAnswer((_) async {});
       await pump(tester);
+      await tester.ensureVisible(find.byType(DesignSystemIconAction));
       await tester.tap(find.byType(DesignSystemIconAction));
       await tester.pumpAndSettle();
       verify(() => models.remove('tiny')).called(1);
@@ -171,6 +349,7 @@ void main() {
       when(() => models.isInstalled('tiny')).thenAnswer((_) async => true);
       when(() => models.remove('tiny')).thenThrow(StateError('busy'));
       await pump(tester);
+      await tester.ensureVisible(find.byType(DesignSystemIconAction));
       await tester.tap(find.byType(DesignSystemIconAction));
       await tester.pumpAndSettle();
       expect(find.text('Downloaded'), findsOneWidget);
@@ -200,6 +379,7 @@ void main() {
         }
         when(() => models.remove('tiny')).thenAnswer((_) async {});
         await pump(tester);
+        await tester.ensureVisible(downloadFor('tiny'));
         await tester.tap(downloadFor('tiny'));
         await tester.pumpAndSettle();
         expect(find.text('Downloaded'), findsOneWidget);
@@ -212,6 +392,7 @@ void main() {
           findsOneWidget,
         );
         verify(() => broadcaster.broadcastIfChanged()).called(1);
+        await tester.ensureVisible(find.byType(DesignSystemIconAction));
         await tester.tap(find.byType(DesignSystemIconAction));
         await tester.pumpAndSettle();
         verify(() => models.remove('tiny')).called(1);
@@ -236,6 +417,7 @@ void main() {
         () => configs.saveConfig(any()),
       ).thenThrow(StateError('database busy'));
       await pump(tester);
+      await tester.ensureVisible(downloadFor('tiny'));
       await tester.tap(downloadFor('tiny'));
       await tester.pumpAndSettle();
       expect(
@@ -248,6 +430,7 @@ void main() {
       when(
         () => configs.saveConfig(any()),
       ).thenAnswer((_) => retryFinished.future);
+      await tester.ensureVisible(find.text('Retry'));
       await tester.tap(find.text('Retry'));
       await tester.pump();
       expect(
@@ -289,12 +472,15 @@ void main() {
     ).thenThrow(StateError('database busy'));
     when(() => models.remove('tiny')).thenThrow(StateError('file busy'));
     await pump(tester);
+    await tester.ensureVisible(downloadFor('tiny'));
     await tester.tap(downloadFor('tiny'));
     await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byType(DesignSystemIconAction));
     await tester.tap(find.byType(DesignSystemIconAction));
     await tester.pumpAndSettle();
     expect(find.text('Retry'), findsOneWidget);
     when(() => configs.saveConfig(any())).thenAnswer((_) async {});
+    await tester.ensureVisible(find.text('Retry'));
     await tester.tap(find.text('Retry'));
     await tester.pumpAndSettle();
     expect(
@@ -315,6 +501,7 @@ void main() {
     when(() => models.remove('tiny')).thenAnswer((_) => removed.future);
     await pump(tester);
     final action = find.byType(DesignSystemIconAction);
+    await tester.ensureVisible(action);
     await tester.tap(action);
     await tester.pump();
     expect(tester.widget<DesignSystemIconAction>(action).isBusy, isTrue);
@@ -344,7 +531,10 @@ void main() {
       expect(actionRect.width, lessThan(rowRect.width));
       expect(actionRect.left, greaterThanOrEqualTo(rowRect.left));
       expect(actionRect.right, lessThanOrEqualTo(rowRect.right));
-      expect(find.text('1,78 GB · Mehrsprachig'), findsOneWidget);
+      expect(
+        find.descendant(of: row, matching: find.text('1,78 GB · Mehrsprachig')),
+        findsOneWidget,
+      );
       expect(tester.takeException(), isNull);
       final semantics = tester.ensureSemantics();
       try {
@@ -361,7 +551,10 @@ void main() {
       await tester.ensureVisible(action);
       await tester.tap(action);
       await tester.pumpAndSettle();
-      expect(find.text('1,78 GB · Mehrsprachig'), findsOneWidget);
+      expect(
+        find.descendant(of: row, matching: find.text('1,78 GB · Mehrsprachig')),
+        findsOneWidget,
+      );
       verify(
         () => models.install('large-v3', onProgress: any(named: 'onProgress')),
       ).called(1);
@@ -388,6 +581,7 @@ void main() {
       () => configs.getConfigsByType(AiConfigType.model),
     ).thenAnswer((_) async => [existing]);
     await pump(tester);
+    await tester.ensureVisible(downloadFor('tiny'));
     await tester.tap(downloadFor('tiny'));
     await tester.pumpAndSettle();
     verifyNever(() => configs.saveConfig(any()));
@@ -404,6 +598,7 @@ void main() {
       () => models.install('tiny', onProgress: any(named: 'onProgress')),
     ).thenAnswer((_) async => '/model');
     await pump(tester);
+    await tester.ensureVisible(downloadFor('tiny'));
     await tester.tap(downloadFor('tiny'));
     await tester.pumpAndSettle();
     expect(find.text('Downloaded'), findsOneWidget);

--- a/test/features/ai/ui/settings/widgets/sherpa_models_section_test.dart
+++ b/test/features/ai/ui/settings/widgets/sherpa_models_section_test.dart
@@ -161,6 +161,68 @@ void main() {
     },
   );
 
+  for (final readFails in [false, true]) {
+    testWidgets(
+      'restores installed configuration after read failure: $readFails',
+      (tester) async {
+        when(() => models.isInstalled('tiny')).thenAnswer((_) async => true);
+        final existing = AiConfig.model(
+          id: 'existing-tiny',
+          name: 'Whisper Tiny',
+          providerModelId: 'tiny',
+          inferenceProviderId: 'sherpa-provider',
+          createdAt: DateTime.utc(2026),
+          inputModalities: [Modality.audio],
+          outputModalities: [Modality.text],
+          isReasoningModel: false,
+        );
+        if (readFails) {
+          when(
+            () => configs.getConfigsByType(AiConfigType.model),
+          ).thenThrow(StateError('read failed'));
+        } else {
+          when(
+            () => configs.getConfigsByType(AiConfigType.model),
+          ).thenAnswer((_) async => [existing]);
+        }
+        await pump(tester);
+        final row = find.byKey(const ValueKey('sherpa-model-tiny'));
+        expect(
+          find.descendant(of: row, matching: find.text('Downloaded')),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(of: row, matching: find.text('Add model')),
+          findsNothing,
+        );
+        if (readFails) {
+          final retry = find.descendant(
+            of: row,
+            matching: find.widgetWithText(DesignSystemButton, 'Retry'),
+          );
+          expect(retry, findsOneWidget);
+          when(
+            () => configs.getConfigsByType(AiConfigType.model),
+          ).thenAnswer((_) async => [existing]);
+          await tester.ensureVisible(retry);
+          await tester.tap(retry);
+          await tester.pumpAndSettle();
+          expect(retry, findsNothing);
+          expect(
+            find.text(
+              'Model downloaded, but its configuration could not be saved.',
+            ),
+            findsNothing,
+          );
+        }
+        verifyNever(() => configs.saveConfig(any()));
+        verifyNever(
+          () => models.install(any(), onProgress: any(named: 'onProgress')),
+        );
+      },
+    );
+  }
+
   testWidgets('keeps an active download alive across catalog searches', (
     tester,
   ) async {

--- a/test/features/ai/ui/unified_ai_skills_modal_test.dart
+++ b/test/features/ai/ui/unified_ai_skills_modal_test.dart
@@ -15,6 +15,7 @@ import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/resolved_profile.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart'
     show AiConfigRepository;
+import 'package:lotti/features/ai/speech/sherpa_installed_models_provider.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/state/profile_automation_providers.dart';
 import 'package:lotti/features/ai/state/reference_image_selection_controller.dart';
@@ -1692,6 +1693,50 @@ void main() {
         });
       });
     }
+
+    testWidgets('transcription dispatch excludes undownloaded sherpa models', (
+      tester,
+    ) async {
+      final fx = _OverrideFixture.twoModelsPlusDecoy(
+        _transcriptionOverrideVariant,
+      );
+      final provider = fx.providers.single.copyWith(
+        inferenceProviderType: InferenceProviderType.sherpa,
+      );
+      TriggerSkillParams? captured;
+      await tester.pumpWidget(
+        buildTestWidget(
+          UnifiedAiPopUpMenu(journalEntity: fx.entity, linkedFromId: null),
+          overrides: [
+            ..._baseOverrides(
+              entity: fx.entity,
+              skill: fx.skill,
+              models: fx.allModels,
+              resolver: _NullProfileResolver(),
+              configs: [...fx.allModels, provider],
+            ),
+            sherpaInstalledModelIdsProvider.overrideWith(
+              (ref) async => {fx.modelB.providerModelId},
+            ),
+            triggerSkillProvider.overrideWith((ref, params) async {
+              captured = params;
+            }),
+          ],
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.byIcon(LottiIcons.assistant));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text(_transcriptionOverrideVariant.skillName));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(captured, isNotNull);
+      expect(captured!.overrideModelId, fx.modelB.id);
+      expect(captured!.skillId, fx.skill.id);
+      expect(find.text(fx.modelA.name), findsNothing);
+    });
 
     testWidgets(
       'multi-provider override: drilling provider -> model fires the trigger '

--- a/test/features/ai/util/model_prepopulation_service_test.dart
+++ b/test/features/ai/util/model_prepopulation_service_test.dart
@@ -50,6 +50,20 @@ void main() {
     }
 
     group('prepopulateModelsForProvider', () {
+      test('does not seed downloadable sherpa catalog entries', () async {
+        final provider = AiConfigInferenceProvider(
+          id: 'sherpa-provider',
+          baseUrl: '',
+          apiKey: '',
+          name: 'On device',
+          createdAt: DateTime(2026, 3, 15),
+          inferenceProviderType: InferenceProviderType.sherpa,
+        );
+        stubRepo(providers: [provider]);
+        expect(await service.prepopulateModelsForProvider(provider), 0);
+        verifyNever(() => mockRepository.saveConfig(any()));
+      });
+
       test(
         'backfills Qwen as a selectable Melious task-agent model',
         () async {

--- a/test/features/ai/util/model_prepopulation_service_test_helpers.dart
+++ b/test/features/ai/util/model_prepopulation_service_test_helpers.dart
@@ -64,7 +64,9 @@ class GeneratedPrepopulationScenario {
 
   List<KnownModel> get modelsToCreate => [
     for (var i = 0; i < knownModels.length; i++)
-      if (!existingKnownModelIndexes.contains(i)) knownModels[i],
+      if (providerType != InferenceProviderType.sherpa &&
+          !existingKnownModelIndexes.contains(i))
+        knownModels[i],
   ];
 
   List<String> get expectedCreatedIds => [


### PR DESCRIPTION
Expands the on-device speech catalog from three Whisper downloads to 22 multilingual models across ten families, with shared search, family filtering, and compact download controls. Follow-up to #4180.

Saved or synced model configuration no longer implies installation. Sherpa setup/backfill does not pre-create catalog entries; settings, profile slots, and invocation candidates require verified files on this device. Provider identity must resolve first, so loading order cannot briefly expose an unavailable model. Existing profile references survive removal. Already-downloaded files can be associated with a provider without downloading again.

The catalog now owns both pinned download manifests and recognizer artifact mappings. It includes Whisper Tiny/Base/Small/Medium/Large v1/v2/v3/Turbo, Parakeet TDT v3, SenseVoice, Dolphin Base/Small, three Omnilingual variants, FireRed ASR2/CTC, two Paraformer exports, WeNet, Qwen3 ASR, and FunASR Nano. Single-language exports are excluded. Canary and Cohere remain outside this automatic-recognition adapter because they require explicit spoken-language configuration.

Validation:
- 315 targeted tests passed through Dart MCP; regression checks were also run with their fixes reverted.
- Native Linux transcription succeeded with Whisper Small/Medium/Turbo and a representative model for every newly supported recognizer architecture, using public audio fixtures and verified model artifacts.
- Analyzer, knowledge/Mermaid validation, and changelog checks passed.
- Visual, UX, and state panels approved the catalog, long-name layouts, filtered/empty states, download recovery, and installation gating.


Screenshots (shared synthetic fixtures):

| Surface | Before | After |
| --- | --- | --- |
| Catalog | ![Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/sherpa-asr-catalog/b607371e2d90f56a9980ec1ed7ab56ec59f49b13/before/models_phone_dark.png) | ![After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/sherpa-asr-catalog/b607371e2d90f56a9980ec1ed7ab56ec59f49b13/after/models_phone_dark.png) |
| Installed models | ![Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/sherpa-asr-catalog/b607371e2d90f56a9980ec1ed7ab56ec59f49b13/before/provider_phone_dark.png) | ![After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/sherpa-asr-catalog/b607371e2d90f56a9980ec1ed7ab56ec59f49b13/after/provider_phone_dark.png) |

<details><summary>Desktop and light appearance</summary>

| Surface | Before | After |
| --- | --- | --- |
| models_desktop_dark | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/sherpa-asr-catalog/b607371e2d90f56a9980ec1ed7ab56ec59f49b13/before/models_desktop_dark.png) | [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/sherpa-asr-catalog/b607371e2d90f56a9980ec1ed7ab56ec59f49b13/after/models_desktop_dark.png) |
| models_desktop_light | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/sherpa-asr-catalog/b607371e2d90f56a9980ec1ed7ab56ec59f49b13/before/models_desktop_light.png) | [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/sherpa-asr-catalog/b607371e2d90f56a9980ec1ed7ab56ec59f49b13/after/models_desktop_light.png) |
| models_phone_light | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/sherpa-asr-catalog/b607371e2d90f56a9980ec1ed7ab56ec59f49b13/before/models_phone_light.png) | [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/sherpa-asr-catalog/b607371e2d90f56a9980ec1ed7ab56ec59f49b13/after/models_phone_light.png) |
| provider_desktop_dark | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/sherpa-asr-catalog/b607371e2d90f56a9980ec1ed7ab56ec59f49b13/before/provider_desktop_dark.png) | [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/sherpa-asr-catalog/b607371e2d90f56a9980ec1ed7ab56ec59f49b13/after/provider_desktop_dark.png) |

</details>
