### PR TITLE
chore(release): 1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5]
+
+### Added
+
+- **Optional mobile navigation launcher.** Enable New mobile navigation in
+  Settings → Config Flags to try a glass Navigate button and a two-column
+  section grid. The existing bottom navigation remains the default.
+
 ## [1.1.4]
 
 ### Added

--- a/changelog.d/2026-09-07-optional-mobile-navigation.md
+++ b/changelog.d/2026-09-07-optional-mobile-navigation.md
@@ -1,4 +1,0 @@
-### Added
-- **Optional mobile navigation launcher.** Enable New mobile navigation in
-  Settings → Config Flags to try a glass Navigate button and a two-column
-  section grid. The existing bottom navigation remains the default.

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -40,6 +40,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="1.1.5" date="2026-09-07">
+      <description>
+        <p>Added: optional mobile navigation launcher. Enable New mobile navigation in Settings → Config Flags to try a glass Navigate button and a two-column section grid. The existing bottom navigation remains the default.</p>
+      </description>
+    </release>
     <release version="1.1.4" date="2026-09-07">
       <description>
         <p>Added: turn check-in commitments into linked tasks. Your relationship agent can suggest tasks on a person's card and in chat, with the source check-in and any proposed due date visible before confirmation. Review suggestions individually or together, see their history, and undo task creation while the task is still unchanged.</p>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.1.4+4379
+version: 1.1.5+4380
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
Prepare **1.1.5+4380** from current `main` (including #4194).

### Added

- **Optional mobile navigation launcher.** Enable New mobile navigation in
  Settings → Config Flags to try a glass Navigate button and a two-column
  section grid. The existing bottom navigation remains the default.

Assembles the release notes in CHANGELOG.md and the Flathub metainfo, increments the patch version and build number, and removes the consumed fragment. No application code changes.

Validation: strict fragment validation before assembly, `make changelog_check`, XML validation, and Flutter analysis. CI validates the release branch. This PR does not tag or publish the release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional mobile navigation launcher, available through Settings → Config Flags.
  - Provides a glass-style Navigate button and a two-column section grid for accessing app areas.
  - The existing bottom navigation remains the default experience.

- **Documentation**
  - Updated release information to document the optional mobile navigation launcher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->