### PR TITLE
fix: people banner full hero

### DIFF
--- a/changelog.d/2026-09-08-people-avatar-banner.md
+++ b/changelog.d/2026-09-08-people-avatar-banner.md
@@ -5,10 +5,11 @@
   person's page, inside the colour that person already had. It stays on your
   devices and the agent never sees it.
 - **A person can have a banner image.** In the person editor's new Photo card,
-  add a wide picture that fills the top of the person's page above the teal
-  band, and drag it left or right to frame it; the page's controls stay legible
-  over any picture. The same card lets you change, re-crop or remove the face
-  photo. Both stay on your devices and the agent never sees them.
+  add a wide picture that fills the top of the person's page, with the face
+  photo sitting across its lower edge, and drag it left or right to frame it;
+  the page's controls stay legible over any picture. The same card lets you
+  change, re-crop or remove the face photo. Both stay on your devices and the
+  agent never sees them.
 
 ### Fixed
 - **People imported from Contacts keep the colour they were reviewed in.** The

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -253,9 +253,7 @@ load-bearing:
 **The banner renders.** With `bannerImageId` set, the photograph is the
 whole hero above the avatar's midline — the toolbar and the band — and there
 is no wash at all: the avatar sits across the picture's lower edge, its lower
-half over the page. (Direction 2b first kept a one-toolbar bar of wash under
-the picture; in the dark theme that bar read as blank space below a cropped
-banner, so it went.) `PersonHeroAppBar` resolves the
+half over the page. `PersonHeroAppBar` resolves the
 banner *above* its sliver through `JournalImageResolver` (a component in a
 sliver slot returns the sliver), so the file's arrival rebuilds the hero; the
 ThumbHash stand-in shows under the same scrim meanwhile, and an id with

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -250,10 +250,12 @@ load-bearing:
   precedent (`setCoverArt(null)`): taking a picture off a person is not
   deleting it from the journal.
 
-**The banner renders — direction 2b.** With `bannerImageId` set, the hero
-becomes two stacked strips: the photograph takes the toolbar and the upper
-band, and the wash keeps a bar exactly one toolbar tall at the bottom of its
-band, which the avatar overlaps as before. `PersonHeroAppBar` resolves the
+**The banner renders.** With `bannerImageId` set, the photograph is the
+whole hero above the avatar's midline — the toolbar and the band — and there
+is no wash at all: the avatar sits across the picture's lower edge, its lower
+half over the page. (Direction 2b first kept a one-toolbar bar of wash under
+the picture; in the dark theme that bar read as blank space below a cropped
+banner, so it went.) `PersonHeroAppBar` resolves the
 banner *above* its sliver through `JournalImageResolver` (a component in a
 sliver slot returns the sliver), so the file's arrival rebuilds the hero; the
 ThumbHash stand-in shows under the same scrim meanwhile, and an id with
@@ -266,8 +268,8 @@ fixed on purpose:
   button and the kebab take black-at-45 % glass and a white glyph whenever a
   banner is drawn — in both themes.
 - **The scrim's extent is pixels, not a fraction of the current strip.**
-  `PhotoScrim` darkens the top 70 % of the strip *at rest*; folding, the bar
-  goes first, then the strip shrinks to the toolbar — and the scrim, fixed,
+  `PhotoScrim` darkens the top 70 % of the strip *at rest*; folding, the
+  strip shrinks with the band down to the toolbar — and the scrim, fixed,
   still covers the toolbar row, which is what keeps the swapped-in name and
   the actions legible over an arbitrary picture at every scroll position.
 - **The decode is bounded to the strip at rest**, so scrolling never re-keys

--- a/lib/features/relationships/README.md
+++ b/lib/features/relationships/README.md
@@ -18,8 +18,9 @@ and person editor, and tapping the avatar opens the person's photo: choose
 one from the library and pick which part of it is the face, adjust that
 later, or remove it. The photo shows wherever the person does, inside their
 usual colour; it stays on the user's devices and never enters agent context.
-A person can also carry a banner image: it fills the top of the hero, above a
-bar of the teal wash, with the header's actions kept legible over it. Both
+A person can also carry a banner image: it fills the whole top of the page,
+down to the avatar, which sits across its lower edge; the header's actions
+stay legible over it. Both
 pictures are managed from the person editor's Photo card — the banner is
 dragged sideways into place there — and the face from the page's avatar too.
 The bottom action bar offers a check-in, voice capture and an available

