### PR TITLE
ci: compile only the tests assigned to each shard

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -537,7 +537,14 @@ CI runs two parallel test lanes — a ten-shard standard matrix plus a Glados jo
 - **Glados Property Tests** — tagged property tests with separate coverage.
 - **Performance Budgets** — tagged stopwatch tests, scheduled weekly and available through workflow dispatch. Deterministic query-count gates stay in the standard lane.
 
-All lanes use `tool/ci/run_tests.dart`. It generates a sorted optimized bundle
+All lanes use `tool/ci/run_tests.dart`. Shard flags are consumed by this runner
+before Flutter starts. It assigns whole files greedily by source size, largest
+first, with path tie-breaks, then generates imports only for that shard. The
+assignment is deterministic for a checkout and every eligible file belongs to
+exactly one shard. Flutter receives no shard flags, avoiding double filtering.
+Source size is a balancing heuristic, not a prediction of test duration.
+
+The runner generates a sorted optimized bundle
 plus `test/.test_targets.json`. A suite with library metadata (`@Tags`,
 `@Timeout`, `@TestOn`, `@Skip`, and other annotations) runs as a standalone file
 so the test runner receives the original metadata. Opting out of optimization

--- a/test/tool/ci/generate_test_optimizer_test.dart
+++ b/test/tool/ci/generate_test_optimizer_test.dart
@@ -151,6 +151,78 @@ void main() {
     );
   });
 
