### PR TITLE
chore(release): correct 1.1.5 navigation instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Optional mobile navigation launcher.** Enable New mobile navigation in
-  Settings → Config Flags to try a glass Navigate button and a two-column
-  section grid. The existing bottom navigation remains the default.
+  Settings → Advanced → Config Flags to try a glass Navigate button and a
+  two-column section grid. The existing bottom navigation remains the default.
 
 ### Fixed
 

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -42,7 +42,7 @@
   <releases>
     <release version="1.1.5" date="2026-09-07">
       <description>
-        <p>Added: optional mobile navigation launcher. Enable New mobile navigation in Settings → Config Flags to try a glass Navigate button and a two-column section grid. The existing bottom navigation remains the default.</p>
+        <p>Added: optional mobile navigation launcher. Enable New mobile navigation in Settings → Advanced → Config Flags to try a glass Navigate button and a two-column section grid. The existing bottom navigation remains the default.</p>
         <p>Fixed: the Android app opened to a blank white screen and never loaded. The on-device speech recognition added in this release brought its own copy of the ONNX Runtime, built against a marginally different release than the one the on-device voice already used. Android ships a single copy of that runtime, so whichever of the two was kept, the other could no longer load it, and that one failure stopped every part of the app from starting. Both features now use the same runtime release, and the app starts normally again.</p>
       </description>
     </release>


### PR DESCRIPTION
The 1.1.5 release notes omit the Advanced settings hub when describing how to enable the new mobile navigation. Correct both CHANGELOG.md and the Flathub metainfo to say **Settings → Advanced → Config Flags**.

Release-metadata correction continuing the authorized 1.1.5 release task under `.agents/skills/release/SKILL.md`. The review on #4195 arrived after it had been merged and tagged, so the correction needs a follow-up release PR. This corrects the repository's release notes without changing the existing tag or build version.

Validation: confirmed the path against `settings_tree_data.dart` and `settings_tree_index.dart`; `make changelog_check`, XML validation, and `git diff --check` pass. No application code changed.