--- a/lib/features/relationships/ui/widgets/person_header.dart
+++ b/lib/features/relationships/ui/widgets/person_header.dart
@@ -75,18 +75,18 @@ class PersonHeroAppBar extends StatelessWidget {
   /// The avatar diameter; half of it hangs below the hero.
   static double avatarSize(DsTokens tokens) => tokens.spacing.step11;
 
-  /// With a banner (design 2026-09-08, direction 2b) the wash keeps only a
-  /// bar at the bottom of its band — exactly one toolbar tall, mirroring the
-  /// bar above it — and the photograph takes everything above.
-  static const double bannerBarExtent = kToolbarHeight;
-
-  /// The banner strip's height at rest: the toolbar and the band, less the
-  /// wash bar. What the strip's decode is bounded to, so a scroll never
-  /// re-keys the picture.
+  /// The banner strip's height at rest: the toolbar and the whole band —
+  /// everything above the avatar's midline. The Photo card's preview mirrors
+  /// it, and the strip's decode is bounded to it so a scroll never re-keys
+  /// the picture. The delegate derives its own from the same
+  /// [_bannerStripExtent], so the two cannot drift.
   static double bannerStripExtent(
     DsTokens tokens, {
     required double topPadding,
-  }) => topPadding + bandExtent(tokens);
+  }) => _bannerStripExtent(
+    topPadding: topPadding,
+    bandExtent: bandExtent(tokens),
+  );
 
   /// The wash itself: the interactive accent at the tint alpha over the page
   /// surface — the same recipe every tone-tinted card fill uses.
@@ -287,10 +287,11 @@ class _PersonHeroDelegate extends SliverPersistentHeaderDelegate {
   /// Everything that folds: the band and the overhang under it.
   double get foldable => bandExtent + overhang;
 
-  /// The banner strip at rest — everything above the wash bar. Fixed, so
-  /// the scrim's extent and the decode's bound do not move with the scroll.
+  /// The banner strip at rest — everything above the avatar's midline.
+  /// Fixed, so the scrim's extent and the decode's bound do not move with
+  /// the scroll.
   double get bannerStripAtRest =>
-      minExtent + bandExtent - PersonHeroAppBar.bannerBarExtent;
+      _bannerStripExtent(topPadding: topPadding, bandExtent: bandExtent);
 
   @override
   double get maxExtent => minExtent + foldable;
@@ -307,24 +308,20 @@ class _PersonHeroDelegate extends SliverPersistentHeaderDelegate {
     // so the wash keeps its height for the first half-diameter of scroll
     // while the avatar tucks up into it.
     final overhangOpen = (overhang - shrinkOffset).clamp(0.0, overhang);
-    // Direction 2b: with a banner, the picture takes the toolbar and the
-    // upper band and the wash keeps a one-toolbar bar under it. Folding,
-    // the bar goes first and the picture only then shrinks to the toolbar,
-    // so at rest and collapsed alike the actions sit on the picture — under
-    // the scrim, whose extent is fixed in pixels for exactly that reason.
+    // With a banner, the picture is the whole hero above the avatar's
+    // midline — the toolbar and the band — and there is no wash at all:
+    // the avatar straddles the picture's lower edge. Folding, the picture
+    // keeps its height while the avatar tucks up into it, then shrinks with
+    // the band to the toolbar, so at rest and collapsed alike the actions
+    // sit on the picture — under the scrim, whose extent is fixed in pixels
+    // for exactly that reason.
     // A pinned sliver's shrinkOffset runs on to maxExtent on a deep scroll;
     // the box itself never gets shorter than minExtent, and neither may
     // the strip — or the banner would vanish behind the toolbar.
     final extent = math.max(minExtent, maxExtent - shrinkOffset);
-    final washBottom = extent - overhangOpen;
+    final bandBottom = extent - overhangOpen;
     final banner = this.banner;
-    final barOpen = banner == null
-        ? 0.0
-        : (washBottom - bannerStripAtRest).clamp(
-            0.0,
-            PersonHeroAppBar.bannerBarExtent,
-          );
-    final stripExtent = banner == null ? 0.0 : washBottom - barOpen;
+    final stripExtent = banner == null ? 0.0 : bandBottom;
     final scrimExtent = math.min(
       stripExtent,
       bannerStripAtRest * PhotoScrim.fadeExtent,
@@ -377,17 +374,17 @@ class _PersonHeroDelegate extends SliverPersistentHeaderDelegate {
               ),
             ),
           ),
-        ],
-        Positioned(
-          top: stripExtent,
-          left: 0,
-          right: 0,
-          bottom: overhangOpen,
-          child: ColoredBox(
-            key: const ValueKey('person-hero-wash'),
-            color: wash,
+        ] else
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: overhangOpen,
+            child: ColoredBox(
+              key: const ValueKey('person-hero-wash'),
+              color: wash,
+            ),
           ),