+  test(
+    'partitions every suite exactly once before rendering imports',
+    () async {
+      final root = Directory.systemTemp.createTempSync('test_shards_');
+      addTearDown(() => root.deleteSync(recursive: true));
+      final directory = Directory(path.join(root.path, 'test'))..createSync();
+      final names = <String>[];
+      for (var i = 0; i < 12; i++) {
+        final name = 'suite_${i}_test.dart';
+        names.add(name);
+        File(path.join(directory.path, name)).writeAsStringSync(
+          '${i.isEven ? "@Timeout(Duration(minutes: 2))\nlibrary;" : ""}\n'
+          '// ${'x' * (100 + i * 30)}\nvoid main() {}',
+        );
+      }
+      final seen = <String>[];
+      final rendered = <String>[];
+      for (var shard = 0; shard < 3; shard++) {
+        final output = await generateTestOptimizer(
+          packageRoot: root.path,
+          totalShards: 3,
+          shardIndex: shard,
+        );
+        final bundle = output.readAsStringSync();
+        final targets =
+            (jsonDecode(
+                      File(
+                        path.join(root.path, testTargetsRelativePath),
+                      ).readAsStringSync(),
+                    )
+                    as List<dynamic>)
+                .cast<String>();
+        final assigned = names
+            .where(
+              (name) =>
+                  bundle.contains("import '$name'") ||
+                  targets.contains('test/$name'),
+            )
+            .toList();
+        expect(assigned, isNotEmpty);
+        expect(assigned.length, lessThan(names.length));
+        for (final name in assigned) {
+          final annotated = int.parse(name.split('_')[1]).isEven;
+          expect(targets.contains('test/$name'), annotated);
+          expect(bundle.contains("import '$name'"), !annotated);
+        }
+        seen.addAll(assigned);
+        rendered.add(bundle);
+      }
+      expect(seen, unorderedEquals(names));
+      final again = await generateTestOptimizer(
+        packageRoot: root.path,
+        totalShards: 3,
+        shardIndex: 1,
+      );
+      expect(again.readAsStringSync(), rendered[1]);
+    },
+  );
+
+  for (final (total, index) in [(0, 0), (2, -1), (2, 2)]) {
+    test('rejects invalid shard $index of $total', () async {
+      await expectLater(
+        generateTestOptimizer(
+          packageRoot: '.',
+          totalShards: total,
+          shardIndex: index,
+        ),
+        throwsArgumentError,
+      );
+    });
+  }
+
   test('fails clearly when the package has no test directory', () async {
     final root = Directory.systemTemp.createTempSync('test_optimizer_');
     addTearDown(() => root.deleteSync(recursive: true));

--- a/test/tool/ci/run_tests_test.dart
+++ b/test/tool/ci/run_tests_test.dart
@@ -6,12 +6,36 @@ import 'package:path/path.dart' as path;
 import '../../../tool/ci/run_tests.dart';
 
 void main() {
+  for (final arguments in [
+    ['--total-shards=2'],
+    ['--shard-index=0'],
+    ['--total-shards'],
+    ['--total-shards=abc', '--shard-index=0'],
+    ['--total-shards=2', '--total-shards=2', '--shard-index=0'],
+    ['--total-shards=2', '--shard-index=2'],
+  ]) {
+    test(
+      'rejects invalid sharding $arguments before launching Flutter',
+      () async {
+        await expectLater(
+          runTestSuites(
+            arguments,
+            packageRoot: '/missing',
+            flutterExecutable: '/missing',
+          ),
+          throwsArgumentError,
+        );
+      },
+    );
+  }
   for (final (arguments, excluded, status) in [
-    (['--exclude-tags', 'glados || performance', '--shard-index=3'], true, 0),
+    (['--exclude-tags', 'glados || performance', '--no-pub'], true, 0),
     (['--exclude-tags= performance || eval-live '], true, 17),
     (['--exclude-tags', 'glados', '--exclude-tags=performance'], true, 0),
     (['--tags', 'performance'], false, 0),
     (['--tags=glados'], false, 0),
+    (['--total-shards=1', '--shard-index=0'], false, 0),
+    (['--total-shards', '1', '--shard-index', '0'], false, 0),
     (['--exclude-tags', 'performance && slow'], false, 0),
     (['--exclude-tags', '!slow'], false, 0),
     (['--exclude-tags', '(performance || slow)'], false, 0),
@@ -55,7 +79,7 @@ exit $status
           await File(path.join(root.path, 'arguments.txt')).readAsLines(),
           [
             'test',
-            ...arguments,
+            if (!arguments.first.startsWith('--total-shards')) ...arguments,
             'test/.test_optimizer.dart',
             'test/mixed_test.dart',
             if (!excluded) 'test/tagged_test.dart',

--- a/tool/ci/generate_test_optimizer.dart
+++ b/tool/ci/generate_test_optimizer.dart
@@ -8,11 +8,16 @@ import 'package:path/path.dart' as path;
 const _outputRelativePath = 'test/.test_optimizer.dart';
 const testTargetsRelativePath = 'test/.test_targets.json';
 
-/// Generates the stable optimized test entrypoint used by sharded CI.
+/// Generates a stable bundle containing only the selected shard’s test files.
 Future<File> generateTestOptimizer({
   required String packageRoot,
   Set<String> excludedSuiteTags = const {},
+  int totalShards = 1,
+  int shardIndex = 0,
 }) async {
+  if (totalShards < 1 || shardIndex < 0 || shardIndex >= totalShards) {
+    throw ArgumentError('Invalid shard $shardIndex of $totalShards');
+  }
   final testDirectory = Directory(path.join(packageRoot, 'test'));
   if (!testDirectory.existsSync()) {
     throw FileSystemException(
@@ -23,6 +28,7 @@ Future<File> generateTestOptimizer({
 
   final testPaths = <String>[];
   final standalonePaths = <String>[];
+  final sizes = <String, int>{};
   for (final entity in testDirectory.listSync(recursive: true)) {
     if (entity is! File || !entity.path.endsWith('_test.dart')) continue;
     final contents = await entity.readAsString();
@@ -37,10 +43,12 @@ Future<File> generateTestOptimizer({
     )) {
       continue;
     }
+    final relative = path
+        .relative(entity.path, from: packageRoot)
+        .replaceAll(r'\', '/');
+    sizes[relative] = contents.length;
     if (libraries.any((directive) => directive.metadata.isNotEmpty)) {
-      standalonePaths.add(
-        path.relative(entity.path, from: packageRoot).replaceAll(r'\', '/'),
-      );
+      standalonePaths.add(relative);
       continue;
     }
     testPaths.add(
@@ -49,6 +57,25 @@ Future<File> generateTestOptimizer({
           .replaceAll(r'\', '/'),
     );
   }
+  // Greedily balance source size before compilation. Path tie-breaks keep the
+  // assignment reproducible without a timing artifact or machine-local state.
+  final candidates = sizes.keys.toList()
+    ..sort((a, b) {
+      final bySize = sizes[b]!.compareTo(sizes[a]!);
+      return bySize == 0 ? a.compareTo(b) : bySize;
+    });
+  final loads = List<int>.filled(totalShards, 0);
+  final selected = <String>{};
+  for (final candidate in candidates) {
+    var shard = 0;
+    for (var index = 1; index < totalShards; index++) {
+      if (loads[index] < loads[shard]) shard = index;
+    }
+    loads[shard] += sizes[candidate]!;
+    if (shard == shardIndex) selected.add(candidate);
+  }
+  testPaths.removeWhere((file) => !selected.contains('test/$file'));
+  standalonePaths.removeWhere((file) => !selected.contains(file));
   testPaths.sort();
   standalonePaths.sort();
 

--- a/tool/ci/run_tests.dart
+++ b/tool/ci/run_tests.dart
@@ -11,11 +11,14 @@ Future<int> runTestSuites(
   required String packageRoot,
   required String flutterExecutable,
 }) async {
+  final selection = _shardArguments(arguments);
   stdout.writeln('Preparing test targets...');
   final preparation = Stopwatch()..start();
   await generateTestOptimizer(
     packageRoot: packageRoot,
     excludedSuiteTags: _excludedSuiteTags(arguments),
+    totalShards: selection.total,
+    shardIndex: selection.index,
   );
   final targets =
       (jsonDecode(
@@ -32,11 +35,50 @@ Future<int> runTestSuites(
   );
   final process = await Process.start(
     flutterExecutable,
-    ['test', ...arguments, ...targets],
+    ['test', ...selection.remaining, ...targets],
     workingDirectory: packageRoot,
     mode: ProcessStartMode.inheritStdio,
   );
   return process.exitCode;
+}
+
+// Consume the shard flags here: forwarding them would shard the already
+// partitioned files a second time and silently omit tests.
+({int total, int index, List<String> remaining}) _shardArguments(
+  List<String> arguments,
+) {
+  final remaining = <String>[];
+  final values = <String, int>{};
+  for (var i = 0; i < arguments.length; i++) {
+    final argument = arguments[i];
+    if (argument == '--') {
+      remaining.addAll(arguments.skip(i));
+      break;
+    }
+    final name = argument.split('=').first;
+    if (name != '--total-shards' && name != '--shard-index') {
+      remaining.add(argument);
+      continue;
+    }
+    final raw = argument.contains('=')
+        ? argument.substring(name.length + 1)
+        : i + 1 < arguments.length
+        ? arguments[++i]
+        : '';
+    final value = int.tryParse(raw);
+    if (value == null || values.containsKey(name)) {
+      throw ArgumentError('Invalid or repeated $name: $raw');
+    }
+    values[name] = value;
+  }
+  if (values.length == 1) {
+    throw ArgumentError('Specify both --total-shards and --shard-index');
+  }
+  return (
+    total: values['--total-shards'] ?? 1,
+    index: values['--shard-index'] ?? 0,
+    remaining: remaining,
+  );
 }
 
 // Positive disjunctions are safe to apply before discovering child-test tags:


### PR DESCRIPTION
Each standard CI shard previously compiled the full test bundle before Flutter selected its tests. The latest warm run still took up to 6m28s per complete shard job.

Assign whole test files to ten shards before generating imports. A deterministic greedy source-size allocation reduces repeated compilation while preserving library annotations, tag filtering, and coverage. Consume the shard flags in the wrapper so Flutter cannot filter the selected tests a second time.

Validation:
- Analyzer clean; all 25 targeted runner/generator tests pass. Disabling partitioning and flag consumption makes three regression cases fail.
- [Final CI run](https://github.com/matthiasn/lotti/actions/runs/34067140975/attempts/2): all ten complete shard jobs passed in **3m07s–4m06s**, median **3m51s**. Durations include setup, test execution, coverage upload, and cleanup. Glados passed in **3m50s**.
- **34,747 tests passed** across all eleven reports. Comparing names against the parent run finds no application tests missing or duplicated; the differences are twelve added tooling tests and one renamed tooling case.
- Codecov patch and project checks pass. Both automated reviews completed without actionable findings.

This achieved the five-minute target on iteration 5 of the five-iteration budget. These are warm-cache timings: the first run started before main saved its native-hook cache and reached 6m08s. Dependency/SDK changes or cache eviction still require a cold native rebuild. The profiled shard's compilation fell from roughly 65s to 41s.
