### PR TITLE
feat(plaza): show task connections as illuminated cables

### DIFF
--- a/changelog.d/2026-09-09-plaza-connection-cables.md
+++ b/changelog.d/2026-09-09-plaza-connection-cables.md
@@ -1,0 +1,12 @@
+### Added
+
+- **Project plazas show task connections as illuminated, sagging cables.**
+  Roof mounts connect linked tasks, travelling lights preserve relationship
+  direction, and looking at a task highlights its connections. The Connections
+  control hides or shows the network; reduced motion pauses its moving lights.
+
+### Fixed
+
+- **Opening or returning from a plaza could show a navigation error when
+  another tab retained the same image.** Inactive tabs now stay out of image
+  transitions while preserving their navigation state.

--- a/docs/plaza/CONNECTION_CABLE_MEASUREMENTS.md
+++ b/docs/plaza/CONNECTION_CABLE_MEASUREMENTS.md
@@ -1,0 +1,55 @@
+# Connection cable measurement record
+
+Measured 2026-09-09 on `feat/plaza-connection-cables`, rebased onto main
+`459a5e642`. Both measurements use the final cable implementation and the
+same Project Waddle fixture: 28 tasks and 51 real task associations. The
+[Plaza concept](../../knowledge/features/plaza.md) describes the implementation.
+
+## Environment and method
+
+- ARM64 Linux VM, Flutter 3.47.2, debug build, isolated Xvfb display.
+- 1600 × 1000 viewport, automatic frame pacing, penguins and meerkats hidden.
+- Existing `PLAZA_BENCH=1` walking sequence. Each phase lasts 14 seconds and
+  excludes its first four seconds. One run per configuration.
+- The comparison uses the second, default phase (4 live / 80 sign facade
+  budget). Both runs ended with 28 signs and zero live facades. The first
+  phase retained startup stalls and is excluded from the comparison.
+- The disabled run uses `PLAZA_HIDE=cables`, bypassing cable construction.
+- No QA build, test, capture or analyzer ran concurrently with these runs.
+  Other host activity was not controlled.
+
+| Metric | Cables disabled | Cables enabled |
+| --- | ---: | ---: |
+| Ordinary static meshes / batches | 4,128 / 198 | 4,128 / 198 |
+| Additional cable meshes / batches | 0 / 0 | 559 / 4 |
+| Moving light instances | 0 | 102 |
+| Mean frame time | 151.5 ms | 154.3 ms |
+| Average FPS | 6.6 | 6.5 |
+| p99 / worst frame time | 266.7 ms | 333.3 ms |
+
+Moving lights share one instanced draw, with a maximum of 192 instances. The
+2.8 ms mean difference in this single noisy VM comparison does not establish
+a reliable cable cost or target-device throughput. These results **do not
+verify 120 FPS on macOS**. Profile/release measurements on the target Mac,
+including larger relationship graphs and active billboards, remain necessary.
+
+## Native and regression checks
+
+The final Linux native build succeeds. Headless fixture captures verify Home,
+Overview, hiding the cable network, selecting a task from search, boosted
+flight to that task, retaining its highlighted connections in Overview, and
+clearing the selection with Escape. Reported flight positions stayed outside
+the generated collision solids.
+
+All 243 targeted tests pass, with one existing opt-in performance test skipped;
+the full analyzer reports no errors. Tests exercise scoped typed relationships,
+rotated/thin obstacle clearance, sag sampling, shared roof supports, light
+direction and budgets, reduced motion, snapshot refresh and HUD controls.
+The two navigation regressions and the lock-during-read regression fail when
+their production fixes are removed. The navigation checks reproduce duplicate
+Heroes in inactive tabs; they do not independently reproduce the reported
+native engine disconnect.
+
+Review captures use fixture data only and are published separately from the
+repository. Follow the [operator notes](HANDOVER.md#review-captures) for capture
+and publication.

--- a/docs/plaza/CONNECTION_CABLE_MEASUREMENTS.md
+++ b/docs/plaza/CONNECTION_CABLE_MEASUREMENTS.md
@@ -1,7 +1,7 @@
 # Connection cable measurement record
 
 Measured 2026-09-09 on `feat/plaza-connection-cables`, rebased onto main
-`459a5e642`. Both measurements use the final cable implementation and the
+`459a5e642`. Both measurements use the initial cable implementation (`6ae3541a4`) and the
 same Project Waddle fixture: 28 tasks and 51 real task associations. The
 [Plaza concept](../../knowledge/features/plaza.md) describes the implementation.
 
@@ -53,3 +53,19 @@ native engine disconnect.
 Review captures use fixture data only and are published separately from the
 repository. Follow the [operator notes](HANDOVER.md#review-captures) for capture
 and publication.
+
+## Spatial batching review follow-up
+
+Review identified that world-space tube vertices with identity node transforms
+merged at the origin cell. Tubes now use local vertices and a node at their
+arc midpoint, allowing the static bake to group them by their actual spatial
+cells. Highlight geometry is created only when a relationship is first selected
+and cached for later focus changes. All scoped relationships remain represented.
+
+The targeted renderer/domain run passes all 16 tests and the full analyzer is
+clean. The new spatial-batching and lazy-selection regressions fail when their
+fixes are removed. The native Linux build succeeds. The timings above predate
+this follow-up; they must not be used as measurements of the revised batching.
+The repeated headless selection/boosted-flight/Overview/Escape check succeeds,
+with no reported collision penetration. The fixture still consolidates 559
+static cable meshes into four batches; disconnected cells are tested separately.

--- a/knowledge/architecture/navigation.md
+++ b/knowledge/architecture/navigation.md
@@ -5,7 +5,7 @@ description: Ten independent Beamer stacks behind one IndexedStack, how the acti
 resource: ../../lib/beamer
 tags: [architecture, navigation, beamer, routing, app-shell]
 status: stable
-generated: { by: claude-code/fable-5, at: 2026-09-02T12:00:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-09T00:27:05Z }
 stale_after: 2027-03-02
 sources:
   - id: route-mirror
@@ -118,7 +118,12 @@ flowchart TD
 
 An `IndexedStack` keeps every tab **mounted**. Tabs preserve scroll position and
 in-flight state across switches, at the cost of every enabled tab holding its
-widgets in memory.
+widgets in memory. `TickerMode` and `ExcludeFocus` disable animation and
+keyboard focus in inactive tabs. `HeroMode` also excludes their retained images
+from root-route Hero discovery: Flutter visits the current route of every nested
+Navigator even when its IndexedStack child is offstage. Only the active tab may
+supply an image for a full-screen transition; otherwise opening or returning
+from a root overlay such as Plaza can throw a duplicate-Hero-tag assertion.
 
 The desktop `Row` has up to four children: the sidebar, its `ResizableDivider`,
 the expanded content stack, and — while the **Tasks tab is active**, the Daily

--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -5,7 +5,7 @@ description: Scoped journal snapshots generate task timelines and category avenu
 resource: ../../lib/features/plaza
 tags: [plaza, 3d, flutter-scene, flutter-gpu, tasks, projects, categories]
 status: draft
-generated: { by: codex/gpt-6, at: 2026-09-08T22:30:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-09T00:27:05Z }
 stale_after: 2027-03-01
 sources:
   - id: repository
@@ -24,6 +24,14 @@ sources:
     resource: ../../lib/features/plaza/scene/category_world_generator.dart
     title: Category project portals and avenue assignments
     last_modified: 2026-09-08
+  - id: cable-path
+    resource: ../../lib/features/plaza/domain/cable_path.dart
+    title: Configurable roof mounts and sagging spans
+    last_modified: 2026-09-09
+  - id: cable-renderer
+    resource: ../../lib/features/plaza/scene/plaza_cables.dart
+    title: Batched cables and instanced directional lights
+    last_modified: 2026-09-09
   - id: world
     resource: ../../lib/features/plaza/scene/plaza_world.dart
     title: Shared CPU scene description
@@ -143,10 +151,15 @@ projects or pulls linked tasks from another project into the world.
 
 Checklist and cover entities, then checklist items, are read in batches bounded
 by the repository's SQLite parameter budget. Deleted/archived checklist content
-is excluded by the projection. Links are bidirectional, deduplicated and kept
-only when both endpoints are visible members; hidden and deleted edges are
-excluded. Dependency IDs include unresolved children and filtered membership so
-late sync arrivals and membership corrections can refresh the snapshot.
+is excluded by the projection. Task relationships retain their stored type and
+direction in `PlazaConnection`. `projectPlazaConnections` excludes non-task link families,
+self-links, hidden/deleted edges and edges outside the visible task set. Basic
+associations normalize endpoint order; typed relationships retain opposing
+directions as distinct edges. Duplicate rows resolve deterministically by ID.
+The per-task linked-ID summary is bidirectional and deduplicated. The category
+lock is rechecked after asynchronous child/link reads, before publication.
+Dependency IDs include unresolved children and filtered membership so late sync
+arrivals and membership corrections can refresh the snapshot.
 
 `projectPlazaTask` is shared with the fixture projection. It computes progress
 from the complete deduplicated checklist while capping the open preview. The
@@ -296,6 +309,41 @@ and shopfront skins use the existing facade-plate depth bias as well as their
 geometric offset. The offset alone loses depth precision on distant towers when
 static batching changes draw order. The shared paving texture draws staggered
 joints over transparent slab centres, avoiding checkerboard shading.
+
+# Suspended task connections
+
+`ProjectWorldConfig.cables` supplies `CableConfig`: cable radius, sag ratio and
+cap, mount height, clearance, support/sample limits and animated-light budget.
+`PlazaWorld.cablePaths` is lazy CPU geometry over the scoped connection list;
+category avenues currently have no aggregate relationship cables.
+
+`CablePath` mounts each endpoint on its building's actual top volume. Each route
+follows a straight horizontal line with parabolic sag between roof supports.
+Intersected rotated solid envelopes are checked analytically, including narrow
+obstacles between samples. Raised mounts keep spans above those envelopes. The default shares one mast
+per task roof, carrying all of its attachment heights; up to two intermediate
+roof supports keep long crossings from requiring excessively tall endpoint
+masts. Their explicit budget can be changed by the generator configuration. Intermediate supports are structural, never
+additional relationship nodes. Cable geometry is excluded from camera collision.
+Arc-length samples let lights move at a constant physical speed.
+
+`PlazaCables` attaches after the ordinary static bake. Tubes, support poles and
+fixed lamps receive their own opaque mesh bake; selected-task overlays remain
+outside it. Selecting a task or looking at its facade emphasizes its incident cables in the existing
+focus teal; white packets leave red/green available for task status. The
+Connections checkbox hides the entire group and survives snapshot replacement.
+Explicit task selection remains emphasized during flight and Overview; Home or
+Escape clears it, and a snapshot removing that task also drops the selection.
+A basic association sends opposing packets; a typed edge sends both packets in
+its stored source-to-destination direction. No task status is inferred from edges.
+
+`PlazaCableBuffer` bounds animation to two packets on each of the nearest 96
+cables, prioritizing incident edges of the focused task. Ranking is throttled to
+four times a second, or refreshed when focus changes. One instanced draw reuses
+its scalar buffer and conservative bounds; reduced motion freezes the packet
+clock. Static lamps and tubes remain visible beyond the moving-light distance.
+The frame pacer includes visible cable motion, and hiding connections removes
+that reason to keep drawing. No meshes are regenerated per frame.
 
 # Attention and navigation
 

--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -320,17 +320,21 @@ category avenues currently have no aggregate relationship cables.
 `CablePath` mounts each endpoint on its building's actual top volume. Each route
 follows a straight horizontal line with parabolic sag between roof supports.
 Intersected rotated solid envelopes are checked analytically, including narrow
-obstacles between samples. Raised mounts keep spans above those envelopes. The default shares one mast
-per task roof, carrying all of its attachment heights; up to two intermediate
+obstacles between samples. Raised mounts keep spans above those envelopes. The
+default shares one mast per task roof, carrying all of its attachment heights; up to two intermediate
 roof supports keep long crossings from requiring excessively tall endpoint
-masts. Their explicit budget can be changed by the generator configuration. Intermediate supports are structural, never
-additional relationship nodes. Cable geometry is excluded from camera collision.
+masts. Their explicit budget can be changed by the generator configuration.
+Intermediate supports are structural, never additional relationship nodes.
+Cable geometry is excluded from camera collision.
 Arc-length samples let lights move at a constant physical speed.
 
 `PlazaCables` attaches after the ordinary static bake. Tubes, support poles and
-fixed lamps receive their own opaque mesh bake; selected-task overlays remain
-outside it. Selecting a task or looking at its facade emphasizes its incident cables in the existing
-focus teal; white packets leave red/green available for task status. The
+fixed lamps receive their own opaque mesh bake. Each tube uses local vertices
+with a node at its arc midpoint, so the bake partitions by actual world cells
+instead of merging every tube at the origin. Selected-task overlays remain
+outside the bake; `PlazaCableSelection` creates them on first focus and caches
+them for reuse. Selecting a task or looking at its facade emphasizes its incident
+cables in the existing focus teal; white packets leave red/green available for task status. The
 Connections checkbox hides the entire group and survives snapshot replacement.
 Explicit task selection remains emphasized during flight and Overview; Home or
 Escape clears it, and a snapshot removing that task also drops the selection.

--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -514,7 +514,9 @@ class _AppScreenState extends ConsumerState<AppScreen> {
   final GlobalKey _contentStackKey = GlobalKey(debugLabel: 'app-content-stack');
 
   /// The one tab host, shared by both layouts. Only the active tab animates
-  /// and can take focus; the rest stay mounted and offstage.
+  /// and can take focus or participate in Hero transitions; the rest stay
+  /// mounted and offstage. Root navigation scans current nested routes even
+  /// inside an IndexedStack, so offstage alone does not isolate their Heroes.
   Widget _buildContentStack({
     required int index,
     required List<Widget> beamerChildren,
@@ -529,7 +531,10 @@ class _AppScreenState extends ConsumerState<AppScreen> {
               enabled: i == index,
               child: ExcludeFocus(
                 excluding: i != index,
-                child: beamerChildren[i],
+                child: HeroMode(
+                  enabled: i == index,
+                  child: beamerChildren[i],
+                ),
               ),
             ),
         ],

--- a/lib/features/plaza/README.md
+++ b/lib/features/plaza/README.md
@@ -10,6 +10,12 @@ towers, structural façade details and illuminated crowns extend that character
 into a denser surrounding city with closer street frontage and a fuller skyline;
 soft light spills connect signs to the paving.
 
+Linked tasks are joined by sagging cables above their roofs, with fixed lamps
+and travelling lights. Directed relationships flow from source to destination;
+ordinary associations flow both ways. Selecting a task or looking at it highlights its incident
+cables. **Connections** hides or shows the cables without changing task data.
+Only links whose endpoints are visible in the same project are included.
+
 Open **Explore project** from a project's details, or **Explore category**
 under a category in the Projects list. A category has an avenue for each
 project. Entering a project opens its own task world; Back returns to the

--- a/lib/features/plaza/data/demo_world_projection.dart
+++ b/lib/features/plaza/data/demo_world_projection.dart
@@ -10,10 +10,23 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/demo/media/demo_media_asset.dart';
 import 'package:lotti/features/demo/seed/demo_world.dart';
 import 'package:lotti/features/plaza/data/task_projection.dart';
+import 'package:lotti/features/plaza/domain/plaza_connection.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 
 /// Fallback category color when the demo category has none.
 const _fallbackColor = 0xFF5C9DFF;
+
+/// Uses the same scoped, typed edge projection as a live project snapshot.
+List<PlazaConnection> plazaConnectionsFromDemoWorld({DateTime? now}) {
+  final world = ManualDemoWorld.penguinLogistics(now: now);
+  return projectPlazaConnections(
+    links: world.links,
+    visibleTaskIds: {
+      for (final task in world.tasks)
+        if (task.meta.deletedAt == null) task.meta.id,
+    },
+  );
+}
 
 /// Category names keyed by the lower-case hex of their colour, for the
 /// side panel's category label (plaza tasks carry only the colour).

--- a/lib/features/plaza/data/plaza_repository.dart
+++ b/lib/features/plaza/data/plaza_repository.dart
@@ -1,9 +1,11 @@
 import 'package:clock/clock.dart';
 import 'package:lotti/classes/change_source.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/plaza/data/task_projection.dart';
+import 'package:lotti/features/plaza/domain/plaza_connection.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/entities_cache_service.dart';
@@ -16,12 +18,14 @@ class ProjectPlazaData {
     required this.project,
     required this.tasks,
     required this.dependencyIds,
+    this.connections = const [],
     this.category,
   });
 
   final ProjectEntry project;
   final CategoryDefinition? category;
   final List<PlazaTask> tasks;
+  final List<PlazaConnection> connections;
 
   /// Includes unresolved child IDs so a later sync arrival refreshes the world.
   final Set<String> dependencyIds;
@@ -200,7 +204,7 @@ class PlazaRepository {
       )).whereType<ChecklistItem>())
         entity.meta.id: entity,
     };