-        ),
         Positioned(
           top: topPadding,
           left: gutter,
@@ -758,3 +755,12 @@ Widget relationshipCadencePill(
     ),
   };
 }
+
+/// The banner strip at rest, in one place: the status inset, the toolbar and
+/// the band — everything above the avatar's midline. [PersonHeroAppBar]'s
+/// static and the delegate both read it, so the decode bound, the scrim and
+/// the Photo card's preview agree by construction.
+double _bannerStripExtent({
+  required double topPadding,
+  required double bandExtent,
+}) => topPadding + kToolbarHeight + bandExtent;

--- a/lib/features/relationships/ui/widgets/person_header.dart
+++ b/lib/features/relationships/ui/widgets/person_header.dart
@@ -75,18 +75,15 @@ class PersonHeroAppBar extends StatelessWidget {
   /// The avatar diameter; half of it hangs below the hero.
   static double avatarSize(DsTokens tokens) => tokens.spacing.step11;
 
-  /// The banner strip's height at rest: the toolbar and the whole band —
+  /// The banner strip's height at rest: the folded hero and the whole band —
   /// everything above the avatar's midline. The Photo card's preview mirrors
   /// it, and the strip's decode is bounded to it so a scroll never re-keys
-  /// the picture. The delegate derives its own from the same
-  /// [_bannerStripExtent], so the two cannot drift.
+  /// the picture. The same sum the delegate's `bannerStripAtRest` is, over
+  /// the one [_heroMinExtent], so the two cannot drift.
   static double bannerStripExtent(
     DsTokens tokens, {
     required double topPadding,
-  }) => _bannerStripExtent(
-    topPadding: topPadding,
-    bandExtent: bandExtent(tokens),
-  );
+  }) => _heroMinExtent(topPadding) + bandExtent(tokens);
 
   /// The wash itself: the interactive accent at the tint alpha over the page
   /// surface — the same recipe every tone-tinted card fill uses.
