### PR TITLE
ci: reduce test startup and retry overhead

### DIFF
--- a/.github/workflows/flutter-test-linux-faster.yml
+++ b/.github/workflows/flutter-test-linux-faster.yml
@@ -70,6 +70,7 @@ jobs:
           mkdir -p reports
           echo "Ordering seed: $TEST_ORDER_SEED" | tee reports/seed.txt
           dart run tool/ci/run_tests.dart \
+            ${{ matrix.shard_index == 0 && '--verbose' || '' }} \
             --coverage \
             --exclude-tags 'glados || performance || eval-live' \
             --total-shards=10 \

--- a/.github/workflows/flutter-test-linux-faster.yml
+++ b/.github/workflows/flutter-test-linux-faster.yml
@@ -71,7 +71,7 @@ jobs:
           echo "Ordering seed: $TEST_ORDER_SEED" | tee reports/seed.txt
           dart run tool/ci/run_tests.dart \
             --coverage \
-            --exclude-tags 'glados || performance' \
+            --exclude-tags 'glados || performance || eval-live' \
             --total-shards=10 \
             --shard-index=${{ matrix.shard_index }} \
             --test-randomize-ordering-seed="$TEST_ORDER_SEED" \
@@ -122,6 +122,7 @@ jobs:
           mkdir -p reports
           echo "Ordering seed: $TEST_ORDER_SEED" | tee reports/seed.txt
           dart run tool/ci/run_tests.dart --coverage --tags glados --no-pub \
+            --exclude-tags 'eval-live' \
             --test-randomize-ordering-seed="$TEST_ORDER_SEED" \
             --file-reporter=json:reports/tests.json
       - name: Summarize test results
@@ -169,6 +170,7 @@ jobs:
           mkdir -p reports
           echo "Ordering seed: $TEST_ORDER_SEED" | tee reports/seed.txt
           dart run tool/ci/run_tests.dart --tags performance --no-pub \
+            --exclude-tags 'eval-live' \
             --test-randomize-ordering-seed="$TEST_ORDER_SEED" \
             --file-reporter=json:reports/tests.json
       - name: Summarize test results

--- a/.github/workflows/flutter-test-linux-faster.yml
+++ b/.github/workflows/flutter-test-linux-faster.yml
@@ -65,11 +65,20 @@ jobs:
           cache: true
       - name: Get dependencies
         run: flutter pub get
+      - name: Cache native build hooks
+        uses: actions/cache@v4
+        with:
+          # flutter_scene writes generated shaders into its package directory
+          # as well as hook output directories; restore them together.
+          path: |
+            .dart_tool/hooks_runner
+            ~/.pub-cache/hosted/pub.dev/flutter_scene-*
+          key: ${{ runner.os }}-${{ runner.arch }}-test-hooks-v1-${{ hashFiles('.fvmrc', 'pubspec.yaml', 'pubspec.lock') }}
       - name: Run Flutter tests (standard)
         run: |
           mkdir -p reports
           echo "Ordering seed: $TEST_ORDER_SEED" | tee reports/seed.txt
-          dart run tool/ci/run_tests.dart \
+          dart ${{ matrix.shard_index == 0 && '--verbose' || '' }} run tool/ci/run_tests.dart \
             ${{ matrix.shard_index == 0 && '--verbose' || '' }} \
             --coverage \
             --exclude-tags 'glados || performance || eval-live' \
@@ -118,6 +127,15 @@ jobs:
           cache: true
       - name: Get dependencies
         run: flutter pub get
+      - name: Cache native build hooks
+        uses: actions/cache@v4
+        with:
+          # flutter_scene writes generated shaders into its package directory
+          # as well as hook output directories; restore them together.
+          path: |
+            .dart_tool/hooks_runner
+            ~/.pub-cache/hosted/pub.dev/flutter_scene-*
+          key: ${{ runner.os }}-${{ runner.arch }}-test-hooks-v1-${{ hashFiles('.fvmrc', 'pubspec.yaml', 'pubspec.lock') }}
       - name: Run Flutter tests (glados)
         run: |
           mkdir -p reports
@@ -166,6 +184,15 @@ jobs:
           cache: true
       - name: Get dependencies
         run: flutter pub get