-    final linksByTask = <String, Set<String>>{};
+    final links = <EntryLink>[];
     final dependencyIds = {
       projectId,
       ?project.meta.categoryId,
@@ -215,17 +219,23 @@ class PlazaRepository {
       final batch = ids.skip(offset).take(_batchSize).toSet();
       for (final link in await db.linksForEntryIdsBidirectional(batch)) {
         dependencyIds.add(link.id);
-        if (link.hidden == true || link.deletedAt != null) continue;
-        if (!taskIds.contains(link.fromId) || !taskIds.contains(link.toId)) {
-          continue;
-        }
-        linksByTask.putIfAbsent(link.fromId, () => {}).add(link.toId);
-        linksByTask.putIfAbsent(link.toId, () => {}).add(link.fromId);
+        links.add(link);
       }
+    }
+    if (cache.lockedCategoryIds.contains(project.meta.categoryId)) return null;
+    final connections = projectPlazaConnections(
+      links: links,
+      visibleTaskIds: taskIds,
+    );
+    final linksByTask = <String, Set<String>>{};
+    for (final edge in connections) {
+      linksByTask.putIfAbsent(edge.fromId, () => {}).add(edge.toId);
+      linksByTask.putIfAbsent(edge.toId, () => {}).add(edge.fromId);
     }
     return ProjectPlazaData(
       project: project,
       category: category,
+      connections: connections,
       dependencyIds: Set.unmodifiable(dependencyIds),
       tasks: List.unmodifiable([
         for (final task in tasks)

--- a/lib/features/plaza/data/task_projection.dart
+++ b/lib/features/plaza/data/task_projection.dart
@@ -1,6 +1,45 @@
+import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/plaza/domain/plaza_connection.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
+import 'package:lotti/features/tasks/model/directed_relation.dart';
+
+/// Projects only relationships whose two tasks are already visible in scope.
+/// Hidden/deleted edges and self-links are omitted. Symmetric associations
+/// deduplicate across directions; distinct typed relations retain direction.
+List<PlazaConnection> projectPlazaConnections({
+  required Iterable<EntryLink> links,
+  required Set<String> visibleTaskIds,
+}) {
+  final sorted = links.toList()..sort((a, b) => a.id.compareTo(b.id));
+  final connections = <(String, String, EntryLinkType), PlazaConnection>{};
+  for (final link in sorted) {
+    if (link.hidden == true ||
+        link.deletedAt != null ||
+        link.fromId == link.toId ||
+        !visibleTaskIds.contains(link.fromId) ||
+        !visibleTaskIds.contains(link.toId)) {
+      continue;
+    }
+    final type = entryLinkTypeOf(link);
+    if (!relationshipSelectorTypes.contains(type)) continue;
+    final reverse =
+        type == EntryLinkType.basic && link.fromId.compareTo(link.toId) > 0;
+    final fromId = reverse ? link.toId : link.fromId;
+    final toId = reverse ? link.fromId : link.toId;
+    connections.putIfAbsent(
+      (fromId, toId, type),
+      () => PlazaConnection(
+        id: link.id,
+        fromId: fromId,
+        toId: toId,
+        type: type,
+      ),
+    );
+  }
+  return List.unmodifiable(connections.values);
+}
 
 /// Projects a persisted task and its resolved checklist items into the plaza.
 ///

--- a/lib/features/plaza/dev_main.dart
+++ b/lib/features/plaza/dev_main.dart
@@ -38,6 +38,7 @@ class PlazaDevApp extends StatelessWidget {
         builder: (context) => PlazaView(
           world: PlazaWorld(
             tasks: plazaTasksFromDemoWorld(now: manualDemoNow),
+            connections: plazaConnectionsFromDemoWorld(now: manualDemoNow),
             now: manualDemoNow,
             projectLabel: 'Project Waddle',
             categoryLabels: demoCategoryLabels(now: manualDemoNow),

--- a/lib/features/plaza/domain/cable_path.dart
+++ b/lib/features/plaza/domain/cable_path.dart
@@ -1,0 +1,249 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:lotti/features/plaza/domain/building_architecture.dart';
+import 'package:lotti/features/plaza/domain/plaza_connection.dart';
+import 'package:lotti/features/plaza/domain/solid.dart';
+import 'package:lotti/features/plaza/domain/street_layout.dart';
+
+/// Cable dimensions in world metres. Geometry is generated once per snapshot;
+/// the light budget bounds animated instances independently of graph size.
+class CableConfig {
+  const CableConfig({
+    this.radius = 0.16,
+    this.sagRatio = 0.09,
+    this.maxSag = 8,
+    this.mountHeight = 3,
+    this.clearance = 1.5,
+    this.maxSupports = 2,
+    this.samplesPerSpan = 24,
+    this.maxAnimatedCables = 96,
+  }) : assert(radius > 0, 'cables need a positive radius'),
+       assert(sagRatio >= 0 && maxSag >= 0, 'sag cannot be negative'),
+       assert(mountHeight > 0 && clearance > 0, 'mounts need clearance'),
+       assert(maxSupports >= 0, 'support budget cannot be negative'),
+       assert(samplesPerSpan >= 4, 'curves need at least four intervals'),
+       assert(maxAnimatedCables >= 0, 'light budget cannot be negative');
+
+  final double radius;
+  final double sagRatio;
+  final double maxSag;
+  final double mountHeight;
+  final double clearance;
+  final int maxSupports;
+  final int samplesPerSpan;
+  final int maxAnimatedCables;
+
+  double sag(double distance) => math.min(maxSag, distance * sagRatio);
+}
+
+/// A roof-mounted endpoint or an intermediate structural support. Supports do
+/// not introduce graph nodes or change the relationship's semantic endpoints.
+typedef CableSupport = ({double x, double y, double z, double baseY});
+
+/// A sampled chain of sagging spans, in the relationship's from → to order.
+/// Arc distances let light packets move at a constant physical speed. Sampling
+/// into an existing buffer performs no allocations during animation.
+class CablePath {
+  CablePath._({
+    required this.connection,
+    required this.supports,
+    required CableConfig config,
+  }) {
+    final count = (supports.length - 1) * config.samplesPerSpan + 1;
+    positions = Float64List(count * 3);
+    distances = Float64List(count);
+    var index = 0;
+    for (var span = 0; span < supports.length - 1; span++) {
+      final a = supports[span];
+      final b = supports[span + 1];
+      final sag = config.sag(groundDistanceBetween(a.x, a.z, b.x, b.z));
+      for (
+        var step = span == 0 ? 0 : 1;
+        step <= config.samplesPerSpan;
+        step++
+      ) {
+        final t = step / config.samplesPerSpan;
+        final offset = index * 3;
+        positions[offset] = a.x + (b.x - a.x) * t;
+        positions[offset + 1] = _height(a.y, b.y, sag, t);
+        positions[offset + 2] = a.z + (b.z - a.z) * t;
+        if (index > 0) {
+          final dx = positions[offset] - positions[offset - 3];
+          final dy = positions[offset + 1] - positions[offset - 2];
+          final dz = positions[offset + 2] - positions[offset - 1];
+          distances[index] =
+              distances[index - 1] + math.sqrt(dx * dx + dy * dy + dz * dz);
+        }
+        index++;
+      }
+    }
+  }
+
+  /// Raises supports only where needed to clear the intersected roof envelopes.
+  /// Each span is checked analytically against rotated footprints, including
+  /// narrow obstacles between samples. Raising either end only improves the
+  /// clearance of an already checked neighbouring span.
+  factory CablePath.plan({
+    required PlazaConnection connection,
+    required PlotPlacement from,
+    required PlotPlacement to,
+    required BuildingArchitecture fromArchitecture,
+    required BuildingArchitecture toArchitecture,
+    required List<Solid> solids,
+    CableConfig config = const CableConfig(),
+  }) {
+    _Mount mount(PlotPlacement plot, BuildingArchitecture architecture) {
+      final roof = architecture.volumes.last;
+      final u =
+          roof.x +
+          (stableUnit(plot.taskId, 'cable-mount') - 0.5) * roof.width * 0.5;
+      final (x, z) = plot.footprint.toWorld(u, roof.z + roof.depth * 0.25);
+      return _Mount(x, roof.top + config.mountHeight, z, roof.top);
+    }
+
+    final a = mount(from, fromArchitecture);
+    final b = mount(to, toArchitecture);
+    final directSag = config.sag(groundDistanceBetween(a.x, a.z, b.x, b.z));
+    final candidates = <({double t, double top, double deficit})>[];
+    for (final solid in solids) {
+      final interval = _interval(a, b, solid.footprint, config);
+      if (interval == null) continue;
+      final (lo, hi) = interval;
+      final deficit =
+          solid.top +
+          config.clearance +
+          config.radius -
+          _minimum(a.y, b.y, directSag, lo, hi);
+      final t = (lo + hi) / 2;
+      if (deficit > 0 && t > 0.05 && t < 0.95) {
+        candidates.add((t: t, top: solid.top, deficit: deficit));
+      }
+    }
+    candidates.sort((a, b) {
+      final byHeight = b.deficit.compareTo(a.deficit);
+      return byHeight == 0 ? a.t.compareTo(b.t) : byHeight;
+    });
+    final chosen = <({double t, double top, double deficit})>[];
+    for (final candidate in candidates) {
+      if (chosen.length >= config.maxSupports) break;
+      if (chosen.any((other) => (other.t - candidate.t).abs() < 0.05)) continue;
+      chosen.add(candidate);
+    }
+    chosen.sort((a, b) => a.t.compareTo(b.t));
+    final mounts = [
+      a,
+      for (final support in chosen)
+        _Mount(
+          a.x + (b.x - a.x) * support.t,
+          support.top + config.mountHeight,
+          a.z + (b.z - a.z) * support.t,
+          support.top,
+        ),
+      b,
+    ];
+    for (var i = 0; i < mounts.length - 1; i++) {
+      final left = mounts[i];
+      final right = mounts[i + 1];
+      final sag = config.sag(
+        groundDistanceBetween(left.x, left.z, right.x, right.z),
+      );
+      for (final solid in solids) {
+        final interval = _interval(left, right, solid.footprint, config);
+        if (interval == null) continue;
+        final (lo, hi) = interval;
+        final raise =
+            solid.top +
+            config.clearance +
+            config.radius -
+            _minimum(left.y, right.y, sag, lo, hi);
+        if (raise > 0) {
+          left.y += raise;
+          right.y += raise;
+        }
+      }
+    }
+    return CablePath._(
+      connection: connection,
+      supports: List.unmodifiable([
+        for (final mount in mounts)
+          (x: mount.x, y: mount.y, z: mount.z, baseY: mount.baseY),
+      ]),
+      config: config,
+    );
+  }
+
+  final PlazaConnection connection;
+  final List<CableSupport> supports;
+  late final Float64List positions;
+  late final Float64List distances;
+
+  double get length => distances.last;
+
+  /// Writes x/y/z into [output] at [offset], clamping to either endpoint.
+  void writePosition(double distance, List<double> output, int offset) {
+    final d = distance.clamp(0.0, length);
+    var lo = 0;
+    var hi = distances.length - 1;
+    while (lo + 1 < hi) {
+      final mid = (lo + hi) ~/ 2;
+      if (distances[mid] < d) {
+        lo = mid;
+      } else {
+        hi = mid;
+      }
+    }
+    final span = distances[hi] - distances[lo];
+    final t = span == 0 ? 0.0 : (d - distances[lo]) / span;
+    for (var axis = 0; axis < 3; axis++) {
+      final a = positions[lo * 3 + axis];
+      output[offset + axis] = a + (positions[hi * 3 + axis] - a) * t;
+    }
+  }
+
+  static double _height(double a, double b, double sag, double t) =>
+      a + (b - a) * t - 4 * sag * t * (1 - t);
+
+  static double _minimum(double a, double b, double sag, double lo, double hi) {
+    final t = sag == 0 ? lo : ((4 * sag + a - b) / (8 * sag)).clamp(lo, hi);
+    return math.min(
+      _height(a, b, sag, t),
+      math.min(_height(a, b, sag, lo), _height(a, b, sag, hi)),
+    );
+  }
+
+  static (double, double)? _interval(
+    _Mount a,
+    _Mount b,
+    Footprint footprint,
+    CableConfig config,
+  ) {
+    final (u, v) = footprint.local(a.x, a.z);
+    final (endU, endV) = footprint.local(b.x, b.z);
+    var lo = 0.0;
+    var hi = 1.0;
+    for (final (start, delta, half) in [
+      (u, endU - u, footprint.width / 2 + config.radius + config.clearance),
+      (v, endV - v, footprint.depth / 2 + config.radius + config.clearance),
+    ]) {
+      if (delta.abs() < 1e-12) {
+        if (start.abs() > half) return null;
+      } else {
+        final near = (-half - start) / delta;
+        final far = (half - start) / delta;
+        lo = math.max(lo, math.min(near, far));
+        hi = math.min(hi, math.max(near, far));
+        if (lo > hi) return null;
+      }
+    }
+    return (lo, hi);
+  }
+}
+
+class _Mount {
+  _Mount(this.x, this.y, this.z, this.baseY);
+  final double x;
+  double y;
+  final double z;
+  final double baseY;
+}

--- a/lib/features/plaza/domain/plaza_connection.dart
+++ b/lib/features/plaza/domain/plaza_connection.dart
@@ -1,0 +1,28 @@
+import 'package:lotti/classes/entry_link.dart';
+import 'package:meta/meta.dart';
+
+/// One visible task relationship, retaining its stored semantic direction.
+/// Plain associations are symmetric; typed relationships read from → to.
+@immutable
+class PlazaConnection {
+  const PlazaConnection({
+    required this.id,
+    required this.fromId,
+    required this.toId,
+    required this.type,
+  });
+
+  final String id;
+  final String fromId;
+  final String toId;
+  final EntryLinkType type;
+
+  bool get isDirected => type != EntryLinkType.basic;
+
+  /// The connected task from either end; unrelated tasks have no destination.
+  String? otherId(String taskId) => taskId == fromId
+      ? toId
+      : taskId == toId
+      ? fromId
+      : null;
+}

--- a/lib/features/plaza/scene/plaza_cables.dart
+++ b/lib/features/plaza/scene/plaza_cables.dart
@@ -12,8 +12,13 @@ import 'package:lotti/features/plaza/ui/plaza_style.dart';
 import 'package:vector_math/vector_math.dart';
 
 /// A continuous, six-sided tube swept along the sampled cable. Its triangles
-/// face outwards; no camera-facing ribbons or per-frame geometry are needed.
-MeshData cableTubeMesh(CablePath path, double radius) {
+/// face outwards, with vertices relative to [origin]; no camera-facing ribbons
+/// or per-frame geometry are needed.
+MeshData cableTubeMesh(
+  CablePath path,
+  double radius, {
+  required Vector3 origin,
+}) {
   const sides = 6;
   final count = path.distances.length;
   final positions = Float32List(count * sides * 3);
@@ -40,7 +45,10 @@ MeshData cableTubeMesh(CablePath path, double radius) {
       final offset = (i * sides + side) * 3;
       for (var axis = 0; axis < 3; axis++) {
         positions[offset + axis] =
-            source[i * 3 + axis] + normal[axis] * u + binormal[axis] * v;
+            source[i * 3 + axis] -
+            origin[axis] +
+            normal[axis] * u +
+            binormal[axis] * v;
       }
       if (i + 1 < count) {
         final a = i * sides + side;
@@ -50,6 +58,26 @@ MeshData cableTubeMesh(CablePath path, double radius) {
     }
   }
   return MeshData.build(positions: positions, indices: indices);
+}
+
+Geometry _uploadCableMesh(MeshData mesh) => MeshGeometry.fromMeshData(mesh);
+
+/// Places the tube at its arc midpoint so static batching assigns it to the
+/// cable's actual spatial cell. Keeping vertices local preserves world geometry
+/// while preventing disconnected districts from merging at the scene origin.
+Node cableTubeNode(
+  CablePath path,
+  double radius,
+  UnlitMaterial material, {
+  Geometry Function(MeshData) upload = _uploadCableMesh,
+}) {
+  final origin = Vector3.zero();
+  path.writePosition(path.length / 2, origin.storage, 0);
+  return Node(
+      mesh: Mesh(upload(cableTubeMesh(path, radius, origin: origin)), material),
+    )
+    ..position = origin
+    ..raycastable = false;
 }
 
 /// A single mast carries every attachment height at the same roof position.
@@ -204,9 +232,46 @@ class _CableLightSource {
   bool focused = false;
 }
 
+/// Allocates highlight geometry only when its connection is first selected.
+/// Repeated focus changes reuse cached overlays; clearing focus hides them.
+class PlazaCableSelection {
+  PlazaCableSelection({
+    required this.paths,
+    required this.root,
+    required this.create,
+  });
+
+  final List<CablePath> paths;
+  final Node root;
+  final Node Function(CablePath) create;
+  final Map<CablePath, Node> _nodes = {};
+  String? _focusedTask;
+
+  void update(String? focusedTask) {
+    if (_focusedTask == focusedTask) return;
+    _focusedTask = focusedTask;
+    for (final entry in _nodes.entries) {
+      entry.value.visible =
+          focusedTask != null &&
+          entry.key.connection.otherId(focusedTask) != null;
+    }
+    if (focusedTask == null) return;
+    for (final path in paths) {
+      if (path.length == 0 || path.connection.otherId(focusedTask) == null) {
+        continue;
+      }
+      if (!_nodes.containsKey(path)) {
+        final node = create(path);
+        _nodes[path] = node;
+        root.add(node);
+      }
+    }
+  }
+}
+
 /// Roof-mounted suspension cables. Static tubes, lamp collars and supports are
-/// baked once; selection overlays share their lifetime and toggle only when
-/// focus changes. All travelling packets use one instanced draw.
+/// baked once; selection overlays are created on first use and reused. All
+/// travelling packets use one instanced draw.
 class PlazaCables {
   PlazaCables({
     required Scene scene,
@@ -225,27 +290,17 @@ class PlazaCables {
       );
     final selected = UnlitMaterial()
       ..baseColorFactor = emissiveColor(PlazaStyle.teal, 1.6);
+    _selection = PlazaCableSelection(
+      paths: world.cablePaths,
+      root: root,
+      create: (path) =>
+          cableTubeNode(path, world.cables.radius * 1.7, selected),
+    );
     final cube = CuboidGeometry(Vector3.all(1));
     final point = Float64List(3);
     for (final path in world.cablePaths) {
       if (path.length == 0) continue;
-      final geometry = MeshGeometry.fromMeshData(
-        cableTubeMesh(path, world.cables.radius),
-      );
-      stationary.add(Node(mesh: Mesh(geometry, body))..raycastable = false);
-      final focus =
-          Node(
-              mesh: Mesh(
-                MeshGeometry.fromMeshData(
-                  cableTubeMesh(path, world.cables.radius * 1.7),
-                ),
-                selected,
-              ),
-            )
-            ..visible = false
-            ..raycastable = false;
-      root.add(focus);
-      _focus.add((path: path, node: focus));
+      stationary.add(cableTubeNode(path, world.cables.radius, body));
       final lamps = math.min(24, math.max(2, (path.length / 12).ceil()));
       for (var i = 1; i < lamps; i++) {
         path.writePosition(path.length * i / lamps, point, 0);
@@ -301,9 +356,8 @@ class PlazaCables {
   }
 
   final Node root = Node()..raycastable = false;
-  final List<({CablePath path, Node node})> _focus = [];
+  late final PlazaCableSelection _selection;
   PlazaCableBuffer? _buffer;
-  String? _focusedTask;
   int meshCount = 0;
   int batchCount = 0;
 
@@ -316,14 +370,7 @@ class PlazaCables {
     String? focusedTask,
     bool animate = true,
   }) {
-    if (_focusedTask != focusedTask) {
-      for (final entry in _focus) {
-        entry.node.visible =
-            focusedTask != null &&
-            entry.path.connection.otherId(focusedTask) != null;
-      }
-      _focusedTask = focusedTask;
-    }
+    _selection.update(focusedTask);
     _buffer?.update(
       seconds,
       eye,

--- a/lib/features/plaza/scene/plaza_cables.dart
+++ b/lib/features/plaza/scene/plaza_cables.dart
@@ -1,0 +1,334 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_scene/scene.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/plaza/domain/cable_path.dart';
+import 'package:lotti/features/plaza/domain/street_layout.dart';
+import 'package:lotti/features/plaza/scene/plaza_primitives.dart';
+import 'package:lotti/features/plaza/scene/plaza_static_meshes.dart';
+import 'package:lotti/features/plaza/scene/plaza_world.dart';
+import 'package:lotti/features/plaza/ui/plaza_style.dart';
+import 'package:vector_math/vector_math.dart';
+
+/// A continuous, six-sided tube swept along the sampled cable. Its triangles
+/// face outwards; no camera-facing ribbons or per-frame geometry are needed.
+MeshData cableTubeMesh(CablePath path, double radius) {
+  const sides = 6;
+  final count = path.distances.length;
+  final positions = Float32List(count * sides * 3);
+  final indices = <int>[];
+  final source = path.positions;
+  // Every span follows the same horizontal line. Keep its section vertical:
+  // rotating rings with the tangent folds faces at a sharp support crest.
+  final tangent = Vector3(
+    source[source.length - 3] - source[0],
+    0,
+    source.last - source[2],
+  );
+  if (tangent.length2 == 0) tangent.y = 1;
+  tangent.normalize();
+  final normal = Vector3(-tangent.z, 0, tangent.x);
+  if (normal.length2 == 0) normal.x = 1;
+  normal.normalize();
+  final binormal = tangent.cross(normal)..normalize();
+  for (var i = 0; i < count; i++) {
+    for (var side = 0; side < sides; side++) {
+      final angle = side * math.pi * 2 / sides;
+      final u = math.cos(angle) * radius;
+      final v = math.sin(angle) * radius;
+      final offset = (i * sides + side) * 3;
+      for (var axis = 0; axis < 3; axis++) {
+        positions[offset + axis] =
+            source[i * 3 + axis] + normal[axis] * u + binormal[axis] * v;
+      }
+      if (i + 1 < count) {
+        final a = i * sides + side;
+        final b = i * sides + (side + 1) % sides;
+        indices.addAll([a, b, a + sides, b, b + sides, a + sides]);
+      }
+    }
+  }
+  return MeshData.build(positions: positions, indices: indices);
+}
+
+/// A single mast carries every attachment height at the same roof position.
+/// Sharing it prevents a highly connected task from becoming a forest of poles.
+List<CableSupport> cableSupportsFor(Iterable<CablePath> paths) {
+  final supports = <(double, double, double), CableSupport>{};
+  for (final path in paths) {
+    for (final support in path.supports) {
+      final key = (support.x, support.z, support.baseY);
+      final existing = supports[key];
+      if (existing == null || support.y > existing.y) supports[key] = support;
+    }
+  }
+  return List.unmodifiable(supports.values);
+}
+
+/// Bounded light packets, ranked by selected-task incidence then camera
+/// distance. Directional edges flow from source to destination; basic links
+/// have opposing packets so they never imply a dependency.
+class PlazaCableBuffer {
+  PlazaCableBuffer({
+    required List<CablePath> paths,
+    required this.data,
+    this.maxCables = 96,
+    this.speed = 12,
+    this.maxDistance = 600,
+  }) : _ranked = [for (final path in paths) _CableLightSource(path)],
+       assert(maxCables >= 0, 'light budget cannot be negative'),
+       assert(speed > 0, 'packet speed must be positive') {
+    if (data.length < count * BillboardGeometry.floatsPerInstance) {
+      throw ArgumentError('instance buffer is smaller than its cable budget');
+    }
+  }
+
+  final Float32List data;
+  final int maxCables;
+  final double speed;
+  final double maxDistance;
+  final List<_CableLightSource> _ranked;
+  final Vector4 _white = emissiveColor(
+    dsTokensDark.colors.text.highEmphasis,
+    1.6,
+  );
+  final Vector4 _focus = emissiveColor(PlazaStyle.teal, 1.6);
+  String? _focusedTask;
+  double? _rankedAt;
+  double? _lastSeconds;
+  double _motionSeconds = 0;
+  bool hasVisibleMotion = false;
+
+  int get count => math.min(maxCables, _ranked.length) * 2;
+
+  /// Commits conservative bounds once for all possible ranked packets.
+  void reserveBounds(void Function(int) commit) {
+    if (count == 0) {
+      commit(0);
+      return;
+    }
+    final min = Vector3.all(double.infinity);
+    final max = Vector3.all(double.negativeInfinity);
+    for (final source in _ranked) {
+      final points = source.path.positions;
+      for (var i = 0; i < points.length; i += 3) {
+        for (var axis = 0; axis < 3; axis++) {
+          min[axis] = math.min(min[axis], points[i + axis] - 4);
+          max[axis] = math.max(max[axis], points[i + axis] + 4);
+        }
+      }
+    }
+    for (var axis = 0; axis < 3; axis++) {
+      data[axis] = min[axis];
+      data[BillboardGeometry.floatsPerInstance + axis] = max[axis];
+    }
+    try {
+      commit(count);
+    } finally {
+      data.fillRange(0, data.length, 0);
+    }
+  }
+
+  void update(
+    double seconds,
+    Vector3 eye, {
+    String? focusedTask,
+    bool animate = true,
+  }) {
+    if (animate && _lastSeconds != null) {
+      _motionSeconds += math.max(0, seconds - _lastSeconds!);
+    }
+    _lastSeconds = seconds;
+    if (_rankedAt == null ||
+        seconds - _rankedAt! >= 0.25 ||
+        _focusedTask != focusedTask) {
+      for (final source in _ranked) {
+        final points = source.path.positions;
+        final mid = (points.length ~/ 6) * 3;
+        final dx = points[mid] - eye.x;
+        final dy = points[mid + 1] - eye.y;
+        final dz = points[mid + 2] - eye.z;
+        source.distanceSquared = dx * dx + dy * dy + dz * dz;
+        source.focused =
+            focusedTask != null &&
+            source.path.connection.otherId(focusedTask) != null;
+      }
+      _ranked.sort(_nearestFirst);
+      _rankedAt = seconds;
+      _focusedTask = focusedTask;
+    }
+    hasVisibleMotion = false;
+    for (var i = 0; i < count ~/ 2; i++) {
+      final source = _ranked[i];
+      final path = source.path;
+      final visible =
+          path.length > 0 &&
+          source.distanceSquared <= maxDistance * maxDistance;
+      if (visible && animate) hasVisibleMotion = true;
+      final color = source.focused ? _focus : _white;
+      for (var packet = 0; packet < 2; packet++) {
+        final offset = (i * 2 + packet) * BillboardGeometry.floatsPerInstance;
+        var fraction =
+            (source.phase +
+                packet / 2 +
+                _motionSeconds * speed / math.max(path.length, 1)) %
+            1;
+        if (!path.connection.isDirected && packet == 1) fraction = 1 - fraction;
+        path.writePosition(fraction * path.length, data, offset);
+        data[offset + 3] = source.focused ? 3 : 2;
+        data[offset + 4] = data[offset + 3];
+        data[offset + 6] = color.x;
+        data[offset + 7] = color.y;
+        data[offset + 8] = color.z;
+        data[offset + 9] = visible ? color.w : 0;
+      }
+    }
+  }
+
+  static int _nearestFirst(_CableLightSource a, _CableLightSource b) {
+    if (a.focused != b.focused) return a.focused ? -1 : 1;
+    final distance = a.distanceSquared.compareTo(b.distanceSquared);
+    return distance == 0
+        ? a.path.connection.id.compareTo(b.path.connection.id)
+        : distance;
+  }
+}
+
+class _CableLightSource {
+  _CableLightSource(this.path)
+    : phase = stableUnit(path.connection.id, 'light');
+  final CablePath path;
+  final double phase;
+  double distanceSquared = 0;
+  bool focused = false;
+}
+
+/// Roof-mounted suspension cables. Static tubes, lamp collars and supports are
+/// baked once; selection overlays share their lifetime and toggle only when
+/// focus changes. All travelling packets use one instanced draw.
+class PlazaCables {
+  PlazaCables({
+    required Scene scene,
+    required PlazaWorld world,
+    required TextureSource glowTexture,
+  }) {
+    scene.add(root);
+    final stationary = Node()..raycastable = false;
+    root.add(stationary);
+    final body = UnlitMaterial()
+      ..baseColorFactor = linearColor(dsTokensDark.colors.background.level03);
+    final lit = UnlitMaterial()
+      ..baseColorFactor = emissiveColor(
+        dsTokensDark.colors.text.highEmphasis,
+        1.6,
+      );
+    final selected = UnlitMaterial()
+      ..baseColorFactor = emissiveColor(PlazaStyle.teal, 1.6);
+    final cube = CuboidGeometry(Vector3.all(1));
+    final point = Float64List(3);
+    for (final path in world.cablePaths) {
+      if (path.length == 0) continue;
+      final geometry = MeshGeometry.fromMeshData(
+        cableTubeMesh(path, world.cables.radius),
+      );
+      stationary.add(Node(mesh: Mesh(geometry, body))..raycastable = false);
+      final focus =
+          Node(
+              mesh: Mesh(
+                MeshGeometry.fromMeshData(
+                  cableTubeMesh(path, world.cables.radius * 1.7),
+                ),
+                selected,
+              ),
+            )
+            ..visible = false
+            ..raycastable = false;
+      root.add(focus);
+      _focus.add((path: path, node: focus));
+      final lamps = math.min(24, math.max(2, (path.length / 12).ceil()));
+      for (var i = 1; i < lamps; i++) {
+        path.writePosition(path.length * i / lamps, point, 0);
+        stationary.add(
+          Node(mesh: Mesh(cube, lit))
+            ..position = Vector3(point[0], point[1], point[2])
+            ..scale = Vector3.all(world.cables.radius * 2)
+            ..raycastable = false,
+        );
+      }
+    }
+    for (final support in cableSupportsFor(world.cablePaths)) {
+      final height = support.y - support.baseY;
+      stationary
+        ..add(
+          Node(mesh: Mesh(cube, body))
+            ..position = Vector3(
+              support.x,
+              support.baseY + height / 2,
+              support.z,
+            )
+            ..scale = Vector3(
+              world.cables.radius * 2,
+              height,
+              world.cables.radius * 2,
+            )
+            ..raycastable = false,
+        )
+        ..add(
+          Node(mesh: Mesh(cube, lit))
+            ..position = Vector3(support.x, support.y, support.z)
+            ..scale = Vector3.all(world.cables.radius * 3)
+            ..raycastable = false,
+        );
+    }
+    final batches = PlazaStaticMeshes(
+      cellSize: world.layout.groupLength * 2,
+    ).bake(stationary, preserve: const {});
+    meshCount = batches.meshes;
+    batchCount = batches.batches;
+    final capacity =
+        math.min(world.cables.maxAnimatedCables, world.cablePaths.length) * 2;
+    if (capacity == 0) return;
+    final geometry = BillboardGeometry(capacity: capacity);
+    final material = SpriteMaterial(colorTexture: glowTexture)
+      ..blendMode = SpriteBlendMode.additive;
+    _buffer = PlazaCableBuffer(
+      paths: world.cablePaths,
+      data: geometry.instanceData,
+      maxCables: world.cables.maxAnimatedCables,
+    )..reserveBounds(geometry.commit);
+    root.add(Node(mesh: Mesh(geometry, material))..raycastable = false);
+  }
+
+  final Node root = Node()..raycastable = false;
+  final List<({CablePath path, Node node})> _focus = [];
+  PlazaCableBuffer? _buffer;
+  String? _focusedTask;
+  int meshCount = 0;
+  int batchCount = 0;
+
+  bool get hasVisibleMotion =>
+      root.visible && (_buffer?.hasVisibleMotion ?? false);
+
+  void update(
+    double seconds,
+    Vector3 eye, {
+    String? focusedTask,
+    bool animate = true,
+  }) {
+    if (_focusedTask != focusedTask) {
+      for (final entry in _focus) {
+        entry.node.visible =
+            focusedTask != null &&
+            entry.path.connection.otherId(focusedTask) != null;
+      }
+      _focusedTask = focusedTask;
+    }
+    _buffer?.update(
+      seconds,
+      eye,
+      focusedTask: focusedTask,
+      animate: animate && root.visible,
+    );
+  }
+}

--- a/lib/features/plaza/scene/plaza_world.dart
+++ b/lib/features/plaza/scene/plaza_world.dart
@@ -1,6 +1,8 @@
 import 'package:lotti/features/plaza/domain/attention.dart';
 import 'package:lotti/features/plaza/domain/building_architecture.dart';
+import 'package:lotti/features/plaza/domain/cable_path.dart';
 import 'package:lotti/features/plaza/domain/morning_walk.dart';
+import 'package:lotti/features/plaza/domain/plaza_connection.dart';
 import 'package:lotti/features/plaza/domain/plaza_layout.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/features/plaza/domain/scenery.dart';
@@ -20,15 +22,29 @@ class PlazaWorld {
     required this.now,
     required this.projectLabel,
     required this.layout,
+    List<PlazaConnection> connections = const [],
     this.epoch,
     this.categoryLabels = const {},
     this.avenueLabels = const {},
     this.avenueByProjectId = const {},
     this.ambientCreatures = 24,
     this.architecture = const ArchitectureConfig(),
+    this.cables = const CableConfig(),
     PlazaCopy? copy,
   }) : copy = copy ?? PlazaCopy.english {
     plan = layout.plan(tasks, epoch: epoch, bucketOverrides: avenueByProjectId);
+    final visibleIds = {
+      for (final task in tasks)
+        if (!task.deleted) task.id,
+    };
+    this.connections = List.unmodifiable(
+      connections.where(
+        (edge) =>
+            edge.fromId != edge.toId &&
+            visibleIds.contains(edge.fromId) &&
+            visibleIds.contains(edge.toId),
+      ),
+    );
     architectureByTaskId = Map.unmodifiable({
       for (final task in tasks)
         task.id: BuildingArchitecture.forPlot(
@@ -99,6 +115,7 @@ class PlazaWorld {
   }
 
   final List<PlazaTask> tasks;
+  late final List<PlazaConnection> connections;
   final DateTime now;
   final String projectLabel;
   final StreetLayout layout;
@@ -106,6 +123,22 @@ class PlazaWorld {
   final PlazaCopy copy;
   final int ambientCreatures;
   final ArchitectureConfig architecture;
+  final CableConfig cables;
+
+  /// Roof routes are computed only when a renderer or inspection needs them.
+  /// They do not become camera obstacles or introduce intermediate graph nodes.
+  late final List<CablePath> cablePaths = List.unmodifiable([
+    for (final edge in connections)
+      CablePath.plan(
+        connection: edge,
+        from: plan.placements[edge.fromId]!,
+        to: plan.placements[edge.toId]!,
+        fromArchitecture: architectureByTaskId[edge.fromId]!,
+        toArchitecture: architectureByTaskId[edge.toId]!,
+        solids: solids,
+        config: cables,
+      ),
+  ]);
   final Map<int, String> avenueLabels;
   final Map<String, int> avenueByProjectId;
   bool get isCategory => avenueByProjectId.isNotEmpty;

--- a/lib/features/plaza/scene/project_world_generator.dart
+++ b/lib/features/plaza/scene/project_world_generator.dart
@@ -1,5 +1,7 @@
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/plaza/domain/building_architecture.dart';
+import 'package:lotti/features/plaza/domain/cable_path.dart';
+import 'package:lotti/features/plaza/domain/plaza_connection.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/features/plaza/domain/street_layout.dart';
 import 'package:lotti/features/plaza/scene/plaza_world.dart';
@@ -16,6 +18,7 @@ class ProjectWorldConfig {
     this.weeksPerRow = 4,
     this.ambientCreatures = 24,
     this.architecture = const ArchitectureConfig(),
+    this.cables = const CableConfig(),
   }) : assert(minimumPlotSpacing > 0, 'plots need positive spacing'),
        assert(completedSetback >= 0, 'setback cannot be negative'),
        assert(weeksPerRow > 0, 'a row must contain weeks'),
@@ -27,6 +30,7 @@ class ProjectWorldConfig {
   final int weeksPerRow;
   final int ambientCreatures;
   final ArchitectureConfig architecture;
+  final CableConfig cables;
 
   StreetLayout layoutFor(String projectId) => StreetLayout(
     projectSeed: stableHash('$projectId:$seed'),
@@ -44,11 +48,13 @@ PlazaWorld generateProjectWorld({
   required ProjectEntry project,
   required List<PlazaTask> tasks,
   required DateTime now,
+  List<PlazaConnection> connections = const [],
   Map<String, String> categoryLabels = const {},
   ProjectWorldConfig config = const ProjectWorldConfig(),
   PlazaCopy? copy,
 }) => PlazaWorld(
   tasks: tasks,
+  connections: connections,
   now: now,
   projectLabel: project.data.title,
   epoch: project.data.dateFrom,
@@ -56,5 +62,6 @@ PlazaWorld generateProjectWorld({
   layout: config.layoutFor(project.meta.id),
   ambientCreatures: config.ambientCreatures,
   architecture: config.architecture,
+  cables: config.cables,
   copy: copy,
 );

--- a/lib/features/plaza/ui/plaza_hud.dart
+++ b/lib/features/plaza/ui/plaza_hud.dart
@@ -29,6 +29,8 @@ class PlazaHud extends StatelessWidget {
     required this.showDebug,
     required this.onShowDebugChanged,
     this.onExit,
+    this.showConnections = true,
+    this.onShowConnectionsChanged,
     this.isCategory = false,
     this.toast,
     this.walkChip,
@@ -44,6 +46,8 @@ class PlazaHud extends StatelessWidget {
   final VoidCallback onOverview;
   final VoidCallback onHome;
   final VoidCallback? onExit;
+  final bool showConnections;
+  final ValueChanged<bool>? onShowConnectionsChanged;
   final PlazaFrameRate frameRate;
   final ValueChanged<PlazaFrameRate> onFrameRateChanged;
   final bool showMeerkats;
@@ -144,6 +148,13 @@ class PlazaHud extends StatelessWidget {
                             ? null
                             : (value) => onShowPenguinsChanged!(value ?? false),
                       ),
+                      if (onShowConnectionsChanged != null)
+                        DesignSystemCheckbox(
+                          value: showConnections,
+                          label: messages.knowledgeGraphViewConnections,
+                          onChanged: (value) =>
+                              onShowConnectionsChanged!(value ?? false),
+                        ),
                       DesignSystemCheckbox(
                         value: showMeerkats,
                         label: messages.plazaMeerkats,

--- a/lib/features/plaza/ui/plaza_view.dart
+++ b/lib/features/plaza/ui/plaza_view.dart
@@ -16,6 +16,7 @@ import 'package:lotti/features/plaza/domain/plaza_layout.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/features/plaza/scene/facade_lod_manager.dart';
 import 'package:lotti/features/plaza/scene/plaza_bench.dart';
+import 'package:lotti/features/plaza/scene/plaza_cables.dart';
 import 'package:lotti/features/plaza/scene/plaza_characters.dart';
 import 'package:lotti/features/plaza/scene/plaza_fire.dart';
 import 'package:lotti/features/plaza/scene/plaza_meerkats.dart';
@@ -119,6 +120,7 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
   late FacadeLodManager _lod;
   late PlazaSprites _sprites;
   PlazaFire? _fire;
+  PlazaCables? _cables;
   PlazaCharacters? _characters;
   Node? _penguinModel;
   Node? _meerkatModel;
@@ -127,6 +129,7 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
   bool _loadingCharacterModels = false;
   bool _animateCharacters = true;
   bool _showPenguins = false;
+  bool _showConnections = true;
   bool _showMeerkats = false;
   late PlazaSurfaces _surfaces;
   late PlazaPicker _picker;
@@ -148,6 +151,7 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
   double _toastUntil = 0;
   MorningWalk? _walk;
   PlazaBuilding? _panel;
+  String? _connectionFocusTaskId;
   bool _searchOpen = false;
   bool _showDebug = false;
   final List<CameraPose> _back = [];
@@ -223,7 +227,8 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
               activeSurface: _lod.stats.live > 0,
               activeAnimation:
                   (_characters?.hasVisibleMotion ?? false) ||
-                  (_meerkats?.hasVisibleMotion ?? false),
+                  (_meerkats?.hasVisibleMotion ?? false) ||
+                  (_cables?.hasVisibleMotion ?? false),
             ),
     );
     if (_renderingEnabled &&
@@ -327,6 +332,7 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
     final input = widget.world;
     _world = PlazaWorld(
       tasks: input.tasks,
+      connections: input.connections,
       now: input.now,
       projectLabel: input.projectLabel,
       categoryLabels: input.categoryLabels,
@@ -334,6 +340,7 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
       copy: input.copy,
       ambientCreatures: input.ambientCreatures,
       architecture: input.architecture,
+      cables: input.cables,
       avenueLabels: input.avenueLabels,
       avenueByProjectId: input.avenueByProjectId,
       layout: input.layout.copyWith(
@@ -377,9 +384,22 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
       pxPerMeter: _sceneController.pxPerMeter,
     );
     final batches = _sceneController.bakeStaticMeshes();
+    _cables = walls == null || _hidden.contains('cables')
+        ? null
+        : PlazaCables(
+            scene: _sceneController.scene,
+            world: _world,
+            glowTexture: walls.pool,
+          );
+    _cables?.root.visible = _showConnections;
     _attachCharacters();
     debugPrint(
       'PLAZA_BATCHES meshes=${batches.meshes} batches=${batches.batches}',
+    );
+    debugPrint(
+      'PLAZA_CABLES edges=${_world.connections.length} '
+      'meshes=${_cables?.meshCount ?? 0} '
+      'batches=${_cables?.batchCount ?? 0}',
     );
     _picker = PlazaPicker(controller: _sceneController, sprites: _sprites);
     final home =
@@ -398,6 +418,9 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
     _beaconCursor = -1;
     _walk = null;
     _panel = null;
+    if (!_world.attention.containsKey(_connectionFocusTaskId)) {
+      _connectionFocusTaskId = null;
+    }
   }
 
   void _attachCharacters() {
@@ -542,6 +565,7 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
   }
 
   void _flyToBuilding(PlazaBuilding building) {
+    _connectionFocusTaskId = building.task.id;
     _lod.prepare(building);
     _flyTo(taskPoseFor(building.placement), building.task.title);
   }
@@ -570,10 +594,13 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
     if (plaza != null) _flyTo(pose(plaza), '$where — ${_world.projectLabel}');
   }
 
-  void _flyHome() => _flyToPlaza(
-    (p) => p.home,
-    context.messages.designSystemBreadcrumbHomeLabel,
-  );
+  void _flyHome() {
+    _connectionFocusTaskId = null;
+    _flyToPlaza(
+      (p) => p.home,
+      context.messages.designSystemBreadcrumbHomeLabel,
+    );
+  }
 
   void _flyOverview() =>
       _flyToPlaza((p) => p.overview, context.messages.plazaOverview);
@@ -657,6 +684,7 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
       final walk = _walk;
       if (walk != null) setState(walk.togglePause);
     } else if (key == LogicalKeyboardKey.escape) {
+      _connectionFocusTaskId = null;
       setState(() => _panel = null);
       _endWalk();
     } else if (key == LogicalKeyboardKey.backquote) {
@@ -688,8 +716,10 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
     if (camera == null) return;
     switch (_picker.pick(camera, _viewSize, point)) {
       case PickedBeacon(:final beacon):
+        _connectionFocusTaskId = beacon.taskId;
         _flyTo(beacon.pose, beacon.label);
       case PickedBuilding(:final building):
+        _connectionFocusTaskId = building.task.id;
         if (!_lod.activate(
           building,
           _camera.position,
@@ -821,6 +851,12 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
     _sceneController.updateForCamera(eye);
     _sprites.update(camera, _viewSize, _elapsed);
     _fire?.update(_elapsed, eye);
+    _cables?.update(
+      _elapsed,
+      eye,
+      focusedTask: _connectionFocusTaskId ?? _lod.focused?.task.id,
+      animate: _animateCharacters,
+    );
     final traffic = _traffic;
     traffic?.update(
       seconds: _elapsed,
@@ -946,6 +982,14 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
                   : (show) {
                       setState(() => _showPenguins = show);
                       _characters?.enabled = show;
+                      _wakeForInput();
+                    },
+              showConnections: _showConnections,
+              onShowConnectionsChanged: _world.connections.isEmpty
+                  ? null
+                  : (show) {
+                      setState(() => _showConnections = show);
+                      _cables?.root.visible = show;
                       _wakeForInput();
                     },
               showMeerkats:

--- a/lib/features/plaza/ui/project_plaza_page.dart
+++ b/lib/features/plaza/ui/project_plaza_page.dart
@@ -132,6 +132,7 @@ class _ProjectPlazaPageState extends ConsumerState<ProjectPlazaPage> {
             _world = generateProjectWorld(
               project: snapshot.project,
               tasks: snapshot.tasks,
+              connections: snapshot.connections,
               now: now,
               copy: PlazaCopy(context.messages),
               categoryLabels: {

--- a/test/beamer/beamer_app_test.dart
+++ b/test/beamer/beamer_app_test.dart
@@ -280,6 +280,26 @@ Future<BeamerDelegate> _createEmptyDelegate(String initialPath) async {
   return delegate;
 }
 
+/// Simulates the same task image retained in two independent tab histories.
+class _HeroTestLocation extends EmptyTestLocation {
+  _HeroTestLocation(super.routeInformation, {required this.label});
+
+  final String label;
+
+  @override
+  List<BeamPage> buildPages(BuildContext context, BeamState state) => [
+    BeamPage(
+      key: ValueKey(label),
+      child: Center(
+        child: Hero(
+          tag: 'shared-task-image',
+          child: Text(label),
+        ),
+      ),
+    ),
+  ];
+}
+
 bool _eventsDisabledByDefault() => false;
 
 Future<void> _stubNavService(
@@ -2671,6 +2691,108 @@ void main() {
       await tester.pumpWidget(const SizedBox.shrink());
       await tester.pump();
     });
+
+    for (final viewport in [_phoneViewportSize, _desktopViewportSize]) {
+      testWidgets('root navigation ignores retained inactive Heroes at '
+          '${viewport.width}px', (tester) async {
+        Future<BeamerDelegate> heroDelegate(String path) async {
+          final delegate = BeamerDelegate(
+            setBrowserTabTitle: false,
+            initialPath: path,
+            updateParent: false,
+            updateFromParent: false,
+            locationBuilder: (information, _) =>
+                _HeroTestLocation(information, label: path),
+          );
+          addTearDown(delegate.dispose);
+          await delegate.setNewRoutePath(
+            RouteInformation(uri: Uri.parse(path)),
+          );
+          return delegate;
+        }
+
+        final indices = StreamController<int>.broadcast();
+        addTearDown(indices.close);
+        final nav = MockNavService();
+        await _stubNavService(
+          nav,
+          indexStream: indices.stream,
+          isProjectsEnabled: () => true,
+          isDailyOsEnabled: () => true,
+          isHabitsEnabled: () => true,
+          isDashboardsEnabled: () => true,
+          projectsDelegate: await heroDelegate('/projects'),
+          settingsDelegate: await heroDelegate('/settings'),
+        );
+        await _registerAppScreenGetIt(nav);
+        addTearDown(tearDownTestGetIt);
+        await _pumpAppScreen(
+          tester,
+          navService: nav,
+          viewportSize: viewport,
+        );
+        final departures = <String>[];
+        final projectHero = find.ancestor(
+          of: find.text('/projects', skipOffstage: false),
+          matching: find.byType(Hero, skipOffstage: false),
+        );
+        final retained = tester.element(projectHero);
+
+        // The plaza has no Hero at all; Flutter still scans both routes.
+        // A subsequent image-viewer transition must use the active tab only.
+        for (final (index, path) in [(2, '/projects'), (6, '/settings')]) {
+          indices.add(index);
+          await tester.pump();
+          await tester.pump();
+          final navigator =
+              Navigator.of(
+                tester.element(find.text(path)),
+                rootNavigator: true,
+              )..push<void>(
+                MaterialPageRoute(
+                  builder: (_) => const Scaffold(body: Text('plaza route')),
+                ),
+              );
+          await tester.pumpAndSettle();
+          expect(tester.takeException(), isNull);
+          expect(navigator.canPop(), isTrue);
+          navigator.pop();
+          await tester.pumpAndSettle();
+          expect(tester.takeException(), isNull);
+          expect(find.text(path), findsOneWidget);
+
+          navigator.push<void>(
+            MaterialPageRoute(
+              builder: (_) => Scaffold(
+                body: Hero(
+                  tag: 'shared-task-image',
+                  flightShuttleBuilder: (_, _, _, from, to) {
+                    departures.add(
+                      ((from.widget as Hero).child as Text).data!,
+                    );
+                    return (to.widget as Hero).child;
+                  },
+                  child: const Text('full-screen image'),
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+          expect(tester.takeException(), isNull);
+          expect(departures.last, path);
+          navigator.pop();
+          await tester.pumpAndSettle();
+          expect(tester.takeException(), isNull);
+        }
+        expect(
+          tester.element(projectHero),
+          same(retained),
+          reason: 'disabling Heroes must preserve the inactive tab state',
+        );
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+      });
+    }
 
     testWidgets('excludes inactive mobile tabs from keyboard focus', (
       tester,

--- a/test/features/plaza/data/demo_world_projection_test.dart
+++ b/test/features/plaza/data/demo_world_projection_test.dart
@@ -1,11 +1,31 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/demo/media/demo_media_asset.dart';
+import 'package:lotti/features/demo/seed/demo_world.dart';
 import 'package:lotti/features/plaza/data/demo_world_projection.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 
 void main() {
   // The demo world is deterministic under a fixed clock, so project once.
   final tasks = plazaTasksFromDemoWorld(now: DateTime(2026, 7, 17, 10, 30));
+
+  test('demo cables retain real demo edges and stay within visible tasks', () {
+    final demo = ManualDemoWorld.penguinLogistics(now: manualDemoNow);
+    final edges = plazaConnectionsFromDemoWorld(now: manualDemoNow);
+    final taskIds = {for (final task in demo.tasks) task.meta.id};
+    expect(edges, isNotEmpty);
+    for (final edge in edges) {
+      expect(taskIds, containsAll([edge.fromId, edge.toId]));
+      expect(
+        demo.links.any((link) => link.id == edge.id),
+        isTrue,
+        reason: 'a cable must represent an actual fixture relationship',
+      );
+    }
+    expect(
+      plazaConnectionsFromDemoWorld(now: manualDemoNow).map((edge) => edge.id),
+      edges.map((edge) => edge.id),
+    );
+  });
 
   group('plazaTasksFromDemoWorld', () {
     test('projects every penguin task with a unique id and a title', () {

--- a/test/features/plaza/data/plaza_repository_test.dart
+++ b/test/features/plaza/data/plaza_repository_test.dart
@@ -226,9 +226,10 @@ void main() {
       EntryLink link(
         String id,
         String toId, {
+        EntryLinkType type = EntryLinkType.basic,
         bool? hidden,
         DateTime? deletedAt,
-      }) => EntryLink.basic(
+      }) => type.buildLink(
         id: id,
         fromId: task.meta.id,
         toId: toId,
@@ -242,15 +243,35 @@ void main() {
         (_) async => [
           link('visible', sibling.meta.id),
           link('duplicate', sibling.meta.id),
+          link('blocker', sibling.meta.id, type: EntryLinkType.blocks),
           link('private-or-unrelated', 'outside-project'),
           link('hidden', third.meta.id, hidden: true),
           link('deleted', third.meta.id, deletedAt: manualDemoNow),
         ],
       );
-      final tasks = (await repository.loadProject(project.meta.id))!.tasks;
+      final snapshot = (await repository.loadProject(project.meta.id))!;
+      final tasks = snapshot.tasks;
       expect(tasks.first.linkedTaskIds, [sibling.meta.id]);
       expect(tasks[1].linkedTaskIds, [task.meta.id]);
       expect(tasks[2].linkedTaskIds, isEmpty);
+      expect(snapshot.connections.map((edge) => edge.id), [
+        'blocker',
+        'duplicate',
+      ]);
+      final blocker = snapshot.connections.first;
+      expect(blocker.type, EntryLinkType.blocks);
+      expect((blocker.fromId, blocker.toId), (task.id, sibling.id));
+    },
+  );
+
+  test(
+    'a category locked during the edge read cannot publish a world',
+    () async {
+      when(() => db.linksForEntryIdsBidirectional(any())).thenAnswer((_) async {
+        when(() => cache.lockedCategoryIds).thenReturn({category.id});
+        return [];
+      });
+      expect(await repository.loadProject(project.id), isNull);
     },
   );
   test(

--- a/test/features/plaza/data/task_projection_test.dart
+++ b/test/features/plaza/data/task_projection_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/demo/seed/demo_world.dart';
@@ -9,6 +10,100 @@ void main() {
   final world = ManualDemoWorld.penguinLogistics(now: manualDemoNow);
   final task = world.tasks.first;
   final item = world.checklistItems.first;
+
+  group('scoped connections', () {
+    EntryLink link(
+      EntryLinkType type, {
+      String? id,
+      String from = 'a',
+      String to = 'b',
+      bool hidden = false,
+      DateTime? deletedAt,
+    }) => type.buildLink(
+      id: id ?? type.name,
+      fromId: from,
+      toId: to,
+      createdAt: manualDemoNow,
+      updatedAt: manualDemoNow,
+      vectorClock: null,
+      hidden: hidden,
+      deletedAt: deletedAt,
+    );
+
+    test('preserves every task relation and excludes other link families', () {
+      final projected = projectPlazaConnections(
+        links: [for (final type in EntryLinkType.values) link(type)],
+        visibleTaskIds: {'a', 'b'},
+      );
+      expect(projected.map((edge) => edge.type).toSet(), {
+        EntryLinkType.basic,
+        EntryLinkType.blocks,
+        EntryLinkType.followsUp,
+        EntryLinkType.duplicates,
+        EntryLinkType.fixes,
+        EntryLinkType.supersedes,
+      });
+      expect(
+        projected.map((edge) => (edge.fromId, edge.toId)),
+        everyElement(('a', 'b')),
+      );
+    });
+
+    test(
+      'scope, hidden edges, tombstones and self-links cannot add cables',
+      () {
+        final projected = projectPlazaConnections(
+          links: [
+            link(EntryLinkType.blocks, id: 'kept'),
+            link(EntryLinkType.basic, from: 'private'),
+            link(EntryLinkType.basic, to: 'outside'),
+            link(EntryLinkType.basic, from: 'unresolved', to: 'outside'),
+            link(EntryLinkType.fixes, hidden: true),
+            link(EntryLinkType.supersedes, deletedAt: manualDemoNow),
+            link(EntryLinkType.followsUp, to: 'a'),
+          ],
+          visibleTaskIds: {'a', 'b'},
+        );
+        expect(projected.map((edge) => edge.id), ['kept']);
+        expect(
+          projectPlazaConnections(
+            links: [link(EntryLinkType.blocks)],
+            visibleTaskIds: {},
+          ),
+          isEmpty,
+        );
+      },
+    );
+
+    test(
+      'deduplicates symmetric links without collapsing semantic direction',
+      () {
+        final links = [
+          link(EntryLinkType.basic, id: 'plain-z'),
+          link(EntryLinkType.basic, id: 'plain-a', from: 'b', to: 'a'),
+          link(EntryLinkType.blocks, id: 'forward'),
+          link(EntryLinkType.blocks, id: 'reverse', from: 'b', to: 'a'),
+          link(EntryLinkType.blocks, id: 'forward'),
+        ];
+        for (final order in [links, links.reversed]) {
+          final projected = projectPlazaConnections(
+            links: order,
+            visibleTaskIds: {'a', 'b'},
+          );
+          expect(
+            projected.map((edge) => (edge.id, edge.fromId, edge.toId)),
+            [
+              ('forward', 'a', 'b'),
+              ('plain-a', 'a', 'b'),
+              ('reverse', 'b', 'a'),
+            ],
+          );
+          expect(projected.clear, throwsUnsupportedError);
+        }
+        expect(links.first.id, 'plain-z');
+      },
+    );
+  });
 
   PlazaTask project({
     Task? source,

--- a/test/features/plaza/domain/cable_path_test.dart
+++ b/test/features/plaza/domain/cable_path_test.dart
@@ -131,15 +131,16 @@ void main() {
   }
 
   test('intermediate supports clear obstacles with a bounded stable route', () {
+    const config = CableConfig(maxSupports: 3);
     final solids = [
       for (var i = -3; i <= 3; i++)
         Solid.post(x: i * 10, z: 0, size: 4, top: 40 + i * 2),
       Solid.post(x: 0, z: 80, size: 4, top: 500),
     ];
-    final a = _path(solids: solids, config: const CableConfig(maxSupports: 3));
+    final a = _path(solids: solids, config: config);
     final b = _path(
       solids: solids.reversed.toList(),
-      config: const CableConfig(maxSupports: 3),
+      config: config,
     );
     expect(a.supports, hasLength(5));
     for (var i = 0; i < a.positions.length; i++) {
@@ -155,7 +156,7 @@ void main() {
             point[0],
             point[1],
             point[2],
-            clearance: 1.66 - 1e-8,
+            clearance: config.clearance + config.radius - 1e-8,
           ),
         ),
         isFalse,

--- a/test/features/plaza/domain/cable_path_test.dart
+++ b/test/features/plaza/domain/cable_path_test.dart
@@ -1,0 +1,183 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/features/plaza/domain/building_architecture.dart';
+import 'package:lotti/features/plaza/domain/cable_path.dart';
+import 'package:lotti/features/plaza/domain/plaza_connection.dart';
+import 'package:lotti/features/plaza/domain/solid.dart';
+import 'package:lotti/features/plaza/domain/street_layout.dart';
+
+PlotPlacement _plot(String id, double x, {double height = 20}) => PlotPlacement(
+  taskId: id,
+  bucketIndex: 0,
+  side: PlotSide.left,
+  x: x,
+  z: 0,
+  facingRadians: 0,
+  width: 12,
+  depth: 10,
+  height: height,
+);
+
+CablePath _path({
+  List<Solid> solids = const [],
+  CableConfig config = const CableConfig(),
+  double toHeight = 20,
+}) {
+  final from = _plot('a', -50);
+  final to = _plot('b', 50, height: toHeight);
+  return CablePath.plan(
+    connection: const PlazaConnection(
+      id: 'a-blocks-b',
+      fromId: 'a',
+      toId: 'b',
+      type: EntryLinkType.blocks,
+    ),
+    from: from,
+    to: to,
+    fromArchitecture: BuildingArchitecture.forPlot(from),
+    toArchitecture: BuildingArchitecture.forPlot(to),
+    solids: solids,
+    config: config,
+  );
+}
+
+void main() {
+  test('roof mounts frame a sagging span in relationship direction', () {
+    final cable = _path();
+    expect(cable.supports, hasLength(2));
+    final a = cable.supports.first;
+    final b = cable.supports.last;
+    expect(a.x, lessThan(b.x));
+    expect(a.baseY, 20);
+    expect(b.baseY, 20);
+    expect(a.y, 23);
+    expect(b.y, 23);
+    expect(cable.positions[12 * 3 + 1], closeTo(15, 1e-9));
+    expect(cable.length, greaterThan(b.x - a.x));
+    expect(cable.supports.clear, throwsUnsupportedError);
+  });
+
+  test(
+    'arc sampling interpolates and clamps without touching other fields',
+    () {
+      final path = _path(toHeight: 60);
+      final output = Float32List(8)..fillRange(0, 8, -1);
+      for (final i in [0, 6, 23, 24]) {
+        path.writePosition(path.distances[i], output, 2);
+        for (var axis = 0; axis < 3; axis++) {
+          expect(output[2 + axis], closeTo(path.positions[i * 3 + axis], 1e-5));
+        }
+      }
+      final halfway = (path.distances[6] + path.distances[7]) / 2;
+      path.writePosition(halfway, output, 2);
+      for (var axis = 0; axis < 3; axis++) {
+        expect(
+          output[2 + axis],
+          closeTo(
+            (path.positions[18 + axis] + path.positions[21 + axis]) / 2,
+            1e-5,
+          ),
+        );
+      }
+      path.writePosition(-100, output, 2);
+      expect(output[2], closeTo(path.supports.first.x, 1e-5));
+      path.writePosition(path.length + 100, output, 2);
+      expect(output[2], closeTo(path.supports.last.x, 1e-5));
+      expect([output[0], output[1], ...output.skip(5)], everyElement(-1));
+      for (var i = 1; i < path.distances.length; i++) {
+        expect(path.distances[i], greaterThan(path.distances[i - 1]));
+      }
+    },
+  );
+
+  for (final angle in [0.0, math.pi / 4, math.pi / 2]) {
+    test('clears a thin rotated tower between samples at $angle', () {
+      const config = CableConfig(samplesPerSpan: 4, maxSupports: 0);
+      final obstacle = Solid(
+        footprint: Footprint(
+          x: 11,
+          z: 0,
+          facingRadians: angle,
+          width: 0.05,
+          depth: 20,
+        ),
+        top: 80,
+      );
+      final path = _path(solids: [obstacle], config: config);
+      final point = Float64List(3);
+      var checked = 0;
+      for (var i = 0; i <= 10000; i++) {
+        path.writePosition(path.length * i / 10000, point, 0);
+        if (obstacle.footprint.contains(
+          point[0],
+          point[2],
+          clearance: config.clearance + config.radius,
+        )) {
+          checked++;
+          expect(
+            point[1],
+            greaterThanOrEqualTo(
+              obstacle.top + config.clearance + config.radius - 1e-9,
+            ),
+          );
+        }
+      }
+      expect(checked, greaterThan(0));
+      expect(path.supports, hasLength(2));
+    });
+  }
+
+  test('intermediate supports clear obstacles with a bounded stable route', () {
+    final solids = [
+      for (var i = -3; i <= 3; i++)
+        Solid.post(x: i * 10, z: 0, size: 4, top: 40 + i * 2),
+      Solid.post(x: 0, z: 80, size: 4, top: 500),
+    ];
+    final a = _path(solids: solids, config: const CableConfig(maxSupports: 3));
+    final b = _path(
+      solids: solids.reversed.toList(),
+      config: const CableConfig(maxSupports: 3),
+    );
+    expect(a.supports, hasLength(5));
+    for (var i = 0; i < a.positions.length; i++) {
+      expect(a.positions[i], closeTo(b.positions[i], 1e-9));
+    }
+    expect(a.supports.map((s) => s.y), everyElement(lessThan(100)));
+    final point = Float64List(3);
+    for (var i = 0; i <= 2000; i++) {
+      a.writePosition(a.length * i / 2000, point, 0);
+      expect(
+        solids.any(
+          (s) => s.contains(
+            point[0],
+            point[1],
+            point[2],
+            clearance: 1.66 - 1e-8,
+          ),
+        ),
+        isFalse,
+      );
+    }
+  });
+
+  test('zero sag produces straight geometry', () {
+    final path = _path(config: const CableConfig(sagRatio: 0));
+    final a = path.supports.first;
+    final b = path.supports.last;
+    expect(
+      path.length,
+      closeTo(
+        math.sqrt(
+          math.pow(b.x - a.x, 2) + math.pow(b.z - a.z, 2),
+        ),
+        1e-9,
+      ),
+    );
+    for (var i = 1; i < path.positions.length; i += 3) {
+      expect(path.positions[i], a.y);
+    }
+  });
+}

--- a/test/features/plaza/domain/plaza_connection_test.dart
+++ b/test/features/plaza/domain/plaza_connection_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/features/plaza/domain/plaza_connection.dart';
+import 'package:lotti/features/tasks/model/directed_relation.dart';
+
+void main() {
+  for (final type in relationshipSelectorTypes) {
+    test(
+      '$type retains direction while allowing exploration from either end',
+      () {
+        final connection = PlazaConnection(
+          id: 'edge',
+          fromId: 'blocker',
+          toId: 'dependent',
+          type: type,
+        );
+        expect(connection.isDirected, type != EntryLinkType.basic);
+        expect(connection.otherId('blocker'), 'dependent');
+        expect(connection.otherId('dependent'), 'blocker');
+        expect(connection.otherId('outside'), isNull);
+        // Exploring the inverse does not rewrite the semantic direction.
+        expect((connection.fromId, connection.toId), ('blocker', 'dependent'));
+      },
+    );
+  }
+}

--- a/test/features/plaza/scene/plaza_cables_test.dart
+++ b/test/features/plaza/scene/plaza_cables_test.dart
@@ -1,0 +1,207 @@
+import 'dart:typed_data';
+
+import 'package:flutter_scene/scene.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/features/plaza/domain/cable_path.dart';
+import 'package:lotti/features/plaza/domain/plaza_connection.dart';
+import 'package:lotti/features/plaza/domain/street_layout.dart';
+import 'package:lotti/features/plaza/scene/plaza_cables.dart';
+import 'package:lotti/features/plaza/scene/plaza_world.dart';
+import 'package:vector_math/vector_math.dart';
+
+import '../plaza_fixtures.dart';
+
+List<CablePath> _paths(EntryLinkType type) {
+  final tasks = syntheticPlazaTasks(
+    count: 12,
+  ).where((t) => !t.deleted).take(6).toList();
+  return PlazaWorld(
+    tasks: tasks,
+    now: syntheticNow(tasks),
+    projectLabel: 'Fixture',
+    layout: StreetLayout(projectSeed: 1),
+    connections: [
+      for (var i = 0; i < 3; i++)
+        PlazaConnection(
+          id: '$i',
+          fromId: tasks[i * 2].id,
+          toId: tasks[i * 2 + 1].id,
+          type: type,
+        ),
+    ],
+  ).cablePaths;
+}
+
+void main() {
+  const stride = BillboardGeometry.floatsPerInstance;
+  test('repeated connections share a roof mast at the highest attachment', () {
+    final tasks = syntheticPlazaTasks(
+      count: 12,
+    ).where((t) => !t.deleted).take(4).toList();
+    final world = PlazaWorld(
+      tasks: tasks,
+      now: syntheticNow(tasks),
+      projectLabel: 'Fixture',
+      layout: StreetLayout(projectSeed: 1),
+      cables: const CableConfig(maxSupports: 0),
+      connections: [
+        for (final task in tasks.skip(1))
+          PlazaConnection(
+            id: task.id,
+            fromId: tasks.first.id,
+            toId: task.id,
+            type: EntryLinkType.blocks,
+          ),
+      ],
+    );
+    final mounts = cableSupportsFor(world.cablePaths);
+    expect(mounts, hasLength(tasks.length));
+    final origin = world.cablePaths.first.supports.first;
+    final mast = mounts.singleWhere((m) => m.x == origin.x && m.z == origin.z);
+    for (final path in world.cablePaths) {
+      expect(path.supports.first.x, origin.x);
+      expect(path.supports.first.z, origin.z);
+      expect(mast.y, greaterThanOrEqualTo(path.supports.first.y));
+    }
+    expect(mounts.clear, throwsUnsupportedError);
+  });
+
+  test(
+    'tube encloses the path with outward triangles and bounded vertices',
+    () {
+      final path = _paths(EntryLinkType.blocks).first;
+      final mesh = cableTubeMesh(path, 0.2);
+      expect(mesh.vertexCount, path.distances.length * 6);
+      expect(mesh.triangleCount, (path.distances.length - 1) * 12);
+      for (var ring = 0; ring < path.distances.length; ring++) {
+        final center = Vector3.array(path.positions, ring * 3);
+        for (var side = 0; side < 6; side++) {
+          final p = Vector3.array(mesh.positions, (ring * 6 + side) * 3);
+          expect(p.distanceTo(center), closeTo(0.2, 1e-5));
+        }
+      }
+      for (final triangle in mesh.triangles) {
+        final normal = (triangle.pb - triangle.pa).cross(
+          triangle.pc - triangle.pa,
+        );
+        final center = Vector3.array(path.positions, (triangle.a ~/ 6) * 3);
+        expect(normal.dot(triangle.pa - center), greaterThan(0));
+      }
+    },
+  );
+
+  for (final type in [EntryLinkType.basic, EntryLinkType.blocks]) {
+    test(
+      '$type packets follow arc distance and preserve relation direction',
+      () {
+        final path = _paths(type).first;
+        final data = Float32List(stride * 2);
+        final buffer = PlazaCableBuffer(paths: [path], data: data);
+        final eye = Vector3.array(path.positions);
+        buffer.update(0, eye);
+        final phase = stableUnit(path.connection.id, 'light');
+        buffer.update(0.1, eye);
+        final expected = Float64List(3);
+        for (var packet = 0; packet < 2; packet++) {
+          var fraction = (phase + packet / 2 + 1.2 / path.length) % 1;
+          if (type == EntryLinkType.basic && packet == 1) {
+            fraction = 1 - fraction;
+          }
+          path.writePosition(fraction * path.length, expected, 0);
+          for (var axis = 0; axis < 3; axis++) {
+            expect(data[packet * stride + axis], closeTo(expected[axis], 1e-5));
+          }
+        }
+        expect(buffer.data, same(data));
+        expect(buffer.hasVisibleMotion, isTrue);
+        final frozen = data.toList();
+        buffer.update(3, eye, animate: false);
+        expect(buffer.hasVisibleMotion, isFalse);
+        expect(data, frozen);
+        buffer.update(3.1, eye);
+        expect(data, isNot(frozen));
+      },
+    );
+  }
+
+  test('selection outranks distance within a fixed instance budget', () {
+    final paths = _paths(EntryLinkType.blocks);
+    final data = Float32List(stride * 2);
+    final buffer = PlazaCableBuffer(paths: paths, data: data, maxCables: 1);
+    final first = paths.first;
+    final eye = Vector3.array(
+      first.positions,
+      (first.positions.length ~/ 6) * 3,
+    );
+    buffer.update(0, eye);
+    final nearby = data.toList();
+    buffer.update(0, eye, focusedTask: paths.last.connection.toId);
+    expect(buffer.count, 2);
+    expect(data, isNot(nearby));
+    expect(data[3], 3);
+    final expected = Float64List(3);
+    paths.last.writePosition(
+      stableUnit(paths.last.connection.id, 'light') * paths.last.length,
+      expected,
+      0,
+    );
+    expect(data[0], closeTo(expected[0], 1e-5));
+    expect(data[1], closeTo(expected[1], 1e-5));
+    buffer.update(1, Vector3.all(10000));
+    expect(buffer.hasVisibleMotion, isFalse);
+    expect(data[9], 0);
+    expect(data[stride + 9], 0);
+  });
+
+  test(
+    'bounds include all routes even when the animated budget is smaller',
+    () {
+      final paths = _paths(EntryLinkType.basic);
+      final data = Float32List(stride * 2);
+      final buffer = PlazaCableBuffer(paths: paths, data: data, maxCables: 1);
+      var committed = -1;
+      buffer.reserveBounds((count) {
+        committed = count;
+        for (final path in paths) {
+          for (var i = 0; i < path.positions.length; i += 3) {
+            for (var axis = 0; axis < 3; axis++) {
+              expect(
+                path.positions[i + axis],
+                inInclusiveRange(data[axis], data[stride + axis]),
+              );
+            }
+          }
+        }
+      });
+      expect(committed, 2);
+      expect(data, everyElement(0));
+    },
+  );
+
+  test(
+    'empty or disabled light budgets draw nothing; short storage rejects',
+    () {
+      for (final paths in [<CablePath>[], _paths(EntryLinkType.basic)]) {
+        final buffer = PlazaCableBuffer(
+          paths: paths,
+          data: Float32List(0),
+          maxCables: 0,
+        );
+        var committed = -1;
+        buffer
+          ..reserveBounds((count) => committed = count)
+          ..update(0, Vector3.zero());
+        expect(committed, 0);
+        expect(buffer.hasVisibleMotion, isFalse);
+      }
+      expect(
+        () => PlazaCableBuffer(
+          paths: _paths(EntryLinkType.basic),
+          data: Float32List(0),
+        ),
+        throwsArgumentError,
+      );
+    },
+  );
+}

--- a/test/features/plaza/scene/plaza_cables_test.dart
+++ b/test/features/plaza/scene/plaza_cables_test.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/plaza/domain/cable_path.dart';
 import 'package:lotti/features/plaza/domain/plaza_connection.dart';
 import 'package:lotti/features/plaza/domain/street_layout.dart';
 import 'package:lotti/features/plaza/scene/plaza_cables.dart';
+import 'package:lotti/features/plaza/scene/plaza_static_meshes.dart';
 import 'package:lotti/features/plaza/scene/plaza_world.dart';
 import 'package:vector_math/vector_math.dart';
 
@@ -35,6 +36,37 @@ List<CablePath> _paths(EntryLinkType type) {
 
 void main() {
   const stride = BillboardGeometry.floatsPerInstance;
+  test('selection creates only incident overlays and reuses them', () {
+    final paths = _paths(EntryLinkType.blocks);
+    final root = Node();
+    final created = <CablePath>[];
+    final selection = PlazaCableSelection(
+      paths: paths,
+      root: root,
+      create: (path) {
+        created.add(path);
+        return Node()..raycastable = false;
+      },
+    )..update(null);
+    expect(created, isEmpty);
+    selection.update(paths.first.connection.fromId);
+    expect(created, [paths.first]);
+    final first = root.children.single;
+    expect(first.visible, isTrue);
+    selection.update(paths.last.connection.toId);
+    expect(created, [paths.first, paths.last]);
+    expect(first.visible, isFalse);
+    expect(root.children.last.visible, isTrue);
+    selection
+      ..update(paths.first.connection.fromId)
+      ..update(paths.first.connection.fromId);
+    expect(created, [paths.first, paths.last]);
+    expect(first.visible, isTrue);
+    expect(root.children.last.visible, isFalse);
+    selection.update(null);
+    expect(root.children.every((n) => !n.visible), isTrue);
+  });
+
   test('repeated connections share a roof mast at the highest attachment', () {
     final tasks = syntheticPlazaTasks(
       count: 12,
@@ -71,7 +103,7 @@ void main() {
     'tube encloses the path with outward triangles and bounded vertices',
     () {
       final path = _paths(EntryLinkType.blocks).first;
-      final mesh = cableTubeMesh(path, 0.2);
+      final mesh = cableTubeMesh(path, 0.2, origin: Vector3.zero());
       expect(mesh.vertexCount, path.distances.length * 6);
       expect(mesh.triangleCount, (path.distances.length - 1) * 12);
       for (var ring = 0; ring < path.distances.length; ring++) {
@@ -90,6 +122,47 @@ void main() {
       }
     },
   );
+
+  test('tube batches retain spatial cells and exact world placement', () {
+    final paths = _paths(EntryLinkType.blocks);
+    final meshes = <Geometry, MeshData>{};
+    Geometry upload(MeshData mesh) {
+      final geometry = UnskinnedGeometry();
+      meshes[geometry] = mesh;
+      return geometry;
+    }
+
+    final root = Node();
+    final material = UnlitMaterial();
+    for (final path in paths) {
+      final expected = cableTubeMesh(path, 0.2, origin: Vector3.zero());
+      for (var copy = 0; copy < 2; copy++) {
+        final node = cableTubeNode(path, 0.2, material, upload: upload);
+        root.add(node);
+        final actual = meshes[node.mesh!.primitives.single.geometry]!
+            .transformed(node.globalTransform);
+        for (var i = 0; i < expected.positions.length; i++) {
+          expect(actual.positions[i], closeTo(expected.positions[i], 1e-4));
+        }
+        expect(node.raycastable, isFalse);
+      }
+    }
+    final batches = PlazaStaticMeshes(
+      cellSize: 1,
+      read: (geometry) => meshes[geometry]!,
+      upload: upload,
+    ).bake(root, preserve: {});
+    expect(batches, (meshes: 6, batches: 3));
+    expect(
+      root.children.map(
+        (n) => meshes[n.mesh!.primitives.single.geometry]!.vertexCount,
+      ),
+      unorderedEquals([
+        for (final path in paths) path.distances.length * 6 * 2,
+      ]),
+      reason: 'each spatial cell contains only its own pair of cable meshes',
+    );
+  });
 
   for (final type in [EntryLinkType.basic, EntryLinkType.blocks]) {
     test(

--- a/test/features/plaza/scene/plaza_world_test.dart
+++ b/test/features/plaza/scene/plaza_world_test.dart
@@ -1,8 +1,10 @@
 import 'dart:math' as math;
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/features/plaza/domain/attention.dart';
 import 'package:lotti/features/plaza/domain/flight.dart';
+import 'package:lotti/features/plaza/domain/plaza_connection.dart';
 import 'package:lotti/features/plaza/domain/plaza_layout.dart';
 import 'package:lotti/features/plaza/domain/scenery.dart';
 import 'package:lotti/features/plaza/domain/street_layout.dart';
@@ -19,6 +21,45 @@ void main() {
     layout: StreetLayout(projectSeed: 1337),
     categoryLabels: {0xFF5C9DFF.toRadixString(16): 'work'},
   );
+
+  test('generation omits cables to deleted, absent or identical endpoints', () {
+    final visible = tasks.where((task) => !task.deleted).take(2).toList();
+    final deleted = tasks.firstWhere((task) => task.deleted);
+    final edges = [
+      for (final toId in [
+        visible.last.id,
+        deleted.id,
+        'outside',
+        visible.first.id,
+      ])
+        PlazaConnection(
+          id: toId,
+          fromId: visible.first.id,
+          toId: toId,
+          type: EntryLinkType.basic,
+        ),
+      PlazaConnection(
+        id: 'outside-incoming',
+        fromId: 'outside',
+        toId: visible.first.id,
+        type: EntryLinkType.blocks,
+      ),
+    ];
+    final connected = PlazaWorld(
+      tasks: tasks,
+      connections: edges,
+      now: world.now,
+      projectLabel: world.projectLabel,
+      layout: world.layout,
+    );
+    expect(connected.connections.map((edge) => edge.id), [visible.last.id]);
+    expect(connected.cablePaths.map((path) => path.connection.id), [
+      visible.last.id,
+    ]);
+    expect(connected.cablePaths, same(connected.cablePaths));
+    expect(connected.cablePaths.clear, throwsUnsupportedError);
+    expect(edges, hasLength(5));
+  });
 
   test('derives plan, plaza, attention, beacons and billboards once', () {
     expect(world.plan.placements.length, tasks.length);

--- a/test/features/plaza/scene/project_world_generator_test.dart
+++ b/test/features/plaza/scene/project_world_generator_test.dart
@@ -2,8 +2,11 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/features/plaza/domain/attention.dart';
 import 'package:lotti/features/plaza/domain/building_architecture.dart';
+import 'package:lotti/features/plaza/domain/cable_path.dart';
+import 'package:lotti/features/plaza/domain/plaza_connection.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/features/plaza/domain/street_layout.dart';
 import 'package:lotti/features/plaza/scene/project_world_generator.dart';
@@ -43,6 +46,30 @@ void main() {
   final project = makeTestProject(id: 'waddle', createdAt: start);
   final tasks = syntheticPlazaTasks(count: 50);
   final now = syntheticNow(tasks);
+
+  test('passes scoped relationship identity and direction into the world', () {
+    final visible = tasks.where((task) => !task.deleted).take(2).toList();
+    final edge = PlazaConnection(
+      id: 'blocker',
+      fromId: visible.first.id,
+      toId: visible.last.id,
+      type: EntryLinkType.blocks,
+    );
+    final world = generateProjectWorld(
+      project: project,
+      tasks: tasks,
+      connections: [edge],
+      now: now,
+      config: const ProjectWorldConfig(
+        cables: CableConfig(samplesPerSpan: 8, maxSupports: 0),
+      ),
+    );
+    expect(world.connections, [same(edge)]);
+    expect(world.connections.clear, throwsUnsupportedError);
+    expect(world.cablePaths.single.connection, same(edge));
+    expect(world.cablePaths.single.distances, hasLength(9));
+    expect(world.cables.samplesPerSpan, 8);
+  });
 
   test(
     'uses project identity and timeline, never fills missing data with demos',

--- a/test/features/plaza/ui/plaza_hud_test.dart
+++ b/test/features/plaza/ui/plaza_hud_test.dart
@@ -17,6 +17,7 @@ void main() {
   late bool showDebug;
   late bool showPenguins;
   late bool showMeerkats;
+  late bool showConnections;
 
   setUp(() {
     walks = 0;
@@ -27,6 +28,7 @@ void main() {
     showDebug = false;
     showPenguins = true;
     showMeerkats = true;
+    showConnections = true;
   });
 
   Widget host({
@@ -35,6 +37,7 @@ void main() {
     bool isCategory = false,
     bool penguinsAvailable = true,
     bool meerkatsAvailable = true,
+    bool connectionsAvailable = false,
   }) => makeTestableWidget2(
     Scaffold(
       body: PlazaHud(
@@ -59,6 +62,10 @@ void main() {
             : null,
         showDebug: showDebug,
         onShowDebugChanged: (show) => showDebug = show,
+        showConnections: showConnections,
+        onShowConnectionsChanged: connectionsAvailable
+            ? (show) => showConnections = show
+            : null,
         toast: toast,
         walkChip: walkChip,
       ),
@@ -89,6 +96,27 @@ void main() {
       expect(showPenguins, isTrue);
     },
   );
+
+  testWidgets('connections toggle is reversible and absent without links', (
+    tester,
+  ) async {
+    await tester.pumpWidget(host(connectionsAvailable: true));
+    await tester.tap(find.text('Connections'));
+    expect(showConnections, isFalse);
+    expect(showPenguins, isTrue);
+    await tester.pumpWidget(host(connectionsAvailable: true));
+    final control = tester.widget<DesignSystemCheckbox>(
+      find.ancestor(
+        of: find.text('Connections'),
+        matching: find.byType(DesignSystemCheckbox),
+      ),
+    );
+    expect(control.value, isFalse);
+    await tester.tap(find.text('Connections'));
+    expect(showConnections, isTrue);
+    await tester.pumpWidget(host());
+    expect(find.text('Connections'), findsNothing);
+  });
 
   testWidgets('shows the project, the counts and the legends', (
     tester,

--- a/test/features/plaza/ui/project_plaza_page_test.dart
+++ b/test/features/plaza/ui/project_plaza_page_test.dart
@@ -2,10 +2,12 @@ import 'dart:async';
 
 import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/features/demo/seed/demo_world.dart';
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
 import 'package:lotti/features/plaza/data/plaza_repository.dart';
 import 'package:lotti/features/plaza/data/task_projection.dart';
+import 'package:lotti/features/plaza/domain/plaza_connection.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/features/plaza/scene/plaza_world.dart';
 import 'package:lotti/features/plaza/state/project_plaza_provider.dart';
@@ -120,6 +122,41 @@ void main() {
       ).called(1);
       await tester.pumpWidget(const SizedBox());
     });
+  });
+
+  testWidgets('live connections reach the renderer and disappear on refresh', (
+    tester,
+  ) async {
+    final other = projectPlazaTask(
+      task: demo.tasks[1],
+      checklistItems: const [],
+      linkedTaskIds: [task.id],
+      categoryColor: task.categoryColor,
+    );
+    final edge = PlazaConnection(
+      id: 'blocks',
+      fromId: task.id,
+      toId: other.id,
+      type: EntryLinkType.blocks,
+    );
+    await tester.pumpWidget(page());
+    snapshots.add(
+      ProjectPlazaData(
+        project: project,
+        tasks: [task, other],
+        connections: [edge],
+        dependencyIds: {project.meta.id, task.id, other.id, edge.id},
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(renderedWorld.connections, [same(edge)]);
+    snapshots.add(snapshot);
+    await tester.pump();
+    await tester.pump();
+    expect(renderedWorld.connections, isEmpty);
+    expect(renderedWorld.tasks, [task]);
+    await tester.pumpWidget(const SizedBox());
   });
 
   testWidgets('failed checklist edits roll back and explain the failure', (


### PR DESCRIPTION
Project plazas now show existing task relationships as illuminated, sagging cables between task buildings. Selecting a task highlights its connections through flight and Overview; the Connections control hides or shows the network. Projects without in-scope links show no cables.

- Preserve the six task relationship types and their direction. Exclude hidden, deleted, self and out-of-project links; deduplicate equivalent associations deterministically. Recheck category locks after asynchronous reads.
- Generate configurable roof mounts and obstacle-cleared sagging spans. Batch static cables and supports by actual world cells; allocate selection overlays on first use and cache them; cap travelling lights at 192 instances in one draw. Directed relationships flow toward their destination, basic associations in both directions; reduced motion freezes the lights.
- Keep inactive navigation tabs out of Hero transitions while preserving their state. This fixes the reproduced duplicate-tag assertion when pushing or returning from a root route.

## Validation

- Full Dart MCP analyzer: no errors. Initial 243 targeted tests passed; one existing opt-in performance test skipped. After review fixes, all 16 affected renderer/domain tests passed, including the two new performance regressions.
- Both navigation regressions, the lock-during-read regression, spatial batching and lazy selection regressions fail with their fixes removed and pass with the fixes restored.
- Linux native build and headless fixture captures: Home, Overview, connection toggle, search-result selection, Shift-boosted flight, retained selection and Escape clearing. Reported flight positions stayed outside collision solids.
- Knowledge/Mermaid and changelog checks passed. Changed Dart files formatted; the whole-repository formatter encounters an existing unreadable Docker media-store directory.
- Fixture: 28 tasks / 51 connections. Cables add four static batches and 102 moving light instances. Before the spatial-batching review fix, one Linux VM debug walking comparison measured 151.5 ms / 6.6 FPS disabled versus 154.3 ms / 6.5 FPS enabled. This is noisy VM evidence, not verification of macOS 120 FPS. [Measurement details](https://github.com/matthiasn/lotti/blob/feat/plaza-connection-cables/docs/plaza/CONNECTION_CABLE_MEASUREMENTS.md).

## Screenshots

Penguin fixture only, 1600 × 1000, captured headlessly. Home/Overview baseline captures were taken before implementation; the later rebase also brought main's separate Meerkats control into the after captures. Creatures are hidden in both.

| Surface | Before cables | After cables |
| --- | --- | --- |
| Home | ![Before home](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-connection-cables/6ae3541a49c12c82ae4255f40d7ef43e4ec76694/before/plaza_home_desktop_dark.png) | ![After home](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-connection-cables/6ae3541a49c12c82ae4255f40d7ef43e4ec76694/after/plaza_home_desktop_dark.png) |
| Overview | ![Before overview](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-connection-cables/6ae3541a49c12c82ae4255f40d7ef43e4ec76694/before/plaza_overview_desktop_dark.png) | ![After overview](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-connection-cables/6ae3541a49c12c82ae4255f40d7ef43e4ec76694/after/plaza_overview_desktop_dark.png) |

Selection interaction, both recaptured after the review fixes:

| Selection cleared | Selected task retained in Overview |
| --- | --- |
| ![Cleared selection](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-connection-cables/a45aefa1a414a8aba4bd6c8f80ce5121a2d6ce89/before/plaza_selection_desktop_dark.png) | ![Selected task connections](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/plaza-connection-cables/a45aefa1a414a8aba4bd6c8f80ce5121a2d6ce89/after/plaza_selection_desktop_dark.png) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added illuminated, sagging cables between linked tasks in Plaza, with roof mounts and animated travelling lights.
  * Added connection highlighting when focusing or selecting tasks.
  * Added a Connections visibility control and reduced-motion support.
  * Preserved relationship direction for directed links and limited connections to visible tasks.

* **Bug Fixes**
  * Fixed navigation errors when opening or returning to Plaza while another tab retained the same image.
  * Inactive tabs remain mounted without participating in image transitions or receiving keyboard focus.

* **Documentation**
  * Added Plaza cable performance measurements and updated feature and navigation documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->