### PR TITLE
feat: dock every list's create action on a glass Navigate row

### DIFF
--- a/changelog.d/2026-09-04-android-16kb-page-size.md
+++ b/changelog.d/2026-09-04-android-16kb-page-size.md
@@ -1,0 +1,13 @@
+### Fixed
+- **Audio transcription could fail on Android devices that use 16 KB memory
+  pages.** Lotti encodes a recording to MP3 before sending it off to be
+  transcribed, and that encoder was still built for the older 4 KB memory
+  layout — which newer 64-bit Android devices refuse to load at all. Every
+  native library Lotti bundles for 64-bit Android is now built for 16 KB
+  pages, so transcription works on current hardware again.
+
+### Changed
+- **The Android download is around 4 MB smaller.** Lotti no longer ships its
+  own copy of OpenSSL. The encryption it was there for now comes from the
+  Matrix package directly, so that library — and the C++ runtime it pulled
+  along with it — are gone.

--- a/changelog.d/2026-09-07-navigate-launcher-glass-row.md
+++ b/changelog.d/2026-09-07-navigate-launcher-glass-row.md
@@ -1,0 +1,14 @@
+### Changed
+- **The optional mobile Navigate button now looks like glass, and each list's
+  create button sits beside it instead of above it.** With *Mobile navigation
+  launcher* switched on, Navigate used to be a solid grey button on a frosted
+  slab, and on Tasks, the Logbook, Projects, Goals and Habits a second button
+  floated in the bottom-right corner just above it — two controls in the same
+  corner, neither of them looking placed. Navigate is now a single translucent
+  pill that lets the page show through it, and while one of those lists is
+  open its create button joins Navigate on the same row as an accent-coloured
+  companion, the pair centred together. Open a page that creates nothing —
+  Daily OS, Dashboards, People, Events, Settings — and Navigate returns to the
+  centre on its own. At the largest text sizes a worded companion keeps its
+  place as a round button rather than squeezing both labels into unreadable
+  stubs.

--- a/knowledge/architecture/navigation.md
+++ b/knowledge/architecture/navigation.md
@@ -113,7 +113,7 @@ flowchart TD
   Chrome -->|desktop| DayCol["DayViewSidePanel (right-docked day view)"]
   Chrome -->|mobile| NavFlag{"enable_mobile_navigation_launcher"}
   NavFlag -->|off or unresolved| Bar["DesignSystemFiveSlotNavBar + More sheet"]
-  NavFlag -->|on| Launcher["Glass Navigate button + two-column grid"]
+  NavFlag -->|on| Launcher["Glass Navigate chip (+ docked page action) + two-column grid"]
 ```
 
 An `IndexedStack` keeps every tab **mounted**. Tabs preserve scroll position and
@@ -523,9 +523,8 @@ navigation**. Startup seeds it with `insertFlagIfNotExists`, preserving an
 existing opt-in. The flag is read only in the mobile shell; desktop keeps its
 existing sidebar and Settings sync counts.
 
-When enabled, `MobileNavigationLauncher` replaces the slot bar with a glass
-Navigate pill. Its backdrop blur and dense theme-aware scrim keep page content
-from competing with the label. `showMobileNavSheet` presents all enabled
+When enabled, `MobileNavigationLauncher` replaces the slot bar with a floating
+row of glass chips. `showMobileNavSheet` presents all enabled
 sections in a two-column grid with 16-point horizontal tile padding, the active
 section highlighted, support links on the left and sync counts on the right.
 Selection dismisses the sheet and resolves the destination index at tap time,
@@ -541,6 +540,105 @@ nonlinear text scaling. Both designs share the existing route-hiding rules.
 
 The new launcher and grid are independent of the legacy slot and More widgets.
 The app shell chooses between them; neither new widget imports the old ones.
+
+### The launcher's row, and the page action docked on it
+
+The launcher is not a bar. It is a transparent strip holding a centred row of
+chips built from the shared glass primitives in
+[`glass_action_bar.dart`](../../lib/features/design_system/components/glass_action_bar.dart)
+— the same `DsGlassPill` / `DsGlassRoundButton` vocabulary the task action bar
+uses, so every floating glass row in the app has one silhouette, one fill
+alpha, one hairline and one `spacing.step4` gap. Navigate is translucent and
+self-blurring: the `BackdropFilter` lives inside each chip's `ClipRRect` rather
+than around the row, because a filter spanning the row would also blur the
+transparent gap between the chips and smear the page the launcher exists to
+leave visible.
+
+`MobileNavigationLauncher.pageAction` is the second slot. The **shell** decides
+who fills it, from the active destination alone
+(`_AppScreenState._launcherDockAction`) — exactly the five destinations whose
+list page floats a create button:
+
+| Destination | Factory | Chip |
+|---|---|---|
+| Tasks | `tasksTabDockAction` | worded — "Add a task" |
+| Logbook | `logbookDockAction` | glyph |
+| Projects | `projectsTabDockAction` | glyph |
+| Goals | `unifiedGoalsDockAction` | glyph |
+| Habits | `habitsTabDockAction` | glyph |
+| Daily OS, Dashboards, People, Events, Settings | — | none |
+
+Nothing is registered from inside a page: the `IndexedStack` keeps every tab
+mounted, so a page-owned registry would keep its action docked on every other
+tab too.
+
+Each page decides its own wording, through the two `MobileNavDockAction`
+constructors, and it is the decision its floating button already made. The task
+list words its action because the app creates tasks, entries, habits, goals and
+projects from one glyph and the plus alone does not say which; the lists whose
+heading already answers that stay glyph-only.
+
+Docked actions resolve their page state at *tap* time, not when the shell built
+the row — `createTaskFromTaskListFilters` reads the task list's filters,
+`logbookCreateCategoryId` the feed's single-category selection — so a filter
+changed since the last shell rebuild still applies.
+
+The same predicate decides both halves of the handover:
+`mobileNavigationLauncherOwnsPageActions(context, ref)` — the flag, and a
+non-desktop window — is read by the shell to pick the launcher and by each of
+the five pages to drop its own `DesignSystemFloatingActionButton`. One rule,
+one place; the action moves onto the row rather than being duplicated above it.
+
+It decides a third thing on the two lists that reserve scroll clearance for
+their floating button on top of the bar's own height — Goals and Projects both
+add a `spacing.step12` allowance to
+`DesignSystemBottomNavigationBar.occupiedHeight`. With the action docked there
+is no floating button to clear, and that allowance is an empty gutter, so the
+same predicate drops it.
+
+Two deliberate divergences from what the floating button did:
+
+- **The Logbook keeps its docked action during the first-run zero state**,
+  where the page withholds the corner button so its inline "Create new entry"
+  CTA is the single primary action. In the corner a second copy competed; on
+  the rail the create chip is persistent chrome beside Navigate, and dropping
+  it only there would make the rail inconsistent across tabs.
+- **Projects docks unconditionally**, where the floating button waits for
+  `visibleProjectGroupsProvider`. The create modal needs nothing from that
+  query, and a chip arriving one beat late would shove Navigate sideways under
+  the user's thumb; on its own layer in the corner the same delay cost nothing.
+
+Route sensitivity is needed in one place only. Projects, Goals and Habits
+slide the whole launcher away on their detail routes (`slideNavAway`), so a
+stale action there is off screen anyway. The journal tab keeps the bar on an
+entry's page — and that page owns a *different* action, an `add linked entry`
+button with its own glyph — so `isLogbookEntryDetailRoute` drops the logbook's
+action from the rail there and lets the detail page keep floating its own.
+That check is why `navService.journalDelegate` joins `_routeChangeListenable`.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Centred
+  Centred --> Worded: Tasks becomes active
+  Centred --> Glyph: Logbook, Projects, Goals or Habits becomes active
+  Worded --> Centred: a destination with no create action becomes active
+  Glyph --> Centred: a destination with no create action becomes active
+  Worded --> Glyph: both labels no longer fit the row
+  Glyph --> Worded: labels fit again, on a worded action
+  Centred: Navigate alone, centred
+  Worded: Navigate + accent-filled labelled pill, pair centred
+  Glyph: Navigate + accent round button, pair centred
+```
+
+`labelsFit` measures both labels with a `TextPainter` at the current scaler
+against `availableRowWidth`, exactly as the slot bar budgets its slots. It is
+consulted only for a `MobileNavDockAction.worded` action; a `.glyph` one is
+round at every width. Below the threshold a worded action drops to
+`DsGlassRoundButton` at the same diameter as the row's chip height — it keeps
+its place, its accent and its accessible name, and only its word goes. The
+row's height is `chipHeight` in every case, so `barHeight` — and every
+clearance derived from it — does not move when an action docks, undocks or
+collapses.
 
 ## The Settings row and its counts
 

--- a/knowledge/features/design_system/component-contracts.md
+++ b/knowledge/features/design_system/component-contracts.md
@@ -559,6 +559,29 @@ The contract:
   contract. It **scales caption line height with `MediaQuery.textScalerOf` and
   rounds fractional line boxes up to the logical pixel Flutter renders**, so
   accessibility scales such as 1.3× cannot overflow the fixed row.
+- `MobileNavigationLauncher.barHeight(context)` owns launcher clearance, and is
+  `chipHeight` plus one `spacing.step2` and the bottom inset (never less than
+  `spacing.step6`). `chipHeight` measures the localized Navigate label at the
+  current text scaler inside symmetric `spacing.step4` padding and never falls
+  below `TapTargets.minimum`. **Docking a page action does not change it** —
+  both chips share that one height, and so does the round button the action
+  collapses to — so a page's clearance never moves as it gains or loses its
+  action. The chips are `DsGlassPill` / `DsGlassRoundButton`
+  ([glass_action_bar.dart](../../../lib/features/design_system/components/glass_action_bar.dart)):
+  no launcher-local fill, radius or alpha exists. Each translucent chip owns
+  its own `BackdropFilter` inside its clip, never the row, so the transparent
+  gap between chips stays unblurred.
+- `MobileNavigationLauncher.labelsFit(context, action)` decides between the
+  two-label row and the glyph-only companion, budgeting `DsGlassPill.intrinsicWidth`
+  against `availableRowWidth` the way the slot bar budgets slots. The pill
+  measures itself — padding, glyph, gap and label at the current text scale —
+  because a caller that restated that arithmetic would drift silently the day
+  the pill's own padding changed. The page
+  action is the half that gives: Navigate names the shell and has no icon-only
+  reading, while a `+` beside a list still reads as "add". It is consulted
+  only for a `MobileNavDockAction.worded` action — the two constructors carry
+  the page's own decision about wording, the same one its floating button
+  made, and a `.glyph` action is a `DsGlassRoundButton` at every width.
 
 # Accessibility is enforced at construction
 

--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -9,12 +9,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_builder_validators/localization/l10n.dart';
 import 'package:lotti/beamer/locations/goals_location.dart';
 import 'package:lotti/beamer/locations/habits_location.dart';
+import 'package:lotti/beamer/locations/journal_location.dart';
 import 'package:lotti/beamer/locations/projects_location.dart';
 import 'package:lotti/beamer/locations/relationships_location.dart';
 import 'package:lotti/beamer/locations/settings_location.dart';
 import 'package:lotti/beamer/locations/tasks_location.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/ai_consumption/ui/widgets/impact_sidebar_entry.dart';
 import 'package:lotti/features/daily_os_next/state/daily_os_onboarding_session_controller.dart';
@@ -33,6 +33,9 @@ import 'package:lotti/features/design_system/state/pane_width_controller.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/goals/state/goal_agent_providers.dart';
+import 'package:lotti/features/goals/ui/pages/unified_goals_page.dart';
+import 'package:lotti/features/habits/ui/habits_page.dart';
+import 'package:lotti/features/journal/ui/pages/infinite_journal_page.dart';
 import 'package:lotti/features/keyboard/domain/app_command.dart';
 import 'package:lotti/features/keyboard/domain/app_command_handler.dart';
 import 'package:lotti/features/keyboard/ui/app_command_host.dart';
@@ -49,6 +52,7 @@ import 'package:lotti/features/nudges/ui/nudge_banner_dock.dart';
 import 'package:lotti/features/onboarding/state/onboarding_trigger_service.dart';
 import 'package:lotti/features/onboarding/ui/onboarding_welcome_modal.dart';
 import 'package:lotti/features/profiles/service/profile_switch_chrome.dart';
+import 'package:lotti/features/projects/ui/pages/projects_tab_page.dart';
 import 'package:lotti/features/settings/state/manual_language_controller.dart';
 import 'package:lotti/features/settings/state/zoom_controller.dart';
 import 'package:lotti/features/settings/ui/pages/outbox/outbox_badge.dart';
@@ -59,6 +63,7 @@ import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_indic
 import 'package:lotti/features/sync/state/matrix_login_controller.dart';
 import 'package:lotti/features/sync/state/synced_audio_inference_providers.dart';
 import 'package:lotti/features/sync/ui/widgets/matrix/incoming_verification_modal.dart';
+import 'package:lotti/features/tasks/ui/pages/tasks_tab_page.dart';
 import 'package:lotti/features/tasks/ui/saved_filters/desktop/sidebar_saved_task_filters.dart';
 import 'package:lotti/features/theming/state/theming_controller.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
@@ -73,7 +78,6 @@ import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/themes/legacy_material_bridge.dart';
-import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/uuid.dart';
 import 'package:lotti/widgets/misc/contact_support_row.dart';
 import 'package:lotti/widgets/misc/desktop_menu.dart';
@@ -115,6 +119,18 @@ bool isTaskDetailRoute(BeamLocation<dynamic>? location, int activeTabIndex) {
   if (activeTabIndex != 0) return false;
   if (location is! TasksLocation) return false;
   return isUuid(location.state.pathParameters['taskId']);
+}
+
+/// Whether the journal tab is showing one entry's detail page rather than
+/// the logbook feed.
+///
+/// The logbook's create action docks on the mobile navigation launcher; an
+/// entry's own page creates a *linked* entry instead — a different action
+/// with a different glyph — and keeps floating its own button, so the
+/// logbook's must not stay on the rail underneath it.
+bool isLogbookEntryDetailRoute(BeamLocation<dynamic>? location) {
+  if (location is! JournalLocation) return false;
+  return isUuid(location.state.pathParameters['entryId']);
 }
 
 /// Layout allowance for the docked day-view column on the desktop shell:
@@ -475,6 +491,10 @@ class _AppScreenState extends ConsumerState<AppScreen> {
     navService.goalsDelegate,
     navService.habitsDelegate,
     navService.relationshipsDelegate,
+    // Not for hiding the bar — the journal tab keeps it on an entry's page —
+    // but so the launcher drops the logbook's docked create action there.
+    // See [isLogbookEntryDetailRoute].
+    navService.journalDelegate,
   ]);
 
   /// Identity for the tab content across the desktop/mobile breakpoint.
@@ -1143,13 +1163,7 @@ class _AppScreenState extends ConsumerState<AppScreen> {
               navService.relationshipsDelegate.currentBeamLocation,
             ));
 
-    final useLauncher =
-        ref
-            .watch(
-              configFlagProvider(enableMobileNavigationLauncherFlag),
-            )
-            .value ??
-        false;
+    final useLauncher = mobileNavigationLauncherOwnsPageActions(context, ref);
     final navigationBarHeight = useLauncher
         ? MobileNavigationLauncher.barHeight(context)
         : DesignSystemFiveSlotNavBar.barHeight(context);
