### PR TITLE
feat: add relationship task suggestions to cards and chat

### DIFF
--- a/changelog.d/2026-09-06-relationship-task-suggestions.md
+++ b/changelog.d/2026-09-06-relationship-task-suggestions.md
@@ -1,0 +1,6 @@
+### Added
+- **Turn check-in commitments into linked tasks.** Your relationship agent can
+  suggest tasks on a person's card and in chat, with the source check-in and any
+  proposed due date visible before confirmation. Review suggestions individually
+  or together, see their history, and undo task creation while the task is still
+  unchanged.

--- a/docs/evaluations/relationship_agent_models/README.md
+++ b/docs/evaluations/relationship_agent_models/README.md
@@ -19,7 +19,7 @@ staleness cost, and that is the cheaper of the two.
 
 ## What is measured
 
-Six scenario families, one catalog
+Seven scenario families, one catalog
 (`relationship_agent_eval_scenarios.dart`, ids in parentheses):
 
 1. **Restraint** — the no-op wakes (`qt_*`): nothing changed → zero tool
@@ -45,8 +45,12 @@ Six scenario families, one catalog
    structurally absent from FACTS (ADR 0041 §5), and the model says so
    instead of inventing a number.
 
+7. **Task proposals** (`pr_*`) — explicit captured commitments produce deferred
+   tasks with structured check-in evidence; contact channels do not create
+   tasks, rejected commitments are not repeated, and a wake queues at most three.
+
 Every expectation derives from the policy matrix
-`relationshipAgentPolicyMatrix` (R1–R17) in the spec file — the single
+`relationshipAgentPolicyMatrix` (R1–R21) in the spec file — the single
 source of truth. The offline self-test enforces that every policy row has
 a scenario.
 
@@ -55,7 +59,7 @@ a scenario.
 The goal suite's tier 1 stated its own headline limitation: authored FACTS
 blocks that can drift from what the runtime actually sends. This suite
 closes that from day one — every scenario's world (relationship,
-check-ins, linked tasks, previous briefing, banners) is rendered through
+check-ins, linked tasks, previous briefing, banners, proposal ledger) is rendered through
 the REAL `RelationshipFactsRenderer` over a cadence derivation from the
 REAL `RelationshipAgentPhaseA.deriveCadenceFacts`, and the wake message is
 composed with the workflow's own suffixes. A renderer change moves the
@@ -68,7 +72,7 @@ The classifier mirrors `RelationshipAgentStrategy` exactly — every shape
 rule it enforces is one the runtime rejects in-conversation (band enum,
 required briefing fields, banner tone/animation catalogs, the
 explicit-offset snooze instant, the active-adId allow-list, one reply and
-one banner per wake), and where the runtime is lenient the classifier is
+one banner per wake, evidence IDs and the three-task limit), and where the runtime is lenient the classifier is
 too (an unknown accent defaults to `calm`). Stricter than the code under
 test is the same defect as looser: both measure the harness.
 
@@ -106,7 +110,7 @@ fvm flutter test test/features/agents/eval/relationship/ \
 
 One sample is not a measurement. The goal suite measured its own noise
 floor over five identical runs — total range 10, sd 3.7 per 250 cases — so a
-single pass over this suite's 24 cases cannot separate a real regression
+single pass over this suite's cases cannot separate a real regression
 from a redraw. Use the matrix runner, which drives N samples per model as
 separate processes (GetIt is a global, so two runs cannot share a Dart VM)
 and merges the artifacts into one report:
@@ -145,6 +149,10 @@ these are thinking models, and a tiny budget makes a *working* model
 return empty content with `finish_reason: length`, indistinguishable from
 a broken one. A 401 is an authentication failure (missing, invalid or
 expired key), never throttling — that arrives as a 429.
+
+The task-proposal policy rows were added after the historical live reports
+below. Offline tests cover their classifier and production contract; these
+changes have not yet been measured in a new live model matrix.
 
 ## Cost (observed, not a target)
 

