### PR TITLE
fix: align ONNX Runtime versions so the Android app starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Settings → Config Flags to try a glass Navigate button and a two-column
   section grid. The existing bottom navigation remains the default.
 
+### Fixed
+
+- **The Android app opened to a blank white screen and never loaded.** The
+  on-device speech recognition added in this release brought its own copy of
+  the ONNX Runtime, built against a marginally different release than the one
+  the on-device voice already used. Android ships a single copy of that
+  runtime, so whichever of the two was kept, the other could no longer load
+  it — and that one failure stopped every part of the app from starting,
+  leaving it running but unable to draw anything at all. Both features now use
+  the same runtime release, and the app starts normally again.
+
 ## [1.1.4]
 
 ### Added

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,7 +44,9 @@ android {
 
     packaging {
         jniLibs {
-            // TTS and sherpa both supply the compatible ORT 1.27 runtime.
+            // TTS and sherpa each contribute a libonnxruntime.so. The
+            // pubspec pins keep both at the same ORT release (1.27.0), so
+            // collapsing the duplicate is safe — see android/build.gradle.
             pickFirsts += ['**/libonnxruntime.so']
         }
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,8 +23,14 @@ buildscript {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-    // sherpa_onnx 1.13.7 needs the ORT 1.27 C API. Keep the Java/JNI
-    // dependency used by TTS on the same API (1.27.1 has no Maven artifact).
+    // sherpa's platform packages and the Java/JNI bridge that Supertonic TTS
+    // loads share the one packaged libonnxruntime.so. ORT exports its C API
+    // with ELF symbol versioning and the version node must match exactly: a
+    // runtime tagged VERS_1.27.1 does not satisfy a consumer asking for
+    // VERS_1.27.0, and the loader fails with "cannot locate symbol
+    // OrtGetApiBase". sherpa is pinned to 1.13.4, whose runtime is 1.27.0, so
+    // force the JNI artifact to the same release. Bump only in lockstep with
+    // the sherpa_onnx_* pins in pubspec.yaml.
     configurations.configureEach {
         resolutionStrategy.force 'com.microsoft.onnxruntime:onnxruntime-android:1.27.0'
     }

--- a/flatpak/com.matthiasn.lotti.flatpak-flutter.yml
+++ b/flatpak/com.matthiasn.lotti.flatpak-flutter.yml
@@ -105,13 +105,13 @@ modules:
       - type: archive
         only-arches:
           - x86_64
-        url: https://github.com/microsoft/onnxruntime/releases/download/v1.27.1/onnxruntime-linux-x64-1.27.1.tgz
-        sha256: 25b1ef1fea1acd210d63f8f24dc870ad6e077795ce1f54876252c6d3803c15af
+        url: https://github.com/microsoft/onnxruntime/releases/download/v1.27.0/onnxruntime-linux-x64-1.27.0.tgz
+        sha256: 547e40a48f1fe73e3f812d7c88a948612c23f896b91e4e2ee1e232d7b468246f
       - type: archive
         only-arches:
           - aarch64
-        url: https://github.com/microsoft/onnxruntime/releases/download/v1.27.1/onnxruntime-linux-aarch64-1.27.1.tgz
-        sha256: 33c67e33d1e25b816878366ea276589a024f71f000e7ff955c4b33224d639edd
+        url: https://github.com/microsoft/onnxruntime/releases/download/v1.27.0/onnxruntime-linux-aarch64-1.27.0.tgz
+        sha256: 3e4d83ac06924a32a07b6d7f91ce6f852876153fc0bbdf931bf517a140bfbe48
   # NOTE: No separate flutter-sdk module - Flutter is included in lotti sources for flatpak-flutter
   - name: lotti
     buildsystem: simple

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -43,6 +43,7 @@
     <release version="1.1.5" date="2026-09-07">
       <description>
         <p>Added: optional mobile navigation launcher. Enable New mobile navigation in Settings → Config Flags to try a glass Navigate button and a two-column section grid. The existing bottom navigation remains the default.</p>
+        <p>Fixed: the Android app opened to a blank white screen and never loaded. The on-device speech recognition added in this release brought its own copy of the ONNX Runtime, built against a marginally different release than the one the on-device voice already used. Android ships a single copy of that runtime, so whichever of the two was kept, the other could no longer load it, and that one failure stopped every part of the app from starting. Both features now use the same runtime release, and the app starts normally again.</p>
       </description>
     </release>
     <release version="1.1.4" date="2026-09-07">

--- a/knowledge/features/ai/embedded-speech.md
+++ b/knowledge/features/ai/embedded-speech.md
@@ -192,18 +192,38 @@ every model in an incoming profile has been downloaded on that node.
 
 # Native packaging
 
-`sherpa_onnx` is pinned to 1.13.7. Its native platform packages supply the C API
-and binaries, including Linux x64/ARM64, Apple platforms, Android, and Windows.
-The existing ONNX plugin continues to own Supertonic TTS.
+`sherpa_onnx` is pinned to 1.13.4, and its native platform packages are pinned
+to the same version in `dependency_overrides` — the package itself only
+constrains them to `^1.13.4`, which resolves higher and silently swaps the
+binaries out. Those packages supply the C API and binaries for Linux x64/ARM64,
+Apple platforms, Android and Windows. The existing ONNX plugin continues to own
+Supertonic TTS.
+
+ONNX Runtime exports its C API under **ELF symbol versioning**, and a version
+node must match exactly: a `libonnxruntime.so` tagged `VERS_1.27.1` does not
+satisfy a consumer that asks for `VERS_1.27.0`. Sharing one runtime between
+sherpa and TTS therefore demands a single ORT *release*, not merely a compatible
+1.27 API level.
 
 Linux packages one ONNX Runtime from sherpa. Its `libonnxruntime.so` also has a
 `libonnxruntime.so.1` symlink for the TTS plugin's SONAME dependency. The official
-ORT headers/download and Flatpak runtime are pinned to the matching 1.27.1
-release; Flatpak's declared sources keep configuration offline. Android aligns
-TTS's Java/JNI dependency to the published 1.27.0 artifact (there is no 1.27.1
-Maven artifact), sharing the compatible 1.27 API with sherpa's runtime. Duplicate
+ORT headers/download and Flatpak runtime are pinned to the matching 1.27.0
+release; Flatpak's declared sources keep configuration offline. Android packages
+one `libonnxruntime.so` shared by sherpa's `libsherpa-onnx-c-api.so` and by the
+`libonnxruntime4j_jni.so` that TTS loads, so `android/build.gradle` forces the
+Java/JNI artifact to the published 1.27.0 release and the duplicate
 `libonnxruntime.so` inputs are merged into one packaged library. Apple's sherpa
 frameworks hide their internal ORT symbols.
+
+sherpa 1.13.5 and later ship a `VERS_1.27.1` runtime, and Maven Central
+publishes no `onnxruntime-android:1.27.1`. Taking that bump without a matching
+Java artifact leaves the JNI bridge unsatisfiable: `OrtEnvironment`'s static
+initialiser throws `UnsatisfiedLinkError` out of
+`GeneratedPluginRegistrant.registerWith`, so *no* plugin registers and the app
+hangs on a white screen rather than crashing. That shipped as 1.1.5+4380. Bump
+the `sherpa_onnx_*` pins, the forced Maven version in `android/build.gradle`,
+`ONNXRUNTIME_VERSION` in `linux/CMakeLists.txt` and the Flatpak ORT sources only
+in lockstep, and only to a release Maven Central actually publishes.
 
 Flatpak copies the bundle with `--remove-destination`: its build-time ORT
 installation links `.so` to `.so.1`, while the bundle links `.so.1` to `.so`.

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -84,8 +84,8 @@ if(_LOTTI_CMAKE_WARN_DEPRECATED_WAS_SET)
     CACHE CMAKE_WARN_DEPRECATED PROPERTY VALUE)
 endif()
 set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
-# Match sherpa_onnx 1.13.7's runtime when flutter_onnxruntime needs headers.
-set(ONNXRUNTIME_VERSION "1.27.1" CACHE STRING "Shared speech runtime" FORCE)
+# Match sherpa_onnx 1.13.4's runtime when flutter_onnxruntime needs headers.
+set(ONNXRUNTIME_VERSION "1.27.0" CACHE STRING "Shared speech runtime" FORCE)
 include(flutter/generated_plugins.cmake)
 
 # Flutter copies plugin files rather than installing their targets. Avoid

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2751,82 +2751,74 @@ packages:
     dependency: "direct main"
     description:
       name: sherpa_onnx
-      sha256: d22c590277619d2d38d3d670afc283b2e435ca0be1ec0b73c64db77878100970
+      sha256: "889c03cf7a8788795e3a6d35bf9f20b66d1862ea7a73a1b6aaf6e450715c870a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.13.7"
+    version: "1.13.4"
   sherpa_onnx_android_arm64:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: sherpa_onnx_android_arm64
-      sha256: "75abd783a9cfa1579d8dd4eb8f3f59cdf0aff559cadab3399568fef3fadaec8c"
+      sha256: "0337650bc2357f39b751f1b9ced37770de3b60026effe66473b557346b4e3f97"
       url: "https://pub.dev"
     source: hosted
-    version: "1.13.7"
+    version: "1.13.4"
   sherpa_onnx_android_armeabi:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: sherpa_onnx_android_armeabi
-      sha256: "072e355714307eec4cf8104156466d64c07d8bd0d507158b84fa64872aa5b48e"
+      sha256: "9e96729d99567c3f64fc6f4c232ef04b57ae4ef3bf1b21364ee6e461103cb7cf"
       url: "https://pub.dev"
     source: hosted
-    version: "1.13.7"
+    version: "1.13.4"
   sherpa_onnx_android_x86:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: sherpa_onnx_android_x86
-      sha256: "38da8703c2f24aa97b6c936b8761699439f4b151c91618a298024326aa6f8bab"
+      sha256: "6eaa462a24bf881c8ee2b3ab5b9fad3d310b714fc9d3ac4b9f650d0a90c9d0ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.13.7"
+    version: "1.13.4"
   sherpa_onnx_android_x86_64:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: sherpa_onnx_android_x86_64
-      sha256: "14066274539b90d5be038d809be1aa57ae7b5aa1f1219a3d712780d076d0e1fd"
+      sha256: "181aa0f0968adf2cf2dcb369c879ea372653864538b82772877e22748a80254f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.13.7"
+    version: "1.13.4"
   sherpa_onnx_ios:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: sherpa_onnx_ios
-      sha256: e2eacf9b2bc630f6e1f976fa2e9357030f8ecbd61b6001ff1bb7be8ebfcda042
+      sha256: "9586b7ddae9a11fd10457367ff5e8a153e0993a8c588828bc31f6cf7afbaf2d2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.13.7"
+    version: "1.13.4"
   sherpa_onnx_linux:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: sherpa_onnx_linux
-      sha256: eeb193b4c0626199eae4ce49f0f21ffb117bd22ec3933db3d579511534246d45
+      sha256: eb2666480e48e002e0dd634c1bbe1ef52162a0821cd9eada39d40a3e12f76c48
       url: "https://pub.dev"
     source: hosted
-    version: "1.13.7"
+    version: "1.13.4"
   sherpa_onnx_macos:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: sherpa_onnx_macos
-      sha256: "5ed5a323f6fe9dc37e5535058a081aa87cdbf427b52798a6cebad330efe7449b"
+      sha256: "55164fa38db3de870dc834b855be6b6b5cc0acb7663d74cea76c3de4e7bd7a47"
       url: "https://pub.dev"
     source: hosted
-    version: "1.13.7"
-  sherpa_onnx_web:
-    dependency: transitive
-    description:
-      name: sherpa_onnx_web
-      sha256: b3b5d54df39e720b626439a8f14ea08ea1bdb5513f64dff2a5c5bb251e6093b7
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.13.7"
+    version: "1.13.4"
   sherpa_onnx_windows:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: sherpa_onnx_windows
-      sha256: "08c145c5ba99a15a9e916ff0a689d6058c2daa60d3c996bc6cac22457ebccb18"
+      sha256: "9bbf2b43308446a894c685d5fe1a147df457b9e400afed7aefc271f72f9290b9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.13.7"
+    version: "1.13.4"
   signature:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.1.5+4380
+version: 1.1.5+4381
 
 msix_config:
   display_name: LottiApp
@@ -122,7 +122,7 @@ dependencies:
   rxdart: ^0.28.0
   share_plus: ^12.0.0
   shared_preferences: ^2.3.2
-  sherpa_onnx: 1.13.7
+  sherpa_onnx: 1.13.4
   sliver_tools: ^0.2.12
   sqflite_common_ffi: ^2.3.3
   sqlite3: ^3.5.1
@@ -164,6 +164,28 @@ dependency_overrides:
   # See: https://github.com/flutter/flutter/issues/178915
   path_provider_foundation: 2.5.1
   rxdart: ^0.28.0
+  # sherpa_onnx's platform packages ship the native ONNX Runtime, and
+  # `sherpa_onnx: 1.13.4` only constrains them to `^1.13.4` — which resolves to
+  # 1.13.7 and reintroduces the mismatch below. Pin them exactly.
+  #
+  # ORT exports its C API with ELF symbol versioning, and the version node must
+  # match exactly: a `libonnxruntime.so` tagged VERS_1.27.1 does not satisfy a
+  # consumer that asks for VERS_1.27.0. Android packages a single
+  # `libonnxruntime.so` shared by sherpa's `libsherpa-onnx-c-api.so` and by the
+  # `libonnxruntime4j_jni.so` that Supertonic TTS loads, so both must want the
+  # same node. sherpa 1.13.5+ ships VERS_1.27.1, which has no
+  # `com.microsoft.onnxruntime:onnxruntime-android` artifact on Maven Central,
+  # leaving the JNI side unsatisfiable; 1.13.4 ships VERS_1.27.0, which Maven
+  # publishes. Bump these only in lockstep with the version forced in
+  # android/build.gradle and pinned in linux/CMakeLists.txt.
+  sherpa_onnx_android_arm64: 1.13.4
+  sherpa_onnx_android_armeabi: 1.13.4
+  sherpa_onnx_android_x86: 1.13.4
+  sherpa_onnx_android_x86_64: 1.13.4
+  sherpa_onnx_ios: 1.13.4
+  sherpa_onnx_linux: 1.13.4
+  sherpa_onnx_macos: 1.13.4
+  sherpa_onnx_windows: 1.13.4
 
 dev_dependencies:
   # Parses Dart directives in test/architecture/feature_import_direction_test.dart.


### PR DESCRIPTION
## What happened

1.1.5 (versionCode 4380) opens to a blank white screen on **every** Android
install, fresh ones included. The process starts, the activity reaches
foreground, and nothing is ever drawn.

## Root cause

#4177 added sherpa on-device speech recognition, a second consumer of ONNX
Runtime. Android packages a single `libonnxruntime.so`, and the two consumers
were built against different releases of it:

```
libsherpa-onnx-c-api.so  (sherpa_onnx 1.13.7)  needs OrtGetApiBase@VERS_1.27.1
libonnxruntime4j_jni.so  (Supertonic TTS)      needs OrtGetApiBase@VERS_1.27.0
```

The collision was resolved with `pickFirst` on the assumption that both wanted
"the compatible ORT 1.27 API". ONNX Runtime exports its C API under **ELF symbol
versioning**, where the version node must match *exactly* — `VERS_1.27.1` never
satisfies a consumer asking for `VERS_1.27.0`. sherpa's copy won, and the Java
bridge could not resolve its symbol.

## Why a white screen and not a crash

`FlutterOnnxruntimePlugin` calls `OrtEnvironment.getEnvironment()` from
`onAttachedToEngine`, so the `UnsatisfiedLinkError` escaped
`GeneratedPluginRegistrant.registerWith`. Flutter catches that and only logs it:

```
E GeneratedPluginsRegister: Tried to automatically register plugins with
  FlutterEngine but could not find or invoke the GeneratedPluginRegistrant.
```

So **no plugin registered at all** — not path_provider, not sqlite, none. Dart's
`main()` then awaited platform channels that never answered. The process stayed
alive and foreground, drawing nothing. A hang, not a crash, which is why it
presents as a permanent white screen.

## The fix

Pin `sherpa_onnx` to **1.13.4**, whose bundled runtime is **1.27.0** — the
release Maven Central actually publishes (`onnxruntime-android:1.27.1` returns
404, which is what pushed #4177 into the mismatch). Every consumer then agrees.

**The package pin alone is not sufficient.** `sherpa_onnx` constrains its
platform packages — the ones carrying the binaries — to `^1.13.4`, which still
resolves to 1.13.7 and reinstates the mismatch. All eight are pinned explicitly
in `dependency_overrides`.

Linux and Flathub move to the matching 1.27.0 runtime in the same change, and
the gradle comments plus the embedded-speech concept are rewritten — both
recorded the assumption that made this look safe.

## Verification

Symbol versions now agree on **every ABI Play ships**, where previously all four
were mismatched (hence: all users, not just some devices):

| ABI | jni requires | runtime provides |
|---|---|---|
| arm64-v8a | `VERS_1.27.0` | `VERS_1.27.0` |
| armeabi-v7a | `VERS_1.27.0` | `VERS_1.27.0` |
| x86 | `VERS_1.27.0` | `VERS_1.27.0` |
| x86_64 | `VERS_1.27.0` | `VERS_1.27.0` |

Linux is consistent at 1.27.0 too, matching the new `linux/CMakeLists.txt` pin
and the Flatpak sources (sha256 recomputed from the actual archives).

- **App launches and renders** on an arm64 emulator — Tasks screen and
  onboarding sheet — with zero `GeneratedPluginsRegister` / `UnsatisfiedLinkError`
  / `cannot locate symbol` hits, and `FlutterSecureStorage` completing its
  migration, which is only reachable once plugin registration succeeds.
- `make analyze` — no issues
- **128 sherpa-dependent tests pass** against the older API (62 in
  `test/features/ai/speech/`, 66 across the models section, audio transcription
  and sync capability probe)
- `make changelog_check`, `make knowledge_check` — pass

### Not verified

- **Never run on physical hardware.** The only Android device to hand is a
  Xiaomi whose MIUI Security Center refuses adb installs
  (`INSTALL_FAILED_USER_RESTRICTED`) via both `adb install` and `pm install`.
- The emulator ran a **debug** build, not the release artifact. The fix is in
  `jniLibs` packaging, identical across build types, and no `minifyEnabled` is
  configured — but it is not literally what Play serves.

Installing this build from a Play internal testing track would close both gaps.

## Release

Included, since this must ship as a build users can actually receive:
`1.1.5+4380` → `1.1.5+4381`. Fix-only, so per `.agents/skills/release/SKILL.md`
the semantic version holds and only the build number moves; the notes append to
the existing `## [1.1.5]` section and its metainfo release block rather than
creating duplicates. Play requires only that versionCode increase.

## Note

Speech recognition drops from sherpa 1.13.7 to 1.13.4 — three patch releases of
ASR work given up to stay on a runtime Maven publishes. Its tests pass and the
model catalog is consistent.

Follow-up worth doing separately: `FlutterOnnxruntimePlugin` initialising ORT
eagerly in `onAttachedToEngine` is why one native library could take down the
entire app rather than just TTS. Making that lazy would turn this class of
failure into a degraded feature instead of a dead app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqGsrA1e7sXGSikXrLSEY1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause the Android app to open to a blank white screen.
  * Improved compatibility between on-device speech recognition and voice features so the app starts normally.

* **Documentation**
  * Added guidance on keeping speech and voice runtime components synchronized across supported platforms.
  * Documented version requirements and troubleshooting information for native speech components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->