@@ -1169,6 +1183,7 @@ class _AppScreenState extends ConsumerState<AppScreen> {
     Widget buildBottomNavigationBar() {
       if (useLauncher) {
         return MobileNavigationLauncher(
+          pageAction: _launcherDockAction(context, destinations[index].kind),
           onNavigate: () => showMobileNavSheet(
             context: context,
             footerTrailing: const SyncQueueCounts(),
@@ -1371,6 +1386,47 @@ class _AppScreenState extends ConsumerState<AppScreen> {
       ),
     );
   }
+
+  /// The active page's primary action, docked on the mobile navigation
+  /// launcher's row instead of floating in the page's own corner.
+  ///
+  /// Exactly the destinations whose list page floats a create button today:
+  /// leaving it in the corner would stack two floating controls above the
+  /// centred launcher, neither of them looking placed. Daily OS, Dashboards,
+  /// People, Events and Settings float nothing, so they leave the launcher
+  /// centred alone — which is what makes a docked action read as belonging
+  /// to the page rather than to the shell.
+  ///
+  /// The page decides the chip's wording, not this switch: the task list
+  /// words its action, the lists whose own heading says what gets added keep
+  /// the bare glyph (see [MobileNavDockAction]).
+  ///
+  /// Route-sensitive only where a tab's detail page keeps the bar *and* owns
+  /// a different action: an entry's own page creates a linked entry, so the
+  /// logbook's action leaves the rail there. The projects, goals and habits
+  /// tabs slide the whole launcher away on their detail routes, so their
+  /// actions need no such check.
+  MobileNavDockAction? _launcherDockAction(
+    BuildContext context,
+    _AppNavigationDestinationKind kind,
+  ) => switch (kind) {
+    _AppNavigationDestinationKind.tasks => tasksTabDockAction(context, ref),
+    _AppNavigationDestinationKind.journal =>
+      isLogbookEntryDetailRoute(navService.journalDelegate.currentBeamLocation)
+          ? null
+          : logbookDockAction(context, ref),
+    _AppNavigationDestinationKind.goals => unifiedGoalsDockAction(context, ref),
+    _AppNavigationDestinationKind.habits => habitsTabDockAction(context, ref),
+    _AppNavigationDestinationKind.projects => projectsTabDockAction(
+      context,
+      ref,
+    ),
+    _AppNavigationDestinationKind.dailyOs ||
+    _AppNavigationDestinationKind.dashboards ||
+    _AppNavigationDestinationKind.people ||
+    _AppNavigationDestinationKind.events ||
+    _AppNavigationDestinationKind.settings => null,
+  };
 
   /// The banner surface a destination maps onto, or null where no dock
   /// mounts — Settings and the Logbook are deliberately excluded, and goal

--- a/lib/features/design_system/components/glass_action_bar.dart
+++ b/lib/features/design_system/components/glass_action_bar.dart
@@ -192,6 +192,38 @@ class DsGlassPill extends StatelessWidget {
   /// a pill and round buttons line up on the same action row.
   static const double defaultHeight = DsGlassRoundButton.defaultDiameter;
 
+  /// Width this pill takes when it hugs its content: the horizontal padding,
+  /// the glyph and its gap when [hasIcon], and [label] laid out at the
+  /// caller's text scale.
+  ///
+  /// Exposed because a caller that budgets a row of pills against a width —
+  /// the mobile navigation launcher deciding whether two labelled chips fit
+  /// beside each other — otherwise has to restate the padding and gap that
+  /// live in [build], and drifts silently the day either changes.
+  static double intrinsicWidth(
+    BuildContext context, {
+    required String label,
+    bool hasIcon = true,
+    double iconSize = DsGlassRoundButton.defaultIconSize,
+  }) {
+    final tokens = context.designTokens;
+    final painter = TextPainter(
+      text: TextSpan(
+        text: label,
+        style: tokens.typography.styles.subtitle.subtitle2,
+      ),
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+      locale: Localizations.maybeLocaleOf(context),
+      maxLines: 1,
+    )..layout();
+    final labelWidth = painter.width;
+    painter.dispose();
+    return tokens.spacing.step5 * 2 +
+        (hasIcon ? iconSize + tokens.spacing.step2 : 0) +
+        labelWidth;
+  }
+
   final String label;
   final VoidCallback onTap;
   final IconData? icon;

--- a/lib/features/goals/ui/pages/unified_goals_page.dart
+++ b/lib/features/goals/ui/pages/unified_goals_page.dart
@@ -32,6 +32,7 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/utils/date_utils_extension.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
+import 'package:lotti/widgets/nav_bar/mobile_navigation_launcher.dart';
 import 'package:material_ui/material_ui.dart';
 
 /// The unified Goals tab (flag: `enable_unified_goals`; design handover
@@ -267,14 +268,26 @@ class _UnifiedGoalsPageState extends ConsumerState<UnifiedGoalsPage>
       );
     }
 
+    // While the mobile navigation launcher carries this page's create action
+    // on its own row (see [unifiedGoalsDockAction]) the page floats no button
+    // of its own — a copy above the launcher would put two create affordances
+    // in the same corner — and the list stops reserving that button's
+    // footprint at the bottom of its scroll.
+    final launcherOwnsCreateAction = mobileNavigationLauncherOwnsPageActions(
+      context,
+      ref,
+    );
+
     return Scaffold(
       backgroundColor: dsPageSurface(context),
-      floatingActionButton: DesignSystemBottomNavigationFabPadding(
-        child: DesignSystemFloatingActionButton(
-          semanticLabel: messages.agentsCreateGoal,
-          onPressed: () => beamToNamed(goalCreatePath),
-        ),
-      ),
+      floatingActionButton: launcherOwnsCreateAction
+          ? null
+          : DesignSystemBottomNavigationFabPadding(
+              child: DesignSystemFloatingActionButton(
+                semanticLabel: messages.agentsCreateGoal,
+                onPressed: createGoalFromGoalsList,
+              ),
+            ),
       body: SafeArea(
         // Centered against the ACTUAL pane, not the window: in desktop layout
         // this page renders beside the navigation sidebar, and window-width
@@ -296,7 +309,9 @@ class _UnifiedGoalsPageState extends ConsumerState<UnifiedGoalsPage>
                         DesignSystemBottomNavigationBar.occupiedHeight(
                           context,
                         ) +
-                        tokens.spacing.step12,
+                        // The floating button's own footprint — nothing to
+                        // clear once the launcher owns the action.
+                        (launcherOwnsCreateAction ? 0 : tokens.spacing.step12),
                   ),
                   sliver: SliverList(
                     delegate: SliverChildListDelegate([
@@ -418,7 +433,7 @@ class _NoGoalsYet extends StatelessWidget {
             label: context.messages.agentsCreateGoal,
             leadingIcon: LottiIcons.add,
             variant: DesignSystemButtonVariant.secondary,
-            onPressed: () => beamToNamed(goalCreatePath),
+            onPressed: createGoalFromGoalsList,
           ),
         ],
       ),
@@ -515,3 +530,22 @@ class _GoalsHeader extends StatelessWidget {
     );
   }
 }
+
+/// Opens the goal creation route. The one entry point every create
+/// affordance on this page goes through — the floating button, the empty
+/// state's inline call to action, and the mobile navigation launcher's
+/// docked action — so none of them can drift from the others.
+void createGoalFromGoalsList() => beamToNamed(goalCreatePath);
+
+/// The goals list's create action as the mobile navigation launcher shows it.
+///
+/// Glyph-only, like the floating button it replaces: this page is titled
+/// Goals and lists goals, so the plus needs no word to say what it makes.
+MobileNavDockAction unifiedGoalsDockAction(
+  BuildContext context,
+  WidgetRef ref,
+) => MobileNavDockAction.glyph(
+  label: context.messages.agentsCreateGoal,
+  icon: LottiIcons.add,
+  onPressed: createGoalFromGoalsList,
+);

--- a/lib/features/habits/ui/habits_page.dart
+++ b/lib/features/habits/ui/habits_page.dart
@@ -25,6 +25,7 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/logic/signals/health_signal_refresh_service.dart';
 import 'package:lotti/logic/signals/signal_needs.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
+import 'package:lotti/widgets/nav_bar/mobile_navigation_launcher.dart';
 import 'package:material_ui/material_ui.dart';
 
 /// Top-level habits tab: a dashboard on the calm [dsPageSurface] canvas, driven
@@ -299,13 +300,20 @@ class _HabitsTabPageState extends ConsumerState<HabitsTabPage> {
         ),
       },
       child: Scaffold(
-        floatingActionButton: DesignSystemBottomNavigationFabPadding(
-          child: DesignSystemFloatingActionButton(
-            key: const ValueKey('habits-create-fab'),
-            semanticLabel: messages.habitEditorCreateTitle,
-            onPressed: () => openHabitEditor(context),
-          ),
-        ),
+        // Null while the mobile navigation launcher carries this page's
+        // create action on its own row (see [habitsTabDockAction]); a
+        // floating copy above it would put two create affordances in the
+        // same corner.
+        floatingActionButton:
+            mobileNavigationLauncherOwnsPageActions(context, ref)
+            ? null
+            : DesignSystemBottomNavigationFabPadding(
+                child: DesignSystemFloatingActionButton(
+                  key: const ValueKey('habits-create-fab'),
+                  semanticLabel: messages.habitEditorCreateTitle,
+                  onPressed: () => openHabitEditor(context),
+                ),
+              ),
         backgroundColor: dsPageSurface(context),
         body: SafeArea(
           // The navigation bar's occupied height already includes the system
@@ -473,3 +481,15 @@ class _CollapsibleRowState extends State<_CollapsibleRow>
     );
   }
 }
+
+/// The habits list's create action as the mobile navigation launcher shows
+/// it.
+///
+/// Glyph-only, like the floating button it replaces: this page is titled
+/// Habits and lists habits, so the plus needs no word to say what it makes.
+MobileNavDockAction habitsTabDockAction(BuildContext context, WidgetRef ref) =>
+    MobileNavDockAction.glyph(
+      label: context.messages.habitEditorCreateTitle,
+      icon: LottiIcons.add,
+      onPressed: () => openHabitEditor(context),
+    );

--- a/lib/features/journal/ui/pages/infinite_journal_page.dart
+++ b/lib/features/journal/ui/pages/infinite_journal_page.dart
@@ -25,6 +25,7 @@ import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/logic/create/create_entry.dart';
+import 'package:lotti/widgets/nav_bar/mobile_navigation_launcher.dart';
 import 'package:material_ui/material_ui.dart';
 
 /// The infinitely-scrolling journal feed (the non-tasks list, `showTasks ==
@@ -78,10 +79,21 @@ class InfiniteJournalPage extends ConsumerWidget {
           // Time Analysis): a calm page canvas a step darker than the cards,
           // instead of the near-black default scaffold.
           backgroundColor: dsPageSurface(context),
+          // Null while the mobile navigation launcher carries this page's
+          // create action on its own row (see [logbookDockAction]); a
+          // floating copy above it would put two create affordances in the
+          // same corner.
+          //
           // During the first-run zero-state the inline "Create new entry" CTA
           // is the single primary action — a second, identical affordance
-          // floating in the corner would just compete with it.
-          floatingActionButton: state.pagingController == null
+          // floating in the corner would just compete with it. That applies
+          // to the corner only: on the launcher's row the create chip is
+          // persistent chrome beside Navigate, the same as on every other
+          // tab, so the shell keeps docking it there.
+          floatingActionButton:
+              mobileNavigationLauncherOwnsPageActions(context, ref)
+              ? null
+              : state.pagingController == null
               ? FloatingAddActionButton(categoryId: categoryId)
               : ValueListenableBuilder<PagingState<int, JournalEntity>>(
                   valueListenable: state.pagingController!,
@@ -328,4 +340,35 @@ class _InfiniteJournalPageBodyState
       ),
     );
   }
+}
+
+/// The logbook's create action as the mobile navigation launcher shows it.
+///
+/// Glyph-only, like the floating button it replaces: the logbook's own
+/// heading says what gets added, and the modal it opens names every entry
+/// kind it can make.
+///
+/// The category the list is filtered to rides along, exactly as it does from
+/// the page's own button, so an entry created from a single-category feed
+/// lands in that category. Resolved at tap time, not when the shell built
+/// the row: the filter can change under a launcher the shell has not
+/// rebuilt.
+MobileNavDockAction logbookDockAction(BuildContext context, WidgetRef ref) =>
+    MobileNavDockAction.glyph(
+      label: context.messages.createEntryLabel,
+      icon: LottiIcons.add,
+      onPressed: () => CreateEntryModal.show(
+        context: context,
+        linkedFromId: null,
+        categoryId: logbookCreateCategoryId(ref),
+      ),
+    );
+
+/// The category a logbook create inherits: the one the feed is filtered to,
+/// or null whenever the feed spans none or several.
+String? logbookCreateCategoryId(WidgetRef ref) {
+  final selected = ref
+      .read(journalPageControllerProvider(false))
+      .selectedCategoryIds;
+  return selected.length == 1 ? selected.first : null;
 }

--- a/lib/features/projects/ui/pages/projects_tab_page.dart
+++ b/lib/features/projects/ui/pages/projects_tab_page.dart
@@ -30,6 +30,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
+import 'package:lotti/widgets/nav_bar/mobile_navigation_launcher.dart';
 import 'package:material_ui/material_ui.dart';
 
 /// Top-level Projects tab.
@@ -247,13 +248,23 @@ class _ProjectsListScaffold extends ConsumerWidget {
               currentProjectStatusFilterIds,
             )) ||
         filter.sortMode != ProjectsSortMode.actionable;
+    // While the mobile navigation launcher carries this page's create action
+    // on its own row (see [projectsTabDockAction]) the page floats no button
+    // of its own — a copy above the launcher would put two create affordances
+    // in the same corner.
+    final launcherOwnsCreateAction = mobileNavigationLauncherOwnsPageActions(
+      context,
+      ref,
+    );
     // Reserve room so the floating create button never lands on top of the
     // last project card. The FAB is lifted above the bottom nav by
     // `occupiedHeight`, so the scroll content must clear that plus the FAB's
     // own footprint (step12) — same clearance the AI settings list uses.
+    // With the action docked on the launcher there is no floating button to
+    // clear, and that allowance would be an empty gutter.
     final listBottomPadding =
         DesignSystemBottomNavigationBar.occupiedHeight(context) +
-        tokens.spacing.step12;
+        (launcherOwnsCreateAction ? 0 : tokens.spacing.step12);
     final categories = overview == null
         ? const <CategoryDefinition>[]
         : _filterCategoriesFromOverview(overview.groups);
@@ -266,7 +277,8 @@ class _ProjectsListScaffold extends ConsumerWidget {
         ) &&
         filter.selectedCategoryIds.isEmpty &&
         filter.textQuery.trim().isEmpty;
