### PR TITLE
feat(plaza): enrich city architecture and smooth fast travel

### DIFF
--- a/changelog.d/2026-09-08-plaza-city-architecture.md
+++ b/changelog.d/2026-09-08-plaza-city-architecture.md
@@ -1,0 +1,8 @@
+### Changed
+- **Project plazas have a richer nighttime skyline.** Glass façades, recessed
+  windows, layered stonework and illuminated tower crowns bring more depth to
+  a denser city, with closer street frontage, a fuller skyline and softer light
+  around billboards and on the paving.
+- **Smoother, faster plaza travel.** Flights follow rounded curves and ease into
+  turns and climbs. Hold Shift while walking or flying for 8× speed.
+- **Penguins start hidden.** Turn them on with the Penguins checkbox.

--- a/docs/plaza/CINEMATIC_CITY_MEASUREMENTS.md
+++ b/docs/plaza/CINEMATIC_CITY_MEASUREMENTS.md
@@ -1,0 +1,110 @@
+# Cinematic city measurement record
+
+Measured 2026-09-08 against merged main `6f088eabfd032145af10435732efc21234c0b373`.
+The comparison is the architecture and light-falloff pass on
+`feat/plaza-cinematic-city`, using the same Project Waddle penguin fixture.
+The runtime implementation is described in the
+[Plaza concept](../../knowledge/features/plaza.md#architectural-recipes).
+
+## Environment and method
+
+- ARM64 Linux VM, Flutter 3.47.2, debug build, isolated Xvfb display.
+- 1600 × 1000 viewport, `GDK_SCALE=1`, automatic frame pacing, penguins enabled.
+- Existing `PLAZA_BENCH=1` walking sequence, first two phases only. Each phase
+  runs for 14 seconds and discards its first four seconds. One run per revision.
+- Default phase caps live/sign facades at 4/80. Both runs ended with 28 signs
+  and zero activated live facades. This does not measure live checklist editing.
+- Builds, captures and tests ran separately from the walking measurements.
+
+| Metric | Merged main | Final architecture pass |
+| --- | ---: | ---: |
+| Static meshes consolidated | 2,429 | 4,128 |
+| Resulting static batches | 216 | 215 |
+| Default phase mean frame time | 289.0 ms | 280.6 ms |
+| Default phase average FPS | 3.5 | 3.6 |
+| Default phase p99 / worst | 466.7 ms | 483.3 ms |
+| Far-only phase mean frame time | 2,619.4 ms | 2,166.7 ms |
+| Far-only phase p99 / worst | 6,650.0 ms | 4,916.7 ms |
+
+The default phase is approximately level with the baseline; one short VM run
+cannot establish a speedup. The far-only phase still contains multi-second
+startup stalls despite its warm-up exclusion, so it is not useful evidence of
+steady rendering throughput. These numbers **do not verify the user's reported
+~120 FPS on macOS**. A profile/release measurement on the target Mac remains
+necessary, including flying, activated facades and larger project worlds.
+
+An earlier candidate used full column grids on supporting buildings and
+separate cornice pieces across the skyline. Its default phase averaged 408 ms.
+That measurement prompted the simplified background recipe retained in the final
+change. Static batch count alone had concealed the additional geometry cost.
+
+## Visual and regression checks
+
+Headless native captures cover Home, the jumbotron, Overview, a timeline block
+and a shopfront, before any edits and after the final geometry changes. They use
+only the penguin fixture and remain outside the repository under
+`/tmp/lotti-pr-screenshots/plaza-cinematic-city/{before,after-final}/`.
+Follow the [operator notes](HANDOVER.md#review-captures) for capture and publication.
+
+Targeted tests cover bounded architecture, priority-scaled sign geometry,
+window texture dimensions and dressing, mesh/material reuse, and reduced
+background detail. The new crown and glass tests fail against merged main;
+the new renderer tests fail when recessed cores and detail selection are removed.
+Native captures additionally check the GPU-only window-depth and halo bindings.
+
+## Density and travel follow-up — 2026-09-09
+
+The next pass tightens and raises the surrounding city, adds swept walking
+collision and increases the held-Shift speed to eight times walking speed.
+Penguins now start hidden. The architecture-pass captures above were retained
+as this pass's before evidence before changing the code.
+
+The same VM, debug build, viewport and walking benchmark produced:
+
+| Metric | Previous architecture pass | Denser city, penguins enabled | Denser city, new default (hidden) |
+| --- | ---: | ---: | ---: |
+| Static meshes consolidated | 4,128 | 4,128 | 4,128 |
+| Resulting static batches | 215 | 198 | 198 |
+| Default phase mean frame time | 280.6 ms | 146.4 ms | 131.6 ms |
+| Default phase average FPS | 3.6 | 6.8 | 7.6 |
+| Default phase p99 / worst | 483.3 ms | 316.7 ms | 266.7 ms |
+
+For the enabled run, the native Penguins checkbox was clicked at the start of
+the default phase's four-second warm-up. A capture confirms it was checked.
+Both new runs ended with 28 sign facades and zero live facades. No other build,
+test, capture or analyzer ran concurrently with either benchmark.
+
+These short runs found no increased frame cost in this VM; they do not establish
+a speedup or macOS throughput. The denser collision geometry can alter the
+walking path and what remains visible, and VM timing varies between runs.
+The benchmark uses normal walking speed, so it does not measure Shift travel.
+Tests independently exercise fast steps across thin and rotated walls, wall
+sliding and corners, modifier release, and recessed-task clearance.
+
+Five before/after views and an additional native Penguins off/on capture are
+staged outside the repository at
+`/tmp/lotti-pr-screenshots/plaza-density-speed/`. The checked/unchecked HUD and
+character visibility were inspected in the native captures. All 81 targeted
+tests passed; replacing the sweep with the former endpoint behavior and restoring
+the former speed/layout/legend makes the corresponding regression tests fail.
+
+## Flight follow-up — 2026-09-09
+
+The subsequent flight change rounds street-guide joins with collision-checked
+Bezier bends and precomputes a continuous timing spline. Slowdowns spread ahead
+of tight turns and steep lifts; holding Shift eases the flight clock up to 8×
+and releasing it eases back. The walking measurements above predate this flight
+change and are not measurements of flight throughput or planning latency.
+
+All 64 targeted flight/camera tests pass, including continuous corner velocity,
+gradual turning, bounded steep-climb speed, exact arrivals, both Shift keys,
+release after lost key-up, and frame-cadence invariance. Collision checks include
+60 randomized translations/rotations of a thin obstacle at the inside of a bend.
+Restoring the old planner/controller makes the new regression checks fail.
+
+An interactive native run on the isolated Xvfb display clicked Morning walk,
+pressed and released Shift during flight, and completed three landings. Every
+reported camera position was outside the generated world's solids (`inside=0`).
+The fixture captures are outside the repository at
+`/tmp/lotti-pr-screenshots/plaza-flight/native/`. This verifies native input and
+navigation; the VM cannot establish motion quality at the target Mac frame rate.

--- a/docs/plaza/HANDOVER.md
+++ b/docs/plaza/HANDOVER.md
@@ -32,7 +32,7 @@ provide the GPU context needed to render the scene.
 
 | Input | Effect |
 |---|---|
-| WASD or arrows | Walk; Shift sprints. Movement from altitude first lands safely. |
+| WASD or arrows | Walk; hold Shift for 8× speed (27.2 m/s). Movement from altitude first lands safely. |
 | Primary-button drag | Look. |
 | Tap a beacon or distant building/sign | Fly to its curated pose. |
 | Tap a nearby facade | Activate its controls. |
@@ -50,6 +50,9 @@ Any manual movement exits the Morning walk. App task facades persist checklist
 edits and open the normal task details page; category facades enter their
 project. The fixture's edits remain in memory and its details open a demo panel.
 The HUD also offers Back, Morning walk, Overview, Home and frame-rate controls.
+Penguins start hidden; use the Penguins checkbox to enable them.
+Hold Shift during a flight to accelerate up to 8× speed; releasing it eases back
+to normal speed. Shift alone does not abandon Morning walk.
 
 ## Headless workflow
 
@@ -102,12 +105,16 @@ before/after pairs and publication after a commit exists. Never commit images.
 `PLAZA_BENCH=1` runs the existing walking benchmark and prints a result per LOD
 budget. `PLAZA_TRACE=1` adds rendering traces; `PLAZA_FPS` selects the
 pacer. Compare the same build mode, fixture, display scale, viewport and frame
-cap. Normal idle caps deliberately reduce FPS, so idle FPS is not a throughput
+cap, including the Penguins checkbox state. Penguins start hidden; enable them
+when comparing against older runs with companions on. Normal idle caps deliberately reduce FPS, so idle FPS is not a throughput
 measurement. `PLAZA_HIDE=fire,life` isolates the new animation layers.
 
 The integration's measurement record and hardware limitations are kept in
 [the implementation notes](../implementation_plans/2026-09-07_plaza_integration.md).
-A Linux VM measurement cannot establish the reported macOS ~120 FPS baseline.
+The subsequent [cinematic city measurements](CINEMATIC_CITY_MEASUREMENTS.md)
+compare the architecture pass with its merged baseline and record the subsequent
+density and faster-travel pass. A Linux VM measurement
+cannot establish the reported macOS ~120 FPS baseline.
 
 ## Remaining boundaries
 

--- a/docs/plaza/NIGHT_CITY_DIRECTION.md
+++ b/docs/plaza/NIGHT_CITY_DIRECTION.md
@@ -3,9 +3,9 @@
 Design proposal, 2026-09-08. The user selected a cinematic nighttime city inspired
 by Times Square. This is the outcome of an AI review panel covering game
 environment art, urban architecture, real-time rendering, and product navigation.
-The board is not a rendered app capture or a performance result. The first
-implementation now includes bounded task-building kits, a stepped project
-landmark, recessed shopfronts, restrained paving and status roofs. The map hides
+The board is not a rendered app capture or a performance result. The current
+implementation includes bounded building kits throughout the city, a stepped
+project landmark, recessed shopfronts, restrained paving and status roofs. The map hides
 decorative enclosure at its altitude threshold. Pylon replacement, additional
 sign typography work and a smooth context fade remain later design work; current
 runtime behaviour belongs in the linked concept.

--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -307,9 +307,10 @@ stateDiagram-v2
 climbs and dives. Guide legs retain swept height clearance against solids.
 Routed flights join those legs with cubic Bezier bends matching both position
 and tangent. A bend trims at most eight metres and at most 35% of either adjacent
-leg; its recursively subdivided control hull must clear every solid with camera
-clearance. A blocked bend shrinks until clear; if no usable radius remains, the
-original guide junction is retained. Arrival look-ahead stops before the rounded
+leg; its recursively subdivided control hull must clear every solid with
+`solidClearance` horizontally and `Flight.clearance` vertically, matching the
+guide legs' headroom. A blocked bend shrinks until clear; if no usable radius
+remains, the original guide junction is retained. Arrival look-ahead stops before the rounded
 pull-off, preserving the road heading until the final orientation blend.
 
 Flight timing includes the actual three-dimensional distance between samples,

--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -5,7 +5,7 @@ description: Scoped journal snapshots generate task timelines and category avenu
 resource: ../../lib/features/plaza
 tags: [plaza, 3d, flutter-scene, flutter-gpu, tasks, projects, categories]
 status: draft
-generated: { by: codex/gpt-6, at: 2026-09-08T12:00:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-08T22:30:00Z }
 stale_after: 2027-03-01
 sources:
   - id: repository
@@ -32,6 +32,10 @@ sources:
     resource: ../../lib/features/plaza/domain/building_architecture.dart
     title: Bounded building volumes and facade dimensions
     last_modified: 2026-09-08
+  - id: architecture-renderer
+    resource: ../../lib/features/plaza/scene/plaza_architecture.dart
+    title: Shared recessed cores, structural piers and lit cornices
+    last_modified: 2026-09-08
   - id: street
     resource: ../../lib/features/plaza/domain/street_layout.dart
     title: Deterministic timeline placement
@@ -43,7 +47,7 @@ sources:
   - id: scene
     resource: ../../lib/features/plaza/scene/plaza_scene.dart
     title: Geometry and static batching
-    last_modified: 2026-09-05
+    last_modified: 2026-09-08
   - id: lod
     resource: ../../lib/features/plaza/scene/facade_lod_manager.dart
     title: Facade promotion and capture budgets
@@ -203,6 +207,15 @@ laterally away from the road. Default low-level layout parameters preserve the
 older fixture contracts; integrated generators enable density and priority
 scaling. Renderer debug tuning preserves the remaining generator parameters.
 
+Background fabric uses compact two-to-3.5-metre alleys and the same shallow
+setback range behind the plot line. Mid-rise blocks stand 24–48 metres high,
+with seeded 56–80-metre accents. Fillers shrink or disappear when they overlap
+another street corridor or a task footprint, including recessed completed plots.
+Avenue landmarks stand 60 metres past a folded row. The skyline retains its
+48-tower budget: broader, taller towers occupy a 36-metre radial band beyond the
+existing district clearance. These dimensions belong to the pure scenery
+recipe; rendering, walking and flight clearance all consume the resulting solids.
+
 Priority scales facade and attention billboard dimensions within their mounts:
 urgent is full size, with successively smaller factors for high, medium and low.
 Mount centers and orientation remain fixed. Completed walls are muted green;
@@ -229,18 +242,36 @@ and picking record. Priority scales the panel about its centre. Configuration
 changes preserve the timeline address and the original street-facing plane.
 
 `BuildingArchitecture` chooses a stepped tower, offset media crown or theater
-setback. A recessed ground floor supports a continuous streetwall and canopy;
-smaller upper volumes expose the silhouette. Every volume stays within the
-plot's width, depth and height, so existing conservative collision and flight
-solids remain valid. The former extra rooftop mass and decorative plant are
-removed. The topmost crown carries the task's status colour, including green for
-done and neutral grey for cancelled. Ordinary storeys have window grids without
-repeating the ground-floor storefront band. The project jumbotron uses the
-stepped family, reserving its entire sign height before beginning the crown.
-Window and shopfront skins use the existing facade-plate depth bias as well as
-their geometric offset. The offset alone loses depth precision on distant
-towers when static batching changes draw order. The shared paving texture draws
-staggered joints over transparent slab centres, avoiding checkerboard shading.
+setback. The stepped family has three narrowing crown tiers. A recessed ground
+floor supports a continuous streetwall and canopy. Every volume stays within
+the plot's width, depth and height, so conservative collision and flight solids
+remain valid. The topmost crown carries the task's status colour, including
+green for done and neutral grey for cancelled.
+
+`PlazaArchitecture` builds inset wall cores under each volume's outer envelope.
+Shared window skins dress those cores; corner piers, side-wall bays and cornices
+occupy the remaining relief. Media towers use horizontal spandrels, while stone
+families use vertical piers and crown flutes. Repeated detail caps at six bays or
+courses per volume. All structure stays behind the street-facing sign plane;
+priority scaling, picking anchors and the task's approach remain unchanged.
+Materials come from the existing scene palette and design-system surface tokens.
+
+Task buildings, the project jumbotron, avenue landmarks, filler blocks and the
+skyline use this builder. Jumbotron and avenue recipes reserve the full screen
+height before starting the crown. Supporting filler blocks and skyline towers
+omit column grids and extra coping. Each lit setback uses one thin cap
+instead of four rim pieces; the street-facing luminous course stays at the
+same height. Skyline towers also omit shopfronts. The renderer creates this geometry once
+and includes it in static batching; it adds no per-frame geometry work or new
+texture families.
+
+Ordinary storeys have window grids without repeating the ground-floor storefront
+band. The office tile has full-height glass and metal mullions; residential
+families retain inset panes. All share the original atlas dimensions. Window
+and shopfront skins use the existing facade-plate depth bias as well as their
+geometric offset. The offset alone loses depth precision on distant towers when
+static batching changes draw order. The shared paving texture draws staggered
+joints over transparent slab centres, avoiding checkerboard shading.
 
 # Attention and navigation
 
@@ -268,13 +299,42 @@ stateDiagram-v2
   Flying --> Walking: arrival
   Flying --> Walking: manual movement or drag cancels
   Flying --> Flying: high movement replaces flight with landing
+  Flying --> Flying: Shift eases flight speed up or down
   Walking --> Walking: collision-constrained movement
 ```
 
 `Flight.route` follows street segments between low poses; `Flight.plan` handles
-climbs and dives. Both use smooth speed profiles, bounded turn timing and swept
-height clearance against solids. Starting flight clears walking velocity, and
-hardware key state prevents a lost key-up from leaving movement latched.
+climbs and dives. Guide legs retain swept height clearance against solids.
+Routed flights join those legs with cubic Bezier bends matching both position
+and tangent. A bend trims at most eight metres and at most 35% of either adjacent
+leg; its recursively subdivided control hull must clear every solid with camera
+clearance. A blocked bend shrinks until clear; if no usable radius remains, the
+original guide junction is retained. Arrival look-ahead stops before the rounded
+pull-off, preserving the road heading until the final orientation blend.
+
+Flight timing includes the actual three-dimensional distance between samples,
+so a steep obstacle lift cannot ignore its vertical travel. A bounded slowdown
+envelope spreads braking before tight sections. Monotone cubic interpolation of
+progress, yaw and pitch shares derivatives between knots, preserving continuous
+velocity. Analytic angular derivative bounds stretch the clock when necessary.
+The bend checks, timing arrays and smoothing weights are computed once per
+flight; frames interpolate the cached plan. Starting flight clears walking
+velocity, and hardware key state prevents lost key-up from latching movement.
+Walking is 3.4 m/s; holding either Shift key multiplies travel speed by eight,
+with the existing acceleration/deceleration easing. The localized control legend
+advertises the modifier. Holding Shift during a flight accelerates its clock
+up to the same eightfold rate without cancelling the flight or Morning walk.
+The multiplier approaches its target with a 0.3-second exponential time constant;
+integrating it exactly makes coarse and fine frame steps agree. Releasing Shift
+smoothly returns to normal speed, even when its key-up goes to an overlay. A new
+flight or landing resets the multiplier. Arrival still clamps to the exact
+endpoint and calls its callback once.
+
+`WalkCollider.move` sweeps the whole movement segment
+against inflated rotated footprints, chooses the earliest contact, then slides
+along the wall. It processes at most four contacts and drops residual motion at
+a complex corner, so speed and slow frames cannot tunnel through thin solids.
+Wall frames are cached and the sweep creates no per-wall objects.
 Camera history returns through prior poses before the route exits.
 
 ```mermaid
@@ -307,7 +367,9 @@ statistics periodically rather than allocating a new history each frame.
 `PlazaBoxes` shares unit meshes and immutable materials. Static opaque meshes are
 baked by spatial cell and compatible material/UV/picking state; pick anchors and
 dynamic groups keep their identity. Translucent pools and individual status
-sprites keep depth ordering. Fog and ground washes recede with altitude, leaving
+sprites keep depth ordering. Ground streaks, scene glows and independently
+animated billboard halos all receive the shared radial falloff texture; missing
+that binding produces hard rectangular sheets of colour. Fog and ground washes recede with altitude, leaving
 road markers and status lights readable in Overview. Decorative filler blocks
 and the skyline ring share a separately baked `city-context` root. It hides at
 the same altitude threshold that reveals map labels, removing their occlusion
@@ -487,8 +549,8 @@ catch-up jump when re-enabled. Characters beyond `visibleRange` stop rendering
 and leave the 30 Hz animation budget. Resuming visibility samples the current
 route time. Rebuilding the world or disposing the explorer detaches the old rigs.
 `PlazaCharacters.enabled` hides the existing root, clears its motion budget,
-and resets the clock baseline on both toggle edges. The HUD preference stays in
-`PlazaView` across data refreshes; toggling it does not call `_load` or move the
+and resets the clock baseline on both toggle edges. The HUD preference starts
+false in each new `PlazaView` and stays there across data refreshes; toggling it does not call `_load` or move the
 camera. Reduced motion leaves visible animals frozen, independently of hiding.
 Optional GLB load failure leaves the data world usable and its control disabled.
 A later zero-to-positive budget change can load the model, with a mounted guard
@@ -497,7 +559,7 @@ omits the layer for scene isolation.
 
 ```mermaid
 stateDiagram-v2
-  [*] --> Visible: attach available model
+  [*] --> Hidden: attach available model with default preference
   Visible --> Hidden: Penguins off
   Hidden --> Visible: Penguins on, reset clock baseline
   Visible --> Frozen: reduced motion

--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -335,6 +335,11 @@ against inflated rotated footprints, chooses the earliest contact, then slides
 along the wall. It processes at most four contacts and drops residual motion at
 a complex corner, so speed and slow frames cannot tunnel through thin solids.
 Wall frames are cached and the sweep creates no per-wall objects.
+Point recovery first pushes through nearest faces. If overlapping buildings
+push the camera back into an earlier wall, it unions the wall intersections
+along both world axes and takes the shorter exit from the containing component.
+This exceptional recovery costs O(n log n); clear movement stays O(n) without
+allocating interval lists. Separate buildings do not extend the escape distance.
 Camera history returns through prior poses before the route exits.
 
 ```mermaid

--- a/lib/features/plaza/README.md
+++ b/lib/features/plaza/README.md
@@ -5,7 +5,10 @@ has a building and a billboard showing its title, status, due date and checklist
 progress. Larger signs emphasize priority; overdue work burns above its signs.
 Completed tasks have quiet green buildings set back from the street, with green
 roofs that remain readable in the aerial overview. Recessed shopfronts and
-stepped tower silhouettes give each task a place along the avenue.
+stepped tower silhouettes give each task a place along the avenue. Glass media
+towers, structural façade details and illuminated crowns extend that character
+into a denser surrounding city with closer street frontage and a fuller skyline;
+soft light spills connect signs to the paving.
 
 Open **Explore project** from a project's details, or **Explore category**
 under a category in the Projects list. A category has an avenue for each
@@ -17,11 +20,14 @@ Black-and-white penguin companions stroll through the streets and open square,
 alone or in pairs, with balancing flippers and orange webbed feet. Companions
 occasionally glance toward one another as if in conversation, with eyes leading
 the turn and independent blinks. A mix of compact, standard and upright builds
-gives the crowd variety. The **Penguins** option shows or hides them, and
+gives the crowd variety. Penguins start hidden; the **Penguins** option shows
+or hides them, and
 reduced-motion settings pause them.
 
 The existing walk, drag-to-look, beacon navigation, search, Home, Overview and
-Morning walk remain available. Nearby task facades offer checklist edits and
+Morning walk remain available. Flights follow rounded curves with gentle turns
+and climbs. Hold **Shift** while walking or flying for **8× speed** through the
+district. Nearby task facades offer checklist edits and
 open the regular task details page.
 
 The feature targets desktop Flutter GPU / Impeller. Unsupported renderers show

--- a/lib/features/plaza/domain/building_architecture.dart
+++ b/lib/features/plaza/domain/building_architecture.dart
@@ -12,7 +12,7 @@ class ArchitectureConfig {
   const ArchitectureConfig({
     this.seed = 0,
     this.streetwallFraction = 0.72,
-    this.towerInsetFraction = 0.16,
+    this.towerInsetFraction = 0.22,
   }) : assert(
          streetwallFraction >= 0.6 && streetwallFraction <= 0.8,
          'street wall must reserve a crown',
@@ -138,14 +138,21 @@ class BuildingArchitecture {
               width: width * (1 - inset),
               depth: depth * (1 - inset),
               bottom: streetwall,
-              height: crownHeight * 0.6,
+              height: crownHeight * 0.45,
               z: -depth * inset / 2,
             ),
             BuildingVolume(
               width: width * (1 - inset * 2),
               depth: depth * (1 - inset * 2),
-              bottom: streetwall + crownHeight * 0.6,
-              height: crownHeight * 0.4,
+              bottom: streetwall + crownHeight * 0.45,
+              height: crownHeight * 0.35,
+              z: -depth * inset,
+            ),
+            BuildingVolume(
+              width: width * (1 - inset * 3),
+              depth: depth * (1 - inset * 2),
+              bottom: streetwall + crownHeight * 0.8,
+              height: crownHeight * 0.2,
               z: -depth * inset,
             ),
           ]);

--- a/lib/features/plaza/domain/flight.dart
+++ b/lib/features/plaza/domain/flight.dart
@@ -1,8 +1,9 @@
 /// Camera flights: the only way the camera moves other than walking.
 ///
 /// Pure Dart. A flight is planned once, from two poses and the world's
-/// solids, as a chain of straight legs with one speed profile over the
-/// whole way: an S-curve that eases up to a cruise and eases down again.
+/// solids, with collision-checked curved joins between the guide legs and
+/// one eased speed profile over the whole way. A precomputed timing spline
+/// limits translation and rotation without abrupt changes between samples.
 /// [Flight.plan] is the direct line, lifted over whatever stands on it;
 /// [Flight.route] follows the street between two stops on the ground.
 library;
@@ -25,11 +26,11 @@ class Flight {
     required List<_Leg> legs,
     required _Profile profile,
     required this.routed,
+    required List<Solid> solids,
     double? wayEnd,
-    // A private field cannot be a named initializing formal.
-    // ignore: prefer_initializing_formals
   }) : _legs = legs,
        _profile = profile,
+       _bends = _Bend.plan(legs, solids),
        _wayEnd = wayEnd ?? profile.length;
 
   /// Plans the direct flight from [from] to [to]: one straight leg, swept
@@ -43,7 +44,8 @@ class Flight {
     CameraPose to, {
     Iterable<Solid> solids = const [],
   }) {
-    final leg = _Leg.plan(from, to, solids, districtArc: true);
+    final obstacles = solids.toList();
+    final leg = _Leg.plan(from, to, obstacles, districtArc: true);
     return Flight._(
       from: from,
       to: to,
@@ -54,20 +56,22 @@ class Flight {
         ramp: rampSeconds,
       ),
       routed: false,
+      solids: obstacles,
     );
   }
 
   /// Plans the flight from [from] to [to] along the street: through every
-  /// point of [via] in order at [streetFlightHeight], cruising at
+  /// guide point of [via] in order at [streetFlightHeight], cruising at
   /// [streetSpeed] and looking [lookAhead] metres down the way, so the
-  /// facades and the billboards pass by and a corner is turned, not cut.
-  /// Every leg is still swept against [solids].
+  /// facades and billboards pass by. Corners are rounded within [cornerRadius];
+  /// bends shrink until their entire Bezier hull clears [solids].
   factory Flight.route(
     CameraPose from,
     CameraPose to, {
     required List<(double, double)> via,
     Iterable<Solid> solids = const [],
   }) {
+    final obstacles = solids.toList();
     final points = <CameraPose>[from];
     for (final (x, z) in via) {
       if (_apart(points.last, x, z) < viaMergeDistance) continue;
@@ -82,7 +86,7 @@ class Flight {
     points.add(to);
     final legs = <_Leg>[
       for (var i = 1; i < points.length; i++)
-        _Leg.plan(points[i - 1], points[i], solids, districtArc: false),
+        _Leg.plan(points[i - 1], points[i], obstacles, districtArc: false),
     ];
     var length = 0.0;
     for (final leg in legs) {
@@ -98,6 +102,7 @@ class Flight {
         ramp: rampSeconds,
       ),
       routed: true,
+      solids: obstacles,
       wayEnd: hop ? length - legs.last.length : length,
     );
   }
@@ -126,6 +131,9 @@ class Flight {
 
   /// A street flight looks at the point this far ahead along the way.
   static const lookAhead = 12.0;
+
+  /// Maximum guide distance trimmed on each side of a street corner.
+  static const cornerRadius = 8.0;
 
   /// A stop beside the road joins it, and leaves it, on a diagonal this
   /// long along the way (see `StreetNetwork.pathBetween`).
@@ -169,9 +177,10 @@ class Flight {
     microseconds: (_timing.seconds * 1e6).ceil(),
   );
 
-  late final _TurnTiming _timing = _TurnTiming(
+  late final _FlightTiming _timing = _FlightTiming(
     _profile.duration,
     _basePoseAt,
+    routed ? streetSpeed : directSpeed,
   );
 
   /// Whether the flight follows the street (see [Flight.route]).
@@ -190,11 +199,12 @@ class Flight {
 
   final List<_Leg> _legs;
   final _Profile _profile;
+  final List<_Bend> _bends;
 
-  /// The way, world metres, legs summed.
+  /// Guide distance, world metres, before rounding corners or adding lift.
   double get length => _profile.length;
 
-  /// How many straight legs the way has.
+  /// How many guide legs the smoothed path follows.
   @visibleForTesting
   int get legCount => _legs.length;
 
@@ -205,7 +215,7 @@ class Flight {
   @visibleForTesting
   double get rampTime => _profile.t;
 
-  /// Peak extra height over the straight line of any leg, world meters.
+  /// Maximum planned obstacle lift among the guide legs, world metres.
   double get arc => _legs.fold(0, (m, leg) => math.max(m, leg.arc));
 
   /// The first leg's ramps, as fractions of that leg.
@@ -285,10 +295,20 @@ class Flight {
     return (_legs.last, 1);
   }
 
-  /// The point [d] metres along the way, on the ground.
-  (double, double) _groundAt(double d) {
+  /// The curved position at guide distance [d], including obstacle clearance.
+  _Point _positionAt(double d) {
+    for (final bend in _bends) {
+      if (d >= bend.start && d <= bend.end) {
+        return bend.at((d - bend.start) / (bend.end - bend.start));
+      }
+    }
     final (leg, f) = _locate(d);
-    return (_lerp(leg.from.x, leg.to.x, f), _lerp(leg.from.z, leg.to.z, f));
+    return leg.pointAt(f);
+  }
+
+  (double, double) _groundAt(double d) {
+    final p = _positionAt(d);
+    return (p.x, p.z);
   }
 
   /// The pose at [t] of the flight's time (0..1): along the way on the
@@ -312,10 +332,11 @@ class Flight {
   }) {
     final d = _profile.distanceAt(t * _profile.duration);
     final (leg, f) = _locate(d);
-    final x = _lerp(leg.from.x, leg.to.x, f);
-    final z = _lerp(leg.from.z, leg.to.z, f);
-    final lift = leg.liftAt(f);
-    final y = _lerp(leg.from.y, leg.to.y, f) + lift;
+    final p = _positionAt(d);
+    final x = p.x;
+    final z = p.z;
+    final y = p.y;
+    final lift = math.max(0, y - _lerp(leg.from.y, leg.to.y, f));
     if (orientation != null) {
       return CameraPose(
         x: x,
@@ -374,17 +395,26 @@ class Flight {
   /// one.
   double _wayHeadingAt(double d) {
     if (!routed) return travelYaw ?? to.yaw;
-    final (leg, f) = _locate(d);
-    final x = _lerp(leg.from.x, leg.to.x, f);
-    final z = _lerp(leg.from.z, leg.to.z, f);
-    return _lookAheadYaw(d, x, z, leg);
+    final (leg, _) = _locate(d);
+    final p = _positionAt(d);
+    return _lookAheadYaw(d, p.x, p.z, leg);
   }
 
   /// The heading from ([x], [z]) to the point [lookAhead] metres further
   /// along the way, which ends where the way leaves the road; past that,
   /// the road's last heading.
   double _lookAheadYaw(double d, double x, double z, _Leg leg) {
-    final ahead = math.min(_wayEnd, d + lookAhead);
+    // The rounded pull-off must not steer the camera toward the stop before
+    // its final orientation blend: look only as far as the last straight.
+    final lastBend = _bends.isEmpty ? null : _bends.last;
+    final roadEnd =
+        arrival &&
+            lastBend != null &&
+            lastBend.start < _wayEnd &&
+            lastBend.end > _wayEnd
+        ? lastBend.start
+        : _wayEnd;
+    final ahead = math.min(roadEnd, d + lookAhead);
     if (ahead <= d + 1e-6) return _heading(_locate(_wayEnd - 1e-6).$1);
     final (ax, az) = _groundAt(ahead);
     final dx = ax - x;
@@ -430,18 +460,17 @@ class Flight {
   }
 }
 
-/// A bounded table computed once per flight. Each original time interval
-/// takes at least enough time to rotate between its endpoints at the limits.
-/// Position remains on the original curve; orientation interpolates between
-/// knots, so even a sharp look-ahead corner cannot exceed the rotation limits.
-class _TurnTiming {
-  factory _TurnTiming(
+/// Monotone cubic timing and orientation, computed once per flight. Shared
+/// knot derivatives keep velocity continuous; exact cubic derivative bounds
+/// stretch the clock when needed to respect the angular speed limits.
+class _FlightTiming {
+  factory _FlightTiming(
     double travelSeconds,
     CameraPose Function(double) poseAt,
+    double speed,
   ) {
     final first = poseAt(0);
     final last = poseAt(1);
-    // A pure turn still needs an eased timeline when translation takes no time.
     final baseSeconds = travelSeconds == 0
         ? 1.5 *
               math.max(
@@ -451,6 +480,8 @@ class _TurnTiming {
         : travelSeconds;
     final steps = (baseSeconds * 120).ceil().clamp(1, 4096);
     final times = Float64List(steps + 1);
+    final intervals = Float64List(steps);
+    final progress = Float64List(steps + 1);
     final yaws = Float64List(steps + 1)..[0] = first.yaw;
     final pitches = Float64List(steps + 1)..[0] = first.pitch;
     var previous = first;
@@ -458,36 +489,90 @@ class _TurnTiming {
       final pose = poseAt(i / steps);
       final yaw = _angle(pose.yaw - previous.yaw);
       final pitch = pose.pitch - previous.pitch;
-      times[i] =
-          times[i - 1] +
-          math.max(
-            baseSeconds / steps,
-            math.max(
-              yaw.abs() / Flight.maxYawSpeed,
-              pitch.abs() / Flight.maxPitchSpeed,
-            ),
-          );
+      intervals[i - 1] = math.max(
+        math.max(baseSeconds / steps, previous.distanceTo(pose) / speed),
+        math.max(
+          yaw.abs() / Flight.maxYawSpeed,
+          pitch.abs() / Flight.maxPitchSpeed,
+        ),
+      );
+      progress[i] = i / steps;
       yaws[i] = yaws[i - 1] + yaw;
       pitches[i] = pose.pitch;
       previous = pose;
     }
-    return _TurnTiming._(times, yaws, pitches);
+    // Spread each necessary slowdown to both sides before filtering. Every
+    // averaging window still contains its original requirement, so smoothing
+    // cannot erase a speed limit. This brakes before a tight bend or climb,
+    // instead of abruptly changing pace at the limiting sample.
+    final radius = baseSeconds == 0
+        ? 1
+        : (0.35 * steps / baseSeconds).ceil().clamp(1, 120);
+    final weights = Float64List(radius + 1);
+    for (var i = 0; i <= radius; i++) {
+      weights[i] = 1 + math.cos(math.pi * i / (radius + 1));
+    }
+    final envelope = Float64List(steps);
+    for (var i = 0; i < steps; i++) {
+      var peak = 0.0;
+      for (
+        var j = math.max(0, i - radius);
+        j <= math.min(steps - 1, i + radius);
+        j++
+      ) {
+        peak = math.max(peak, intervals[j]);
+      }
+      envelope[i] = peak;
+    }
+    for (var i = 0; i < steps; i++) {
+      var sum = 0.0;
+      var totalWeight = 0.0;
+      for (
+        var j = math.max(0, i - radius);
+        j <= math.min(steps - 1, i + radius);
+        j++
+      ) {
+        final weight = weights[(j - i).abs()];
+        sum += envelope[j] * weight;
+        totalWeight += weight;
+      }
+      times[i + 1] = times[i] + sum / totalWeight;
+    }
+    final positions = _Spline(times, progress);
+    final headings = _Spline(times, yaws, easeEnds: true);
+    final tilts = _Spline(times, pitches, easeEnds: true);
+    // A monotone cubic can move faster than its interval's secant. Bound
+    // its quadratic derivative analytically instead of sampling at runtime.
+    final double stretch = math.max(
+      1,
+      math.max(
+        headings.maxSpeed / Flight.maxYawSpeed,
+        tilts.maxSpeed / Flight.maxPitchSpeed,
+      ),
+    );
+    return _FlightTiming._(times, positions, headings, tilts, stretch);
   }
 
-  const _TurnTiming._(this._times, this._yaws, this._pitches);
-
+  const _FlightTiming._(
+    this._times,
+    this._progress,
+    this._yaws,
+    this._pitches,
+    this._stretch,
+  );
   final Float64List _times;
-  final Float64List _yaws;
-  final Float64List _pitches;
+  final _Spline _progress;
+  final _Spline _yaws;
+  final _Spline _pitches;
+  final double _stretch;
 
-  double get seconds => _times.last;
-
+  double get seconds => _times.last * _stretch;
   static double _angle(double radians) =>
       math.atan2(math.sin(radians), math.cos(radians));
 
   ({double progress, double yaw, double pitch}) at(double t) {
     final progress = t.clamp(0.0, 1.0);
-    final time = progress * seconds;
+    final time = progress * _times.last;
     var lo = 0;
     var hi = _times.length - 1;
     while (hi - lo > 1) {
@@ -501,10 +586,183 @@ class _TurnTiming {
     final span = _times[hi] - _times[lo];
     final f = span == 0 ? progress : (time - _times[lo]) / span;
     return (
-      progress: (lo + f) / (_times.length - 1),
-      yaw: _lerp(_yaws[lo], _yaws[hi], f),
-      pitch: _lerp(_pitches[lo], _pitches[hi], f),
+      progress: _progress.at(lo, f),
+      yaw: _yaws.at(lo, f),
+      pitch: _pitches.at(lo, f),
     );
+  }
+}
+
+/// Shape-preserving Hermite interpolation on a nonuniform clock. Harmonic
+/// slopes prevent overshoot and join adjacent intervals with the same velocity.
+class _Spline {
+  _Spline(this.times, this.values, {bool easeEnds = false})
+    : slopes = Float64List(values.length) {
+    double secant(int i) {
+      final dt = times[i + 1] - times[i];
+      return dt == 0 ? 0 : (values[i + 1] - values[i]) / dt;
+    }
+
+    if (!easeEnds) {
+      slopes[0] = secant(0);
+      slopes[slopes.length - 1] = secant(values.length - 2);
+    }
+    for (var i = 1; i < slopes.length - 1; i++) {
+      final left = secant(i - 1);
+      final right = secant(i);
+      if (left * right <= 0) continue;
+      final before = times[i] - times[i - 1];
+      final after = times[i + 1] - times[i];
+      final a = 2 * after + before;
+      final b = after + 2 * before;
+      slopes[i] = (a + b) / (a / left + b / right);
+    }
+  }
+  final Float64List times;
+  final Float64List values;
+  final Float64List slopes;
+
+  (double, double, double) coefficients(int i) {
+    final span = times[i + 1] - times[i];
+    final delta = values[i + 1] - values[i];
+    final a = slopes[i] * span;
+    final b = slopes[i + 1] * span;
+    return (a + b - 2 * delta, 3 * delta - 2 * a - b, a);
+  }
+
+  double at(int i, double t) {
+    final (a, b, c) = coefficients(i);
+    return ((a * t + b) * t + c) * t + values[i];
+  }
+
+  double get maxSpeed {
+    var result = 0.0;
+    for (var i = 0; i < values.length - 1; i++) {
+      final span = times[i + 1] - times[i];
+      if (span == 0) continue;
+      final (a, b, c) = coefficients(i);
+      var peak = math.max(c.abs(), (3 * a + 2 * b + c).abs());
+      if (a != 0) {
+        final t = -b / (3 * a);
+        if (t > 0 && t < 1) {
+          peak = math.max(peak, ((3 * a * t + 2 * b) * t + c).abs());
+        }
+      }
+      result = math.max(result, peak / span);
+    }
+    return result;
+  }
+}
+
+typedef _Point = ({double x, double y, double z});
+
+_Point _mix(_Point a, _Point b, double t) =>
+    (x: _lerp(a.x, b.x, t), y: _lerp(a.y, b.y, t), z: _lerp(a.z, b.z, t));
+
+/// A cubic join matching both neighbouring legs' position and tangent.
+/// Collision checks use the convex hull of recursively subdivided control
+/// points, so a narrow obstacle cannot fall between samples.
+class _Bend {
+  const _Bend(this.start, this.end, this.a, this.b, this.c, this.d);
+  final double start;
+  final double end;
+  final _Point a;
+  final _Point b;
+  final _Point c;
+  final _Point d;
+
+  static List<_Bend> plan(List<_Leg> legs, List<Solid> solids) {
+    final bends = <_Bend>[];
+    var along = 0.0;
+    for (var i = 1; i < legs.length; i++) {
+      final incoming = legs[i - 1];
+      final outgoing = legs[i];
+      along += incoming.length;
+      var radius = math.min(
+        Flight.cornerRadius,
+        math.min(incoming.length, outgoing.length) * 0.35,
+      );
+      while (radius > 1e-4) {
+        final f = 1 - radius / incoming.length;
+        final g = radius / outgoing.length;
+        final a = incoming.pointAt(f);
+        final d = outgoing.pointAt(g);
+        final ta = incoming.tangentAt(f);
+        final td = outgoing.tangentAt(g);
+        final handle = 2 * radius / 3;
+        final bend = _Bend(
+          along - radius,
+          along + radius,
+          a,
+          (
+            x: a.x + ta.x * handle,
+            y: a.y + ta.y * handle,
+            z: a.z + ta.z * handle,
+          ),
+          (
+            x: d.x - td.x * handle,
+            y: d.y - td.y * handle,
+            z: d.z - td.z * handle,
+          ),
+          d,
+        );
+        if (solids.every((s) => bend._clears(s, 0))) {
+          bends.add(bend);
+          break;
+        }
+        radius /= 2;
+      }
+    }
+    return bends;
+  }
+
+  _Point at(double t) {
+    final u = 1 - t;
+    final wa = u * u * u;
+    final wb = 3 * u * u * t;
+    final wc = 3 * u * t * t;
+    final wd = t * t * t;
+    return (
+      x: wa * a.x + wb * b.x + wc * c.x + wd * d.x,
+      y: wa * a.y + wb * b.y + wc * c.y + wd * d.y,
+      z: wa * a.z + wb * b.z + wc * c.z + wd * d.z,
+    );
+  }
+
+  bool _clears(Solid solid, int depth) {
+    final footprint = solid.footprint;
+    var minU = double.infinity;
+    var maxU = double.negativeInfinity;
+    var minV = double.infinity;
+    var maxV = double.negativeInfinity;
+    var minY = double.infinity;
+    var maxY = double.negativeInfinity;
+    for (final p in [a, b, c, d]) {
+      final (u, v) = footprint.local(p.x, p.z);
+      minU = math.min(minU, u);
+      maxU = math.max(maxU, u);
+      minV = math.min(minV, v);
+      maxV = math.max(maxV, v);
+      minY = math.min(minY, p.y);
+      maxY = math.max(maxY, p.y);
+    }
+    if (minU >= footprint.width / 2 + solidClearance ||
+        maxU <= -footprint.width / 2 - solidClearance ||
+        minV >= footprint.depth / 2 + solidClearance ||
+        maxV <= -footprint.depth / 2 - solidClearance ||
+        minY >= solid.top + solidClearance ||
+        maxY <= solid.bottom - solidClearance) {
+      return true;
+    }
+    if (depth >= 10) return false;
+    final ab = _mix(a, b, 0.5);
+    final bc = _mix(b, c, 0.5);
+    final cd = _mix(c, d, 0.5);
+    final abc = _mix(ab, bc, 0.5);
+    final bcd = _mix(bc, cd, 0.5);
+    final mid = _mix(abc, bcd, 0.5);
+    return _Bend(start, end, a, ab, abc, mid)._clears(solid, depth + 1) &&
+        _Bend(start, end, mid, bcd, cd, d)._clears(solid, depth + 1);
   }
 }
 
@@ -614,6 +872,28 @@ class _Leg {
   /// The fraction of the leg the climb takes, and the descent.
   final double rampStart;
   final double rampEnd;
+
+  _Point pointAt(double s) => (
+    x: _lerp(from.x, to.x, s),
+    y: _lerp(from.y, to.y, s) + liftAt(s),
+    z: _lerp(from.z, to.z, s),
+  );
+
+  _Point tangentAt(double s) {
+    var slope = 0.0;
+    if (s < rampStart) {
+      final t = s / rampStart;
+      slope = 6 * t * (1 - t) / rampStart;
+    } else if (s > 1 - rampEnd) {
+      final t = (1 - s) / rampEnd;
+      slope = -6 * t * (1 - t) / rampEnd;
+    }
+    return (
+      x: (to.x - from.x) / length,
+      y: (to.y - from.y + arc * slope) / length,
+      z: (to.z - from.z) / length,
+    );
+  }
 
   /// Extra height over the straight line at [s] of the leg (0..1).
   double liftAt(double s) => arc * _profile(s, rampStart, rampEnd);

--- a/lib/features/plaza/domain/flight.dart
+++ b/lib/features/plaza/domain/flight.dart
@@ -144,8 +144,8 @@ class Flight {
 
   static const arcThreshold = 60.0;
 
-  /// How far above a solid's top, or below its bottom, a leg must stay to
-  /// count as clearing it; the lift over a solid ends this high.
+  /// How far above a solid's top, or below its bottom, legs and rounded
+  /// bends must stay to count as clearing it; a lift ends this high.
   static const clearance = 1.5;
 
   /// The lift profile of a leg: a climb over the first [rampStart] of it,
@@ -750,8 +750,8 @@ class _Bend {
         maxU <= -footprint.width / 2 - solidClearance ||
         minV >= footprint.depth / 2 + solidClearance ||
         maxV <= -footprint.depth / 2 - solidClearance ||
-        minY >= solid.top + solidClearance ||
-        maxY <= solid.bottom - solidClearance) {
+        minY >= solid.top + Flight.clearance ||
+        maxY <= solid.bottom - Flight.clearance) {
       return true;
     }
     if (depth >= 10) return false;

--- a/lib/features/plaza/domain/scenery.dart
+++ b/lib/features/plaza/domain/scenery.dart
@@ -237,7 +237,7 @@ Solid plotSpireSolidFor(PlotPlacement p) => Solid.post(
 );
 
 /// Fillers stand this far past the plots' back line.
-const fillerSetback = 4.0;
+const fillerSetback = 2.0;
 
 /// No filler stands on the plaza or within this margin of it.
 const fillerPlazaMargin = 12.0;
@@ -279,7 +279,9 @@ Footprint streetCorridorFor(
 /// and nothing in any street: the folds bring the rows closer than a
 /// filler's reach, so a block that would stand in the next row's corridor
 /// is cut back to an alley short of it, or left out when too little of it
-/// is left. A dropped block never shifts its neighbours.
+/// is left. Recessed task plots are also reserved. Two-to-3.5-metre alleys
+/// and shallow setbacks keep the fabric continuous without adding another
+/// layer of buildings. A dropped block never shifts its neighbours.
 List<FillerBlock> fillerBlocksFor(
   StreetPlan plan,
   FrontierPlaza? plaza, {
@@ -287,9 +289,11 @@ List<FillerBlock> fillerBlocksFor(
   required double plotDepth,
 }) {
   final lateralBase = roadWidth / 2 + plotDepth + fillerSetback;
-  final corridors = [
+  final obstacles = [
     for (final segment in plan.segments)
       streetCorridorFor(segment, roadWidth: roadWidth, plotDepth: plotDepth),
+    // Completed plots stand behind the normal street frontage too.
+    for (final plot in plan.placements.values) plot.footprint,
   ];
   final plazaGround = plaza?.footprint;
   bool onPlaza(double x, double z) =>
@@ -311,9 +315,9 @@ List<FillerBlock> fillerBlocksFor(
         // landmarks so the roofline behind a row is jagged.
         final tall = stableUnit(id, 'tall') < 0.25;
         final height = tall
-            ? 40 + stableUnit(id, 'h') * 20
-            : 12 + stableUnit(id, 'h') * 22;
-        final inner = lateralBase + stableUnit(id, 'l') * 4;
+            ? 56 + stableUnit(id, 'h') * 24
+            : 24 + stableUnit(id, 'h') * 24;
+        final inner = lateralBase + stableUnit(id, 'l') * 1.5;
         FillerBlock at(double reach) {
           final (x, z) = frameToWorld(
             segment.startX,
@@ -340,12 +344,12 @@ List<FillerBlock> fillerBlocksFor(
           // Cut the reach back, a metre at a time, until the block stands
           // in no street.
           while (block.width >= fillerMinReach &&
-              corridors.any((c) => footprintsOverlap(block.footprint, c))) {
+              obstacles.any((c) => footprintsOverlap(block.footprint, c))) {
             block = at(block.width - 1);
           }
           if (block.width >= fillerMinReach) blocks.add(block);
         }
-        along += frontage + 2 + stableUnit(id, 'gap') * 4;
+        along += frontage + 2 + stableUnit(id, 'gap') * 1.5;
         i++;
       }
     }
@@ -354,7 +358,7 @@ List<FillerBlock> fillerBlocksFor(
 }
 
 /// How far past a folding row's end its hero tower stands.
-const heroTowerStandOff = 90.0;
+const heroTowerStandOff = 60.0;
 
 /// One hero tower past the far end of every row that folds, on the row's
 /// axis, facing back down the row. The last row's far end has the
@@ -420,7 +424,7 @@ JumbotronTower? jumbotronTowerFor(BillboardSlot? jumbotron) {
 }
 
 /// Towers on the skyline ring, and how far beyond the district's radius
-/// the ring starts. The towers stand 24 to 78 m so their lit rooflines
+/// the ring starts. The towers stand 42 to 96 m so their lit rooflines
 /// show over the fillers from the street.
 const skylineTowerCount = 48;
 const skylineRingClearance = 50.0;
@@ -459,8 +463,8 @@ List<SkylineTower> skylineFor(StreetPlan plan, FrontierPlaza? plaza) {
     final id = 'skyline-$i';
     final angle =
         i / skylineTowerCount * 2 * math.pi + stableUnit(id, 'a') * 0.1;
-    final r = radius + stableUnit(id, 'r') * 90;
-    final width = 16 + stableUnit(id, 'w') * 26;
+    final r = radius + stableUnit(id, 'r') * 36;
+    final width = 24 + stableUnit(id, 'w') * 26;
     towers.add(
       SkylineTower(
         id: id,
@@ -470,7 +474,7 @@ List<SkylineTower> skylineFor(StreetPlan plan, FrontierPlaza? plaza) {
         yawRadians: -angle,
         width: width,
         depth: width * 0.8,
-        height: 24 + stableUnit(id, 'h') * 54,
+        height: 42 + stableUnit(id, 'h') * 54,
       ),
     );
   }

--- a/lib/features/plaza/domain/walk_collider.dart
+++ b/lib/features/plaza/domain/walk_collider.dart
@@ -160,6 +160,7 @@ class WalkCollider {
   (double, double) resolve(double x, double z) {
     var rx = x;
     var rz = z;
+    var displaced = false;
     for (final w in _walls) {
       final dx = rx - w.x;
       final dz = rz - w.z;
@@ -171,6 +172,7 @@ class WalkCollider {
       final u = dx * w.cosF - dz * w.sinF;
       final v = dx * w.sinF + dz * w.cosF;
       if (u.abs() >= w.halfW || v.abs() >= w.halfD) continue;
+      displaced = true;
       // Push out through the nearest face.
       final pushU = w.halfW - u.abs();
       final pushV = w.halfD - v.abs();
@@ -184,7 +186,7 @@ class WalkCollider {
       rx = w.x + nu * w.cosF + nv * w.sinF;
       rz = w.z - nu * w.sinF + nv * w.cosF;
     }
-    if ((rx != x || rz != z) && _walls.any((wall) => wall.contains(rx, rz))) {
+    if (displaced && _walls.any((wall) => wall.contains(rx, rz))) {
       final escapeX = _escapeDistance(x, z, alongX: true);
       final escapeZ = _escapeDistance(x, z, alongX: false);
       return escapeX.abs() < escapeZ.abs()

--- a/lib/features/plaza/domain/walk_collider.dart
+++ b/lib/features/plaza/domain/walk_collider.dart
@@ -2,9 +2,9 @@
 /// footprints, with a margin so the camera never clips a wall, even when
 /// a fast step crosses an entire building.
 ///
-/// Pure Dart, O(footprints) per move/resolve; each footprint's frame is fixed
-/// once. Point recovery rejects distant footprints before rotating into
-/// their local frame; movement checks the complete segment.
+/// Pure Dart, O(footprints) for normal movement; each footprint's frame is
+/// fixed once. Overlapping-wall recovery uses O(footprints log footprints)
+/// interval unions only when a nearest-face push cannot leave all buildings.
 library;
 
 import 'dart:math' as math;
@@ -30,8 +30,8 @@ class WalkCollider {
   /// the second's clearance and the second pushes it back: the sweep never
   /// settles. Aligned neighbours (same facing, same row line, same depth)
   /// whose clearances overlap are merged into one footprint, repeatedly, so
-  /// the alley between them is solid and every footprint left is at least
-  /// a clearance from the next.
+  /// the alley between them is solid. Other overlaps, including rotated
+  /// skyline towers, are handled by point recovery.
   static List<Footprint> _mergeAligned(List<Footprint> input, double margin) {
     final out = [...input];
     var merged = true;
@@ -152,7 +152,11 @@ class WalkCollider {
     return (x, z);
   }
 
-  /// Returns the nearest point outside every footprint to (x, z).
+  /// Pushes through the nearest faces to leave the footprints around (x, z).
+  ///
+  /// If overlapping buildings push back into an earlier wall, escape the
+  /// complete overlap along the shorter world-axis exit. This recovery path
+  /// sorts wall intersections; ordinary movement allocates no interval lists.
   (double, double) resolve(double x, double z) {
     var rx = x;
     var rz = z;
@@ -180,7 +184,60 @@ class WalkCollider {
       rx = w.x + nu * w.cosF + nv * w.sinF;
       rz = w.z - nu * w.sinF + nv * w.cosF;
     }
+    if ((rx != x || rz != z) && _walls.any((wall) => wall.contains(rx, rz))) {
+      final escapeX = _escapeDistance(x, z, alongX: true);
+      final escapeZ = _escapeDistance(x, z, alongX: false);
+      return escapeX.abs() < escapeZ.abs()
+          ? (x + escapeX, z)
+          : (x, z + escapeZ);
+    }
     return (rx, rz);
+  }
+
+  /// Nearest end of the union containing the origin on an axis through it.
+  double _escapeDistance(double x, double z, {required bool alongX}) {
+    final intervals = <(double, double)>[];
+    for (final wall in _walls) {
+      final u = (x - wall.x) * wall.cosF - (z - wall.z) * wall.sinF;
+      final v = (x - wall.x) * wall.sinF + (z - wall.z) * wall.cosF;
+      final du = alongX ? wall.cosF : -wall.sinF;
+      final dv = alongX ? wall.sinF : wall.cosF;
+      var enter = double.negativeInfinity;
+      var exit = double.infinity;
+      if (du.abs() < 1e-12) {
+        if (u.abs() >= wall.halfW) continue;
+      } else {
+        final a = (-wall.halfW - u) / du;
+        final b = (wall.halfW - u) / du;
+        enter = math.min(a, b);
+        exit = math.max(a, b);
+      }
+      if (dv.abs() < 1e-12) {
+        if (v.abs() >= wall.halfD) continue;
+      } else {
+        final a = (-wall.halfD - v) / dv;
+        final b = (wall.halfD - v) / dv;
+        enter = math.max(enter, math.min(a, b));
+        exit = math.min(exit, math.max(a, b));
+      }
+      if (enter < exit) intervals.add((enter, exit));
+    }
+    intervals.sort((a, b) => a.$1.compareTo(b.$1));
+    // Recovery starts inside a wall, so each axis has a component containing
+    // zero. Ignore separate buildings before and after that component.
+    var (lower, upper) = intervals.first;
+    const separation = 1e-7;
+    for (var i = 1; i < intervals.length; i++) {
+      final (start, end) = intervals[i];
+      if (start <= upper + 2 * separation) {
+        upper = math.max(upper, end);
+      } else {
+        if (upper >= 0) break;
+        lower = start;
+        upper = end;
+      }
+    }
+    return lower.abs() < upper.abs() ? lower - separation : upper + separation;
   }
 }
 
@@ -204,4 +261,12 @@ class _Wall {
   /// The corner is the box's farthest point from its centre: a point at
   /// least this far (squared, so no root per footprint) is outside.
   double get cornerDistanceSquared => halfW * halfW + halfD * halfD;
+
+  /// Ignore sub-nanometre round-off on an already resolved face.
+  bool contains(double px, double pz) {
+    final dx = px - x;
+    final dz = pz - z;
+    return (dx * cosF - dz * sinF).abs() < halfW - 1e-9 &&
+        (dx * sinF + dz * cosF).abs() < halfD - 1e-9;
+  }
 }

--- a/lib/features/plaza/domain/walk_collider.dart
+++ b/lib/features/plaza/domain/walk_collider.dart
@@ -1,10 +1,10 @@
-/// Keeps the walker out of every solid: a point-versus-rotated-rectangle
-/// push against every footprint, with a margin so the camera never clips a
-/// wall.
+/// Keeps the walker out of every solid: swept movement against rotated
+/// footprints, with a margin so the camera never clips a wall, even when
+/// a fast step crosses an entire building.
 ///
-/// Pure Dart, O(footprints) per resolve; each footprint's frame is fixed
-/// once, and a footprint too far away to touch is rejected before it is
-/// rotated into.
+/// Pure Dart, O(footprints) per move/resolve; each footprint's frame is fixed
+/// once. Point recovery rejects distant footprints before rotating into
+/// their local frame; movement checks the complete segment.
 library;
 
 import 'dart:math' as math;
@@ -77,6 +77,80 @@ class WalkCollider {
 
   /// Extra clearance around every footprint, world meters.
   final double margin;
+
+  /// Sweeps the entire step, stopping at the first wall and sliding along it.
+  ///
+  /// At most four contacts are processed, independent of speed or frame time;
+  /// any remaining motion is discarded at a complex corner. The slabs and
+  /// contact normals use cached wall frames, with no per-wall allocations.
+  (double, double) move(double fromX, double fromZ, double toX, double toZ) {
+    var (x, z) = resolve(fromX, fromZ);
+    var dx = toX - fromX;
+    var dz = toZ - fromZ;
+    const epsilon = 1e-9;
+    for (var contact = 0; contact < 4; contact++) {
+      if (dx.abs() + dz.abs() < epsilon) break;
+      var earliest = 1.0;
+      var normalX = 0.0;
+      var normalZ = 0.0;
+      var hit = false;
+      for (final w in _walls) {
+        final u = (x - w.x) * w.cosF - (z - w.z) * w.sinF;
+        final v = (x - w.x) * w.sinF + (z - w.z) * w.cosF;
+        final du = dx * w.cosF - dz * w.sinF;
+        final dv = dx * w.sinF + dz * w.cosF;
+        var enterU = double.negativeInfinity;
+        var exitU = double.infinity;
+        var enterV = double.negativeInfinity;
+        var exitV = double.infinity;
+        if (du.abs() < epsilon) {
+          if (u.abs() >= w.halfW) continue;
+        } else {
+          final a = (-w.halfW - u) / du;
+          final b = (w.halfW - u) / du;
+          enterU = math.min(a, b);
+          exitU = math.max(a, b);
+        }
+        if (dv.abs() < epsilon) {
+          if (v.abs() >= w.halfD) continue;
+        } else {
+          final a = (-w.halfD - v) / dv;
+          final b = (w.halfD - v) / dv;
+          enterV = math.min(a, b);
+          exitV = math.max(a, b);
+        }
+        final enter = math.max(enterU, enterV);
+        final exit = math.min(exitU, exitV);
+        // Ignore grazing, motion away from a face, and walls beyond this step.
+        if (enter < -epsilon ||
+            enter > earliest ||
+            exit <= math.max(0, enter)) {
+          continue;
+        }
+        earliest = math.max(0, enter);
+        hit = true;
+        if (enterU > enterV) {
+          normalX = -du.sign * w.cosF;
+          normalZ = du.sign * w.sinF;
+        } else {
+          normalX = -dv.sign * w.sinF;
+          normalZ = -dv.sign * w.cosF;
+        }
+      }
+      x += dx * earliest;
+      z += dz * earliest;
+      if (!hit) break;
+      // A sub-micron separation avoids round-off placing the next sweep inside.
+      x += normalX * 1e-7;
+      z += normalZ * 1e-7;
+      dx *= 1 - earliest;
+      dz *= 1 - earliest;
+      final intoWall = dx * normalX + dz * normalZ;
+      dx -= intoWall * normalX;
+      dz -= intoWall * normalZ;
+    }
+    return (x, z);
+  }
 
   /// Returns the nearest point outside every footprint to (x, z).
   (double, double) resolve(double x, double z) {

--- a/lib/features/plaza/scene/plaza_architecture.dart
+++ b/lib/features/plaza/scene/plaza_architecture.dart
@@ -1,0 +1,194 @@
+import 'dart:math' as math;
+
+import 'package:flutter_scene/scene.dart';
+import 'package:lotti/features/plaza/domain/building_architecture.dart';
+import 'package:lotti/features/plaza/scene/plaza_boxes.dart';
+import 'package:vector_math/vector_math.dart';
+
+/// Articulates reserved building volumes with recessed glazing, structural
+/// piers, cornices and illuminated setbacks. All dimensions are world metres;
+/// materials belong to the caller's existing scene palette.
+///
+/// Unit meshes and materials remain shared. Detail is bounded per volume,
+/// generated once, and baked with the rest of the static city. Skyline towers
+/// retain their silhouette and crown without the street-level column grid.
+class PlazaArchitecture {
+  PlazaArchitecture(this.boxes);
+
+  final PlazaBoxes boxes;
+
+  /// Builds in the recipe's ground-centred frame. [onVolume] dresses the inset
+  /// wall core (usually with shared window textures); trim remains inside the
+  /// original envelope and never crosses the front sign plane.
+  Node build(
+    BuildingArchitecture architecture, {
+    required UnlitMaterial wall,
+    required UnlitMaterial trim,
+    required UnlitMaterial light,
+    required void Function(Node, BuildingVolume, {required bool groundFloor})
+    onVolume,
+    bool detailed = true,
+  }) {
+    final root = Node(name: 'architecture-${architecture.family.name}');
+    for (final (index, volume) in architecture.volumes.indexed) {
+      final relief = math.min(0.28, math.min(volume.width, volume.depth) / 20);
+      final core = BuildingVolume(
+        width: volume.width - relief * 2,
+        depth: volume.depth - relief * 2,
+        bottom: volume.bottom,
+        height: volume.height,
+        x: volume.x,
+        z: volume.z,
+      );
+      final tier = boxes.node(
+        Vector3(core.width, core.height, core.depth),
+        wall,
+        transform: Matrix4.translation(
+          Vector3(core.x, core.bottom + core.height / 2, core.z),
+        ),
+        shaded: true,
+      );
+      root.add(tier);
+      onVolume(tier, core, groundFloor: index == 0);
+
+      final crown = volume.bottom >= architecture.frontageHeight;
+      final band = math.min(0.3, volume.height / 12);
+      if (!detailed) {
+        // Background buildings are read by silhouette. Keep just the lit crown
+        // course as one cap: four separate rim pieces and a ground-floor
+        // coping across the skyline cost vertices even when draw counts match.
+        if (crown) {
+          _piece(
+            root,
+            Vector3(volume.x, volume.top - band * 1.75, volume.z),
+            Vector3(volume.width, band / 2, volume.depth),
+            light,
+          );
+        }
+        continue;
+      }
+      _rim(root, volume, volume.top - band, band, trim);
+      // A recessed luminous course under the coping gives the stepped crown
+      // a recognizable silhouette without adding an opaque roof-sized light.
+      if (crown || index == 0) {
+        _rim(root, volume, volume.top - band * 2, band / 2, light);
+      }
+      if (index == 0) continue;
+
+      final pier = math.min(0.42, math.min(volume.width, volume.depth) / 12);
+      final height = volume.height - band;
+      // Four corner piers frame the sign, with their outer edge on the solid.
+      for (final side in [-1.0, 1.0]) {
+        for (final end in [-1.0, 1.0]) {
+          _piece(
+            root,
+            Vector3(
+              volume.x + side * (volume.width - pier) / 2,
+              volume.bottom + height / 2,
+              volume.z + end * (volume.depth - pier) / 2,
+            ),
+            Vector3(pier, height, pier),
+            trim,
+          );
+        }
+      }
+
+      if (architecture.family == BuildingFamily.mediaTower) {
+        // Side-wall spandrels give the glass family a horizontal rhythm.
+        // Deliberately omit the street-facing span where the task sign lives.
+        final courses = (volume.height / 9).floor().clamp(0, 6);
+        for (var i = 1; i <= courses; i++) {
+          _rim(
+            root,
+            volume,
+            volume.bottom + volume.height * i / (courses + 1),
+            band / 2,
+            trim,
+            front: crown,
+          );
+        }
+      } else {
+        // Stone/theater bays have real depth instead of a printed grid.
+        // The count caps generation even for unusually wide task envelopes.
+        final bays = (volume.depth / 5).floor().clamp(1, 6);
+        for (var i = 1; i < bays; i++) {
+          for (final side in [-1.0, 1.0]) {
+            _piece(
+              root,
+              Vector3(
+                volume.x + side * (volume.width - relief) / 2,
+                volume.bottom + height / 2,
+                volume.z - volume.depth / 2 + volume.depth * i / bays,
+              ),
+              Vector3(relief, height, pier),
+              trim,
+            );
+          }
+        }
+        // Crown flutes are visible from Home; below it the sign stays clear.
+        if (crown) {
+          final flutes = (volume.width / 4).floor().clamp(1, 6);
+          for (var i = 1; i < flutes; i++) {
+            _piece(
+              root,
+              Vector3(
+                volume.x - volume.width / 2 + volume.width * i / flutes,
+                volume.bottom + height / 2,
+                volume.z + (volume.depth - relief) / 2,
+              ),
+              Vector3(pier, height, relief),
+              trim,
+            );
+          }
+        }
+      }
+    }
+    return root;
+  }
+
+  void _piece(Node root, Vector3 center, Vector3 size, UnlitMaterial material) {
+    root.add(
+      boxes.node(
+        size,
+        material,
+        transform: Matrix4.translation(center),
+        shaded: true,
+      ),
+    );
+  }
+
+  void _rim(
+    Node root,
+    BuildingVolume volume,
+    double bottom,
+    double height,
+    UnlitMaterial material, {
+    bool front = true,
+  }) {
+    final reach = math.min(0.35, math.min(volume.width, volume.depth) / 10);
+    for (final side in [-1.0, 1.0]) {
+      if (side < 0 || front) {
+        _piece(
+          root,
+          Vector3(
+            volume.x,
+            bottom + height / 2,
+            volume.z + side * (volume.depth - reach) / 2,
+          ),
+          Vector3(volume.width, height, reach),
+          material,
+        );
+      }
+      _piece(
+        root,
+        Vector3(
+          volume.x + side * (volume.width - reach) / 2,
+          bottom + height / 2,
+          volume.z,
+        ),
+        Vector3(reach, height, volume.depth),
+        material,
+      );
+    }
+  }
+}

--- a/lib/features/plaza/scene/plaza_buildings.dart
+++ b/lib/features/plaza/scene/plaza_buildings.dart
@@ -25,45 +25,28 @@ extension _PlazaBuildingsBuilder on PlazaSceneController {
     final wallTint = linearColor(PlazaStyle.categoryWall(task));
     final stone = _boxes.solid(wallTint);
     final cornice = _boxes.solid(linearColor(colors.background.level03));
-    for (final (index, volume) in architecture.volumes.indexed) {
-      final tier = _boxes.node(
-        Vector3(volume.width, volume.height, volume.depth),
-        stone,
-        transform: Matrix4.translation(
-          Vector3(
-            volume.x,
-            volume.bottom + volume.height / 2 - h / 2,
-            volume.z,
-          ),
-        ),
-        shaded: true,
-      );
-      node.add(tier);
-      if (_shown('walls')) {
+    final structure = PlazaArchitecture(_boxes).build(
+      architecture,
+      wall: stone,
+      trim: cornice,
+      light: _boxes.solid(linearColor(PlazaStyle.taskColor(attention))),
+      onVolume: (tier, volume, {required groundFloor}) {
+        if (!_shown('walls')) return;
         _windowedBox(
           tier,
-          id: '${task.id}-$index',
+          id: '${task.id}-${volume.bottom}',
           w: volume.width,
           d: volume.depth,
           height: volume.height,
           state: attention.lantern,
-          groundFloor: index == 0,
+          groundFloor: groundFloor,
           tint: wallTint,
           variant: parade,
           family: kit,
         );
-      }
-      // Continuous cornices tie the family together, with a recessed crown
-      // rather than roof clutter extending beyond the reserved solid.
-      _rim(
-        tier,
-        w: volume.width,
-        d: volume.depth,
-        y: volume.height / 2 - 0.1,
-        thickness: 0.2,
-        material: cornice,
-      );
-    }
+      },
+    )..localTransform = Matrix4.translation(Vector3(0, -h / 2, 0));
+    node.add(structure);
     _box(
       node,
       Vector3(0, -h / 2 + 0.02, 0),

--- a/lib/features/plaza/scene/plaza_furniture.dart
+++ b/lib/features/plaza/scene/plaza_furniture.dart
@@ -264,36 +264,36 @@ extension _PlazaFurnitureBuilder on PlazaSceneController {
         family: BuildingFamily.steppedTower,
         minimumFrontageHeight: jumbotron.bottom + jumbotron.height,
       );
-      final tower = Node(
-        localTransform: Matrix4.translation(
-          Vector3(0, towerH / 2, -jumbotronTowerSetback),
-        ),
-      );
-      for (final (index, volume) in architecture.volumes.indexed) {
-        final tier = _boxes.node(
-          Vector3(volume.width, volume.height, volume.depth),
-          PlazaSceneController._towerMaterial,
-          transform: Matrix4.translation(
-            Vector3(
-              volume.x,
-              volume.bottom + volume.height / 2 - towerH / 2,
-              volume.z,
+      final tower =
+          Node(
+            localTransform: Matrix4.translation(
+              Vector3(0, towerH / 2, -jumbotronTowerSetback),
             ),
-          ),
-          shaded: true,
-        );
-        _windowedBox(
-          tier,
-          id: 'jumbotron-$index',
-          w: volume.width,
-          d: volume.depth,
-          height: volume.height,
-          state: LanternState.inProgress,
-          tint: PlazaSceneController._tower,
-          groundFloor: index == 0,
-        );
-        tower.add(tier);
-      }
+          )..add(
+            PlazaArchitecture(_boxes).build(
+              architecture,
+              wall: PlazaSceneController._towerMaterial,
+              trim: _boxes.solid(
+                linearColor(dsTokensDark.colors.background.level03),
+              ),
+              light: _boxes.solid(
+                emissiveColor(PlazaStyle.teal, PlazaSceneController.neonBoost),
+              ),
+              onVolume: (tier, volume, {required groundFloor}) {
+                _windowedBox(
+                  tier,
+                  id: 'jumbotron-${volume.bottom}',
+                  w: volume.width,
+                  d: volume.depth,
+                  height: volume.height,
+                  state: LanternState.inProgress,
+                  tint: PlazaSceneController._tower,
+                  groundFloor: groundFloor,
+                  family: 2,
+                );
+              },
+            )..localTransform = Matrix4.translation(Vector3(0, -towerH / 2, 0)),
+          );
       // The corner strips and crown at a quarter, so the screen's own
       // border is the one teal frame on the tower.
       final corner = UnlitMaterial()

--- a/lib/features/plaza/scene/plaza_scene.dart
+++ b/lib/features/plaza/scene/plaza_scene.dart
@@ -9,6 +9,7 @@ import 'package:lotti/features/plaza/domain/plaza_layout.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/features/plaza/domain/scenery.dart';
 import 'package:lotti/features/plaza/domain/street_layout.dart';
+import 'package:lotti/features/plaza/scene/plaza_architecture.dart';
 import 'package:lotti/features/plaza/scene/plaza_boxes.dart';
 import 'package:lotti/features/plaza/scene/plaza_primitives.dart';
 import 'package:lotti/features/plaza/scene/plaza_scene_records.dart';
@@ -70,9 +71,6 @@ class PlazaSceneController {
   static final Vector4 _post = linearColor(const Color(0xFF14171F));
   static final Vector4 _tower = linearColor(const Color(0xFF0E0B18));
 
-  /// The skyline ring's body: a shade above the fillers so distant
-  /// silhouettes read against the sky instead of dissolving into it.
-  static final Vector4 _skyline = linearColor(const Color(0xFF161428));
   static final Vector4 _pavement = linearColor(const Color(0xFF232532));
   static final Vector4 _kerb = linearColor(const Color(0xFF5A5E72));
 
@@ -155,8 +153,13 @@ class PlazaSceneController {
           ..baseColorFactor = Vector4(1, 1, 1, 1);
       }
     }
-    for (final (material, _) in _pools) {
+    for (final (material, _) in [..._pools, ..._washes]) {
       material.baseColorTexture = textures.pool;
+    }
+    // Billboard glows have their own animation owner, but still need the
+    // falloff texture. An untextured blended quad reads as a coloured sheet.
+    for (final billboard in bindings.billboards) {
+      billboard.glow?.baseColorTexture = textures.pool;
     }
     for (final material in _grainMaterials) {
       material.baseColorTexture = textures.grain;

--- a/lib/features/plaza/scene/plaza_skyline.dart
+++ b/lib/features/plaza/scene/plaza_skyline.dart
@@ -54,31 +54,16 @@ extension _PlazaSkylineBuilder on PlazaSceneController {
       final bh = block.height;
       // Local x is lateral, local z runs along the road: the block is
       // bw long along the street and bd deep away from it.
-      final node = _boxes.node(
-        Vector3(bd, bh, bw),
-        PlazaSceneController._towerMaterial,
-        transform: Matrix4.translation(Vector3(block.x, bh / 2, block.z))
-          ..rotateY(block.yawRadians),
-        shaded: true,
-      );
-      final parade = stableIndex(id, 'parade', WallTextures.paradeVariants);
-      final kit = stableIndex(id, 'kit', WallTextures.tileFamilies);
-      // Windows on every face: a filler is seen from the street, from
-      // the plaza and from above.
-      _windowedBox(
-        node,
-        id: id,
-        w: bd,
-        d: bw,
-        height: bh,
-        faces: const [_Face.right, _Face.left, _Face.front, _Face.back],
-        state: LanternState.open,
-        tint: PlazaSceneController._tower,
-        // The fabric trades all night, whatever its flats are doing.
-        shops: LanternState.inProgress,
-        variant: parade,
-        family: kit,
-      );
+      final node =
+          _sceneryArchitecture(
+              block,
+              state: LanternState.open,
+              light: PlazaStyle.lamp,
+              detailed: false,
+            )
+            ..localTransform = (Matrix4.translation(
+              Vector3(block.x, 0, block.z),
+            )..rotateY(block.yawRadians));
       // The parade's light on the pavement, on the street side.
       {
         final yaw = block.yawRadians + (side < 0 ? math.pi / 2 : -math.pi / 2);
@@ -108,7 +93,7 @@ extension _PlazaSkylineBuilder on PlazaSceneController {
           final pick = stableIndex(id, 'pick', weekTasks.length);
           final anchor = Node(
             localTransform: Matrix4.translation(
-              Vector3(-side * (bd / 2 + 0.08), bh * 0.15, -bw / 2 + 1.2),
+              Vector3(-side * (bd / 2 + 0.08), bh * 0.65, -bw / 2 + 1.2),
             )..rotateY(side < 0 ? math.pi / 2 : -math.pi / 2),
           );
           node.add(anchor);
@@ -125,40 +110,23 @@ extension _PlazaSkylineBuilder on PlazaSceneController {
   /// toward. The last row's far end has the jumbotron instead.
   void _buildHeroTowers() {
     for (final tower in world.scenery.heroTowers) {
-      final id = tower.id;
       final w = tower.width;
       final bd = tower.depth;
       final height = tower.height;
       // The root faces back down the row.
-      final root = Node(
-        localTransform: Matrix4.translation(Vector3(tower.x, 0, tower.z))
-          ..rotateY(tower.yawRadians),
-      );
-      final box = _boxes.node(
-        Vector3(w, height, bd),
-        PlazaSceneController._towerMaterial,
-        transform: Matrix4.translation(Vector3(0, height / 2, 0)),
-        shaded: true,
-      );
-      final parade = stableIndex(id, 'parade', WallTextures.paradeVariants);
-      root.add(box);
-      _windowedBox(
-        box,
-        id: id,
-        w: w,
-        d: bd,
-        height: height,
-        state: LanternState.inProgress,
-        tint: PlazaSceneController._tower,
-        variant: parade,
-      );
-      // Crown: a lit trim and a spire with a blinking light.
-      _box(
-        root,
-        Vector3(0, height + 0.1, 0),
-        Vector3(w + 0.3, 0.2, bd + 0.3),
-        _boxes.solid(linearColor(PlazaStyle.teal, alpha: 0.9)),
-      );
+      final root =
+          Node(
+            localTransform: Matrix4.translation(Vector3(tower.x, 0, tower.z))
+              ..rotateY(tower.yawRadians),
+          )..add(
+            _sceneryArchitecture(
+              tower,
+              state: LanternState.inProgress,
+              light: PlazaStyle.teal,
+              landmark: true,
+              minimumFrontageHeight: height * 0.62 + w * 0.9 * 0.62 / 2,
+            ),
+          );
       _spire(
         root,
         Vector3(0, height, 0),
@@ -210,34 +178,21 @@ extension _PlazaSkylineBuilder on PlazaSceneController {
   /// data.
   void _buildSkyline() {
     for (final tower in world.scenery.skyline) {
-      final id = tower.id;
       final i = tower.index;
       final w = tower.width;
       final h = tower.height;
-      final node = _boxes.node(
-        Vector3(w, h, tower.depth),
-        _boxes.solid(PlazaSceneController._skyline),
-        transform: Matrix4.translation(Vector3(tower.x, h / 2, tower.z))
-          ..rotateY(tower.yawRadians),
-        shaded: true,
-      );
-      // A lit roofline along the district-facing edge, warm and teal by
-      // turns, so the ring is a glowing horizon and not a row of dots.
-      final roofline = i.isEven ? const Color(0xFFFFC46B) : PlazaStyle.teal;
-      _box(
-        node,
-        Vector3(0, h / 2 + 0.1, tower.depth / 2 - 0.1),
-        Vector3(w + 0.2, 0.25, 0.25),
-        _boxes.solid(
-          emissiveColor(roofline, PlazaSceneController.neonBoost, alpha: 0.95),
-        ),
-      );
-      node.add(
-        _glowQuad(w + 4, 3, roofline, 0.16)
-          ..localTransform = Matrix4.translation(
-            Vector3(0, h / 2 + 0.6, tower.depth / 2 + 0.05),
-          ),
-      );
+      final node =
+          _sceneryArchitecture(
+              tower,
+              state: LanternState.off,
+              light: i.isEven ? PlazaStyle.lamp : PlazaStyle.teal,
+              detailed: false,
+              shops: false,
+              minimumFrontageHeight: math.min(h, h * 0.55 + w * 0.82 * 0.5 / 2),
+            )
+            ..localTransform = (Matrix4.translation(
+              Vector3(tower.x, 0, tower.z),
+            )..rotateY(tower.yawRadians));
       // Every fourth tower carries a big screen on its district-facing
       // face: the hi-rises behind Times Square are where the screens are.
       if (i % 4 == 1 && world.anomalies.isNotEmpty) {
@@ -249,7 +204,7 @@ extension _PlazaSkylineBuilder on PlazaSceneController {
           node,
           width: sw,
           height: sh,
-          y: sy - h / 2,
+          y: sy,
           front: tower.depth / 2,
           frame: PlazaStyle.lantern(world.anomalies[rank].lantern),
           glowMargin: 6,
@@ -257,19 +212,68 @@ extension _PlazaSkylineBuilder on PlazaSceneController {
           rank: rank,
         );
       }
-      // Two windowed faces toward the district, tiled from one offset.
-      _windowedBox(
-        node,
-        id: id,
-        w: w,
-        d: tower.depth,
-        height: h,
-        faces: const [_Face.front, _Face.left],
-        state: LanternState.off,
-        tint: PlazaSceneController._tower,
-        perFaceOffset: false,
-      );
       _cityContext.add(node);
     }
+  }
+
+  /// Shared recipes for supporting city fabric and avenue landmarks. A distant
+  /// tower keeps its massing and crown with no column grid or shopfront capture.
+  Node _sceneryArchitecture(
+    SceneryBox box, {
+    required LanternState state,
+    required Color light,
+    bool landmark = false,
+    bool detailed = true,
+    bool shops = true,
+    double minimumFrontageHeight = 0,
+  }) {
+    final architecture = BuildingArchitecture.forEnvelope(
+      id: box.id,
+      width: box.width,
+      depth: box.depth,
+      height: box.height,
+      config: world.architecture,
+      family: landmark ? BuildingFamily.steppedTower : null,
+      minimumFrontageHeight: minimumFrontageHeight,
+    );
+    final colors = dsTokensDark.colors;
+    final glow = landmark
+        ? light
+        : Color.lerp(colors.background.level02, light, SurfaceAlphas.muted)!;
+    final variant = stableIndex(box.id, 'parade', WallTextures.paradeVariants);
+    final family = switch (architecture.family) {
+      BuildingFamily.mediaTower => 2,
+      BuildingFamily.theater => 1,
+      BuildingFamily.steppedTower => 0,
+    };
+    return PlazaArchitecture(_boxes).build(
+      architecture,
+      wall: PlazaSceneController._towerMaterial,
+      trim: _boxes.solid(
+        linearColor(
+          landmark ? colors.background.level03 : colors.background.level02,
+        ),
+      ),
+      light: _boxes.solid(
+        emissiveColor(glow, landmark ? PlazaSceneController.neonBoost : 1),
+      ),
+      detailed: detailed,
+      onVolume: (tier, volume, {required groundFloor}) {
+        _windowedBox(
+          tier,
+          id: '${box.id}-${volume.bottom}',
+          w: volume.width,
+          d: volume.depth,
+          height: volume.height,
+          state: state,
+          tint: PlazaSceneController._tower,
+          groundFloor: shops && groundFloor,
+          shops: LanternState.inProgress,
+          variant: variant,
+          family: family,
+          faces: shops ? _Face.values : const [_Face.front, _Face.left],
+        );
+      },
+    );
   }
 }

--- a/lib/features/plaza/scene/plaza_walls.dart
+++ b/lib/features/plaza/scene/plaza_walls.dart
@@ -143,8 +143,7 @@ extension _PlazaWallsBuilder on PlazaSceneController {
 
   /// Windowed walls ([_windowedWall]) on [faces] of the [w] × [d] box
   /// under [parent], in that order, whose centre sits at half [height].
-  /// Each face tiles from its own hashed offset so it starts at its own
-  /// shop, unless [perFaceOffset] is off and every face shares one.
+  /// Each face tiles from its own hashed offset so it starts at its own shop.
   void _windowedBox(
     Node parent, {
     required String id,
@@ -154,7 +153,6 @@ extension _PlazaWallsBuilder on PlazaSceneController {
     required LanternState state,
     required Vector4 tint,
     List<_Face> faces = _Face.values,
-    bool perFaceOffset = true,
     bool groundFloor = true,
     LanternState? shops,
     int variant = 0,
@@ -179,7 +177,7 @@ extension _PlazaWallsBuilder on PlazaSceneController {
         height: height,
         state: state,
         tint: tint,
-        uOffset: stableUnit(id, perFaceOffset ? 'tile$yaw' : 'tile') * 3,
+        uOffset: stableUnit(id, 'tile$yaw') * 3,
         groundFloor: groundFloor,
         shops: shops,
         variant: variant,

--- a/lib/features/plaza/scene/wall_textures.dart
+++ b/lib/features/plaza/scene/wall_textures.dart
@@ -19,8 +19,9 @@ class WallTextures {
 
   /// How many window-tile families there are: the same lit ratio in
   /// three occupancies (mixed flats, a residential stack with dark floors
-  /// and one lit edge to edge, a cool office grid), so adjacent walls do
-  /// not share one wallpaper.
+  /// and one lit edge to edge, a cool office curtain wall), so adjacent walls
+  /// do not share one wallpaper. The office family has larger glass panes
+  /// and metal mullions; all families share the same atlas dimensions.
   static const tileFamilies = 3;
 
   /// One tile is [floors] storeys tall and [bays] windows wide, in world
@@ -1207,7 +1208,10 @@ class WallTextures {
       ..scale(_textureScale)
       ..drawRect(
         ui.Rect.fromLTWH(0, 0, w.toDouble(), h.toDouble()),
-        ui.Paint()..color = _night,
+        ui.Paint()
+          ..color = family == 2
+              ? dsTokensDark.colors.aiCard.background
+              : _night,
       );
     final rng = math.Random(state.index * 7919 + 17 + family * 101);
     final tint = _tints[state]!;
@@ -1224,11 +1228,17 @@ class WallTextures {
     final blindShare = family == 2 ? 0.15 : 0.4;
     for (var floor = 0; floor < floors; floor++) {
       for (var bay = 0; bay < bays; bay++) {
-        // A pane clearly smaller than a shop door, so the storeys read
-        // as storeys next to the 4 m band.
-        final x = bay * _px + _px * 0.27;
-        final y = floor * _px + _px * 0.3;
-        final rect = ui.Rect.fromLTWH(x, y, _px * 0.46, _px * 0.5);
+        // Residential punched windows contrast with floor-to-ceiling office
+        // glazing. This changes the architecture without another atlas or draw.
+        final office = family == 2;
+        final x = bay * _px + _px * (office ? 0.08 : 0.27);
+        final y = floor * _px + _px * (office ? 0.14 : 0.3);
+        final rect = ui.Rect.fromLTWH(
+          x,
+          y,
+          _px * (office ? 0.84 : 0.46),
+          _px * (office ? 0.78 : 0.5),
+        );
         final roll = rng.nextDouble() < lit;
         final on = floor != darkFloor && (floor == litFloor || roll);
         // Two tints per state: most windows warm, a few the cooler one,
@@ -1283,6 +1293,18 @@ class WallTextures {
               rect.height * (0.25 + rng.nextDouble() * 0.35),
             ),
             ui.Paint()..color = const ui.Color(0xB30B0A14),
+          );
+        }
+        if (office) {
+          // Narrow metal caps catch the city light between the dark glazing.
+          canvas.drawRect(
+            ui.Rect.fromLTWH(
+              bay * _px.toDouble(),
+              floor * _px.toDouble(),
+              _px * 0.025,
+              _px.toDouble(),
+            ),
+            ui.Paint()..color = dsTokensDark.colors.background.level03,
           );
         }
       }

--- a/lib/features/plaza/ui/fly_camera_controller.dart
+++ b/lib/features/plaza/ui/fly_camera_controller.dart
@@ -11,8 +11,8 @@ import 'package:vector_math/vector_math.dart' show Vector3;
 
 /// First-person walk camera with flights.
 ///
-/// WASD/arrows walk (shift sprints), drag looks, and [flyTo] hands the pose
-/// to a [Flight]: between two stops on the ground it follows the street
+/// WASD/arrows walk (hold Shift for 8× travel), drag looks, and [flyTo]
+/// hands the pose to a [Flight]: between two stops on the ground it follows the street
 /// network; otherwise it is the direct line. Either way it is planned over
 /// the world's solids, so it lifts over whatever stands on its line; any
 /// movement input cancels a flight in place. Walking happens at
@@ -32,7 +32,11 @@ class FlyCameraController {
   // ignore_for_file: prefer_initializing_formals
 
   static const walkSpeed = 3.4;
-  static const _sprintFactor = 2.5;
+  static const _sprintFactor = 8.0;
+
+  /// Shift changes flight time continuously, including a gentle release.
+  static const _flightSpeedRamp = 0.3;
+  double _flightSpeed = 1;
 
   /// Vertical field of view: a game camera, not a phone lens.
   static const double fovRadiansY = 60 * math.pi / 180;
@@ -69,6 +73,7 @@ class FlyCameraController {
     _pose = value;
     _flight = null;
     _landing = false;
+    _flightSpeed = 1;
     _vForward = 0;
     _vStrafe = 0;
   }
@@ -119,6 +124,7 @@ class FlyCameraController {
         : Flight.plan(_pose, target, solids: _solids);
     _flight = flight;
     _landing = false;
+    _flightSpeed = 1;
     _vForward = 0;
     _vStrafe = 0;
     return flight;
@@ -182,6 +188,7 @@ class FlyCameraController {
       solids: _solids,
     );
     _landing = true;
+    _flightSpeed = 1;
   }
 
   /// Mouse-drag look, in logical pixels. Cancels a flight in place and
@@ -206,8 +213,20 @@ class FlyCameraController {
   void update(double dt) {
     final flight = _flight;
     if (flight != null) {
+      // Read actual modifiers even when Shift was held before entering the
+      // view, or a key-up went to an overlay. Shift alone never cancels flight.
+      final target = HardwareKeyboard.instance.isShiftPressed
+          ? _sprintFactor
+          : 1.0;
+      final step = math.max(0, dt);
+      final decay = math.exp(-step / _flightSpeedRamp);
+      // Integrate the exponential exactly: boost feels the same at any FPS.
+      final elapsed =
+          target * step +
+          (_flightSpeed - target) * _flightSpeedRamp * (1 - decay);
+      _flightSpeed = target + (_flightSpeed - target) * decay;
       _pose = flight.advance(
-        Duration(microseconds: (dt * 1e6).round()),
+        Duration(microseconds: (elapsed * 1e6).round()),
       );
       if (flight.done) {
         _flight = null;
@@ -263,7 +282,7 @@ class FlyCameraController {
       z += (cosY * _vForward - sinY * _vStrafe) * dt;
       final collider = _collider;
       if (collider != null) {
-        (x, z) = collider.resolve(x, z);
+        (x, z) = collider.move(_pose.x, _pose.z, x, z);
       }
     }
     _pose = CameraPose(x: x, y: y, z: z, yaw: _pose.yaw, pitch: _pose.pitch);

--- a/lib/features/plaza/ui/plaza_view.dart
+++ b/lib/features/plaza/ui/plaza_view.dart
@@ -119,7 +119,7 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
   Node? _penguinModel;
   bool _loadingPenguinModel = false;
   bool _animateCharacters = true;
-  bool _showPenguins = true;
+  bool _showPenguins = false;
   late PlazaSurfaces _surfaces;
   late PlazaPicker _picker;
   late FlyCameraController _camera;

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -3846,7 +3846,7 @@
   "plazaCategoryEmpty": "V této kategorii nejsou žádné viditelné projekty.",
   "plazaClosedForNight": "NA NOC ZAVŘENO",
   "plazaCloseHint": "Esc zavře",
-  "plazaControls": "WASD chůze · tažením se rozhlížej · Tab další maják · H domů · M přehled · / hledat · ⌘[ zpět",
+  "plazaControls": "WASD chůze · drž Shift: 8× rychlost · tažením se rozhlížej · Tab další maják · H domů · M přehled · / hledat · ⌘[ zpět",
   "plazaCornerAfter": "Odbočka za {week}",
   "plazaDebug": "Ladění",
   "plazaDecisionStrip": "ČEKÁ NA ROZHODNUTÍ",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4313,7 +4313,7 @@
   "plazaCategoryEmpty": "Denne kategori har ingen synlige projekter.",
   "plazaClosedForNight": "LUKKET FOR NATTEN",
   "plazaCloseHint": "Esc for at lukke",
-  "plazaControls": "WASD gå · træk for at se dig omkring · Tab næste fyr · H hjem · M overblik · / søg · ⌘[ tilbage",
+  "plazaControls": "WASD gå · hold Shift: 8× hastighed · træk for at se dig omkring · Tab næste fyr · H hjem · M overblik · / søg · ⌘[ tilbage",
   "plazaCornerAfter": "Drej efter {week}",
   "plazaDebug": "Fejlfinding",
   "plazaDecisionStrip": "KRÆVER EN BESLUTNING",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3839,7 +3839,7 @@
   "plazaCategoryEmpty": "Diese Kategorie hat keine sichtbaren Projekte.",
   "plazaClosedForNight": "ÜBER NACHT GESCHLOSSEN",
   "plazaCloseHint": "Esc zum Schließen",
-  "plazaControls": "WASD gehen · Ziehen zum Umschauen · Tab nächstes Leuchtfeuer · H Start · M Übersicht · / Suche · ⌘[ zurück",
+  "plazaControls": "WASD gehen · Shift halten: 8× Tempo · Ziehen zum Umschauen · Tab nächstes Leuchtfeuer · H Start · M Übersicht · / Suche · ⌘[ zurück",
   "plazaCornerAfter": "Abzweigung nach {week}",
   "plazaDebug": "Debug",
   "plazaDecisionStrip": "ENTSCHEIDUNG NÖTIG",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5791,7 +5791,7 @@
   "plazaCategoryEmpty": "This category has no visible projects.",
   "plazaClosedForNight": "CLOSED FOR THE NIGHT",
   "plazaCloseHint": "Esc to close",
-  "plazaControls": "WASD walk · drag to look · Tab next beacon · H home · M overview · / search · ⌘[ back",
+  "plazaControls": "WASD walk · hold Shift: 8× speed · drag to look · Tab next beacon · H home · M overview · / search · ⌘[ back",
   "plazaCornerAfter": "Corner after {week}",
   "@plazaCornerAfter": {
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -3839,7 +3839,7 @@
   "plazaCategoryEmpty": "Esta categoría no tiene proyectos visibles.",
   "plazaClosedForNight": "CERRADO POR LA NOCHE",
   "plazaCloseHint": "Esc para cerrar",
-  "plazaControls": "WASD caminar · arrastra para mirar · Tab siguiente baliza · H inicio · M vista general · / buscar · ⌘[ volver",
+  "plazaControls": "WASD caminar · mantén Shift: velocidad ×8 · arrastra para mirar · Tab siguiente baliza · H inicio · M vista general · / buscar · ⌘[ volver",
   "plazaCornerAfter": "Giro después de {week}",
   "plazaDebug": "Depuración",
   "plazaDecisionStrip": "NECESITA UNA DECISIÓN",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3839,7 +3839,7 @@
   "plazaCategoryEmpty": "Cette catégorie ne contient aucun projet visible.",
   "plazaClosedForNight": "FERMÉ POUR LA NUIT",
   "plazaCloseHint": "Échap pour fermer",
-  "plazaControls": "WASD marcher · glisse pour regarder · Tab balise suivante · H accueil · M vue d’ensemble · / recherche · ⌘[ retour",
+  "plazaControls": "WASD marcher · maintiens Shift : vitesse ×8 · glisse pour regarder · Tab balise suivante · H accueil · M vue d’ensemble · / recherche · ⌘[ retour",
   "plazaCornerAfter": "Virage après {week}",
   "plazaDebug": "Débogage",
   "plazaDecisionStrip": "DÉCISION NÉCESSAIRE",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4313,7 +4313,7 @@
   "plazaCategoryEmpty": "Questa categoria non ha progetti visibili.",
   "plazaClosedForNight": "CHIUSO PER LA NOTTE",
   "plazaCloseHint": "Esc per chiudere",
-  "plazaControls": "WASD cammina · trascina per guardare · Tab prossimo segnale · H inizio · M panoramica · / cerca · ⌘[ indietro",
+  "plazaControls": "WASD cammina · tieni premuto Shift: velocità ×8 · trascina per guardare · Tab prossimo segnale · H inizio · M panoramica · / cerca · ⌘[ indietro",
   "plazaCornerAfter": "Svolta dopo {week}",
   "plazaDebug": "Debug",
   "plazaDecisionStrip": "SERVE UNA DECISIONE",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -17188,7 +17188,7 @@ abstract class AppLocalizations {
   /// No description provided for @plazaControls.
   ///
   /// In en, this message translates to:
-  /// **'WASD walk · drag to look · Tab next beacon · H home · M overview · / search · ⌘[ back'**
+  /// **'WASD walk · hold Shift: 8× speed · drag to look · Tab next beacon · H home · M overview · / search · ⌘[ back'**
   String get plazaControls;
 
   /// No description provided for @plazaCornerAfter.

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -10258,7 +10258,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get plazaControls =>
-      'WASD chůze · tažením se rozhlížej · Tab další maják · H domů · M přehled · / hledat · ⌘[ zpět';
+      'WASD chůze · drž Shift: 8× rychlost · tažením se rozhlížej · Tab další maják · H domů · M přehled · / hledat · ⌘[ zpět';
 
   @override
   String plazaCornerAfter(String week) {

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -10130,7 +10130,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get plazaControls =>
-      'WASD gå · træk for at se dig omkring · Tab næste fyr · H hjem · M overblik · / søg · ⌘[ tilbage';
+      'WASD gå · hold Shift: 8× hastighed · træk for at se dig omkring · Tab næste fyr · H hjem · M overblik · / søg · ⌘[ tilbage';
 
   @override
   String plazaCornerAfter(String week) {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -10198,7 +10198,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get plazaControls =>
-      'WASD gehen · Ziehen zum Umschauen · Tab nächstes Leuchtfeuer · H Start · M Übersicht · / Suche · ⌘[ zurück';
+      'WASD gehen · Shift halten: 8× Tempo · Ziehen zum Umschauen · Tab nächstes Leuchtfeuer · H Start · M Übersicht · / Suche · ⌘[ zurück';
 
   @override
   String plazaCornerAfter(String week) {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -10082,7 +10082,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get plazaControls =>
-      'WASD walk · drag to look · Tab next beacon · H home · M overview · / search · ⌘[ back';
+      'WASD walk · hold Shift: 8× speed · drag to look · Tab next beacon · H home · M overview · / search · ⌘[ back';
 
   @override
   String plazaCornerAfter(String week) {

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -10279,7 +10279,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get plazaControls =>
-      'WASD caminar · arrastra para mirar · Tab siguiente baliza · H inicio · M vista general · / buscar · ⌘[ volver';
+      'WASD caminar · mantén Shift: velocidad ×8 · arrastra para mirar · Tab siguiente baliza · H inicio · M vista general · / buscar · ⌘[ volver';
 
   @override
   String plazaCornerAfter(String week) {

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -10304,7 +10304,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get plazaControls =>
-      'WASD marcher · glisse pour regarder · Tab balise suivante · H accueil · M vue d’ensemble · / recherche · ⌘[ retour';
+      'WASD marcher · maintiens Shift : vitesse ×8 · glisse pour regarder · Tab balise suivante · H accueil · M vue d’ensemble · / recherche · ⌘[ retour';
 
   @override
   String plazaCornerAfter(String week) {

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -10261,7 +10261,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get plazaControls =>
-      'WASD cammina · trascina per guardare · Tab prossimo segnale · H inizio · M panoramica · / cerca · ⌘[ indietro';
+      'WASD cammina · tieni premuto Shift: velocità ×8 · trascina per guardare · Tab prossimo segnale · H inizio · M panoramica · / cerca · ⌘[ indietro';
 
   @override
   String plazaCornerAfter(String week) {

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -10147,7 +10147,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get plazaControls =>
-      'WASD lopen · sleep om rond te kijken · Tab volgend baken · H start · M overzicht · / zoeken · ⌘[ terug';
+      'WASD lopen · houd Shift ingedrukt: 8× snelheid · sleep om rond te kijken · Tab volgend baken · H start · M overzicht · / zoeken · ⌘[ terug';
 
   @override
   String plazaCornerAfter(String week) {

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -10225,7 +10225,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get plazaControls =>
-      'WASD caminhar · arrasta para olhar · Tab próximo sinal · H início · M visão geral · / procurar · ⌘[ voltar';
+      'WASD caminhar · mantém Shift: velocidade ×8 · arrasta para olhar · Tab próximo sinal · H início · M visão geral · / procurar · ⌘[ voltar';
 
   @override
   String plazaCornerAfter(String week) {

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -10325,7 +10325,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get plazaControls =>
-      'WASD mers · trageți pentru a privi · Tab următorul reper · H acasă · M vedere de ansamblu · / căutare · ⌘[ înapoi';
+      'WASD mers · țineți apăsat Shift: viteză ×8 · trageți pentru a privi · Tab următorul reper · H acasă · M vedere de ansamblu · / căutare · ⌘[ înapoi';
 
   @override
   String plazaCornerAfter(String week) {

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -10139,7 +10139,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get plazaControls =>
-      'WASD gå · dra för att se dig omkring · Tab nästa fyr · H hem · M översikt · / sök · ⌘[ tillbaka';
+      'WASD gå · håll Shift: 8× hastighet · dra för att se dig omkring · Tab nästa fyr · H hem · M översikt · / sök · ⌘[ tillbaka';
 
   @override
   String plazaCornerAfter(String week) {

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4312,7 +4312,7 @@
   "plazaCategoryEmpty": "Deze categorie heeft geen zichtbare projecten.",
   "plazaClosedForNight": "GESLOTEN VOOR DE NACHT",
   "plazaCloseHint": "Esc om te sluiten",
-  "plazaControls": "WASD lopen · sleep om rond te kijken · Tab volgend baken · H start · M overzicht · / zoeken · ⌘[ terug",
+  "plazaControls": "WASD lopen · houd Shift ingedrukt: 8× snelheid · sleep om rond te kijken · Tab volgend baken · H start · M overzicht · / zoeken · ⌘[ terug",
   "plazaCornerAfter": "Bocht na {week}",
   "plazaDebug": "Debuggen",
   "plazaDecisionStrip": "BESLISSING NODIG",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4312,7 +4312,7 @@
   "plazaCategoryEmpty": "Esta categoria não tem projetos visíveis.",
   "plazaClosedForNight": "FECHADO DURANTE A NOITE",
   "plazaCloseHint": "Esc para fechar",
-  "plazaControls": "WASD caminhar · arrasta para olhar · Tab próximo sinal · H início · M visão geral · / procurar · ⌘[ voltar",
+  "plazaControls": "WASD caminhar · mantém Shift: velocidade ×8 · arrasta para olhar · Tab próximo sinal · H início · M visão geral · / procurar · ⌘[ voltar",
   "plazaCornerAfter": "Curva depois de {week}",
   "plazaDebug": "Depuração",
   "plazaDecisionStrip": "PRECISA DE UMA DECISÃO",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -3839,7 +3839,7 @@
   "plazaCategoryEmpty": "Această categorie nu are proiecte vizibile.",
   "plazaClosedForNight": "ÎNCHIS PESTE NOAPTE",
   "plazaCloseHint": "Esc pentru a închide",
-  "plazaControls": "WASD mers · trageți pentru a privi · Tab următorul reper · H acasă · M vedere de ansamblu · / căutare · ⌘[ înapoi",
+  "plazaControls": "WASD mers · țineți apăsat Shift: viteză ×8 · trageți pentru a privi · Tab următorul reper · H acasă · M vedere de ansamblu · / căutare · ⌘[ înapoi",
   "plazaCornerAfter": "Viraj după {week}",
   "plazaDebug": "Depanare",
   "plazaDecisionStrip": "ESTE NECESARĂ O DECIZIE",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4313,7 +4313,7 @@
   "plazaCategoryEmpty": "Den här kategorin har inga synliga projekt.",
   "plazaClosedForNight": "STÄNGT FÖR NATTEN",
   "plazaCloseHint": "Esc för att stänga",
-  "plazaControls": "WASD gå · dra för att se dig omkring · Tab nästa fyr · H hem · M översikt · / sök · ⌘[ tillbaka",
+  "plazaControls": "WASD gå · håll Shift: 8× hastighet · dra för att se dig omkring · Tab nästa fyr · H hem · M översikt · / sök · ⌘[ tillbaka",
   "plazaCornerAfter": "Sväng efter {week}",
   "plazaDebug": "Felsökning",
   "plazaDecisionStrip": "BEHÖVER ETT BESLUT",

--- a/test/README.md
+++ b/test/README.md
@@ -208,6 +208,9 @@ counter increment alone does not prove that a decoded cover reached the GPU.
 An empty `UnskinnedGeometry` with explicit local bounds also needs no GPU
 upload: `plaza_boxes_test.dart` uses it to verify shared geometry and material
 identity and the placement of scaled meshes under unscaled anchors.
+`plaza_architecture_test.dart` supplies the same GPU-free boxes to check
+architectural relief, sign clearance, bounded detail and the simplified skyline
+recipe. Native captures still verify window-skin depth and light falloff.
 
 ## Hover-divider tests: `test_utils/hover_divider_harness.dart`
 

--- a/test/features/plaza/domain/building_architecture_test.dart
+++ b/test/features/plaza/domain/building_architecture_test.dart
@@ -2,6 +2,26 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/plaza/domain/building_architecture.dart';
 
 void main() {
+  test('Art Deco crown narrows through three distinct setbacks', () {
+    final kit = BuildingArchitecture.forEnvelope(
+      id: 'landmark',
+      width: 30,
+      depth: 12,
+      height: 80,
+      family: BuildingFamily.steppedTower,
+      minimumFrontageHeight: 60,
+    );
+    final crown = kit.volumes.where((volume) => volume.bottom >= 60).toList();
+    expect(crown, hasLength(3));
+    expect(crown.first.bottom, 60);
+    expect(crown.last.top, 80);
+    for (var i = 1; i < crown.length; i++) {
+      expect(crown[i].width, lessThan(crown[i - 1].width));
+      expect(crown[i].bottom, crown[i - 1].top);
+    }
+    expect(crown.last.width, lessThan(30 / 2));
+  });
+
   for (final family in BuildingFamily.values) {
     test('$family keeps solids and signs within the reserved plot', () {
       for (final width in [5.0, 14.0, 30.0]) {

--- a/test/features/plaza/domain/flight_test.dart
+++ b/test/features/plaza/domain/flight_test.dart
@@ -217,6 +217,44 @@ void main() {
       expect(corner.x, greaterThanOrEqualTo(49 - 1e-9));
       expect(corner.z, lessThanOrEqualTo(1 + 1e-9));
     });
+
+    for (final (bottom, top) in [(0.0, 4.0), (6.0, 8.0)]) {
+      test('a rounded join preserves vertical clearance at $bottom–$top', () {
+        final obstacle = box(
+          x: 48,
+          z: 2,
+          width: 0.4,
+          depth: 0.4,
+          bottom: bottom,
+          top: top,
+        );
+        final blind = Flight.route(from, to, via: via);
+        final blindCorner = blind.poseAt(timeAt(blind, 50));
+        expect(
+          obstacle.footprint.contains(blindCorner.x, blindCorner.z),
+          isTrue,
+          reason: 'only the bend crosses the roof or overhead panel',
+        );
+        final clear = Flight.route(from, to, via: via, solids: [obstacle]);
+        for (var i = 0; i <= 1000; i++) {
+          final pose = clear.poseAt(i / 1000);
+          final horizontallyInside = obstacle.footprint.contains(
+            pose.x,
+            pose.z,
+            clearance: solidClearance,
+          );
+          expect(
+            horizontallyInside &&
+                pose.y > bottom - Flight.clearance &&
+                pose.y < top + Flight.clearance,
+            isFalse,
+            reason: 'rounded flight must retain the guide legs’ headroom',
+          );
+        }
+        expect(clear.poseAt(0).distanceTo(from), closeTo(0, 1e-9));
+        expect(clear.poseAt(1).distanceTo(to), closeTo(0, 1e-9));
+      });
+    }
   });
 
   test('turning in place takes time and still lands exactly', () {

--- a/test/features/plaza/domain/flight_test.dart
+++ b/test/features/plaza/domain/flight_test.dart
@@ -36,6 +36,21 @@ Solid box({
   top: top,
 );
 
+/// The time at which the flight is [d] metres along its way.
+double timeAt(Flight flight, double d) {
+  var lo = 0.0;
+  var hi = 1.0;
+  for (var i = 0; i < 60; i++) {
+    final mid = (lo + hi) / 2;
+    if (flight.distanceAt(mid) < d) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  return (lo + hi) / 2;
+}
+
 void main() {
   const a = CameraPose(x: 0, y: 2.2, z: 0, yaw: 0);
 
@@ -74,6 +89,134 @@ void main() {
       expect(maxYaw, lessThanOrEqualTo(math.pi / 4 + 1e-5));
       expect(maxPitch, lessThanOrEqualTo(math.pi / 6 + 1e-5));
     }
+  });
+
+  group('smooth flight paths', () {
+    const from = CameraPose(x: 0, y: 5, z: 0, yaw: math.pi / 2);
+    const to = CameraPose(x: 50, y: 5, z: 50, yaw: 0);
+    const via = [(50.0, 0.0)];
+
+    test('rounds a street corner with continuous position and velocity', () {
+      final f = Flight.route(from, to, via: via);
+      final corner = f.poseAt(timeAt(f, 50));
+      expect(corner.x, inExclusiveRange(47, 49));
+      expect(corner.z, inExclusiveRange(1, 3));
+      expect(corner.y, closeTo(5, 1e-9));
+      // Compare physical velocities on either side of both joins and the bend.
+      final dt = 0.00001 / seconds(f);
+      for (final d in [42.0, 50.0, 58.0]) {
+        final t = timeAt(f, d);
+        final before = f.poseAt(t - dt);
+        final at = f.poseAt(t);
+        final after = f.poseAt(t + dt);
+        final jump =
+            math.sqrt(
+              math.pow(after.x - 2 * at.x + before.x, 2) +
+                  math.pow(after.y - 2 * at.y + before.y, 2) +
+                  math.pow(after.z - 2 * at.z + before.z, 2),
+            ) /
+            0.00001;
+        expect(
+          jump,
+          lessThan(0.005),
+          reason: 'velocity jump at guide distance $d',
+        );
+      }
+    });
+
+    test('turning builds and releases gradually through a corner', () {
+      final f = Flight.route(from, to, via: via);
+      final count = (seconds(f) * 240).ceil();
+      final dt = seconds(f) / count;
+      var previous = f.poseAt(0).yaw;
+      var previousRate = 0.0;
+      var peak = 0.0;
+      for (var i = 1; i <= count; i++) {
+        final yaw = f.poseAt(i / count).yaw;
+        final delta = math.atan2(
+          math.sin(yaw - previous),
+          math.cos(yaw - previous),
+        );
+        final rate = delta / dt;
+        peak = math.max(peak, (rate - previousRate).abs() / dt);
+        previous = yaw;
+        previousRate = rate;
+      }
+      expect(peak, lessThan(math.pi));
+    });
+
+    test('a lifted direct flight respects speed through a steep climb', () {
+      const from = CameraPose(x: 0, y: 2.2, z: 0, yaw: 0);
+      const to = CameraPose(x: 0, y: 2.2, z: 60, yaw: 0);
+      final tower = box(x: 0, z: 15, depth: 26, top: 80);
+      final f = Flight.plan(from, to, solids: [tower]);
+      final count = (seconds(f) * 240).ceil();
+      final dt = seconds(f) / count;
+      var previous = f.poseAt(0);
+      var peak = 0.0;
+      for (var i = 1; i <= count; i++) {
+        final pose = f.poseAt(i / count);
+        peak = math.max(peak, pose.distanceTo(previous) / dt);
+        previous = pose;
+      }
+      expect(peak, lessThanOrEqualTo(Flight.directSpeed * 1.01));
+      expect(passesThrough(f, [tower]), isFalse);
+      expect((previous.x, previous.y, previous.z), (to.x, to.y, to.z));
+    });
+
+    glados.Glados3<double, double, double>(
+      glados.any.doubleInRange(-1000, 1000),
+      glados.any.doubleInRange(-1000, 1000),
+      glados.any.doubleInRange(-math.pi, math.pi),
+      glados.ExploreConfig(numRuns: 60),
+    ).test('rounded clearance is invariant under translation and rotation', (
+      x,
+      z,
+      yaw,
+    ) {
+      final (endX, endZ) = frameToWorld(x, z, yaw, 50, 50);
+      final (viaX, viaZ) = frameToWorld(x, z, yaw, 50, 0);
+      final (blockX, blockZ) = frameToWorld(x, z, yaw, 48, 2);
+      final start = CameraPose(x: x, y: 5, z: z, yaw: yaw + math.pi / 2);
+      final end = CameraPose(x: endX, y: 5, z: endZ, yaw: yaw);
+      final obstacles = [
+        box(
+          x: blockX,
+          z: blockZ,
+          width: 0.3,
+          depth: 2,
+          facing: yaw + math.pi / 4,
+          top: 20,
+        ),
+      ];
+      final via = [(viaX, viaZ)];
+      expect(
+        passesThrough(Flight.route(start, end, via: via), obstacles),
+        isTrue,
+      );
+      final safe = Flight.route(start, end, via: via, solids: obstacles);
+      expect(passesThrough(safe, obstacles), isFalse);
+      expect(safe.poseAt(0).distanceTo(start), closeTo(0, 1e-9));
+      expect(safe.poseAt(1).distanceTo(end), closeTo(0, 1e-9));
+    }, tags: 'glados');
+
+    test('a rounded join shrinks to clear a thin rotated obstacle', () {
+      final obstacle = box(
+        x: 48,
+        z: 2,
+        width: 0.3,
+        depth: 2,
+        facing: math.pi / 4,
+        top: 20,
+      );
+      final clear = Flight.route(from, to, via: via, solids: [obstacle]);
+      final blind = Flight.route(from, to, via: via);
+      expect(passesThrough(blind, [obstacle]), isTrue);
+      expect(passesThrough(clear, [obstacle]), isFalse);
+      final corner = clear.poseAt(timeAt(clear, 50));
+      expect(corner.x, greaterThanOrEqualTo(49 - 1e-9));
+      expect(corner.z, lessThanOrEqualTo(1 + 1e-9));
+    });
   });
 
   test('turning in place takes time and still lands exactly', () {
@@ -129,10 +272,11 @@ void main() {
     final f = Flight.plan(a, const CameraPose(x: 0, y: 2.2, z: 1000, yaw: 0));
     expect(f.cruiseSpeed, Flight.directSpeed);
     expect(f.rampTime, Flight.rampSeconds);
-    // Two ramps, each covering half a cruise-ramp, then the rest at cruise.
+    // The actual 3D arc adds travel beyond the guide distance; its lift
+    // must not make the camera exceed cruise speed.
     expect(
       seconds(f),
-      closeTo(2 * 1.6 + (1000 - 36 * 1.6) / 36, 1e-6),
+      greaterThan(2 * 1.6 + (1000 - 36 * 1.6) / 36 + 0.1),
     );
     expect(f.distanceAt(0), 0);
     expect(f.distanceAt(1), closeTo(1000, 1e-9));
@@ -447,54 +591,42 @@ void main() {
     const via = [(0.0, 0.0), (50.0, 0.0), (50.0, 50.0)];
     final f = Flight.route(from, to, via: via);
 
-    /// The time at which the flight is [d] metres along its way.
-    double timeAt(Flight flight, double d) {
-      var lo = 0.0;
-      var hi = 1.0;
-      for (var i = 0; i < 60; i++) {
-        final mid = (lo + hi) / 2;
-        if (flight.distanceAt(mid) < d) {
-          lo = mid;
-        } else {
-          hi = mid;
-        }
-      }
-      return (lo + hi) / 2;
-    }
-
     bool visits(Flight flight, double x, double z) {
       for (var t = 0.0; t <= 1.0001; t += 0.0005) {
         final p = flight.poseAt(t);
-        if ((p.x - x).abs() < 0.2 && (p.z - z).abs() < 0.2) return true;
+        if (groundDistanceBetween(p.x, p.z, x, z) < 4) return true;
       }
       return false;
     }
 
-    test('runs the way through every point, at street height and speed', () {
-      expect(f.routed, isTrue);
-      expect(f.legCount, 4);
-      // The first and last legs climb to street height and drop again,
-      // and that climb is part of the way.
-      final hop = math.sqrt(3 * 3 + 2.8 * 2.8);
-      expect(f.length, closeTo(hop + 50 + 50 + hop, 1e-9));
-      expect(f.cruiseSpeed, Flight.streetSpeed);
-      expect(f.rampTime, Flight.rampSeconds);
-      // Departure, corner and arrival turns add time to the base profile.
-      expect(seconds(f), greaterThan(f.length / 10 + 1.6));
-      final midStreet = timeAt(f, 30);
-      final dt = 0.01 / seconds(f);
-      expect(
-        (f.distanceAt(midStreet + dt) - f.distanceAt(midStreet - dt)) / 0.02,
-        closeTo(Flight.streetSpeed, 1e-6),
-      );
-      for (final (x, z) in via) {
-        expect(visits(f, x, z), isTrue, reason: '$x, $z');
-      }
-      expect(f.poseAt(0).y, 2.2);
-      expect(f.poseAt(0.5).y, closeTo(Flight.streetFlightHeight, 1e-9));
-      expect(f.poseAt(1).y, closeTo(2.2, 1e-9));
-      expect(f.arc, 0);
-    });
+    test(
+      'rounds the guide points while preserving street height and cruise',
+      () {
+        expect(f.routed, isTrue);
+        expect(f.legCount, 4);
+        // The first and last legs climb to street height and drop again,
+        // and that climb is part of the way.
+        final hop = math.sqrt(3 * 3 + 2.8 * 2.8);
+        expect(f.length, closeTo(hop + 50 + 50 + hop, 1e-9));
+        expect(f.cruiseSpeed, Flight.streetSpeed);
+        expect(f.rampTime, Flight.rampSeconds);
+        // Departure, corner and arrival turns add time to the base profile.
+        expect(seconds(f), greaterThan(f.length / 10 + 1.6));
+        final midStreet = timeAt(f, 30);
+        final dt = 0.01 / seconds(f);
+        expect(
+          (f.distanceAt(midStreet + dt) - f.distanceAt(midStreet - dt)) / 0.02,
+          closeTo(Flight.streetSpeed, 0.2),
+        );
+        for (final (x, z) in via) {
+          expect(visits(f, x, z), isTrue, reason: '$x, $z');
+        }
+        expect(f.poseAt(0).y, 2.2);
+        expect(f.poseAt(0.5).y, closeTo(Flight.streetFlightHeight, 1e-9));
+        expect(f.poseAt(1).y, closeTo(2.2, 1e-9));
+        expect(f.arc, 0);
+      },
+    );
 
     test(
       'looks down the way, turns before the corner, settles on the stop',

--- a/test/features/plaza/domain/scenery_test.dart
+++ b/test/features/plaza/domain/scenery_test.dart
@@ -116,7 +116,7 @@ void main() {
     });
 
     test('a wider fold leaves room: blocks are cut back, not dropped', () {
-      final wide = StreetLayout(projectSeed: 1337, connectorLength: 60);
+      final wide = StreetLayout(projectSeed: 1337, connectorLength: 54);
       final widePlan = wide.plan(tasks);
       final cut = fillerBlocksFor(
         widePlan,
@@ -161,6 +161,70 @@ void main() {
             final next = row[i + 1].$1 - row[i + 1].$2 / 2;
             expect(next - end, greaterThanOrEqualTo(2 - 1e-9));
           }
+        }
+      }
+    });
+
+    test('forms a close streetwall with compact alleys', () {
+      final blocks = fillerBlocksFor(
+        plan,
+        null,
+        roadWidth: layout.roadWidth,
+        plotDepth: layout.plotDepth,
+      );
+      var checkedAlleys = 0;
+      for (final segment in segmentsByBucket.values) {
+        final row = blocks
+            .where((f) => f.bucketIndex == segment.bucketIndex && f.side == -1)
+            .toList();
+        for (final f in row) {
+          final (_, lateral) = _inSegment(segment, f.x, f.z);
+          final setback =
+              lateral.abs() -
+              f.width / 2 -
+              layout.roadWidth / 2 -
+              layout.plotDepth;
+          expect(setback, inInclusiveRange(2 - 1e-9, 3.5 + 1e-9));
+        }
+        for (var i = 0; i + 1 < row.length; i++) {
+          final a = row[i];
+          final b = row[i + 1];
+          // Exclude slots removed to protect another street.
+          if (int.parse(b.id.split('-').last) !=
+              int.parse(a.id.split('-').last) + 1) {
+            continue;
+          }
+          final gap =
+              _inSegment(segment, b.x, b.z).$1 -
+              b.depth / 2 -
+              _inSegment(segment, a.x, a.z).$1 -
+              a.depth / 2;
+          expect(gap, inInclusiveRange(2 - 1e-9, 3.5 + 1e-9));
+          checkedAlleys++;
+        }
+      }
+      expect(checkedAlleys, greaterThan(0));
+    });
+
+    test('keeps recessed completed plots clear of background blocks', () {
+      final recessed = StreetLayout(
+        projectSeed: 1337,
+        completedSetback: 12,
+      ).plan(tasks);
+      final blocks = fillerBlocksFor(
+        recessed,
+        null,
+        roadWidth: layout.roadWidth,
+        plotDepth: layout.plotDepth,
+      );
+      expect(blocks, isNotEmpty);
+      for (final block in blocks) {
+        for (final plot in recessed.placements.values) {
+          expect(
+            footprintsOverlap(block.footprint, plot.footprint),
+            isFalse,
+            reason: '${block.id} covers ${plot.taskId}',
+          );
         }
       }
     });
@@ -213,11 +277,11 @@ void main() {
       for (final f in fillers) {
         expect(f.depth, inInclusiveRange(7, 16));
         expect(f.width, inInclusiveRange(8, 16));
-        expect(f.height, inInclusiveRange(12, 60));
+        expect(f.height, inInclusiveRange(24, 80));
       }
       // The fabric is the tall layer: a quarter are mid-rise landmarks
       // above every plot, the rest still rise over the shops.
-      final landmarks = fillers.where((f) => f.height >= 40);
+      final landmarks = fillers.where((f) => f.height >= 56);
       expect(landmarks.length, greaterThan(fillers.length ~/ 8));
       expect(landmarks.length, lessThan(fillers.length ~/ 2));
       final again = fillerBlocksFor(
@@ -323,7 +387,7 @@ void main() {
         );
         expect(
           r,
-          inInclusiveRange(inner - 1e-9, inner + 90 + 1e-9),
+          inInclusiveRange(inner - 1e-9, inner + 36 + 1e-9),
           reason: tower.id,
         );
         final angle = math.atan2(tower.z - cz, tower.x - cx);
@@ -332,9 +396,9 @@ void main() {
         final delta = (angle - slot + math.pi) % (2 * math.pi) - math.pi;
         expect(delta, inInclusiveRange(-1e-9, 0.1 + 1e-9), reason: tower.id);
         expect(tower.yawRadians, closeTo(-slot - delta, 1e-9));
-        expect(tower.width, inInclusiveRange(16, 42));
+        expect(tower.width, inInclusiveRange(24, 50));
         expect(tower.depth, closeTo(tower.width * 0.8, 1e-9));
-        expect(tower.height, inInclusiveRange(24, 78));
+        expect(tower.height, inInclusiveRange(42, 96));
       }
     });
 
@@ -348,7 +412,7 @@ void main() {
           r,
           inInclusiveRange(
             skylineRingClearance - 1e-9,
-            skylineRingClearance + 90 + 1e-9,
+            skylineRingClearance + 36 + 1e-9,
           ),
         );
       }

--- a/test/features/plaza/domain/walk_collider_test.dart
+++ b/test/features/plaza/domain/walk_collider_test.dart
@@ -22,6 +22,17 @@ Footprint _box({
 
 void main() {
   group('overlapping footprint recovery', () {
+    test('a push cycle returning to the start still escapes', () {
+      final collider = WalkCollider([
+        _box(),
+        _box(z: 5.6, width: 8, depth: 10),
+      ]);
+      final (x, z) = collider.resolve(0, 0);
+      expect(x, closeTo(0, 1e-6));
+      expect(z, closeTo(-3.6, 1e-6));
+      expect(collider.move(0, 0, 0, 0), (x, z));
+    });
+
     for (final facing in [0.0, math.pi / 4, math.pi / 2, -math.pi / 3]) {
       test('escapes overlapping chains at $facing in either order', () {
         final walls = [

--- a/test/features/plaza/domain/walk_collider_test.dart
+++ b/test/features/plaza/domain/walk_collider_test.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/features/plaza/domain/street_layout.dart';
 import 'package:lotti/features/plaza/domain/walk_collider.dart';
@@ -20,6 +21,74 @@ Footprint _box({
 );
 
 void main() {
+  group('swept movement', () {
+    for (final facing in [0.0, math.pi / 4, math.pi / 2, -math.pi / 3]) {
+      for (final direction in [-1.0, 1.0]) {
+        test('cannot cross a thin rotated wall ($facing, $direction)', () {
+          final box = _box(x: 13, z: -7, facing: facing, depth: 0.2);
+          final collider = WalkCollider([box]);
+          final (sx, sz) = frameToWorld(13, -7, facing, 0, direction * 30);
+          final (tx, tz) = frameToWorld(13, -7, facing, 0, -direction * 30);
+          final (x, z) = collider.move(sx, sz, tx, tz);
+          final (u, v) = box.local(x, z);
+          expect(u, closeTo(0, 1e-6));
+          expect(v, closeTo(direction * 0.7, 1e-6));
+        });
+      }
+    }
+
+    glados.Glados3<double, double, double>(
+      glados.any.doubleInRange(-math.pi, math.pi),
+      glados.any.doubleInRange(2, 200),
+      glados.any.doubleInRange(-40, 40),
+      glados.ExploreConfig(numRuns: 80),
+    ).test('sweep stops on the entry face across headings and step lengths', (
+      facing,
+      distance,
+      lateral,
+    ) {
+      final box = _box(x: 13, z: -7, facing: facing, width: 100, depth: 0.2);
+      final collider = WalkCollider([box]);
+      final (sx, sz) = frameToWorld(13, -7, facing, lateral, distance);
+      final (tx, tz) = frameToWorld(13, -7, facing, lateral, -distance);
+      final (x, z) = collider.move(sx, sz, tx, tz);
+      final (u, v) = box.local(x, z);
+      expect(u, closeTo(lateral, 1e-6));
+      expect(v, closeTo(0.7, 1e-6));
+    }, tags: 'glados');
+
+    test('slides along a rotated wall after a long diagonal step', () {
+      final box = _box(facing: math.pi / 4, width: 100, depth: 0.2);
+      final collider = WalkCollider([box]);
+      final (sx, sz) = frameToWorld(0, 0, math.pi / 4, -10, 20);
+      final (tx, tz) = frameToWorld(0, 0, math.pi / 4, 10, -20);
+      final (x, z) = collider.move(sx, sz, tx, tz);
+      final (u, v) = box.local(x, z);
+      expect(u, closeTo(10, 1e-6));
+      expect(v, closeTo(0.7, 1e-6));
+    });
+
+    test('stops at both walls of a corner in either obstacle order', () {
+      final walls = [
+        _box(x: 10, width: 0.2, depth: 100),
+        _box(z: 10, width: 100, depth: 0.2),
+      ];
+      for (final order in [walls, walls.reversed]) {
+        final (x, z) = WalkCollider(order).move(0, 0, 40, 30);
+        expect(x, closeTo(9.3, 1e-6));
+        expect(z, closeTo(9.3, 1e-6));
+      }
+    });
+
+    test('allows travel parallel to and away from a contacted wall', () {
+      final collider = WalkCollider([_box()]);
+      expect(collider.move(0, 3.6, 3, 3.6), (3, 3.6));
+      expect(collider.move(0, 3.6, 0, 30), (0, 30));
+      expect(collider.move(20, 20, 20, 20), (20, 20));
+      expect(collider.move(0, 2.5, 0, 20), (0, 21.1));
+    });
+  });
+
   test('a long box turned 45° still pushes out near its far corner', () {
     // Width 20 along local X, depth 2: the far corner is 10.05 m from the
     // centre, well past the |dx| + |dz| a square box of that reach would

--- a/test/features/plaza/domain/walk_collider_test.dart
+++ b/test/features/plaza/domain/walk_collider_test.dart
@@ -21,6 +21,59 @@ Footprint _box({
 );
 
 void main() {
+  group('overlapping footprint recovery', () {
+    for (final facing in [0.0, math.pi / 4, math.pi / 2, -math.pi / 3]) {
+      test('escapes overlapping chains at $facing in either order', () {
+        final walls = [
+          for (var i = 0; i < 5; i++)
+            _box(
+              x: frameToWorld(13, -7, facing, 0, i * 4).$1,
+              z: frameToWorld(13, -7, facing, 0, i * 4).$2,
+              facing: facing,
+              width: 10 - i.toDouble(),
+            ),
+          // Separate components on both sides must not extend the escape.
+          _box(x: -100, z: -7),
+          _box(x: 100, z: -7),
+          _box(x: 13, z: -100),
+          _box(x: 13, z: 100),
+        ];
+        for (final order in [walls, walls.reversed]) {
+          final collider = WalkCollider(order);
+          for (var i = 0; i < 5; i++) {
+            final start = frameToWorld(13, -7, facing, 0, i * 4);
+            final (x, z) = collider.resolve(start.$1, start.$2);
+            expect(
+              walls.any((wall) => wall.contains(x, z, clearance: 0.6 - 1e-8)),
+              isFalse,
+              reason: 'recovery at $start leaves the complete overlap',
+            );
+            final (againX, againZ) = collider.resolve(x, z);
+            expect(againX, closeTo(x, 1e-9));
+            expect(againZ, closeTo(z, 1e-9));
+            expect(
+              math.sqrt(math.pow(x - start.$1, 2) + math.pow(z - start.$2, 2)),
+              lessThan(9),
+              reason: 'do not jump past separate buildings',
+            );
+          }
+        }
+      });
+    }
+
+    test('a step starting inside an overlap recovers before sweeping', () {
+      final walls = [_box(), _box(z: 4, width: 8)];
+      final collider = WalkCollider(walls);
+      final (x, z) = collider.move(0, 0, 0, 30);
+      expect(x, closeTo(0, 1e-6));
+      expect(z, closeTo(-3.6, 1e-6));
+      expect(
+        walls.any((wall) => wall.contains(x, z, clearance: 0.6 - 1e-8)),
+        isFalse,
+      );
+    });
+  });
+
   group('swept movement', () {
     for (final facing in [0.0, math.pi / 4, math.pi / 2, -math.pi / 3]) {
       for (final direction in [-1.0, 1.0]) {

--- a/test/features/plaza/scene/plaza_architecture_test.dart
+++ b/test/features/plaza/scene/plaza_architecture_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/plaza/domain/building_architecture.dart';
+import 'package:lotti/features/plaza/scene/plaza_architecture.dart';
+import 'package:lotti/features/plaza/scene/plaza_boxes.dart';
+import 'package:vector_math/vector_math.dart';
+
+void main() {
+  late PlazaArchitecture builder;
+  late Geometry geometry;
+  late UnlitMaterial wall;
+  late UnlitMaterial trim;
+  late UnlitMaterial light;
+
+  setUp(() {
+    geometry = UnskinnedGeometry()
+      ..setLocalBounds(Aabb3.minMax(Vector3.all(-0.5), Vector3.all(0.5)), null);
+    final boxes = PlazaBoxes(cube: geometry, shadedCube: geometry);
+    builder = PlazaArchitecture(boxes);
+    wall = boxes.solid(Vector4(0.1, 0.1, 0.1, 1));
+    trim = boxes.solid(Vector4(0.3, 0.3, 0.3, 1));
+    light = boxes.solid(Vector4(0, 1, 0, 1));
+  });
+
+  for (final family in BuildingFamily.values) {
+    test('$family relief fits the collider and leaves the sign clear', () {
+      for (final width in [5.0, 18.0, 100.0]) {
+        for (final height in [6.0, 30.0, 150.0]) {
+          final kit = BuildingArchitecture.forEnvelope(
+            id: 'task',
+            width: width,
+            depth: 12,
+            height: height,
+            family: family,
+          );
+          final cores = <BuildingVolume>[];
+          final groundFloors = <bool>[];
+          final root = builder.build(
+            kit,
+            wall: wall,
+            trim: trim,
+            light: light,
+            onVolume: (node, volume, {required groundFloor}) {
+              cores.add(volume);
+              groundFloors.add(groundFloor);
+            },
+          );
+          expect(cores, hasLength(kit.volumes.length));
+          expect(groundFloors, [true, ...List.filled(cores.length - 1, false)]);
+          for (final (i, core) in cores.indexed) {
+            expect(core.width, lessThan(kit.volumes[i].width));
+            expect(core.depth, lessThan(kit.volumes[i].depth));
+            expect(core.bottom, kit.volumes[i].bottom);
+          }
+          var litPieces = 0;
+          for (final mesh in _meshes(root)) {
+            final primitive = mesh.mesh!.primitives.single;
+            expect(primitive.geometry, same(geometry));
+            expect(
+              primitive.material,
+              anyOf(same(wall), same(trim), same(light)),
+            );
+            final bounds = _bounds(mesh);
+            expect(bounds.min.x, greaterThanOrEqualTo(-width / 2 - 1e-5));
+            expect(bounds.max.x, lessThanOrEqualTo(width / 2 + 1e-5));
+            expect(bounds.min.z, greaterThanOrEqualTo(-6 - 1e-5));
+            expect(bounds.max.z, lessThanOrEqualTo(6 + 1e-5));
+            expect(bounds.min.y, greaterThanOrEqualTo(-1e-5));
+            expect(bounds.max.y, lessThanOrEqualTo(height + 1e-5));
+            // Actual task posters sit just outside the reserved street plane.
+            expect(bounds.max.z, lessThan(kit.front + 0.03));
+            if (identical(primitive.material, light)) litPieces++;
+          }
+          expect(litPieces, greaterThanOrEqualTo(8));
+          // Geometry density cannot scale with an arbitrary plot's dimensions.
+          expect(_meshes(root).length, lessThan(180));
+        }
+      }
+    });
+  }
+
+  test('distant recipe preserves wall and crown, omitting column detail', () {
+    final kit = BuildingArchitecture.forEnvelope(
+      id: 'landmark',
+      width: 30,
+      depth: 20,
+      height: 80,
+    );
+    Node build({required bool detailed}) => builder.build(
+      kit,
+      wall: wall,
+      trim: trim,
+      light: light,
+      detailed: detailed,
+      onVolume: (_, _, {required groundFloor}) {},
+    );
+    final near = _meshes(build(detailed: true)).toList();
+    final far = _meshes(build(detailed: false)).toList();
+    int count(List<Node> nodes, UnlitMaterial material) => nodes
+        .where(
+          (node) => identical(node.mesh!.primitives.single.material, material),
+        )
+        .length;
+    expect(far.length, lessThan(near.length));
+    expect(count(far, wall), count(near, wall));
+    // Distant buildings use one cap at each lit crown course instead of four
+    // rim pieces, preserving the height of every luminous skyline edge.
+    Set<double> crownCourses(List<Node> nodes) => {
+      for (final node in nodes)
+        if (identical(node.mesh!.primitives.single.material, light) &&
+            _bounds(node).min.y >= kit.frontageHeight)
+          _bounds(node).min.y,
+    };
+    final courses = crownCourses(far).toList()..sort();
+    final nearCourses = crownCourses(near).toList()..sort();
+    expect(courses, isNotEmpty);
+    expect(courses.length, nearCourses.length);
+    for (var i = 0; i < courses.length; i++) {
+      expect(courses[i], closeTo(nearCourses[i], 1e-5));
+    }
+    expect(count(far, light), courses.length);
+    expect(count(far, trim), lessThan(count(near, trim)));
+  });
+}
+
+Iterable<Node> _meshes(Node node) sync* {
+  if (node.mesh != null) yield node;
+  for (final child in node.children) {
+    yield* _meshes(child);
+  }
+}
+
+Aabb3 _bounds(Node node) => Aabb3.minMax(
+  node.globalTransform.transform3(Vector3.all(-0.5)),
+  node.globalTransform.transform3(Vector3.all(0.5)),
+);

--- a/test/features/plaza/scene/wall_textures_test.dart
+++ b/test/features/plaza/scene/wall_textures_test.dart
@@ -93,6 +93,40 @@ const _glassBottom = 3.5;
 
 void main() {
   test(
+    'office glazing fills its bays while residential windows stay inset',
+    () async {
+      final images = [
+        WallTextures.paintWindows(LanternState.open),
+        WallTextures.paintWindows(LanternState.open, family: 2),
+      ];
+      for (final image in images) {
+        addTearDown(image.dispose);
+      }
+      final residential = (await images[0].toByteData())!;
+      final office = (await images[1].toByteData())!;
+      // At 15% across a bay, the residential tile is still solid wall, while
+      // the office's full-height glazing has already begun. Test every floor
+      // and bay so one seeded lit pane cannot accidentally satisfy the test.
+      var glassSamples = 0;
+      for (var floor = 0; floor < WallTextures.floors; floor++) {
+        for (var bay = 0; bay < WallTextures.bays; bay++) {
+          final x = ((bay + 0.15) * images[0].width / WallTextures.bays)
+              .floor();
+          final y = ((floor + 0.65) * images[0].height / WallTextures.floors)
+              .floor();
+          final offset = (y * images[0].width + x) * 4;
+          final wallPixel = residential.getUint32(offset);
+          expect(wallPixel, 0x0B0A14FF);
+          if (office.getUint32(offset) != wallPixel) glassSamples++;
+        }
+      }
+      expect(glassSamples, WallTextures.floors * WallTextures.bays);
+      expect(images[1].width, images[0].width);
+      expect(images[1].height, images[0].height);
+    },
+  );
+
+  test(
     'paving preserves unlit slab centres and alternates mortar joints',
     () async {
       final image = WallTextures.paintPaving();

--- a/test/features/plaza/ui/fly_camera_controller_test.dart
+++ b/test/features/plaza/ui/fly_camera_controller_test.dart
@@ -73,28 +73,72 @@ void main() {
       expect(camera.pose.z, zAfterWalk);
     });
 
-    testWidgets('shift sprints', (tester) async {
-      final walker = _controller();
-      final sprinter = _controller();
-      await simulateKeyDownEvent(LogicalKeyboardKey.keyW);
-      walker
-        ..handleKeyEvent(
-          _down(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
-        )
-        ..update(1);
-      await simulateKeyDownEvent(LogicalKeyboardKey.shiftLeft);
-      sprinter
-        ..handleKeyEvent(
-          _down(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
-        )
-        ..handleKeyEvent(
-          _down(LogicalKeyboardKey.shiftLeft, PhysicalKeyboardKey.shiftLeft),
-        )
-        ..update(1);
-      expect(sprinter.pose.z, closeTo(walker.pose.z * 2.5, 0.05));
-      await simulateKeyUpEvent(LogicalKeyboardKey.shiftLeft);
-      await simulateKeyUpEvent(LogicalKeyboardKey.keyW);
-    });
+    testWidgets(
+      'holding Shift travels eight times faster and releasing slows',
+      (tester) async {
+        final walker = _controller();
+        final sprinter = _controller();
+        await simulateKeyDownEvent(LogicalKeyboardKey.keyW);
+        walker
+          ..handleKeyEvent(
+            _down(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
+          )
+          ..update(1);
+        await simulateKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+        sprinter
+          ..handleKeyEvent(
+            _down(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
+          )
+          ..handleKeyEvent(
+            _down(LogicalKeyboardKey.shiftLeft, PhysicalKeyboardKey.shiftLeft),
+          )
+          ..update(1);
+        expect(sprinter.pose.z, closeTo(walker.pose.z * 8, 0.05));
+        await simulateKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+        final beforeRelease = sprinter.pose.z;
+        sprinter
+          ..handleKeyEvent(
+            _up(LogicalKeyboardKey.shiftLeft, PhysicalKeyboardKey.shiftLeft),
+          )
+          ..update(1);
+        expect(sprinter.pose.z - beforeRelease, closeTo(walker.pose.z, 0.05));
+        await simulateKeyUpEvent(LogicalKeyboardKey.keyW);
+      },
+    );
+
+    testWidgets(
+      'fast travel cannot tunnel through a building on a slow frame',
+      (tester) async {
+        final camera = _controller(
+          collider: WalkCollider([
+            const Footprint(
+              x: 0,
+              z: 8,
+              facingRadians: 0,
+              width: 20,
+              depth: 0.2,
+            ),
+          ]),
+        );
+        await simulateKeyDownEvent(LogicalKeyboardKey.keyW);
+        await simulateKeyDownEvent(LogicalKeyboardKey.shiftRight);
+        camera
+          ..handleKeyEvent(
+            _down(LogicalKeyboardKey.keyW, PhysicalKeyboardKey.keyW),
+          )
+          ..handleKeyEvent(
+            _down(
+              LogicalKeyboardKey.shiftRight,
+              PhysicalKeyboardKey.shiftRight,
+            ),
+          )
+          ..update(1);
+        expect(camera.pose.z, closeTo(7.3, 1e-6));
+        expect(camera.pose.x, 0);
+        await simulateKeyUpEvent(LogicalKeyboardKey.shiftRight);
+        await simulateKeyUpEvent(LogicalKeyboardKey.keyW);
+      },
+    );
 
     test('forward follows yaw and pitch', () {
       final c = _controller();
@@ -155,6 +199,87 @@ void main() {
       // stops the walker at the facade plus the margin.
       expect(camera.pose.z, closeTo(8 - 3 - 0.6, 1e-6));
     });
+  });
+
+  group('flight speed boost', () {
+    const target = CameraPose(x: 0, y: 2.2, z: 1000, yaw: 0);
+    for (final (logical, physical) in [
+      (LogicalKeyboardKey.shiftLeft, PhysicalKeyboardKey.shiftLeft),
+      (LogicalKeyboardKey.shiftRight, PhysicalKeyboardKey.shiftRight),
+    ]) {
+      testWidgets('$logical accelerates flight without cancelling it', (
+        tester,
+      ) async {
+        final camera = _controller();
+        var moves = 0;
+        camera.onMovement = () => moves++;
+        final flight = camera.flyTo(target);
+        await simulateKeyDownEvent(logical);
+        camera
+          ..handleKeyEvent(_down(logical, physical))
+          ..update(0.05);
+        final firstStep = flight.elapsed.inMicroseconds / 1e6;
+        expect(firstStep, greaterThan(0.05));
+        expect(firstStep, lessThan(0.1)); // no instantaneous 8× jump
+        camera.update(0.95);
+        expect(flight.elapsed.inMicroseconds / 1e6, inExclusiveRange(5, 8));
+        expect(camera.flight, same(flight));
+        expect(moves, 0);
+        final before = flight.elapsed;
+        camera.update(1);
+        expect((flight.elapsed - before).inMicroseconds / 1e6, closeTo(8, 0.1));
+        // A key-up delivered elsewhere still releases the modifier.
+        await simulateKeyUpEvent(logical);
+        camera.update(2);
+        final released = flight.elapsed;
+        camera.update(0.1);
+        expect(
+          (flight.elapsed - released).inMicroseconds / 1e6,
+          closeTo(0.1, 0.002),
+        );
+      });
+    }
+
+    testWidgets(
+      'holding Shift before launch and frame cadence give the same boost',
+      (tester) async {
+        await simulateKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+        final coarse = _controller();
+        final fine = _controller();
+        final a = coarse.flyTo(target);
+        final b = fine.flyTo(target);
+        coarse.update(1);
+        for (var i = 0; i < 120; i++) {
+          fine.update(1 / 120);
+        }
+        expect(a.elapsed.inMicroseconds, greaterThan(5000000));
+        expect((a.elapsed - b.elapsed).inMicroseconds.abs(), lessThan(120));
+        expect(coarse.pose.distanceTo(fine.pose), lessThan(0.005));
+        await simulateKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      },
+    );
+
+    testWidgets(
+      'boosted arrival lands exactly and fires once, then resets boost',
+      (tester) async {
+        final camera = _controller();
+        var arrivals = 0;
+        camera.onArrived = () => arrivals++;
+        final flight = camera.flyTo(target);
+        await simulateKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+        camera.update(10);
+        expect(flight.done, isTrue);
+        expect(camera.flying, isFalse);
+        expect(camera.pose.distanceTo(target), 0);
+        expect(arrivals, 1);
+        await simulateKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+        camera.update(1);
+        expect(arrivals, 1);
+        final next = camera.flyTo(_origin);
+        camera.update(0.1);
+        expect(next.elapsed, const Duration(milliseconds: 100));
+      },
+    );
   });
 
   group('walk feel', () {
@@ -513,7 +638,7 @@ void main() {
       while (camera.flying) {
         camera.update(0.02);
         final p = camera.pose;
-        if ((p.x - 60).abs() < 0.3 && (p.z - 0).abs() < 0.3) turned = true;
+        if (p.x > 57 && p.x < 59 && p.z > 1 && p.z < 3) turned = true;
         expect(p.y, lessThanOrEqualTo(Flight.streetFlightHeight + 1e-9));
       }
       expect(turned, isTrue);

--- a/test/features/plaza/ui/plaza_hud_test.dart
+++ b/test/features/plaza/ui/plaza_hud_test.dart
@@ -89,7 +89,10 @@ void main() {
     await tester.pumpWidget(host());
     expect(find.text('Project Waddle — Plaza'), findsOneWidget);
     expect(find.text('28 tasks · 6 weeks · 4 need attention'), findsOneWidget);
-    expect(find.textContaining('WASD'), findsOneWidget);
+    expect(
+      find.textContaining('WASD walk · hold Shift: 8× speed'),
+      findsOneWidget,
+    );
     for (final state in ['In Progress', 'Open', 'Blocked', 'Overdue', 'Done']) {
       expect(find.text(state), findsOneWidget);
     }


### PR DESCRIPTION
Project plazas felt sparse, and automatic flights changed direction abruptly. This adds denser nighttime streets and more articulated buildings, then rounds flight paths and smooths their speed and camera turns.

- Add recessed facades, corner piers, stepped crowns, richer glass, and soft ground lighting while retaining shared geometry and static batching.
- Tighten filler buildings and the skyline around the plaza, preserving task plots and street clearance.
- Round flight corners with collision-checked curves and consistent vertical clearance; smooth translation, yaw, and pitch, including steep climbs and final approaches.
- Hold **Shift for 8× speed** when walking or flying. Flight boost eases in and out; walking sweeps for collisions to prevent tunneling through buildings.
- Recover safely from overlapping building footprints, including full push cycles.
- Hide penguins by default, with the existing control available to show them.

### Validation

- Full Dart MCP analysis: no diagnostics. Touched Dart files formatted.
- Targeted architecture/texture, scenery/collision, flight/camera, and HUD/view tests pass. New regressions were also run against the previous implementation and failed as expected.
- Main Linux debug app builds. An isolated native Xvfb run completed three automatic flights, exercised Shift press/release, and recorded no building penetration or framework exceptions. All app runs were headless.
- Knowledge/Mermaid and changelog validation pass.

### Performance

The final denser scene uses **4,128 static meshes in 198 batches**, compared with **2,429 meshes in 216 batches** on the merged base. In short walking runs on the ARM64 Linux VM under Xvfb, the denser scene averaged **131.6 ms/frame with penguins hidden** and **146.4 ms/frame with penguins enabled**. These debug VM measurements are noisy and do not establish macOS performance or verify the 120 FPS target. They predate the flight-smoothing follow-up; native flight validation checked navigation and collision behavior, not throughput. See [measurement notes](docs/plaza/CINEMATIC_CITY_MEASUREMENTS.md).

### Before / after

Penguin demo fixtures only, captured headlessly at 1600 × 1000. Before is the merged base; after shows the denser architecture and default-hidden penguins. Images are stored outside the repository at immutable URLs for commit `a37a776`.

| Surface | Before | After |
| --- | --- | --- |
| Home | ![Home before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-cinematic-city/a37a7763410230fe441945cdc33b6e41fc600f49/before/home_before.png) | ![Home after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-cinematic-city/a37a7763410230fe441945cdc33b6e41fc600f49/after/home_after.png) |
| Project billboard | ![Project billboard before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-cinematic-city/a37a7763410230fe441945cdc33b6e41fc600f49/before/jumbotron_before.png) | ![Project billboard after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-cinematic-city/a37a7763410230fe441945cdc33b6e41fc600f49/after/jumbotron_after.png) |
| Overview | ![Overview before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-cinematic-city/a37a7763410230fe441945cdc33b6e41fc600f49/before/overview_before.png) | ![Overview after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-cinematic-city/a37a7763410230fe441945cdc33b6e41fc600f49/after/overview_after.png) |
| City block | ![City block before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-cinematic-city/a37a7763410230fe441945cdc33b6e41fc600f49/before/block_before.png) | ![City block after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-cinematic-city/a37a7763410230fe441945cdc33b6e41fc600f49/after/block_after.png) |
| Shopfront | ![Shopfront before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-cinematic-city/a37a7763410230fe441945cdc33b6e41fc600f49/before/shopfront_before.png) | ![Shopfront after](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-cinematic-city/a37a7763410230fe441945cdc33b6e41fc600f49/after/shopfront_after.png) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plaza scenery now offers denser, taller city buildings with richer façades, illuminated crowns, softer lighting, and more detailed nighttime skylines.
  * Travel through the plaza now follows smoother curved routes with improved collision handling.
  * Hold **Shift** to move at up to 8× speed, with gradual acceleration and slowdown.
* **User Interface**
  * Penguins are now hidden when the plaza opens and can be shown using the Penguins option.
  * Controls guidance has been updated across supported languages.
* **Documentation**
  * Added guidance and measurement records for the updated plaza experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->