### PR TITLE
fix: guard relationship task deletion against concurrent changes

### DIFF
--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -269,6 +269,35 @@ existing `idx_sync_sequence_log_host_status` index and sorting that sparse
 subset. This deliberately avoids SQLite choosing a host/counter history scan
 merely to satisfy ordering. The query has no new index or migration cost.
 
+# Conditional journal writes
+
+`PersistenceLogic.updateDbEntity` forwards an optional read-only `precondition`
+to `JournalDb.updateJournalEntity`. The callback runs inside the same journal
+transaction as vector-clock comparison and the entity write. It may read this
+journal’s rows and links, but must not perform external work or mutations.
+A false result returns `overwritePrevented` without changing the row, conflicts,
+labels or JSON sidecar. The persistence facade burns the unused clock reservation
+and returns before search indexing, notifications, badges, and sync publication.
+Those publication steps also skip other refused updates.
+
+```mermaid
+flowchart TD
+  Request[Update entity] --> Transaction[Journal transaction]
+  Transaction --> Guard{Precondition holds or absent?}
+  Guard -->|No| Refuse[Return overwritePrevented]
+  Guard -->|Yes| Compare[Compare vector clocks and apply write]
+  Compare --> Applied{Write applied?}
+  Applied -->|No| RefuseWrite[Return skip reason]
+  Applied -->|Yes| Commit[Commit then publish JSON sidecar]
+  Refuse --> Burn[Burn unused clock reservation]
+  RefuseWrite --> Burn
+  Commit --> Publish[Record sequence, notify, index, enqueue sync]
+```
+
+This is a local database condition, not a distributed lease. The relationship
+proposal deletion policy built on it is documented in
+[Relationships](../features/relationships.md#deferred-task-suggestions).
+
 # Migrations
 
 `JournalDb`, `SyncDatabase`, and `AgentDatabase` each have substantial migration

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -274,7 +274,9 @@ merely to satisfy ordering. The query has no new index or migration cost.
 `PersistenceLogic.updateDbEntity` forwards an optional read-only `precondition`
 to `JournalDb.updateJournalEntity`. The callback runs inside the same journal
 transaction as vector-clock comparison and the entity write. It may read this
-journal’s rows and links, but must not perform external work or mutations.
+journal’s rows and links through direct queries, but must not perform external
+work or mutations. Shared/coalesced readers can join a wave outside the
+transaction: use `entityById`, not `journalEntityById`, for the guarded snapshot.
 A false result returns `overwritePrevented` without changing the row, conflicts,
 labels or JSON sidecar. The persistence facade burns the unused clock reservation
 and returns before search indexing, notifications, badges, and sync publication.

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -695,8 +695,9 @@ stateDiagram-v2
 is the only apply path. It rechecks visible evidence, its quoted narrative,
 and current consent; creates a task with the person's category, inherited
 privacy (also preserving private evidence), evidence link and proposed due
-date; then links it to the person. A link failure tombstones the new task;
-a failed compensation is non-retryable to avoid duplicate creation. The shared
+date; then links it to the person. A link failure tombstones the new task only
+if it is unchanged and has no live links. A refused compensation is
+non-retryable, preserving tasks already edited or linked by another writer. The shared
 category-default assignment helper provisions its task agent. The task has a
 stable UUID derived from the person, source check-in, title and quoted
 commitment, so the same synced proposal confirmed on two devices converges on
@@ -705,15 +706,22 @@ this explicit identity and preserves its existing insert-only write contract.
 A live task found under that identity is linked without overwriting it or
 creating a fresh undo receipt from potentially edited data. Reconfirmation
 after undo restores the tombstoned identity with a vector clock descended
-from the tombstone.
+from the tombstone. An active, visible relationship link in either direction
+turns a duplicate link refusal into success without a new undo receipt.
 
 [`relationship_proposal_service.dart`](../../lib/features/relationships/service/relationship_proposal_service.dart)
 wraps the generic confirmation service. The exact creation snapshot is stored
 under `_relationshipTaskReceipt` on the user decision's args, leaving immutable
 proposal args and fingerprints unchanged. It supplies the durable task
 navigation destination and guards undo against task edits. Undo checks the
-task and additional journal links twice, tombstones the untouched task, then
-cleans up its relationship link. A refused deletion leaves the live task
+task and additional journal links before removal. The dispatcher repeats the
+exact snapshot and allowed-link checks inside the journal write transaction,
+then tombstones the untouched task; the service cleans up its relationship
+link afterward. Undo allows only the originating person’s relationship links;
+compensation allows no live links, including hidden links. Link changes do not
+advance the task’s vector clock, so clock comparison alone cannot guard this
+operation. This protects local writes and peer changes already received, not
+changes still offline on another device. A refused deletion leaves the live task
 linked. Failed link cleanup is logged and leaves only a link to a tombstoned
 task, which relationship task queries exclude; it does not undo the successful
 deletion or reopen an unsafe compensation path.

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -707,7 +707,8 @@ A live task found under that identity is linked without overwriting it or
 creating a fresh undo receipt from potentially edited data. Reconfirmation
 after undo restores the tombstoned identity with a vector clock descended
 from the tombstone. An active, visible relationship link in either direction
-turns a duplicate link refusal into success without a new undo receipt.
+turns a duplicate refusal or a thrown post-write error into success without a
+new undo receipt.
 
 [`relationship_proposal_service.dart`](../../lib/features/relationships/service/relationship_proposal_service.dart)
 wraps the generic confirmation service. The exact creation snapshot is stored

--- a/lib/database/database_entity_ops.dart
+++ b/lib/database/database_entity_ops.dart
@@ -108,7 +108,8 @@ mixin _JournalDbEntityOps
   ///
   /// [precondition], when supplied, runs inside that same transaction before
   /// any write. It must only read this journal database, without side effects
-  /// or external awaits. Returning false leaves the row and sidecar untouched.
+  /// or external awaits. Use direct queries, not readers that coalesce calls
+  /// across transaction zones. Returning false leaves the row and sidecar untouched.
   ///
   /// The JSON sidecar is written **after** the transaction commits: it is
   /// the sync payload, so it must never describe a row that rolled back,

--- a/lib/database/database_entity_ops.dart
+++ b/lib/database/database_entity_ops.dart
@@ -106,6 +106,10 @@ mixin _JournalDbEntityOps
   /// check and the write. A caller that already holds a transaction (the
   /// sync inbound handler) simply nests this one.
   ///
+  /// [precondition], when supplied, runs inside that same transaction before
+  /// any write. It must only read this journal database, without side effects
+  /// or external awaits. Returning false leaves the row and sidecar untouched.
+  ///
   /// The JSON sidecar is written **after** the transaction commits: it is
   /// the sync payload, so it must never describe a row that rolled back,
   /// and writing it inside the transaction would hold the journal writer
@@ -115,6 +119,7 @@ mixin _JournalDbEntityOps
     JournalEntity updated, {
     bool overrideComparison = false,
     bool overwrite = true,
+    Future<bool> Function()? precondition,
   }) async {
     final dbEntity = toDbEntity(updated).copyWith(
       updatedAt: clock.now(),
@@ -126,6 +131,11 @@ mixin _JournalDbEntityOps
       JournalUpdateSkipReason? skipReason;
       var rowsWritten = 0;
 
+      if (precondition != null && !await precondition()) {
+        return JournalUpdateResult.skipped(
+          reason: JournalUpdateSkipReason.overwritePrevented,
+        );
+      }
       final existingDbEntity = await entityById(dbEntity.id);
 
       if (existingDbEntity != null && !overwrite) {

--- a/lib/database/journal_update_result.dart
+++ b/lib/database/journal_update_result.dart
@@ -6,7 +6,8 @@ enum JournalUpdateSkipReason {
   /// Update could not be applied because of a concurrent conflict.
   conflict,
 
-  /// Update was withheld because overwrite was disabled.
+  /// Update was withheld because overwrite was disabled or a caller’s
+  /// transactional write precondition refused it.
   overwritePrevented,
 
   /// The expected base entity was missing (e.g., pruned or never replicated).

--- a/lib/features/relationships/service/relationship_proposal_service.dart
+++ b/lib/features/relationships/service/relationship_proposal_service.dart
@@ -32,7 +32,8 @@ class RelationshipProposalService {
   final AgentSyncService syncService;
   final JournalDb journalDb;
   final RelationshipRepository relationshipRepository;
-  final Future<bool> Function(Task) taskRemover;
+  final Future<bool> Function(Task, {String? allowedRelationshipId})
+  taskRemover;
   final _busy = <String>{};
   final _receipts = <String, Task>{};
   static const receiptKey = '_relationshipTaskReceipt';
@@ -185,7 +186,10 @@ class RelationshipProposalService {
           final latest = await journalDb.journalEntityById(original.id);
           if (latest != original ||
               await _hasAdditionalLinks(original.id, fresh.taskId) ||
-              !await taskRemover(current)) {
+              !await taskRemover(
+                current,
+                allowedRelationshipId: fresh.taskId,
+              )) {
             return false;
           }
           // A refused deletion must never detach a live task. Once tombstoned,

--- a/lib/features/relationships/workflow/relationship_tool_dispatcher.dart
+++ b/lib/features/relationships/workflow/relationship_tool_dispatcher.dart
@@ -102,10 +102,7 @@ class RelationshipToolDispatcher {
       if (existing is! Task) {
         return _failure('Task identity is unavailable', permanent: true);
       }
-      final linked = await relationshipRepository.linkTask(
-        relationshipId: relationshipId,
-        taskId: taskId,
-      );
+      final linked = await _tryLinkTask(taskId, relationshipId);
       // Do not mint an undo receipt from a task a peer may already have edited.
       return (linked || await _hasRelationshipLink(taskId, relationshipId))
           ? ToolExecutionResult(
@@ -186,17 +183,14 @@ class RelationshipToolDispatcher {
           current.data.status is RelationshipActive &&
           current.meta.categoryId == categoryId &&
           current.meta.private == person.meta.private) {
-        linked = await relationshipRepository.linkTask(
-          relationshipId: relationshipId,
-          taskId: task.id,
-        );
+        linked = await _tryLinkTask(task.id, relationshipId);
         if (!linked) {
           alreadyLinked = await _hasRelationshipLink(task.id, relationshipId);
           linked = alreadyLinked;
         }
       }
     } catch (_) {
-      // The same compensation applies to rejected and throwing link writes.
+      // If validation or reconciliation fails, compensation is still guarded.
     }
     if (!linked) {
       final rolledBack = await removeTask(task);
@@ -229,6 +223,19 @@ class RelationshipToolDispatcher {
       );
     }
     return RelationshipTaskCreationResult(task);
+  }
+
+  /// A link may commit before post-write work throws. Both callers reconcile
+  /// the stored link after a false result, without issuing another undo receipt.
+  Future<bool> _tryLinkTask(String taskId, String personId) async {
+    try {
+      return await relationshipRepository.linkTask(
+        relationshipId: personId,
+        taskId: taskId,
+      );
+    } catch (_) {
+      return false;
+    }
   }
 
   Future<bool> _hasRelationshipLink(String taskId, String personId) async {

--- a/lib/features/relationships/workflow/relationship_tool_dispatcher.dart
+++ b/lib/features/relationships/workflow/relationship_tool_dispatcher.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:developer' as developer;
 
 import 'package:clock/clock.dart';
+import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/relationship_data.dart';
@@ -106,7 +107,7 @@ class RelationshipToolDispatcher {
         taskId: taskId,
       );
       // Do not mint an undo receipt from a task a peer may already have edited.
-      return linked
+      return (linked || await _hasRelationshipLink(taskId, relationshipId))
           ? ToolExecutionResult(
               success: true,
               output: 'Task already exists',
@@ -173,6 +174,7 @@ class RelationshipToolDispatcher {
     }
     if (task == null) return _failure('Task creation failed');
     var linked = false;
+    var alreadyLinked = false;
     try {
       // A deleted person must not gain a task while an async create was running.
       final current = await relationshipRepository.getRelationshipById(
@@ -188,6 +190,10 @@ class RelationshipToolDispatcher {
           relationshipId: relationshipId,
           taskId: task.id,
         );
+        if (!linked) {
+          alreadyLinked = await _hasRelationshipLink(task.id, relationshipId);
+          linked = alreadyLinked;
+        }
       }
     } catch (_) {
       // The same compensation applies to rejected and throwing link writes.
@@ -199,6 +205,14 @@ class RelationshipToolDispatcher {
             ? 'Task linking failed; creation rolled back'
             : 'Task linking failed and rollback failed',
         permanent: !rolledBack,
+      );
+    }
+    if (alreadyLinked) {
+      // The peer's confirmation owns this task. Do not issue a local undo receipt.
+      return ToolExecutionResult(
+        success: true,
+        output: 'Task already exists',
+        mutatedEntityId: task.id,
       );
     }
     final assignment = await assignCategoryDefaultTaskAgent(
@@ -217,14 +231,47 @@ class RelationshipToolDispatcher {
     return RelationshipTaskCreationResult(task);
   }
 
-  /// Tombstones a task for compensation or a guarded proposal undo.
-  Future<bool> removeTask(Task task) async {
+  Future<bool> _hasRelationshipLink(String taskId, String personId) async {
+    final links = await journalDb.linksForEntryIdsBidirectional({taskId});
+    return links.any(
+      (link) =>
+          link.deletedAt == null &&
+          link.hidden != true &&
+          _isPersonLink(link, taskId, personId),
+    );
+  }
+
+  static bool _isPersonLink(EntryLink link, String taskId, String? personId) =>
+      link is RelationshipLink &&
+      ((link.fromId == personId && link.toId == taskId) ||
+          (link.fromId == taskId && link.toId == personId));
+
+  /// Tombstones only the unchanged snapshot, checking links in the journal write
+  /// transaction. Compensation permits no live links; undo may retain only the
+  /// originating person's relationship links until its subsequent cleanup.
+  Future<bool> removeTask(Task task, {String? allowedRelationshipId}) async {
     try {
       final meta = await persistenceLogic.updateMetadata(
         task.meta,
         deletedAt: clock.now(),
       );
-      return await persistenceLogic.updateDbEntity(task.copyWith(meta: meta)) ??
+      return await persistenceLogic.updateDbEntity(
+            task.copyWith(meta: meta),
+            precondition: () async {
+              if (task.isDeleted ||
+                  await journalDb.journalEntityById(task.id) != task) {
+                return false;
+              }
+              final links = await journalDb.linksForEntryIdsBidirectional({
+                task.id,
+              });
+              return !links.any(
+                (link) =>
+                    link.deletedAt == null &&
+                    !_isPersonLink(link, task.id, allowedRelationshipId),
+              );
+            },
+          ) ??
           false;
     } catch (_) {
       return false;

--- a/lib/features/relationships/workflow/relationship_tool_dispatcher.dart
+++ b/lib/features/relationships/workflow/relationship_tool_dispatcher.dart
@@ -7,6 +7,7 @@ import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/relationship_data.dart';
 import 'package:lotti/classes/task.dart';
+import 'package:lotti/database/conversions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/agents/service/task_agent_service.dart';
 import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
@@ -265,8 +266,12 @@ class RelationshipToolDispatcher {
       return await persistenceLogic.updateDbEntity(
             task.copyWith(meta: meta),
             precondition: () async {
+              // The public lookup coalesces callers across transaction zones.
+              // Read directly so this snapshot belongs to the write transaction.
+              final current = await journalDb.entityById(task.id);
               if (task.isDeleted ||
-                  await journalDb.journalEntityById(task.id) != task) {
+                  current == null ||
+                  fromDbEntity(current) != task) {
                 return false;
               }
               final links = await journalDb.linksForEntryIdsBidirectional({

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -346,12 +346,14 @@ class PersistenceLogic implements PersistenceLogicContract {
     bool enqueueSync = true,
     bool overrideComparison = false,
     Future<void> Function()? beforeNotify,
+    Future<bool> Function()? precondition,
   }) => _updates.updateDbEntity(
     journalEntity,
     linkedId: linkedId,
     enqueueSync: enqueueSync,
     overrideComparison: overrideComparison,
     beforeNotify: beforeNotify,
+    precondition: precondition,
   );
 
   // --- Entry-update builders (PersistenceUpdateOps) ------------------------

--- a/lib/logic/persistence_logic_contract.dart
+++ b/lib/logic/persistence_logic_contract.dart
@@ -48,12 +48,16 @@ abstract class PersistenceLogicContract {
     bool linkCollapsed = false,
   });
 
+  /// Updates an entity, optionally guarded by read-only journal queries in
+  /// [precondition] executed inside the write transaction. A refused write
+  /// publishes no notifications, search-index updates, or sync payload.
   Future<bool?> updateDbEntity(
     JournalEntity journalEntity, {
     String? linkedId,
     bool enqueueSync = true,
     bool overrideComparison = false,
     Future<void> Function()? beforeNotify,
+    Future<bool> Function()? precondition,
   });
 
   void addGeolocation(String journalEntityId);

--- a/lib/logic/persistence_updates.dart
+++ b/lib/logic/persistence_updates.dart
@@ -144,6 +144,7 @@ class PersistenceUpdates extends PersistenceCollaboratorBase {
     bool enqueueSync = true,
     bool overrideComparison = false,
     Future<void> Function()? beforeNotify,
+    Future<bool> Function()? precondition,
   }) async {
     try {
       return await vectorClockService.withVcScope<bool?>(
@@ -151,6 +152,7 @@ class PersistenceUpdates extends PersistenceCollaboratorBase {
           final updateResult = await journalDb.updateJournalEntity(
             journalEntity,
             overrideComparison: overrideComparison,
+            precondition: precondition,
           );
           final applied = updateResult.applied;
 
@@ -164,16 +166,15 @@ class PersistenceUpdates extends PersistenceCollaboratorBase {
               journalEntity.meta.vectorClock,
               reason: 'updateDbEntity write rejected id=${journalEntity.id}',
             );
+            return false;
           }
 
-          if (applied) {
-            await recordJournalSequence(
-              journalEntity,
-              subDomain: 'updateDbEntity.recordSent',
-            );
-          }
+          await recordJournalSequence(
+            journalEntity,
+            subDomain: 'updateDbEntity.recordSent',
+          );
 
-          if (applied && beforeNotify != null) {
+          if (beforeNotify != null) {
             try {
               await beforeNotify();
             } catch (exception, stackTrace) {
@@ -219,7 +220,7 @@ class PersistenceUpdates extends PersistenceCollaboratorBase {
             removePrevious: true,
           );
 
-          if (enqueueSync && applied) {
+          if (enqueueSync) {
             try {
               await outboxService.enqueueMessage(
                 SyncMessage.journalEntity(

--- a/test/database/database_entity_ops_test.dart
+++ b/test/database/database_entity_ops_test.dart
@@ -753,6 +753,68 @@ void main() {
 
     group('Write-path atomicity -', () {
       test(
+        'refused precondition preserves the stored row and JSON sidecar',
+        () async {
+          final entry = createJournalEntryWithVclock(
+            const VectorClock({'a': 1}),
+            id: 'guarded',
+          );
+          await db!.updateJournalEntity(entry);
+          final file = File(entityPath(entry, getIt<Directory>()));
+          final before = await file.readAsString();
+          final updated = entry.copyWith(
+            meta: entry.meta.copyWith(
+              vectorClock: const VectorClock({'a': 2}),
+              deletedAt: DateTime(2026, 9, 6),
+            ),
+          );
+          final result = await db!.updateJournalEntity(
+            updated,
+            precondition: () async => false,
+          );
+          expect(result.applied, isFalse);
+          expect(result.skipReason, JournalUpdateSkipReason.overwritePrevented);
+          expect(await db!.journalEntityById(entry.id), entry);
+          expect(await file.readAsString(), before);
+          expect(await db!.conflictById(entry.id), isNull);
+        },
+      );
+
+      test('precondition reads and write share one transaction', () async {
+        final entry = createJournalEntryWithVclock(
+          const VectorClock({'a': 1}),
+          id: 'guard-race',
+        );
+        await db!.updateJournalEntity(entry);
+        final entered = Completer<void>();
+        final release = Completer<void>();
+        final updated = entry.copyWith(
+          meta: entry.meta.copyWith(vectorClock: const VectorClock({'a': 3})),
+        );
+        final deletion = db!.updateJournalEntity(
+          updated,
+          precondition: () async {
+            entered.complete();
+            await release.future;
+            return await db!.journalEntityById(entry.id) == entry;
+          },
+        );
+        await entered.future;
+        final competing = db!.updateJournalEntity(
+          entry.copyWith(
+            meta: entry.meta.copyWith(vectorClock: const VectorClock({'a': 2})),
+          ),
+        );
+        release.complete();
+        expect((await deletion).applied, isTrue);
+        expect(
+          (await competing).skipReason,
+          JournalUpdateSkipReason.olderOrEqual,
+        );
+        expect(await db!.journalEntityById(entry.id), updated);
+      });
+
+      test(
         'concurrent writes of the same id are serialised: the second sees '
         'the first and records a conflict instead of overwriting it',
         () async {

--- a/test/database/database_entity_ops_test.dart
+++ b/test/database/database_entity_ops_test.dart
@@ -796,7 +796,8 @@ void main() {
           precondition: () async {
             entered.complete();
             await release.future;
-            return await db!.journalEntityById(entry.id) == entry;
+            return (await db!.entityById(entry.id))?.serialized ==
+                jsonEncode(entry);
           },
         );
         await entered.future;

--- a/test/features/labels/race_condition_labels_persistence_test.dart
+++ b/test/features/labels/race_condition_labels_persistence_test.dart
@@ -143,6 +143,7 @@ class _TestPersistenceLogic extends PersistenceLogic {
     bool enqueueSync = true,
     bool overrideComparison = false,
     Future<void> Function()? beforeNotify,
+    Future<bool> Function()? precondition,
   }) async {
     _lastSaved = journalEntity;
     await beforeNotify?.call();

--- a/test/features/relationships/service/relationship_proposal_service_test.dart
+++ b/test/features/relationships/service/relationship_proposal_service_test.dart
@@ -57,7 +57,8 @@ void main() {
       syncService: sync,
       journalDb: db,
       relationshipRepository: relationships,
-      taskRemover: (task) async {
+      taskRemover: (task, {allowedRelationshipId}) async {
+        expect(allowedRelationshipId, set.taskId);
         removed.add(task);
         return removeSucceeds;
       },
@@ -358,6 +359,91 @@ void main() {
         );
         expect(await service.undo(confirmed, 0), isTrue);
         expect(removed, [testTask]);
+      },
+    );
+  }
+  for (final lateNote in [false, true]) {
+    test(
+      'undo transaction preserves a late note but allows its own link (lateNote=$lateNote)',
+      () async {
+        final persistence = MockPersistenceLogic();
+        final links = <EntryLink>[
+          EntryLink.relationship(
+            id: 'person-task',
+            fromId: set.taskId,
+            toId: testTask.id,
+            createdAt: testTask.meta.createdAt,
+            updatedAt: testTask.meta.updatedAt,
+            vectorClock: null,
+          ),
+        ];
+        var tombstoned = false;
+        when(
+          () => db.linksForEntryIdsBidirectional({testTask.id}),
+        ).thenAnswer((_) async => links);
+        when(
+          () => persistence.updateMetadata(
+            testTask.meta,
+            deletedAt: any(named: 'deletedAt'),
+          ),
+        ).thenAnswer((_) async {
+          if (lateNote) {
+            links.add(
+              EntryLink.basic(
+                id: 'late-note',
+                fromId: testTask.id,
+                toId: 'new-note',
+                createdAt: testTask.meta.createdAt,
+                updatedAt: testTask.meta.updatedAt,
+                vectorClock: null,
+              ),
+            );
+          }
+          return testTask.meta.copyWith(deletedAt: testTask.meta.updatedAt);
+        });
+        when(
+          () => persistence.updateDbEntity(
+            any(),
+            precondition: any(named: 'precondition'),
+          ),
+        ).thenAnswer((call) async {
+          final guard =
+              call.namedArguments[#precondition] as Future<bool> Function()?;
+          return tombstoned = guard == null || await guard();
+        });
+        final dispatcher = RelationshipToolDispatcher(
+          relationshipRepository: relationships,
+          persistenceLogic: persistence,
+          entitiesCacheService: MockEntitiesCacheService(),
+          taskAgentService: MockTaskAgentService(),
+          journalDb: db,
+        );
+        service = RelationshipProposalService(
+          confirmation: confirmation,
+          repository: repository,
+          syncService: sync,
+          journalDb: db,
+          relationshipRepository: relationships,
+          taskRemover: dispatcher.removeTask,
+        );
+        expect(await service.undo(confirmed, 0), !lateNote);
+        expect(tombstoned, !lateNote);
+        if (lateNote) {
+          verifyNever(
+            () => relationships.unlinkTask(
+              relationshipId: set.taskId,
+              taskId: testTask.id,
+            ),
+          );
+          expect(await service.receipt(confirmed, 0), testTask);
+        } else {
+          verify(
+            () => relationships.unlinkTask(
+              relationshipId: set.taskId,
+              taskId: testTask.id,
+            ),
+          ).called(1);
+        }
       },
     );
   }

--- a/test/features/relationships/service/relationship_proposal_service_test.dart
+++ b/test/features/relationships/service/relationship_proposal_service_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/conversions.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
@@ -45,6 +46,9 @@ void main() {
     repository = MockAgentRepository();
     sync = MockAgentSyncService();
     db = MockJournalDb();
+    when(
+      () => db.entityById(testTask.id),
+    ).thenAnswer((_) async => toDbEntity(testTask));
     when(
       () => db.linksForEntryIdsBidirectional(any()),
     ).thenAnswer((_) async => []);

--- a/test/features/relationships/workflow/relationship_tool_dispatcher_test.dart
+++ b/test/features/relationships/workflow/relationship_tool_dispatcher_test.dart
@@ -2,6 +2,7 @@ import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/check_in_data.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
@@ -51,7 +52,12 @@ void main() {
     cache = MockEntitiesCacheService();
     agents = MockTaskAgentService();
     db = MockJournalDb();
-    when(() => db.journalEntityById(any())).thenAnswer((_) async => null);
+    when(() => db.journalEntityById(any())).thenAnswer(
+      (call) async => call.positionalArguments.single == task.id ? task : null,
+    );
+    when(
+      () => db.linksForEntryIdsBidirectional(any()),
+    ).thenAnswer((_) async => []);
     dispatcher = RelationshipToolDispatcher(
       relationshipRepository: relationships,
       persistenceLogic: persistence,
@@ -84,7 +90,16 @@ void main() {
         deletedAt: any(named: 'deletedAt'),
       ),
     ).thenAnswer((_) async => task.meta.copyWith(deletedAt: now));
-    when(() => persistence.updateDbEntity(any())).thenAnswer((_) async => true);
+    when(
+      () => persistence.updateDbEntity(
+        any(),
+        precondition: any(named: 'precondition'),
+      ),
+    ).thenAnswer((call) async {
+      final guard =
+          call.namedArguments[#precondition] as Future<bool> Function()?;
+      return guard == null || await guard();
+    });
   });
 
   test(
@@ -144,7 +159,10 @@ void main() {
         expect(result.nonRetryable, isFalse);
         final deleted =
             verify(
-                  () => persistence.updateDbEntity(captureAny()),
+                  () => persistence.updateDbEntity(
+                    captureAny(),
+                    precondition: any(named: 'precondition'),
+                  ),
                 ).captured.single
                 as Task;
         expect(deleted.meta.deletedAt, now);
@@ -160,7 +178,10 @@ void main() {
             relationships.linkTask(relationshipId: person.id, taskId: task.id),
       ).thenAnswer((_) async => false);
       when(
-        () => persistence.updateDbEntity(any()),
+        () => persistence.updateDbEntity(
+          any(),
+          precondition: any(named: 'precondition'),
+        ),
       ).thenAnswer((_) async => false);
       final result = await dispatcher.dispatch(
         'create_and_link_task',
@@ -316,7 +337,12 @@ void main() {
         () =>
             relationships.linkTask(relationshipId: person.id, taskId: task.id),
       );
-      verify(() => persistence.updateDbEntity(any())).called(1);
+      verify(
+        () => persistence.updateDbEntity(
+          any(),
+          precondition: any(named: 'precondition'),
+        ),
+      ).called(1);
     },
   );
 
@@ -371,7 +397,10 @@ void main() {
     'metadata failures and refused tombstone writes refuse compensation',
     () async {
       when(
-        () => persistence.updateDbEntity(any()),
+        () => persistence.updateDbEntity(
+          any(),
+          precondition: any(named: 'precondition'),
+        ),
       ).thenAnswer((_) async => null);
       expect(await dispatcher.removeTask(task), isFalse);
       when(
@@ -496,7 +525,12 @@ void main() {
             private: any(named: 'private'),
           ),
         );
-        verifyNever(() => persistence.updateDbEntity(any()));
+        verifyNever(
+          () => persistence.updateDbEntity(
+            any(),
+            precondition: any(named: 'precondition'),
+          ),
+        );
       },
     );
   }
@@ -523,7 +557,10 @@ void main() {
               invocation.positionalArguments.first as Metadata,
         );
         when(
-          () => persistence.updateDbEntity(any()),
+          () => persistence.updateDbEntity(
+            any(),
+            precondition: any(named: 'precondition'),
+          ),
         ).thenAnswer((_) async => saved);
         when(
           () => relationships.linkTask(
@@ -539,7 +576,10 @@ void main() {
         expect(result.success, saved);
         final restored =
             verify(
-                  () => persistence.updateDbEntity(captureAny()),
+                  () => persistence.updateDbEntity(
+                    captureAny(),
+                    precondition: any(named: 'precondition'),
+                  ),
                 ).captured.single
                 as Task;
         expect(restored.id, identity);
@@ -627,7 +667,127 @@ void main() {
         () =>
             relationships.linkTask(relationshipId: person.id, taskId: task.id),
       ).called(1);
-      verifyNever(() => persistence.updateDbEntity(any()));
+      verifyNever(
+        () => persistence.updateDbEntity(
+          any(),
+          precondition: any(named: 'precondition'),
+        ),
+      );
     },
   );
+  EntryLink personLink({
+    String? from,
+    String? to,
+    bool hidden = false,
+    bool deleted = false,
+  }) => EntryLink.relationship(
+    id: 'peer-link',
+    fromId: from ?? person.id,
+    toId: to ?? task.id,
+    createdAt: now,
+    updatedAt: now,
+    vectorClock: null,
+    hidden: hidden,
+    deletedAt: deleted ? now : null,
+  );
+
+  for (final reverse in [false, true]) {
+    test(
+      'duplicate relationship link is success without an undo receipt (reverse=$reverse)',
+      () async {
+        when(
+          () => relationships.linkTask(
+            relationshipId: person.id,
+            taskId: task.id,
+          ),
+        ).thenAnswer((_) async {
+          when(() => db.linksForEntryIdsBidirectional({task.id})).thenAnswer(
+            (_) async => [
+              personLink(
+                from: reverse ? task.id : person.id,
+                to: reverse ? person.id : task.id,
+              ),
+            ],
+          );
+          return false;
+        });
+        final result = await dispatcher.dispatch(
+          'create_and_link_task',
+          args,
+          person.id,
+        );
+        expect(result.success, isTrue);
+        expect(result.mutatedEntityId, task.id);
+        expect(result, isNot(isA<RelationshipTaskCreationResult>()));
+        verifyNever(
+          () => persistence.updateMetadata(
+            any(),
+            deletedAt: any(named: 'deletedAt'),
+          ),
+        );
+      },
+    );
+  }
+
+  test(
+    'a throwing link write preserves a peer-linked task during compensation',
+    () async {
+      when(
+        () =>
+            relationships.linkTask(relationshipId: person.id, taskId: task.id),
+      ).thenAnswer((_) async {
+        when(
+          () => db.linksForEntryIdsBidirectional({task.id}),
+        ).thenAnswer((_) async => [personLink()]);
+        throw StateError('local link failure');
+      });
+      final result = await dispatcher.dispatch(
+        'create_and_link_task',
+        args,
+        person.id,
+      );
+      expect(result.success, isFalse);
+      expect(result.nonRetryable, isTrue);
+      expect(result.errorMessage, contains('rollback failed'));
+    },
+  );
+
+  for (final (name, link, personId, allowed) in [
+    ('peer', personLink(), null, false),
+    ('hidden', personLink(hidden: true), null, false),
+    ('other person', personLink(from: 'other-person'), person.id, false),
+    ('reverse', personLink(from: task.id, to: person.id), person.id, true),
+    ('deleted link', personLink(deleted: true), null, true),
+  ]) {
+    test('transactional removal guard handles $name', () async {
+      when(
+        () => db.linksForEntryIdsBidirectional({task.id}),
+      ).thenAnswer((_) async => [link]);
+      expect(
+        await dispatcher.removeTask(task, allowedRelationshipId: personId),
+        allowed,
+      );
+    });
+  }
+
+  for (final (name, current) in [
+    ('edit', task.copyWith(data: task.data.copyWith(title: 'Edited by user'))),
+    ('missing', null),
+    ('deleted', task.copyWith(meta: task.meta.copyWith(deletedAt: now))),
+  ]) {
+    test('transactional removal guard refuses a $name snapshot', () async {
+      when(
+        () => persistence.updateMetadata(
+          task.meta,
+          deletedAt: any(named: 'deletedAt'),
+        ),
+      ).thenAnswer((_) async {
+        when(
+          () => db.journalEntityById(task.id),
+        ).thenAnswer((_) async => current);
+        return task.meta.copyWith(deletedAt: now);
+      });
+      expect(await dispatcher.removeTask(task), isFalse);
+    });
+  }
 }

--- a/test/features/relationships/workflow/relationship_tool_dispatcher_test.dart
+++ b/test/features/relationships/workflow/relationship_tool_dispatcher_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
+import 'package:lotti/database/conversions.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/relationships/workflow/relationship_tool_dispatcher.dart';
 import 'package:mocktail/mocktail.dart';
@@ -52,6 +53,9 @@ void main() {
     cache = MockEntitiesCacheService();
     agents = MockTaskAgentService();
     db = MockJournalDb();
+    when(
+      () => db.entityById(task.id),
+    ).thenAnswer((_) async => toDbEntity(task));
     when(() => db.journalEntityById(any())).thenAnswer(
       (call) async => call.positionalArguments.single == task.id ? task : null,
     );
@@ -782,6 +786,8 @@ void main() {
     ('deleted', task.copyWith(meta: task.meta.copyWith(deletedAt: now))),
   ]) {
     test('transactional removal guard refuses a $name snapshot', () async {
+      // The coalesced public read still reports the original snapshot; only
+      // the direct transactional read sees the change after metadata reservation.
       when(
         () => persistence.updateMetadata(
           task.meta,
@@ -789,8 +795,8 @@ void main() {
         ),
       ).thenAnswer((_) async {
         when(
-          () => db.journalEntityById(task.id),
-        ).thenAnswer((_) async => current);
+          () => db.entityById(task.id),
+        ).thenAnswer((_) async => current == null ? null : toDbEntity(current));
         return task.meta.copyWith(deletedAt: now);
       });
       expect(await dispatcher.removeTask(task), isFalse);

--- a/test/features/relationships/workflow/relationship_tool_dispatcher_test.dart
+++ b/test/features/relationships/workflow/relationship_tool_dispatcher_test.dart
@@ -730,7 +730,7 @@ void main() {
   }
 
   test(
-    'a throwing link write preserves a peer-linked task during compensation',
+    'a throwing link write reconciles its committed link without an undo receipt',
     () async {
       when(
         () =>
@@ -746,9 +746,15 @@ void main() {
         args,
         person.id,
       );
-      expect(result.success, isFalse);
-      expect(result.nonRetryable, isTrue);
-      expect(result.errorMessage, contains('rollback failed'));
+      expect(result.success, isTrue);
+      expect(result.mutatedEntityId, task.id);
+      expect(result, isNot(isA<RelationshipTaskCreationResult>()));
+      verifyNever(
+        () => persistence.updateMetadata(
+          any(),
+          deletedAt: any(named: 'deletedAt'),
+        ),
+      );
     },
   );
 

--- a/test/logic/create/create_entry_test.dart
+++ b/test/logic/create/create_entry_test.dart
@@ -45,6 +45,7 @@ class _RejectingTaskCleanupPersistenceLogic extends PersistenceLogic {
     bool enqueueSync = true,
     bool overrideComparison = false,
     Future<void> Function()? beforeNotify,
+    Future<bool> Function()? precondition,
   }) async {
     if (journalEntity is Task && journalEntity.meta.deletedAt != null) {
       if (commitBeforeFailure) {
@@ -58,6 +59,7 @@ class _RejectingTaskCleanupPersistenceLogic extends PersistenceLogic {
       enqueueSync: enqueueSync,
       overrideComparison: overrideComparison,
       beforeNotify: beforeNotify,
+      precondition: precondition,
     );
   }
 }

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -293,6 +293,7 @@ class TestPersistenceLogic extends PersistenceLogic {
     bool enqueueSync = true,
     bool overrideComparison = false,
     Future<void> Function()? beforeNotify,
+    Future<bool> Function()? precondition,
   }) async {
     lastUpdateDbEntity = journalEntity;
     if (updateDbEntityHandler != null) {
@@ -310,6 +311,7 @@ class TestPersistenceLogic extends PersistenceLogic {
       enqueueSync: enqueueSync,
       overrideComparison: overrideComparison,
       beforeNotify: beforeNotify,
+      precondition: precondition,
     );
   }
 }
@@ -2849,6 +2851,57 @@ void main() {
       },
     );
 
+    test(
+      'refused write precondition burns the clock without publishing deletion',
+      () async {
+        final entry = buildEntry();
+        Future<bool> precondition() async => false;
+        when(
+          () => journalDb.updateJournalEntity(
+            entry,
+            // ignore: avoid_redundant_argument_values
+            overrideComparison: false,
+            precondition: precondition,
+          ),
+        ).thenAnswer(
+          (_) async => JournalUpdateResult.skipped(
+            reason: JournalUpdateSkipReason.overwritePrevented,
+          ),
+        );
+        var notified = false;
+        expect(
+          await logic.updateDbEntity(
+            entry,
+            precondition: precondition,
+            beforeNotify: () async {
+              notified = true;
+            },
+          ),
+          isFalse,
+        );
+        verify(
+          () => journalDb.updateJournalEntity(
+            entry,
+            // ignore: avoid_redundant_argument_values
+            overrideComparison: false,
+            precondition: precondition,
+          ),
+        ).called(1);
+        verify(
+          () => vectorClockService.burnUnboundVectorClock(
+            entry.meta.vectorClock,
+            reason: any(named: 'reason'),
+          ),
+        ).called(1);
+        expect(notified, isFalse);
+        verifyNever(() => updateNotifications.notify(any()));
+        verifyNever(() => updateNotifications.notifyUiOnly(any()));
+        verifyNever(() => fts5Db.insertText(any(), removePrevious: true));
+        verifyNever(notificationService.updateBadge);
+        verifyNever(() => outboxService.enqueueMessage(any<SyncMessage>()));
+      },
+    );
+
     test('updateDbEntity returns false when update skipped', () async {
       stubUpdateResult(
         JournalUpdateResult.skipped(
@@ -2952,6 +3005,14 @@ void main() {
         );
 
         expect(result, scenario.applied, reason: '$scenario');
+
+        if (!scenario.applied) {
+          verifyNever(() => updateNotifications.notify(any()));
+          verifyNever(() => fts5Db.insertText(any(), removePrevious: true));
+          verifyNever(notificationService.updateBadge);
+          verifyNever(() => outboxService.enqueueMessage(any<SyncMessage>()));
+          return;
+        }
 
         final notificationIds =
             verify(


### PR DESCRIPTION
Undo or a failed relationship-task link could delete a task after another writer had attached content to it. Task vector clocks do not cover link changes, so the previous read-before-delete checks left a race.

This follow-up to #4188 checks the exact task snapshot and live links inside the journal write transaction. Undo permits only the originating person's relationship links; rollback requires no live links. An existing visible relationship link counts as success without issuing another undo receipt. Refused writes also skip notifications, search indexing, badges, and sync publication.

The guard protects task and link changes committed before deletion; it is not a cross-device lease. No UI or schema changes. No new changelog fragment: this fixes the still-unreleased feature introduced by #4188.

Validation:
- 220 targeted tests passed. CI: all ten unit-test shards, Glados, analyzer, and Matrix/journal integration checks passed; 100% patch coverage (99.34% project coverage). Regression tests cover late links, peer confirmations, and concurrent writes.
- Mutation checks: removing safeguards breaks the regression tests; moving the precondition outside the transaction breaks the concurrency test.
- Analyzer and knowledge checks.

Addresses the two post-merge review findings: https://github.com/matthiasn/lotti/pull/4188#discussion_r3945329848 and https://github.com/matthiasn/lotti/pull/4188#discussion_r3945329852.

Separate follow-up identified in review: local link creation can still attach to an endpoint after deletion has committed. That existing app-wide invariant needs a local link-write guard while preserving out-of-order sync ingestion; see https://github.com/matthiasn/lotti/pull/4189#discussion_r3945377592. This PR deliberately does not expand into that link-creation policy.