-    final floatingActionButton = visibleGroupsAsync.value == null
+    final floatingActionButton =
+        visibleGroupsAsync.value == null || launcherOwnsCreateAction
         ? null
         : DesignSystemFloatingActionButton(
             semanticLabel: context.messages.projectCreateButton,
@@ -544,3 +556,24 @@ List<CategoryDefinition> _filterCategoriesFromOverview(
       .whereType<CategoryDefinition>()
       .toList(growable: false);
 }
+
+/// The projects list's create action as the mobile navigation launcher shows
+/// it.
+///
+/// Glyph-only, like the floating button it replaces: this page is titled
+/// Projects and lists projects, so the plus needs no word to say what it
+/// makes.
+///
+/// Unconditional, where the floating button waits for the overview to load:
+/// the modal needs nothing from that query, and a chip appearing on the
+/// launcher's row one beat after the page would shift Navigate sideways
+/// under the user's thumb. On its own layer in the corner the same delay
+/// cost nothing.
+MobileNavDockAction projectsTabDockAction(
+  BuildContext context,
+  WidgetRef ref,
+) => MobileNavDockAction.glyph(
+  label: context.messages.projectCreateButton,
+  icon: LottiIcons.add,
+  onPressed: () => showProjectCreateModal(context: context),
+);

--- a/lib/features/tasks/ui/pages/tasks_tab_page.dart
+++ b/lib/features/tasks/ui/pages/tasks_tab_page.dart
@@ -50,6 +50,7 @@ import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/utils/color.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
+import 'package:lotti/widgets/nav_bar/mobile_navigation_launcher.dart';
 import 'package:material_ui/material_ui.dart';
 
 /// Signature for the create-task action invoked by the [TasksTabPage] FAB.
@@ -211,6 +212,13 @@ class _TasksTabPageState extends ConsumerState<TasksTabPage> {
   Widget build(BuildContext context) {
     final state = ref.watch(journalPageControllerProvider(true));
     final filterContext = TaskCreationFilterContext.fromPageState(state);
+    // The mobile navigation launcher docks this page's create action on its
+    // own row (see [tasksTabDockAction]); floating a second copy of it above
+    // the launcher would stack two labelled pills in the same corner.
+    final launcherOwnsCreateAction = mobileNavigationLauncherOwnsPageActions(
+      context,
+      ref,
+    );
     final floatingActionButton = DesignSystemFloatingActionButton(
       semanticLabel: context.messages.addActionCreateTask,
       // Worded, not a bare `+`: this pane creates tasks while the app's other
@@ -262,9 +270,11 @@ class _TasksTabPageState extends ConsumerState<TasksTabPage> {
           floatingActionButtonLocation: _ActionBarAlignedFabLocation(
             bottomMargin: context.designTokens.spacing.step4,
           ),
-          floatingActionButton: DesignSystemBottomNavigationFabPadding(
-            child: floatingActionButton,
-          ),
+          floatingActionButton: launcherOwnsCreateAction
+              ? null
+              : DesignSystemBottomNavigationFabPadding(
+                  child: floatingActionButton,
+                ),
           body: _TasksTabPageBody(
             searchFocusNode: _searchFocusNode,
             collapseController: _collapseController,
@@ -1072,6 +1082,36 @@ Future<void> _defaultCreateTaskPressed(
   await autoAssignCategoryAgentWith(agentService, task);
   getIt<NavService>().beamToNamed('/tasks/${task.meta.id}');
 }
+
+/// Creates a task from the task list's *current* filters and opens it.
+///
+/// The launcher's docked action resolves the filter context at tap time
+/// rather than capturing it when the row was built: the row lives in the app
+/// shell, outside this page, and a filter changed since the last shell
+/// rebuild would otherwise create a task under the previous selection.
+Future<void> createTaskFromTaskListFilters(WidgetRef ref) {
+  return _defaultCreateTaskPressed(
+    ref,
+    TaskCreationFilterContext.fromPageState(
+      ref.read(journalPageControllerProvider(true)),
+    ),
+  );
+}
+
+/// The task list's create action as the mobile navigation launcher shows it.
+///
+/// The launcher docks it beside Navigate while the Tasks tab is on screen,
+/// which is why this page drops its own floating button there — the action
+/// does not disappear, it moves onto the launcher's row. It keeps the FAB's
+/// wording for the same reason the FAB has one: the app creates entries,
+/// habits and goals from the same glyph elsewhere, so a bare plus would not
+/// say what this one makes.
+MobileNavDockAction tasksTabDockAction(BuildContext context, WidgetRef ref) =>
+    MobileNavDockAction.worded(
+      label: context.messages.addActionCreateTask,
+      icon: LottiIcons.add,
+      onPressed: () => unawaited(createTaskFromTaskListFilters(ref)),
+    );
 
 /// End-aligned floating location that sits [bottomMargin] above the content
 /// edge instead of the framework's fixed [kFloatingActionButtonMargin].

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5766,6 +5766,18 @@ abstract class AppLocalizations {
   /// **'Enable the Matrix integration to sync your entries across devices and with other Matrix users.'**
   String get configFlagEnableMatrixDescription;
 
+  /// No description provided for @configFlagEnableMobileNavigationLauncher.
+  ///
+  /// In en, this message translates to:
+  /// **'New mobile navigation'**
+  String get configFlagEnableMobileNavigationLauncher;
+
+  /// No description provided for @configFlagEnableMobileNavigationLauncherDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Use one Navigate button to open all app sections.'**
+  String get configFlagEnableMobileNavigationLauncherDescription;
+
   /// No description provided for @configFlagEnableNotifications.
   ///
   /// In en, this message translates to:
@@ -16093,6 +16105,12 @@ abstract class AppLocalizations {
   /// **'More'**
   String get navTabTitleMore;
 
+  /// No description provided for @navTabTitleNavigate.
+  ///
+  /// In en, this message translates to:
+  /// **'Navigate'**
+  String get navTabTitleNavigate;
+
   /// No description provided for @navTabTitlePeople.
   ///
   /// In en, this message translates to:
@@ -24778,24 +24796,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Skip'**
   String get whatsNewSkipButton;
-
-  /// No description provided for @navTabTitleNavigate.
-  ///
-  /// In en, this message translates to:
-  /// **'Navigate'**
-  String get navTabTitleNavigate;
-
-  /// No description provided for @configFlagEnableMobileNavigationLauncher.
-  ///
-  /// In en, this message translates to:
-  /// **'New mobile navigation'**
-  String get configFlagEnableMobileNavigationLauncher;
-
-  /// No description provided for @configFlagEnableMobileNavigationLauncherDescription.
-  ///
-  /// In en, this message translates to:
-  /// **'Use one Navigate button to open all app sections.'**
-  String get configFlagEnableMobileNavigationLauncherDescription;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3433,6 +3433,14 @@ class AppLocalizationsCs extends AppLocalizations {
       'Povolit integraci s Matrix pro synchronizaci vašich záznamů mezi zařízeními a s ostatními uživateli Matrix.';
 
   @override
+  String get configFlagEnableMobileNavigationLauncher =>
+      'Nová mobilní navigace';
+
+  @override
+  String get configFlagEnableMobileNavigationLauncherDescription =>
+      'Otevírej všechny části aplikace jedním tlačítkem Navigace.';
+
+  @override
   String get configFlagEnableNotifications => 'Povolit oznámení?';
 
   @override
@@ -9602,6 +9610,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get navTabTitleMore => 'Více';
 
   @override
+  String get navTabTitleNavigate => 'Navigovat';
+
+  @override
   String get navTabTitlePeople => 'Lidé';
 
   @override
@@ -15057,15 +15068,4 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Přeskočit';
-
-  @override
-  String get navTabTitleNavigate => 'Navigovat';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncher =>
-      'Nová mobilní navigace';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncherDescription =>
-      'Otevírej všechny části aplikace jedním tlačítkem Navigace.';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3391,6 +3391,13 @@ class AppLocalizationsDa extends AppLocalizations {
       'Aktivér Matrix-integrationen for at synkronisere dine poster på tværs af enheder og med andre Matrix-brugere.';
 
   @override
+  String get configFlagEnableMobileNavigationLauncher => 'Ny mobilnavigation';
+
+  @override
+  String get configFlagEnableMobileNavigationLauncherDescription =>
+      'Åbn alle appens sektioner med én navigationsknap.';
+
+  @override
   String get configFlagEnableNotifications => 'Aktivere notifikationer?';
 
   @override
@@ -9479,6 +9486,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get navTabTitleMore => 'Mere';
 
   @override
+  String get navTabTitleNavigate => 'Naviger';
+
+  @override
   String get navTabTitlePeople => 'Personer';
 
   @override
@@ -14860,14 +14870,4 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Spring over';
-
-  @override
-  String get navTabTitleNavigate => 'Naviger';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncher => 'Ny mobilnavigation';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncherDescription =>
-      'Åbn alle appens sektioner med én navigationsknap.';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3417,6 +3417,14 @@ class AppLocalizationsDe extends AppLocalizations {
       'Aktiviert die Matrix-Integration, um deine Einträge geräteübergreifend und mit anderen Matrix-Benutzern zu synchronisieren.';
 
   @override
+  String get configFlagEnableMobileNavigationLauncher =>
+      'Neue mobile Navigation';
+
+  @override
+  String get configFlagEnableMobileNavigationLauncherDescription =>
+      'Öffne alle App-Bereiche über eine einzige Navigationsschaltfläche.';
+
+  @override
   String get configFlagEnableNotifications => 'Benachrichtigungen aktivieren?';
 
   @override
@@ -9542,6 +9550,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get navTabTitleMore => 'Mehr';
 
   @override
+  String get navTabTitleNavigate => 'Navigieren';
+
+  @override
   String get navTabTitlePeople => 'Menschen';
 
   @override
@@ -14965,15 +14976,4 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Überspringen';
-
-  @override
-  String get navTabTitleNavigate => 'Navigieren';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncher =>
-      'Neue mobile Navigation';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncherDescription =>
-      'Öffne alle App-Bereiche über eine einzige Navigationsschaltfläche.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3375,6 +3375,14 @@ class AppLocalizationsEn extends AppLocalizations {
       'Enable the Matrix integration to sync your entries across devices and with other Matrix users.';
 
   @override
+  String get configFlagEnableMobileNavigationLauncher =>
+      'New mobile navigation';
+
+  @override
+  String get configFlagEnableMobileNavigationLauncherDescription =>
+      'Use one Navigate button to open all app sections.';
+
+  @override
   String get configFlagEnableNotifications => 'Enable notifications?';
 
   @override
@@ -9439,6 +9447,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get navTabTitleMore => 'More';
 
   @override
+  String get navTabTitleNavigate => 'Navigate';
+
+  @override
   String get navTabTitlePeople => 'People';
 
   @override
@@ -14772,17 +14783,6 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Skip';
-
-  @override
-  String get navTabTitleNavigate => 'Navigate';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncher =>
-      'New mobile navigation';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncherDescription =>
-      'Use one Navigate button to open all app sections.';
 }
 
 /// The translations for English, as used in the United Kingdom (`en_GB`).

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3435,6 +3435,14 @@ class AppLocalizationsEs extends AppLocalizations {
       'Habilitar la integración de Matrix para sincronizar tus entradas entre dispositivos y con otros usuarios de Matrix.';
 
   @override
+  String get configFlagEnableMobileNavigationLauncher =>
+      'Nueva navegación móvil';
+
+  @override
+  String get configFlagEnableMobileNavigationLauncherDescription =>
+      'Abre todas las secciones de la app con un único botón de navegación.';
+
+  @override
   String get configFlagEnableNotifications => '¿Habilitar notificaciones?';
 
   @override
@@ -9625,6 +9633,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get navTabTitleMore => 'Más';
 
   @override
+  String get navTabTitleNavigate => 'Navegar';
+
+  @override
   String get navTabTitlePeople => 'Personas';
 
   @override
@@ -15066,15 +15077,4 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Omitir';
-
-  @override
-  String get navTabTitleNavigate => 'Navegar';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncher =>
-      'Nueva navegación móvil';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncherDescription =>
-      'Abre todas las secciones de la app con un único botón de navegación.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3440,6 +3440,14 @@ class AppLocalizationsFr extends AppLocalizations {
       'Activer l\'intégration Matrix pour synchroniser tes entrées sur plusieurs appareils et avec d\'autres utilisateurs Matrix.';
 
   @override
+  String get configFlagEnableMobileNavigationLauncher =>
+      'Nouvelle navigation mobile';
+
+  @override
+  String get configFlagEnableMobileNavigationLauncherDescription =>
+      'Ouvre toutes les sections de l’app avec un seul bouton de navigation.';
+
+  @override
   String get configFlagEnableNotifications => 'Activer les notifications ?';
 
   @override
@@ -9650,6 +9658,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get navTabTitleMore => 'Plus';
 
   @override
+  String get navTabTitleNavigate => 'Naviguer';
+
+  @override
   String get navTabTitlePeople => 'Proches';
 
   @override
@@ -15111,15 +15122,4 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Ignorer';
-
-  @override
-  String get navTabTitleNavigate => 'Naviguer';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncher =>
-      'Nouvelle navigation mobile';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncherDescription =>
-      'Ouvre toutes les sections de l’app avec un seul bouton de navigation.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3433,6 +3433,14 @@ class AppLocalizationsIt extends AppLocalizations {
       'Abilitare l\'integrazione Matrix per sincronizzare le voci tra i dispositivi e con altri utenti Matrix.';
 
   @override
+  String get configFlagEnableMobileNavigationLauncher =>
+      'Nuova navigazione mobile';
+
+  @override
+  String get configFlagEnableMobileNavigationLauncherDescription =>
+      'Apri tutte le sezioni dell’app con un unico pulsante di navigazione.';
+
+  @override
   String get configFlagEnableNotifications => 'Attivare le notifiche?';
 
   @override
@@ -9605,6 +9613,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get navTabTitleMore => 'Altro';
 
   @override
+  String get navTabTitleNavigate => 'Naviga';
+
+  @override
   String get navTabTitlePeople => 'Persone';
 
   @override
@@ -15053,15 +15064,4 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Salta!';
-
-  @override
-  String get navTabTitleNavigate => 'Naviga';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncher =>
-      'Nuova navigazione mobile';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncherDescription =>
-      'Apri tutte le sezioni dell’app con un unico pulsante di navigazione.';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3402,6 +3402,14 @@ class AppLocalizationsNl extends AppLocalizations {
       'Schakel de integratie van Matrix in om uw items te synchroniseren tussen apparaten en met andere Matrix-gebruikers.';
 
   @override
+  String get configFlagEnableMobileNavigationLauncher =>
+      'Nieuwe mobiele navigatie';
+
+  @override
+  String get configFlagEnableMobileNavigationLauncherDescription =>
+      'Open alle onderdelen van de app met één navigatieknop.';
+
+  @override
   String get configFlagEnableNotifications =>
       'Notificatieberichten inschakelen?';
 
@@ -9498,6 +9506,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get navTabTitleMore => 'Meer';
 
   @override
+  String get navTabTitleNavigate => 'Navigeren';
+
+  @override
   String get navTabTitlePeople => 'Mensen';
 
   @override
@@ -14899,15 +14910,4 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Overslaan';
-
-  @override
-  String get navTabTitleNavigate => 'Navigeren';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncher =>
-      'Nieuwe mobiele navigatie';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncherDescription =>
-      'Open alle onderdelen van de app met één navigatieknop.';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3423,6 +3423,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Habilite a integração do Matrix para sincronizar suas entradas entre dispositivos e com outros usuários do Matrix.';
 
   @override
+  String get configFlagEnableMobileNavigationLauncher => 'Nova navegação móvel';
+
+  @override
+  String get configFlagEnableMobileNavigationLauncherDescription =>
+      'Abre todas as secções da app com um único botão de navegação.';
+
+  @override
   String get configFlagEnableNotifications => 'Ativar notificações?';
 
   @override
@@ -9572,6 +9579,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get navTabTitleMore => 'Mais';
 
   @override
+  String get navTabTitleNavigate => 'Navegar';
+
+  @override
   String get navTabTitlePeople => 'Pessoas';
 
   @override
@@ -14997,14 +15007,4 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Pular';
-
-  @override
-  String get navTabTitleNavigate => 'Navegar';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncher => 'Nova navegação móvel';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncherDescription =>
-      'Abre todas as secções da app com um único botão de navegação.';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3447,6 +3447,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Activați integrarea Matrix pentru a sincroniza intrările dvs. între dispozitive și cu alți utilizatori Matrix.';
 
   @override
+  String get configFlagEnableMobileNavigationLauncher => 'Navigare mobilă nouă';
+
+  @override
+  String get configFlagEnableMobileNavigationLauncherDescription =>
+      'Deschideți toate secțiunile aplicației cu un singur buton de navigare.';
+
+  @override
   String get configFlagEnableNotifications =>
       'Activați notificările pe desktop?';
 
@@ -9666,6 +9673,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get navTabTitleMore => 'Mai multe';
 
   @override
+  String get navTabTitleNavigate => 'Navigare';
+
+  @override
   String get navTabTitlePeople => 'Persoane';
 
   @override
@@ -15164,14 +15174,4 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Omite';
-
-  @override
-  String get navTabTitleNavigate => 'Navigare';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncher => 'Navigare mobilă nouă';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncherDescription =>
-      'Deschideți toate secțiunile aplicației cu un singur buton de navigare.';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3399,6 +3399,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Aktivera Matrix-integrationen för att synkronisera dina poster mellan enheter och med andra Matrix-användare.';
 
   @override
+  String get configFlagEnableMobileNavigationLauncher => 'Ny mobilnavigering';
+
+  @override
+  String get configFlagEnableMobileNavigationLauncherDescription =>
+      'Öppna alla appens avsnitt med en enda navigeringsknapp.';
+
+  @override
   String get configFlagEnableNotifications => 'Aktivera notiser?';
 
   @override
@@ -9488,6 +9495,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get navTabTitleMore => 'Mer';
 
   @override
+  String get navTabTitleNavigate => 'Navigera';
+
+  @override
   String get navTabTitlePeople => 'Personer';
 
   @override
@@ -14881,14 +14891,4 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Hoppa över';
-
-  @override
-  String get navTabTitleNavigate => 'Navigera';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncher => 'Ny mobilnavigering';
-
-  @override
-  String get configFlagEnableMobileNavigationLauncherDescription =>
-      'Öppna alla appens avsnitt med en enda navigeringsknapp.';
 }

--- a/lib/widgets/nav_bar/mobile_navigation_launcher.dart
+++ b/lib/widgets/nav_bar/mobile_navigation_launcher.dart
@@ -1,26 +1,164 @@
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
-import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/design_system/components/glass_action_bar.dart';
 import 'package:lotti/features/design_system/components/glass_strip.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:material_ui/material_ui.dart';
 
-/// A single mobile navigation launcher on backdrop-blurred glass.
-/// The transparent surrounding area leaves
-/// the page visible; the shell owns the recording indicators above the button.
+/// Whether the mobile navigation launcher owns the bottom action row on the
+/// current surface.
+///
+/// The launcher floats one centred control over the page instead of docking
+/// an edge-to-edge bar, which leaves the bottom-right corner — where a page
+/// would otherwise float its own action button — reading as a second,
+/// unrelated layer. While this is true a page hands its primary action to
+/// the launcher (see [MobileNavigationLauncher.pageAction]) rather than
+/// floating it above the launcher, so the two land on one row.
+///
+/// The desktop layout has no launcher at all: the sidebar replaces the
+/// bottom navigation there, and floating actions keep their corner.
+bool mobileNavigationLauncherOwnsPageActions(
+  BuildContext context,
+  WidgetRef ref,
+) =>
+    !isDesktopLayout(context) &&
+    (ref.watch(configFlagProvider(enableMobileNavigationLauncherFlag)).value ??
+        false);
+
+/// A page-owned primary action docked beside the launcher's Navigate
+/// control while that page is the active tab.
+///
+/// Deliberately data, not a widget: the launcher owns the whole row's
+/// silhouette — one chip height, one radius, one glass treatment — so a
+/// page contributes only what its action *is*, never how it looks.
+///
+/// The two constructors carry the page's own decision about wording, the
+/// same one its floating button made. The task list words its create action
+/// because the app makes tasks, entries, habits, goals and projects from one
+/// glyph and the plus alone would not say which; the lists whose own title
+/// already answers that keep the bare glyph.
+@immutable
+class MobileNavDockAction {
+  /// An action that shows [label] beside [icon] whenever the row has room
+  /// for both words (see [MobileNavigationLauncher.labelsFit]).
+  const MobileNavDockAction.worded({
+    required this.label,
+    required this.icon,
+    required this.onPressed,
+    this.semanticLabel,
+  }) : worded = true;
+
+  /// A glyph-only action: [label] names it for assistive tech and never
+  /// renders. For the lists whose heading already says what gets added.
+  const MobileNavDockAction.glyph({
+    required this.label,
+    required this.icon,
+    required this.onPressed,
+  }) : worded = false,
+       semanticLabel = null;
+
+  /// The action's name — rendered beside [icon] on a [worded] action, and
+  /// announced by assistive tech either way.
+  final String label;
+
+  final IconData icon;
+  final VoidCallback onPressed;
+
+  /// Overrides [label] for screen readers. Null announces [label].
+  final String? semanticLabel;
+
+  /// Whether [label] rides beside the glyph when the row has room for it.
+  final bool worded;
+}
+
+/// The mobile navigation launcher: one floating glass row over the page.
+///
+/// The row holds the shell's Navigate control and, on pages that hand one
+/// over, that page's primary action ([pageAction]) as an accent-filled peer
+/// of the same height and silhouette. The pair is centred as a group, so a
+/// page with an action reads as one deliberate cluster rather than a pill
+/// with something bolted to its side, and leaving that page returns the
+/// Navigate control to the centre on its own.
+///
+/// The surrounding area stays transparent so the page remains visible; the
+/// shell owns the recording indicators riding above the row.
 class MobileNavigationLauncher extends StatelessWidget {
-  const MobileNavigationLauncher({required this.onNavigate, super.key});
+  const MobileNavigationLauncher({
+    required this.onNavigate,
+    this.pageAction,
+    super.key,
+  });
 
   final VoidCallback onNavigate;
 
-  /// Height of the large, padded design-system button plus safe-area spacing.
-  /// Shared with the shell so recordings and page actions clear the launcher.
-  static double barHeight(BuildContext context) {
+  /// The active page's primary action, or null when the page has none — the
+  /// Navigate control is then centred alone.
+  final MobileNavDockAction? pageAction;
+
+  /// Gap between the two chips, matching the task action bar's rhythm so
+  /// every glass row in the app spaces its controls identically.
+  static double chipGap(BuildContext context) =>
+      context.designTokens.spacing.step4;
+
+  /// Height of one chip: a label line inside symmetric padding, never below
+  /// the tap-target floor. Both chips share it, so the row has one baseline
+  /// whether or not a page action is docked.
+  static double chipHeight(BuildContext context) {
     final tokens = context.designTokens;
-    final labelPainter = TextPainter(
+    return math.max(
+      TapTargets.minimum,
+      _labelLineHeight(context) + tokens.spacing.step4 * 2,
+    );
+  }
+
+  /// Vertical screen estate the launcher occupies. Shared with the shell so
+  /// recordings and page actions clear it.
+  static double barHeight(BuildContext context) =>
+      chipHeight(context) +
+      context.designTokens.spacing.step2 +
+      _bottomPadding(context);
+
+  /// Horizontal space the chip row gets, inside the launcher's own gutters
+  /// and the window's safe-area insets.
+  static double availableRowWidth(BuildContext context) {
+    final insets = MediaQuery.paddingOf(context);
+    return MediaQuery.sizeOf(context).width -
+        insets.left -
+        insets.right -
+        context.designTokens.spacing.step3 * 2;
+  }
+
+  /// Whether both chips fit side by side with their labels intact.
+  ///
+  /// Two worded chips on a phone are comfortable at the default text size
+  /// and impossible at the largest accessibility scales, where ellipsising
+  /// both would leave two unreadable stubs. Below the threshold the page
+  /// action drops to its glyph — still the same height, still the same
+  /// accent, still announcing its full name — and the Navigate control
+  /// keeps its word. It is the page action that gives because Navigate
+  /// names the shell and has no icon-only reading, while a `+` beside a
+  /// list still reads as "add".
+  ///
+  /// Only consulted for a [MobileNavDockAction.worded] action; a
+  /// [MobileNavDockAction.glyph] one is round at every width.
+  static bool labelsFit(BuildContext context, MobileNavDockAction action) =>
+      DsGlassPill.intrinsicWidth(
+            context,
+            label: context.messages.navTabTitleNavigate,
+          ) +
+          chipGap(context) +
+          DsGlassPill.intrinsicWidth(context, label: action.label) <=
+      availableRowWidth(context);
+
+  static double _labelLineHeight(BuildContext context) {
+    final tokens = context.designTokens;
+    final painter = TextPainter(
       text: TextSpan(
         text: context.messages.navTabTitleNavigate,
         style: tokens.typography.styles.subtitle.subtitle1,
@@ -30,17 +168,12 @@ class MobileNavigationLauncher extends StatelessWidget {
       locale: Localizations.maybeLocaleOf(context),
       maxLines: 1,
     )..layout();
-    final labelHeight = math.max(
-      labelPainter.height,
+    final height = math.max(
+      painter.height,
       tokens.typography.lineHeight.subtitle1,
     );
-    labelPainter.dispose();
-    return math.max(
-          TapTargets.minimum,
-          labelHeight + tokens.spacing.step4 * 2,
-        ) +
-        tokens.spacing.step2 +
-        _bottomPadding(context);
+    painter.dispose();
+    return height;
   }
 
   static double _bottomPadding(BuildContext context) => math.max(
@@ -51,6 +184,8 @@ class MobileNavigationLauncher extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
+    final action = pageAction;
+    final height = chipHeight(context);
     return Padding(
       padding: EdgeInsets.fromLTRB(
         MediaQuery.paddingOf(context).left + tokens.spacing.step3,
@@ -58,47 +193,132 @@ class MobileNavigationLauncher extends StatelessWidget {
         MediaQuery.paddingOf(context).right + tokens.spacing.step3,
         _bottomPadding(context),
       ),
-      child: Center(
-        heightFactor: 1,
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(tokens.radii.xl),
-            boxShadow: DsShadows.floatingSurface,
-          ),
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(tokens.radii.xl),
-            child: BackdropFilter(
-              filter: ui.ImageFilter.blur(
-                sigmaX: DesignSystemGlassStrip.blurSigma,
-                sigmaY: DesignSystemGlassStrip.blurSigma,
-              ),
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: DesignSystemGlassStrip.overlayColors(tokens),
-                  ),
-                ),
-                child: DecoratedBox(
-                  position: DecorationPosition.foreground,
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(tokens.radii.xl),
-                    border: dsGlassChipBorder(tokens),
-                  ),
-                  child: DesignSystemButton(
-                    label: context.messages.navTabTitleNavigate,
-                    onPressed: onNavigate,
-                    leadingIcon: LottiIcons.menu,
-                    variant: DesignSystemButtonVariant.secondary,
-                    size: DesignSystemButtonSize.large,
-                    tapTargetSize: MaterialTapTargetSize.padded,
-                  ),
-                ),
+      child: Row(
+        // Max, not min: the launcher spans the window (the shell positions
+        // it edge to edge) and centres its chips inside that span. A
+        // shrink-wrapped row would inherit whatever alignment its parent
+        // happened to impose, which is how a "centred" control ends up
+        // hugging the leading edge in a host that hands down loose
+        // constraints.
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Flexible(
+            child: _LauncherGlassChip(
+              radius: BorderRadius.circular(tokens.radii.badgesPills),
+              blurred: true,
+              child: DsGlassPill(
+                label: context.messages.navTabTitleNavigate,
+                icon: LottiIcons.menu,
+                onTap: onNavigate,
+                height: height,
               ),
             ),
           ),
+          if (action != null) ...[
+            SizedBox(width: chipGap(context)),
+            Flexible(
+              child: _LauncherPageActionChip(
+                action: action,
+                height: height,
+                labeled: action.worded && labelsFit(context, action),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// The page action as it rides the launcher's row: the interactive accent
+/// on a chip the same height as the Navigate control beside it.
+///
+/// Filled rather than translucent — it is the page's primary action, and a
+/// second glass chip would read as a pair of equals with nothing to choose
+/// between them. The fill is opaque, so it skips the backdrop blur its
+/// translucent neighbour needs.
+class _LauncherPageActionChip extends StatelessWidget {
+  const _LauncherPageActionChip({
+    required this.action,
+    required this.height,
+    required this.labeled,
+  });
+
+  final MobileNavDockAction action;
+  final double height;
+  final bool labeled;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final fill = tokens.colors.interactive.enabled;
+    final foreground = tokens.colors.text.onInteractiveAlert;
+    if (!labeled) {
+      return _LauncherGlassChip(
+        radius: BorderRadius.circular(height / 2),
+        blurred: false,
+        child: DsGlassRoundButton(
+          icon: action.icon,
+          semanticLabel: action.semanticLabel ?? action.label,
+          onPressed: action.onPressed,
+          backgroundColor: fill,
+          iconColor: foreground,
+          diameter: height,
         ),
+      );
+    }
+    return _LauncherGlassChip(
+      radius: BorderRadius.circular(tokens.radii.badgesPills),
+      blurred: false,
+      child: DsGlassPill(
+        label: action.label,
+        icon: action.icon,
+        onTap: action.onPressed,
+        fillColor: fill,
+        foregroundColor: foreground,
+        semanticLabel: action.semanticLabel,
+        height: height,
+      ),
+    );
+  }
+}
+
+/// One chip of the launcher row: the floating-surface shadow every chip
+/// wears, and — for the translucent ones — the backdrop blur that makes the
+/// page visible through the glass.
+///
+/// The blur has to live here rather than around the whole row: a filter
+/// spanning both chips would also blur the transparent gap between them,
+/// smearing the page content the launcher is supposed to leave alone.
+class _LauncherGlassChip extends StatelessWidget {
+  const _LauncherGlassChip({
+    required this.radius,
+    required this.blurred,
+    required this.child,
+  });
+
+  final BorderRadius radius;
+  final bool blurred;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: radius,
+        boxShadow: DsShadows.floatingSurface,
+      ),
+      child: ClipRRect(
+        borderRadius: radius,
+        child: blurred
+            ? BackdropFilter(
+                filter: ui.ImageFilter.blur(
+                  sigmaX: DesignSystemGlassStrip.blurSigma,
+                  sigmaY: DesignSystemGlassStrip.blurSigma,
+                ),
+                child: child,
+              )
+            : child,
       ),
     );
   }

--- a/test/beamer/beamer_app_test.dart
+++ b/test/beamer/beamer_app_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/beamer/beamer_app.dart';
 import 'package:lotti/beamer/locations/goals_location.dart';
 import 'package:lotti/beamer/locations/habits_location.dart';
+import 'package:lotti/beamer/locations/journal_location.dart';
 import 'package:lotti/beamer/locations/projects_location.dart';
 import 'package:lotti/beamer/locations/relationships_location.dart';
 import 'package:lotti/beamer/locations/settings_location.dart';
@@ -68,6 +69,7 @@ import 'package:lotti/features/whats_new/model/whats_new_state.dart';
 import 'package:lotti/features/whats_new/state/whats_new_controller.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/nav_service.dart';
@@ -734,6 +736,240 @@ void main() {
       await tester.tap(find.text('Events'));
       await tester.pumpAndSettle();
       verify(() => nav.tapIndex(8)).called(1);
+      await tester.pumpWidget(const SizedBox.shrink());
+    },
+  );
+
+  testWidgets(
+    'the launcher docks the task list create action only while Tasks is the '
+    'active tab',
+    (tester) async {
+      final indexController = StreamController<int>.broadcast();
+      addTearDown(indexController.close);
+      final nav = MockNavService();
+      await _stubNavService(
+        nav,
+        indexStream: indexController.stream,
+        isProjectsEnabled: () => false,
+        isDailyOsEnabled: () => true,
+        isHabitsEnabled: () => false,
+        isDashboardsEnabled: () => false,
+      );
+      var index = 0;
+      when(() => nav.index).thenAnswer((_) => index);
+      await _registerAppScreenGetIt(nav);
+      addTearDown(tearDownTestGetIt);
+      await _pumpAppScreen(
+        tester,
+        navService: nav,
+        extraOverrides: [
+          configFlagProvider(
+            enableMobileNavigationLauncherFlag,
+          ).overrideWith((_) => Stream.value(true)),
+        ],
+      );
+
+      indexController.add(0);
+      await tester.pumpAndSettle();
+      final onTasks = tester
+          .widget<MobileNavigationLauncher>(
+            find.byType(MobileNavigationLauncher),
+          )
+          .pageAction;
+      expect(onTasks, isNotNull);
+      expect(onTasks!.icon, LottiIcons.add);
+      expect(
+        onTasks.label,
+        tester
+            .element(find.byType(MobileNavigationLauncher))
+            .messages
+            .addActionCreateTask,
+      );
+      expect(find.bySemanticsLabel(onTasks.label), findsOneWidget);
+
+      // Daily OS sits at index 1 and contributes nothing: the Navigate
+      // control goes back to being alone in the centre.
+      index = 1;
+      indexController.add(1);
+      await tester.pumpAndSettle();
+      expect(
+        tester
+            .widget<MobileNavigationLauncher>(
+              find.byType(MobileNavigationLauncher),
+            )
+            .pageAction,
+        isNull,
+      );
+      expect(find.bySemanticsLabel(onTasks.label), findsNothing);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+    },
+  );
+
+  testWidgets(
+    'every destination whose list floats a create button docks it on the '
+    'launcher instead, and no other destination docks anything',
+    (tester) async {
+      final indexController = StreamController<int>.broadcast();
+      addTearDown(indexController.close);
+      final nav = MockNavService()..relationshipsPageEnabled = true;
+      await _stubNavService(
+        nav,
+        indexStream: indexController.stream,
+        isProjectsEnabled: () => true,
+        isDailyOsEnabled: () => true,
+        isHabitsEnabled: () => true,
+        isDashboardsEnabled: () => true,
+        isUnifiedGoalsEnabled: true,
+        isEventsEnabled: () => true,
+      );
+      var index = 0;
+      when(() => nav.index).thenAnswer((_) => index);
+      await _registerAppScreenGetIt(nav);
+      addTearDown(tearDownTestGetIt);
+      await _pumpAppScreen(
+        tester,
+        navService: nav,
+        extraOverrides: [
+          configFlagProvider(
+            enableMobileNavigationLauncherFlag,
+          ).overrideWith((_) => Stream.value(true)),
+        ],
+      );
+
+      MobileNavDockAction? dockedAt(int destination) {
+        index = destination;
+        indexController.add(destination);
+        return null;
+      }
+
+      // Destination order is fixed by `_buildNavigationDestinations`:
+      // Tasks, Daily OS, Projects, Goals, Habits, Dashboards, People,
+      // Logbook, Events, Settings.
+      final messages = tester
+          .element(find.byType(MobileNavigationLauncher))
+          .messages;
+      final expected = <int, ({String? label, bool worded})>{
+        0: (label: messages.addActionCreateTask, worded: true),
+        1: (label: null, worded: false),
+        2: (label: messages.projectCreateButton, worded: false),
+        3: (label: messages.agentsCreateGoal, worded: false),
+        4: (label: messages.habitEditorCreateTitle, worded: false),
+        5: (label: null, worded: false),
+        6: (label: null, worded: false),
+        7: (label: messages.createEntryLabel, worded: false),
+        8: (label: null, worded: false),
+        9: (label: null, worded: false),
+      };
+
+      for (final entry in expected.entries) {
+        dockedAt(entry.key);
+        await tester.pumpAndSettle();
+        final action = tester
+            .widget<MobileNavigationLauncher>(
+              find.byType(MobileNavigationLauncher),
+            )
+            .pageAction;
+        if (entry.value.label == null) {
+          expect(action, isNull, reason: 'destination ${entry.key}');
+          continue;
+        }
+        expect(action, isNotNull, reason: 'destination ${entry.key}');
+        expect(
+          action!.label,
+          entry.value.label,
+          reason: 'destination ${entry.key}',
+        );
+        expect(action.icon, LottiIcons.add, reason: 'destination ${entry.key}');
+        expect(
+          action.worded,
+          entry.value.worded,
+          reason: 'destination ${entry.key}',
+        );
+      }
+
+      await tester.pumpWidget(const SizedBox.shrink());
+    },
+  );
+
+  group('isLogbookEntryDetailRoute', () {
+    BeamLocation<dynamic> journalAt(String path) =>
+        JournalLocation(RouteInformation(uri: Uri.parse(path)));
+
+    test('the logbook feed is not an entry detail', () {
+      expect(isLogbookEntryDetailRoute(journalAt('/journal')), isFalse);
+    });
+
+    test('an entry uuid is', () {
+      expect(
+        isLogbookEntryDetailRoute(journalAt('/journal/${const Uuid().v4()}')),
+        isTrue,
+      );
+    });
+
+    test('a non-uuid segment is not — /journal/fill_survey greedily matches '
+        'the same pattern', () {
+      expect(
+        isLogbookEntryDetailRoute(journalAt('/journal/fill_survey/cfq11')),
+        isFalse,
+      );
+    });
+
+    test("another tab's location is not", () {
+      expect(
+        isLogbookEntryDetailRoute(
+          TasksLocation(
+            RouteInformation(uri: Uri.parse('/tasks/${const Uuid().v4()}')),
+          ),
+        ),
+        isFalse,
+      );
+    });
+
+    test('no location at all is not', () {
+      expect(isLogbookEntryDetailRoute(null), isFalse);
+    });
+  });
+
+  testWidgets(
+    'the docked action never reaches the legacy slot bar — with the launcher '
+    'flag off the task list keeps its own floating button',
+    (tester) async {
+      final nav = MockNavService();
+      await _stubNavService(
+        nav,
+        indexStream: Stream.value(0),
+        isProjectsEnabled: () => false,
+        isDailyOsEnabled: () => true,
+        isHabitsEnabled: () => false,
+        isDashboardsEnabled: () => false,
+      );
+      when(() => nav.index).thenReturn(0);
+      await _registerAppScreenGetIt(nav);
+      addTearDown(tearDownTestGetIt);
+      await _pumpAppScreen(
+        tester,
+        navService: nav,
+        extraOverrides: [
+          configFlagProvider(
+            enableMobileNavigationLauncherFlag,
+          ).overrideWith((_) => Stream.value(false)),
+        ],
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DesignSystemBottomNavigationBar), findsOneWidget);
+      expect(find.byType(MobileNavigationLauncher), findsNothing);
+      expect(
+        find.bySemanticsLabel(
+          tester
+              .element(find.byType(DesignSystemBottomNavigationBar))
+              .messages
+              .addActionCreateTask,
+        ),
+        findsNothing,
+      );
+
       await tester.pumpWidget(const SizedBox.shrink());
     },
   );

--- a/test/features/design_system/components/glass_action_bar_test.dart
+++ b/test/features/design_system/components/glass_action_bar_test.dart
@@ -198,6 +198,99 @@ void main() {
   });
 
   group('DsGlassPill', () {
+    group('intrinsicWidth', () {
+      // The launcher budgets two pills against a row width with this; if the
+      // formula ever drifts from what `build` lays out, the row starts
+      // ellipsising (or collapsing) at the wrong width with nothing failing.
+      // These pin the two together.
+      testWidgets('matches the width the pill actually renders at', (
+        tester,
+      ) async {
+        for (final label in ['Add', 'Add a task', 'Add a task to this list']) {
+          await _pump(
+            tester,
+            DsGlassPill(label: label, icon: LottiIcons.add, onTap: () {}),
+          );
+
+          final context = tester.element(find.byType(DsGlassPill));
+          expect(
+            DsGlassPill.intrinsicWidth(context, label: label),
+            closeTo(tester.getSize(find.byType(DsGlassPill)).width, 0.01),
+            reason: label,
+          );
+        }
+      });
+
+      testWidgets('matches a pill rendered without a glyph', (tester) async {
+        await _pump(tester, DsGlassPill(label: 'Save', onTap: () {}));
+
+        final context = tester.element(find.byType(DsGlassPill));
+        expect(
+          DsGlassPill.intrinsicWidth(context, label: 'Save', hasIcon: false),
+          closeTo(tester.getSize(find.byType(DsGlassPill)).width, 0.01),
+        );
+      });
+
+      testWidgets('grows with the text scale, so a budget made at one scale '
+          'is not spent at another', (tester) async {
+        await _pump(
+          tester,
+          DsGlassPill(label: 'Add a task', icon: LottiIcons.add, onTap: () {}),
+        );
+        final unscaled = DsGlassPill.intrinsicWidth(
+          tester.element(find.byType(DsGlassPill)),
+          label: 'Add a task',
+        );
+
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            DsGlassPill(
+              label: 'Add a task',
+              icon: LottiIcons.add,
+              onTap: () {},
+            ),
+            theme: DesignSystemTheme.light(),
+            mediaQueryData: const MediaQueryData(
+              size: Size(390, 844),
+              textScaler: TextScaler.linear(2),
+            ),
+          ),
+        );
+        final scaled = DsGlassPill.intrinsicWidth(
+          tester.element(find.byType(DsGlassPill)),
+          label: 'Add a task',
+        );
+
+        expect(scaled, greaterThan(unscaled));
+        expect(
+          scaled,
+          closeTo(tester.getSize(find.byType(DsGlassPill)).width, 0.01),
+        );
+      });
+
+      testWidgets('counts the glyph and its gap', (tester) async {
+        await _pump(
+          tester,
+          DsGlassPill(label: 'Add', icon: LottiIcons.add, onTap: () {}),
+        );
+
+        final context = tester.element(find.byType(DsGlassPill));
+        final tokens = context.designTokens;
+        expect(
+          DsGlassPill.intrinsicWidth(context, label: 'Add') -
+              DsGlassPill.intrinsicWidth(
+                context,
+                label: 'Add',
+                hasIcon: false,
+              ),
+          closeTo(
+            DsGlassRoundButton.defaultIconSize + tokens.spacing.step2,
+            0.01,
+          ),
+        );
+      });
+    });
+
     testWidgets('renders label and leading icon and fires onTap', (
       tester,
     ) async {

--- a/test/features/goals/ui/pages/unified_goals_page_test.dart
+++ b/test/features/goals/ui/pages/unified_goals_page_test.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/goal_criterion.dart';
 import 'package:lotti/classes/goal_enums.dart';
 import 'package:lotti/classes/goal_window.dart';
+import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
@@ -28,9 +30,13 @@ import 'package:lotti/features/habits/ui/widgets/habits_summary_card.dart';
 import 'package:lotti/features/habits/ui/widgets/heatmap/habit_heatmap_card.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/device_region.dart';
+import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
+import 'package:lotti/widgets/nav_bar/mobile_navigation_launcher.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -419,6 +425,136 @@ void main() {
     await tester.tap(find.byType(DesignSystemFloatingActionButton));
     await tester.pump();
     expect(navigated, ['/goals/create']);
+  });
+
+  group('the mobile navigation launcher owns the create action', () {
+    List<Override> launcher({required bool enabled}) => [
+      configFlagProvider(
+        enableMobileNavigationLauncherFlag,
+      ).overrideWith((_) => Stream.value(enabled)),
+    ];
+
+    testWidgets('the goals list drops its floating button so the launcher '
+        'can dock the same action on its own row', (tester) async {
+      // The default viewport is 800 wide — below `kDesktopBreakpoint`, so the
+      // page is in its mobile layout where the launcher exists.
+      await pump(
+        tester,
+        baseState(),
+        extraOverrides: launcher(enabled: true),
+      );
+
+      expect(find.byType(DesignSystemFloatingActionButton), findsNothing);
+      expect(find.byType(DesignSystemBottomNavigationFabPadding), findsNothing);
+    });
+
+    testWidgets('the floating button stays with the flag off', (tester) async {
+      await pump(
+        tester,
+        baseState(),
+        extraOverrides: launcher(enabled: false),
+      );
+
+      expect(find.byType(DesignSystemFloatingActionButton), findsOneWidget);
+    });
+
+    testWidgets('a desktop window keeps the floating button even with the '
+        'flag on', (tester) async {
+      await pump(
+        tester,
+        baseState(),
+        viewport: const Size(1280, 2600),
+        extraOverrides: launcher(enabled: true),
+      );
+
+      expect(find.byType(DesignSystemFloatingActionButton), findsOneWidget);
+    });
+
+    // Read off the page's own scroll padding: the first SliverPadding is the
+    // one wrapping the goals column.
+    double listBottomPadding(WidgetTester tester) => tester
+        .widgetList<SliverPadding>(find.byType(SliverPadding))
+        .first
+        .padding
+        .resolve(TextDirection.ltr)
+        .bottom;
+
+    testWidgets(
+      "the list reserves the floating button's own footprint while it "
+      'floats one',
+      (tester) async {
+        await pump(
+          tester,
+          baseState(),
+          extraOverrides: launcher(enabled: false),
+        );
+
+        final context = tester.element(find.byType(UnifiedGoalsPage));
+        final tokens = context.designTokens;
+        final occupied = DesignSystemBottomNavigationBar.occupiedHeight(
+          context,
+        );
+        // A zero here would make the assertion below vacuous.
+        expect(occupied, greaterThan(0));
+        expect(
+          listBottomPadding(tester),
+          tokens.spacing.step6 + occupied + tokens.spacing.step12,
+        );
+      },
+    );
+
+    testWidgets(
+      'and stops reserving it once the launcher owns the action, so the '
+      'docked chip leaves no empty gutter above it',
+      (tester) async {
+        await pump(
+          tester,
+          baseState(),
+          extraOverrides: launcher(enabled: true),
+        );
+
+        final context = tester.element(find.byType(UnifiedGoalsPage));
+        final tokens = context.designTokens;
+        final occupied = DesignSystemBottomNavigationBar.occupiedHeight(
+          context,
+        );
+        expect(occupied, greaterThan(0));
+        // The bar's own height stays reserved; only the button's footprint
+        // goes, because there is no button.
+        expect(listBottomPadding(tester), tokens.spacing.step6 + occupied);
+      },
+    );
+
+    testWidgets('unifiedGoalsDockAction is a glyph action opening the same '
+        'wizard as the floating button', (tester) async {
+      final navigated = <String>[];
+      beamToNamedOverride = navigated.add;
+      addTearDown(() => beamToNamedOverride = null);
+
+      MobileNavDockAction? action;
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          Consumer(
+            builder: (context, ref, _) {
+              action = unifiedGoalsDockAction(context, ref);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Glyph, not worded: the page is titled Goals and lists goals.
+      expect(action!.worded, isFalse);
+      expect(action!.icon, LottiIcons.add);
+      expect(
+        action!.label,
+        tester.element(find.byType(Consumer)).messages.agentsCreateGoal,
+      );
+
+      action!.onPressed();
+      expect(navigated, ['/goals/create']);
+    });
   });
 
   testWidgets('the later filter arm selects the pending-later bucket', (

--- a/test/features/habits/ui/pages/habits_tab_page_test.dart
+++ b/test/features/habits/ui/pages/habits_tab_page_test.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/habits/state/habits_controller.dart';
@@ -16,13 +19,16 @@ import 'package:lotti/features/habits/ui/widgets/habits_section_header.dart';
 import 'package:lotti/features/keyboard/ui/app_command_host.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/logic/signals/health_signal_refresh_service.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/device_region.dart';
 import 'package:lotti/widgets/misc/timespan_segmented_control.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
+import 'package:lotti/widgets/nav_bar/mobile_navigation_launcher.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -109,6 +115,7 @@ void main() {
       HabitsState state, {
       MediaQueryData? mediaQueryData,
       HealthSignalRefreshService? healthRefreshService,
+      List<Override> extraOverrides = const [],
     }) async {
       final controller = FakeHabitsController(state);
       await tester.pumpWidget(
@@ -128,6 +135,7 @@ void main() {
               healthSignalRefreshServiceProvider.overrideWithValue(
                 healthRefreshService,
               ),
+            ...extraOverrides,
           ],
         ),
       );
@@ -666,6 +674,96 @@ void main() {
             )
             .onPressed!();
         expect(beamedTo, '/habits/create');
+      });
+
+      group('the mobile navigation launcher owns the create action', () {
+        List<Override> launcher({required bool enabled}) => [
+          configFlagProvider(
+            enableMobileNavigationLauncherFlag,
+          ).overrideWith((_) => Stream.value(enabled)),
+        ];
+
+        testWidgets('the habits list drops its floating button so the '
+            'launcher can dock the same action on its own row', (tester) async {
+          await pump(
+            tester,
+            HabitsState.initial(),
+            extraOverrides: launcher(enabled: true),
+          );
+          // The Scaffold animates its floating button out, so it outlives the
+          // rebuild that dropped it.
+          await tester.pump(const Duration(milliseconds: 400));
+
+          expect(find.byKey(const ValueKey('habits-create-fab')), findsNothing);
+          expect(
+            find.byType(DesignSystemBottomNavigationFabPadding),
+            findsNothing,
+          );
+        });
+
+        testWidgets('the floating button stays with the flag off', (
+          tester,
+        ) async {
+          await pump(
+            tester,
+            HabitsState.initial(),
+            extraOverrides: launcher(enabled: false),
+          );
+
+          expect(
+            find.byKey(const ValueKey('habits-create-fab')),
+            findsOneWidget,
+          );
+        });
+
+        testWidgets('a desktop window keeps the floating button even with '
+            'the flag on', (tester) async {
+          await pump(
+            tester,
+            HabitsState.initial(),
+            mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+            extraOverrides: launcher(enabled: true),
+          );
+
+          expect(
+            find.byKey(const ValueKey('habits-create-fab')),
+            findsOneWidget,
+          );
+        });
+
+        testWidgets('habitsTabDockAction is a glyph action opening the same '
+            'editor as the floating button', (tester) async {
+          String? beamedTo;
+          beamToNamedOverride = (path) => beamedTo = path;
+          addTearDown(() => beamToNamedOverride = null);
+
+          MobileNavDockAction? action;
+          await tester.pumpWidget(
+            makeTestableWidgetNoScroll(
+              Consumer(
+                builder: (context, ref, _) {
+                  action = habitsTabDockAction(context, ref);
+                  return const SizedBox.shrink();
+                },
+              ),
+            ),
+          );
+          await tester.pump();
+
+          // Glyph, not worded: the page is titled Habits and lists habits.
+          expect(action!.worded, isFalse);
+          expect(action!.icon, LottiIcons.add);
+          expect(
+            action!.label,
+            tester
+                .element(find.byType(Consumer))
+                .messages
+                .habitEditorCreateTitle,
+          );
+
+          action!.onPressed();
+          expect(beamedTo, '/habits/create');
+        });
       });
     });
   });

--- a/test/features/journal/ui/pages/infinite_journal_page_test.dart
+++ b/test/features/journal/ui/pages/infinite_journal_page_test.dart
@@ -2,6 +2,7 @@
 
 import 'dart:io';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
@@ -9,6 +10,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/design_system/components/headers/tab_section_header.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/state/journal_page_controller.dart';
@@ -26,6 +28,7 @@ import 'package:lotti/features/keyboard/ui/app_command_controller.dart';
 import 'package:lotti/features/keyboard/ui/app_command_host.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/entities_cache_service.dart';
@@ -34,6 +37,7 @@ import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/utils/consts.dart';
+import 'package:lotti/widgets/nav_bar/mobile_navigation_launcher.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path_provider/path_provider.dart';
@@ -894,6 +898,156 @@ void main() {
         expect(fab.categoryId, isNull);
       },
     );
+
+    group('the mobile navigation launcher owns the create action', () {
+      const feedState = JournalPageState(
+        match: '',
+        filters: <DisplayFilter>{},
+        showPrivateEntries: false,
+        showTasks: false,
+        selectedEntryTypes: <String>[],
+        fullTextMatches: <String>{},
+        pagingController: null,
+        taskStatuses: <String>[],
+        selectedTaskStatuses: <String>{},
+        selectedCategoryIds: {'cat-only-one'},
+        selectedLabelIds: <String>{},
+        selectedPriorities: <String>{},
+      );
+
+      Future<void> pumpLogbook(
+        WidgetTester tester, {
+        required bool launcherEnabled,
+        JournalPageState state = feedState,
+        MediaQueryData? mediaQueryData,
+      }) async {
+        await tester.pumpWidget(
+          makeTestableWidgetNoScroll(
+            const InfiniteJournalPage(),
+            mediaQueryData: mediaQueryData,
+            overrides: [
+              journalPageScopeProvider.overrideWithValue(false),
+              journalPageControllerProvider(
+                false,
+              ).overrideWith(() => FakeJournalPageController(state)),
+              configFlagProvider(
+                enableMobileNavigationLauncherFlag,
+              ).overrideWith((_) => Stream.value(launcherEnabled)),
+            ],
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 16));
+        // The Scaffold animates its floating button out, so it outlives the
+        // rebuild that dropped it.
+        await tester.pump(const Duration(milliseconds: 400));
+      }
+
+      testWidgets('the logbook drops its floating button so the launcher can '
+          'dock the same action on its own row', (tester) async {
+        await pumpLogbook(tester, launcherEnabled: true);
+
+        expect(find.byType(FloatingAddActionButton), findsNothing);
+      });
+
+      testWidgets('the floating button stays with the flag off', (
+        tester,
+      ) async {
+        await pumpLogbook(tester, launcherEnabled: false);
+
+        expect(find.byType(FloatingAddActionButton), findsOneWidget);
+      });
+
+      testWidgets('a desktop window keeps the floating button even with the '
+          'flag on', (tester) async {
+        await pumpLogbook(
+          tester,
+          launcherEnabled: true,
+          mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+        );
+
+        expect(find.byType(FloatingAddActionButton), findsOneWidget);
+      });
+
+      testWidgets('logbookDockAction is a glyph action named for the create '
+          'modal it opens', (tester) async {
+        MobileNavDockAction? action;
+        await tester.pumpWidget(
+          makeTestableWidgetNoScroll(
+            Consumer(
+              builder: (context, ref, _) {
+                action = logbookDockAction(context, ref);
+                return const SizedBox.shrink();
+              },
+            ),
+            overrides: [
+              journalPageScopeProvider.overrideWithValue(false),
+              journalPageControllerProvider(
+                false,
+              ).overrideWith(() => FakeJournalPageController(feedState)),
+            ],
+          ),
+        );
+        await tester.pump();
+
+        // Glyph, not worded: the logbook's own heading says what gets added,
+        // and the modal names every entry kind it can make.
+        expect(action!.worded, isFalse);
+        expect(action!.icon, LottiIcons.add);
+        expect(
+          action!.label,
+          tester.element(find.byType(Consumer)).messages.createEntryLabel,
+        );
+
+        // ...and it opens the same modal the floating button opens.
+        final messages = tester.element(find.byType(Consumer)).messages;
+        action!.onPressed();
+        await tester.pumpAndSettle();
+        expect(find.text(messages.createEntryTitle), findsOneWidget);
+      });
+
+      testWidgets(
+        'logbookCreateCategoryId inherits a single-category feed and nothing '
+        'else, resolved when the action is tapped',
+        (tester) async {
+          final controller = FakeJournalPageController(feedState);
+          late WidgetRef probeRef;
+          await tester.pumpWidget(
+            makeTestableWidgetNoScroll(
+              Consumer(
+                builder: (context, ref, _) {
+                  ref.watch(journalPageControllerProvider(false));
+                  probeRef = ref;
+                  return const SizedBox.shrink();
+                },
+              ),
+              overrides: [
+                journalPageScopeProvider.overrideWithValue(false),
+                journalPageControllerProvider(
+                  false,
+                ).overrideWith(() => controller),
+              ],
+            ),
+          );
+          await tester.pump();
+
+          expect(logbookCreateCategoryId(probeRef), 'cat-only-one');
+
+          // The feed widens after the shell built the launcher's row: a
+          // create must not inherit a category the feed no longer spans.
+          controller.updateState(
+            feedState.copyWith(selectedCategoryIds: {'cat-one', 'cat-two'}),
+          );
+          await tester.pump();
+          expect(logbookCreateCategoryId(probeRef), isNull);
+
+          controller.updateState(
+            feedState.copyWith(selectedCategoryIds: const <String>{}),
+          );
+          await tester.pump();
+          expect(logbookCreateCategoryId(probeRef), isNull);
+        },
+      );
+    });
 
     testWidgets('commands refresh, create, and focus journal search', (
       tester,

--- a/test/features/projects/ui/pages/projects_tab_page_test.dart
+++ b/test/features/projects/ui/pages/projects_tab_page_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/project_data.dart';
+import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
 import 'package:lotti/features/design_system/components/checkboxes/design_system_checkbox.dart';
 import 'package:lotti/features/design_system/components/chips/active_filter_chip.dart';
@@ -32,7 +33,9 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/themes/theme.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
+import 'package:lotti/widgets/nav_bar/mobile_navigation_launcher.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -242,6 +245,137 @@ void main() {
 
     final textField = tester.widget<TextField>(find.byType(TextField));
     expect(textField.enabled, isTrue);
+  });
+
+  group('the mobile navigation launcher owns the create action', () {
+    List<Override> launcher({required bool enabled}) => [
+      configFlagProvider(
+        enableMobileNavigationLauncherFlag,
+      ).overrideWith((_) => Stream.value(enabled)),
+    ];
+
+    testWidgets('the projects list drops its floating button so the launcher '
+        'can dock the same action on its own row', (tester) async {
+      await pumpPage(
+        tester,
+        groups: [buildWorkGroup()],
+        extraOverrides: launcher(enabled: true),
+      );
+      // The Scaffold animates its floating button out, so it outlives the
+      // rebuild that dropped it.
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.byType(DesignSystemFloatingActionButton), findsNothing);
+      expect(find.byType(DesignSystemBottomNavigationFabPadding), findsNothing);
+    });
+
+    testWidgets('the floating button stays with the flag off', (tester) async {
+      await pumpPage(
+        tester,
+        groups: [buildWorkGroup()],
+        extraOverrides: launcher(enabled: false),
+      );
+
+      expect(find.byType(DesignSystemFloatingActionButton), findsOneWidget);
+    });
+
+    testWidgets('a desktop window keeps the floating button even with the '
+        'flag on', (tester) async {
+      await pumpPage(
+        tester,
+        groups: [buildWorkGroup()],
+        mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+        extraOverrides: launcher(enabled: true),
+      );
+
+      expect(find.byType(DesignSystemFloatingActionButton), findsOneWidget);
+    });
+
+    testWidgets(
+      'projectsTabDockAction is a glyph action named for the create modal it '
+      'opens, and needs nothing from the overview query the floating button '
+      'waits for — a chip arriving late would shove Navigate sideways',
+      (tester) async {
+        // Deliberately no page and no `projectsOverviewProvider`: the factory
+        // is a pure function of context, which is what makes the docked
+        // action available from the first frame.
+        MobileNavDockAction? action;
+        await tester.pumpWidget(
+          makeTestableWidgetNoScroll(
+            Consumer(
+              builder: (context, ref, _) {
+                action = projectsTabDockAction(context, ref);
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // Glyph, not worded: the page is titled Projects and lists projects.
+        expect(action, isNotNull);
+        expect(action!.worded, isFalse);
+        expect(action!.icon, LottiIcons.add);
+        expect(
+          action!.label,
+          tester.element(find.byType(Consumer)).messages.projectCreateButton,
+        );
+
+        // ...and it opens the same modal the floating button opens.
+        action!.onPressed();
+        await tester.pumpAndSettle();
+        expect(find.byType(ProjectCreateForm), findsOneWidget);
+      },
+    );
+
+    double listBottomPadding(WidgetTester tester) => tester
+        .widget<ProjectsOverviewContent>(find.byType(ProjectsOverviewContent))
+        .listBottomPadding;
+
+    testWidgets(
+      "and stops reserving the floating button's footprint, so the docked "
+      'chip leaves no empty gutter above it',
+      (tester) async {
+        await pumpPage(
+          tester,
+          groups: [buildWorkGroup()],
+          extraOverrides: launcher(enabled: true),
+        );
+        await tester.pump(const Duration(milliseconds: 400));
+
+        final context = tester.element(find.byType(ProjectsTabPage));
+        final occupied = DesignSystemBottomNavigationBar.occupiedHeight(
+          context,
+        );
+        // A zero here would make the assertion below vacuous. The
+        // with-a-button value (occupied + step12) is pinned by
+        // 'list bottom padding clears the docked nav bar plus the FAB
+        // footprint'.
+        expect(occupied, greaterThan(0));
+        expect(listBottomPadding(tester), occupied);
+      },
+    );
+
+    testWidgets(
+      'the page still withholds its own floating button until the overview '
+      'resolves',
+      (tester) async {
+        await pumpPage(
+          tester,
+          groups: [buildWorkGroup()],
+          overrideVisibleGroups: false,
+          extraOverrides: [
+            ...launcher(enabled: false),
+            visibleProjectGroupsProvider.overrideWith(
+              (ref) => const AsyncValue<List<ProjectCategoryGroup>>.loading(),
+            ),
+          ],
+        );
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.byType(DesignSystemFloatingActionButton), findsNothing);
+      },
+    );
   });
 
   testWidgets(

--- a/test/features/tasks/ui/pages/tasks_tab_page_test.dart
+++ b/test/features/tasks/ui/pages/tasks_tab_page_test.dart
@@ -4,11 +4,14 @@ import 'dart:async';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/state/task_agent_providers.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
@@ -39,7 +42,9 @@ import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/time_service.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
+import 'package:lotti/widgets/nav_bar/mobile_navigation_launcher.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -202,11 +207,21 @@ void main() {
     );
   }
 
+  List<Override> pageOverrides({bool launcherEnabled = false}) => [
+    journalPageScopeProvider.overrideWithValue(true),
+    journalPageControllerProvider(true).overrideWith(() => fakeController),
+    taskAgentServiceProvider.overrideWithValue(MockTaskAgentService()),
+    configFlagProvider(
+      enableMobileNavigationLauncherFlag,
+    ).overrideWith((_) => Stream.value(launcherEnabled)),
+  ];
+
   Widget buildSubject({
     required JournalPageState state,
     TasksTabCreateTaskCallback? onCreateTaskPressed,
     TasksTabPageController? controller,
     MediaQueryData? mediaQueryData,
+    bool launcherEnabled = false,
   }) {
     fakeController = FakeJournalPageController(state);
 
@@ -220,10 +235,39 @@ void main() {
         ),
       ),
       mediaQueryData: mediaQueryData,
+      overrides: pageOverrides(launcherEnabled: launcherEnabled),
+    );
+  }
+
+  /// Renders only a [Consumer] in the page's provider scope, for the two
+  /// launcher entry points that are plain functions over a `WidgetRef`
+  /// rather than part of the page's tree. The [Scaffold] is what the failed
+  /// create's toast presents into.
+  Widget buildRefProbe({
+    required JournalPageState state,
+    required void Function(BuildContext context, WidgetRef ref) onBuild,
+  }) {
+    fakeController = FakeJournalPageController(state);
+
+    return makeTestableWidgetNoScroll(
+      Scaffold(
+        body: Consumer(
+          builder: (context, ref, _) {
+            // Keeps the list's controller alive, so the docked action reads
+            // live filters the way the page does.
+            ref.watch(journalPageControllerProvider(true));
+            onBuild(context, ref);
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
       overrides: [
         journalPageScopeProvider.overrideWithValue(true),
         journalPageControllerProvider(true).overrideWith(() => fakeController),
         taskAgentServiceProvider.overrideWithValue(MockTaskAgentService()),
+        configFlagProvider(
+          enableMobileNavigationLauncherFlag,
+        ).overrideWith((_) => Stream.value(false)),
       ],
     );
   }
@@ -732,6 +776,212 @@ void main() {
 
     expect(find.byType(DesignSystemBottomNavigationFabPadding), findsOneWidget);
     expect(find.byType(DesignSystemFloatingActionButton), findsOneWidget);
+  });
+
+  group('the mobile navigation launcher owns the create action', () {
+    testWidgets(
+      'the task list drops its floating button so the launcher can dock the '
+      'same action on its own row',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(state: state(), launcherEnabled: true),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(find.byType(DesignSystemFloatingActionButton), findsNothing);
+        // The clearance wrapper goes with it: nothing is left to pad away
+        // from the launcher.
+        expect(
+          find.byType(DesignSystemBottomNavigationFabPadding),
+          findsNothing,
+        );
+        // The page itself is untouched — only the action moved.
+        expect(find.byType(TabSectionHeader), findsWidgets);
+      },
+    );
+
+    testWidgets(
+      'a desktop window keeps the floating button even with the flag on — '
+      'the sidebar replaces the launcher there',
+      (tester) async {
+        tester.view
+          ..physicalSize = const Size(1280, 800)
+          ..devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+        when(
+          () => mockNavService.desktopSelectedTaskId,
+        ).thenReturn(ValueNotifier<String?>(null));
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: state(),
+            launcherEnabled: true,
+            mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(find.byType(DesignSystemFloatingActionButton), findsOneWidget);
+      },
+    );
+
+    testWidgets('the floating button returns when the flag goes off', (
+      tester,
+    ) async {
+      final flag = StreamController<bool>.broadcast();
+      addTearDown(flag.close);
+      fakeController = FakeJournalPageController(state());
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          const AppCommandHost(
+            handlers: {},
+            platform: TargetPlatform.windows,
+            child: TasksTabPage(),
+          ),
+          overrides: [
+            journalPageScopeProvider.overrideWithValue(true),
+            journalPageControllerProvider(
+              true,
+            ).overrideWith(() => fakeController),
+            taskAgentServiceProvider.overrideWithValue(MockTaskAgentService()),
+            configFlagProvider(
+              enableMobileNavigationLauncherFlag,
+            ).overrideWith((_) => flag.stream),
+          ],
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      for (final enabled in [true, false, true]) {
+        flag.add(enabled);
+        // Settled, not pumped: the Scaffold animates its floating button out,
+        // so the widget outlives the rebuild that dropped it.
+        await tester.pumpAndSettle();
+        expect(
+          find.byType(DesignSystemFloatingActionButton),
+          enabled ? findsNothing : findsOneWidget,
+          reason: 'launcher flag $enabled',
+        );
+      }
+    });
+
+    testWidgets('tasksTabDockAction words the chip the way the FAB words '
+        'itself', (tester) async {
+      MobileNavDockAction? docked;
+      await tester.pumpWidget(
+        buildRefProbe(
+          state: state(),
+          onBuild: (context, ref) => docked = tasksTabDockAction(context, ref),
+        ),
+      );
+      await tester.pump();
+
+      final messages = tester.element(find.byType(Consumer)).messages;
+      expect(docked, isNotNull);
+      expect(docked!.label, messages.addActionCreateTask);
+      expect(docked!.icon, LottiIcons.add);
+      expect(docked!.semanticLabel, isNull);
+    });
+
+    testWidgets(
+      'the docked action creates a task under the filters the list carries '
+      'at tap time, not the ones the shell last built with',
+      (tester) async {
+        final createdTask = TestTaskFactory.create(
+          id: 'docked-task',
+          title: 'Docked',
+          categoryId: 'cat-1',
+          dateFrom: DateTime(2026, 4, 8, 9),
+          dateTo: DateTime(2026, 4, 8, 10),
+        );
+        when(
+          () => mockPersistenceLogic.createTaskEntry(
+            data: any(named: 'data'),
+            entryText: any(named: 'entryText'),
+            categoryId: any(named: 'categoryId'),
+            labelIds: any(named: 'labelIds'),
+          ),
+        ).thenAnswer((_) async => createdTask);
+
+        MobileNavDockAction? docked;
+        await tester.pumpWidget(
+          buildRefProbe(
+            state: state(selectedLabelIds: const {'label-1'}),
+            onBuild: (context, ref) =>
+                docked = tasksTabDockAction(context, ref),
+          ),
+        );
+        await tester.pump();
+
+        // The list's filters move on after the shell built the row.
+        fakeController.updateState(
+          state(
+            selectedLabelIds: const {'label-2'},
+            selectedCategoryIds: const {'cat-9'},
+          ),
+        );
+        await tester.pump();
+
+        docked!.onPressed();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final captured = verify(
+          () => mockPersistenceLogic.createTaskEntry(
+            data: any(named: 'data'),
+            entryText: any(named: 'entryText'),
+            categoryId: captureAny(named: 'categoryId'),
+            labelIds: captureAny(named: 'labelIds'),
+          ),
+        ).captured;
+        expect(
+          captured,
+          containsAll(<Object?>[
+            'cat-9',
+            ['label-2'],
+          ]),
+        );
+        verify(
+          () => mockNavService.beamToNamed('/tasks/docked-task', data: null),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'createTaskFromTaskListFilters surfaces a failed create as a toast '
+      'instead of navigating',
+      (tester) async {
+        when(
+          () => mockPersistenceLogic.createTaskEntry(
+            data: any(named: 'data'),
+            entryText: any(named: 'entryText'),
+            categoryId: any(named: 'categoryId'),
+            labelIds: any(named: 'labelIds'),
+          ),
+        ).thenThrow(Exception('nope'));
+
+        WidgetRef? probeRef;
+        await tester.pumpWidget(
+          buildRefProbe(
+            state: state(),
+            onBuild: (context, ref) => probeRef = ref,
+          ),
+        );
+        await tester.pump();
+
+        await createTaskFromTaskListFilters(probeRef!);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        verifyNever(
+          () => mockNavService.beamToNamed(any(), data: any(named: 'data')),
+        );
+      },
+    );
   });
 
   testWidgets(

--- a/test/test_utils/fake_journal_page_controller.dart
+++ b/test/test_utils/fake_journal_page_controller.dart
@@ -48,10 +48,15 @@ class FakeJournalPageController extends JournalPageController {
   @override
   JournalPageState build() => _initialState;
 
-  @override
-  JournalPageState get state => _initialState;
-
-  /// Update state for testing - this updates Riverpod's internal state
+  /// Moves the controller to [newState] and notifies every listener, the way
+  /// a real filter change does.
+  ///
+  /// There is deliberately no `state` getter override here. One used to
+  /// return [_initialState] unconditionally, which made this method a silent
+  /// no-op: the write landed on the notifier and every read — including
+  /// Riverpod's own — got the original state back, so a test that moved the
+  /// state and asserted the consequence passed without the widget ever
+  /// seeing the change.
   // ignore: use_setters_to_change_properties
   void updateState(JournalPageState newState) => state = newState;
 

--- a/test/widgets/nav_bar/mobile_navigation_launcher_test.dart
+++ b/test/widgets/nav_bar/mobile_navigation_launcher_test.dart
@@ -1,67 +1,674 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/database/state/config_flag_provider.dart';
+import 'package:lotti/features/design_system/components/glass_action_bar.dart';
+import 'package:lotti/features/design_system/components/glass_strip.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:lotti/widgets/nav_bar/mobile_navigation_launcher.dart';
 import 'package:material_ui/material_ui.dart';
 
+import '../../test_utils/screenshot_harness.dart';
 import '../../widget_test_utils.dart';
 
 void main() {
-  void onNavigate() {}
+  // Width-driven layout assertions pin the fonts themselves. `FontLoader`
+  // registers process-wide with no unload, so under the single-isolate
+  // optimizer a file that loaded Inter earlier in the shard silently changes
+  // every later file's text metrics. Tuned against whichever font the bundle
+  // order happened to leave behind, the break points below describe a layout
+  // that does not ship — see test/README.md, "Committed per-feature
+  // harnesses".
+  setUpAll(loadAppFonts);
 
-  group('MobileNavigationLauncher', () {
-    testWidgets('centers one labeled launcher and dispatches its action', (
+  void onNavigate() {}
+  void onAction() {}
+
+  MobileNavDockAction action({
+    VoidCallback? onPressed,
+    String label = 'Add a task',
+    String? semanticLabel,
+  }) => MobileNavDockAction.worded(
+    label: label,
+    icon: LottiIcons.add,
+    onPressed: onPressed ?? onAction,
+    semanticLabel: semanticLabel,
+  );
+
+  MobileNavDockAction glyphAction({
+    VoidCallback? onPressed,
+    String label = 'Add a habit',
+  }) => MobileNavDockAction.glyph(
+    label: label,
+    icon: LottiIcons.add,
+    onPressed: onPressed ?? onAction,
+  );
+
+  // A large phone, comfortably wider than the two labels need at the real
+  // font — the default for tests that are not about the fit threshold.
+  const roomy = MediaQueryData(
+    size: Size(430, 932),
+    padding: EdgeInsets.only(top: 47, bottom: 34),
+  );
+
+  MediaQueryData sized(Size size, [TextScaler scaler = TextScaler.noScaling]) =>
+      MediaQueryData(
+        size: size,
+        padding: roomy.padding,
+        textScaler: scaler,
+      );
+
+  MediaQueryData scaled(TextScaler scaler) => sized(roomy.size, scaler);
+
+  Widget subject({
+    MobileNavDockAction? pageAction,
+    VoidCallback? navigate,
+    MediaQueryData? mediaQueryData,
+    ThemeData? theme,
+  }) => makeTestableWidgetWithScaffold(
+    MobileNavigationLauncher(
+      onNavigate: navigate ?? onNavigate,
+      pageAction: pageAction,
+    ),
+    theme: theme ?? DesignSystemTheme.light(),
+    mediaQueryData: mediaQueryData ?? roomy,
+  );
+
+  /// Pumps the launcher on a viewport whose chip row is [delta] pixels wider
+  /// than the two labels actually need at [scaler].
+  ///
+  /// Calibrated rather than guessed: a hard-coded width pins the threshold to
+  /// one font's metrics, and the assertion then passes or fails for reasons
+  /// that have nothing to do with the branch under test. Measuring first puts
+  /// the row a single pixel on the intended side of
+  /// [MobileNavigationLauncher.labelsFit].
+  Future<void> pumpAtFitThreshold(
+    WidgetTester tester, {
+    required MobileNavDockAction pageAction,
+    required double delta,
+    TextScaler scaler = TextScaler.noScaling,
+  }) async {
+    // A generous first pass, only to get a context to measure through; the
+    // intrinsic widths depend on the text scale, not the viewport.
+    await tester.pumpWidget(
+      subject(
+        pageAction: pageAction,
+        mediaQueryData: sized(const Size(2000, 932), scaler),
+      ),
+    );
+    final context = tester.element(find.byType(MobileNavigationLauncher));
+    final needed =
+        DsGlassPill.intrinsicWidth(
+          context,
+          label: context.messages.navTabTitleNavigate,
+        ) +
+        MobileNavigationLauncher.chipGap(context) +
+        DsGlassPill.intrinsicWidth(context, label: pageAction.label);
+    // `availableRowWidth` takes the launcher's own gutters off the window.
+    final gutters = context.designTokens.spacing.step3 * 2;
+
+    await tester.pumpWidget(
+      subject(
+        pageAction: pageAction,
+        mediaQueryData: sized(Size(needed + gutters + delta, 932), scaler),
+      ),
+    );
+  }
+
+  Rect chipRect(WidgetTester tester, int index) =>
+      tester.getRect(find.byType(DsGlassPill).at(index));
+
+  Rect launcherRect(WidgetTester tester) =>
+      tester.getRect(find.byType(MobileNavigationLauncher));
+
+  double chipGapOf(WidgetTester tester) => MobileNavigationLauncher.chipGap(
+    tester.element(find.byType(MobileNavigationLauncher)),
+  );
+
+  group('mobileNavigationLauncherOwnsPageActions', () {
+    Future<bool?> resolve(
+      WidgetTester tester, {
+      required Stream<bool> flag,
+      required Size size,
+    }) async {
+      bool? owns;
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          Consumer(
+            builder: (context, ref, _) {
+              owns = mobileNavigationLauncherOwnsPageActions(context, ref);
+              return const SizedBox.shrink();
+            },
+          ),
+          theme: DesignSystemTheme.light(),
+          mediaQueryData: MediaQueryData(size: size),
+          overrides: [
+            configFlagProvider(
+              enableMobileNavigationLauncherFlag,
+            ).overrideWith((_) => flag),
+          ],
+        ),
+      );
+      await tester.pump();
+      return owns;
+    }
+
+    testWidgets('is false while the flag has not resolved yet', (tester) async {
+      final pending = StreamController<bool>();
+      addTearDown(pending.close);
+      expect(
+        await resolve(
+          tester,
+          flag: pending.stream,
+          size: const Size(390, 844),
+        ),
+        isFalse,
+      );
+    });
+
+    testWidgets('is false while the launcher flag is off', (tester) async {
+      expect(
+        await resolve(
+          tester,
+          flag: Stream.value(false),
+          size: const Size(390, 844),
+        ),
+        isFalse,
+      );
+    });
+
+    testWidgets('is true on a compact window with the flag on', (tester) async {
+      expect(
+        await resolve(
+          tester,
+          flag: Stream.value(true),
+          size: const Size(390, 844),
+        ),
+        isTrue,
+      );
+    });
+
+    testWidgets(
+      'is false on a desktop window even with the flag on — the sidebar '
+      'replaces the launcher there, so floating actions keep their corner',
+      (tester) async {
+        expect(
+          await resolve(
+            tester,
+            flag: Stream.value(true),
+            size: const Size(1280, 800),
+          ),
+          isFalse,
+        );
+      },
+    );
+  });
+
+  group('Navigate alone', () {
+    testWidgets('centers one labeled chip and dispatches its action', (
       tester,
     ) async {
       var taps = 0;
-      await tester.pumpWidget(
-        makeTestableWidgetWithScaffold(
-          MobileNavigationLauncher(onNavigate: () => taps++),
-          theme: DesignSystemTheme.light(),
-        ),
+      await tester.pumpWidget(subject(navigate: () => taps++));
+
+      final chip = chipRect(tester, 0);
+      final container = launcherRect(tester);
+      expect(find.byType(DsGlassPill), findsOneWidget);
+      // The launcher spans its host and centres inside it; a shrink-wrapped
+      // row would make every centring assertion below trivially true.
+      expect(
+        container.width,
+        tester.getSize(find.byType(Scaffold)).width,
       );
-      final button = tester.getRect(find.byType(DesignSystemButton));
-      final container = tester.getRect(
-        find.byType(MobileNavigationLauncher),
-      );
-      expect(button.width, lessThan(container.width));
-      expect(button.center.dx, container.center.dx);
-      expect(button.height, greaterThanOrEqualTo(TapTargets.minimum));
+      expect(chip.width, lessThan(container.width / 2));
+      expect(chip.center.dx, closeTo(container.center.dx, 0.01));
+      expect(chip.height, greaterThanOrEqualTo(TapTargets.minimum));
+
       await tester.tap(find.text('Navigate'));
       expect(taps, 1);
     });
 
+    testWidgets('wears the glass treatment: blurred backdrop, translucent '
+        'fill and the floating-surface shadow', (tester) async {
+      await tester.pumpWidget(subject());
+
+      final pill = tester.widget<DsGlassPill>(find.byType(DsGlassPill));
+      // No fill of its own — the shared translucent glass-chip fill shows the
+      // blurred page through it. A solid fill here is what made the previous
+      // launcher read as a grey slab rather than glass.
+      expect(pill.fillColor, isNull);
+      expect(pill.icon, LottiIcons.menu);
+
+      final filter = tester.widget<BackdropFilter>(
+        find
+            .ancestor(
+              of: find.byType(DsGlassPill),
+              matching: find.byType(BackdropFilter),
+            )
+            .first,
+      );
+      expect(
+        filter.filter.toString(),
+        contains('${DesignSystemGlassStrip.blurSigma}'),
+      );
+
+      expect(
+        tester
+            .widgetList<DecoratedBox>(
+              find.ancestor(
+                of: find.byType(DsGlassPill),
+                matching: find.byType(DecoratedBox),
+              ),
+            )
+            .map((box) => (box.decoration as BoxDecoration).boxShadow),
+        contains(DsShadows.floatingSurface),
+      );
+    });
+  });
+
+  group('docked page action', () {
+    testWidgets('rides the same row and centers the pair, not either chip', (
+      tester,
+    ) async {
+      await tester.pumpWidget(subject(pageAction: action()));
+
+      final navigate = chipRect(tester, 0);
+      final create = chipRect(tester, 1);
+      final container = launcherRect(tester);
+
+      // One row: same top, same height, in reading order.
+      expect(create.top, closeTo(navigate.top, 0.01));
+      expect(create.height, closeTo(navigate.height, 0.01));
+      expect(create.left, greaterThan(navigate.right));
+
+      // The pair is centered as a group — neither chip owns the centre.
+      expect(
+        (navigate.left + create.right) / 2,
+        closeTo(container.center.dx, 0.01),
+      );
+      expect(navigate.center.dx, lessThan(container.center.dx));
+      expect(create.center.dx, greaterThan(container.center.dx));
+    });
+
+    testWidgets('separates the chips by the shared glass-row gap', (
+      tester,
+    ) async {
+      await tester.pumpWidget(subject(pageAction: action()));
+
+      final tokens = tester
+          .element(find.byType(MobileNavigationLauncher))
+          .designTokens;
+      expect(chipGapOf(tester), tokens.spacing.step4);
+      expect(
+        chipRect(tester, 1).left - chipRect(tester, 0).right,
+        closeTo(tokens.spacing.step4, 0.01),
+      );
+    });
+
+    testWidgets('is the accent-filled peer of the translucent Navigate chip', (
+      tester,
+    ) async {
+      await tester.pumpWidget(subject(pageAction: action()));
+
+      final tokens = tester
+          .element(find.byType(MobileNavigationLauncher))
+          .designTokens;
+      final create = tester.widget<DsGlassPill>(
+        find.byType(DsGlassPill).at(1),
+      );
+      expect(create.fillColor, tokens.colors.interactive.enabled);
+      expect(create.foregroundColor, tokens.colors.text.onInteractiveAlert);
+      expect(create.icon, LottiIcons.add);
+      expect(create.label, 'Add a task');
+    });
+
+    testWidgets('an opaque accent chip skips the backdrop blur it cannot show '
+        'through', (tester) async {
+      await tester.pumpWidget(subject(pageAction: action()));
+
+      expect(
+        find.ancestor(
+          of: find.byType(DsGlassPill).at(1),
+          matching: find.byType(BackdropFilter),
+        ),
+        findsNothing,
+      );
+      expect(
+        find.ancestor(
+          of: find.byType(DsGlassPill).at(0),
+          matching: find.byType(BackdropFilter),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('dispatches its own action, not the launcher sheet', (
+      tester,
+    ) async {
+      var navigateTaps = 0;
+      var actionTaps = 0;
+      await tester.pumpWidget(
+        subject(
+          navigate: () => navigateTaps++,
+          pageAction: action(onPressed: () => actionTaps++),
+        ),
+      );
+
+      await tester.tap(find.text('Add a task'));
+      expect(actionTaps, 1);
+      expect(navigateTaps, 0);
+
+      await tester.tap(find.text('Navigate'));
+      expect(navigateTaps, 1);
+      expect(actionTaps, 1);
+    });
+
+    testWidgets('announces its semantic label override', (tester) async {
+      await tester.pumpWidget(
+        subject(
+          pageAction: action(semanticLabel: 'Add a task to this list'),
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Add a task to this list'), findsOneWidget);
+    });
+
+    testWidgets('leaving the page re-centers Navigate on its own', (
+      tester,
+    ) async {
+      await tester.pumpWidget(subject(pageAction: action()));
+      expect(find.byType(DsGlassPill), findsNWidgets(2));
+      final docked = chipRect(tester, 0);
+
+      await tester.pumpWidget(subject());
+      expect(find.byType(DsGlassPill), findsOneWidget);
+
+      final alone = chipRect(tester, 0);
+      final container = launcherRect(tester);
+      expect(alone.center.dx, closeTo(container.center.dx, 0.01));
+      expect(alone.center.dx, greaterThan(docked.center.dx));
+      expect(alone.height, closeTo(docked.height, 0.01));
+    });
+
+    testWidgets('docking an action does not change the launcher clearance', (
+      tester,
+    ) async {
+      await tester.pumpWidget(subject());
+      final alone = tester.getSize(find.byType(MobileNavigationLauncher));
+
+      await tester.pumpWidget(subject(pageAction: action()));
+      expect(
+        tester.getSize(find.byType(MobileNavigationLauncher)).height,
+        alone.height,
+      );
+    });
+  });
+
+  group('labelsFit', () {
+    testWidgets('keeps both words when the row has room for them', (
+      tester,
+    ) async {
+      // One pixel on the other side of the same threshold, so the pair of
+      // tests brackets it rather than describing two unrelated widths.
+      await pumpAtFitThreshold(tester, pageAction: action(), delta: 0);
+
+      expect(
+        MobileNavigationLauncher.labelsFit(
+          tester.element(find.byType(MobileNavigationLauncher)),
+          action(),
+        ),
+        isTrue,
+      );
+      expect(find.text('Navigate'), findsOneWidget);
+      expect(find.text('Add a task'), findsOneWidget);
+      expect(find.byType(DsGlassRoundButton), findsNothing);
+    });
+
+    testWidgets('drops the action to its glyph rather than ellipsising two '
+        'stubs when the words no longer fit', (tester) async {
+      await pumpAtFitThreshold(
+        tester,
+        pageAction: action(),
+        delta: -1,
+        scaler: const TextScaler.linear(2),
+      );
+
+      expect(find.text('Add a task'), findsNothing);
+      // Navigate keeps its word; the page action keeps its name for
+      // assistive tech and its place on the row.
+      expect(find.text('Navigate'), findsOneWidget);
+      expect(find.bySemanticsLabel('Add a task'), findsOneWidget);
+
+      final round = tester.widget<DsGlassRoundButton>(
+        find.byType(DsGlassRoundButton),
+      );
+      final tokens = tester
+          .element(find.byType(MobileNavigationLauncher))
+          .designTokens;
+      expect(round.icon, LottiIcons.add);
+      expect(round.backgroundColor, tokens.colors.interactive.enabled);
+      expect(round.iconColor, tokens.colors.text.onInteractiveAlert);
+    });
+
+    testWidgets('the collapsed glyph keeps the row on one baseline', (
+      tester,
+    ) async {
+      await pumpAtFitThreshold(
+        tester,
+        pageAction: action(),
+        delta: -1,
+        scaler: const TextScaler.linear(2),
+      );
+
+      final navigate = chipRect(tester, 0);
+      final glyph = tester.getRect(find.byType(DsGlassRoundButton));
+      expect(glyph.height, closeTo(navigate.height, 0.01));
+      expect(glyph.center.dy, closeTo(navigate.center.dy, 0.01));
+      expect(
+        (navigate.left + glyph.right) / 2,
+        closeTo(launcherRect(tester).center.dx, 0.01),
+      );
+    });
+
+    testWidgets('a longer action label collapses the row sooner', (
+      tester,
+    ) async {
+      await tester.pumpWidget(subject(pageAction: action()));
+      final context = tester.element(find.byType(MobileNavigationLauncher));
+
+      expect(
+        MobileNavigationLauncher.labelsFit(context, action()),
+        isTrue,
+      );
+      expect(
+        MobileNavigationLauncher.labelsFit(
+          context,
+          action(label: 'Add a task to the currently filtered list'),
+        ),
+        isFalse,
+      );
+    });
+
+    testWidgets('the collapsed glyph still dispatches the action', (
+      tester,
+    ) async {
+      var taps = 0;
+      await pumpAtFitThreshold(
+        tester,
+        pageAction: action(onPressed: () => taps++),
+        delta: -1,
+        scaler: const TextScaler.linear(2),
+      );
+
+      await tester.tap(find.byType(DsGlassRoundButton));
+      expect(taps, 1);
+    });
+  });
+
+  group('a glyph-only page action', () {
+    testWidgets('is round at a width where a worded action still fits', (
+      tester,
+    ) async {
+      // Same viewport that keeps the worded pair labeled, so the difference
+      // is the page's own decision and not the fit rule.
+      await tester.pumpWidget(subject(pageAction: action()));
+      expect(find.byType(DsGlassPill), findsNWidgets(2));
+
+      await tester.pumpWidget(subject(pageAction: glyphAction()));
+      expect(find.byType(DsGlassPill), findsOneWidget);
+      expect(find.byType(DsGlassRoundButton), findsOneWidget);
+      expect(find.text('Add a habit'), findsNothing);
+      expect(find.text('Navigate'), findsOneWidget);
+    });
+
+    testWidgets('keeps the row on one baseline and centres the pair', (
+      tester,
+    ) async {
+      await tester.pumpWidget(subject(pageAction: glyphAction()));
+
+      final navigate = chipRect(tester, 0);
+      final glyph = tester.getRect(find.byType(DsGlassRoundButton));
+      expect(glyph.height, closeTo(navigate.height, 0.01));
+      expect(glyph.width, closeTo(navigate.height, 0.01));
+      expect(glyph.center.dy, closeTo(navigate.center.dy, 0.01));
+      expect(glyph.left - navigate.right, closeTo(chipGapOf(tester), 0.01));
+      expect(
+        (navigate.left + glyph.right) / 2,
+        closeTo(launcherRect(tester).center.dx, 0.01),
+      );
+    });
+
+    testWidgets('wears the accent and announces its name', (tester) async {
+      await tester.pumpWidget(subject(pageAction: glyphAction()));
+
+      final tokens = tester
+          .element(find.byType(MobileNavigationLauncher))
+          .designTokens;
+      final round = tester.widget<DsGlassRoundButton>(
+        find.byType(DsGlassRoundButton),
+      );
+      expect(round.backgroundColor, tokens.colors.interactive.enabled);
+      expect(round.iconColor, tokens.colors.text.onInteractiveAlert);
+      expect(round.semanticLabel, 'Add a habit');
+      expect(find.bySemanticsLabel('Add a habit'), findsOneWidget);
+    });
+
+    testWidgets('dispatches its action', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        subject(pageAction: glyphAction(onPressed: () => taps++)),
+      );
+
+      await tester.tap(find.byType(DsGlassRoundButton));
+      expect(taps, 1);
+    });
+
+    testWidgets('does not change the launcher clearance either', (
+      tester,
+    ) async {
+      await tester.pumpWidget(subject());
+      final alone = tester.getSize(find.byType(MobileNavigationLauncher));
+
+      await tester.pumpWidget(subject(pageAction: glyphAction()));
+      expect(
+        tester.getSize(find.byType(MobileNavigationLauncher)).height,
+        alone.height,
+      );
+    });
+
+    testWidgets('stays round however long its accessible name is — a glyph '
+        'action never consults the fit rule', (tester) async {
+      await tester.pumpWidget(
+        subject(
+          pageAction: glyphAction(
+            label: 'Add an entry to the currently filtered logbook feed',
+          ),
+        ),
+      );
+
+      expect(find.byType(DsGlassRoundButton), findsOneWidget);
+      expect(find.byType(DsGlassPill), findsOneWidget);
+    });
+  });
+
+  group('clearance', () {
     for (final scaler in const [
       TextScaler.linear(1.3),
       TextScaler.linear(2),
       TextScaler.linear(3),
       _NonlinearTextScaler(),
     ]) {
-      testWidgets('launcher clearance matches large text at $scaler', (
-        tester,
-      ) async {
-        await tester.pumpWidget(
-          makeTestableWidgetWithScaffold(
-            MobileNavigationLauncher(onNavigate: onNavigate),
-            theme: DesignSystemTheme.light(),
-            mediaQueryData: MediaQueryData(
-              size: const Size(390, 844),
-              textScaler: scaler,
-              padding: const EdgeInsets.only(bottom: 34),
-            ),
-          ),
+      for (final docked in const [false, true]) {
+        testWidgets(
+          'launcher clearance matches large text at $scaler '
+          '(docked action: $docked)',
+          (tester) async {
+            await tester.pumpWidget(
+              subject(
+                pageAction: docked ? action() : null,
+                mediaQueryData: scaled(scaler),
+              ),
+            );
+            final finder = find.byType(MobileNavigationLauncher);
+            expect(
+              tester.getSize(finder).height,
+              MobileNavigationLauncher.barHeight(tester.element(finder)),
+            );
+            expect(tester.takeException(), isNull);
+          },
         );
-        final finder = find.byType(MobileNavigationLauncher);
-        expect(
-          tester.getSize(finder).height,
-          MobileNavigationLauncher.barHeight(
-            tester.element(finder),
-          ),
-        );
-        expect(tester.takeException(), isNull);
-      });
+      }
     }
+
+    testWidgets('the safe-area inset only ever adds clearance', (tester) async {
+      await tester.pumpWidget(
+        subject(
+          mediaQueryData: const MediaQueryData(size: Size(430, 932)),
+        ),
+      );
+      final withoutInset = tester.getSize(
+        find.byType(MobileNavigationLauncher),
+      );
+      final tokens = tester
+          .element(find.byType(MobileNavigationLauncher))
+          .designTokens;
+
+      await tester.pumpWidget(
+        subject(
+          mediaQueryData: MediaQueryData(
+            size: const Size(430, 932),
+            padding: EdgeInsets.only(bottom: tokens.spacing.step6 * 2),
+          ),
+        ),
+      );
+      expect(
+        tester.getSize(find.byType(MobileNavigationLauncher)).height,
+        withoutInset.height + tokens.spacing.step6,
+      );
+    });
+  });
+
+  group('dark theme', () {
+    testWidgets('resolves the accent and its ink from the dark token set', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        subject(pageAction: action(), theme: DesignSystemTheme.dark()),
+      );
+
+      final tokens = tester
+          .element(find.byType(MobileNavigationLauncher))
+          .designTokens;
+      final create = tester.widget<DsGlassPill>(
+        find.byType(DsGlassPill).at(1),
+      );
+      expect(create.fillColor, tokens.colors.interactive.enabled);
+      expect(create.foregroundColor, tokens.colors.text.onInteractiveAlert);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

With the opt-in **Mobile navigation launcher** flag on, the bottom of every
list that creates something held two floating controls that had never been
designed together: a centred *Navigate* button and, one row above it in the
trailing corner, that list's create button. Neither looked placed. This makes
them one row, on all five such lists.

- **Navigate is glass now, not a slab.** The launcher used to nest a
  `DesignSystemButton(secondary)` — an opaque surface fill — inside a blurred,
  scrimmed container, so the blur was hidden behind the very button it was
  meant to sit under. The chips are now built from the design system's own
  glass primitives (`DsGlassPill` / `DsGlassRoundButton`), the same vocabulary
  the task action bar uses. **No new colour, alpha, radius or spacing value was
  introduced** — every value is an existing token or glass constant.
- **Each list's create action moved onto that row.** While Tasks, the Logbook,
  Projects, Goals or Habits is on screen the launcher carries that page's
  create action as an accent-filled peer of the same height, and the pair is
  centred as a group. Open a destination that creates nothing — Daily OS,
  Dashboards, People, Events, Settings — and Navigate returns to the centre
  alone. The pages stop floating their own buttons rather than duplicating
  them: one control cluster replaces two.
- **Each page keeps its own wording.** `MobileNavDockAction.worded` / `.glyph`
  carry the decision the page's floating button already made — the task list
  words its action, the four lists whose heading already says what gets added
  dock as round accent buttons.
- **The row degrades instead of shrinking into stubs.** For a worded action,
  `labelsFit` measures both labels at the current text scale against the row
  width; below the threshold it drops to a round accent button of the same
  diameter, keeping its accent, place and accessible name. `barHeight` is
  unchanged in every case, so page clearance never moves as an action docks,
  undocks or collapses.

Nothing changes with the flag off (the default), and nothing changes on
desktop, where the sidebar replaces the launcher and floating actions keep
their corner.

## Design decisions worth naming

- **The shell owns the second slot, not the page.** `AppScreen` resolves it
  from the active destination (`_launcherDockAction`), because the
  `IndexedStack` keeps every tab mounted — a page-owned registry would leave
  each list's action docked on every other tab.
- **One predicate, three consequences.**
  `mobileNavigationLauncherOwnsPageActions` (flag ∧ not desktop) picks the
  launcher in the shell, drops the floating button on all five pages, and on
  Goals and Projects also drops the `step12` scroll allowance those lists
  reserve for that button — otherwise it would be an empty gutter.
- **Docked actions resolve page state at tap time.**
  `createTaskFromTaskListFilters` reads the task list's filters and
  `logbookCreateCategoryId` the feed's single-category selection when tapped,
  not when the shell last built the row.
- **Blur per chip, never per row.** A `BackdropFilter` spanning the row would
  also blur the transparent gap between the chips and smear the page the
  launcher exists to leave visible.
- **`DsGlassPill.intrinsicWidth` is new**, so the launcher's fit budgeting asks
  the pill for its own measurements instead of restating the padding and gap
  that live in its `build`.

Two deliberate divergences from what the floating buttons did:

- **The Logbook keeps its docked action during the first-run zero state**,
  where the page withholds its corner button so the inline "Create new entry"
  CTA is the single primary action. In the corner a second copy competed; on
  the rail the create chip is persistent chrome beside Navigate.
- **Projects docks unconditionally**, where its floating button waits for
  `visibleProjectGroupsProvider`. The create modal needs nothing from that
  query, and a chip arriving one beat late would shove Navigate sideways.

Route sensitivity is needed in one place only: Projects, Goals and Habits slide
the whole launcher away on their detail routes, but the journal tab keeps the
bar on an entry's page — and that page owns a *different* action, an add-linked-entry
button — so `isLogbookEntryDetailRoute` drops the logbook's action from the rail
there. That is why `navService.journalDelegate` joins `_routeChangeListenable`.

## Tests

- `mobile_navigation_launcher_test.dart` — the ownership predicate across all
  four states, the glass treatment, the docked row's geometry (one baseline,
  the `step4` gap, the pair centred rather than either chip), the accent
  pairing in both themes, the worded/glyph distinction, the `labelsFit`
  threshold in both directions, and clearance at 1.3×/2×/3×/nonlinear scaling.
  It pins fonts (`setUpAll(loadAppFonts)`) and calibrates its thresholds by
  measuring rather than hard-coding a width, per `test/README.md` — a
  hard-coded break point describes whichever font the shard order left loaded.
- `beamer_app_test.dart` — a destination matrix asserting which of the ten
  destinations dock an action, its label, glyph and wording, that the other
  five dock nothing, and `isLogbookEntryDetailRoute` across the feed, an entry
  uuid, the `fill_survey` path that greedily matches the same pattern, another
  tab's location and null.
- The five page suites — each list drops its floating button with the flag on,
  keeps it with the flag off and on a desktop window, stops reserving the
  button's footprint (Goals, Projects), and its dock-action factory carries the
  right wording, glyph and behaviour.
- `glass_action_bar_test.dart` — `intrinsicWidth` pinned against the width the
  pill actually renders at, with and without a glyph, and at 2× text scale.
- `FakeJournalPageController.updateState` was a silent no-op (a `state` getter
  override returned the initial state forever, so writes never landed). Fixed
  in the shared harness rather than worked around per file.

## Verification

- `fvm flutter analyze` on every touched file: zero issues
- **410 tests** pass across the eight suites this touches — launcher 35,
  beamer 149, tasks 73, projects 47, goals 29, habits 28, journal 26,
  glass action bar 23
- **359 tests** pass across a sweep of every other `FakeJournalPageController`
  consumer, since that shared harness changed
- Every changed executable line is covered: **168/168**, zero uncovered
- `make knowledge_check` (101 concepts, 540 mermaid blocks), `make changelog_check`

## Documentation

- `knowledge/architecture/navigation.md` — a table of who fills the second
  slot, why the shell rather than the page, the worded/glyph decision, the
  tap-time state reads, the gutter rule, the two divergences above, and a
  `stateDiagram-v2` for centred → worded → glyph.
- `knowledge/features/design_system/component-contracts.md` — the launcher's
  height and fit contracts, updated for the two-chip row.

## Screenshots

Hosted in `matthiasn/lotti-docs` on branch `agent/navigate-glass-row-screenshots`
(commit `712a3cda666fda6fa08a81d6b8bf2da6d16c2bcf`).

Before is the base commit (`8fef7ba54`), after is this branch, both with the
launcher flag on. Fixtures are synthetic — Intergalactic Penguin Logistics
tasks, and the shared Flossing habits.

### Task list — the worded docked action, mobile dark

| Before | After |
|---|---|
| ![Task list dark before](https://raw.githubusercontent.com/matthiasn/lotti-docs/712a3cda666fda6fa08a81d6b8bf2da6d16c2bcf/pr-screenshots/navigate-glass-row/before/task_list_launcher_mobile_dark.png) | ![Task list dark after](https://raw.githubusercontent.com/matthiasn/lotti-docs/712a3cda666fda6fa08a81d6b8bf2da6d16c2bcf/pr-screenshots/navigate-glass-row/after/task_list_launcher_mobile_dark.png) |

### Task list — mobile light

| Before | After |
|---|---|
| ![Task list light before](https://raw.githubusercontent.com/matthiasn/lotti-docs/712a3cda666fda6fa08a81d6b8bf2da6d16c2bcf/pr-screenshots/navigate-glass-row/before/task_list_launcher_mobile_light.png) | ![Task list light after](https://raw.githubusercontent.com/matthiasn/lotti-docs/712a3cda666fda6fa08a81d6b8bf2da6d16c2bcf/pr-screenshots/navigate-glass-row/after/task_list_launcher_mobile_light.png) |

### Habits — the glyph-only docked action, mobile dark

| Before | After |
|---|---|
| ![Habits dark before](https://raw.githubusercontent.com/matthiasn/lotti-docs/712a3cda666fda6fa08a81d6b8bf2da6d16c2bcf/pr-screenshots/navigate-glass-row/before/habits_launcher_mobile_dark.png) | ![Habits dark after](https://raw.githubusercontent.com/matthiasn/lotti-docs/712a3cda666fda6fa08a81d6b8bf2da6d16c2bcf/pr-screenshots/navigate-glass-row/after/habits_launcher_mobile_dark.png) |

### Habits — mobile light

| Before | After |
|---|---|
| ![Habits light before](https://raw.githubusercontent.com/matthiasn/lotti-docs/712a3cda666fda6fa08a81d6b8bf2da6d16c2bcf/pr-screenshots/navigate-glass-row/before/habits_launcher_mobile_light.png) | ![Habits light after](https://raw.githubusercontent.com/matthiasn/lotti-docs/712a3cda666fda6fa08a81d6b8bf2da6d16c2bcf/pr-screenshots/navigate-glass-row/after/habits_launcher_mobile_light.png) |

The Logbook, Projects and Goals dock the same glyph-only chip as Habits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FifN11cJ1KLv8ukGYYL7wJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the optional mobile navigation launcher as a centered glass-style control row.
  - Added docked create actions for Tasks, Journal, Goals, Habits, and Projects.
  - Create actions now adapt to text size, available space, and detail-page context.
  - Added Android 16 KB page-size support for audio transcription.
  - Reduced the Android download size by approximately 4 MB.

- **Bug Fixes**
  - Prevented duplicate floating create buttons when actions are shown in the launcher.

- **Documentation**
  - Updated navigation and design-system documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