--- a/docs/implementation_plans/2026-09-06_people_redesign.md
+++ b/docs/implementation_plans/2026-09-06_people_redesign.md
@@ -61,9 +61,9 @@ People list gains grouping, a summary card and truthful pills.
   Call).
 - Left out, on purpose: the *Automatic updates* switch (the relationship runtime does
   not read the flag, so the switch would lie), *Cancel* on a running wake (no cancel
-  API exists for a running wake), and the suggestions band — the generic change-set
-  ledger is keyed by task and nothing produces relationship proposals yet; it comes
-  with the agent tools (schedule a call, create a task), a separate project.
+  API exists for a running wake), and the suggestions band, delivered separately with its producer. Task proposals
+  now use the generic ledger scoped to a relationship; see
+  [the relationship concept](../../knowledge/features/relationships.md#deferred-task-suggestions).
 
 ### D · Check-in capture with duration
 - Order: how it felt → what you talked about (+ Speak instead) → when and how long
@@ -101,5 +101,6 @@ fragment, before/after captures from the handover recipe (`capture/` in the hand
 folder), README and knowledge concept kept in step.
 
 ## Out of this plan
-The suggestion-producing agent tools (S1 schedule a call onto the day plan, S2 create
-and link a task, S3 add to a task) and the `tint-*` design tokens.
+S1 (schedule a call onto the day plan), S3 (add to a task), and the `tint-*`
+design tokens remain out of this redesign. S2 (create and link a task) and its
+card/chat proposal surfaces are documented in the relationship concept.

--- a/knowledge/features/agents/ui-surfaces.md
+++ b/knowledge/features/agents/ui-surfaces.md
@@ -623,3 +623,11 @@ lookahead stay out of the inline sidebar and remain on the full page; additional
 in-window wakes collapse into the overflow row rather than turning the navigation
 rail into a wake manager. The collapsed icon-only sidebar suppresses the slot
 entirely.
+
+The shared proposal sections accept host row builders, and `ProposalRow` accepts
+optional confirmation/rejection callbacks and a details slot. Hosts without
+callbacks retain the task confirmation service. Relationship card/chat hosts
+supply their own scoped service and evidence/history details; see
+[deferred relationship suggestions](../relationships.md#deferred-task-suggestions).
+The kind resolver recognizes `create_and_link_task` by literal tool name,
+keeping shared agent UI independent of the relationship feature.

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -649,19 +649,83 @@ just now" does not stay on screen for hours. *Mark important* on the plain
 card also mints the agent through `ensureAgentForRelationship`, the same
 lazy-create call the edit form makes.
 
-Three things the card deliberately does not have. The chat entry lives in the
-page's hero. There is no *Automatic updates* switch, because the relationship
-runtime never reads `AgentConfig.automaticUpdatesEnabled` — offering the
-switch would lie. And the suggestions band from the design waits for the
-agent tools that would fill it (schedule a call, create a task; see the plan)
-— the generic change-set ledger is keyed by task, and a band with no producer
-would be untestable theatre.
+The chat entry lives in the page's hero. There is no *Automatic updates*
+switch, because the relationship runtime never reads
+`AgentConfig.automaticUpdatesEnabled`. Task proposals appear below the TL;DR
+and above the footer, including when a later wake fails. Their scope and
+confirmation path are described below.
 
 The pills are the header block's own: [`relationshipCadencePill`](../../lib/features/relationships/ui/widgets/person_header.dart)
 renders the list model's cadence fact under a per-host key prefix, and the
 health band pill shares `relationshipHealthBandColor`. The cost pill sums
 `agentTokenUsageSummariesProvider`; the "as of" meta uses the shared
 [`relativeAgoLabel`](../../lib/utils/relative_age_label.dart).
+
+## Deferred task suggestions
+
+[`relationship_agent_contract.dart`](../../lib/features/relationships/workflow/relationship_agent_contract.dart)
+exposes `create_and_link_task` as a deferred tool. It requires an explicit
+commitment, a quoted description, a structured `sourceCheckInId`, and a reason;
+`dueDate` is optional and must be a real calendar date. The renderer includes
+check-in IDs in its ten-entry window and the relationship-scoped `PROPOSALS`
+ledger. Pending, confirmed and rejected decisions therefore feed the next wake;
+contact channels remain outside FACTS. The strategy accepts only IDs from that
+rendered window, deduplicates source/title pairs, and queues at most three tasks.
+
+The workflow persists those items inside its existing output transaction,
+rechecking that the person is live, important and active. A deterministic
+agent/run change-set ID prevents a retry overwriting decisions. A fresh ledger
+read suppresses structural and display duplicates. The historic `taskId` column
+stores the relationship ID: the ledger already supports arbitrary subjects,
+so no schema migration is involved. Paraphrase suppression remains an LLM
+policy; deterministic dedup cannot recognize every equivalent commitment.
+
+```mermaid
+stateDiagram-v2
+  [*] --> pending: validated proposal persisted
+  pending --> confirmed: user confirms
+  pending --> rejected: user rejects
+  confirmed --> pending: retryable dispatch failure
+  confirmed --> retracted: permanent dispatch failure
+  rejected --> pending: undo rejection
+  confirmed --> pending: undo removes untouched task and link
+```
+
+[`relationship_tool_dispatcher.dart`](../../lib/features/relationships/workflow/relationship_tool_dispatcher.dart)
+is the only apply path. It rechecks visible evidence, its quoted narrative,
+and current consent; creates a task with the person's category, inherited
+privacy (also preserving private evidence), evidence link and proposed due
+date; then links it to the person. A link failure tombstones the new task;
+a failed compensation is non-retryable to avoid duplicate creation. The shared
+category-default assignment helper provisions its task agent.
+
+[`relationship_proposal_service.dart`](../../lib/features/relationships/service/relationship_proposal_service.dart)
+wraps the generic confirmation service. The exact creation snapshot is stored
+under `_relationshipTaskReceipt` on the user decision's args, leaving immutable
+proposal args and fingerprints unchanged. It supplies the durable task
+navigation destination and guards undo against task edits. Undo unlinks,
+rechecks the task and additional journal links, then tombstones it; a refused delete restores the link.
+Malformed or absent receipts disable confirmed-task undo. A receipt write
+failure after successful creation is logged and keeps confirmation successful;
+the local receipt remains usable, but its destination/undo may be unavailable
+after restart until a durable receipt exists. Cross-database confirmation and
+journal writes are not one atomic transaction.
+
+[`relationship_proposal_providers.dart`](../../lib/features/relationships/state/relationship_proposal_providers.dart)
+reads the agent/person ledger and receipt decisions. Ledger entries carry their
+originating run key from the existing query, avoiding a per-history-row read. The band retains previous
+async data and resolving rows while their shared task-card animations finish.
+It folds after three pending rows, offers bulk confirmation only for a single
+kind, links evidence to the check-in editor, and provides handled history and
+undo. Confirmation briefly highlights the created task in the Tasks card.
+It does not use the task-specific `ChangeSetNotificationService`.
+
+The shared chat projection carries each reply's `runKey`.
+[`relationship_chat_pane.dart`](../../lib/features/relationships/ui/widgets/relationship_chat_pane.dart)
+uses the existing attachment slot to render the same band filtered to that
+run, including its handled history. Card and chat act on the same decisions.
+Call scheduling and task-note proposals remain separate follow-up work; this
+tool does not create Daily OS blocks or OS reminders.
 
 ## The check-in capture sheet
 

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -728,7 +728,8 @@ reads the agent/person ledger and receipt decisions. Ledger entries carry their
 originating run key from the existing query, avoiding a per-history-row read. The band retains previous
 async data and resolving rows while their shared task-card animations finish.
 It folds after three pending rows, offers bulk confirmation only for a single
-kind, links evidence to the check-in editor, and provides handled history and
+kind, keeps per-row buttons and swipes inert during bulk writes, links evidence
+to the check-in editor, and provides handled history and
 undo. Confirmation briefly highlights the created task in the Tasks card.
 It does not use the task-specific `ChangeSetNotificationService`.
 

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -688,7 +688,7 @@ stateDiagram-v2
   confirmed --> pending: retryable dispatch failure
   confirmed --> retracted: permanent dispatch failure
   rejected --> pending: undo rejection
-  confirmed --> pending: undo removes untouched task and link
+  confirmed --> pending: undo tombstones untouched task and cleans up link
 ```
 
 [`relationship_tool_dispatcher.dart`](../../lib/features/relationships/workflow/relationship_tool_dispatcher.dart)
@@ -697,14 +697,26 @@ and current consent; creates a task with the person's category, inherited
 privacy (also preserving private evidence), evidence link and proposed due
 date; then links it to the person. A link failure tombstones the new task;
 a failed compensation is non-retryable to avoid duplicate creation. The shared
-category-default assignment helper provisions its task agent.
+category-default assignment helper provisions its task agent. The task has a
+stable UUID derived from the person, source check-in, title and quoted
+commitment, so the same synced proposal confirmed on two devices converges on
+one journal row despite different clocks. The task-creation facade accepts
+this explicit identity and preserves its existing insert-only write contract.
+A live task found under that identity is linked without overwriting it or
+creating a fresh undo receipt from potentially edited data. Reconfirmation
+after undo restores the tombstoned identity with a vector clock descended
+from the tombstone.
 
 [`relationship_proposal_service.dart`](../../lib/features/relationships/service/relationship_proposal_service.dart)
 wraps the generic confirmation service. The exact creation snapshot is stored
 under `_relationshipTaskReceipt` on the user decision's args, leaving immutable
 proposal args and fingerprints unchanged. It supplies the durable task
-navigation destination and guards undo against task edits. Undo unlinks,
-rechecks the task and additional journal links, then tombstones it; a refused delete restores the link.
+navigation destination and guards undo against task edits. Undo checks the
+task and additional journal links twice, tombstones the untouched task, then
+cleans up its relationship link. A refused deletion leaves the live task
+linked. Failed link cleanup is logged and leaves only a link to a tombstoned
+task, which relationship task queries exclude; it does not undo the successful
+deletion or reopen an unsafe compensation path.
 Malformed or absent receipts disable confirmed-task undo. A receipt write
 failure after successful creation is logged and keeps confirmation successful;
 the local receipt remains usable, but its destination/undo may be unavailable

--- a/lib/features/agents/database/agent_proposal_ledger.dart
+++ b/lib/features/agents/database/agent_proposal_ledger.dart
@@ -150,6 +150,7 @@ class AgentProposalLedger {
         }
         final entry = LedgerEntry(
           changeSetId: set.id,
+          runKey: set.runKey,
           itemIndex: i,
           toolName: item.toolName,
           args: item.args,

--- a/lib/features/agents/model/proposal_ledger.dart
+++ b/lib/features/agents/model/proposal_ledger.dart
@@ -23,10 +23,14 @@ class LedgerEntry {
     this.resolvedBy,
     this.verdict,
     this.reason,
+    this.runKey,
   });
 
   /// The parent `ChangeSetEntity.id`.
   final String changeSetId;
+
+  /// Originating wake, used to attach proposals to their durable chat reply.
+  final String? runKey;
 
   /// The zero-based position of this item within its parent set's items list.
   final int itemIndex;

--- a/lib/features/agents/state/agent_chat_projection.dart
+++ b/lib/features/agents/state/agent_chat_projection.dart
@@ -15,12 +15,16 @@ class AgentChatMessage {
     required this.role,
     required this.text,
     required this.createdAt,
+    this.runKey,
   });
 
   final String id;
   final AgentChatRole role;
   final String text;
   final DateTime createdAt;
+
+  /// Associates attachments with the durable agent reply that produced them.
+  final String? runKey;
 }
 
 /// Bounded, durable conversation projection. Model context and private agent
@@ -81,6 +85,7 @@ Future<List<AgentChatMessage>> agentChatProjection(
             : AgentChatRole.agent,
         text: text.trim(),
         createdAt: message.createdAt,
+        runKey: message.metadata.runKey,
       ),
     );
   }

--- a/lib/features/agents/ui/ai_summary_card/proposal_kind_part.dart
+++ b/lib/features/agents/ui/ai_summary_card/proposal_kind_part.dart
@@ -15,6 +15,7 @@ enum ProposalKind {
   status,
   label,
   due,
+  task,
 }
 
 class KindMeta {
@@ -29,6 +30,8 @@ class KindMeta {
 /// each one onto the closest visual kind.
 ProposalKind resolveKind(String toolName, Map<String, dynamic> args) {
   switch (toolName) {
+    case 'create_and_link_task':
+      return ProposalKind.task;
     case TaskAgentToolNames.addMultipleChecklistItems:
     case TaskAgentToolNames.addChecklistItem:
     case TaskAgentToolNames.createFollowUpTask:
@@ -65,6 +68,8 @@ ProposalKind resolveKind(String toolName, Map<String, dynamic> args) {
 KindMeta kindMeta(BuildContext context, ProposalKind kind) {
   final messages = context.messages;
   switch (kind) {
+    case ProposalKind.task:
+      return KindMeta(label: messages.entryTypeLabelTask);
     case ProposalKind.add:
       return KindMeta(
         label: messages.aiCardProposalKindAdd,

--- a/lib/features/agents/ui/ai_summary_card/proposal_row_part.dart
+++ b/lib/features/agents/ui/ai_summary_card/proposal_row_part.dart
@@ -10,6 +10,7 @@ import 'package:lotti/features/agents/model/proposal_ledger.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/change_set_providers.dart';
 import 'package:lotti/features/agents/state/unified_suggestion_providers.dart';
+import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
 import 'package:lotti/features/agents/ui/ai_summary_card/proposal_kind_part.dart';
 import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_widgets_part.dart';
 import 'package:lotti/features/agents/ui/localized_change_summary.dart';
@@ -57,21 +58,36 @@ class ProposalRow extends ConsumerStatefulWidget {
     this.onResolveEnd,
     this.settling = false,
     this.pendingCount = 0,
+    this.onConfirm,
+    this.onReject,
+    this.details,
     super.key,
   }) : entry = null;
 
-  const ProposalRow.fromLedger({required LedgerEntry this.entry, super.key})
-    : suggestion = null,
-      isFirst = false,
-      confirmAllPulse = 0,
-      cascadeIndex = 0,
-      onResolveStart = null,
-      onResolveEnd = null,
-      settling = false,
-      pendingCount = 0;
+  const ProposalRow.fromLedger({
+    required LedgerEntry this.entry,
+    this.details,
+    super.key,
+  }) : suggestion = null,
+       onConfirm = null,
+       onReject = null,
+       isFirst = false,
+       confirmAllPulse = 0,
+       cascadeIndex = 0,
+       onResolveStart = null,
+       onResolveEnd = null,
+       settling = false,
+       pendingCount = 0;
 
   final PendingSuggestion? suggestion;
   final LedgerEntry? entry;
+
+  /// Feature-owned confirmation paths; absent on the existing task host.
+  final Future<ToolExecutionResult> Function()? onConfirm;
+  final Future<bool> Function()? onReject;
+
+  /// Evidence or consequence links owned by the feature hosting this row.
+  final Widget? details;
 
   /// Whether this row is the topmost pending row. Drives the
   /// swipe-affordance wiggle hint on narrow viewports.
@@ -480,13 +496,16 @@ class _ProposalRowState extends ConsumerState<ProposalRow>
     final messages = context.messages;
     final textDirection = Directionality.of(context);
     final view = View.of(context);
-    final service = ref.read(changeSetConfirmationServiceProvider);
     final notifier = ref.read(updateNotificationsProvider);
     try {
-      final result = await service.confirmItem(
-        suggestion.changeSet,
-        suggestion.itemIndex,
-      );
+      final result =
+          await (widget.onConfirm?.call() ??
+              ref
+                  .read(changeSetConfirmationServiceProvider)
+                  .confirmItem(
+                    suggestion.changeSet,
+                    suggestion.itemIndex,
+                  ));
       notifier.notify({suggestion.changeSet.agentId});
       if (result.success && result.errorMessage == null) {
         // Pure success: the in-place resolve beat + the ticking pending count
@@ -553,13 +572,16 @@ class _ProposalRowState extends ConsumerState<ProposalRow>
     final messages = context.messages;
     final textDirection = Directionality.of(context);
     final view = View.of(context);
-    final service = ref.read(changeSetConfirmationServiceProvider);
     final notifier = ref.read(updateNotificationsProvider);
     try {
-      final applied = await service.rejectItem(
-        suggestion.changeSet,
-        suggestion.itemIndex,
-      );
+      final applied =
+          await (widget.onReject?.call() ??
+              ref
+                  .read(changeSetConfirmationServiceProvider)
+                  .rejectItem(
+                    suggestion.changeSet,
+                    suggestion.itemIndex,
+                  ));
       notifier.notify({suggestion.changeSet.agentId});
       if (applied) {
         // As with confirm: the in-place dismiss beat + pending count carry it,
@@ -746,18 +768,25 @@ class _ProposalRowState extends ConsumerState<ProposalRow>
                 opacity: _collapseContentOpacity,
                 child: Opacity(
                   opacity: dimmed ? 0.45 : 1,
-                  child: ProposalRowContent(
-                    meta: meta,
-                    text: cleanText,
-                    lineThrough: lineThrough,
-                    isResolved: widget.isResolved,
-                    resolvedStatus: _resolvedStatus,
-                    busy: _busy,
-                    // While resolving, the badge below is the indicator — hide
-                    // the trailing buttons/spinner so they don't peek behind it.
-                    resolving: resolveKindLocal != null,
-                    onReject: _reject,
-                    onConfirm: _confirm,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      ProposalRowContent(
+                        meta: meta,
+                        text: cleanText,
+                        lineThrough: lineThrough,
+                        isResolved: widget.isResolved,
+                        resolvedStatus: _resolvedStatus,
+                        busy: _busy,
+                        // While resolving, the badge below is the indicator — hide
+                        // the trailing buttons/spinner so they don't peek behind it.
+                        resolving: resolveKindLocal != null,
+                        onReject: _reject,
+                        onConfirm: _confirm,
+                      ),
+                      ?widget.details,
+                    ],
                   ),
                 ),
               ),

--- a/lib/features/agents/ui/ai_summary_card/proposals_section_part.dart
+++ b/lib/features/agents/ui/ai_summary_card/proposals_section_part.dart
@@ -32,10 +32,14 @@ class ProposalsSection extends StatelessWidget {
     this.onResolveEnd,
     this.settling = false,
     this.newlyArrived = const {},
+    this.rowBuilder,
     super.key,
   });
 
   final List<PendingSuggestion> open;
+
+  /// Optional feature host for evidence links and scoped confirmation.
+  final Widget Function(PendingSuggestion suggestion, int index)? rowBuilder;
 
   /// The count to show in the pending pill. Excludes rows that are committed
   /// and collapsing out, so the count ticks down in sync with the action.
@@ -134,26 +138,28 @@ class ProposalsSection extends StatelessWidget {
                     'enter-${open[i].changeSet.id}-${open[i].itemIndex}',
                   ),
                   animate: newlyArrived.contains(open[i].fingerprint),
-                  child: ProposalRow(
-                    // Stable identity (set id + item index) so the row's
-                    // timer/animation/busy state stays bound to its suggestion
-                    // when the open list mutates (e.g. confirm-all), instead of
-                    // index-based element reuse transferring it to a sibling.
-                    key: ValueKey(
-                      'open-${open[i].changeSet.id}-${open[i].itemIndex}',
-                    ),
-                    suggestion: open[i],
-                    // Only the first pending row gets the swipe-affordance
-                    // wiggle hint so the page doesn't pulse with every
-                    // visible row.
-                    isFirst: i == 0,
-                    confirmAllPulse: confirmAllPulse,
-                    cascadeIndex: i,
-                    onResolveStart: onResolveStart,
-                    onResolveEnd: onResolveEnd,
-                    settling: settling,
-                    pendingCount: pendingCount ?? open.length,
-                  ),
+                  child:
+                      rowBuilder?.call(open[i], i) ??
+                      ProposalRow(
+                        // Stable identity (set id + item index) so the row's
+                        // timer/animation/busy state stays bound to its suggestion
+                        // when the open list mutates (e.g. confirm-all), instead of
+                        // index-based element reuse transferring it to a sibling.
+                        key: ValueKey(
+                          'open-${open[i].changeSet.id}-${open[i].itemIndex}',
+                        ),
+                        suggestion: open[i],
+                        // Only the first pending row gets the swipe-affordance
+                        // wiggle hint so the page doesn't pulse with every
+                        // visible row.
+                        isFirst: i == 0,
+                        confirmAllPulse: confirmAllPulse,
+                        cascadeIndex: i,
+                        onResolveStart: onResolveStart,
+                        onResolveEnd: onResolveEnd,
+                        settling: settling,
+                        pendingCount: pendingCount ?? open.length,
+                      ),
                 ),
               // Bottom rail: the one list-level operation, trailing-aligned.
               // Open rows already end with their own trailing gap, so the
@@ -201,6 +207,7 @@ class ProposalHistorySection extends StatelessWidget {
     required this.resolved,
     required this.open,
     required this.onToggle,
+    this.rowBuilder,
     super.key,
   });
 
@@ -211,6 +218,9 @@ class ProposalHistorySection extends StatelessWidget {
   /// Whether the resolved list is disclosed.
   final bool open;
   final VoidCallback onToggle;
+
+  /// Feature-owned history details, such as destinations and Undo.
+  final Widget Function(LedgerEntry entry)? rowBuilder;
 
   @override
   Widget build(BuildContext context) {
@@ -252,12 +262,14 @@ class ProposalHistorySection extends StatelessWidget {
                           ? tokens.spacing.step3
                           : 0,
                     ),
-                    child: ProposalRow.fromLedger(
-                      key: ValueKey(
-                        'resolved-${resolved[i].changeSetId}-${resolved[i].itemIndex}',
-                      ),
-                      entry: resolved[i],
-                    ),
+                    child:
+                        rowBuilder?.call(resolved[i]) ??
+                        ProposalRow.fromLedger(
+                          key: ValueKey(
+                            'resolved-${resolved[i].changeSetId}-${resolved[i].itemIndex}',
+                          ),
+                          entry: resolved[i],
+                        ),
                   ),
               ],
             ],

--- a/lib/features/agents/ui/localized_change_summary.dart
+++ b/lib/features/agents/ui/localized_change_summary.dart
@@ -87,6 +87,7 @@ String? localizedChangeSummary(
     messages.agentSummaryUpdateProjectStatus(
       _projectStatus(messages, args['status']),
     ),
+  'create_and_link_task' => _string(args['title'], fallback: '?'),
   ProjectAgentToolNames.createTask => messages.agentSummaryCreateTask(
     _string(args['title'], fallback: '?'),
   ),

--- a/lib/features/relationships/README.md
+++ b/lib/features/relationships/README.md
@@ -1,150 +1,82 @@
 # Relationships
 
-A personal CRM for a small, deliberately curated set of people. One
-relationship entity per person, with a timeline of **check-ins** — structured
-interaction logs (type, sentiment, topics, narrative) — and, for people
-marked important, a dedicated agent that tracks check-in cadence and briefs
-the user before the next conversation.
+A personal CRM for a small, deliberately curated set of people. Each person
+has a timeline of **check-ins** — interaction type, sentiment, topics and
+narrative — and can have tasks linked to them. Marking someone important
+opts them into a dedicated agent that tracks contact cadence and prepares
+briefings from captured check-ins.
 
-This feature is landing in phases; see the
-[implementation plan](../../../docs/implementation_plans/2026-08-13_relationship_management_v2.md)
-and ADRs 0037–0041 plus 0059. What exists today (phases 1–5 and 7, behind
-the `enable_relationships` flag):
+The feature is behind `enable_relationships`. The **People** tab (`/people`)
+groups people into *Due*, *On track* and *Not enrolled*, with a summary of
+who is due and who lapses next. Rows show the last contact and cadence.
+Desktop uses a list/detail split; phones open a dedicated person page.
 
-- **Domain model** in `lib/classes/`: `relationship_data.dart`
-  (`RelationshipData`, `RelationshipStatus`, `ContactChannel`) and
-  `check_in_data.dart` (`CheckInData`, interaction type and sentiment enums).
-  Both ride the journal table as `JournalEntity.relationship` /
-  `JournalEntity.checkIn` — payload-agnostic sync, `private` flag,
-  categories, and export all apply with zero new infrastructure.
-- **Linking**: `EntryLink.relationship` binds relationship → check-in and
-  relationship ↔ task. Check-ins also carry a denormalized
-  `relationshipId` so `affectedIds` emits a precise agent wake token and the
-  journal `subtype` column supports indexed check-in queries.
-- `repository/` — `RelationshipRepository`: CRUD for both entity types
-  (create, edit, delete — relationship deletion cascades to its check-ins,
-  ADR 0037 §5) plus the recency-ordered list used by the People tab.
-- `ui/` + `state/` — the flag-gated **People tab** (`/people`, its own
-  beamer location): the People list — banded *Due · On track · Not enrolled*
-  under a summary card that counts who is due now and names who lapses next,
-  each row naming the last contact (`Call · Today 12:44 · Weekly`) with a
-  truthful cadence pill, and on desktop a list/detail split like Tasks —
-  the per-person page, a sibling of the task page: a cover-style hero
-  (back · Talk to agent · edit · a menu with link-contact and delete) with
-  the persona avatar hanging off it, a header block (category · Important,
-  the full name, nickname and last contact, then the cadence fact, the
-  health band and the next due day as pills), and section cards in the
-  design's order — Briefing · Next time (what the latest check-in asked to
-  bring up or avoid) · Check-ins (mono `timestamp · type · duration`, the
-  sentiment as a tinted pill, topics as tags) · Reach (channels with the
-  actions the device can service, under the privacy line) · Tasks
-  (`RelationshipLink` both ways, a picker that also creates the task when
-  none exists yet, per-row unlink) — above a sticky action bar: *Log
-  check-in*, a mic that opens the capture sheet already recording, and the
-  first channel the platform can open. The add/edit person modal — three
-  cards (*Who* · *Important* · *How to reach them*), the category as a colour
-  dot, cadence presets that appear once importance is on, and the manual
-  contact-channel editor beside *or from contacts* where an address book
-  exists (desktop parity per ADR 0041 §2) — and the check-in capture sheet: how it felt
-  (user-set sentiment — never AI-filled, ADR 0038), what you talked about
-  (or *Speak instead*), when and how long (interaction type, a *Started*
-  date and time, a duration picked from the lengths you log most or spun on
-  the wheel), and topics plus next-time guidance folded under *More*, with
-  Save pinned; after a call the sheet opens prefilled from the offer.
-  Check-ins are editable and deletable afterwards.
+The person page holds a header with category, importance, name, nickname
+and recent contact, followed by the agent briefing, *Next time*, check-ins,
+contact channels and linked tasks. The header opens the agent conversation
+and person editor. The bottom action bar offers a check-in, voice capture
+and an available contact action.
 
-- `runtime/` + `service/` + `state/` — the **relationship agent's
-  deterministic tier** (plan v2 phase 4, ADR 0059): marking a person
-  important quietly creates their dedicated agent, which tracks the
-  check-in cadence every day at zero AI cost. Deleting a person destroys
-  their agent (the cascade's agent leg).
-- `workflow/` + the rest of `service/`, `state/`, `ui/` — the **LLM tier**
-  (plan v2 phase 5): a lapsed cadence, a check-in newer than the current
-  briefing, a chat message, or an explicit "Brief me" triggers one AI run
-  that writes an executive briefing (with a health band) and at most one
-  check-in banner. The person page mounts the relationship agent's card —
-  the *same* AI panel as the task agent's section and the goal agent's read,
-  so the briefing renders as Markdown and "Read more" and "Open agent
-  internals" behave exactly as they do on a task — in one of seven faces:
-  not enrolled (a plain card with *Mark important*), no briefing yet (*Brief
-  now*, which names the cloud provider first, per ADR 0037), running,
-  failed (the reason, with *Choose a model* or *Try again* as the fix),
-  current (*Update now*, the cost so far, the model row), out of date, and
-  due (*Log check-in* · *Call*). `/people/<id>/chat`
-  opens the per-person agent chat from the page's hero, under a header that
-  names the agent and what it can see — a full page on phones, the detail
-  pane itself on desktop, where *Agent internals* sits beside it. A briefing runs on the AI profile of the
-  person's category unless the person has one of their own. Banners surface through the
-  kind-agnostic channel (`lib/features/nudges/`), tapping through to the
-  person.
+## Briefings and suggestions
 
-- **Voice check-ins** (plan v2 phase 6): "Speak check-in" on the capture
-  sheet records through the shared recording sheet with the *person* as the
-  recording's linked entity, then waits for the transcript and drops it into
-  the narrative field for the user to edit and confirm. Nothing auto-saves —
-  the check-in stays user-authored, and speaking never overwrites text the
-  user already typed. Transcription resolves the person's inference profile
-  (or their category's) because the automation path is now kind-agnostic
-  rather than task-only, and the finished transcript wakes the relationship
-  agent so the briefing catches up with what was just said.
+The agent card has six states: not enrolled, no briefing, running, failed,
+current and out of date. It offers the appropriate action: mark important,
+brief now, choose a model, retry, or update. The card shows the briefing's
+age, health band, inference cost and model information. A first cloud
+briefing names the provider before sending relationship context.
 
-  The button only needs a **transcription model** — not the category's
-  automatic-inference switch. That switch governs unattended runs, so when it
-  is off (or the person has no category at all) the sheet runs the
-  transcription the user just asked for itself, rather than refusing. With no
-  model configured anywhere it says so before recording, instead of capturing
-  audio for a transcript that can never arrive — and if the recording sheet's
-  speech-recognition checkbox was unticked for that take, it says so straight
-  away rather than waiting out the transcription timeout.
+The agent can propose tasks from explicit commitments in check-ins. The
+card and chat show the source check-in and any proposed due date before
+confirmation. Confirming creates a task with inherited category/privacy,
+links it to the person and briefly highlights its Tasks row. History
+provides a task destination and undo while the task remains unchanged.
+More than three suggestions fold, and same-kind suggestions can be
+confirmed together. Call scheduling and task-note suggestions are not
+implemented yet.
 
-  Transcription accuracy for names comes from the **category's
-  `speechDictionary`**: terms listed there are sent to the provider as
-  context bias and injected into the transcription prompt, so a category
-  used for people should list the names it expects to hear. It is edited in
-  category settings, and applies to every recording in that category — a
-  spoken check-in included.
+The conversation uses the shared agent chat surface under an identity header.
+Phones open `/people/<id>/chat`; desktop keeps chat in the People detail pane.
+Check-in banners use the shared nudge system and open the person page.
+Cadence reminders also have an OS-notification projection for when the app
+is closed. The deterministic cadence tier does not require an AI model.
 
-- `service/relationship_reminder_service.dart` — **OS check-in reminders**
-  (plan v2 phase 8, ADR 0039). The banner needs the app open; this covers the
-  case it cannot. The deterministic tier's cadence verdict is projected onto a
-  durable notification row armed *ahead* of the due day, so the OS is already
-  holding the alarm when the app closes. One row per cadence episode, retracted
-  and replaced when a check-in moves the due day, and cleared outright when a
-  person stops being eligible or is deleted. Lock-screen copy carries the
-  person's name and nothing else about them.
+## Capturing and linking
 
-- `service/` + `state/` + `ui/` — **contacts, quick actions and the
-  post-call loop** (plan v2 phase 7, ADR 0041), on Android and iOS only.
-  `contacts_service.dart` is the sole boundary to `flutter_contacts`, and
-  `contact_import_mapper.dart` the sole file that knows its types; the
-  import screen, the link action and their tests all run without a platform
-  channel. The People tab gains a multi-select import (pick, then set
-  importance and cadence per person before anyone is created), the detail
-  page gains "Link contact" / "Update from contact" — a merge that never
-  discards a hand-typed channel and never overwrites the name — and each
-  contact channel renders call/message/email buttons for the actions the
-  device can actually service. Launching one records a device-local marker
-  in `settings.sqlite` (never synced, never journalled), which the next
-  resume turns into a pre-filled check-in offer.
+Check-ins are user-authored. Voice capture records against the person,
+transcribes with their inference configuration and fills the narrative for
+review; it never saves automatically or overwrites existing typed text.
+A missing transcription model is explained before recording. Category
+speech dictionaries can improve recognition of names.
 
-Phases 1–8 are built; phase 9 (privacy documentation, the manual pages
-and release readiness) is outstanding. Relationships and check-ins
-deliberately do not appear in the main journal timeline; the People tab is
-their home. Desktop keeps manual channel entry: contact import and the
-quick actions are absent there, by design.
+On Android and iOS, contact import lets the user select contacts and set
+importance and cadence before creating people. Linking or refreshing a
+contact preserves hand-edited channels and names. Available call, message
+and email actions use the device's capabilities; returning after a contact
+action can offer a prefilled check-in. Desktop retains manual channel entry.
 
-Privacy stance (ADR 0037): relationship data is the most sensitive class the
-app holds — it describes third parties. It stays on-device, syncs only via
-the user's own end-to-end encrypted Matrix rooms, and contact channels never
-enter AI context. Concretely, `private` covers the whole person: a check-in
-inherits the relationship's `private` flag when it is created, the detail
-page resolves a private person to "no longer tracked" while private entries
-are hidden (the list filter alone would leave the `/people/<id>` route open),
-and the delete cascade reads check-ins unfiltered so hidden ones cannot
-survive the person they describe.
+Tasks can be linked, unlinked, or created from the person's task picker.
+Deleting a person removes their check-ins and agent; it does not delete
+independent tasks linked to them.
 
-Why check-ins are bound to a person twice, how the People list orders by
-recency without a per-person query, the status lifecycle, and what the delete
-cascade does and does not reach are documented in the knowledge bundle:
+## Ownership and privacy
 
-**→ [knowledge/features/relationships.md](../../../knowledge/features/relationships.md)**
+- `lib/classes/` owns the relationship/check-in journal variants and data.
+- `repository/` owns person and check-in persistence and relationship links.
+- `runtime/` owns deterministic cadence evaluation; `workflow/` owns agent
+  context, tool policy, briefing production and deferred task proposals.
+- `service/` owns agent lifecycle, chat, proposal confirmation, reminders,
+  contact integration and the post-contact check-in loop.
+- `state/` and `ui/` own the People surfaces and their reactive state.
+  Shared agents, tasks, speech, nudges and design-system modules provide the
+  underlying capabilities.
+
+Relationships and check-ins live in People, outside the main journal
+stream. Data stays on-device and syncs through the user's own end-to-end
+encrypted Matrix rooms. Private people are hidden from both list and detail
+routes when private entries are hidden; new check-ins inherit that privacy.
+Contact channels never enter agent context.
+
+Phases 1–8 of the original implementation plan are built; phase 9's privacy
+manuals and release readiness remain outstanding. The architecture,
+lifecycles, invariants, original plan and decision records are mapped in
+[the relationship knowledge concept](../../../knowledge/features/relationships.md).

--- a/lib/features/relationships/service/relationship_proposal_service.dart
+++ b/lib/features/relationships/service/relationship_proposal_service.dart
@@ -1,0 +1,222 @@
+import 'dart:convert';
+import 'dart:developer' as developer;
+
+import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/features/agents/database/agent_repository.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/service/change_set_confirmation_service.dart';
+import 'package:lotti/features/agents/sync/agent_sync_service.dart';
+import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
+import 'package:lotti/features/relationships/repository/relationship_repository.dart';
+import 'package:lotti/features/relationships/workflow/relationship_tool_dispatcher.dart';
+
+/// Confirms proposals and remembers their task receipts on the decision row.
+/// The immutable proposal args stay unchanged, preserving ledger fingerprints.
+/// Receipts make the handled row's destination available after a restart/sync.
+class RelationshipProposalService {
+  RelationshipProposalService({
+    required this.confirmation,
+    required this.repository,
+    required this.syncService,
+    required this.journalDb,
+    required this.relationshipRepository,
+    required this.taskRemover,
+  });
+
+  final ChangeSetConfirmationService confirmation;
+  final AgentRepository repository;
+  final AgentSyncService syncService;
+  final JournalDb journalDb;
+  final RelationshipRepository relationshipRepository;
+  final Future<bool> Function(Task) taskRemover;
+  final _busy = <String>{};
+  final _receipts = <String, Task>{};
+  static const receiptKey = '_relationshipTaskReceipt';
+
+  String _key(String setId, int index) => '$setId:$index';
+
+  /// Retrieves the last user decision for an item; decisions are agent-scoped.
+  Future<ChangeDecisionEntity?> _decision(
+    ChangeSetEntity set,
+    int index,
+  ) async {
+    final decisions =
+        (await repository.getEntitiesByAgentId(
+              set.agentId,
+              type: AgentEntityTypes.changeDecision,
+            ))
+            .whereType<ChangeDecisionEntity>()
+            .where(
+              (d) =>
+                  d.changeSetId == set.id &&
+                  d.itemIndex == index &&
+                  d.deletedAt == null &&
+                  d.actor == DecisionActor.user,
+            )
+            .toList()
+          ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    return decisions.firstOrNull;
+  }
+
+  /// Local fallback when a successful creation outlived a receipt write error.
+  Task? cachedReceipt(String setId, int index) => _receipts[_key(setId, index)];
+
+  /// A durable snapshot of the task created by this confirmation, if any.
+  Future<Task?> receipt(ChangeSetEntity set, int index) async {
+    final cached = _receipts[_key(set.id, index)];
+    if (cached != null) return cached;
+    final raw = (await _decision(set, index))?.args?[receiptKey];
+    return decodeReceipt(raw);
+  }
+
+  /// Older or malformed peer data must not make the entire ledger unreadable.
+  static Task? decodeReceipt(Object? raw) {
+    if (raw is! Map<String, dynamic>) return null;
+    try {
+      final entity = JournalEntity.fromJson(
+        jsonDecode(jsonEncode(raw)) as Map<String, dynamic>,
+      );
+      return entity is Task ? entity : null;
+    } on Object {
+      return null;
+    }
+  }
+
+  Future<ToolExecutionResult> confirm(ChangeSetEntity set, int index) async {
+    final key = _key(set.id, index);
+    if (set.agentId != relationshipAgentIdFor(set.taskId) || !_busy.add(key)) {
+      return const ToolExecutionResult(
+        success: false,
+        output: 'Proposal is unavailable',
+      );
+    }
+    try {
+      final result = await confirmation.confirmItem(set, index);
+      if (!result.success || result.mutatedEntityId == null) return result;
+      final entity = result is RelationshipTaskCreationResult
+          ? result.task
+          : null;
+      if (entity != null) {
+        _receipts[key] = entity;
+        try {
+          final decision = await _decision(set, index);
+          if (decision != null) {
+            await syncService.upsertEntity(
+              decision.copyWith(
+                args: {
+                  ...?decision.args,
+                  receiptKey: jsonDecode(jsonEncode(entity.toJson())),
+                },
+              ),
+            );
+          }
+        } catch (error, stackTrace) {
+          // Confirmation already created the task. Never offer a second create
+          // because persisting its receipt failed; this session can still undo.
+          developer.log(
+            'Could not persist relationship task receipt',
+            name: 'RelationshipProposalService',
+            error: error,
+            stackTrace: stackTrace,
+          );
+        }
+      }
+      return result;
+    } finally {
+      _busy.remove(key);
+    }
+  }
+
+  /// Resolves a history row against its current durable change set.
+  Future<bool> undoById(String setId, int index) async {
+    final set = await repository.getEntity(setId);
+    return set is ChangeSetEntity && await undo(set, index);
+  }
+
+  Future<bool> reject(ChangeSetEntity set, int index) async {
+    final key = _key(set.id, index);
+    if (set.agentId != relationshipAgentIdFor(set.taskId) || !_busy.add(key)) {
+      return false;
+    }
+    try {
+      return await confirmation.rejectItem(set, index);
+    } finally {
+      _busy.remove(key);
+    }
+  }
+
+  /// Reopens a rejection, or removes an untouched task and its relationship
+  /// link. A changed task is never overwritten by an old receipt.
+  Future<bool> undo(ChangeSetEntity set, int index) async {
+    final key = _key(set.id, index);
+    if (set.agentId != relationshipAgentIdFor(set.taskId) || !_busy.add(key)) {
+      return false;
+    }
+    try {
+      final fresh = await repository.getEntity(set.id);
+      if (fresh is! ChangeSetEntity ||
+          index < 0 ||
+          index >= fresh.items.length) {
+        return false;
+      }
+      final status = fresh.items[index].status;
+      if (status == ChangeItemStatus.rejected) {
+        return await confirmation.reopenItem(fresh, index);
+      }
+      if (status != ChangeItemStatus.confirmed) return false;
+      final original = await receipt(fresh, index);
+      if (original == null) return false;
+      final reopened = await confirmation.reopenItem(
+        fresh,
+        index,
+        revert: () async {
+          final current = await journalDb.journalEntityById(original.id);
+          if (current != original ||
+              current is! Task ||
+              current.isDeleted ||
+              await _hasAdditionalLinks(original.id, fresh.taskId)) {
+            return false;
+          }
+          final unlinked = await relationshipRepository.unlinkTask(
+            relationshipId: fresh.taskId,
+            taskId: original.id,
+          );
+          if (!unlinked) return false;
+          final latest = await journalDb.journalEntityById(original.id);
+          if (latest == original &&
+              !await _hasAdditionalLinks(original.id, fresh.taskId) &&
+              await taskRemover(current)) {
+            return true;
+          }
+          // A refused delete must leave the still-live task linked as before.
+          await relationshipRepository.linkTask(
+            relationshipId: fresh.taskId,
+            taskId: original.id,
+          );
+          return false;
+        },
+      );
+      if (reopened) _receipts.remove(key);
+      return reopened;
+    } finally {
+      _busy.remove(key);
+    }
+  }
+
+  /// Notes, checklist entries or another relationship make a task independently
+  /// useful even when linking them did not change the task's own metadata.
+  Future<bool> _hasAdditionalLinks(String taskId, String personId) async {
+    final links = await journalDb.linksForEntryIdsBidirectional({taskId});
+    return links.any(
+      (link) =>
+          link.deletedAt == null &&
+          !(link is RelationshipLink &&
+              ((link.fromId == personId && link.toId == taskId) ||
+                  (link.fromId == taskId && link.toId == personId))),
+    );
+  }
+}

--- a/lib/features/relationships/service/relationship_proposal_service.dart
+++ b/lib/features/relationships/service/relationship_proposal_service.dart
@@ -150,7 +150,8 @@ class RelationshipProposalService {
   }
 
   /// Reopens a rejection, or removes an untouched task and its relationship
-  /// link. A changed task is never overwritten by an old receipt.
+  /// link, in that order. Failed cleanup can leave a link to a tombstoned task;
+  /// failed deletion always preserves the live link. Changed tasks are refused.
   Future<bool> undo(ChangeSetEntity set, int index) async {
     final key = _key(set.id, index);
     if (set.agentId != relationshipAgentIdFor(set.taskId) || !_busy.add(key)) {
@@ -181,23 +182,35 @@ class RelationshipProposalService {
               await _hasAdditionalLinks(original.id, fresh.taskId)) {
             return false;
           }
-          final unlinked = await relationshipRepository.unlinkTask(
-            relationshipId: fresh.taskId,
-            taskId: original.id,
-          );
-          if (!unlinked) return false;
           final latest = await journalDb.journalEntityById(original.id);
-          if (latest == original &&
-              !await _hasAdditionalLinks(original.id, fresh.taskId) &&
-              await taskRemover(current)) {
-            return true;
+          if (latest != original ||
+              await _hasAdditionalLinks(original.id, fresh.taskId) ||
+              !await taskRemover(current)) {
+            return false;
           }
-          // A refused delete must leave the still-live task linked as before.
-          await relationshipRepository.linkTask(
-            relationshipId: fresh.taskId,
-            taskId: original.id,
-          );
-          return false;
+          // A refused deletion must never detach a live task. Once tombstoned,
+          // a leftover link is invisible to relationship task queries and is
+          // safe to clean up independently.
+          try {
+            final unlinked = await relationshipRepository.unlinkTask(
+              relationshipId: fresh.taskId,
+              taskId: original.id,
+            );
+            if (!unlinked) {
+              developer.log(
+                'Task removed; relationship link cleanup was refused',
+                name: 'RelationshipProposalService',
+              );
+            }
+          } catch (error, stackTrace) {
+            developer.log(
+              'Task removed; relationship link cleanup failed',
+              name: 'RelationshipProposalService',
+              error: error,
+              stackTrace: stackTrace,
+            );
+          }
+          return true;
         },
       );
       if (reopened) _receipts.remove(key);

--- a/lib/features/relationships/state/relationship_proposal_providers.dart
+++ b/lib/features/relationships/state/relationship_proposal_providers.dart
@@ -1,0 +1,196 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/agents/service/change_set_confirmation_service.dart';
+import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/agents/state/task_agent_providers.dart';
+import 'package:lotti/features/agents/state/unified_suggestion_providers.dart';
+import 'package:lotti/features/labels/repository/labels_repository.dart';
+import 'package:lotti/features/relationships/repository/relationship_repository.dart';
+import 'package:lotti/features/relationships/service/relationship_proposal_service.dart';
+import 'package:lotti/features/relationships/workflow/relationship_tool_dispatcher.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/providers/service_providers.dart';
+import 'package:lotti/services/entities_cache_service.dart';
+
+final Provider<RelationshipToolDispatcher> relationshipToolDispatcherProvider =
+    Provider(
+      (ref) => RelationshipToolDispatcher(
+        relationshipRepository: ref.watch(relationshipRepositoryProvider),
+        persistenceLogic: getIt<PersistenceLogic>(),
+        entitiesCacheService: getIt<EntitiesCacheService>(),
+        taskAgentService: ref.watch(taskAgentServiceProvider),
+      ),
+    );
+
+final Provider<ChangeSetConfirmationService>
+relationshipChangeSetConfirmationServiceProvider = Provider(
+  (ref) => ChangeSetConfirmationService(
+    syncService: ref.watch(agentSyncServiceProvider),
+    toolDispatcher: ref.watch(relationshipToolDispatcherProvider).dispatch,
+    labelsRepository: ref.watch(labelsRepositoryProvider),
+    domainLogger: ref.watch(domainLoggerProvider),
+  ),
+);
+
+final Provider<RelationshipProposalService>
+relationshipProposalServiceProvider = Provider(
+  (ref) => RelationshipProposalService(
+    confirmation: ref.watch(relationshipChangeSetConfirmationServiceProvider),
+    repository: ref.watch(agentRepositoryProvider),
+    syncService: ref.watch(agentSyncServiceProvider),
+    journalDb: ref.watch(journalDbProvider),
+    relationshipRepository: ref.watch(relationshipRepositoryProvider),
+    taskRemover: ref.watch(relationshipToolDispatcherProvider).removeTask,
+  ),
+);
+
+/// The shared suggestion rows plus durable destinations of confirmed tasks.
+class RelationshipProposalSnapshot {
+  const RelationshipProposalSnapshot({
+    required this.suggestions,
+    this.receipts = const {},
+    this.runKeys = const {},
+  });
+  const RelationshipProposalSnapshot.empty()
+    : suggestions = const UnifiedSuggestionList.empty(),
+      receipts = const {},
+      runKeys = const {};
+  final UnifiedSuggestionList suggestions;
+  final Map<String, Task> receipts;
+  final Map<String, String> runKeys;
+  static String itemKey(String setId, int index) => '$setId:$index';
+}
+
+/// Relationship-scoped ledger read. Agent updates refresh only this band;
+/// hosts keep the previous value while the asynchronous read is running.
+final FutureProviderFamily<RelationshipProposalSnapshot, String>
+relationshipSuggestionListProvider = FutureProvider.autoDispose
+    .family<RelationshipProposalSnapshot, String>((ref, relationshipId) async {
+      final agentId = relationshipAgentIdFor(relationshipId);
+      ref.watch(agentUpdateStreamProvider(agentId));
+      final repository = ref.watch(agentRepositoryProvider);
+      final ledger = await repository.getProposalLedger(
+        agentId,
+        taskId: relationshipId,
+      );
+      final seen = <String>{};
+      final open = <PendingSuggestion>[];
+      for (final set in ledger.pendingSets) {
+        for (var index = 0; index < set.items.length; index++) {
+          final item = set.items[index];
+          if (item.status != ChangeItemStatus.pending) continue;
+          final fingerprint = ChangeItem.fingerprint(item);
+          if (!seen.add(fingerprint)) continue;
+          open.add(
+            PendingSuggestion(
+              changeSet: set,
+              itemIndex: index,
+              item: item,
+              fingerprint: fingerprint,
+            ),
+          );
+        }
+      }
+      final runKeys = {
+        for (final set in ledger.pendingSets) set.id: set.runKey,
+      };
+      for (final entry in ledger.resolved) {
+        if (entry.runKey case final String runKey) {
+          runKeys[entry.changeSetId] = runKey;
+        }
+      }
+      final receipts = <String, Task>{};
+      if (ledger.resolved.isNotEmpty) {
+        final decisions =
+            (await repository.getEntitiesByAgentId(
+                  agentId,
+                  type: AgentEntityTypes.changeDecision,
+                ))
+                .whereType<ChangeDecisionEntity>()
+                .where((d) => d.deletedAt == null)
+                .toList()
+              ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+        final seenDecisions = <String>{};
+        for (final decision in decisions) {
+          final key = RelationshipProposalSnapshot.itemKey(
+            decision.changeSetId,
+            decision.itemIndex,
+          );
+          if (!seenDecisions.add(key) ||
+              decision.verdict != ChangeDecisionVerdict.confirmed) {
+            continue;
+          }
+          final raw = decision.args?[RelationshipProposalService.receiptKey];
+          final task = RelationshipProposalService.decodeReceipt(raw);
+          if (task != null) receipts[key] = task;
+        }
+      }
+      for (final entry in ledger.resolved) {
+        final key = RelationshipProposalSnapshot.itemKey(
+          entry.changeSetId,
+          entry.itemIndex,
+        );
+        if (entry.status == ChangeItemStatus.confirmed &&
+            !receipts.containsKey(key)) {
+          final local = ref
+              .read(relationshipProposalServiceProvider)
+              .cachedReceipt(entry.changeSetId, entry.itemIndex);
+          if (local != null) receipts[key] = local;
+        }
+      }
+      final activityKeys = <String>{};
+      return RelationshipProposalSnapshot(
+        suggestions: UnifiedSuggestionList(
+          open: open,
+          activity: [
+            for (final entry in ledger.resolved)
+              if (activityKeys.add(
+                RelationshipProposalSnapshot.itemKey(
+                  entry.changeSetId,
+                  entry.itemIndex,
+                ),
+              ))
+                entry,
+          ],
+        ),
+        receipts: receipts,
+        runKeys: runKeys,
+      );
+    });
+
+/// Briefly marks newly confirmed tasks on the person's linked-task card.
+final relationshipTaskHighlightProvider =
+    NotifierProvider<RelationshipTaskHighlight, Set<String>>(
+      RelationshipTaskHighlight.new,
+    );
+
+class RelationshipTaskHighlight extends Notifier<Set<String>> {
+  final _timers = <String, Timer>{};
+
+  @override
+  Set<String> build() {
+    ref.onDispose(() {
+      for (final timer in _timers.values) {
+        timer.cancel();
+      }
+    });
+    return {};
+  }
+
+  void highlight(String taskId) {
+    _timers.remove(taskId)?.cancel();
+    state = {...state, taskId};
+    _timers[taskId] = Timer(const Duration(seconds: 3), () {
+      _timers.remove(taskId);
+      state = {...state}..remove(taskId);
+    });
+  }
+}

--- a/lib/features/relationships/state/relationship_proposal_providers.dart
+++ b/lib/features/relationships/state/relationship_proposal_providers.dart
@@ -27,6 +27,7 @@ final Provider<RelationshipToolDispatcher> relationshipToolDispatcherProvider =
         persistenceLogic: getIt<PersistenceLogic>(),
         entitiesCacheService: getIt<EntitiesCacheService>(),
         taskAgentService: ref.watch(taskAgentServiceProvider),
+        journalDb: ref.watch(journalDbProvider),
       ),
     );
 

--- a/lib/features/relationships/ui/widgets/linked_tasks_card.dart
+++ b/lib/features/relationships/ui/widgets/linked_tasks_card.dart
@@ -13,6 +13,7 @@ import 'package:lotti/features/design_system/components/toasts/design_system_toa
 import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
+import 'package:lotti/features/relationships/state/relationship_proposal_providers.dart';
 import 'package:lotti/features/relationships/ui/widgets/person_page_cards.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/linked_task_row.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/task_search_picker_body.dart';
@@ -223,6 +224,7 @@ class LinkedTasksCard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final highlightedTasks = ref.watch(relationshipTaskHighlightProvider);
     final tokens = context.designTokens;
     final messages = context.messages;
 
@@ -261,6 +263,7 @@ class LinkedTasksCard extends ConsumerWidget {
             for (final task in tasks)
               DesignSystemListItem(
                 key: ValueKey('person-task-${task.meta.id}'),
+                activated: highlightedTasks.contains(task.id),
                 size: DesignSystemListItemSize.small,
                 title: task.data.title.isEmpty
                     ? messages.taskUntitled

--- a/lib/features/relationships/ui/widgets/relationship_briefing_card.dart
+++ b/lib/features/relationships/ui/widgets/relationship_briefing_card.dart
@@ -34,6 +34,7 @@ import 'package:lotti/features/relationships/ui/widgets/check_in_capture_sheet.d
 import 'package:lotti/features/relationships/ui/widgets/contact_quick_actions.dart';
 import 'package:lotti/features/relationships/ui/widgets/person_header.dart';
 import 'package:lotti/features/relationships/ui/widgets/relationship_form_modal.dart';
+import 'package:lotti/features/relationships/ui/widgets/relationship_suggestions_band.dart';
 import 'package:lotti/l10n/app_localizations.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/utils/relative_age_label.dart';
@@ -439,6 +440,7 @@ class _RelationshipBriefingCardState
       state: cardState,
       item: item,
       checkInCount: widget.checkIns.length,
+      checkIns: widget.checkIns,
       report: report,
       agentState: state,
       health: health,
@@ -604,6 +606,7 @@ class _AgentCard extends StatelessWidget {
     required this.state,
     required this.item,
     required this.checkInCount,
+    required this.checkIns,
     required this.report,
     required this.agentState,
     required this.health,
@@ -625,6 +628,7 @@ class _AgentCard extends StatelessWidget {
   final RelationshipAgentCardState state;
   final RelationshipListItem item;
   final int checkInCount;
+  final List<CheckInEntry> checkIns;
   final AgentReportEntity? report;
   final AgentStateEntity? agentState;
   final RelationshipHealthMetrics? health;
@@ -905,6 +909,11 @@ class _AgentCard extends StatelessWidget {
             body is TldrBody ? 0 : tokens.spacing.step4,
           ),
           child: body,
+        ),
+        RelationshipSuggestionsBand(
+          relationshipId: item.relationship.id,
+          checkIns: checkIns,
+          showHistory: expanded,
         ),
         _AgentCardFooter(
           status: footer.status,

--- a/lib/features/relationships/ui/widgets/relationship_chat_pane.dart
+++ b/lib/features/relationships/ui/widgets/relationship_chat_pane.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/state/agent_chat_projection.dart';
 import 'package:lotti/features/agents/state/agent_query_providers.dart';
 import 'package:lotti/features/agents/ui/agent_internals_panel.dart';
 import 'package:lotti/features/agents/ui/chat/agent_chat_view.dart';
@@ -9,6 +10,8 @@ import 'package:lotti/features/design_system/components/buttons/design_system_bu
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/relationships/state/relationship_chat_controller.dart';
+import 'package:lotti/features/relationships/state/relationships_providers.dart';
+import 'package:lotti/features/relationships/ui/widgets/relationship_suggestions_band.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:material_ui/material_ui.dart';
 
@@ -30,8 +33,7 @@ class RelationshipChatPane extends ConsumerWidget {
 
   final String relationshipId;
 
-  /// Renders a back affordance in the header when supplied. The phone route
-  /// leaves this null: its app bar already has one.
+  /// Renders a back affordance in the header when supplied by either host.
   final VoidCallback? onBack;
 
   /// Whether the header offers *Agent internals*. The desktop pane does,
@@ -104,6 +106,31 @@ class RelationshipChatPane extends ConsumerWidget {
       onDraftChanged: controller.updateDraft,
       onSend: controller.send,
       onRetry: controller.retry,
+      attachmentBuilder: (context, message) {
+        if (message.role != AgentChatRole.agent || message.runKey == null) {
+          return null;
+        }
+        return Consumer(
+          builder: (context, ref, child) {
+            final detail = ref
+                .watch(
+                  relationshipDetailControllerProvider(
+                    relationshipId,
+                  ),
+                )
+                .value;
+            return RelationshipSuggestionsBand(
+              key: ValueKey(
+                'relationship-chat-proposals-${message.id}',
+              ),
+              relationshipId: relationshipId,
+              checkIns: detail?.checkIns ?? const [],
+              runKey: message.runKey,
+              showHistory: true,
+            );
+          },
+        );
+      },
     );
   }
 }

--- a/lib/features/relationships/ui/widgets/relationship_suggestions_band.dart
+++ b/lib/features/relationships/ui/widgets/relationship_suggestions_band.dart
@@ -268,7 +268,9 @@ class _RelationshipSuggestionsBandState
                 confirmAllPulse: _confirmed.contains(_key(row)) ? 1 : 0,
                 pendingCount: current.length,
                 settling:
-                    _resolving.isNotEmpty && !_resolving.containsKey(_key(row)),
+                    _bulkBusy ||
+                    (_resolving.isNotEmpty &&
+                        !_resolving.containsKey(_key(row))),
                 onResolveStart: _start,
                 onResolveEnd: _end,
                 onConfirm: () => _confirm(row),

--- a/lib/features/relationships/ui/widgets/relationship_suggestions_band.dart
+++ b/lib/features/relationships/ui/widgets/relationship_suggestions_band.dart
@@ -1,0 +1,333 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/proposal_ledger.dart';
+import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/agents/state/unified_suggestion_providers.dart';
+import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
+import 'package:lotti/features/agents/ui/ai_summary_card/proposal_kind_part.dart';
+import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_part.dart';
+import 'package:lotti/features/agents/ui/ai_summary_card/proposals_section_part.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_inline_action.dart';
+import 'package:lotti/features/design_system/components/motion/size_fade_collapse.dart';
+import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
+import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/relationships/state/relationship_proposal_providers.dart';
+import 'package:lotti/features/relationships/ui/widgets/check_in_capture_sheet.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/services/nav_service.dart';
+import 'package:material_ui/material_ui.dart';
+
+/// Evidence-backed proposals on the relationship card. Retains resolving rows
+/// until their shared exit animation ends, independently of ledger refreshes.
+class RelationshipSuggestionsBand extends ConsumerStatefulWidget {
+  const RelationshipSuggestionsBand({
+    required this.relationshipId,
+    required this.checkIns,
+    this.showHistory = false,
+    this.runKey,
+    super.key,
+  });
+  final String relationshipId;
+  final List<CheckInEntry> checkIns;
+  final bool showHistory;
+
+  /// A chat host can show only proposals from this conversation turn.
+  final String? runKey;
+
+  @override
+  ConsumerState<RelationshipSuggestionsBand> createState() =>
+      _RelationshipSuggestionsBandState();
+}
+
+class _RelationshipSuggestionsBandState
+    extends ConsumerState<RelationshipSuggestionsBand> {
+  final _resolving = <String, PendingSuggestion>{};
+  final _removed = <String>{};
+  final _confirmed = <String>{};
+  bool _sectionVisible = false;
+  bool _all = false;
+  bool _bulkBusy = false;
+  bool _historyOpen = false;
+  bool _handledHere = false;
+  bool _undoBusy = false;
+
+  String _key(PendingSuggestion row) =>
+      RelationshipProposalSnapshot.itemKey(row.changeSet.id, row.itemIndex);
+  void _refresh() => ref.read(updateNotificationsProvider).notifyUiOnly({
+    relationshipAgentIdFor(widget.relationshipId),
+  });
+
+  void _start(PendingSuggestion row) {
+    setState(() => _resolving[_key(row)] = row);
+  }
+
+  void _end(PendingSuggestion row, {required bool removed}) {
+    if (!mounted) return;
+    setState(() {
+      _resolving.remove(_key(row));
+      if (removed) {
+        _removed.add(_key(row));
+        _handledHere = true;
+        _historyOpen = true;
+      }
+    });
+  }
+
+  Future<void> _confirmAll(List<PendingSuggestion> rows) async {
+    if (_bulkBusy || rows.isEmpty) return;
+    final kinds = rows
+        .map((row) => resolveKind(row.item.toolName, row.item.args))
+        .toSet();
+    if (kinds.length != 1) return;
+    setState(() {
+      _bulkBusy = true;
+      _all = true;
+      for (final row in rows) {
+        _resolving[_key(row)] = row;
+      }
+    });
+    try {
+      for (final row in rows) {
+        ToolExecutionResult result;
+        try {
+          result = await _confirm(row);
+        } catch (_) {
+          result = const ToolExecutionResult(
+            success: false,
+            output: 'Confirmation failed',
+          );
+        }
+        if (!mounted) return;
+        if (result.success) {
+          setState(() => _confirmed.add(_key(row)));
+        } else {
+          _end(row, removed: false);
+          context.showToast(
+            tone: DesignSystemToastTone.error,
+            title: context.messages.relationshipErrorLinkTaskFailed,
+          );
+        }
+        _refresh();
+      }
+    } finally {
+      if (mounted) setState(() => _bulkBusy = false);
+    }
+  }
+
+  Future<ToolExecutionResult> _confirm(PendingSuggestion row) async {
+    final highlighter = ref.read(relationshipTaskHighlightProvider.notifier);
+    final result = await ref
+        .read(relationshipProposalServiceProvider)
+        .confirm(row.changeSet, row.itemIndex);
+    if (result.success && result.mutatedEntityId != null) {
+      highlighter.highlight(result.mutatedEntityId!);
+    }
+    return result;
+  }
+
+  Future<void> _undo(LedgerEntry entry) async {
+    if (_undoBusy) return;
+    final service = ref.read(relationshipProposalServiceProvider);
+    setState(() => _undoBusy = true);
+    var undone = false;
+    try {
+      undone = await service.undoById(entry.changeSetId, entry.itemIndex);
+    } catch (_) {
+      /* A refused undo leaves the handled row in place. */
+    }
+    if (!mounted) return;
+    setState(() {
+      _undoBusy = false;
+      if (undone) {
+        final key = RelationshipProposalSnapshot.itemKey(
+          entry.changeSetId,
+          entry.itemIndex,
+        );
+        _removed.remove(key);
+        _confirmed.remove(key);
+      }
+    });
+    if (!undone) {
+      context.showToast(
+        tone: DesignSystemToastTone.error,
+        title: context.messages.relationshipProposalUndoFailed,
+      );
+    }
+    _refresh();
+  }
+
+  Widget _evidence(Map<String, dynamic> args) {
+    final source = widget.checkIns
+        .where((entry) => entry.id == args['sourceCheckInId'])
+        .firstOrNull;
+    final due = args['dueDate'] is String
+        ? DateTime.tryParse(args['dueDate'] as String)
+        : null;
+    final tokens = context.designTokens;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (due != null)
+          Text(
+            context.messages.taskDueDateWithDate(
+              DateFormat.yMMMd(context.messages.localeName).format(due),
+            ),
+            style: tokens.typography.styles.others.caption.copyWith(
+              color: tokens.colors.aiCard.metaText,
+            ),
+          ),
+        if (source != null)
+          DesignSystemInlineAction(
+            label: context.messages.relationshipProposalEvidence(
+              DateFormat.yMMMd(
+                context.messages.localeName,
+              ).format(source.meta.dateFrom),
+            ),
+            semanticsLabel: context.messages.relationshipProposalEvidence(
+              DateFormat.yMMMd(
+                context.messages.localeName,
+              ).format(source.meta.dateFrom),
+            ),
+            onTap: () =>
+                showCheckInEditSheet(context: context, checkIn: source),
+          ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final snapshot =
+        ref
+            .watch(relationshipSuggestionListProvider(widget.relationshipId))
+            .value ??
+        const RelationshipProposalSnapshot.empty();
+    final current = snapshot.suggestions.open
+        .where(
+          (row) =>
+              widget.runKey == null || row.changeSet.runKey == widget.runKey,
+        )
+        .toList();
+    // Once the ledger acknowledges a removal, forget the local tombstone.
+    // A peer can then reopen the same item without it staying hidden here.
+    final currentKeys = current.map(_key).toSet();
+    _removed.removeWhere((key) => !currentKeys.contains(key));
+    _confirmed.removeWhere(
+      (key) => !currentKeys.contains(key) && !_resolving.containsKey(key),
+    );
+    final byKey = {
+      for (final row in current)
+        if (!_removed.contains(_key(row))) _key(row): row,
+      ..._resolving,
+    };
+    final rows = byKey.values.toList();
+    if (rows.isNotEmpty) _sectionVisible = true;
+    final shown = _all ? rows : rows.take(3).toList();
+    final sameKind =
+        current
+            .map((row) => resolveKind(row.item.toolName, row.item.args))
+            .toSet()
+            .length ==
+        1;
+    final history = snapshot.suggestions.activity
+        .where(
+          (entry) =>
+              widget.runKey == null ||
+              snapshot.runKeys[entry.changeSetId] == widget.runKey,
+        )
+        .toList();
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (_sectionVisible)
+          SizeFadeCollapse(
+            onCollapsed: () {
+              if (mounted) setState(() => _sectionVisible = false);
+            },
+            collapsed: rows.isEmpty,
+            duration: ProposalMotion.collapse,
+            child: ProposalsSection(
+              open: shown,
+              pendingCount: current.length,
+              confirmAllBusy: _bulkBusy,
+              onConfirmAll: current.length > 1 && sameKind && _resolving.isEmpty
+                  ? () => _confirmAll(current)
+                  : null,
+              confirmAllPulse: 0,
+              rowBuilder: (row, index) => ProposalRow(
+                key: ValueKey('relationship-proposal-${_key(row)}'),
+                suggestion: row,
+                isFirst: index == 0,
+                cascadeIndex: index,
+                confirmAllPulse: _confirmed.contains(_key(row)) ? 1 : 0,
+                pendingCount: current.length,
+                settling:
+                    _resolving.isNotEmpty && !_resolving.containsKey(_key(row)),
+                onResolveStart: _start,
+                onResolveEnd: _end,
+                onConfirm: () => _confirm(row),
+                onReject: () => ref
+                    .read(relationshipProposalServiceProvider)
+                    .reject(row.changeSet, row.itemIndex),
+                details: _evidence(row.item.args),
+              ),
+            ),
+          ),
+        if (!_all && rows.length > 3)
+          DesignSystemInlineAction(
+            label: context.messages.projectNextStepsShowMore(rows.length - 3),
+            semanticsLabel: context.messages.projectNextStepsShowMore(
+              rows.length - 3,
+            ),
+            onTap: () => setState(() => _all = true),
+          ),
+        if ((widget.showHistory || _handledHere) &&
+            history.isNotEmpty &&
+            _resolving.isEmpty)
+          ProposalHistorySection(
+            resolved: history,
+            open: _historyOpen,
+            onToggle: () => setState(() => _historyOpen = !_historyOpen),
+            rowBuilder: (entry) {
+              final task =
+                  snapshot.receipts[RelationshipProposalSnapshot.itemKey(
+                    entry.changeSetId,
+                    entry.itemIndex,
+                  )];
+              return ProposalRow.fromLedger(
+                entry: entry,
+                details: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _evidence(entry.args),
+                    if (task != null)
+                      DesignSystemInlineAction(
+                        label: context.messages.relationshipProposalAdded(
+                          task.data.title,
+                        ),
+                        semanticsLabel: context.messages
+                            .relationshipProposalAdded(task.data.title),
+                        onTap: () => beamToNamed('/tasks/${task.id}'),
+                      ),
+                    if (entry.status == ChangeItemStatus.rejected ||
+                        task != null)
+                      DesignSystemInlineAction(
+                        label: context.messages.designSystemUndoLabel,
+                        semanticsLabel: context.messages.designSystemUndoLabel,
+                        onTap: _undoBusy ? null : () => unawaited(_undo(entry)),
+                      ),
+                  ],
+                ),
+              );
+            },
+          ),
+      ],
+    );
+  }
+}

--- a/lib/features/relationships/workflow/relationship_agent_contract.dart
+++ b/lib/features/relationships/workflow/relationship_agent_contract.dart
@@ -10,13 +10,14 @@ import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/tools/agent_tool_registry.dart';
 import 'package:lotti/features/relationships/model/relationship_health_metrics.dart';
 
-/// Tool names of the relationship-agent surface —
-/// `<verb>_relationship_<noun>` throughout, the uniform-prefix lesson from
-/// the goal contract.
+/// Tool names of the relationship-agent surface.
+/// Domain tools use `<verb>_relationship_<noun>`; the shared reply carrier
+/// and deferred `create_and_link_task` keep their cross-feature names.
 class RelationshipAgentToolNames {
   static const String replyToUser = AgentConversationToolNames.replyToUser;
   static const updateRelationshipReport = 'update_relationship_report';
   static const createRelationshipAd = 'create_relationship_ad';
+  static const createAndLinkTask = 'create_and_link_task';
   static const snoozeRelationshipAd = 'snooze_relationship_ad';
 }
 
@@ -81,7 +82,15 @@ Act in this order of precedence:
    details, no health data, no third-party names beyond this person's.
    For an explicit temporary-hide request, call snooze_relationship_ad with
    the future instant.
-4. Nothing material changed: call no tools and write nothing.
+4. Proposals: only an explicit commitment in a captured check-in justifies
+   create_and_link_task. Quote the evidence in description and pass its
+   sourceCheckInId as a structured argument. Queue at most three per wake.
+   Never re-propose pending, confirmed or rejected proposals from FACTS,
+   including paraphrases. Never derive a task from a contact channel.
+   These tools only propose: user confirmation is required before any task
+   exists. Never claim a proposal was already applied. Propose a dueDate
+   only when the evidence supports it.
+5. Nothing material changed: call no tools and write nothing.
 ''';
 
 /// Header introducing the pending user message appended to an interactive
@@ -233,4 +242,61 @@ final List<AgentToolDefinition> relationshipAgentTools = [
       'required': ['adId', 'until', 'reason'],
     },
   ),
+  const AgentToolDefinition(
+    name: RelationshipAgentToolNames.createAndLinkTask,
+    description:
+        'Propose a task from an explicit check-in commitment. '
+        'Nothing is created until the user confirms.',
+    parameters: {
+      'type': 'object',
+      'additionalProperties': false,
+      'properties': {
+        'title': {'type': 'string', 'description': 'Concise task title.'},
+        'description': {
+          'type': 'string',
+          'description': 'Quote the commitment sentence from the check-in.',
+        },
+        'sourceCheckInId': {
+          'type': 'string',
+          'description': 'Exact checkInId from FACTS.',
+        },
+        'reason': {
+          'type': 'string',
+          'description': 'Why this commitment needs a task.',
+        },
+        'dueDate': {
+          'type': 'string',
+          'description': 'Optional evidence-supported due date, YYYY-MM-DD.',
+        },
+      },
+      'required': ['title', 'description', 'sourceCheckInId', 'reason'],
+    },
+  ),
 ];
+
+/// Mutations that are accumulated for user confirmation, never run by the LLM.
+const Set<String> relationshipDeferredTools = {
+  RelationshipAgentToolNames.createAndLinkTask,
+};
+
+/// Rejects malformed task proposals at both production and confirmation.
+/// Calendar dates must round-trip: Dart otherwise normalizes February 30.
+String? relationshipTaskProposalError(Map<String, dynamic> args) {
+  for (final key in ['title', 'description', 'sourceCheckInId', 'reason']) {
+    final value = args[key];
+    if (value is! String || value.trim().isEmpty) {
+      return '$key must be a non-empty string';
+    }
+  }
+  final due = args['dueDate'];
+  if (due != null) {
+    final parsed = due is String ? DateTime.tryParse(due) : null;
+    if (due is! String ||
+        !RegExp(r'^\d{4}-\d{2}-\d{2}$').hasMatch(due) ||
+        parsed == null ||
+        parsed.toIso8601String().substring(0, 10) != due) {
+      return 'dueDate must be a valid YYYY-MM-DD calendar date';
+    }
+  }
+  return null;
+}

--- a/lib/features/relationships/workflow/relationship_agent_strategy.dart
+++ b/lib/features/relationships/workflow/relationship_agent_strategy.dart
@@ -48,6 +48,7 @@ class RelationshipAgentStrategy extends ConversationStrategy
     required this.threadId,
     required this.runKey,
     required this._activeAdIds,
+    this.sourceCheckInIds = const {},
   });
 
   @override
@@ -62,6 +63,14 @@ class RelationshipAgentStrategy extends ConversationStrategy
   /// Ad ids currently rendered — the only ids snooze may reference, so a
   /// hallucinated id fails in-conversation instead of corrupting state.
   final Set<String> _activeAdIds;
+
+  /// Only check-ins actually rendered in this wake may supply evidence.
+  final Set<String> sourceCheckInIds;
+  final _deferredItems = <Map<String, dynamic>>[];
+
+  /// Deferred mutations; the workflow alone owns their persistence.
+  List<Map<String, dynamic>> get deferredItems =>
+      List.unmodifiable(_deferredItems);
 
   RelationshipBriefing? _briefing;
   String? _finalResponse;
@@ -115,6 +124,8 @@ class RelationshipAgentStrategy extends ConversationStrategy
       await recordActionMessage(toolName: toolName);
 
       switch (toolName) {
+        case RelationshipAgentToolNames.createAndLinkTask:
+          await _handleTaskProposal(call, args, manager);
         case RelationshipAgentToolNames.replyToUser:
           await _handleReplyToUser(call, args, manager);
         case RelationshipAgentToolNames.updateRelationshipReport:
@@ -143,6 +154,56 @@ class RelationshipAgentStrategy extends ConversationStrategy
   /// train churn back in (the goal-strategy lesson).
   @override
   String? getContinuationPrompt(ConversationManager manager) => null;
+
+  Future<void> _handleTaskProposal(
+    ChatCompletionMessageToolCall call,
+    Map<String, dynamic> args,
+    ConversationManager manager,
+  ) async {
+    final error = relationshipTaskProposalError(args);
+    if (error != null || !sourceCheckInIds.contains(args['sourceCheckInId'])) {
+      await _reject(
+        call: call,
+        manager: manager,
+        error:
+            'Error: ${error ?? 'sourceCheckInId must name a rendered check-in'}.',
+      );
+      return;
+    }
+    final normalized = <String, dynamic>{
+      for (final key in [
+        'title',
+        'description',
+        'sourceCheckInId',
+        'reason',
+        'dueDate',
+      ])
+        if (args[key] case final String value) key: value.trim(),
+    };
+    if (_deferredItems.any((item) {
+      final previous = item['args'] as Map<String, dynamic>;
+      return previous['sourceCheckInId'] == normalized['sourceCheckInId'] &&
+          (previous['title'] as String).toLowerCase() ==
+              (normalized['title'] as String).toLowerCase();
+    })) {
+      await _accept(call, manager, 'Already queued for confirmation.');
+      return;
+    }
+    if (_deferredItems.length >= 3) {
+      await _reject(
+        call: call,
+        manager: manager,
+        error: 'Error: at most three task proposals per wake.',
+      );
+      return;
+    }
+    _deferredItems.add({'toolName': call.function.name, 'args': normalized});
+    await _accept(
+      call,
+      manager,
+      'Queued for user confirmation; no task created.',
+    );
+  }
 
   Future<void> _handleUpdateReport(
     ChatCompletionMessageToolCall call,

--- a/lib/features/relationships/workflow/relationship_agent_workflow.dart
+++ b/lib/features/relationships/workflow/relationship_agent_workflow.dart
@@ -9,12 +9,14 @@ import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/agents/util/agent_error_logging.dart';
 import 'package:lotti/features/agents/util/inference_provider_resolver.dart';
 import 'package:lotti/features/agents/util/text_utils.dart';
 import 'package:lotti/features/agents/workflow/agent_system_prompt.dart';
 import 'package:lotti/features/agents/workflow/carrierless_attribution.dart';
+import 'package:lotti/features/agents/workflow/deferred_change_items.dart';
 import 'package:lotti/features/agents/workflow/wake_result.dart';
 import 'package:lotti/features/ai/conversation/conversation_repository.dart';
 import 'package:lotti/features/ai/helpers/profile_automation_resolver.dart';
@@ -330,6 +332,10 @@ class RelationshipAgentWorkflow with AgentErrorLogging {
     final checkIns = await _relationshipRepository
         .getAllCheckInsForRelationship(relationshipId);
 
+    final proposals = await _repository.getProposalLedger(
+      agentId,
+      taskId: relationshipId,
+    );
     var factsBlock = _factsRenderer.render(
       relationship: relationship,
       derivation: derivation,
@@ -339,6 +345,7 @@ class RelationshipAgentWorkflow with AgentErrorLogging {
       nudges: nudges,
       now: now,
       preTransitionStatus: preTransitionStatus,
+      proposals: proposals,
     );
     if (interactive) {
       factsBlock =
@@ -386,6 +393,9 @@ class RelationshipAgentWorkflow with AgentErrorLogging {
       threadId: threadId,
       runKey: runKey,
       activeAdIds: activeAdIds,
+      sourceCheckInIds: {
+        for (final entry in relationshipCheckInWindow(checkIns)) entry.id,
+      },
     );
     final tools = [
       for (final tool in relationshipAgentTools)
@@ -689,6 +699,60 @@ class RelationshipAgentWorkflow with AgentErrorLogging {
           (!subject.data.important ||
               subject.data.status is! RelationshipActive)) {
         return;
+      }
+
+      if (strategy.deferredItems.isNotEmpty &&
+          subject.data.important &&
+          subject.data.status is RelationshipActive) {
+        final setId = const Uuid().v5(
+          Namespace.url.value,
+          'lotti://relationship-agent/$agentId/$runKey/proposals',
+        );
+        // Retry must not replace a set the user has already acted on.
+        if (await _repository.getEntity(setId) == null) {
+          final ledger = await _repository.getProposalLedger(
+            agentId,
+            taskId: relationshipId,
+          );
+          final fingerprints = {
+            for (final entry in [...ledger.open, ...ledger.resolved])
+              entry.fingerprint,
+          };
+          final displayKeys = {
+            for (final entry in [...ledger.open, ...ledger.resolved])
+              ChangeItem.displayDuplicateKeyFromParts(
+                entry.toolName,
+                entry.humanSummary,
+                args: entry.args,
+              ),
+          };
+          final items =
+              buildDeferredChangeItems(
+                    strategy.deferredItems,
+                    (tool, args) => 'Create task: ${args['title']}',
+                  )
+                  .where(
+                    (item) =>
+                        fingerprints.add(ChangeItem.fingerprint(item)) &&
+                        displayKeys.add(ChangeItem.displayDuplicateKey(item)),
+                  )
+                  .toList();
+          if (items.isNotEmpty) {
+            await _syncService.upsertEntity(
+              AgentDomainEntity.changeSet(
+                id: setId,
+                agentId: agentId,
+                taskId: relationshipId,
+                threadId: threadId,
+                runKey: runKey,
+                status: ChangeSetStatus.pending,
+                items: items,
+                createdAt: now,
+                vectorClock: null,
+              ),
+            );
+          }
+        }
       }
 
       // RE-READ inside the transaction: the user may have dismissed a

--- a/lib/features/relationships/workflow/relationship_facts_renderer.dart
+++ b/lib/features/relationships/workflow/relationship_facts_renderer.dart
@@ -1,8 +1,11 @@
+import 'dart:convert';
+
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/nudge_models.dart';
 import 'package:lotti/classes/relationship_trigger_tokens.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/proposal_ledger.dart';
 import 'package:lotti/features/relationships/runtime/relationship_agent_phase_a.dart';
 
 /// How many recent check-ins feed the FACTS block (ADR 0040 Decision 4:
@@ -42,6 +45,7 @@ class RelationshipFactsRenderer {
     required List<RelationshipNudgeEntity> nudges,
     required DateTime now,
     RelationshipCadenceStatus? preTransitionStatus,
+    ProposalLedger proposals = const ProposalLedger.empty(),
   }) {
     final data = relationship.data;
     final buffer = StringBuffer()
@@ -81,9 +85,7 @@ class RelationshipFactsRenderer {
         );
     }
 
-    final recent = [...checkIns]
-      ..sort((a, b) => b.meta.dateFrom.compareTo(a.meta.dateFrom));
-    final window = recent.take(relationshipCheckInLookback).toList();
+    final window = relationshipCheckInWindow(checkIns);
     buffer.writeln(
       'CHECK-INS (newest first, ${window.length} of ${checkIns.length}):',
     );
@@ -93,6 +95,7 @@ class RelationshipFactsRenderer {
     for (final checkIn in window) {
       final d = checkIn.data;
       final parts = <String>[
+        'checkInId=${checkIn.id}',
         _day(checkIn.meta.dateFrom),
         d.interactionType.name,
         if (d.sentiment != null) 'sentiment(user-set)=${d.sentiment!.name}',
@@ -167,6 +170,15 @@ class RelationshipFactsRenderer {
       );
     }
 
+    buffer.writeln('PROPOSALS (do not repeat, including paraphrases):');
+    for (final entry in [...proposals.open, ...proposals.resolved]) {
+      buffer.writeln(
+        '- ${entry.status.name} | ${entry.toolName} | '
+        '${jsonEncode(entry.args)} | ${entry.humanSummary}',
+      );
+    }
+    if (proposals.isEmpty) buffer.writeln('- none');
+
     return buffer.toString().trimRight();
   }
 
@@ -218,4 +230,11 @@ class RelationshipFactsRenderer {
     if (collapsed.length <= relationshipNarrativeExcerptChars) return collapsed;
     return '${collapsed.substring(0, relationshipNarrativeExcerptChars)}…';
   }
+}
+
+/// The exact evidence window shared by prompt rendering and tool validation.
+List<CheckInEntry> relationshipCheckInWindow(List<CheckInEntry> checkIns) {
+  final sorted = [...checkIns]
+    ..sort((a, b) => b.meta.dateFrom.compareTo(a.meta.dateFrom));
+  return sorted.take(relationshipCheckInLookback).toList();
 }

--- a/lib/features/relationships/workflow/relationship_tool_dispatcher.dart
+++ b/lib/features/relationships/workflow/relationship_tool_dispatcher.dart
@@ -1,0 +1,179 @@
+import 'dart:developer' as developer;
+
+import 'package:clock/clock.dart';
+import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/relationship_data.dart';
+import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/agents/service/task_agent_service.dart';
+import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
+import 'package:lotti/features/relationships/repository/relationship_repository.dart';
+import 'package:lotti/features/relationships/workflow/relationship_agent_contract.dart';
+import 'package:lotti/logic/create/task_agent_assignment.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/entities_cache_service.dart';
+import 'package:uuid/uuid.dart';
+
+/// The exact creation snapshot, before any asynchronous follow-up can edit it.
+class RelationshipTaskCreationResult extends ToolExecutionResult {
+  RelationshipTaskCreationResult(this.task)
+    : super(
+        success: true,
+        output: 'Created and linked task',
+        mutatedEntityId: task.id,
+      );
+
+  final Task task;
+}
+
+/// Applies user-confirmed relationship proposals. Evidence and consent are
+/// checked again at apply time; the model never writes journal entities.
+class RelationshipToolDispatcher {
+  RelationshipToolDispatcher({
+    required this.relationshipRepository,
+    required this.persistenceLogic,
+    required this.entitiesCacheService,
+    required this.taskAgentService,
+  });
+
+  final RelationshipRepository relationshipRepository;
+  final PersistenceLogic persistenceLogic;
+  final EntitiesCacheService entitiesCacheService;
+  final TaskAgentService taskAgentService;
+
+  Future<ToolExecutionResult> dispatch(
+    String toolName,
+    Map<String, dynamic> args,
+    String relationshipId,
+  ) async {
+    if (toolName != RelationshipAgentToolNames.createAndLinkTask) {
+      return _failure('Unknown relationship tool', permanent: true);
+    }
+    final invalid = relationshipTaskProposalError(args);
+    if (invalid != null) return _failure(invalid, permanent: true);
+    final person = await relationshipRepository.getRelationshipById(
+      relationshipId,
+    );
+    if (person == null ||
+        person.isDeleted ||
+        !person.data.important ||
+        person.data.status is! RelationshipActive) {
+      return _failure('Relationship is no longer eligible', permanent: true);
+    }
+    final evidence = (await relationshipRepository.getCheckInsForRelationship(
+      relationshipId,
+    )).where((entry) => entry.id == args['sourceCheckInId']).firstOrNull;
+    if (evidence == null ||
+        evidence.isDeleted ||
+        evidence.data.relationshipId != relationshipId) {
+      return _failure(
+        'Source check-in is no longer available',
+        permanent: true,
+      );
+    }
+    final quote = (args['description'] as String).trim();
+    final narrative = evidence.entryText?.plainText ?? '';
+    if (!narrative.contains(quote)) {
+      return _failure(
+        'The quoted commitment is no longer in the source check-in',
+        permanent: true,
+      );
+    }
+    final now = clock.now();
+    final categoryId = person.meta.categoryId;
+    final category = categoryId == null
+        ? null
+        : entitiesCacheService.getCategoryById(categoryId);
+    final description = args['description'] as String;
+    final evidenceUrl = 'lotti://journal/${evidence.id}';
+    final task = await persistenceLogic.createTaskEntry(
+      data: TaskData(
+        title: (args['title'] as String).trim(),
+        status: TaskStatus.open(
+          id: const Uuid().v4(),
+          createdAt: now,
+          utcOffset: now.timeZoneOffset.inMinutes,
+        ),
+        dateFrom: now,
+        dateTo: now,
+        statusHistory: const [],
+        profileId: category?.defaultProfileId,
+        due: args['dueDate'] == null
+            ? null
+            : DateTime.parse(args['dueDate'] as String),
+      ),
+      entryText: EntryText(
+        plainText: '$description\n\nlotti://journal/${evidence.id}',
+        markdown: '$description\n\n[$evidenceUrl]($evidenceUrl)',
+      ),
+      categoryId: categoryId,
+      private: person.meta.private == true || evidence.meta.private == true,
+    );
+    if (task == null) return _failure('Task creation failed');
+    var linked = false;
+    try {
+      // A deleted person must not gain a task while an async create was running.
+      final current = await relationshipRepository.getRelationshipById(
+        relationshipId,
+      );
+      if (current != null &&
+          !current.isDeleted &&
+          current.data.important &&
+          current.data.status is RelationshipActive &&
+          current.meta.categoryId == categoryId &&
+          current.meta.private == person.meta.private) {
+        linked = await relationshipRepository.linkTask(
+          relationshipId: relationshipId,
+          taskId: task.id,
+        );
+      }
+    } catch (_) {
+      // The same compensation applies to rejected and throwing link writes.
+    }
+    if (!linked) {
+      final rolledBack = await removeTask(task);
+      return _failure(
+        rolledBack
+            ? 'Task linking failed; creation rolled back'
+            : 'Task linking failed and rollback failed',
+        permanent: !rolledBack,
+      );
+    }
+    final assignment = await assignCategoryDefaultTaskAgent(
+      service: taskAgentService,
+      task: task,
+      category: category,
+    );
+    if (assignment.status == TaskAgentAssignmentStatus.failed) {
+      developer.log(
+        'Could not assign category agent to relationship task',
+        name: 'RelationshipToolDispatcher',
+        error: assignment.error,
+        stackTrace: assignment.stackTrace,
+      );
+    }
+    return RelationshipTaskCreationResult(task);
+  }
+
+  /// Tombstones a task for compensation or a guarded proposal undo.
+  Future<bool> removeTask(Task task) async {
+    try {
+      final meta = await persistenceLogic.updateMetadata(
+        task.meta,
+        deletedAt: clock.now(),
+      );
+      return await persistenceLogic.updateDbEntity(task.copyWith(meta: meta)) ??
+          false;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  ToolExecutionResult _failure(String reason, {bool permanent = false}) =>
+      ToolExecutionResult(
+        success: false,
+        output: reason,
+        errorMessage: reason,
+        nonRetryable: permanent,
+      );
+}

--- a/lib/features/relationships/workflow/relationship_tool_dispatcher.dart
+++ b/lib/features/relationships/workflow/relationship_tool_dispatcher.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:developer' as developer;
 
 import 'package:clock/clock.dart';
@@ -5,6 +6,7 @@ import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/relationship_data.dart';
 import 'package:lotti/classes/task.dart';
+import 'package:lotti/database/database.dart';
 import 'package:lotti/features/agents/service/task_agent_service.dart';
 import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
@@ -34,12 +36,14 @@ class RelationshipToolDispatcher {
     required this.persistenceLogic,
     required this.entitiesCacheService,
     required this.taskAgentService,
+    required this.journalDb,
   });
 
   final RelationshipRepository relationshipRepository;
   final PersistenceLogic persistenceLogic;
   final EntitiesCacheService entitiesCacheService;
   final TaskAgentService taskAgentService;
+  final JournalDb journalDb;
 
   Future<ToolExecutionResult> dispatch(
     String toolName,
@@ -79,6 +83,37 @@ class RelationshipToolDispatcher {
         permanent: true,
       );
     }
+    // One journal identity per evidence-backed commitment, independent of
+    // device-local creation timestamps or status UUIDs. Retrying or syncing
+    // concurrent confirmations cannot produce a second task row.
+    final taskId = const Uuid().v5(
+      Namespace.nil.value,
+      jsonEncode([
+        'relationship-task',
+        relationshipId,
+        args['sourceCheckInId'],
+        (args['title'] as String).trim(),
+        quote,
+      ]),
+    );
+    final existing = await journalDb.journalEntityById(taskId);
+    if (existing != null && !existing.isDeleted) {
+      if (existing is! Task) {
+        return _failure('Task identity is unavailable', permanent: true);
+      }
+      final linked = await relationshipRepository.linkTask(
+        relationshipId: relationshipId,
+        taskId: taskId,
+      );
+      // Do not mint an undo receipt from a task a peer may already have edited.
+      return linked
+          ? ToolExecutionResult(
+              success: true,
+              output: 'Task already exists',
+              mutatedEntityId: taskId,
+            )
+          : _failure('Existing task linking failed');
+    }
     final now = clock.now();
     final categoryId = person.meta.categoryId;
     final category = categoryId == null
@@ -86,29 +121,56 @@ class RelationshipToolDispatcher {
         : entitiesCacheService.getCategoryById(categoryId);
     final description = args['description'] as String;
     final evidenceUrl = 'lotti://journal/${evidence.id}';
-    final task = await persistenceLogic.createTaskEntry(
-      data: TaskData(
-        title: (args['title'] as String).trim(),
-        status: TaskStatus.open(
-          id: const Uuid().v4(),
-          createdAt: now,
-          utcOffset: now.timeZoneOffset.inMinutes,
-        ),
-        dateFrom: now,
-        dateTo: now,
-        statusHistory: const [],
-        profileId: category?.defaultProfileId,
-        due: args['dueDate'] == null
-            ? null
-            : DateTime.parse(args['dueDate'] as String),
+    final data = TaskData(
+      title: (args['title'] as String).trim(),
+      status: TaskStatus.open(
+        id: const Uuid().v4(),
+        createdAt: now,
+        utcOffset: now.timeZoneOffset.inMinutes,
       ),
-      entryText: EntryText(
-        plainText: '$description\n\nlotti://journal/${evidence.id}',
-        markdown: '$description\n\n[$evidenceUrl]($evidenceUrl)',
-      ),
-      categoryId: categoryId,
-      private: person.meta.private == true || evidence.meta.private == true,
+      dateFrom: now,
+      dateTo: now,
+      statusHistory: const [],
+      profileId: category?.defaultProfileId,
+      due: args['dueDate'] == null
+          ? null
+          : DateTime.parse(args['dueDate'] as String),
     );
+    final entryText = EntryText(
+      plainText: '$description\n\nlotti://journal/${evidence.id}',
+      markdown: '$description\n\n[$evidenceUrl]($evidenceUrl)',
+    );
+    final private =
+        person.meta.private == true || evidence.meta.private == true;
+    final Task? task;
+    if (existing is Task && existing.isDeleted) {
+      // Undo retains a tombstone. A new confirmation restores the same identity
+      // with a clock descended from that tombstone, so peers accept the restore.
+      final restored = Task(
+        meta: await persistenceLogic.updateMetadata(
+          existing.meta.copyWith(
+            deletedAt: null,
+            categoryId: categoryId,
+            private: private,
+          ),
+          dateFrom: now,
+          dateTo: now,
+        ),
+        data: data,
+        entryText: entryText,
+      );
+      task = await persistenceLogic.updateDbEntity(restored) == true
+          ? restored
+          : null;
+    } else {
+      task = await persistenceLogic.createTaskEntry(
+        id: taskId,
+        data: data,
+        entryText: entryText,
+        categoryId: categoryId,
+        private: private,
+      );
+    }
     if (task == null) return _failure('Task creation failed');
     var linked = false;
     try {

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4485,6 +4485,9 @@
       }
     }
   },
+  "relationshipProposalAdded": "Přidáno → {title}",
+  "relationshipProposalEvidence": "Z kontaktu dne {date}",
+  "relationshipProposalUndoFailed": "Akci se nepodařilo vrátit. Úkol se možná změnil.",
   "relationshipReachPrivacy": "Zůstává v tomto zařízení · nikdy se nesdílí s AI",
   "relationshipReachTitle": "Kontakt",
   "relationshipRelinkContact": "Propojit jiný kontakt",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4982,7 +4982,7 @@
     }
   },
   "relationshipProposalAdded": "Tilføjet → {title}",
-  "relationshipProposalEvidence": "Fra kontakten den {date}",
+  "relationshipProposalEvidence": "Fra check-in den {date}",
   "relationshipProposalUndoFailed": "Kunne ikke fortryde. Opgaven kan være blevet ændret.",
   "relationshipReachPrivacy": "Bliver på denne enhed · deles aldrig med AI'en",
   "relationshipReachTitle": "Kontakt",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4981,6 +4981,9 @@
       }
     }
   },
+  "relationshipProposalAdded": "Tilføjet → {title}",
+  "relationshipProposalEvidence": "Fra kontakten den {date}",
+  "relationshipProposalUndoFailed": "Kunne ikke fortryde. Opgaven kan være blevet ændret.",
   "relationshipReachPrivacy": "Bliver på denne enhed · deles aldrig med AI'en",
   "relationshipReachTitle": "Kontakt",
   "relationshipRelinkContact": "Tilknyt en anden kontakt",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -4478,6 +4478,9 @@
       }
     }
   },
+  "relationshipProposalAdded": "Hinzugefügt → {title}",
+  "relationshipProposalEvidence": "Aus dem Check-in vom {date}",
+  "relationshipProposalUndoFailed": "Rückgängig machen nicht möglich. Die Aufgabe wurde möglicherweise geändert.",
   "relationshipReachPrivacy": "Bleibt auf diesem Gerät · nie mit der KI geteilt",
   "relationshipReachTitle": "Erreichen",
   "relationshipRelinkContact": "Anderen Kontakt verknüpfen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6700,6 +6700,23 @@
       }
     }
   },
+  "relationshipProposalAdded": "Added → {title}",
+  "@relationshipProposalAdded": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipProposalEvidence": "From the check-in on {date}",
+  "@relationshipProposalEvidence": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "relationshipProposalUndoFailed": "Could not undo. The task may have changed.",
   "relationshipReachPrivacy": "Stays on this device · never shared with the AI",
   "relationshipReachTitle": "Reach",
   "relationshipRelinkContact": "Link a different contact",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4478,6 +4478,9 @@
       }
     }
   },
+  "relationshipProposalAdded": "Añadida → {title}",
+  "relationshipProposalEvidence": "Del contacto del {date}",
+  "relationshipProposalUndoFailed": "No se pudo deshacer. Puede que la tarea haya cambiado.",
   "relationshipReachPrivacy": "Se queda en este dispositivo · nunca se comparte con la IA",
   "relationshipReachTitle": "Contacto",
   "relationshipRelinkContact": "Vincular otro contacto",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4478,6 +4478,9 @@
       }
     }
   },
+  "relationshipProposalAdded": "Ajoutée → {title}",
+  "relationshipProposalEvidence": "Depuis l’échange du {date}",
+  "relationshipProposalUndoFailed": "Impossible d’annuler. La tâche a peut-être été modifiée.",
   "relationshipReachPrivacy": "Reste sur cet appareil · jamais partagé avec l'IA",
   "relationshipReachTitle": "Contacter",
   "relationshipRelinkContact": "Associer un autre contact",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4981,6 +4981,9 @@
       }
     }
   },
+  "relationshipProposalAdded": "Aggiunta → {title}",
+  "relationshipProposalEvidence": "Dal contatto del {date}",
+  "relationshipProposalUndoFailed": "Impossibile annullare. L’attività potrebbe essere stata modificata.",
   "relationshipReachPrivacy": "Resta su questo dispositivo · mai condiviso con l'IA",
   "relationshipReachTitle": "Contatti",
   "relationshipRelinkContact": "Collega un altro contatto",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -19027,6 +19027,24 @@ abstract class AppLocalizations {
   /// **'You wrote to {name} {minutes, plural, =0{less than a minute} =1{1 minute} other{{minutes} minutes}} ago — log it while it is fresh?'**
   String relationshipPostCallOfferMessage(String name, int minutes);
 
+  /// No description provided for @relationshipProposalAdded.
+  ///
+  /// In en, this message translates to:
+  /// **'Added → {title}'**
+  String relationshipProposalAdded(String title);
+
+  /// No description provided for @relationshipProposalEvidence.
+  ///
+  /// In en, this message translates to:
+  /// **'From the check-in on {date}'**
+  String relationshipProposalEvidence(String date);
+
+  /// No description provided for @relationshipProposalUndoFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not undo. The task may have changed.'**
+  String get relationshipProposalUndoFailed;
+
   /// No description provided for @relationshipReachPrivacy.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -11617,6 +11617,20 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String relationshipProposalAdded(String title) {
+    return 'Přidáno → $title';
+  }
+
+  @override
+  String relationshipProposalEvidence(String date) {
+    return 'Z kontaktu dne $date';
+  }
+
+  @override
+  String get relationshipProposalUndoFailed =>
+      'Akci se nepodařilo vrátit. Úkol se možná změnil.';
+
+  @override
   String get relationshipReachPrivacy =>
       'Zůstává v tomto zařízení · nikdy se nesdílí s AI';
 

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -11445,6 +11445,20 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String relationshipProposalAdded(String title) {
+    return 'Tilføjet → $title';
+  }
+
+  @override
+  String relationshipProposalEvidence(String date) {
+    return 'Fra kontakten den $date';
+  }
+
+  @override
+  String get relationshipProposalUndoFailed =>
+      'Kunne ikke fortryde. Opgaven kan være blevet ændret.';
+
+  @override
   String get relationshipReachPrivacy =>
       'Bliver på denne enhed · deles aldrig med AI\'en';
 

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -11451,7 +11451,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String relationshipProposalEvidence(String date) {
-    return 'Fra kontakten den $date';
+    return 'Fra check-in den $date';
   }
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -11513,6 +11513,20 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String relationshipProposalAdded(String title) {
+    return 'Hinzugefügt → $title';
+  }
+
+  @override
+  String relationshipProposalEvidence(String date) {
+    return 'Aus dem Check-in vom $date';
+  }
+
+  @override
+  String get relationshipProposalUndoFailed =>
+      'Rückgängig machen nicht möglich. Die Aufgabe wurde möglicherweise geändert.';
+
+  @override
   String get relationshipReachPrivacy =>
       'Bleibt auf diesem Gerät · nie mit der KI geteilt';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -11387,6 +11387,20 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String relationshipProposalAdded(String title) {
+    return 'Added → $title';
+  }
+
+  @override
+  String relationshipProposalEvidence(String date) {
+    return 'From the check-in on $date';
+  }
+
+  @override
+  String get relationshipProposalUndoFailed =>
+      'Could not undo. The task may have changed.';
+
+  @override
   String get relationshipReachPrivacy =>
       'Stays on this device · never shared with the AI';
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -11609,6 +11609,20 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String relationshipProposalAdded(String title) {
+    return 'Añadida → $title';
+  }
+
+  @override
+  String relationshipProposalEvidence(String date) {
+    return 'Del contacto del $date';
+  }
+
+  @override
+  String get relationshipProposalUndoFailed =>
+      'No se pudo deshacer. Puede que la tarea haya cambiado.';
+
+  @override
   String get relationshipReachPrivacy =>
       'Se queda en este dispositivo · nunca se comparte con la IA';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -11641,6 +11641,20 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String relationshipProposalAdded(String title) {
+    return 'Ajoutée → $title';
+  }
+
+  @override
+  String relationshipProposalEvidence(String date) {
+    return 'Depuis l’échange du $date';
+  }
+
+  @override
+  String get relationshipProposalUndoFailed =>
+      'Impossible d’annuler. La tâche a peut-être été modifiée.';
+
+  @override
   String get relationshipReachPrivacy =>
       'Reste sur cet appareil · jamais partagé avec l\'IA';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -11588,6 +11588,20 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String relationshipProposalAdded(String title) {
+    return 'Aggiunta → $title';
+  }
+
+  @override
+  String relationshipProposalEvidence(String date) {
+    return 'Dal contatto del $date';
+  }
+
+  @override
+  String get relationshipProposalUndoFailed =>
+      'Impossibile annullare. L’attività potrebbe essere stata modificata.';
+
+  @override
   String get relationshipReachPrivacy =>
       'Resta su questo dispositivo · mai condiviso con l\'IA';
 

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -11470,7 +11470,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String relationshipProposalEvidence(String date) {
-    return 'Uit het contact van $date';
+    return 'Uit de check-in van $date';
   }
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -11464,6 +11464,20 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String relationshipProposalAdded(String title) {
+    return 'Toegevoegd → $title';
+  }
+
+  @override
+  String relationshipProposalEvidence(String date) {
+    return 'Uit het contact van $date';
+  }
+
+  @override
+  String get relationshipProposalUndoFailed =>
+      'Ongedaan maken is mislukt. De taak is mogelijk gewijzigd.';
+
+  @override
   String get relationshipReachPrivacy =>
       'Blijft op dit apparaat · nooit gedeeld met de AI';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -11549,6 +11549,20 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String relationshipProposalAdded(String title) {
+    return 'Adicionada → $title';
+  }
+
+  @override
+  String relationshipProposalEvidence(String date) {
+    return 'Do contacto de $date';
+  }
+
+  @override
+  String get relationshipProposalUndoFailed =>
+      'Não foi possível desfazer. A tarefa pode ter sido alterada.';
+
+  @override
   String get relationshipReachPrivacy =>
       'Fica neste dispositivo · nunca partilhado com a IA';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -11555,7 +11555,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String relationshipProposalEvidence(String date) {
-    return 'Do contacto de $date';
+    return 'Do check-in de $date';
   }
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -11682,6 +11682,20 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String relationshipProposalAdded(String title) {
+    return 'Adăugată → $title';
+  }
+
+  @override
+  String relationshipProposalEvidence(String date) {
+    return 'Din interacțiunea din $date';
+  }
+
+  @override
+  String get relationshipProposalUndoFailed =>
+      'Anularea nu a reușit. Este posibil ca sarcina să fi fost modificată.';
+
+  @override
   String get relationshipReachPrivacy =>
       'Rămâne pe acest dispozitiv · niciodată partajat cu AI-ul';
 

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -11455,6 +11455,20 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String relationshipProposalAdded(String title) {
+    return 'Tillagd → $title';
+  }
+
+  @override
+  String relationshipProposalEvidence(String date) {
+    return 'Från kontakten den $date';
+  }
+
+  @override
+  String get relationshipProposalUndoFailed =>
+      'Kunde inte ångra. Uppgiften kan ha ändrats.';
+
+  @override
   String get relationshipReachPrivacy =>
       'Stannar på den här enheten · delas aldrig med AI:n';
 

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -11461,7 +11461,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String relationshipProposalEvidence(String date) {
-    return 'Från kontakten den $date';
+    return 'Från avstämningen den $date';
   }
 
   @override

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4981,7 +4981,7 @@
     }
   },
   "relationshipProposalAdded": "Toegevoegd → {title}",
-  "relationshipProposalEvidence": "Uit het contact van {date}",
+  "relationshipProposalEvidence": "Uit de check-in van {date}",
   "relationshipProposalUndoFailed": "Ongedaan maken is mislukt. De taak is mogelijk gewijzigd.",
   "relationshipReachPrivacy": "Blijft op dit apparaat · nooit gedeeld met de AI",
   "relationshipReachTitle": "Contact",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4980,6 +4980,9 @@
       }
     }
   },
+  "relationshipProposalAdded": "Toegevoegd → {title}",
+  "relationshipProposalEvidence": "Uit het contact van {date}",
+  "relationshipProposalUndoFailed": "Ongedaan maken is mislukt. De taak is mogelijk gewijzigd.",
   "relationshipReachPrivacy": "Blijft op dit apparaat · nooit gedeeld met de AI",
   "relationshipReachTitle": "Contact",
   "relationshipRelinkContact": "Ander contact koppelen",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4980,6 +4980,9 @@
       }
     }
   },
+  "relationshipProposalAdded": "Adicionada → {title}",
+  "relationshipProposalEvidence": "Do contacto de {date}",
+  "relationshipProposalUndoFailed": "Não foi possível desfazer. A tarefa pode ter sido alterada.",
   "relationshipReachPrivacy": "Fica neste dispositivo · nunca partilhado com a IA",
   "relationshipReachTitle": "Contactar",
   "relationshipRelinkContact": "Associar outro contacto",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4981,7 +4981,7 @@
     }
   },
   "relationshipProposalAdded": "Adicionada → {title}",
-  "relationshipProposalEvidence": "Do contacto de {date}",
+  "relationshipProposalEvidence": "Do check-in de {date}",
   "relationshipProposalUndoFailed": "Não foi possível desfazer. A tarefa pode ter sido alterada.",
   "relationshipReachPrivacy": "Fica neste dispositivo · nunca partilhado com a IA",
   "relationshipReachTitle": "Contactar",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4478,6 +4478,9 @@
       }
     }
   },
+  "relationshipProposalAdded": "Adăugată → {title}",
+  "relationshipProposalEvidence": "Din interacțiunea din {date}",
+  "relationshipProposalUndoFailed": "Anularea nu a reușit. Este posibil ca sarcina să fi fost modificată.",
   "relationshipReachPrivacy": "Rămâne pe acest dispozitiv · niciodată partajat cu AI-ul",
   "relationshipReachTitle": "Contact",
   "relationshipRelinkContact": "Asociați alt contact",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4981,6 +4981,9 @@
       }
     }
   },
+  "relationshipProposalAdded": "Tillagd → {title}",
+  "relationshipProposalEvidence": "Från kontakten den {date}",
+  "relationshipProposalUndoFailed": "Kunde inte ångra. Uppgiften kan ha ändrats.",
   "relationshipReachPrivacy": "Stannar på den här enheten · delas aldrig med AI:n",
   "relationshipReachTitle": "Kontakt",
   "relationshipRelinkContact": "Länka en annan kontakt",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4982,7 +4982,7 @@
     }
   },
   "relationshipProposalAdded": "Tillagd → {title}",
-  "relationshipProposalEvidence": "Från kontakten den {date}",
+  "relationshipProposalEvidence": "Från avstämningen den {date}",
   "relationshipProposalUndoFailed": "Kunde inte ångra. Uppgiften kan ha ändrats.",
   "relationshipReachPrivacy": "Stannar på den här enheten · delas aldrig med AI:n",
   "relationshipReachTitle": "Kontakt",

--- a/lib/logic/persistence_create_ops.dart
+++ b/lib/logic/persistence_create_ops.dart
@@ -302,6 +302,7 @@ class PersistenceCreateOps extends PersistenceCollaboratorBase {
     return null;
   }
 
+  /// Builds a task with an optional stable [id] and preserves the insert verdict.
   Future<Task?> createTaskEntryImpl({
     required TaskData data,
     required EntryText entryText,
@@ -309,24 +310,23 @@ class PersistenceCreateOps extends PersistenceCollaboratorBase {
     String? categoryId,
     List<String>? labelIds,
     bool? private,
+    String? id,
   }) async {
     try {
+      final metadata = await logic.createMetadata(
+        dateFrom: data.dateFrom,
+        dateTo: data.dateTo,
+        uuidV5Input: json.encode(data),
+        categoryId: categoryId,
+        labelIds: labelIds,
+        starred: false,
+        private: private,
+      );
       final task = Task(
         data: data,
         entryText: entryText,
-        meta: await logic.createMetadata(
-          dateFrom: data.dateFrom,
-          dateTo: data.dateTo,
-          uuidV5Input: json.encode(data),
-          categoryId: categoryId,
-          labelIds: labelIds,
-          starred: false,
-          // Only a link-free creation context supplies this: with a
-          // `linkedId`, `createDbEntity` copies privacy off the linked entity
-          // instead. Without either, a task created from a private parent
-          // persists as public.
-          private: private,
-        ),
+        // With a linked parent, createDbEntity applies the parent's privacy.
+        meta: id == null ? metadata : metadata.copyWith(id: id),
       );
 
       // The write's own verdict, not just the absence of a throw.

--- a/lib/logic/persistence_entries.dart
+++ b/lib/logic/persistence_entries.dart
@@ -138,6 +138,7 @@ class PersistenceEntries extends PersistenceCollaboratorBase {
     String? categoryId,
     List<String>? labelIds,
     bool? private,
+    String? id,
   }) => logic.createTaskEntryImpl(
     data: data,
     entryText: entryText,
@@ -145,6 +146,7 @@ class PersistenceEntries extends PersistenceCollaboratorBase {
     categoryId: categoryId,
     labelIds: labelIds,
     private: private,
+    id: id,
   );
 
   Future<AiResponseEntry?> createAiResponseEntry({

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -123,6 +123,8 @@ class PersistenceLogic implements PersistenceLogicContract {
     comment: comment,
   );
 
+  /// Creates a task, optionally using a stable [id] supplied by its caller.
+  /// Existing identities are never overwritten by this insert-only path.
   Future<Task?> createTaskEntry({
     required TaskData data,
     required EntryText entryText,
@@ -130,6 +132,7 @@ class PersistenceLogic implements PersistenceLogicContract {
     String? categoryId,
     List<String>? labelIds,
     bool? private,
+    String? id,
   }) => _entries.createTaskEntry(
     data: data,
     entryText: entryText,
@@ -137,6 +140,7 @@ class PersistenceLogic implements PersistenceLogicContract {
     categoryId: categoryId,
     labelIds: labelIds,
     private: private,
+    id: id,
   );
 
   Future<AiResponseEntry?> createAiResponseEntry({
@@ -245,6 +249,7 @@ class PersistenceLogic implements PersistenceLogicContract {
     String? categoryId,
     List<String>? labelIds,
     bool? private,
+    String? id,
   }) => _create.createTaskEntryImpl(
     data: data,
     entryText: entryText,
@@ -252,6 +257,7 @@ class PersistenceLogic implements PersistenceLogicContract {
     categoryId: categoryId,
     labelIds: labelIds,
     private: private,
+    id: id,
   );
 
   @override

--- a/lib/logic/persistence_logic_contract.dart
+++ b/lib/logic/persistence_logic_contract.dart
@@ -92,6 +92,7 @@ abstract class PersistenceLogicContract {
     String? categoryId,
     List<String>? labelIds,
     bool? private,
+    String? id,
   });
 
   Future<AiResponseEntry?> createAiResponseEntryImpl({

--- a/test/features/agents/database/agent_proposal_ledger_test.dart
+++ b/test/features/agents/database/agent_proposal_ledger_test.dart
@@ -34,11 +34,13 @@ void main() {
     ChangeSetStatus status = ChangeSetStatus.pending,
     List<ChangeItem>? items,
     int clock = 1,
+    String runKey = 'source-run',
     DateTime? createdAt,
   }) async {
     final entity = makeTestChangeSet(
       id: id,
       agentId: agentId,
+      runKey: runKey,
       taskId: taskId,
       status: status,
       items: items,
@@ -74,6 +76,48 @@ void main() {
         .into(db.agentEntities)
         .insert(AgentDbConversions.toEntityCompanion(entity));
   }
+
+  test(
+    'open and handled proposals retain their originating chat run',
+    () async {
+      await insertChangeSet(
+        id: 'open',
+        agentId: 'agent',
+        taskId: 'person',
+        runKey: 'open-run',
+        items: const [
+          ChangeItem(
+            toolName: 'create_and_link_task',
+            args: {},
+            humanSummary: 'Task',
+          ),
+        ],
+      );
+      await insertChangeSet(
+        id: 'handled',
+        agentId: 'agent',
+        taskId: 'person',
+        runKey: 'handled-run',
+        status: ChangeSetStatus.resolved,
+        items: const [
+          ChangeItem(
+            toolName: 'create_and_link_task',
+            args: {},
+            humanSummary: 'Task',
+          ),
+        ],
+      );
+      await insertDecision(
+        id: 'decision',
+        agentId: 'agent',
+        taskId: 'person',
+        changeSetId: 'handled',
+      );
+      final result = await ledger.getProposalLedger('agent', taskId: 'person');
+      expect(result.open.single.runKey, 'open-run');
+      expect(result.resolved.single.runKey, 'handled-run');
+    },
+  );
 
   test('the newest decision for an item wins in the ledger', () async {
     // This is the invariant the compound ORDER BY protects: getProposalLedger

--- a/test/features/agents/eval/relationship/relationship_agent_eval_runner_test.dart
+++ b/test/features/agents/eval/relationship/relationship_agent_eval_runner_test.dart
@@ -106,6 +106,45 @@ void main() {
     assistantContent: assistantContent,
   );
 
+  group('deferred relationship task policy', () {
+    RelationshipAgentEvalToolCall task({
+      String source = 'ci-commitment',
+      int index = 0,
+    }) => call(
+      'create_and_link_task',
+      jsonEncode({
+        'title': 'Commitment $index',
+        'description': 'I promised to send the checklist.',
+        'sourceCheckInId': source,
+        'reason': 'Explicit promise',
+      }),
+    );
+    test('accepts structured evidence and refuses an invented source', () {
+      expect(
+        classify('pr_explicit_commitment', [task()]),
+        RelationshipAgentEvalFailureCategory.none,
+      );
+      expect(
+        classify('pr_explicit_commitment', [task(source: 'invented')]),
+        RelationshipAgentEvalFailureCategory.argumentMismatch,
+      );
+    });
+    test('allows three distinct commitments but refuses a fourth', () {
+      expect(
+        classify('pr_bounded_commitments', [
+          for (var i = 0; i < 3; i++) task(index: i),
+        ]),
+        RelationshipAgentEvalFailureCategory.none,
+      );
+      expect(
+        classify('pr_bounded_commitments', [
+          for (var i = 0; i < 4; i++) task(index: i),
+        ]),
+        RelationshipAgentEvalFailureCategory.toolCallOverBudget,
+      );
+    });
+  });
+
   group('classifyRelationshipAgentResult — happy paths', () {
     test('a stale-briefing wake refreshing the briefing passes', () {
       expect(

--- a/test/features/agents/eval/relationship/relationship_agent_eval_scenarios_test.dart
+++ b/test/features/agents/eval/relationship/relationship_agent_eval_scenarios_test.dart
@@ -313,11 +313,12 @@ void main() {
       );
     });
 
-    test('tool names use the shared reply carrier or '
+    test('tool names use shared conversation and deferred tools or '
         'verb_relationship_noun', () {
       for (final tool in relationshipAgentTools) {
         expect(
           tool.name == RelationshipAgentToolNames.replyToUser ||
+              relationshipDeferredTools.contains(tool.name) ||
               RegExp(r'^[a-z]+_relationship_[a-z0-9_]+$').hasMatch(tool.name),
           isTrue,
           reason: tool.name,

--- a/test/features/agents/eval/relationship/support/relationship_agent_eval_fixtures.dart
+++ b/test/features/agents/eval/relationship/support/relationship_agent_eval_fixtures.dart
@@ -31,6 +31,7 @@ import 'package:lotti/classes/relationship_data.dart';
 import 'package:lotti/classes/relationship_trigger_tokens.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/proposal_ledger.dart';
 import 'package:lotti/features/relationships/runtime/relationship_agent_phase_a.dart';
 import 'package:lotti/features/relationships/workflow/relationship_facts_renderer.dart';
 import 'package:mocktail/mocktail.dart';
@@ -352,8 +353,10 @@ class RelationshipEvalWorld {
     this.previousReport,
     this.nudges = const [],
     this.preTransitionStatus,
+    this.proposals = const ProposalLedger.empty(),
   });
 
+  final ProposalLedger proposals;
   final RelationshipEntry relationship;
   final List<CheckInEntry> checkIns;
   final List<Task> linkedTasks;
@@ -418,5 +421,6 @@ Future<String> renderEvalFacts(
     nudges: world.nudges,
     now: at,
     preTransitionStatus: world.preTransitionStatus,
+    proposals: world.proposals,
   );
 }

--- a/test/features/agents/eval/relationship/support/relationship_agent_eval_runner.dart
+++ b/test/features/agents/eval/relationship/support/relationship_agent_eval_runner.dart
@@ -7,7 +7,7 @@
 /// * **The full tool surface is always offered.** `GoalAgentWorkflow`
 ///   withholds the ad tools from a wake its deterministic tier has already
 ///   ruled out; `RelationshipAgentWorkflow` does not — it hands over all
-///   four tools every time and enforces the banner rules in the FACTS block
+///   the full tool surface every time and enforces the banner rules in the FACTS block
 ///   and again at persistence. Withholding here would measure a surface the
 ///   app never presents.
 /// * **The classifier mirrors `RelationshipAgentStrategy` exactly.** Every
@@ -389,6 +389,16 @@ RelationshipAgentEvalFailureCategory classifyRelationshipAgentResult({
   for (final call in toolCalls) {
     final args = call.jsonObjectArguments!;
     switch (call.name) {
+      case RelationshipAgentToolNames.createAndLinkTask:
+        if (relationshipTaskProposalError(args) != null) {
+          return RelationshipAgentEvalFailureCategory.invalidToolArguments;
+        }
+        final ids = RegExp(
+          r'checkInId=([^\s|]+)',
+        ).allMatches(scenario.facts).map((m) => m.group(1)).toSet();
+        if (!ids.contains(args['sourceCheckInId'])) {
+          return RelationshipAgentEvalFailureCategory.argumentMismatch;
+        }
       case RelationshipAgentToolNames.updateRelationshipReport:
         final band = args['healthBand'];
         final validBand =
@@ -487,6 +497,23 @@ RelationshipAgentEvalFailureCategory classifyRelationshipAgentResult({
       if (!exchanges.add(call.exchangeIndex)) {
         return RelationshipAgentEvalFailureCategory.toolCallOverBudget;
       }
+    }
+  }
+
+  final taskProposalsByExchange = <int, Set<String>>{};
+  for (final call in toolCalls.where(
+    (c) => c.name == RelationshipAgentToolNames.createAndLinkTask,
+  )) {
+    final args = call.jsonObjectArguments!;
+    final keys =
+        taskProposalsByExchange.putIfAbsent(
+          call.exchangeIndex,
+          () => <String>{},
+        )..add(
+          '${args['sourceCheckInId']}:${(args['title'] as String).trim().toLowerCase()}',
+        );
+    if (keys.length > 3) {
+      return RelationshipAgentEvalFailureCategory.toolCallOverBudget;
     }
   }
 

--- a/test/features/agents/eval/relationship/support/relationship_agent_eval_scenarios.dart
+++ b/test/features/agents/eval/relationship/support/relationship_agent_eval_scenarios.dart
@@ -14,6 +14,9 @@ import 'package:lotti/classes/check_in_data.dart';
 import 'package:lotti/classes/nudge_models.dart';
 import 'package:lotti/classes/relationship_trigger_tokens.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/agents/model/proposal_ledger.dart';
 import 'package:lotti/features/relationships/model/relationship_health_metrics.dart';
 
 import 'relationship_agent_eval_fixtures.dart';
@@ -933,6 +936,90 @@ buildRelationshipAgentEvalScenarios() async {
     requiredAssistantContentTermGroups: const [
       ['interview', '12th'],
       ['flat sale', 'flat', 'sale'],
+    ],
+  );
+
+  const commitment = 'I promised to send Tove the checklist.';
+  final proposalArgs = <String, dynamic>{
+    'title': 'Send Tove the checklist',
+    'description': commitment,
+    'sourceCheckInId': 'ci-commitment',
+    'reason': 'Explicit commitment.',
+  };
+  RelationshipEvalWorld proposalWorld({
+    bool rejected = false,
+    bool many = false,
+  }) => RelationshipEvalWorld(
+    relationship: relationshipEvalTove(),
+    checkIns: [
+      relationshipEvalCheckIn(
+        id: 'ci-commitment',
+        at: DateTime(2026, 8, 7, 12),
+        interactionType: CheckInInteractionType.call,
+        narrative: many
+            ? '$commitment I promised to book the flights. '
+                  'I promised to pack the fish. I promised to send the photos.'
+            : commitment,
+      ),
+    ],
+    previousReport: relationshipEvalPreviousBriefing(
+      createdAt: DateTime(2026, 8, 6),
+    ),
+    proposals: rejected
+        ? ProposalLedger(
+            open: const [],
+            resolved: [
+              LedgerEntry(
+                changeSetId: 'old-set',
+                itemIndex: 0,
+                toolName: 'create_and_link_task',
+                args: proposalArgs,
+                humanSummary: 'Create task: Send Tove the checklist',
+                fingerprint: ChangeItem.fingerprintFromParts(
+                  'create_and_link_task',
+                  proposalArgs,
+                ),
+                status: ChangeItemStatus.rejected,
+                verdict: ChangeDecisionVerdict.rejected,
+                createdAt: DateTime(2026, 8, 7, 13),
+              ),
+            ],
+          )
+        : const ProposalLedger.empty(),
+  );
+  await add(
+    id: 'pr_explicit_commitment',
+    policyRuleId: 'R18',
+    description: 'An explicit promise earns a deferred task, with evidence.',
+    world: proposalWorld(),
+    expectedToolCalls: const [
+      RelationshipAgentExpectedToolCall(
+        'create_and_link_task',
+        expectedArgumentsSubset: {'sourceCheckInId': 'ci-commitment'},
+      ),
+    ],
+  );
+  await add(
+    id: 'pr_no_channel_tasks',
+    policyRuleId: 'R19',
+    description: 'Channels cannot manufacture a commitment.',
+    world: _quietWorld(),
+    forbiddenToolNames: const ['create_and_link_task'],
+  );
+  await add(
+    id: 'pr_rejected_commitment',
+    policyRuleId: 'R20',
+    description: 'A rejected promise is not proposed again.',
+    world: proposalWorld(rejected: true),
+    forbiddenToolNames: const ['create_and_link_task'],
+  );
+  await add(
+    id: 'pr_bounded_commitments',
+    policyRuleId: 'R21',
+    description: 'Four promises produce at most three proposals.',
+    world: proposalWorld(many: true),
+    expectedToolCalls: const [
+      RelationshipAgentExpectedToolCall('create_and_link_task'),
     ],
   );
 

--- a/test/features/agents/eval/relationship/support/relationship_agent_spec.dart
+++ b/test/features/agents/eval/relationship/support/relationship_agent_spec.dart
@@ -153,4 +153,25 @@ const relationshipAgentPolicyMatrix = [
         'the briefing may cite them by title and status, and invents '
         'neither a task nor a status FACTS does not carry',
   ),
+  RelationshipAgentPolicyRule(
+    id: 'R18',
+    given: 'a captured check-in contains an explicit commitment',
+    expected:
+        'propose a task with the exact sourceCheckInId, without claiming it exists',
+  ),
+  RelationshipAgentPolicyRule(
+    id: 'R19',
+    given: 'contact channels exist but no captured commitment exists',
+    expected: 'never propose a task from contact channels',
+  ),
+  RelationshipAgentPolicyRule(
+    id: 'R20',
+    given: 'the proposal ledger records a rejected task',
+    expected: 'never re-propose the rejected commitment, including paraphrases',
+  ),
+  RelationshipAgentPolicyRule(
+    id: 'R21',
+    given: 'more than three explicit commitments in the current evidence',
+    expected: 'queue no more than three task proposals in one wake',
+  ),
 ];

--- a/test/features/agents/state/agent_chat_projection_test.dart
+++ b/test/features/agents/state/agent_chat_projection_test.dart
@@ -47,6 +47,7 @@ void main() {
       kind: AgentMessageKind.action,
       payloadId: 'payload-reply',
       toolName: AgentConversationToolNames.replyToUser,
+      runKey: 'reply-run',
     );
     final privateThought = message(
       id: 'thought',
@@ -105,6 +106,7 @@ void main() {
       AgentChatRole.user,
       AgentChatRole.agent,
     ]);
+    expect(projection.map((message) => message.runKey), [null, 'reply-run']);
     verifyNever(() => repository.getEntity('payload-thought'));
     verifyNever(() => repository.getEntity('payload-facts'));
   });

--- a/test/features/relationships/service/relationship_proposal_service_test.dart
+++ b/test/features/relationships/service/relationship_proposal_service_test.dart
@@ -142,16 +142,16 @@ void main() {
     );
   });
   test(
-    'a failed delete restores the relationship link and refuses undo',
+    'a failed delete preserves the original link and refuses undo',
     () async {
       removeSucceeds = false;
       expect(await service.undo(confirmed, 0), isFalse);
-      verify(
-        () => relationships.linkTask(
+      verifyNever(
+        () => relationships.unlinkTask(
           relationshipId: set.taskId,
           taskId: testTask.id,
         ),
-      ).called(1);
+      );
     },
   );
   test('rejection makes no journal mutation', () async {
@@ -183,24 +183,24 @@ void main() {
   });
 
   test(
-    'an edit during unlink refuses deletion and restores the link',
+    'an edit during validation refuses deletion without touching the link',
     () async {
       var reads = 0;
       when(() => db.journalEntityById(testTask.id)).thenAnswer(
         (_) async => reads++ == 0
             ? testTask
             : testTask.copyWith(
-                data: testTask.data.copyWith(title: 'Edited during unlink'),
+                data: testTask.data.copyWith(title: 'Edited during validation'),
               ),
       );
       expect(await service.undo(confirmed, 0), isFalse);
       expect(removed, isEmpty);
-      verify(
-        () => relationships.linkTask(
+      verifyNever(
+        () => relationships.unlinkTask(
           relationshipId: set.taskId,
           taskId: testTask.id,
         ),
-      ).called(1);
+      );
     },
   );
 
@@ -286,16 +286,33 @@ void main() {
     verifyNever(() => db.journalEntityById(any()));
   });
 
-  test('a refused unlink never deletes the still-linked task', () async {
-    when(
-      () => relationships.unlinkTask(
-        relationshipId: set.taskId,
-        taskId: testTask.id,
-      ),
-    ).thenAnswer((_) async => false);
-    expect(await service.undo(confirmed, 0), isFalse);
-    expect(removed, isEmpty);
-  });
+  for (final throws in [false, true]) {
+    test(
+      'failed link cleanup leaves only a tombstoned task (throws: $throws)',
+      () async {
+        when(
+          () => relationships.unlinkTask(
+            relationshipId: set.taskId,
+            taskId: testTask.id,
+          ),
+        ).thenAnswer((_) async {
+          expect(removed, [
+            testTask,
+          ], reason: 'only unlink after the task is safely removed');
+          if (throws) throw StateError('link write failed');
+          return false;
+        });
+        expect(await service.undo(confirmed, 0), isTrue);
+        expect(removed, [testTask]);
+        verifyNever(
+          () => relationships.linkTask(
+            relationshipId: set.taskId,
+            taskId: testTask.id,
+          ),
+        );
+      },
+    );
+  }
 
   test(
     'a missing decision disables undo and a successful creation keeps a local receipt',
@@ -322,4 +339,26 @@ void main() {
       isNull,
     );
   });
+
+  for (final reverse in [false, true]) {
+    test(
+      'the original relationship link permits undo in either direction (reverse: $reverse)',
+      () async {
+        when(() => db.linksForEntryIdsBidirectional({testTask.id})).thenAnswer(
+          (_) async => [
+            EntryLink.relationship(
+              id: 'relationship-link',
+              fromId: reverse ? testTask.id : set.taskId,
+              toId: reverse ? set.taskId : testTask.id,
+              createdAt: testTask.meta.createdAt,
+              updatedAt: testTask.meta.createdAt,
+              vectorClock: null,
+            ),
+          ],
+        );
+        expect(await service.undo(confirmed, 0), isTrue);
+        expect(removed, [testTask]);
+      },
+    );
+  }
 }

--- a/test/features/relationships/service/relationship_proposal_service_test.dart
+++ b/test/features/relationships/service/relationship_proposal_service_test.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
 import 'package:lotti/features/relationships/service/relationship_proposal_service.dart';
 import 'package:lotti/features/relationships/workflow/relationship_tool_dispatcher.dart';
 import 'package:mocktail/mocktail.dart';
@@ -236,4 +239,87 @@ void main() {
       );
     },
   );
+
+  test(
+    'an in-flight confirmation locks out duplicate confirm, reject and undo',
+    () async {
+      final pending = Completer<ToolExecutionResult>();
+      when(
+        () => confirmation.confirmItem(set, 0),
+      ).thenAnswer((_) => pending.future);
+      final first = service.confirm(set, 0);
+      expect((await service.confirm(set, 0)).success, isFalse);
+      expect(await service.reject(set, 0), isFalse);
+      expect(await service.undo(set, 0), isFalse);
+      pending.complete(
+        const ToolExecutionResult(success: false, output: 'retry'),
+      );
+      expect((await first).success, isFalse);
+      when(() => confirmation.rejectItem(set, 0)).thenAnswer((_) async => true);
+      expect(await service.reject(set, 0), isTrue);
+      verify(() => confirmation.confirmItem(set, 0)).called(1);
+    },
+  );
+
+  test(
+    'missing, malformed and still-pending history cannot be undone',
+    () async {
+      when(() => repository.getEntity('missing')).thenAnswer((_) async => null);
+      expect(await service.undoById('missing', 0), isFalse);
+      expect(await service.undo(set, -1), isFalse);
+      expect(await service.undo(set, 10), isFalse);
+      when(() => repository.getEntity(set.id)).thenAnswer((_) async => set);
+      expect(await service.undoById(set.id, 0), isFalse);
+      when(() => repository.getEntity(set.id)).thenAnswer((_) async => null);
+      expect(await service.undo(set, 0), isFalse);
+      expect(removed, isEmpty);
+    },
+  );
+
+  test('undo rejection reopens without touching journal tasks', () async {
+    final rejected = set.copyWith(
+      items: [set.items.single.copyWith(status: ChangeItemStatus.rejected)],
+    );
+    when(() => repository.getEntity(set.id)).thenAnswer((_) async => rejected);
+    expect(await service.undoById(set.id, 0), isTrue);
+    verify(() => confirmation.reopenItem(rejected, 0)).called(1);
+    verifyNever(() => db.journalEntityById(any()));
+  });
+
+  test('a refused unlink never deletes the still-linked task', () async {
+    when(
+      () => relationships.unlinkTask(
+        relationshipId: set.taskId,
+        taskId: testTask.id,
+      ),
+    ).thenAnswer((_) async => false);
+    expect(await service.undo(confirmed, 0), isFalse);
+    expect(removed, isEmpty);
+  });
+
+  test(
+    'a missing decision disables undo and a successful creation keeps a local receipt',
+    () async {
+      when(
+        () => repository.getEntitiesByAgentId(
+          set.agentId,
+          type: AgentEntityTypes.changeDecision,
+        ),
+      ).thenAnswer((_) async => []);
+      expect(await service.undo(confirmed, 0), isFalse);
+      when(
+        () => confirmation.confirmItem(set, 0),
+      ).thenAnswer((_) async => RelationshipTaskCreationResult(testTask));
+      expect((await service.confirm(set, 0)).success, isTrue);
+      expect(service.cachedReceipt(set.id, 0), testTask);
+      verifyNever(() => sync.upsertEntity(any()));
+    },
+  );
+
+  test('a non-task receipt cannot enable task deletion', () {
+    expect(
+      RelationshipProposalService.decodeReceipt(testRelationship.toJson()),
+      isNull,
+    );
+  });
 }

--- a/test/features/relationships/service/relationship_proposal_service_test.dart
+++ b/test/features/relationships/service/relationship_proposal_service_test.dart
@@ -1,0 +1,239 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/relationships/service/relationship_proposal_service.dart';
+import 'package:lotti/features/relationships/workflow/relationship_tool_dispatcher.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
+import '../../../test_data/test_data.dart';
+import '../../agents/test_data/change_set_factories.dart';
+
+void main() {
+  setUpAll(registerAllFallbackValues);
+  final set = makeTestChangeSet(
+    agentId: relationshipAgentIdFor('person'),
+    taskId: 'person',
+    items: const [
+      ChangeItem(
+        toolName: 'create_and_link_task',
+        args: {'title': 'Pack fish'},
+        humanSummary: 'Create task: Pack fish',
+      ),
+    ],
+  );
+  final confirmed = set.copyWith(
+    items: [set.items.single.copyWith(status: ChangeItemStatus.confirmed)],
+  );
+  late MockChangeSetConfirmationService confirmation;
+  late MockAgentRepository repository;
+  late MockAgentSyncService sync;
+  late MockJournalDb db;
+  late MockRelationshipRepository relationships;
+  late RelationshipProposalService service;
+  late List<Task> removed;
+  late bool removeSucceeds;
+  setUp(() {
+    confirmation = MockChangeSetConfirmationService();
+    repository = MockAgentRepository();
+    sync = MockAgentSyncService();
+    db = MockJournalDb();
+    when(
+      () => db.linksForEntryIdsBidirectional(any()),
+    ).thenAnswer((_) async => []);
+    relationships = MockRelationshipRepository();
+    removed = [];
+    removeSucceeds = true;
+    service = RelationshipProposalService(
+      confirmation: confirmation,
+      repository: repository,
+      syncService: sync,
+      journalDb: db,
+      relationshipRepository: relationships,
+      taskRemover: (task) async {
+        removed.add(task);
+        return removeSucceeds;
+      },
+    );
+    when(() => repository.getEntity(set.id)).thenAnswer((_) async => confirmed);
+    when(
+      () => repository.getEntitiesByAgentId(
+        set.agentId,
+        type: AgentEntityTypes.changeDecision,
+      ),
+    ).thenAnswer(
+      (_) async => [
+        makeTestChangeDecision(
+          agentId: set.agentId,
+          changeSetId: set.id,
+          args: {RelationshipProposalService.receiptKey: testTask.toJson()},
+        ),
+      ],
+    );
+    when(
+      () => db.journalEntityById(testTask.id),
+    ).thenAnswer((_) async => testTask);
+    when(() => sync.upsertEntity(any())).thenAnswer((_) async {});
+    when(
+      () => relationships.unlinkTask(
+        relationshipId: set.taskId,
+        taskId: testTask.id,
+      ),
+    ).thenAnswer((_) async => true);
+    when(
+      () => relationships.linkTask(
+        relationshipId: set.taskId,
+        taskId: testTask.id,
+      ),
+    ).thenAnswer((_) async => true);
+    when(
+      () => confirmation.reopenItem(any(), any(), revert: any(named: 'revert')),
+    ).thenAnswer((invocation) async {
+      final revert =
+          invocation.namedArguments[#revert] as Future<bool> Function()?;
+      return revert == null || await revert();
+    });
+  });
+
+  test(
+    'confirmation persists a task receipt on the decision, leaving proposal args intact',
+    () async {
+      when(() => confirmation.confirmItem(set, 0)).thenAnswer(
+        (_) async => RelationshipTaskCreationResult(testTask),
+      );
+      expect((await service.confirm(set, 0)).success, isTrue);
+      expect(await service.receipt(set, 0), testTask);
+      verify(() => sync.upsertEntity(any())).called(1);
+      expect(set.items.single.args, {'title': 'Pack fish'});
+    },
+  );
+  test(
+    'undo reads the durable receipt and removes an unchanged task after unlinking',
+    () async {
+      expect(await service.undo(confirmed, 0), isTrue);
+      expect(removed, [testTask]);
+      verify(
+        () => relationships.unlinkTask(
+          relationshipId: set.taskId,
+          taskId: testTask.id,
+        ),
+      ).called(1);
+    },
+  );
+  test('undo refuses a task changed since confirmation', () async {
+    when(() => db.journalEntityById(testTask.id)).thenAnswer(
+      (_) async =>
+          testTask.copyWith(data: testTask.data.copyWith(title: 'Edited')),
+    );
+    expect(await service.undo(confirmed, 0), isFalse);
+    expect(removed, isEmpty);
+    verifyNever(
+      () => relationships.unlinkTask(
+        relationshipId: set.taskId,
+        taskId: testTask.id,
+      ),
+    );
+  });
+  test(
+    'a failed delete restores the relationship link and refuses undo',
+    () async {
+      removeSucceeds = false;
+      expect(await service.undo(confirmed, 0), isFalse);
+      verify(
+        () => relationships.linkTask(
+          relationshipId: set.taskId,
+          taskId: testTask.id,
+        ),
+      ).called(1);
+    },
+  );
+  test('rejection makes no journal mutation', () async {
+    when(() => confirmation.rejectItem(set, 0)).thenAnswer((_) async => true);
+    expect(await service.reject(set, 0), isTrue);
+    expect(removed, isEmpty);
+    verifyNever(() => db.journalEntityById(any()));
+  });
+
+  test(
+    'receipt write failure preserves success and the creation snapshot',
+    () async {
+      when(
+        () => confirmation.confirmItem(set, 0),
+      ).thenAnswer((_) async => RelationshipTaskCreationResult(testTask));
+      when(() => sync.upsertEntity(any())).thenThrow(StateError('offline'));
+      expect((await service.confirm(set, 0)).success, isTrue);
+      expect(await service.receipt(set, 0), testTask);
+      verifyNever(() => db.journalEntityById(any()));
+    },
+  );
+
+  test('malformed receipt cannot enable undo', () {
+    expect(
+      RelationshipProposalService.decodeReceipt({'runtimeType': 'task'}),
+      isNull,
+    );
+    expect(RelationshipProposalService.decodeReceipt('broken'), isNull);
+  });
+
+  test(
+    'an edit during unlink refuses deletion and restores the link',
+    () async {
+      var reads = 0;
+      when(() => db.journalEntityById(testTask.id)).thenAnswer(
+        (_) async => reads++ == 0
+            ? testTask
+            : testTask.copyWith(
+                data: testTask.data.copyWith(title: 'Edited during unlink'),
+              ),
+      );
+      expect(await service.undo(confirmed, 0), isFalse);
+      expect(removed, isEmpty);
+      verify(
+        () => relationships.linkTask(
+          relationshipId: set.taskId,
+          taskId: testTask.id,
+        ),
+      ).called(1);
+    },
+  );
+
+  test(
+    'another agent scope cannot reject or reopen a relationship proposal',
+    () async {
+      final foreign = set.copyWith(agentId: 'task-agent');
+      expect(await service.reject(foreign, 0), isFalse);
+      expect(await service.undo(foreign, 0), isFalse);
+      verifyNever(() => confirmation.rejectItem(any(), any()));
+      verifyNever(() => repository.getEntity(any()));
+    },
+  );
+  test(
+    'a newly linked note prevents undo even if the task itself is unchanged',
+    () async {
+      when(() => db.linksForEntryIdsBidirectional({testTask.id})).thenAnswer(
+        (_) async => [
+          EntryLink.basic(
+            id: 'new-note-link',
+            fromId: testTask.id,
+            toId: 'note',
+            createdAt: testTask.meta.createdAt,
+            updatedAt: testTask.meta.createdAt,
+            vectorClock: null,
+          ),
+        ],
+      );
+      expect(await service.undo(confirmed, 0), isFalse);
+      expect(removed, isEmpty);
+      verifyNever(
+        () => relationships.unlinkTask(
+          relationshipId: set.taskId,
+          taskId: testTask.id,
+        ),
+      );
+    },
+  );
+}

--- a/test/features/relationships/state/relationship_proposal_providers_test.dart
+++ b/test/features/relationships/state/relationship_proposal_providers_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/agents/model/proposal_ledger.dart';
+import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/relationships/service/relationship_proposal_service.dart';
+import 'package:lotti/features/relationships/state/relationship_proposal_providers.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../mocks/mocks.dart';
+import '../../../test_data/test_data.dart';
+import '../../agents/test_data/change_set_factories.dart';
+
+void main() {
+  test(
+    'reads the relationship scope and deduplicates pending proposals',
+    () async {
+      final repository = MockAgentRepository();
+      final agentId = relationshipAgentIdFor('person');
+      final set = makeTestChangeSet(
+        agentId: agentId,
+        taskId: 'person',
+        items: const [
+          ChangeItem(
+            toolName: 'create_and_link_task',
+            args: {'title': 'Pack fish'},
+            humanSummary: 'Create task: Pack fish',
+          ),
+        ],
+      );
+      when(
+        () => repository.getProposalLedger(agentId, taskId: 'person'),
+      ).thenAnswer(
+        (_) async => ProposalLedger(
+          open: const [],
+          resolved: const [],
+          pendingSets: [
+            set,
+            set.copyWith(id: 'duplicate'),
+          ],
+        ),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          agentRepositoryProvider.overrideWithValue(repository),
+          agentUpdateStreamProvider(
+            agentId,
+          ).overrideWith((ref) => const Stream.empty()),
+        ],
+      );
+      addTearDown(container.dispose);
+      final provider = relationshipSuggestionListProvider('person');
+      final subscription = container.listen(provider, (_, _) {});
+      addTearDown(subscription.close);
+      final snapshot = await container.read(provider.future);
+      expect(snapshot.suggestions.open, hasLength(1));
+      expect(snapshot.suggestions.open.single.changeSet.taskId, 'person');
+      expect(snapshot.suggestions.open.single.item.args['title'], 'Pack fish');
+      verify(
+        () => repository.getProposalLedger(agentId, taskId: 'person'),
+      ).called(1);
+    },
+  );
+  for (final durable in [true, false]) {
+    test(
+      'resolved history retains its run and destination (durable: $durable)',
+      () async {
+        final repository = MockAgentRepository();
+        final agentId = relationshipAgentIdFor('person');
+        final set = makeTestChangeSet(
+          agentId: agentId,
+          taskId: 'person',
+          runKey: 'chat-run',
+        );
+        final item = set.items.first;
+        final entry = LedgerEntry(
+          runKey: 'chat-run',
+          changeSetId: set.id,
+          itemIndex: 0,
+          toolName: item.toolName,
+          args: item.args,
+          humanSummary: item.humanSummary,
+          fingerprint: ChangeItem.fingerprint(item),
+          status: ChangeItemStatus.confirmed,
+          createdAt: set.createdAt,
+        );
+        when(
+          () => repository.getProposalLedger(agentId, taskId: 'person'),
+        ).thenAnswer(
+          (_) async => ProposalLedger(open: const [], resolved: [entry, entry]),
+        );
+        when(() => repository.getEntity(set.id)).thenAnswer((_) async => set);
+        when(
+          () => repository.getEntitiesByAgentId(
+            agentId,
+            type: AgentEntityTypes.changeDecision,
+          ),
+        ).thenAnswer(
+          (_) async => [
+            makeTestChangeDecision(
+              agentId: agentId,
+              changeSetId: set.id,
+              args: durable
+                  ? {RelationshipProposalService.receiptKey: testTask.toJson()}
+                  : {},
+            ),
+          ],
+        );
+        final service = MockRelationshipProposalService();
+        when(() => service.cachedReceipt(set.id, 0)).thenReturn(testTask);
+        final container = ProviderContainer(
+          overrides: [
+            agentRepositoryProvider.overrideWithValue(repository),
+            relationshipProposalServiceProvider.overrideWithValue(service),
+            agentUpdateStreamProvider(
+              agentId,
+            ).overrideWith((ref) => const Stream.empty()),
+          ],
+        );
+        addTearDown(container.dispose);
+        final provider = relationshipSuggestionListProvider('person');
+        final sub = container.listen(provider, (_, _) {});
+        addTearDown(sub.close);
+        final snapshot = await container.read(provider.future);
+        expect(snapshot.suggestions.activity, [entry]);
+        if (durable) {
+          verifyNever(() => service.cachedReceipt(any(), any()));
+        } else {
+          verify(() => service.cachedReceipt(set.id, 0)).called(1);
+        }
+        expect(snapshot.runKeys, {set.id: 'chat-run'});
+        expect(
+          snapshot.receipts[RelationshipProposalSnapshot.itemKey(set.id, 0)],
+          testTask,
+        );
+      },
+    );
+  }
+}

--- a/test/features/relationships/state/relationship_proposal_providers_test.dart
+++ b/test/features/relationships/state/relationship_proposal_providers_test.dart
@@ -1,19 +1,31 @@
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/model/proposal_ledger.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/agents/state/task_agent_providers.dart';
+import 'package:lotti/features/labels/repository/labels_repository.dart';
+import 'package:lotti/features/relationships/repository/relationship_repository.dart';
 import 'package:lotti/features/relationships/service/relationship_proposal_service.dart';
 import 'package:lotti/features/relationships/state/relationship_proposal_providers.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/providers/service_providers.dart';
+import 'package:lotti/services/entities_cache_service.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../../../test_data/test_data.dart';
+import '../../../widget_test_utils.dart';
 import '../../agents/test_data/change_set_factories.dart';
 
 void main() {
+  setUpAll(registerAllFallbackValues);
   test(
     'reads the relationship scope and deduplicates pending proposals',
     () async {
@@ -138,4 +150,93 @@ void main() {
       },
     );
   }
+
+  test(
+    'provider wiring records a rejection in the relationship ledger',
+    () async {
+      final repository = MockAgentRepository();
+      final sync = MockAgentSyncService();
+      final persistence = MockPersistenceLogic();
+      await setUpTestGetIt(
+        additionalSetup: () {
+          getIt
+            ..registerSingleton<PersistenceLogic>(persistence)
+            ..registerSingleton<EntitiesCacheService>(
+              MockEntitiesCacheService(),
+            );
+        },
+      );
+      addTearDown(tearDownTestGetIt);
+      final set = makeTestChangeSet(
+        agentId: relationshipAgentIdFor('person'),
+        taskId: 'person',
+        items: const [
+          ChangeItem(
+            toolName: 'create_and_link_task',
+            args: {'title': 'Pack fish'},
+            humanSummary: 'Create task: Pack fish',
+          ),
+        ],
+      );
+      when(() => sync.repository).thenReturn(repository);
+      when(() => repository.getEntity(set.id)).thenAnswer((_) async => set);
+      when(() => sync.upsertEntity(any())).thenAnswer((_) async {});
+      final container = ProviderContainer(
+        overrides: [
+          agentRepositoryProvider.overrideWithValue(repository),
+          agentSyncServiceProvider.overrideWithValue(sync),
+          taskAgentServiceProvider.overrideWithValue(MockTaskAgentService()),
+          labelsRepositoryProvider.overrideWithValue(MockLabelsRepository()),
+          relationshipRepositoryProvider.overrideWithValue(
+            MockRelationshipRepository(),
+          ),
+          journalDbProvider.overrideWithValue(MockJournalDb()),
+          domainLoggerProvider.overrideWithValue(MockDomainLogger()),
+        ],
+      );
+      addTearDown(container.dispose);
+      expect(
+        await container
+            .read(relationshipProposalServiceProvider)
+            .reject(set, 0),
+        isTrue,
+      );
+      final writes = verify(() => sync.upsertEntity(captureAny())).captured;
+      final decision = writes.whereType<ChangeDecisionEntity>().single;
+      expect(decision.agentId, set.agentId);
+      expect(decision.taskId, 'person');
+      expect(decision.verdict, ChangeDecisionVerdict.rejected);
+      expect(
+        writes.whereType<ChangeSetEntity>().last.items.single.status,
+        ChangeItemStatus.rejected,
+      );
+      verifyNever(
+        () => persistence.createTaskEntry(
+          data: any(named: 'data'),
+          entryText: any(named: 'entryText'),
+          categoryId: any(named: 'categoryId'),
+          private: any(named: 'private'),
+        ),
+      );
+    },
+  );
+
+  test(
+    'disposing highlights cancels pending expiry and repeated highlights reset it',
+    () {
+      fakeAsync((async) {
+        final container = ProviderContainer();
+        final highlighter = container.read(
+          relationshipTaskHighlightProvider.notifier,
+        )..highlight('task');
+        async.elapse(const Duration(seconds: 2));
+        highlighter.highlight('task');
+        async.elapse(const Duration(seconds: 2));
+        expect(container.read(relationshipTaskHighlightProvider), {'task'});
+        expect(async.nonPeriodicTimerCount, 1);
+        container.dispose();
+        expect(async.nonPeriodicTimerCount, 0);
+      });
+    },
+  );
 }

--- a/test/features/relationships/ui/widgets/linked_tasks_card_test.dart
+++ b/test/features/relationships/ui/widgets/linked_tasks_card_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
@@ -7,6 +8,7 @@ import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
+import 'package:lotti/features/relationships/state/relationship_proposal_providers.dart';
 import 'package:lotti/features/relationships/ui/widgets/linked_tasks_card.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/linked_task_row.dart';
 import 'package:lotti/get_it.dart';
@@ -165,4 +167,24 @@ void main() {
     expect(find.text('Send photos'), findsOneWidget);
     expect(find.text('Prepare the call'), findsOneWidget);
   });
+
+  testWidgets(
+    'newly confirmed tasks highlight briefly without selecting other rows',
+    (tester) async {
+      await pump(tester, [task('new'), task('existing')]);
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(LinkedTasksCard)),
+      );
+      container
+          .read(relationshipTaskHighlightProvider.notifier)
+          .highlight('new');
+      await tester.pump();
+      DesignSystemListItem row(String id) =>
+          tester.widget(find.byKey(ValueKey('person-task-$id')));
+      expect(row('new').activated, isTrue);
+      expect(row('existing').activated, isFalse);
+      await tester.pump(const Duration(seconds: 3));
+      expect(row('new').activated, isFalse);
+    },
+  );
 }

--- a/test/features/relationships/ui/widgets/relationship_chat_pane_test.dart
+++ b/test/features/relationships/ui/widgets/relationship_chat_pane_test.dart
@@ -9,9 +9,14 @@ import 'package:lotti/features/agents/state/agent_chat_projection.dart';
 import 'package:lotti/features/agents/state/agent_query_providers.dart';
 import 'package:lotti/features/agents/ui/chat/agent_chat_view.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/relationships/repository/relationship_repository.dart';
+import 'package:lotti/features/relationships/state/relationship_proposal_providers.dart';
 import 'package:lotti/features/relationships/ui/widgets/relationship_chat_pane.dart';
+import 'package:lotti/features/relationships/ui/widgets/relationship_suggestions_band.dart';
 import 'package:material_ui/material_ui.dart';
+import 'package:mocktail/mocktail.dart';
 
+import '../../../../mocks/mocks.dart';
 import '../../../../widget_test_utils.dart';
 
 void main() {
@@ -257,4 +262,62 @@ void main() {
     await tester.pump();
     expect(backs, 2);
   });
+  testWidgets(
+    'only durable agent replies attach proposals from their own run',
+    (tester) async {
+      await setUpTestGetIt();
+      addTearDown(tearDownTestGetIt);
+      final repository = MockRelationshipRepository();
+      when(
+        () => repository.getRelationshipById(relationshipId),
+      ).thenAnswer((_) async => null);
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          const Scaffold(
+            body: RelationshipChatPane(relationshipId: relationshipId),
+          ),
+          overrides: [
+            relationshipRepositoryProvider.overrideWithValue(repository),
+            relationshipSuggestionListProvider(relationshipId).overrideWith(
+              (ref) async => const RelationshipProposalSnapshot.empty(),
+            ),
+            agentIdentityProvider(
+              agentId,
+            ).overrideWith((ref) async => identity()),
+            agentChatProjectionProvider(agentId).overrideWith(
+              (ref) async => [
+                AgentChatMessage(
+                  id: 'user',
+                  role: AgentChatRole.user,
+                  text: 'What did I promise?',
+                  createdAt: DateTime(2026),
+                ),
+                AgentChatMessage(
+                  id: 'old-reply',
+                  role: AgentChatRole.agent,
+                  text: 'Earlier reply',
+                  createdAt: DateTime(2026),
+                ),
+                AgentChatMessage(
+                  id: 'reply',
+                  role: AgentChatRole.agent,
+                  text: 'A task is ready for confirmation.',
+                  createdAt: DateTime(2026),
+                  runKey: 'reply-run',
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+      final band = tester.widget<RelationshipSuggestionsBand>(
+        find.byType(RelationshipSuggestionsBand),
+      );
+      expect(band.relationshipId, relationshipId);
+      expect(band.runKey, 'reply-run');
+      expect(band.showHistory, isTrue);
+      expect(find.text('A task is ready for confirmation.'), findsOneWidget);
+    },
+  );
 }

--- a/test/features/relationships/ui/widgets/relationship_suggestions_band_test.dart
+++ b/test/features/relationships/ui/widgets/relationship_suggestions_band_test.dart
@@ -1,0 +1,324 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/check_in_data.dart';
+import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/agents/model/proposal_ledger.dart';
+import 'package:lotti/features/agents/state/unified_suggestion_providers.dart';
+import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
+import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_part.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/relationships/state/relationship_proposal_providers.dart';
+import 'package:lotti/features/relationships/ui/widgets/relationship_suggestions_band.dart';
+import 'package:lotti/services/nav_service.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../helpers/fallbacks.dart';
+import '../../../../mocks/mocks.dart';
+import '../../../../test_data/test_data.dart';
+import '../../../../widget_test_utils.dart';
+import '../../../agents/test_data/change_set_factories.dart';
+
+void main() {
+  setUpAll(registerAllFallbackValues);
+  late MockRelationshipProposalService service;
+  setUp(() async {
+    await setUpTestGetIt();
+    service = MockRelationshipProposalService();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (_) async => null);
+  });
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+    await tearDownTestGetIt();
+  });
+  PendingSuggestion proposal(
+    int index, {
+    String tool = 'create_and_link_task',
+    String runKey = 'run-1',
+  }) {
+    final item = ChangeItem(
+      toolName: tool,
+      args: {'title': 'Commitment $index'},
+      humanSummary: 'Create task: Commitment $index',
+    );
+    final set = makeTestChangeSet(
+      id: 'set-$index',
+      runKey: runKey,
+      agentId: relationshipAgentIdFor('person'),
+      taskId: 'person',
+      items: [item],
+    );
+    return PendingSuggestion(
+      changeSet: set,
+      itemIndex: 0,
+      item: item,
+      fingerprint: ChangeItem.fingerprint(item),
+    );
+  }
+
+  Future<void> pump(
+    WidgetTester tester,
+    RelationshipProposalSnapshot Function() snapshot, {
+    String? runKey,
+    bool showHistory = false,
+    List<CheckInEntry> checkIns = const [],
+  }) async {
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        SingleChildScrollView(
+          child: RelationshipSuggestionsBand(
+            relationshipId: 'person',
+            checkIns: checkIns,
+            runKey: runKey,
+            showHistory: showHistory,
+          ),
+        ),
+        overrides: [
+          relationshipProposalServiceProvider.overrideWithValue(service),
+          relationshipSuggestionListProvider(
+            'person',
+          ).overrideWith((ref) async => snapshot()),
+        ],
+      ),
+    );
+    await tester.pump();
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('folds beyond three and offers Confirm all only for one kind', (
+    tester,
+  ) async {
+    final rows = [for (var i = 0; i < 4; i++) proposal(i)];
+    await pump(
+      tester,
+      () => RelationshipProposalSnapshot(
+        suggestions: UnifiedSuggestionList(open: rows, activity: const []),
+      ),
+    );
+    expect(find.byType(ProposalRow), findsNWidgets(3));
+    expect(find.text('Show 1 more'), findsOneWidget);
+    expect(find.text('Confirm all'), findsOneWidget);
+    await tester.tap(find.text('Show 1 more'));
+    await tester.pump();
+    expect(find.byType(ProposalRow), findsNWidgets(4));
+  });
+  testWidgets('mixed proposal kinds have no bulk confirmation', (tester) async {
+    await pump(
+      tester,
+      () => RelationshipProposalSnapshot(
+        suggestions: UnifiedSuggestionList(
+          open: [
+            proposal(0),
+            proposal(1, tool: 'set_task_status'),
+          ],
+          activity: const [],
+        ),
+      ),
+    );
+    final buttons = tester.widgetList<Widget>(
+      find.text('Confirm all').hitTestable(),
+    );
+    expect(buttons, isEmpty);
+  });
+  testWidgets(
+    'uses the relationship confirmation path and retains a row through refresh',
+    (tester) async {
+      final row = proposal(0);
+      var snapshot = RelationshipProposalSnapshot(
+        suggestions: UnifiedSuggestionList(open: [row], activity: const []),
+      );
+      final applied = Completer<ToolExecutionResult>();
+      when(
+        () => service.confirm(row.changeSet, 0),
+      ).thenAnswer((_) => applied.future);
+      await pump(tester, () => snapshot);
+      await tester.tap(find.byIcon(LottiIcons.confirm).first);
+      await tester.pump();
+      verify(() => service.confirm(row.changeSet, 0)).called(1);
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(RelationshipSuggestionsBand)),
+      );
+      snapshot = const RelationshipProposalSnapshot.empty();
+      container.invalidate(relationshipSuggestionListProvider('person'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(
+        find.byType(ProposalRow),
+        findsOneWidget,
+        reason: 'the provider must not unmount an in-flight row',
+      );
+      applied.complete(
+        const ToolExecutionResult(success: true, output: 'Created'),
+      );
+      await tester.pump();
+      for (var i = 0; i < 15; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      expect(find.byType(ProposalRow), findsNothing);
+      snapshot = RelationshipProposalSnapshot(
+        suggestions: UnifiedSuggestionList(open: [row], activity: const []),
+      );
+      container.invalidate(relationshipSuggestionListProvider('person'));
+      await tester.pumpAndSettle();
+      expect(
+        find.textContaining('Commitment 0'),
+        findsOneWidget,
+        reason:
+            'a peer undo must restore the same item after its ledger removal',
+      );
+    },
+  );
+
+  testWidgets(
+    'bulk failure releases rows so an individual confirmation can retry',
+    (tester) async {
+      final rows = [proposal(0), proposal(1)];
+      when(
+        () => service.confirm(any(), any()),
+      ).thenThrow(StateError('write failed'));
+      await pump(
+        tester,
+        () => RelationshipProposalSnapshot(
+          suggestions: UnifiedSuggestionList(open: rows, activity: const []),
+        ),
+      );
+      await tester.tap(find.text('Confirm all'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      verify(() => service.confirm(any(), any())).called(2);
+      when(() => service.confirm(any(), any())).thenAnswer(
+        (_) async =>
+            const ToolExecutionResult(success: true, output: 'Created'),
+      );
+      await tester.tap(find.byIcon(LottiIcons.confirm).first);
+      await tester.pump();
+      verify(() => service.confirm(rows.first.changeSet, 0)).called(1);
+      await tester.pumpWidget(const SizedBox());
+    },
+  );
+  testWidgets('chat filters pending and history to its own reply run', (
+    tester,
+  ) async {
+    final row = proposal(0);
+    final own = row.changeSet.runKey;
+    final entry = LedgerEntry(
+      changeSetId: 'old-set',
+      itemIndex: 0,
+      toolName: row.item.toolName,
+      args: row.item.args,
+      humanSummary: 'Older commitment',
+      fingerprint: row.fingerprint,
+      status: ChangeItemStatus.rejected,
+      createdAt: row.changeSet.createdAt,
+    );
+    await pump(
+      tester,
+      () => RelationshipProposalSnapshot(
+        suggestions: UnifiedSuggestionList(
+          open: [
+            row,
+            proposal(1, runKey: 'other-run'),
+          ],
+          activity: [entry],
+        ),
+        runKeys: {'old-set': 'other-run'},
+      ),
+      runKey: own,
+      showHistory: true,
+    );
+    expect(find.textContaining('Commitment 0'), findsOneWidget);
+    expect(find.textContaining('Commitment 1'), findsNothing);
+    expect(find.textContaining('History'), findsNothing);
+    expect(find.textContaining('Older commitment'), findsNothing);
+  });
+
+  testWidgets('evidence opens the exact source narrative for review', (
+    tester,
+  ) async {
+    final row = proposal(0);
+    final source = CheckInEntry(
+      meta: testRelationship.meta.copyWith(id: 'source'),
+      data: const CheckInData(
+        relationshipId: 'person',
+        interactionType: CheckInInteractionType.call,
+      ),
+      entryText: const EntryText(
+        plainText: 'I promised to send the launch checklist.',
+      ),
+    );
+    final item = row.item.copyWith(
+      args: {...row.item.args, 'sourceCheckInId': source.id},
+    );
+    final withSource = PendingSuggestion(
+      changeSet: row.changeSet.copyWith(items: [item]),
+      itemIndex: 0,
+      item: item,
+      fingerprint: ChangeItem.fingerprint(item),
+    );
+    await pump(
+      tester,
+      () => RelationshipProposalSnapshot(
+        suggestions: UnifiedSuggestionList(
+          open: [withSource],
+          activity: const [],
+        ),
+      ),
+      checkIns: [source],
+    );
+    await tester.tap(find.textContaining('From the check-in on'));
+    await tester.pumpAndSettle();
+    expect(
+      find.text('I promised to send the launch checklist.'),
+      findsOneWidget,
+    );
+    expect(find.text('Edit check-in'), findsOneWidget);
+  });
+  testWidgets(
+    'handled task history opens its destination and delegates safe undo',
+    (tester) async {
+      final row = proposal(0);
+      final entry = LedgerEntry(
+        changeSetId: row.changeSet.id,
+        itemIndex: 0,
+        toolName: row.item.toolName,
+        args: row.item.args,
+        humanSummary: row.item.humanSummary,
+        fingerprint: row.fingerprint,
+        status: ChangeItemStatus.confirmed,
+        createdAt: row.changeSet.createdAt,
+      );
+      final routes = <String>[];
+      beamToNamedOverride = routes.add;
+      addTearDown(() => beamToNamedOverride = null);
+      when(
+        () => service.undoById(row.changeSet.id, 0),
+      ).thenAnswer((_) async => true);
+      await pump(
+        tester,
+        () => RelationshipProposalSnapshot(
+          suggestions: UnifiedSuggestionList(open: const [], activity: [entry]),
+          receipts: {
+            RelationshipProposalSnapshot.itemKey(row.changeSet.id, 0): testTask,
+          },
+        ),
+        showHistory: true,
+      );
+      await tester.tap(find.textContaining('History'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Added → ${testTask.data.title}'));
+      expect(routes, ['/tasks/${testTask.id}']);
+      await tester.tap(find.text('Undo'));
+      await tester.pump();
+      verify(() => service.undoById(row.changeSet.id, 0)).called(1);
+    },
+  );
+}

--- a/test/features/relationships/ui/widgets/relationship_suggestions_band_test.dart
+++ b/test/features/relationships/ui/widgets/relationship_suggestions_band_test.dart
@@ -7,6 +7,7 @@ import 'package:lotti/classes/check_in_data.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/model/proposal_ledger.dart';
@@ -321,4 +322,109 @@ void main() {
       verify(() => service.undoById(row.changeSet.id, 0)).called(1);
     },
   );
+
+  testWidgets(
+    'bulk confirmation highlights each created task and removes its row',
+    (tester) async {
+      final rows = [proposal(0), proposal(1)];
+      when(() => service.confirm(any(), any())).thenAnswer((invocation) async {
+        final set = invocation.positionalArguments.first as ChangeSetEntity;
+        return ToolExecutionResult(
+          success: true,
+          output: 'Created',
+          mutatedEntityId: 'task-${set.id}',
+        );
+      });
+      var snapshot = RelationshipProposalSnapshot(
+        suggestions: UnifiedSuggestionList(open: rows, activity: const []),
+      );
+      await pump(tester, () => snapshot);
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(RelationshipSuggestionsBand)),
+      );
+      await tester.tap(find.text('Confirm all'));
+      await tester.pump();
+      expect(container.read(relationshipTaskHighlightProvider), {
+        'task-set-0',
+        'task-set-1',
+      });
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      expect(find.textContaining('Commitment 0'), findsNothing);
+      expect(find.textContaining('Commitment 1'), findsNothing);
+      snapshot = const RelationshipProposalSnapshot.empty();
+      container.invalidate(relationshipSuggestionListProvider('person'));
+      await tester.pump();
+      await tester.pump();
+      verify(() => service.confirm(rows[0].changeSet, 0)).called(1);
+      verify(() => service.confirm(rows[1].changeSet, 0)).called(1);
+      await tester.pump(const Duration(seconds: 2));
+    },
+  );
+
+  testWidgets('a rejected task proposal disappears without creating a task', (
+    tester,
+  ) async {
+    final row = proposal(0);
+    when(() => service.reject(row.changeSet, 0)).thenAnswer((_) async => true);
+    await pump(
+      tester,
+      () => RelationshipProposalSnapshot(
+        suggestions: UnifiedSuggestionList(open: [row], activity: const []),
+      ),
+    );
+    await tester.tap(find.byIcon(LottiIcons.close).first);
+    for (var i = 0; i < 20; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+    expect(find.textContaining('Commitment 0'), findsNothing);
+    verify(() => service.reject(row.changeSet, 0)).called(1);
+    verifyNever(() => service.confirm(any(), any()));
+  });
+
+  for (final throws in [false, true]) {
+    testWidgets(
+      'refused undo keeps handled history and explains failure (throws: $throws)',
+      (tester) async {
+        final row = proposal(0);
+        final entry = LedgerEntry(
+          changeSetId: row.changeSet.id,
+          itemIndex: 0,
+          toolName: row.item.toolName,
+          args: {...row.item.args, 'dueDate': '2026-09-09'},
+          humanSummary: row.item.humanSummary,
+          fingerprint: row.fingerprint,
+          status: ChangeItemStatus.rejected,
+          createdAt: row.changeSet.createdAt,
+        );
+        when(() => service.undoById(row.changeSet.id, 0)).thenAnswer((_) async {
+          if (throws) throw StateError('write failed');
+          return false;
+        });
+        await pump(
+          tester,
+          () => RelationshipProposalSnapshot(
+            suggestions: UnifiedSuggestionList(
+              open: const [],
+              activity: [entry],
+            ),
+          ),
+          showHistory: true,
+        );
+        await tester.tap(find.textContaining('History'));
+        await tester.pumpAndSettle();
+        expect(find.text('Due: Sep 9, 2026'), findsOneWidget);
+        await tester.tap(find.text('Undo'));
+        await tester.pump();
+        expect(
+          find.text('Could not undo. The task may have changed.'),
+          findsOneWidget,
+        );
+        expect(find.textContaining('Commitment 0'), findsOneWidget);
+        verify(() => service.undoById(row.changeSet.id, 0)).called(1);
+        await tester.pumpWidget(const SizedBox());
+      },
+    );
+  }
 }

--- a/test/features/relationships/ui/widgets/relationship_suggestions_band_test.dart
+++ b/test/features/relationships/ui/widgets/relationship_suggestions_band_test.dart
@@ -427,4 +427,53 @@ void main() {
       },
     );
   }
+
+  testWidgets(
+    'bulk confirmation ignores row buttons and swipes until all writes finish',
+    (tester) async {
+      final rows = [proposal(0), proposal(1)];
+      final first = Completer<ToolExecutionResult>();
+      final second = Completer<ToolExecutionResult>();
+      when(
+        () => service.confirm(rows[0].changeSet, 0),
+      ).thenAnswer((_) => first.future);
+      when(
+        () => service.confirm(rows[1].changeSet, 0),
+      ).thenAnswer((_) => second.future);
+      when(() => service.reject(any(), any())).thenAnswer((_) async => true);
+      await pump(
+        tester,
+        () => RelationshipProposalSnapshot(
+          suggestions: UnifiedSuggestionList(open: rows, activity: const []),
+        ),
+      );
+      await tester.tap(find.text('Confirm all'));
+      await tester.pump();
+      await tester.tap(find.byIcon(LottiIcons.confirm).first);
+      await tester.tap(find.byIcon(LottiIcons.close).first);
+      await tester.drag(
+        find.textContaining('Commitment 1'),
+        const Offset(-200, 0),
+      );
+      await tester.pump();
+      verify(() => service.confirm(rows[0].changeSet, 0)).called(1);
+      verifyNever(() => service.reject(any(), any()));
+      first.complete(
+        const ToolExecutionResult(success: true, output: 'Created'),
+      );
+      await tester.pump();
+      await tester.tap(find.byIcon(LottiIcons.confirm).last);
+      await tester.tap(find.byIcon(LottiIcons.close).last);
+      verify(() => service.confirm(rows[1].changeSet, 0)).called(1);
+      verifyNever(() => service.reject(any(), any()));
+      second.complete(
+        const ToolExecutionResult(success: true, output: 'Created'),
+      );
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      expect(find.textContaining('Commitment 0'), findsNothing);
+      expect(find.textContaining('Commitment 1'), findsNothing);
+    },
+  );
 }

--- a/test/features/relationships/workflow/relationship_agent_contract_test.dart
+++ b/test/features/relationships/workflow/relationship_agent_contract_test.dart
@@ -6,7 +6,7 @@ import 'package:lotti/features/relationships/workflow/relationship_agent_contrac
 void main() {
   test('the system prompt stays lean — growth is argued, not accreted '
       '(the goal-contract hard-cap discipline)', () {
-    expect(relationshipAgentSystemPrompt.length, lessThanOrEqualTo(3600));
+    expect(relationshipAgentSystemPrompt.length, lessThanOrEqualTo(4300));
   });
 
   test('the prompt carries the ADR 0040 honesty rules and the privacy '
@@ -42,14 +42,39 @@ void main() {
     expect(RelationshipAgentToolNames.replyToUser, 'reply_to_user');
   });
 
-  test('the tool surface is exactly the four tools of plan v2 phase 5', () {
+  test('the tool surface is briefing tools and the deferred task proposal', () {
     expect(relationshipAgentTools.map((tool) => tool.name), [
       RelationshipAgentToolNames.replyToUser,
       RelationshipAgentToolNames.updateRelationshipReport,
       RelationshipAgentToolNames.createRelationshipAd,
       RelationshipAgentToolNames.snoozeRelationshipAd,
+      RelationshipAgentToolNames.createAndLinkTask,
     ]);
   });
+
+  test(
+    'task proposals require structured evidence and explicit confirmation',
+    () {
+      final tool = relationshipAgentTools.singleWhere(
+        (tool) => tool.name == RelationshipAgentToolNames.createAndLinkTask,
+      );
+      expect(
+        tool.parameters['required'],
+        containsAll([
+          'title',
+          'description',
+          'sourceCheckInId',
+          'reason',
+        ]),
+      );
+      expect(relationshipDeferredTools, {
+        RelationshipAgentToolNames.createAndLinkTask,
+      });
+      expect(relationshipAgentSystemPrompt, contains('explicit commitment'));
+      expect(relationshipAgentSystemPrompt, contains('Never re-propose'));
+      expect(relationshipAgentSystemPrompt, contains('confirmation'));
+    },
+  );
 
   test('the catalogs are derived from the real enums — the contract cannot '
       'drift from the code-owned presets (ADR 0058)', () {

--- a/test/features/relationships/workflow/relationship_agent_strategy_test.dart
+++ b/test/features/relationships/workflow/relationship_agent_strategy_test.dart
@@ -58,6 +58,7 @@ void main() {
       threadId: 'thread-1',
       runKey: 'run-1',
       activeAdIds: {'ad-live'},
+      sourceCheckInIds: {'check-in-1'},
     );
   });
 
@@ -69,6 +70,94 @@ void main() {
             ),
           ).captured.last)
           as String;
+
+  group('create_and_link_task', () {
+    Map<String, dynamic> taskArgs({String source = 'check-in-1'}) => {
+      'title': 'Send Pip the launch checklist',
+      'description': 'I promised to send the launch checklist.',
+      'sourceCheckInId': source,
+      'reason': 'An explicit commitment in the check-in.',
+    };
+
+    test(
+      'queues a task for confirmation without writing a change set',
+      () async {
+        await strategy.processToolCalls(
+          toolCalls: [_call(name: 'create_and_link_task', args: taskArgs())],
+          manager: manager,
+        );
+        expect(strategy.deferredItems.single['args'], taskArgs());
+        expect(lastResponse(), contains('confirmation'));
+        // Message recording is permitted; domain mutations are not.
+        expect(strategy.briefing, isNull);
+      },
+    );
+
+    test('rejects evidence outside the rendered check-in window', () async {
+      await strategy.processToolCalls(
+        toolCalls: [
+          _call(
+            name: 'create_and_link_task',
+            args: taskArgs(source: 'other-person'),
+          ),
+        ],
+        manager: manager,
+      );
+      expect(strategy.deferredItems, isEmpty);
+      expect(lastResponse(), contains('sourceCheckInId'));
+    });
+
+    test('rejects empty fields and invalid calendar dates', () async {
+      for (final args in [
+        {...taskArgs(), 'title': ' '},
+        {...taskArgs(), 'description': 42},
+        {...taskArgs(), 'reason': ''},
+        {...taskArgs(), 'dueDate': '2026-02-30'},
+        {...taskArgs(), 'dueDate': 'tomorrow'},
+      ]) {
+        await strategy.processToolCalls(
+          toolCalls: [_call(name: 'create_and_link_task', args: args)],
+          manager: manager,
+        );
+        expect(strategy.deferredItems, isEmpty);
+        expect(lastResponse(), startsWith('Error:'));
+      }
+    });
+
+    test('deduplicates repeated commitments within a wake', () async {
+      await strategy.processToolCalls(
+        toolCalls: [
+          _call(name: 'create_and_link_task', args: taskArgs()),
+          _call(
+            name: 'create_and_link_task',
+            args: {
+              ...taskArgs(),
+              'title': 'SEND PIP THE LAUNCH CHECKLIST',
+              'reason': 'Reworded rationale',
+            },
+          ),
+        ],
+        manager: manager,
+      );
+      expect(strategy.deferredItems, hasLength(1));
+      expect(strategy.deferredItems.single['args'], taskArgs());
+    });
+
+    test('bounds proposals per wake', () async {
+      await strategy.processToolCalls(
+        toolCalls: [
+          for (var i = 0; i < 5; i++)
+            _call(
+              name: 'create_and_link_task',
+              args: {...taskArgs(), 'title': 'Commitment $i'},
+            ),
+        ],
+        manager: manager,
+      );
+      expect(strategy.deferredItems, hasLength(3));
+      expect(lastResponse(), contains('three'));
+    });
+  });
 
   group('update_relationship_report', () {
     test('accumulates the full briefing with band and confidence', () async {

--- a/test/features/relationships/workflow/relationship_agent_workflow_test.dart
+++ b/test/features/relationships/workflow/relationship_agent_workflow_test.dart
@@ -12,6 +12,8 @@ import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/agents/model/proposal_ledger.dart';
 import 'package:lotti/features/agents/workflow/wake_result.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/inference_usage.dart';
@@ -173,6 +175,9 @@ void main() {
     conversationRepository = MockConversationRepository(conversationManager);
     when(() => conversationManager.messages).thenReturn(const []);
     upserts = [];
+    when(
+      () => repository.getProposalLedger(agentId, taskId: relationshipId),
+    ).thenAnswer((_) async => const ProposalLedger.empty());
     workflow = RelationshipAgentWorkflow(
       repository: repository,
       syncService: syncService,
@@ -248,6 +253,116 @@ void main() {
       pendingUserMessage: pendingUserMessage,
     ),
   );
+
+  void stubTaskProposal() {
+    stubGlmResolution();
+    conversationRepository
+      ..maxDelegateCalls = 1
+      ..sendMessageDelegate =
+          ({
+            required conversationId,
+            required message,
+            required model,
+            required provider,
+            required inferenceRepo,
+            tools,
+            toolChoice,
+            temperature = 0,
+            strategy,
+          }) async {
+            expect(message, contains('checkInId=c-1'));
+            expect(message, contains('PROPOSALS'));
+            await strategy!.processToolCalls(
+              toolCalls: [
+                toolCall(RelationshipAgentToolNames.createAndLinkTask, {
+                  'title': 'Send Pip the checklist',
+                  'description': 'I promised to send the checklist.',
+                  'sourceCheckInId': 'c-1',
+                  'reason': 'An explicit commitment.',
+                }),
+                toolCall(
+                  RelationshipAgentToolNames.updateRelationshipReport,
+                  briefingArgs(),
+                  id: 'report',
+                ),
+                toolCall(
+                  RelationshipAgentToolNames.createRelationshipAd,
+                  adArgs(),
+                  id: 'ad',
+                ),
+              ],
+              manager: conversationManager,
+            );
+            return null;
+          };
+  }
+
+  test(
+    'defers the task in a relationship-scoped change set with evidence',
+    () async {
+      stubTaskProposal();
+      expect((await run()).success, isTrue);
+      final set = upserts.whereType<ChangeSetEntity>().single;
+      expect(set.taskId, relationshipId);
+      expect(set.agentId, agentId);
+      expect(set.status, ChangeSetStatus.pending);
+      expect(set.items.single.args['sourceCheckInId'], 'c-1');
+      expect(
+        set.items.single.humanSummary,
+        'Create task: Send Pip the checklist',
+      );
+    },
+  );
+
+  for (final status in [
+    ChangeItemStatus.pending,
+    ChangeItemStatus.confirmed,
+    ChangeItemStatus.rejected,
+  ]) {
+    test('does not repeat a $status task when its rationale changes', () async {
+      stubTaskProposal();
+      expect((await run()).success, isTrue);
+      final previous = upserts.whereType<ChangeSetEntity>().single;
+      final item = previous.items.single.copyWith(
+        args: {...previous.items.single.args, 'reason': 'Different rationale'},
+      );
+      final entry = LedgerEntry(
+        changeSetId: 'previous',
+        itemIndex: 0,
+        toolName: item.toolName,
+        args: item.args,
+        humanSummary: item.humanSummary,
+        fingerprint: ChangeItem.fingerprint(item),
+        status: status,
+        createdAt: now,
+      );
+      when(
+        () => repository.getProposalLedger(agentId, taskId: relationshipId),
+      ).thenAnswer(
+        (_) async => ProposalLedger(
+          open: status == ChangeItemStatus.pending ? [entry] : [],
+          resolved: status == ChangeItemStatus.pending ? [] : [entry],
+        ),
+      );
+      upserts.clear();
+      conversationRepository.maxDelegateCalls = 2;
+      expect((await run()).success, isTrue);
+      expect(upserts.whereType<ChangeSetEntity>(), isEmpty);
+    });
+  }
+
+  test('a retry never replaces an already persisted proposal set', () async {
+    stubTaskProposal();
+    expect((await run()).success, isTrue);
+    final previous = upserts.whereType<ChangeSetEntity>().single;
+    when(
+      () => repository.getEntity(previous.id),
+    ).thenAnswer((_) async => previous);
+    upserts.clear();
+    conversationRepository.maxDelegateCalls = 2;
+    expect((await run()).success, isTrue);
+    expect(upserts.whereType<ChangeSetEntity>(), isEmpty);
+  });
 
   group('the €0 gates — no inference without a live fact', () {
     test('an agent with no link is a benign no-op', () async {

--- a/test/features/relationships/workflow/relationship_facts_renderer_test.dart
+++ b/test/features/relationships/workflow/relationship_facts_renderer_test.dart
@@ -168,6 +168,8 @@ void main() {
     final facts = render(checkIns: many);
     expect(facts, contains('CHECK-INS (newest first, 10 of 14):'));
     expect(facts, contains('topic-14'));
+    expect(facts, contains('checkInId=c-14'));
+    expect(facts, isNot(contains('checkInId=c-4 |')));
     expect(
       facts,
       isNot(contains('topic-4')),

--- a/test/features/relationships/workflow/relationship_tool_dispatcher_test.dart
+++ b/test/features/relationships/workflow/relationship_tool_dispatcher_test.dart
@@ -310,4 +310,98 @@ void main() {
       verify(() => persistence.updateDbEntity(any())).called(1);
     },
   );
+
+  test('unknown tools and malformed proposals cannot create a task', () async {
+    for (final input in [
+      ('unknown', args),
+      ('create_and_link_task', <String, dynamic>{}),
+      ('create_and_link_task', {...args, 'dueDate': '2026-02-30'}),
+    ]) {
+      final result = await dispatcher.dispatch(input.$1, input.$2, person.id);
+      expect(result.success, isFalse);
+      expect(result.nonRetryable, isTrue);
+    }
+    verifyNever(
+      () => persistence.createTaskEntry(
+        data: any(named: 'data'),
+        entryText: any(named: 'entryText'),
+        categoryId: any(named: 'categoryId'),
+        private: any(named: 'private'),
+      ),
+    );
+  });
+
+  test(
+    'refused creation stays retryable and never attempts a relationship link',
+    () async {
+      when(
+        () => persistence.createTaskEntry(
+          data: any(named: 'data'),
+          entryText: any(named: 'entryText'),
+          categoryId: any(named: 'categoryId'),
+          private: any(named: 'private'),
+        ),
+      ).thenAnswer((_) async => null);
+      final result = await dispatcher.dispatch(
+        'create_and_link_task',
+        args,
+        person.id,
+      );
+      expect(result.success, isFalse);
+      expect(result.nonRetryable, isFalse);
+      verifyNever(
+        () =>
+            relationships.linkTask(relationshipId: person.id, taskId: task.id),
+      );
+    },
+  );
+
+  test(
+    'metadata failures and refused tombstone writes refuse compensation',
+    () async {
+      when(
+        () => persistence.updateDbEntity(any()),
+      ).thenAnswer((_) async => null);
+      expect(await dispatcher.removeTask(task), isFalse);
+      when(
+        () => persistence.updateMetadata(
+          task.meta,
+          deletedAt: any(named: 'deletedAt'),
+        ),
+      ).thenThrow(StateError('database unavailable'));
+      expect(await dispatcher.removeTask(task), isFalse);
+    },
+  );
+
+  test(
+    'private evidence keeps a public person’s task private, and no due date stays absent',
+    () async {
+      when(() => relationships.getRelationshipById(person.id)).thenAnswer(
+        (_) async =>
+            person.copyWith(meta: person.meta.copyWith(private: false)),
+      );
+      final input = {...args}..remove('dueDate');
+      expect(
+        (await dispatcher.dispatch(
+          'create_and_link_task',
+          input,
+          person.id,
+        )).success,
+        isTrue,
+      );
+      final captured = verify(
+        () => persistence.createTaskEntry(
+          data: captureAny(named: 'data'),
+          entryText: captureAny(named: 'entryText'),
+          categoryId: 'category',
+          private: true,
+        ),
+      ).captured;
+      expect((captured[0] as TaskData).due, isNull);
+      expect(
+        (captured[1] as EntryText).markdown,
+        contains('(lotti://journal/${evidence.id})'),
+      );
+    },
+  );
 }

--- a/test/features/relationships/workflow/relationship_tool_dispatcher_test.dart
+++ b/test/features/relationships/workflow/relationship_tool_dispatcher_test.dart
@@ -43,17 +43,21 @@ void main() {
   late MockPersistenceLogic persistence;
   late MockEntitiesCacheService cache;
   late MockTaskAgentService agents;
+  late MockJournalDb db;
   late RelationshipToolDispatcher dispatcher;
   setUp(() {
     relationships = MockRelationshipRepository();
     persistence = MockPersistenceLogic();
     cache = MockEntitiesCacheService();
     agents = MockTaskAgentService();
+    db = MockJournalDb();
+    when(() => db.journalEntityById(any())).thenAnswer((_) async => null);
     dispatcher = RelationshipToolDispatcher(
       relationshipRepository: relationships,
       persistenceLogic: persistence,
       entitiesCacheService: cache,
       taskAgentService: agents,
+      journalDb: db,
     );
     when(
       () => relationships.getRelationshipById(person.id),
@@ -64,6 +68,7 @@ void main() {
     when(() => cache.getCategoryById('category')).thenReturn(null);
     when(
       () => persistence.createTaskEntry(
+        id: any(named: 'id'),
         data: any(named: 'data'),
         entryText: any(named: 'entryText'),
         categoryId: any(named: 'categoryId'),
@@ -94,6 +99,7 @@ void main() {
       expect((result as RelationshipTaskCreationResult).task, task);
       final captured = verify(
         () => persistence.createTaskEntry(
+          id: any(named: 'id'),
           data: captureAny(named: 'data'),
           entryText: captureAny(named: 'entryText'),
           categoryId: 'category',
@@ -200,6 +206,7 @@ void main() {
       );
       verifyNever(
         () => persistence.createTaskEntry(
+          id: any(named: 'id'),
           data: any(named: 'data'),
           entryText: any(named: 'entryText'),
           categoryId: any(named: 'categoryId'),
@@ -248,6 +255,7 @@ void main() {
       final data =
           verify(
                 () => persistence.createTaskEntry(
+                  id: any(named: 'id'),
                   data: captureAny(named: 'data'),
                   entryText: any(named: 'entryText'),
                   categoryId: 'category',
@@ -280,6 +288,7 @@ void main() {
     expect(result.nonRetryable, isTrue);
     verifyNever(
       () => persistence.createTaskEntry(
+        id: any(named: 'id'),
         data: any(named: 'data'),
         entryText: any(named: 'entryText'),
         categoryId: any(named: 'categoryId'),
@@ -323,6 +332,7 @@ void main() {
     }
     verifyNever(
       () => persistence.createTaskEntry(
+        id: any(named: 'id'),
         data: any(named: 'data'),
         entryText: any(named: 'entryText'),
         categoryId: any(named: 'categoryId'),
@@ -336,6 +346,7 @@ void main() {
     () async {
       when(
         () => persistence.createTaskEntry(
+          id: any(named: 'id'),
           data: any(named: 'data'),
           entryText: any(named: 'entryText'),
           categoryId: any(named: 'categoryId'),
@@ -391,6 +402,7 @@ void main() {
       );
       final captured = verify(
         () => persistence.createTaskEntry(
+          id: any(named: 'id'),
           data: captureAny(named: 'data'),
           entryText: captureAny(named: 'entryText'),
           categoryId: 'category',
@@ -402,6 +414,220 @@ void main() {
         (captured[1] as EntryText).markdown,
         contains('(lotti://journal/${evidence.id})'),
       );
+    },
+  );
+
+  test(
+    'two independent devices create the same task identity despite different clocks',
+    () async {
+      final other = RelationshipToolDispatcher(
+        relationshipRepository: relationships,
+        persistenceLogic: persistence,
+        entitiesCacheService: cache,
+        taskAgentService: agents,
+        journalDb: db,
+      );
+      expect(
+        (await withClock(
+          Clock.fixed(now),
+          () => dispatcher.dispatch('create_and_link_task', args, person.id),
+        )).success,
+        isTrue,
+      );
+      expect(
+        (await withClock(
+          Clock.fixed(now.add(const Duration(hours: 2))),
+          () => other.dispatch('create_and_link_task', Map.of(args), person.id),
+        )).success,
+        isTrue,
+      );
+      final captures = verify(
+        () => persistence.createTaskEntry(
+          id: captureAny(named: 'id'),
+          data: captureAny(named: 'data'),
+          entryText: any(named: 'entryText'),
+          categoryId: any(named: 'categoryId'),
+          private: any(named: 'private'),
+        ),
+      ).captured;
+      final ids = captures.whereType<String>().toList();
+      final payloads = captures.whereType<TaskData>().toList();
+      expect(ids.first, isNotEmpty);
+      expect(ids.first, ids.last);
+      expect(payloads.first.dateFrom, now);
+      expect(
+        payloads.last.dateFrom,
+        now.add(const Duration(hours: 2)),
+      );
+    },
+  );
+
+  for (final linked in [true, false]) {
+    test(
+      'an existing peer task is never overwritten or made undoable (linked: $linked)',
+      () async {
+        when(() => db.journalEntityById(any())).thenAnswer(
+          (invocation) async => task.copyWith(
+            meta: task.meta.copyWith(
+              id: invocation.positionalArguments.first as String,
+            ),
+            data: task.data.copyWith(title: 'Already edited by a peer'),
+          ),
+        );
+        when(
+          () => relationships.linkTask(
+            relationshipId: person.id,
+            taskId: any(named: 'taskId'),
+          ),
+        ).thenAnswer((_) async => linked);
+        final result = await dispatcher.dispatch(
+          'create_and_link_task',
+          args,
+          person.id,
+        );
+        expect(result.success, linked);
+        expect(result, isNot(isA<RelationshipTaskCreationResult>()));
+        verifyNever(
+          () => persistence.createTaskEntry(
+            id: any(named: 'id'),
+            data: any(named: 'data'),
+            entryText: any(named: 'entryText'),
+            categoryId: any(named: 'categoryId'),
+            private: any(named: 'private'),
+          ),
+        );
+        verifyNever(() => persistence.updateDbEntity(any()));
+      },
+    );
+  }
+
+  for (final saved in [true, false]) {
+    test(
+      'confirmation after undo restores the tombstoned identity (saved: $saved)',
+      () async {
+        String? identity;
+        when(() => db.journalEntityById(any())).thenAnswer((invocation) async {
+          identity = invocation.positionalArguments.first as String;
+          return task.copyWith(
+            meta: task.meta.copyWith(id: identity!, deletedAt: now),
+          );
+        });
+        when(
+          () => persistence.updateMetadata(
+            any(),
+            dateFrom: any(named: 'dateFrom'),
+            dateTo: any(named: 'dateTo'),
+          ),
+        ).thenAnswer(
+          (invocation) async =>
+              invocation.positionalArguments.first as Metadata,
+        );
+        when(
+          () => persistence.updateDbEntity(any()),
+        ).thenAnswer((_) async => saved);
+        when(
+          () => relationships.linkTask(
+            relationshipId: person.id,
+            taskId: any(named: 'taskId'),
+          ),
+        ).thenAnswer((_) async => true);
+        final result = await dispatcher.dispatch(
+          'create_and_link_task',
+          args,
+          person.id,
+        );
+        expect(result.success, saved);
+        final restored =
+            verify(
+                  () => persistence.updateDbEntity(captureAny()),
+                ).captured.single
+                as Task;
+        expect(restored.id, identity);
+        expect(restored.meta.deletedAt, isNull);
+        expect(restored.data.title, args['title']);
+        if (saved) {
+          expect((result as RelationshipTaskCreationResult).task, restored);
+        } else {
+          verifyNever(
+            () => relationships.linkTask(
+              relationshipId: person.id,
+              taskId: any(named: 'taskId'),
+            ),
+          );
+        }
+        verifyNever(
+          () => persistence.createTaskEntry(
+            id: any(named: 'id'),
+            data: any(named: 'data'),
+            entryText: any(named: 'entryText'),
+            categoryId: any(named: 'categoryId'),
+            private: any(named: 'private'),
+          ),
+        );
+      },
+    );
+  }
+
+  test('a non-task identity collision refuses creation', () async {
+    when(() => db.journalEntityById(any())).thenAnswer((_) async => person);
+    final result = await dispatcher.dispatch(
+      'create_and_link_task',
+      args,
+      person.id,
+    );
+    expect(result.success, isFalse);
+    expect(result.nonRetryable, isTrue);
+    verifyNever(
+      () => persistence.createTaskEntry(
+        id: any(named: 'id'),
+        data: any(named: 'data'),
+        entryText: any(named: 'entryText'),
+        categoryId: any(named: 'categoryId'),
+        private: any(named: 'private'),
+      ),
+    );
+  });
+
+  test(
+    'a failed default agent assignment keeps the successfully linked task',
+    () async {
+      when(() => cache.getCategoryById('category')).thenReturn(
+        CategoryDefinition(
+          id: 'category',
+          createdAt: now,
+          updatedAt: now,
+          name: 'Penguin crew',
+          vectorClock: null,
+          private: false,
+          active: true,
+          defaultProfileId: 'profile',
+          defaultTemplateId: 'template',
+        ),
+      );
+      when(
+        () => agents.createTaskAgent(
+          taskId: task.id,
+          templateId: 'template',
+          profileId: 'profile',
+          setupOrigin: AgentInferenceSetupOrigin.categorySnapshot,
+          setupOriginEntityId: 'category',
+          allowedCategoryIds: {'category'},
+          awaitContent: true,
+          automaticUpdatesEnabled: any(named: 'automaticUpdatesEnabled'),
+        ),
+      ).thenThrow(StateError('agent unavailable'));
+      final result = await dispatcher.dispatch(
+        'create_and_link_task',
+        args,
+        person.id,
+      );
+      expect(result.success, isTrue);
+      expect(result.mutatedEntityId, task.id);
+      verify(
+        () =>
+            relationships.linkTask(relationshipId: person.id, taskId: task.id),
+      ).called(1);
+      verifyNever(() => persistence.updateDbEntity(any()));
     },
   );
 }

--- a/test/features/relationships/workflow/relationship_tool_dispatcher_test.dart
+++ b/test/features/relationships/workflow/relationship_tool_dispatcher_test.dart
@@ -1,0 +1,313 @@
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/check_in_data.dart';
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/relationships/workflow/relationship_tool_dispatcher.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
+import '../../../test_data/test_data.dart';
+import '../../agents/test_data/entity_factories.dart';
+
+void main() {
+  setUpAll(registerAllFallbackValues);
+  final now = DateTime(2026, 9, 6, 12);
+  final person = testRelationship.copyWith(
+    data: testRelationship.data.copyWith(important: true),
+    meta: testRelationship.meta.copyWith(categoryId: 'category', private: true),
+  );
+  final task = testTask.copyWith(
+    meta: testTask.meta.copyWith(id: 'created-task', categoryId: 'category'),
+  );
+  final evidence = CheckInEntry(
+    meta: person.meta.copyWith(id: 'evidence'),
+    data: CheckInData(
+      relationshipId: person.id,
+      interactionType: CheckInInteractionType.call,
+    ),
+    entryText: const EntryText(plainText: 'I promised to send the checklist.'),
+  );
+  final args = <String, dynamic>{
+    'title': 'Send the checklist',
+    'description': 'I promised to send the checklist.',
+    'sourceCheckInId': evidence.id,
+    'reason': 'An explicit commitment.',
+    'dueDate': '2026-09-10',
+  };
+  late MockRelationshipRepository relationships;
+  late MockPersistenceLogic persistence;
+  late MockEntitiesCacheService cache;
+  late MockTaskAgentService agents;
+  late RelationshipToolDispatcher dispatcher;
+  setUp(() {
+    relationships = MockRelationshipRepository();
+    persistence = MockPersistenceLogic();
+    cache = MockEntitiesCacheService();
+    agents = MockTaskAgentService();
+    dispatcher = RelationshipToolDispatcher(
+      relationshipRepository: relationships,
+      persistenceLogic: persistence,
+      entitiesCacheService: cache,
+      taskAgentService: agents,
+    );
+    when(
+      () => relationships.getRelationshipById(person.id),
+    ).thenAnswer((_) async => person);
+    when(
+      () => relationships.getCheckInsForRelationship(person.id),
+    ).thenAnswer((_) async => [evidence]);
+    when(() => cache.getCategoryById('category')).thenReturn(null);
+    when(
+      () => persistence.createTaskEntry(
+        data: any(named: 'data'),
+        entryText: any(named: 'entryText'),
+        categoryId: any(named: 'categoryId'),
+        private: any(named: 'private'),
+      ),
+    ).thenAnswer((_) async => task);
+    when(
+      () => relationships.linkTask(relationshipId: person.id, taskId: task.id),
+    ).thenAnswer((_) async => true);
+    when(
+      () => persistence.updateMetadata(
+        task.meta,
+        deletedAt: any(named: 'deletedAt'),
+      ),
+    ).thenAnswer((_) async => task.meta.copyWith(deletedAt: now));
+    when(() => persistence.updateDbEntity(any())).thenAnswer((_) async => true);
+  });
+
+  test(
+    'confirmation creates and links the private task with due date and evidence',
+    () async {
+      final result = await withClock(
+        Clock.fixed(now),
+        () => dispatcher.dispatch('create_and_link_task', args, person.id),
+      );
+      expect(result.success, isTrue);
+      expect(result.mutatedEntityId, task.id);
+      expect((result as RelationshipTaskCreationResult).task, task);
+      final captured = verify(
+        () => persistence.createTaskEntry(
+          data: captureAny(named: 'data'),
+          entryText: captureAny(named: 'entryText'),
+          categoryId: 'category',
+          private: true,
+        ),
+      ).captured;
+      final data = captured[0] as TaskData;
+      expect(data.title, args['title']);
+      expect(data.due, DateTime(2026, 9, 10));
+      expect(
+        (captured[1] as EntryText).plainText,
+        contains(args['description']),
+      );
+      verify(
+        () =>
+            relationships.linkTask(relationshipId: person.id, taskId: task.id),
+      ).called(1);
+    },
+  );
+
+  for (final throwing in [false, true]) {
+    test(
+      'a ${throwing ? 'throwing' : 'refused'} link compensates task creation',
+      () async {
+        final stub = when(
+          () => relationships.linkTask(
+            relationshipId: person.id,
+            taskId: task.id,
+          ),
+        );
+        if (throwing) {
+          stub.thenThrow(StateError('link failed'));
+        } else {
+          stub.thenAnswer((_) async => false);
+        }
+        final result = await dispatcher.dispatch(
+          'create_and_link_task',
+          args,
+          person.id,
+        );
+        expect(result.success, isFalse);
+        expect(result.nonRetryable, isFalse);
+        final deleted =
+            verify(
+                  () => persistence.updateDbEntity(captureAny()),
+                ).captured.single
+                as Task;
+        expect(deleted.meta.deletedAt, now);
+      },
+    );
+  }
+
+  test(
+    'failed compensation retracts instead of allowing duplicate tasks on retry',
+    () async {
+      when(
+        () =>
+            relationships.linkTask(relationshipId: person.id, taskId: task.id),
+      ).thenAnswer((_) async => false);
+      when(
+        () => persistence.updateDbEntity(any()),
+      ).thenAnswer((_) async => false);
+      final result = await dispatcher.dispatch(
+        'create_and_link_task',
+        args,
+        person.id,
+      );
+      expect(result.success, isFalse);
+      expect(result.nonRetryable, isTrue);
+    },
+  );
+
+  test(
+    'rejects missing evidence, another person’s evidence and withdrawn consent',
+    () async {
+      for (final source in [
+        null,
+        evidence.copyWith(
+          data: evidence.data.copyWith(relationshipId: 'someone-else'),
+        ),
+      ]) {
+        when(
+          () => relationships.getCheckInsForRelationship(person.id),
+        ).thenAnswer((_) async => [?source]);
+        expect(
+          (await dispatcher.dispatch(
+            'create_and_link_task',
+            args,
+            person.id,
+          )).nonRetryable,
+          isTrue,
+        );
+      }
+      when(
+        () => relationships.getRelationshipById(person.id),
+      ).thenAnswer((_) async => null);
+      expect(
+        (await dispatcher.dispatch(
+          'create_and_link_task',
+          args,
+          person.id,
+        )).nonRetryable,
+        isTrue,
+      );
+      verifyNever(
+        () => persistence.createTaskEntry(
+          data: any(named: 'data'),
+          entryText: any(named: 'entryText'),
+          categoryId: any(named: 'categoryId'),
+          private: any(named: 'private'),
+        ),
+      );
+    },
+  );
+
+  test(
+    'inherits category profile and provisions the category default agent',
+    () async {
+      when(() => cache.getCategoryById('category')).thenReturn(
+        CategoryDefinition(
+          id: 'category',
+          createdAt: now,
+          updatedAt: now,
+          name: 'Penguin crew',
+          vectorClock: null,
+          private: false,
+          active: true,
+          defaultProfileId: 'profile',
+          defaultTemplateId: 'template',
+        ),
+      );
+      when(
+        () => agents.createTaskAgent(
+          taskId: task.id,
+          templateId: 'template',
+          profileId: 'profile',
+          setupOrigin: AgentInferenceSetupOrigin.categorySnapshot,
+          setupOriginEntityId: 'category',
+          allowedCategoryIds: {'category'},
+          awaitContent: true,
+          automaticUpdatesEnabled: any(named: 'automaticUpdatesEnabled'),
+        ),
+      ).thenAnswer((_) async => makeTestIdentity());
+      expect(
+        (await dispatcher.dispatch(
+          'create_and_link_task',
+          args,
+          person.id,
+        )).success,
+        isTrue,
+      );
+      final data =
+          verify(
+                () => persistence.createTaskEntry(
+                  data: captureAny(named: 'data'),
+                  entryText: any(named: 'entryText'),
+                  categoryId: 'category',
+                  private: true,
+                ),
+              ).captured.single
+              as TaskData;
+      expect(data.profileId, 'profile');
+      verify(
+        () => agents.createTaskAgent(
+          taskId: task.id,
+          templateId: 'template',
+          profileId: 'profile',
+          setupOrigin: AgentInferenceSetupOrigin.categorySnapshot,
+          setupOriginEntityId: 'category',
+          allowedCategoryIds: {'category'},
+          awaitContent: true,
+          automaticUpdatesEnabled: any(named: 'automaticUpdatesEnabled'),
+        ),
+      ).called(1);
+    },
+  );
+
+  test('a changed quote retracts before creating a task', () async {
+    final result = await dispatcher.dispatch('create_and_link_task', {
+      ...args,
+      'description': 'I promised something else.',
+    }, person.id);
+    expect(result.success, isFalse);
+    expect(result.nonRetryable, isTrue);
+    verifyNever(
+      () => persistence.createTaskEntry(
+        data: any(named: 'data'),
+        entryText: any(named: 'entryText'),
+        categoryId: any(named: 'categoryId'),
+        private: any(named: 'private'),
+      ),
+    );
+  });
+
+  test(
+    'consent withdrawn during creation rolls back without linking',
+    () async {
+      var reads = 0;
+      when(() => relationships.getRelationshipById(person.id)).thenAnswer(
+        (_) async => reads++ == 0
+            ? person
+            : person.copyWith(data: person.data.copyWith(important: false)),
+      );
+      final result = await dispatcher.dispatch(
+        'create_and_link_task',
+        args,
+        person.id,
+      );
+      expect(result.success, isFalse);
+      verifyNever(
+        () =>
+            relationships.linkTask(relationshipId: person.id, taskId: task.id),
+      );
+      verify(() => persistence.updateDbEntity(any())).called(1);
+    },
+  );
+}

--- a/test/logic/persistence_create_ops_test.dart
+++ b/test/logic/persistence_create_ops_test.dart
@@ -517,4 +517,23 @@ void main() {
       ).called(1);
     },
   );
+
+  test(
+    'task creation writes the supplied stable identity rather than its payload hash',
+    () async {
+      final result = await ops.createTaskEntryImpl(
+        id: 'relationship-commitment-id',
+        data: testTask.data,
+        entryText: const EntryText(plainText: 'I promised to pack fish.'),
+      );
+      expect(result?.id, 'relationship-commitment-id');
+      final written =
+          verify(
+                () => logic.createDbEntity(captureAny()),
+              ).captured.single
+              as Task;
+      expect(written.id, 'relationship-commitment-id');
+      expect(written.data, testTask.data);
+    },
+  );
 }

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -645,9 +645,18 @@ void main() {
 
       // create test task
       final task = await getIt<PersistenceLogic>().createTaskEntry(
+        id: 'stable-relationship-task',
         data: taskData,
         entryText: const EntryText(plainText: testTaskText),
       );
+
+      expect(task?.id, 'stable-relationship-task');
+      final duplicate = await getIt<PersistenceLogic>().createTaskEntry(
+        id: 'stable-relationship-task',
+        data: taskData.copyWith(title: 'Duplicate from another confirmation'),
+        entryText: const EntryText(plainText: 'Another device'),
+      );
+      expect(duplicate, isNull);
 
       // expect to find created task
       final testTask =

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io' as io;
+
 import 'package:beamer/beamer.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:drift/drift.dart' as drift;
@@ -144,6 +145,7 @@ import 'package:lotti/features/relationships/repository/relationship_repository.
 import 'package:lotti/features/relationships/runtime/relationship_agent_phase_a.dart';
 import 'package:lotti/features/relationships/service/relationship_agent_service.dart';
 import 'package:lotti/features/relationships/service/relationship_chat_service.dart';
+import 'package:lotti/features/relationships/service/relationship_proposal_service.dart';
 import 'package:lotti/features/relationships/service/relationship_reminder_service.dart';
 import 'package:lotti/features/relationships/workflow/relationship_agent_workflow.dart';
 import 'package:lotti/features/speech/repository/audio_recorder_repository.dart';
@@ -1610,3 +1612,6 @@ class MockSherpaTranscriptionRepository extends Mock
 class MockSherpaRecognizer extends Mock implements sherpa.OfflineRecognizer {}
 
 class MockSherpaStream extends Mock implements sherpa.OfflineStream {}
+
+class MockRelationshipProposalService extends Mock
+    implements RelationshipProposalService {}


### PR DESCRIPTION
Captured check-in commitments can now become task proposals on a person's agent card and in their chat. Nothing is created until the user confirms; confirmation creates and links a task with inherited category/privacy, an evidence link, an optional due date, and the category's default agent.

The shared proposal rows support relationship-scoped confirmation, same-kind bulk actions with per-row input disabled while writes run, folded pending rows, handled history, task navigation and guarded undo. Undo refuses tasks that have changed or gained linked content. The agent receives pending and handled decisions as feedback, with deterministic deduplication and at most three proposals per wake. No schema migration is required.

Task IDs are stable across devices confirming the same commitment. Existing tasks are preserved, and confirmation after undo restores the tombstoned identity. Undo removes the untouched task before cleaning up its link, so a failed deletion never detaches a live task.

Call scheduling and task-note suggestions remain follow-up work. The new model-policy scenarios have offline coverage; the live model evaluation matrix has not been rerun.

Validation: 379 targeted feature tests and 20 post-rebase chat integration tests passed via Dart MCP. The final review fixes passed 172 targeted service, UI and persistence tests; analyzer and knowledge/Mermaid checks are clean. New regression tests were also run with the corresponding safeguards disabled and failed as expected. The latest bulk-input guard passed all 12 band tests, and localized card/chat capture tests passed for Danish, Dutch, Portuguese and Swedish. CI is rerunning after those final review corrections; the preceding commit had 100% patch and 99.34% project coverage.

| Surface | Before | After |
| --- | --- | --- |
| Person card · mobile light | ![Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/before/person_detail_briefing_mobile_light.png) | ![After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/after/person_detail_briefing_mobile_light.png) |
| Chat · mobile light | ![Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/before/person_chat_mobile_light.png) | ![After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/after/person_chat_mobile_light.png) |
| Person card · desktop dark | ![Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/before/person_detail_briefing_desktop_dark.png) | ![After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/after/person_detail_briefing_desktop_dark.png) |
| Chat · desktop dark | ![Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/before/person_chat_desktop_dark.png) | ![After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/after/person_chat_desktop_dark.png) |

<details>
<summary>Localized evidence-label corrections</summary>

| Language | Card | Chat |
| --- | --- | --- |
| Danish | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/before/person_detail_briefing_mobile_light_da.png) · [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/after/person_detail_briefing_mobile_light_da.png) | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/before/person_chat_mobile_light_da.png) · [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/after/person_chat_mobile_light_da.png) |
| Dutch | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/before/person_detail_briefing_mobile_light_nl.png) · [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/after/person_detail_briefing_mobile_light_nl.png) | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/before/person_chat_mobile_light_nl.png) · [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/after/person_chat_mobile_light_nl.png) |
| Portuguese | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/before/person_detail_briefing_mobile_light_pt.png) · [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/after/person_detail_briefing_mobile_light_pt.png) | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/before/person_chat_mobile_light_pt.png) · [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/after/person_chat_mobile_light_pt.png) |
| Swedish | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/before/person_detail_briefing_mobile_light_sv.png) · [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/after/person_detail_briefing_mobile_light_sv.png) | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/before/person_chat_mobile_light_sv.png) · [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-task-suggestions/1f5162fb33790ef52b20168c4e804b80492ec70b/after/person_chat_mobile_light_sv.png) |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Relationship agents can suggest tasks based on explicit check-in commitments.
  * Review proposals on a person’s card or in chat, with source check-in and due-date details.
  * Confirm individually or in bulk, view proposal history, undo supported actions, and navigate to linked tasks.
  * Task suggestions are limited, deduplicated, and safely linked to relationships.
* **Bug Fixes**
  * Improved handling of retries, duplicate confirmations, failed links, and undo conflicts.
* **Documentation**
  * Updated relationship feature, evaluation, and agent-surface documentation.
* **Localization**
  * Added proposal messaging across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->