@@ -278,7 +275,7 @@ class _PersonHeroDelegate extends SliverPersistentHeaderDelegate {
   final Widget actions;
 
   @override
-  double get minExtent => topPadding + kToolbarHeight;
+  double get minExtent => _heroMinExtent(topPadding);
 
   /// The half of the avatar below the wash, carried as transparent extent so
   /// the avatar is whole inside the sliver.
@@ -290,8 +287,7 @@ class _PersonHeroDelegate extends SliverPersistentHeaderDelegate {
   /// The banner strip at rest — everything above the avatar's midline.
   /// Fixed, so the scrim's extent and the decode's bound do not move with
   /// the scroll.
-  double get bannerStripAtRest =>
-      _bannerStripExtent(topPadding: topPadding, bandExtent: bandExtent);
+  double get bannerStripAtRest => minExtent + bandExtent;
 
   @override
   double get maxExtent => minExtent + foldable;
@@ -304,9 +300,9 @@ class _PersonHeroDelegate extends SliverPersistentHeaderDelegate {
   ) {
     final collapsed = shrinkOffset >= foldable - collapseSlack;
     final bandOpen = 1 - (shrinkOffset / foldable).clamp(0.0, 1.0);
-    // The clear strip under the wash closes before the band itself folds,
-    // so the wash keeps its height for the first half-diameter of scroll
-    // while the avatar tucks up into it.
+    // The clear strip under the band closes before the band itself folds,
+    // so the wash — or the picture — keeps its height for the first
+    // half-diameter of scroll while the avatar tucks up into it.
     final overhangOpen = (overhang - shrinkOffset).clamp(0.0, overhang);
     // With a banner, the picture is the whole hero above the avatar's
     // midline — the toolbar and the band — and there is no wash at all:
@@ -756,11 +752,8 @@ Widget relationshipCadencePill(
   };
 }
 
-/// The banner strip at rest, in one place: the status inset, the toolbar and
-/// the band — everything above the avatar's midline. [PersonHeroAppBar]'s
-/// static and the delegate both read it, so the decode bound, the scrim and
-/// the Photo card's preview agree by construction.
-double _bannerStripExtent({
-  required double topPadding,
-  required double bandExtent,
-}) => topPadding + kToolbarHeight + bandExtent;
+/// The folded hero — the status inset and the toolbar — in one place: the
+/// delegate's `minExtent` and [PersonHeroAppBar.bannerStripExtent] both read
+/// it, so the decode bound, the scrim and the Photo card's preview agree with
+/// the hero's own height by construction.
+double _heroMinExtent(double topPadding) => topPadding + kToolbarHeight;

--- a/test/features/relationships/ui/pages/people_inventory_screenshots_test.dart
+++ b/test/features/relationships/ui/pages/people_inventory_screenshots_test.dart
@@ -22,6 +22,8 @@
 library;
 
 import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
 
 import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -45,6 +47,7 @@ import 'package:lotti/features/agents/state/task_agent_model_providers.dart';
 import 'package:lotti/features/agents/state/unified_suggestion_providers.dart';
 import 'package:lotti/features/agents/ui/ai_summary_card/proposal_row_part.dart';
 import 'package:lotti/features/ai/model/resolved_profile.dart';
+import 'package:lotti/features/demo/media/demo_media_asset.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/keyboard/ui/app_command_host.dart';
@@ -88,6 +91,7 @@ import 'package:mocktail/mocktail.dart';
 import '../../../../helpers/fake_entry_controller.dart';
 import '../../../../helpers/fallbacks.dart';
 import '../../../../helpers/journal_image_fixtures.dart';
+import '../../../../helpers/manual_demo_world.dart';
 import '../../../../helpers/thumb_hash_fixtures.dart';
 import '../../../../mocks/mocks.dart';
 import '../../../../widget_test_utils.dart';
@@ -148,6 +152,15 @@ final JournalImage _pipPhoto = buildJournalImage(
   id: 'image-pip',
   imageFile: 'pip.png',
 );
+
+/// Pip's banner: a landscape photograph of its own, so the strip's edges are
+/// straight. The avatar placeholder is a circle with transparent corners —
+/// right inside a ring, wrong as a banner, where the hero's full-height
+/// strip would show its curvature at the bottom corners.
+final JournalImage _pipBanner = buildJournalImage(
+  id: 'image-pip-banner',
+  imageFile: 'pip-banner.png',
+);
 final JournalImage _skuaArriving = buildJournalImage(
   id: 'image-skua',
   imageFile: 'skua.webp',
@@ -163,6 +176,27 @@ final JournalImage _tillyPending = buildJournalImage(
 final List<int> _fixturePngBytes = File(
   'assets/design_system/avatar_placeholder.png',
 ).readAsBytesSync();
+
+/// A real landscape photograph for the banner: the penguin demo world's
+/// habitat cover, fetched from R2 the way the manual capture suites fetch
+/// theirs and transcoded to PNG so the headless engine decodes it
+/// deterministically. Fetched once per process, in `setUpAll`, on the real
+/// event loop.
+late final Uint8List _bannerPngBytes;
+
+Future<Uint8List> _fetchBannerPng() async {
+  final asset = demoMediaAssets.firstWhere(
+    (asset) => asset.fileName == 'manual_task_cover_habitat.webp',
+  );
+  final codec = await ui.instantiateImageCodec(
+    await downloadManualDemoMedia(asset.uri),
+  );
+  final frame = await codec.getNextFrame();
+  final png = await frame.image.toByteData(format: ui.ImageByteFormat.png);
+  frame.image.dispose();
+  codec.dispose();
+  return png!.buffer.asUint8List();
+}
 
 /// A Thursday afternoon. Every cadence pill, "last spoke" line and relative
 /// timestamp in the capture is read against this instant, so the inventory is
@@ -421,9 +455,7 @@ void main() {
     channels: const [_pipMobile, _pipEmail],
     avatarImageId: _pipPhoto.id,
     avatarCrop: const AvatarCrop(y: 0.35, scale: 1.4),
-    // The same picture as the banner: a wide crop of it is what a person's
-    // "something that reminds me of them" is likely to be anyway.
-    bannerImageId: _pipPhoto.id,
+    bannerImageId: _pipBanner.id,
   );
   final pipCheckIns = [
     checkIn(
@@ -622,8 +654,13 @@ void main() {
           ..registerSingleton<PersistenceLogic>(MockPersistenceLogic());
       },
     );
-    // Only Pip's file exists; Skua's and Tilly's are deliberately absent.
+    // Only Pip's files exist; Skua's and Tilly's are deliberately absent.
     createImageFile(_pipPhoto, bytes: _fixturePngBytes);
+    createImageFile(_pipBanner, bytes: _bannerPngBytes);
+  });
+
+  setUpAll(() async {
+    _bannerPngBytes = await _fetchBannerPng();
   });
 
   tearDown(() async {
@@ -698,6 +735,7 @@ void main() {
       (ref) async => proposals ?? const RelationshipProposalSnapshot.empty(),
     ),
     createEntryControllerOverride(_pipPhoto),
+    createEntryControllerOverride(_pipBanner),
     createEntryControllerOverride(_skuaArriving),
     createEntryControllerOverride(_tillyPending),
   ];
@@ -732,7 +770,7 @@ void main() {
       // shell's full width — the same key the hero builds.
       await precacheImage(
         boundedFileImage(
-          path,
+          getFullImagePath(_pipBanner),
           bounds: Size(
             device.size.width,
             PersonHeroAppBar.bannerStripExtent(dsTokensDark, topPadding: 0),
@@ -849,7 +887,7 @@ void main() {
       final width = tester.getSize(banner).width;
       if (width != device.size.width) {
         final key = boundedFileImage(
-          getFullImagePath(_pipPhoto),
+          getFullImagePath(_pipBanner),
           bounds: Size(
             width,
             PersonHeroAppBar.bannerStripExtent(dsTokensDark, topPadding: 0),
@@ -1423,7 +1461,7 @@ void main() {
             tester.tap(find.byKey(const ValueKey('person-form-cancel'))),
         measure: find.byKey(const ValueKey('person-form-banner-preview')),
         keyFor: (strip) => boundedFileImage(
-          getFullImagePath(_pipPhoto),
+          getFullImagePath(_pipBanner),
           bounds: strip,
           devicePixelRatio: _mediaQueryFor(device).devicePixelRatio,
         ),

--- a/test/features/relationships/ui/widgets/person_header_test.dart
+++ b/test/features/relationships/ui/widgets/person_header_test.dart
@@ -413,8 +413,9 @@ void main() {
       final banner = find.byKey(const ValueKey('person-hero-banner'));
       final scrim = find.byKey(const ValueKey('person-hero-scrim'));
       final wash = find.byKey(const ValueKey('person-hero-wash'));
+      // From the hero itself: under a banner there is no wash element.
       DsTokens tokensOf(WidgetTester tester) =>
-          tester.element(wash).designTokens;
+          tester.element(find.byType(PersonHeroAppBar)).designTokens;
       Color chatGlyph(WidgetTester tester) => tester
           .widget<Icon>(
             find.descendant(
@@ -439,10 +440,9 @@ void main() {
         }
       });
 
-      testWidgets('with a banner: the picture above, a one-toolbar wash bar '
-          'below, the scrim over the top, and photo-neutral chrome', (
-        tester,
-      ) async {
+      testWidgets('with a banner: the picture is the whole hero above the '
+          "avatar's midline, no wash at all, the scrim over the top, and "
+          'photo-neutral chrome', (tester) async {
         final image = buildJournalImage(imageFile: 'banner.jpg');
         createImageFile(image);
 
@@ -458,13 +458,20 @@ void main() {
           topPadding: 0,
         );
 
-        expect(tester.getSize(banner).height, strip);
-        expect(tester.getTopLeft(wash).dy, strip);
         expect(
-          tester.getSize(wash).height,
-          PersonHeroAppBar.bannerBarExtent,
-          reason: 'the wash keeps exactly one toolbar of its band',
+          strip,
+          kToolbarHeight + PersonHeroAppBar.bandExtent(tokens),
+          reason: 'the strip is the toolbar and the whole band',
         );
+        expect(tester.getSize(banner).height, strip);
+        expect(
+          wash,
+          findsNothing,
+          reason: 'the picture replaces the wash; no bar is left under it',
+        );
+        // The avatar straddles the picture's lower edge.
+        final avatar = find.byKey(const ValueKey('person-hero-avatar-tap'));
+        expect(tester.getCenter(avatar).dy, closeTo(strip, 1e-9));
         expect(
           tester.getSize(scrim).height,
           closeTo(strip * PhotoScrim.fadeExtent, 1e-9),
@@ -546,8 +553,8 @@ void main() {
         },
       );
 
-      testWidgets('folding: the bar goes first, then the picture shrinks to '
-          'the toolbar, and the scrim still covers the toolbar', (
+      testWidgets('folding: the picture keeps its height while the avatar '
+          'tucks up, then shrinks to the toolbar, still under the scrim', (
         tester,
       ) async {
         final image = buildJournalImage(imageFile: 'banner.jpg');
@@ -559,19 +566,14 @@ void main() {
           overrides: [createEntryControllerOverride(image)],
         );
         final tokens = tokensOf(tester);
-        final strip = PersonHeroAppBar.bannerStripExtent(
-          tokens,
-          topPadding: 0,
-        );
+        // Spelled out rather than read from the static, so this pins the
+        // shape: the picture is the toolbar and the whole band.
+        final strip = kToolbarHeight + PersonHeroAppBar.bandExtent(tokens);
         final overhang = PersonHeroAppBar.avatarSize(tokens) / 2;
 
-        // Past the overhang and the bar: the bar is gone, the picture whole.
-        await tester.drag(
-          find.byType(CustomScrollView),
-          Offset(0, -(overhang + PersonHeroAppBar.bannerBarExtent)),
-        );
+        // Past the overhang: the avatar has tucked up, the picture is whole.
+        await tester.drag(find.byType(CustomScrollView), Offset(0, -overhang));
         await tester.pumpAndSettle();
-        expect(tester.getSize(wash).height, closeTo(0, 1e-9));
         expect(tester.getSize(banner).height, closeTo(strip, 1e-9));
 
         // Fully folded: the picture is the toolbar, still under the scrim.


### PR DESCRIPTION
Follow-up to #4205. The banner stopped a toolbar's height above the avatar's
midline, leaving a bar of the teal wash under it, which the avatar overlapped.
In the dark theme that bar is almost the page's own colour, so the picture read
as cropped with blank space beneath it. The picture now fills the whole hero
above the avatar's midline, and the avatar sits across its lower edge — the
LinkedIn shape.

## What changes

- **`_PersonHeroDelegate`** — with a banner there is no wash at all: the strip
  is everything above the avatar's midline, and folding it keeps its height
  while the avatar tucks up, then shrinks with the band to the toolbar. The
  scrim is unchanged: the top 70 % of the strip *at rest*, in pixels, so the
  toolbar row stays covered at every scroll position.
- **One home for the toolbar height.** The delegate's `minExtent` and
  `PersonHeroAppBar.bannerStripExtent` (the Photo card's preview height, the
  capture suite's decode key) both read `_heroMinExtent`, and the delegate's
  `bannerStripAtRest` is `minExtent + bandExtent`; the review of #4205 flagged
  that the strip was two expressions that happened to agree. `bannerBarExtent`
  is gone with the bar.
- **The scrim is unchanged on purpose.** Its fade is a fraction of the strip
  at rest, so it reaches about 40 points deeper than before; checked on the
  light capture below, it fades well above the picture's subject and the
  toolbar glyphs stay legible, so it stays.
- The Photo card's banner preview grows with it — it mirrors the hero's strip
  by construction — so what is framed there is still what the page shows.

## Docs and release note

The README, the relationships concept and the unreleased fragment from #4205
describe the new shape; the banner has not shipped, so the fragment is
reworded rather than a second one added.

## Tests

`person_header_test`: with a banner the strip is the toolbar plus the band,
there is no wash element, and the avatar's centre sits on the strip's bottom
edge; folding past the overhang leaves the picture whole, fully folded it is
the toolbar under the scrim. Both banner tests fail with the delegate change
reverted. The 46-capture suite regenerates with every photo painted.

## Screenshots

Fictional penguin crew. **Before** is `main` at `a2040eabe`, captured by the
same suite. The banner fixture changed with this PR: the suite used the
design system's avatar placeholder — a circle with transparent corners — for
the banner too, and the full-height strip showed its curvature at the bottom
corners. Pip's banner is now the penguin demo world's habitat cover, fetched
from R2 the way the manual capture suites fetch theirs, so both columns show a
photograph with straight edges.

| Surface | Before | After |
|---|---|---|
| Person page · phone dark | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/59a232cf0784bd2e3195368e0e5e09addd1fbc21/pr-screenshots/people-banner-full-hero/before/person_page_mobile_dark.png" width="300"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/59a232cf0784bd2e3195368e0e5e09addd1fbc21/pr-screenshots/people-banner-full-hero/after/person_page_mobile_dark.png" width="300"> |
| Person page · phone light | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/59a232cf0784bd2e3195368e0e5e09addd1fbc21/pr-screenshots/people-banner-full-hero/before/person_page_mobile_light.png" width="300"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/59a232cf0784bd2e3195368e0e5e09addd1fbc21/pr-screenshots/people-banner-full-hero/after/person_page_mobile_light.png" width="300"> |
| Person page · desktop | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/59a232cf0784bd2e3195368e0e5e09addd1fbc21/pr-screenshots/people-banner-full-hero/before/person_page_desktop_dark.png" width="480"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/59a232cf0784bd2e3195368e0e5e09addd1fbc21/pr-screenshots/people-banner-full-hero/after/person_page_desktop_dark.png" width="480"> |
| Banner still arriving | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/59a232cf0784bd2e3195368e0e5e09addd1fbc21/pr-screenshots/people-banner-full-hero/before/person_page_banner_arriving_mobile_dark.png" width="300"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/59a232cf0784bd2e3195368e0e5e09addd1fbc21/pr-screenshots/people-banner-full-hero/after/person_page_banner_arriving_mobile_dark.png" width="300"> |
| Hero folded | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/59a232cf0784bd2e3195368e0e5e09addd1fbc21/pr-screenshots/people-banner-full-hero/before/person_page_banner_folded_mobile_dark.png" width="300"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/59a232cf0784bd2e3195368e0e5e09addd1fbc21/pr-screenshots/people-banner-full-hero/after/person_page_banner_folded_mobile_dark.png" width="300"> |
| Edit person · phone — the preview mirrors the hero | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/59a232cf0784bd2e3195368e0e5e09addd1fbc21/pr-screenshots/people-banner-full-hero/before/person_form_edit_mobile_dark.png" width="300"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/59a232cf0784bd2e3195368e0e5e09addd1fbc21/pr-screenshots/people-banner-full-hero/after/person_form_edit_mobile_dark.png" width="300"> |
| Edit person · desktop | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/59a232cf0784bd2e3195368e0e5e09addd1fbc21/pr-screenshots/people-banner-full-hero/before/person_form_edit_desktop_dark.png" width="480"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/59a232cf0784bd2e3195368e0e5e09addd1fbc21/pr-screenshots/people-banner-full-hero/after/person_form_edit_desktop_dark.png" width="480"> |

The identical pair is staged at `/tmp/lotti-pr-screenshots/people-banner-full-hero/`
for `make pr_screenshots_publish` if the R2 copy is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JyUKQyhMw38JE276qMJkR




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Person page banners now extend across the full hero area behind the avatar.
  * Removed the previous bottom wash strip when a banner image is present.
  * Header controls remain legible over the banner.
  * During scrolling, the banner folds smoothly with the header while the toolbar remains covered for readability.

* **Documentation**
  * Updated descriptions to clarify banner placement and available face-photo actions.
  * Clarified that photos remain stored locally on the device and hidden from the agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