+      - name: Cache native build hooks
+        uses: actions/cache@v4
+        with:
+          # flutter_scene writes generated shaders into its package directory
+          # as well as hook output directories; restore them together.
+          path: |
+            .dart_tool/hooks_runner
+            ~/.pub-cache/hosted/pub.dev/flutter_scene-*
+          key: ${{ runner.os }}-${{ runner.arch }}-test-hooks-v1-${{ hashFiles('.fvmrc', 'pubspec.yaml', 'pubspec.lock') }}
       - name: Run Flutter tests (performance)
         run: |
           mkdir -p reports

--- a/Makefile
+++ b/Makefile
@@ -34,21 +34,21 @@ MANUAL_MEDIA_DIR ?= $(abspath build/manual_media)
 
 .PHONY: test
 test:
-	$(DART_CMD) run tool/ci/run_tests.dart --coverage --exclude-tags performance
+	$(DART_CMD) run tool/ci/run_tests.dart --coverage --exclude-tags "performance || eval-live"
 
 .PHONY: test_standard
 test_standard:
 	rm -rf coverage
-	$(DART_CMD) run tool/ci/run_tests.dart --coverage --exclude-tags "glados || performance"
+	$(DART_CMD) run tool/ci/run_tests.dart --coverage --exclude-tags "glados || performance || eval-live"
 
 .PHONY: test_glados
 test_glados:
 	rm -rf coverage
-	$(DART_CMD) run tool/ci/run_tests.dart --coverage --tags glados
+	$(DART_CMD) run tool/ci/run_tests.dart --coverage --tags glados --exclude-tags eval-live
 
 .PHONY: test_performance test_policy_check
 test_performance:
-	$(DART_CMD) run tool/ci/run_tests.dart --tags performance
+	$(DART_CMD) run tool/ci/run_tests.dart --tags performance --exclude-tags eval-live
 
 test_policy_check:
 	$(DART_CMD) run tool/ci/check_test_tags.dart
@@ -113,7 +113,7 @@ junit_test:
 .PHONY: slow_tests
 slow_tests: deps
 	@mkdir -p reports
-	$(DART_CMD) run tool/ci/run_tests.dart --exclude-tags performance --file-reporter json:reports/tests.json
+	$(DART_CMD) run tool/ci/run_tests.dart --exclude-tags "performance || eval-live" --file-reporter json:reports/tests.json
 	$(DART_CMD) run test/tool/analyze_test_timings.dart reports/tests.json $(THRESH)
 
 .PHONY: junit_upload

--- a/test/README.md
+++ b/test/README.md
@@ -542,6 +542,10 @@ plus `test/.test_targets.json`. A suite with library metadata (`@Tags`,
 `@Timeout`, `@TestOn`, `@Skip`, and other annotations) runs as a standalone file
 so the test runner receives the original metadata. Opting out of optimization
 never opts out of execution. Both generated files are ignored by Git.
+For a shared timeout that does not require isolation, pass a common
+`Timeout` to each test (as in `database/labels_performance_test.dart`).
+Test-level timeouts survive both standalone and bundled execution without
+forcing another compilation.
 
 Before compilation, the runner omits suites whose literal library `@Tags`
 match a positive `--exclude-tags` disjunction (for example,
@@ -557,7 +561,9 @@ coverage. Every unit/property/performance job uploads its JSON event report and
 ordering seed even on failure, and summarizes failures, skips, incomplete tests,
 and durations measured from each test's start to completion. The timing tool is
 `test/tool/analyze_test_timings.dart`; concurrent completion gaps are not test
-durations.
+durations. The runner logs target-preparation time; the first standard shard
+also enables Flutter's verbose phase timings to distinguish compilation,
+execution, and coverage collection from suite-loading time.
 
 The weekly run shuffles test order using its recorded workflow run number as the
 seed. Workflow dispatch accepts a `seed` to reproduce the order; `0` keeps

--- a/test/README.md
+++ b/test/README.md
@@ -562,8 +562,11 @@ ordering seed even on failure, and summarizes failures, skips, incomplete tests,
 and durations measured from each test's start to completion. The timing tool is
 `test/tool/analyze_test_timings.dart`; concurrent completion gaps are not test
 durations. The runner logs target-preparation time; the first standard shard
-also enables Flutter's verbose phase timings to distinguish compilation,
-execution, and coverage collection from suite-loading time.
+also enables Dart and Flutter verbose timings to distinguish build hooks,
+compilation, execution, and coverage collection from suite-loading time.
+Native hook outputs and `flutter_scene`'s generated package assets are cached
+together, keyed by runner OS/architecture, `.fvmrc`, and both pubspec manifests.
+The hooks still validate dependencies and build inputs before reusing outputs.
 
 The weekly run shuffles test order using its recorded workflow run number as the
 seed. Workflow dispatch accepts a `seed` to reproduce the order; `0` keeps

--- a/test/README.md
+++ b/test/README.md
@@ -533,7 +533,7 @@ The `tags` argument is a passthrough to `package:test`'s `test()`. It works the 
 ### Why the tag matters for CI
 
 CI runs two parallel test lanes — a ten-shard standard matrix plus a Glados job — followed by a final Codecov status job gated on both:
-- **Unit & Widget Tests** — ten deterministic shards, excluding `glados` and `performance`.
+- **Unit & Widget Tests** — ten deterministic shards, excluding `glados`, `performance`, and opt-in `eval-live` suites.
 - **Glados Property Tests** — tagged property tests with separate coverage.
 - **Performance Budgets** — tagged stopwatch tests, scheduled weekly and available through workflow dispatch. Deterministic query-count gates stay in the standard lane.
 
@@ -542,6 +542,14 @@ plus `test/.test_targets.json`. A suite with library metadata (`@Tags`,
 `@Timeout`, `@TestOn`, `@Skip`, and other annotations) runs as a standalone file
 so the test runner receives the original metadata. Opting out of optimization
 never opts out of execution. Both generated files are ignored by Git.
+
+Before compilation, the runner omits suites whose literal library `@Tags`
+match a positive `--exclude-tags` disjunction (for example,
+`glados || performance || eval-live`). Other expressions and unknown metadata
+are left to Flutter. Include selectors never prune suites: an untagged library
+can still contain tagged tests. Mixed suites keep running, including the label
+query-count checks and the celebration rendering assertions. CI excludes live
+model evaluations in every lane; run those explicitly using their env gates.
 
 Codecov merges all ten standard shards and the Glados report; the final status
 job runs after all eleven uploads succeed. The performance lane does not upload
@@ -558,7 +566,7 @@ declaration order. This changes test ordering, not Glados's generated inputs.
 ### Local commands
 
 Use targeted files during development. These broader targets are for explicitly
-requested suite runs:
+requested suite runs. These Make targets exclude opt-in live-model evaluations:
 
 ```bash
 make test_standard      # excludes glados and performance; resets coverage/
@@ -573,7 +581,7 @@ make test               # unit, widget and property tests; excludes performance
 To reproduce one standard CI shard without replacing an existing coverage report:
 
 ```bash
-fvm dart run tool/ci/run_tests.dart --exclude-tags 'glados || performance' \
+fvm dart run tool/ci/run_tests.dart --exclude-tags 'glados || performance || eval-live' \
   --total-shards=10 --shard-index=0 --test-randomize-ordering-seed=0 --no-pub
 ```
 

--- a/test/database/labels_performance_test.dart
+++ b/test/database/labels_performance_test.dart
@@ -1,8 +1,5 @@
 // ignore_for_file: avoid_redundant_argument_values
 
-@Timeout(Duration(minutes: 2))
-library;
-
 import 'dart:io';
 
 import 'package:drift/drift.dart';
@@ -17,6 +14,9 @@ import 'package:lotti/get_it.dart';
 import '../widget_test_utils.dart';
 
 void main() {
+  // Test-level timeouts survive optimized imports without requiring another
+  // compilation of this suite and its application dependencies.
+  const timeout = Timeout(Duration(minutes: 2));
   late JournalDb db;
   late Directory directory;
 
@@ -120,6 +120,7 @@ void main() {
       );
     },
     tags: 'performance',
+    timeout: timeout,
   );
 
   // intentionally giving more time because of anemic GitHub Actions test runner
@@ -154,6 +155,7 @@ void main() {
       expect(labeled, hasLength(1));
     },
     tags: 'performance',
+    timeout: timeout,
   );
 
   for (final size in [10, 100, 1000]) {
@@ -192,7 +194,7 @@ void main() {
         reason:
             'One privacy flag lookup and one task query, independent of results',
       );
-    });
+    }, timeout: timeout);
   }
 
   test(
@@ -231,6 +233,7 @@ void main() {
       expect(labelIds, isNot(contains('label-2')));
     },
     tags: 'performance',
+    timeout: timeout,
   );
 
   test(
@@ -259,6 +262,7 @@ void main() {
       expect(stopwatch.elapsedMilliseconds, lessThan(250));
     },
     tags: 'performance',
+    timeout: timeout,
   );
 
   test(
@@ -320,6 +324,7 @@ void main() {
       expect(stopwatch.elapsedMilliseconds, lessThan(300));
     },
     tags: 'performance',
+    timeout: timeout,
   );
 
   test(
@@ -345,6 +350,7 @@ void main() {
       expect(labeled, hasLength(labelCount));
     },
     tags: 'performance',
+    timeout: timeout,
   );
 }
 

--- a/test/features/knowledge_graph/ui/task_knowledge_graph_page_test.dart
+++ b/test/features/knowledge_graph/ui/task_knowledge_graph_page_test.dart
@@ -1258,11 +1258,15 @@ void main() {
       // synchronous test scheduler the rejected future stays AsyncLoading),
       // hence the invalidate + future-drain inside `tester.runAsync`.
       var shouldThrow = false;
+      var providerBuilds = 0;
       final result = makeTestableWidgetWithContainer(
         const TaskKnowledgeGraphPage(taskId: taskId),
         mediaQueryData: const MediaQueryData(size: Size(390, 844)),
+        // Deliver the deliberate failure without real backoff delays.
+        retry: (_, _) => null,
         overrides: [
           taskGraphProvider(taskId).overrideWith((ref) async {
+            providerBuilds++;
             if (shouldThrow) throw failure;
             return multiNodeData();
           }),
@@ -1297,6 +1301,8 @@ void main() {
       // listener.
       await tester.pump();
       await tester.pump();
+
+      expect(providerBuilds, 2);
 
       // Established content remains visible while the error is logged.
       expect(find.text(l10n.knowledgeGraphError), findsNothing);

--- a/test/tool/ci/generate_test_optimizer_test.dart
+++ b/test/tool/ci/generate_test_optimizer_test.dart
@@ -107,6 +107,48 @@ void main() {
     },
   );
 
+  test('excludes only suites with inherited matching literal tags', () async {
+    final root = Directory.systemTemp.createTempSync('test_optimizer_');
+    addTearDown(() => root.deleteSync(recursive: true));
+    final directory = Directory(path.join(root.path, 'test'))..createSync();
+    final fixtures = {
+      'excluded': "@test.Tags(['eval-live'])\nlibrary;",
+      'unknown': '@Tags(suiteTags)\nlibrary;',
+      'conditional': "@Tags([if (enabled) 'eval-live'])\nlibrary;",
+      'other': "@Tags(['other'])\nlibrary;",
+      'mixed': '@Timeout(Duration(minutes: 2))\nlibrary;',
+      'bare': 'library;',
+      'fixture': "const fixture = \"@Tags(['eval-live']) library;\";",
+      'plain': '',
+    };
+    for (final entry in fixtures.entries) {
+      File(
+        path.join(directory.path, '${entry.key}_test.dart'),
+      ).writeAsStringSync('${entry.value}\nvoid main() {}');
+    }
+    final output = await generateTestOptimizer(
+      packageRoot: root.path,
+      excludedSuiteTags: {'eval-live'},
+    );
+    final contents = await output.readAsString();
+    expect(contents, isNot(contains('excluded_test.dart')));
+    for (final name in ['bare', 'fixture', 'plain']) {
+      expect(contents, contains("import '${name}_test.dart'"));
+    }
+    expect(
+      jsonDecode(
+        File(path.join(root.path, testTargetsRelativePath)).readAsStringSync(),
+      ),
+      [
+        'test/.test_optimizer.dart',
+        'test/conditional_test.dart',
+        'test/mixed_test.dart',
+        'test/other_test.dart',
+        'test/unknown_test.dart',
+      ],
+    );
+  });
+
   test('fails clearly when the package has no test directory', () async {
     final root = Directory.systemTemp.createTempSync('test_optimizer_');
     addTearDown(() => root.deleteSync(recursive: true));

--- a/test/tool/ci/generate_test_optimizer_test.dart
+++ b/test/tool/ci/generate_test_optimizer_test.dart
@@ -113,6 +113,7 @@ void main() {
     final directory = Directory(path.join(root.path, 'test'))..createSync();
     final fixtures = {
       'excluded': "@test.Tags(['eval-live'])\nlibrary;",
+      'excluded_set': "@Tags({'eval-live'})\nlibrary;",
       'unknown': '@Tags(suiteTags)\nlibrary;',
       'conditional': "@Tags([if (enabled) 'eval-live'])\nlibrary;",
       'other': "@Tags(['other'])\nlibrary;",
@@ -132,6 +133,7 @@ void main() {
     );
     final contents = await output.readAsString();
     expect(contents, isNot(contains('excluded_test.dart')));
+    expect(contents, isNot(contains('excluded_set_test.dart')));
     for (final name in ['bare', 'fixture', 'plain']) {
       expect(contents, contains("import '${name}_test.dart'"));
     }

--- a/test/tool/ci/run_tests_test.dart
+++ b/test/tool/ci/run_tests_test.dart
@@ -6,9 +6,20 @@ import 'package:path/path.dart' as path;
 import '../../../tool/ci/run_tests.dart';
 
 void main() {
-  for (final status in [0, 17]) {
+  for (final (arguments, excluded, status) in [
+    (['--exclude-tags', 'glados || performance', '--shard-index=3'], true, 0),
+    (['--exclude-tags= performance || eval-live '], true, 17),
+    (['--exclude-tags', 'glados', '--exclude-tags=performance'], true, 0),
+    (['--tags', 'performance'], false, 0),
+    (['--tags=glados'], false, 0),
+    (['--exclude-tags', 'performance && slow'], false, 0),
+    (['--exclude-tags', '!slow'], false, 0),
+    (['--exclude-tags', '(performance || slow)'], false, 0),
+    (['--exclude-tags'], false, 17),
+    (['--', '--exclude-tags=performance'], false, 17),
+  ]) {
     test(
-      'forwards all suites and selectors, preserving exit status $status',
+      'selects suites for $arguments and preserves exit status $status',
       () async {
         final root = await Directory.systemTemp.createTemp('test_runner_');
         addTearDown(() => root.delete(recursive: true));
@@ -18,6 +29,10 @@ void main() {
         ).writeAsString('void main() {}');
         await File(path.join(root.path, 'test/tagged_test.dart')).writeAsString(
           "@Tags(['performance'])\nlibrary;\nvoid main() {}",
+        );
+        await File(path.join(root.path, 'test/mixed_test.dart')).writeAsString(
+          '@Timeout(Duration(minutes: 2))\nlibrary;\n'
+          "void main() { test('property', () {}, tags: 'glados'); }",
         );
         // A process double records argv and its working directory; no Flutter
         // suite is launched recursively from this test.
@@ -31,7 +46,7 @@ exit $status
         final permissions = await Process.run('chmod', ['+x', executable.path]);
         expect(permissions.exitCode, 0);
         final result = await runTestSuites(
-          ['--exclude-tags', 'glados || performance', '--shard-index=3'],
+          arguments,
           packageRoot: root.path,
           flutterExecutable: executable.path,
         );
@@ -40,11 +55,10 @@ exit $status
           await File(path.join(root.path, 'arguments.txt')).readAsLines(),
           [
             'test',
-            '--exclude-tags',
-            'glados || performance',
-            '--shard-index=3',
+            ...arguments,
             'test/.test_optimizer.dart',
-            'test/tagged_test.dart',
+            'test/mixed_test.dart',
+            if (!excluded) 'test/tagged_test.dart',
           ],
         );
         expect(

--- a/tool/ci/generate_test_optimizer.dart
+++ b/tool/ci/generate_test_optimizer.dart
@@ -9,7 +9,10 @@ const _outputRelativePath = 'test/.test_optimizer.dart';
 const testTargetsRelativePath = 'test/.test_targets.json';
 
 /// Generates the stable optimized test entrypoint used by sharded CI.
-Future<File> generateTestOptimizer({required String packageRoot}) async {
+Future<File> generateTestOptimizer({
+  required String packageRoot,
+  Set<String> excludedSuiteTags = const {},
+}) async {
   final testDirectory = Directory(path.join(packageRoot, 'test'));
   if (!testDirectory.existsSync()) {
     throw FileSystemException(
@@ -26,10 +29,15 @@ Future<File> generateTestOptimizer({required String packageRoot}) async {
     // Library metadata belongs to a suite, not the imported main() function.
     // Keep annotated suites intact so the test runner interprets their tags,
     // timeouts, platform selectors, skips and retries without losing context.
-    final unit = parseString(content: contents).unit;
-    if (unit.directives.whereType<LibraryDirective>().any(
-      (directive) => directive.metadata.isNotEmpty,
+    final libraries = parseString(
+      content: contents,
+    ).unit.directives.whereType<LibraryDirective>();
+    if (libraries.any(
+      (directive) => _isExcluded(directive, excludedSuiteTags),
     )) {
+      continue;
+    }
+    if (libraries.any((directive) => directive.metadata.isNotEmpty)) {
       standalonePaths.add(
         path.relative(entity.path, from: packageRoot).replaceAll(r'\', '/'),
       );
@@ -50,6 +58,24 @@ Future<File> generateTestOptimizer({required String packageRoot}) async {
     jsonEncode([_outputRelativePath, ...standalonePaths]),
   );
   return output;
+}
+
+// Only inherited literal tags can prove that every test is excluded. Unknown
+// constants and per-test tags stay with Flutter's own discovery/filtering.
+bool _isExcluded(LibraryDirective library, Set<String> excludedTags) {
+  for (final annotation in library.metadata) {
+    if (annotation.name.name.split('.').last != 'Tags') continue;
+    final arguments = annotation.arguments?.arguments;
+    if (arguments == null || arguments.length != 1) continue;
+    final tags = arguments.single;
+    if (tags is! ListLiteral) continue;
+    if (tags.elements.whereType<StringLiteral>().any(
+      (tag) => excludedTags.contains(tag.stringValue),
+    )) {
+      return true;
+    }
+  }
+  return false;
 }
 
 String _renderBundle(List<String> testPaths) {

--- a/tool/ci/generate_test_optimizer.dart
+++ b/tool/ci/generate_test_optimizer.dart
@@ -67,9 +67,12 @@ bool _isExcluded(LibraryDirective library, Set<String> excludedTags) {
     if (annotation.name.name.split('.').last != 'Tags') continue;
     final arguments = annotation.arguments?.arguments;
     if (arguments == null || arguments.length != 1) continue;
-    final tags = arguments.single;
-    if (tags is! ListLiteral) continue;
-    if (tags.elements.whereType<StringLiteral>().any(
+    final elements = switch (arguments.single) {
+      ListLiteral(:final elements) => elements,
+      SetOrMapLiteral(:final elements) => elements,
+      _ => const <CollectionElement>[],
+    };
+    if (elements.whereType<StringLiteral>().any(
       (tag) => excludedTags.contains(tag.stringValue),
     )) {
       return true;

--- a/tool/ci/run_tests.dart
+++ b/tool/ci/run_tests.dart
@@ -5,13 +5,16 @@ import 'package:path/path.dart' as path;
 
 import 'generate_test_optimizer.dart';
 
-/// Executes every suite exactly once and propagates the test process status.
+/// Executes selected suites once and propagates the test process status.
 Future<int> runTestSuites(
   List<String> arguments, {
   required String packageRoot,
   required String flutterExecutable,
 }) async {
-  await generateTestOptimizer(packageRoot: packageRoot);
+  await generateTestOptimizer(
+    packageRoot: packageRoot,
+    excludedSuiteTags: _excludedSuiteTags(arguments),
+  );
   final targets =
       (jsonDecode(
                 await File(
@@ -27,6 +30,29 @@ Future<int> runTestSuites(
     mode: ProcessStartMode.inheritStdio,
   );
   return process.exitCode;
+}
+
+// Positive disjunctions are safe to apply before discovering child-test tags:
+// adding tags cannot make them false. Leave all other expressions to Flutter.
+Set<String> _excludedSuiteTags(List<String> arguments) {
+  final tags = <String>{};
+  final disjunction = RegExp(
+    r'^[a-zA-Z_][a-zA-Z0-9_-]*(\s*\|\|\s*[a-zA-Z_][a-zA-Z0-9_-]*)*$',
+  );
+  for (var index = 0; index < arguments.length; index++) {
+    final argument = arguments[index];
+    if (argument == '--') break;
+    String? expression;
+    if (argument.startsWith('--exclude-tags=')) {
+      expression = argument.substring('--exclude-tags='.length);
+    } else if (argument == '--exclude-tags' && index + 1 < arguments.length) {
+      expression = arguments[++index];
+    }
+    if (expression != null && disjunction.hasMatch(expression.trim())) {
+      tags.addAll(expression.split('||').map((tag) => tag.trim()));
+    }
+  }
+  return tags;
 }
 
 /// Runs with the Flutter SDK containing the Dart executable that launched us.

--- a/tool/ci/run_tests.dart
+++ b/tool/ci/run_tests.dart
@@ -11,6 +11,8 @@ Future<int> runTestSuites(
   required String packageRoot,
   required String flutterExecutable,
 }) async {
+  stdout.writeln('Preparing test targets...');
+  final preparation = Stopwatch()..start();
   await generateTestOptimizer(
     packageRoot: packageRoot,
     excludedSuiteTags: _excludedSuiteTags(arguments),
@@ -23,6 +25,11 @@ Future<int> runTestSuites(
               )
               as List<dynamic>)
           .cast<String>();
+  preparation.stop();
+  stdout.writeln(
+    'Prepared ${targets.length} test targets in '
+    '${preparation.elapsedMilliseconds} ms; starting Flutter.',
+  );
   final process = await Process.start(
     flutterExecutable,
     ['test', ...arguments, ...targets],


### PR DESCRIPTION
CI compiles opt-in live evaluations even when their tests are disabled, and compiles the label query suite separately solely to preserve its library timeout. Omit suites whose inherited literal tags guarantee exclusion, and put the label suite’s existing two-minute limit on its individual tests so it can share the optimized bundle.

The graph background-error regression disables automatic provider retries through the shared harness and verifies one initial load plus one failed refresh. This removes its deterministic 38.2-second real backoff while preserving the existing UI and logging assertions.

Complex exclusion expressions, unknown metadata, and include selectors remain delegated to Flutter. Explicit isolation and platform restrictions are retained. Standard, Glados, and performance lanes exclude live evaluations; Make targets match. Cache native hook outputs together with flutter_scene’s generated package assets, keyed by OS, architecture, Flutter version, and dependency manifests. Hooks retain their normal input validation. Target-preparation logs and verbose phase timings on the first shard make remaining startup costs measurable.

Validation: 13 runner/generator tests, all nine label tests, and all 21 graph-page tests pass; analyzer reports no diagnostics. Disabling filtering produces four regression failures, and set-literal coverage fails before that support is added. The graph regression fails with 12 provider builds instead of 2 when retry suppression is removed.

The filtering-only runs ([first](https://github.com/matthiasn/lotti/actions/runs/34064536941), [second](https://github.com/matthiasn/lotti/actions/runs/34065125653)) had median test-step times of 345.5s and 347.5s, versus 366s on [main](https://github.com/matthiasn/lotti/actions/runs/34064362502). First-run median shard-job time fell from 431.5s to 403.5s. JSON reports confirm all existing application tests remain: 34,738 passing tests on main versus 34,747 here, with the difference entirely in expanded tooling tests. The label-bundling run had a 340s median test step. The cold cache-seeding run had a 357s median test step. Warm-cache measurements are pending; no larger speedup is claimed yet.
