### PR TITLE
feat(projects): task thumbnails, and stop the agent's proposals accumulating

### DIFF
--- a/changelog.d/2026-09-09-project-task-thumbnails-and-proposal-retraction.md
+++ b/changelog.d/2026-09-09-project-task-thumbnails-and-proposal-retraction.md
@@ -1,0 +1,23 @@
+### Added
+- **A project's task list now shows each task's cover art.** A task with a
+  picture was recognisable everywhere except inside its own project, where the
+  list was text only. Its thumbnail now leads the row, cropped the way it was
+  set on the task, and tasks without one are unchanged.
+
+### Fixed
+- **The project agent proposed the same change on every wake, and the
+  "Proposed changes" list grew a copy each time.** A wake could not see the
+  suggestions already waiting for a decision, so a project the agent thought
+  should be Active collected "Update project status to Active" over and over —
+  thirteen identical rows in one report, none of which the agent could take
+  back. Each wake now reads its open proposals, is refused when it proposes a
+  status the project already has or a change that is already on screen, and can
+  withdraw one of its own suggestions that has gone stale. Withdrawals land
+  together with that wake's new suggestions, so the list never blinks empty in
+  between.
+
+### Changed
+- **Explore project moved into the project title row.** It sat in a band of its
+  own under the title, pushing the description and the report down the page; it
+  now sits in the top-right corner beside the project menu, and drops to its map
+  glyph on a narrow window or at large text.

--- a/knowledge/features/agents/project-and-event-agents.md
+++ b/knowledge/features/agents/project-and-event-agents.md
@@ -15,7 +15,11 @@ sources:
   - id: project-workflow
     resource: ../../../lib/features/agents/workflow/project_agent_workflow.dart
     title: ProjectAgentWorkflow
-    last_modified: 2026-08-14
+    last_modified: 2026-09-09
+  - id: project-proposals
+    resource: ../../../lib/features/agents/workflow/project_proposal_reconciler.dart
+    title: The guards that stop proposals accumulating
+    last_modified: 2026-09-09
   - id: event-workflow
     resource: ../../../lib/features/agents/workflow/event_agent_workflow.dart
     title: EventAgentWorkflow
@@ -306,9 +310,11 @@ the other committed while it was waiting.
 `ProjectAgentWorkflow.execute()` loads state and resolves `activeProjectId`,
 retires a dormant legacy scheduled wake before inference, loads the project
 entity and prior observations, resolves template/version and inference profile,
-builds linked-task context **including task-agent reports**, runs the
-conversation with `ProjectAgentStrategy`, and persists token usage, final
-thought, report, observations, deferred change set and updated state.
+builds linked-task context **including task-agent reports**, reads the
+proposal ledger for the project, runs the conversation with
+`ProjectAgentStrategy`, and persists token usage, final thought, report,
+observations, staged retractions, the deduplicated deferred change set and
+updated state.
 State that lacks `activeProjectId` enters the same shared failure path as a
 missing project or provider, advancing any overdue fallback instead of leaving
 it due on every scheduler scan.
@@ -322,9 +328,73 @@ rather than relegating internal navigation to the external Links block.
 
 ## Tools and recommendations
 
-Immediate local tools: `update_project_report`, `record_observations`.
+Immediate local tools: `update_project_report`, `record_observations`, and —
+only on a wake that has open proposals — `retract_suggestions`.
 
 Deferred mutations: `update_project_status`, `create_task`.
+
+### Proposals do not accumulate
+
+A pending `ChangeSet` outlives the wake that wrote it: it sits in the project
+card's **Proposed changes** band until the user decides it. Wakes used to be
+blind to that and wrote a fresh set every time, so an agent that believed a
+project should be Active proposed exactly that on every wake — one report was
+seen carrying thirteen identical "Update project status to Active" rows, none
+of which the agent could take back.
+
+Three guards, deliberately separate, because each catches a different mistake:
+
+| Guard | Where | Catches |
+|---|---|---|
+| `normalizeProjectProposalArgs` | `ProjectAgentStrategy`, as the call is queued | a status **alias** — `on_track`, `blocked`, `done` — which the apply path and the row both collapse anyway, so storing the raw word made two identical-looking proposals compare as different everywhere downstream |
+| `projectStatusProposalIsRedundant` | `ProjectAgentStrategy`, at the tool call | a status the project already has — applying it is a no-op, and the model is told so inside the wake rather than losing the call silently |
+| `reconcileProjectProposals` | `project_agent_execute.dart`, at persist time | a proposal matching one still open (by structural fingerprint **or** rendered summary), one the user already rejected, and a duplicate proposed twice in one wake — on both keys, so two `create_task` calls sharing a title but not their optional args collapse to one row rather than creating the task twice |
+| `retract_suggestions` | `SuggestionRetractionService`, shared with the task agent | one the *agent* judges stale — the project moved on, the user did it by hand |
+
+Normalization comes first on purpose: it is what makes the two comparisons
+below it correct without either having to know about status aliases. `on_hold`
+keeps its reason, which is user-facing text the apply path treats as a real
+change, so two holds for different reasons stay two proposals.
+
+The first two are deterministic and hold whatever the model does. The third
+needs the model to know what is open, so `ProjectAgentContextBuilder` reads
+`AgentRepository.getProposalLedger(agentId, taskId: projectId)` before the
+conversation and renders an **Open Proposal Guard** section — one line per open
+proposal carrying the `fp=…` fingerprint `retract_suggestions` addresses it by
+— as the last block of the user message, after the trigger tokens. The tool is
+withheld when nothing is open, so an agent with nothing to withdraw cannot
+hallucinate a fingerprint. A ledger read that fails is non-fatal: the wake runs
+without the guard rather than not at all.
+
+The redundancy check compares through `canonicalProjectStatusOf`, the reverse
+of the `canonicalProjectStatus` alias table, so `on_track` is recognised as the
+`active` the project already is. `on_hold` also compares its reason: the same
+reason is redundant, a new one is a real change.
+
+Retractions are **staged, not written**, while the conversation runs, and
+applied inside the wake's persistence transaction alongside the proposals that
+replace them — the band never reads empty between a withdrawal and its
+replacement. A fingerprint the agent retracts *and* re-proposes in the same
+wake is skipped (`skipFingerprints`): the re-proposal has already been dropped
+as a duplicate, so applying the retraction would make a stable row vanish and
+reappear under the user's finger.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Proposed: model calls a deferred tool
+  Proposed --> Normalized: status alias resolved to its canonical value
+  Normalized --> Refused: status the project already has
+  Normalized --> Dropped: already open, or already rejected
+  Normalized --> Written: genuinely new
+  Written --> Open
+  Open --> Open: later wake re-proposes it (dropped)
+  Open --> Retracted: agent calls retract_suggestions
+  Open --> Confirmed: user confirms
+  Open --> Rejected: user rejects
+  Rejected --> Rejected: later wake re-proposes it (dropped, sticky)
+  Refused --> [*]
+  Dropped --> [*]
+```
 
 The final `recommend_next_steps` call in a conversation replaces any earlier
 payloads in that run, then is published as

--- a/knowledge/features/agents/project-and-event-agents.md
+++ b/knowledge/features/agents/project-and-event-agents.md
@@ -342,7 +342,7 @@ project should be Active proposed exactly that on every wake — one report was
 seen carrying thirteen identical "Update project status to Active" rows, none
 of which the agent could take back.
 
-Three guards, deliberately separate, because each catches a different mistake:
+Four guards, deliberately separate, because each catches a different mistake:
 
 | Guard | Where | Catches |
 |---|---|---|
@@ -351,12 +351,12 @@ Three guards, deliberately separate, because each catches a different mistake:
 | `reconcileProjectProposals` | `project_agent_execute.dart`, at persist time | a proposal matching one still open (by structural fingerprint **or** rendered summary), one the user already rejected, and a duplicate proposed twice in one wake — on both keys, so two `create_task` calls sharing a title but not their optional args collapse to one row rather than creating the task twice |
 | `retract_suggestions` | `SuggestionRetractionService`, shared with the task agent | one the *agent* judges stale — the project moved on, the user did it by hand |
 
-Normalization comes first on purpose: it is what makes the two comparisons
-below it correct without either having to know about status aliases. `on_hold`
+Normalization comes first on purpose: it is what makes the comparisons below
+it correct without any of them having to know about status aliases. `on_hold`
 keeps its reason, which is user-facing text the apply path treats as a real
 change, so two holds for different reasons stay two proposals.
 
-The first two are deterministic and hold whatever the model does. The third
+The first three are deterministic and hold whatever the model does. The fourth
 needs the model to know what is open, so `ProjectAgentContextBuilder` reads
 `AgentRepository.getProposalLedger(agentId, taskId: projectId)` before the
 conversation and renders an **Open Proposal Guard** section — one line per open

--- a/knowledge/features/projects.md
+++ b/knowledge/features/projects.md
@@ -336,7 +336,11 @@ surface instead of becoming competing cards or duplicating the report in the
 editor. The AI surface appears above the task list. `ProjectRecommendationsPanel`
 renders two bands inside the card: the newest run's **recommended next steps**
 (`ProjectNextStepRow`, one per step) and the agent's **proposed changes**
-(`ProjectProposalRow`, reusing Task Details' `RowActions` rail). A step offers
+(`ProjectProposalRow`, reusing Task Details' `RowActions` rail). What keeps
+that second band from growing a fresh copy of the same suggestion on every
+wake — the redundancy refusal, the dedup against open and rejected proposals,
+and the agent's own `retract_suggestions` — is
+[project and event agents](agents/project-and-event-agents.md#proposals-do-not-accumulate). A step offers
 **Add task** and **Dismiss** as labelled controls, and on touch the same two
 by swipe — right adds, left dismisses. Proposal rows swipe the same way (right
 confirms, left rejects), so the gesture means the same thing in both bands and
@@ -443,6 +447,13 @@ state; it never repeats the project description under an AI-authored heading
 or presents the project's own modification time as report freshness.
 
 # The task list groups and orders itself
+
+A task's row leads with its cover art when it has one —
+`TaskSummaryRow` draws the same `CoverArtThumbnail` square as the day
+planner's agenda card, at `spacing.step9`, honouring the crop stored on the
+task, so a picture identifies a task the same way in its project as in the
+tasks list. `projectTaskCoverArtId` is what decides: a missing *or blank*
+`coverArtId` reserves nothing and leaves the row exactly the width it had.
 
 `ProjectTasksSliverPanel` no longer renders one flat list. The pure model in
 `ui/model/project_task_groups.dart` turns the record's task summaries into

--- a/lib/features/agents/tools/project_tool_definitions.dart
+++ b/lib/features/agents/tools/project_tool_definitions.dart
@@ -1,5 +1,6 @@
 // Tool definitions for the project agent.
 
+import 'package:lotti/classes/project_data.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/agents/model/project_agent_report_contract.dart';
 import 'package:lotti/features/agents/tools/agent_tool_registry.dart';
@@ -11,6 +12,7 @@ abstract final class ProjectAgentToolNames {
   static const recommendNextSteps = 'recommend_next_steps';
   static const updateProjectStatus = 'update_project_status';
   static const createTask = 'create_task';
+  static const retractSuggestions = 'retract_suggestions';
 }
 
 /// The canonical `update_project_status` wire value for [raw], or `null` when
@@ -36,6 +38,20 @@ String? canonicalProjectStatus(String raw) {
     _ => null,
   };
 }
+
+/// The canonical `update_project_status` wire value [status] already carries.
+///
+/// The reverse of [canonicalProjectStatus], and its counterpart: comparing a
+/// proposal's canonical value against this one is what tells a wake that
+/// "set it to Active" would change nothing on an already-active project.
+String canonicalProjectStatusOf(ProjectStatus status) => switch (status) {
+  ProjectOpen() => 'open',
+  ProjectActive() => 'active',
+  ProjectMonitoring() => 'monitoring',
+  ProjectOnHold() => 'on_hold',
+  ProjectCompleted() => 'completed',
+  ProjectArchived() => 'archived',
+};
 
 /// The [TaskPriority] a project-agent priority word means, or `null` when the
 /// word is outside the vocabulary. A missing priority is medium, the default
@@ -248,6 +264,71 @@ const projectAgentTools = <AgentToolDefinition>[
       'required': ['title'],
     },
   ),
+];
+
+/// Withdraws the agent's own still-open proposals.
+///
+/// Advertised only on a wake that actually has open proposals — see
+/// [projectAgentToolsFor]. Offering it to an agent with nothing to withdraw
+/// invites a hallucinated fingerprint and a wasted turn.
+const projectRetractSuggestionsTool = AgentToolDefinition(
+  name: ProjectAgentToolNames.retractSuggestions,
+  description:
+      'Withdraw one or more of your own previously-proposed changes that are '
+      'no longer relevant (the project already matches them, or they '
+      'duplicate another open proposal). The user is NOT prompted — the '
+      'retraction is recorded in your decision history and the items '
+      'disappear from the "Proposed changes" list. Use this to keep that '
+      'list free of stale proposals. Only already-pending items can be '
+      'retracted; items already confirmed, rejected, or retracted are '
+      'no-ops.',
+  parameters: {
+    'type': 'object',
+    'properties': {
+      'proposals': {
+        'type': 'array',
+        'minItems': 1,
+        'items': {
+          'type': 'object',
+          'properties': {
+            'fingerprint': {
+              'type': 'string',
+              'description':
+                  'The fingerprint shown in the open-proposal guard for the '
+                  'item you want to withdraw. Must exactly match an `fp=...` '
+                  'value listed there.',
+            },
+            'reason': {
+              'type': 'string',
+              'minLength': 1,
+              'maxLength': 500,
+              'description':
+                  'One short sentence explaining why this proposal is no '
+                  'longer relevant (e.g. "the project is already Active", '
+                  '"the user created this task by hand").',
+            },
+          },
+          'required': ['fingerprint', 'reason'],
+          'additionalProperties': false,
+        },
+        'description':
+            'One entry per proposal you want to retract in this call.',
+      },
+    },
+    'required': ['proposals'],
+    'additionalProperties': false,
+  },
+);
+
+/// The tool surface for one wake.
+///
+/// [hasOpenProposals] adds [projectRetractSuggestionsTool]; without open
+/// proposals there is nothing a retraction could target.
+List<AgentToolDefinition> projectAgentToolsFor({
+  required bool hasOpenProposals,
+}) => [
+  ...projectAgentTools,
+  if (hasOpenProposals) projectRetractSuggestionsTool,
 ];
 
 /// Project agent tools whose mutations require user confirmation.

--- a/lib/features/agents/workflow/project_agent_context_builder.dart
+++ b/lib/features/agents/workflow/project_agent_context_builder.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/agents/database/agent_repository.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
+import 'package:lotti/features/agents/model/proposal_ledger.dart';
 import 'package:lotti/features/agents/tools/project_tool_definitions.dart';
 import 'package:lotti/features/agents/workflow/agent_system_prompt.dart';
 import 'package:lotti/features/ai/conversation/conversation_manager.dart';
@@ -112,7 +113,24 @@ The `update_project_status` and `create_task` tools queue changes for user revie
 run. A later call replaces earlier calls in the same run. It replaces previous
 next steps when the run succeeds, including clearing
 old steps when none are recommended. Users confirm, dismiss, or create a task
-from each suggestion individually. Include only steps that remain relevant.''';
+from each suggestion individually. Include only steps that remain relevant.
+
+## Your Own Open Proposals
+
+Queued changes do **not** disappear when a wake ends. Everything you proposed on
+an earlier wake and the user has not yet decided is still on their screen, and
+is listed under `## Open Proposal Guard` with its fingerprint.
+
+1. **Never propose something that is already open.** Re-proposing an open
+   change adds a second identical row to the user's list; it does not refresh
+   the first.
+2. **Never propose a status the project already has.** Applying it would change
+   nothing.
+3. **Withdraw what went stale.** If an open proposal no longer makes sense —
+   the project moved on, the user did it by hand, another open proposal
+   supersedes it — call `retract_suggestions` with its `fp=…` fingerprint and a
+   one-sentence reason. Do not retract a proposal only to re-propose the same
+   thing, and do not retract one because the user acted on a different one.''';
 
     return composeAgentSystemPrompt(
       scaffold: scaffold,
@@ -129,6 +147,7 @@ from each suggestion individually. Include only steps that remain relevant.''';
     required String linkedTasksContext,
     required Set<String> triggerTokens,
     String? compactedLog,
+    ProposalLedger ledger = const ProposalLedger.empty(),
   }) {
     final buf = StringBuffer();
 
@@ -200,7 +219,44 @@ from each suggestion individually. Include only steps that remain relevant.''';
         ..writeln(sortedTriggerTokens.join(', '));
     }
 
+    // Last, so the proposals the user is still looking at are the freshest
+    // thing in the prompt when the model starts proposing.
+    final guard = formatOpenProposalGuard(ledger);
+    if (guard.isNotEmpty) {
+      buf
+        ..writeln()
+        ..write(guard);
+    }
+
     return (text: buf.toString(), logStart: logStart, logEnd: logEnd);
+  }
+
+  /// The prompt section listing every proposal the user has not yet decided,
+  /// each with the fingerprint `retract_suggestions` addresses it by.
+  ///
+  /// Empty when nothing is open — there is then nothing to compare against
+  /// and nothing to withdraw, and a "(none)" heading would only invite the
+  /// model to invent a fingerprint for it.
+  static String formatOpenProposalGuard(ProposalLedger ledger) {
+    if (ledger.open.isEmpty) return '';
+    final buf = StringBuffer()
+      ..writeln('## Open Proposal Guard')
+      ..writeln()
+      ..writeln(
+        "These proposals are already on the user's screen, awaiting their "
+        'decision. Before proposing any change, compare it against this '
+        'list: never propose the same change again. If one of these is '
+        'stale, call `${ProjectAgentToolNames.retractSuggestions}` with its '
+        'fingerprint; otherwise leave it open.',
+      )
+      ..writeln();
+    for (final entry in ledger.open) {
+      buf.writeln(
+        '- [fp=${entry.fingerprint}] `${entry.toolName}`: '
+        '${entry.humanSummary.trim()}',
+      );
+    }
+    return (buf..writeln()).toString();
   }
 
   void _writeProjectContext(StringBuffer buf, JournalEntity entity) {
@@ -249,8 +305,16 @@ from each suggestion individually. Include only steps that remain relevant.''';
     }
   }
 
-  List<ChatCompletionTool> buildToolDefinitions() {
-    return projectAgentTools.map((tool) {
+  /// The tool surface for one wake.
+  ///
+  /// [hasOpenProposals] admits `retract_suggestions`; an agent with nothing
+  /// open has nothing it could withdraw.
+  List<ChatCompletionTool> buildToolDefinitions({
+    bool hasOpenProposals = false,
+  }) {
+    return projectAgentToolsFor(hasOpenProposals: hasOpenProposals).map((
+      tool,
+    ) {
       return ChatCompletionTool(
         type: ChatCompletionToolType.function,
         function: FunctionObject(

--- a/lib/features/agents/workflow/project_agent_execute.dart
+++ b/lib/features/agents/workflow/project_agent_execute.dart
@@ -190,6 +190,17 @@ extension ProjectAgentExecute on ProjectAgentWorkflow {
     // 6c. Load linked tasks and their task-agent reports.
     final linkedTasksContext = await _buildLinkedTasksContext(projectId);
 
+    // 6d. Load the proposals the user has not decided yet. Wakes used to be
+    // blind to them and re-proposed the same change every time, so the
+    // "Proposed changes" band grew a fresh identical row per wake. The ledger
+    // feeds three things: the guard in the prompt, the tool surface (retract
+    // is only offered when there is something to retract), and the dedup that
+    // refuses to write a duplicate whatever the model does.
+    final ledger = await _loadProposalLedger(
+      agentId: agentId,
+      projectId: projectId,
+    );
+
     // 7. Assemble system prompt and user message.
     final systemPrompt = _buildSystemPrompt(templateCtx);
     final builtMessage = _buildUserMessage(
@@ -199,6 +210,7 @@ extension ProjectAgentExecute on ProjectAgentWorkflow {
       observationPayloads: observationPayloads,
       linkedTasksContext: linkedTasksContext,
       triggerTokens: triggerTokens,
+      ledger: ledger,
       // Only attach the compacted log when the read actually flips; the
       // legacy sections render otherwise.
       compactedLog: memoryView.useCompactedLog ? memoryView.compactedLog : null,
@@ -253,14 +265,26 @@ extension ProjectAgentExecute on ProjectAgentWorkflow {
     }
 
     try {
+      final retractionService = SuggestionRetractionService(
+        syncService: syncService,
+        domainLogger: domainLogger,
+      );
       final strategy = ProjectAgentStrategy(
         syncService: syncService,
         agentId: agentId,
         threadId: threadId,
         runKey: runKey,
+        projectId: projectId,
+        currentProjectStatus: projectEntity.maybeMap(
+          project: (project) => project.data.status,
+          orElse: () => null,
+        ),
+        retractionService: retractionService,
       );
 
-      final tools = _buildToolDefinitions();
+      final tools = _buildToolDefinitions(
+        hasOpenProposals: ledger.open.isNotEmpty,
+      );
       final inferenceRepo = CloudInferenceWrapper(
         cloudRepository: this.cloudInferenceRepository,
         geminiThinkingMode: resolvedProfile.thinkingModel?.geminiThinkingMode,
@@ -474,12 +498,27 @@ extension ProjectAgentExecute on ProjectAgentWorkflow {
             )
             .toList();
         // Only actual project mutations need deferred tool confirmation.
-        if (mutations.isNotEmpty) {
-          final changeItems = buildDeferredChangeItems(
-            mutations,
-            ProjectAgentWorkflow._buildHumanSummary,
-          );
+        final proposedItems = buildDeferredChangeItems(
+          mutations,
+          ProjectAgentWorkflow._buildHumanSummary,
+        );
+        final changeItems = reconcileProjectProposals(
+          proposed: proposedItems,
+          ledger: ledger,
+        );
 
+        // Apply the retractions the agent staged, in the same transaction as
+        // the proposals that replace them, so the band never reads empty in
+        // between. Anything the agent retracted *and* re-proposed this wake
+        // is left open instead: the re-proposal has already been dropped as a
+        // duplicate above, so applying the retraction would make a stable
+        // suggestion disappear for no reason.
+        await retractionService.applyStaged(
+          strategy.extractStagedRetractions(),
+          skipFingerprints: proposedItems.map(ChangeItem.fingerprint).toSet(),
+        );
+
+        if (changeItems.isNotEmpty) {
           await syncService.upsertEntity(
             AgentDomainEntity.changeSet(
               id: ProjectAgentWorkflow._uuid.v4(),
@@ -492,6 +531,13 @@ extension ProjectAgentExecute on ProjectAgentWorkflow {
               createdAt: now,
               vectorClock: null,
             ),
+          );
+        }
+        if (changeItems.length < proposedItems.length) {
+          _log(
+            'dropped ${proposedItems.length - changeItems.length} duplicate '
+            'proposal(s) already open or rejected',
+            subDomain: 'execute',
           );
         }
 

--- a/lib/features/agents/workflow/project_agent_strategy.dart
+++ b/lib/features/agents/workflow/project_agent_strategy.dart
@@ -1,13 +1,16 @@
 import 'dart:convert';
 import 'dart:developer' as developer;
 
+import 'package:lotti/classes/project_data.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/observation_record.dart';
 import 'package:lotti/features/agents/model/project_agent_report_contract.dart';
+import 'package:lotti/features/agents/service/suggestion_retraction_service.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/agents/tools/project_tool_definitions.dart';
 import 'package:lotti/features/agents/workflow/agent_message_recording.dart';
 import 'package:lotti/features/agents/workflow/agent_tool_arg_parsing.dart';
+import 'package:lotti/features/agents/workflow/project_proposal_reconciler.dart';
 import 'package:lotti/features/ai/conversation/conversation_manager.dart';
 import 'package:lotti/features/projects/state/project_health_metrics.dart';
 import 'package:openai_dart/openai_dart.dart';
@@ -30,6 +33,9 @@ class ProjectAgentStrategy extends ConversationStrategy
     required this.agentId,
     required this.threadId,
     required this.runKey,
+    this.projectId,
+    this.currentProjectStatus,
+    this.retractionService,
   });
 
   /// Sync-aware write service for persisting messages.
@@ -47,6 +53,23 @@ class ProjectAgentStrategy extends ConversationStrategy
   /// The run key for the current wake cycle.
   @override
   final String runKey;
+
+  /// The project this wake is about. Required for `retract_suggestions`,
+  /// which addresses change sets by their target entity.
+  final String? projectId;
+
+  /// The project's status at wake start. When supplied, an
+  /// `update_project_status` call that would change nothing is refused with an
+  /// explanation instead of being queued — the model learns inside the wake,
+  /// and the band never grows a row that does nothing when applied.
+  final ProjectStatus? currentProjectStatus;
+
+  /// Withdraws the agent's own open proposals. `null` leaves
+  /// `retract_suggestions` unwired, and a call to it reports that.
+  final SuggestionRetractionService? retractionService;
+
+  final _stagedRetractions = <StagedRetraction>[];
+  final _stagedRetractionKeys = <String>{};
 
   String? _reportContent;
   String? _reportTldr;
@@ -102,11 +125,42 @@ class ProjectAgentStrategy extends ConversationStrategy
         continue;
       }
 
+      if (toolName == ProjectAgentToolNames.retractSuggestions) {
+        await _handleRetractSuggestions(args, call.id, manager);
+        continue;
+      }
+
       // Deferred tools: accumulate for later persistence.
       if (projectDeferredTools.contains(toolName)) {
+        // A status the project already has is not queued: applying it is a
+        // no-op, so the row would sit in the band forever doing nothing.
+        // Telling the model now also stops it burning the next turn
+        // re-proposing the same thing.
+        //
+        // Reported as an ordinary tool result, not an error — the guard
+        // working is not a failure, and `errorMessage` renders in the agent's
+        // activity log in the error colour. The task agent reports its own
+        // redundancy checks the same way (`ChangeProposalFilter`).
+        final status = currentProjectStatus;
+        if (toolName == ProjectAgentToolNames.updateProjectStatus &&
+            status != null &&
+            projectStatusProposalIsRedundant(current: status, args: args)) {
+          manager.addToolResponse(
+            toolCallId: call.id,
+            response:
+                'Skipped: the project is already ${status.label}, so this '
+                'would change nothing. Do not propose it again.',
+          );
+          await recordToolResultMessage(toolName: toolName);
+          continue;
+        }
         _deferredItems.add({
           'toolName': toolName,
-          'args': args,
+          // Canonicalized here, where the model's word enters: a status alias
+          // renders and applies as its canonical status, so storing the alias
+          // would make two identical-looking proposals compare as different
+          // everywhere downstream.
+          'args': normalizeProjectProposalArgs(toolName, args),
         });
         final response = 'Queued $toolName for user review.';
         manager.addToolResponse(toolCallId: call.id, response: response);
@@ -173,6 +227,12 @@ class ProjectAgentStrategy extends ConversationStrategy
   /// Returns deferred tool items accumulated during the conversation.
   List<Map<String, dynamic>> extractDeferredItems() =>
       List.unmodifiable(_deferredItems);
+
+  /// The retractions this wake staged, for the workflow to apply at the end
+  /// of the wake — in the same transaction as the new proposals, so the band
+  /// never reads empty between a withdrawal and its replacement.
+  List<StagedRetraction> extractStagedRetractions() =>
+      List.unmodifiable(_stagedRetractions);
 
   // ── Report handling ────────────────────────────────────────────────────────
 
@@ -250,6 +310,145 @@ class ProjectAgentStrategy extends ConversationStrategy
     );
     await recordToolResultMessage(
       toolName: ProjectAgentToolNames.updateProjectReport,
+    );
+  }
+
+  // ── Retraction handling ────────────────────────────────────────────────────
+
+  /// Handles `retract_suggestions`: validates the requested fingerprints
+  /// against the project's open proposals, stages the matches for end-of-wake
+  /// application, and reports the per-entry outcome back to the model.
+  ///
+  /// Nothing is written here. Staging until the end of the wake is what keeps
+  /// the "Proposed changes" band from flashing empty between a withdrawal and
+  /// the replacement this same wake is about to propose.
+  Future<void> _handleRetractSuggestions(
+    Map<String, dynamic> args,
+    String callId,
+    ConversationManager manager,
+  ) async {
+    final service = retractionService;
+    final targetId = projectId;
+    if (service == null || targetId == null) {
+      await _rejectToolCall(
+        callId: callId,
+        toolName: ProjectAgentToolNames.retractSuggestions,
+        errorMsg: 'Error: retract_suggestions is not wired up for this agent.',
+        manager: manager,
+      );
+      return;
+    }
+
+    final rawProposals = args['proposals'];
+    if (rawProposals is! List || rawProposals.isEmpty) {
+      await _rejectToolCall(
+        callId: callId,
+        toolName: ProjectAgentToolNames.retractSuggestions,
+        errorMsg:
+            'Error: "proposals" must be a non-empty array of '
+            '{fingerprint, reason} objects.',
+        manager: manager,
+      );
+      return;
+    }
+
+    final requests = <RetractionRequest>[];
+    final parseErrors = <String>[];
+    for (var i = 0; i < rawProposals.length; i++) {
+      final entry = rawProposals[i];
+      if (entry is! Map) {
+        parseErrors.add('proposals[$i] is not an object');
+        continue;
+      }
+      final fingerprint = entry['fingerprint'];
+      final reason = entry['reason'];
+      if (fingerprint is! String || fingerprint.trim().isEmpty) {
+        parseErrors.add('proposals[$i].fingerprint missing or empty');
+        continue;
+      }
+      if (reason is! String || reason.trim().isEmpty) {
+        parseErrors.add('proposals[$i].reason missing or empty');
+        continue;
+      }
+      requests.add(
+        RetractionRequest(
+          fingerprint: fingerprint.trim(),
+          reason: reason.trim(),
+        ),
+      );
+    }
+
+    if (requests.isEmpty) {
+      await _rejectToolCall(
+        callId: callId,
+        toolName: ProjectAgentToolNames.retractSuggestions,
+        errorMsg:
+            'Error: no valid proposals to retract. ${parseErrors.join('; ')}',
+        manager: manager,
+      );
+      return;
+    }
+
+    // `plan` reads the pending change sets and the proposal ledger. A failed
+    // read must not take the wake down with it: retraction is the least
+    // valuable thing a wake produces, and losing the report, the
+    // observations and the next steps with it would be wildly
+    // disproportionate — the same reason the workflow's own ledger read is
+    // non-fatal. Report it and let the conversation continue.
+    final RetractionPlan plan;
+    try {
+      plan = await service.plan(
+        agentId: agentId,
+        taskId: targetId,
+        requests: requests,
+        alreadyStagedKeys: _stagedRetractionKeys,
+      );
+    } catch (e) {
+      developer.log(
+        'retract_suggestions could not read open proposals '
+        '(errorType=${e.runtimeType})',
+        name: 'ProjectAgentStrategy',
+      );
+      await _rejectToolCall(
+        callId: callId,
+        toolName: ProjectAgentToolNames.retractSuggestions,
+        errorMsg:
+            'Error: your open proposals could not be read, so nothing was '
+            'retracted. Continue without retracting.',
+        manager: manager,
+      );
+      return;
+    }
+    for (final retraction in plan.staged) {
+      _stagedRetractions.add(retraction);
+      _stagedRetractionKeys.add(retraction.key);
+    }
+
+    final response = StringBuffer('Retraction results:');
+    for (final result in plan.results) {
+      final label = switch (result.outcome) {
+        RetractionOutcome.retracted => 'retracted',
+        RetractionOutcome.notOpen => 'not_open (already resolved)',
+        RetractionOutcome.notFound => 'not_found',
+      };
+      final summary = result.humanSummary?.trim();
+      final detail = (summary != null && summary.isNotEmpty)
+          ? ' — "$summary"'
+          : (result.toolName != null ? ' — ${result.toolName}' : '');
+      response.writeln('\n- [fp=${result.fingerprint}] $label$detail');
+    }
+    if (parseErrors.isNotEmpty) {
+      response
+        ..writeln()
+        ..writeln('Skipped malformed entries: ${parseErrors.join('; ')}');
+    }
+
+    manager.addToolResponse(
+      toolCallId: callId,
+      response: response.toString().trim(),
+    );
+    await recordToolResultMessage(
+      toolName: ProjectAgentToolNames.retractSuggestions,
     );
   }
 

--- a/lib/features/agents/workflow/project_agent_workflow.dart
+++ b/lib/features/agents/workflow/project_agent_workflow.dart
@@ -7,11 +7,14 @@ import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_time_utils.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/model/project_agent_report_contract.dart';
+import 'package:lotti/features/agents/model/proposal_ledger.dart';
 import 'package:lotti/features/agents/service/agent_log_llm_summarizer.dart';
 import 'package:lotti/features/agents/service/agent_template_service.dart';
 import 'package:lotti/features/agents/service/project_recommendation_service.dart';
 import 'package:lotti/features/agents/service/soul_document_service.dart';
+import 'package:lotti/features/agents/service/suggestion_retraction_service.dart';
 import 'package:lotti/features/agents/sync/agent_input_capture_service.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/agents/tools/project_tool_definitions.dart';
@@ -22,6 +25,7 @@ import 'package:lotti/features/agents/workflow/carrierless_attribution.dart';
 import 'package:lotti/features/agents/workflow/deferred_change_items.dart';
 import 'package:lotti/features/agents/workflow/project_agent_context_builder.dart';
 import 'package:lotti/features/agents/workflow/project_agent_strategy.dart';
+import 'package:lotti/features/agents/workflow/project_proposal_reconciler.dart';
 import 'package:lotti/features/agents/workflow/prompt_record.dart';
 import 'package:lotti/features/agents/workflow/task_source_renderer.dart';
 import 'package:lotti/features/agents/workflow/wake_result.dart';
@@ -327,6 +331,7 @@ class ProjectAgentWorkflow with AgentErrorLogging {
     required Map<String, AgentMessagePayloadEntity> observationPayloads,
     required String linkedTasksContext,
     required Set<String> triggerTokens,
+    required ProposalLedger ledger,
     String? compactedLog,
   }) => _contextBuilder.buildUserMessage(
     projectEntity: projectEntity,
@@ -336,10 +341,37 @@ class ProjectAgentWorkflow with AgentErrorLogging {
     linkedTasksContext: linkedTasksContext,
     triggerTokens: triggerTokens,
     compactedLog: compactedLog,
+    ledger: ledger,
   );
 
-  List<ChatCompletionTool> _buildToolDefinitions() =>
-      _contextBuilder.buildToolDefinitions();
+  List<ChatCompletionTool> _buildToolDefinitions({
+    required bool hasOpenProposals,
+  }) => _contextBuilder.buildToolDefinitions(
+    hasOpenProposals: hasOpenProposals,
+  );
+
+  /// Reads every proposal this agent has open on [projectId], plus the recent
+  /// verdicts, so the wake can list them in the prompt and refuse to write a
+  /// duplicate. A failed read is non-fatal: the wake proceeds without the
+  /// guard rather than not running at all.
+  Future<ProposalLedger> _loadProposalLedger({
+    required String agentId,
+    required String projectId,
+  }) async {
+    try {
+      return await agentRepository.getProposalLedger(
+        agentId,
+        taskId: projectId,
+      );
+    } catch (error, stackTrace) {
+      logError(
+        'failed to load the proposal ledger',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return const ProposalLedger.empty();
+    }
+  }
 
   String? _extractFinalAssistantContent(ConversationManager? manager) =>
       _contextBuilder.extractFinalAssistantContent(manager);

--- a/lib/features/agents/workflow/project_proposal_reconciler.dart
+++ b/lib/features/agents/workflow/project_proposal_reconciler.dart
@@ -1,0 +1,132 @@
+/// Keeps the project agent's "Proposed changes" band from accumulating the
+/// same suggestion once per wake.
+///
+/// A project wake used to write a fresh pending `ChangeSetEntity` and never
+/// look at the ones already on screen, so an agent that thought the project
+/// should be Active proposed exactly that on every wake — thirteen identical
+/// rows, none of which the previous wake could withdraw. Two rules fix that,
+/// and they are deliberately separate:
+///
+///  * **Redundant against the project**: a status the project already has
+///    changes nothing when applied, so it is never worth proposing. Caught by
+///    [projectStatusProposalIsRedundant] the moment the tool is called, so the
+///    model gets told inside the wake rather than silently losing the call.
+///  * **Redundant against the band**: a proposal the user is already looking
+///    at — or has already turned down — must not be written a second time.
+///    Caught by [reconcileProjectProposals] at persist time, against the
+///    ledger the wake was handed.
+///
+/// Retraction is the third leg and lives in `SuggestionRetractionService`:
+/// the guard in the prompt lists open proposals by fingerprint so the agent
+/// can withdraw the ones that went stale.
+library;
+
+import 'package:lotti/classes/project_data.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/agents/model/proposal_ledger.dart';
+import 'package:lotti/features/agents/tools/project_tool_definitions.dart';
+import 'package:lotti/features/agents/workflow/change_item_dedup.dart';
+
+/// The args to persist for a deferred [toolName] call, with an
+/// `update_project_status` status word replaced by its canonical value.
+///
+/// The tool accepts aliases — `on_track` and `in_progress` both mean `active`,
+/// `blocked` means `on_hold` — and the apply path and the row the user reads
+/// both collapse them. The *stored* args did not, so two proposals that read
+/// identically ("Update project status to Active") carried different
+/// fingerprints and different summaries, and every duplicate check downstream
+/// missed them: the band accumulated rows that were the same suggestion
+/// spelled differently.
+///
+/// Normalizing here, at the boundary where the model's word enters, makes
+/// fingerprint *and* display-key comparison correct everywhere at once
+/// instead of teaching each comparison about status aliases. A word outside
+/// the vocabulary is left verbatim, so the apply path can still report what
+/// the vocabulary is.
+Map<String, dynamic> normalizeProjectProposalArgs(
+  String toolName,
+  Map<String, dynamic> args,
+) {
+  if (toolName != ProjectAgentToolNames.updateProjectStatus) return args;
+  final raw = args['status'];
+  if (raw is! String) return args;
+  final canonical = canonicalProjectStatus(raw);
+  if (canonical == null || canonical == raw) return args;
+  return {...args, 'status': canonical};
+}
+
+/// Whether an `update_project_status` call would leave the project exactly as
+/// it is.
+///
+/// [args] are the raw tool arguments. A status word outside the vocabulary is
+/// **not** redundant — it is invalid, and the apply path reports that far more
+/// usefully than a silent drop here would.
+///
+/// `on_hold` carries a reason the user reads, so re-proposing it with a
+/// different reason is a real change and stays proposable; the same reason
+/// (whitespace aside) is not.
+bool projectStatusProposalIsRedundant({
+  required ProjectStatus current,
+  required Map<String, dynamic> args,
+}) {
+  final raw = args['status'];
+  if (raw is! String) return false;
+  final proposed = canonicalProjectStatus(raw);
+  if (proposed == null) return false;
+  if (proposed != canonicalProjectStatusOf(current)) return false;
+
+  if (current case ProjectOnHold(:final reason)) {
+    final proposedReason = args['reason'];
+    final next = proposedReason is String ? proposedReason.trim() : '';
+    return next.isEmpty || next == reason.trim();
+  }
+  return true;
+}
+
+/// The subset of [proposed] worth persisting, given what the band already
+/// holds.
+///
+/// Drops anything whose structural fingerprint or user-facing summary matches
+/// a still-open proposal in [ledger], and anything matching a proposal the
+/// user has already rejected — the sticky-rejection rule the task agent's
+/// change-set builder applies, reused here rather than restated.
+///
+/// Order is preserved and the first occurrence of a fingerprint wins, so a
+/// wake that proposes the same change twice in one conversation writes it
+/// once.
+List<ChangeItem> reconcileProjectProposals({
+  required List<ChangeItem> proposed,
+  required ProposalLedger ledger,
+}) {
+  if (proposed.isEmpty) return proposed;
+  final open = [
+    for (final entry in ledger.open)
+      ChangeItem(
+        toolName: entry.toolName,
+        args: entry.args,
+        humanSummary: entry.humanSummary,
+      ),
+  ];
+  final deduped = deduplicateItems(
+    proposed,
+    open,
+    rejectedFingerprints: ledger.rejectedFingerprints,
+    rejectedDisplayKeys: ledger.rejectedDisplayKeys,
+  );
+  // `deduplicateItems` compares each proposal against [open] only, so two
+  // items that duplicate each other *inside* one wake both survive it.
+  // Collapse those on the same two keys the cross-wake pass uses: two
+  // `create_task` calls with one title but different descriptions carry
+  // different fingerprints and render the same row, and confirming both
+  // would create the task twice.
+  final seenFingerprints = <String>{};
+  final seenDisplayKeys = <String>{};
+  final collapsed = <ChangeItem>[];
+  for (final item in deduped) {
+    if (!seenFingerprints.add(ChangeItem.fingerprint(item))) continue;
+    final displayKey = ChangeItem.displayDuplicateKey(item);
+    if (displayKey != null && !seenDisplayKeys.add(displayKey)) continue;
+    collapsed.add(item);
+  }
+  return collapsed;
+}

--- a/lib/features/projects/README.md
+++ b/lib/features/projects/README.md
@@ -9,8 +9,9 @@ project agent is attached — a summary and health read that the agent maintains
 ## What it does for the user
 
 - **Groups related tasks.** A task belongs to at most one project, and the
-  project shows its tasks and their rollup. The list groups by the month each
-  task was created, newest first, folds finished tasks into a collapsed Done
+  project shows its tasks and their rollup, each row led by the task's cover art
+  when it has one. The list groups by the month each task was created, newest
+  first, folds finished tasks into a collapsed Done
   group, and offers a Sort and group control (status, priority, due window or
   no grouping; actionability, creation, due date, estimate, priority, last
   update or title) as a popover on desktop and a sheet on a phone. Group
@@ -38,6 +39,8 @@ project agent is attached — a summary and health read that the agent maintains
 - **Makes room to focus on one project.** On desktop, the project list can be
   hidden after a project is selected and restored without losing its filters,
   search or scroll position. The embedded detail has no misleading Back action.
+  Explore project sits in the title's top-right corner beside the project menu,
+  and shows its map glyph alone when the pane is narrow or the text is large.
 - **Keeps agent output actionable.** The AI report leads the task list with
   the agent's current next steps. Each step offers two labelled actions: **Add
   task** creates a project-linked task and links the step to it, **Dismiss**
@@ -47,9 +50,14 @@ project agent is attached — a summary and health read that the agent maintains
   link scrolls it into view. Bulk actions add or dismiss every open step. The
   agent's proposed changes (a status change, a task it wants to create) sit in
   their own band under the steps; applying or rejecting one can be undone for
-  eight seconds, which puts the project back and reopens the proposal. Each successful analysis replaces the list;
-  a run that was already fully decided collapses to a one-line summary with its
-  history, and an empty run says when the agent last looked.
+  eight seconds, which puts the project back and reopens the proposal. **That
+  band does not accumulate.** A wake sees what is still awaiting a decision, is
+  refused when it proposes a status the project already has or a change
+  already on screen, and can withdraw one that has gone stale — landing that
+  withdrawal with the same wake's replacements, so nothing blinks empty. Each
+  successful analysis replaces the next-steps list; a run that was already fully
+  decided collapses to a one-line summary with its history, and an empty run
+  says when the agent last looked.
 
 The whole visible experience is behind a feature flag; with it off there is no
 projects tab, no category projects section, and no project chip on tasks.

--- a/lib/features/projects/ui/widgets/project_header_title_row.dart
+++ b/lib/features/projects/ui/widgets/project_header_title_row.dart
@@ -1,0 +1,233 @@
+import 'dart:math' as math;
+
+import 'package:flutter/rendering.dart';
+import 'package:material_ui/material_ui.dart';
+
+/// The project header's title beside a trailing action rail, laid out so the
+/// rail never sets the header's height.
+///
+/// A plain `Row` would. The overflow menu is a fixed 48 pt tap target and the
+/// title around 32 pt, so the row would grow to 48 and open an empty band
+/// between the title and the status pills beneath it — the "empty toolbar row"
+/// this header has always avoided, back when the menu was a `Stack` overlay.
+/// Explore project joined the same rail and needed the same treatment, but a
+/// labelled button's width is not known in advance, so a fixed overlay inset
+/// could no longer keep the title clear of it.
+///
+/// So: the header is exactly as tall as its title; the action rail is
+/// measured first, gets the trailing corner, and the title gets what is left
+/// minus [gap] — long project names wrap or ellipsize against the rail instead
+/// of running under it. [lift] raises the rail so its glyphs sit nearer the
+/// title's optical centre than its box top.
+///
+/// A rail taller than the title hangs below the header, exactly as the
+/// overlaid menu did, and the overhanging part is not tappable — the trade the
+/// header already made for a compact title band.
+class ProjectHeaderTitleRow extends MultiChildRenderObjectWidget {
+  ProjectHeaderTitleRow({
+    required Widget title,
+    required Widget actions,
+    required this.gap,
+    required this.lift,
+    super.key,
+  }) : super(children: [title, actions]);
+
+  /// Horizontal space kept clear between the title and the rail.
+  final double gap;
+
+  /// How far the rail is raised above the header's top edge.
+  final double lift;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      RenderProjectHeaderTitleRow(
+        gap: gap,
+        lift: lift,
+        textDirection: Directionality.of(context),
+      );
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    RenderProjectHeaderTitleRow renderObject,
+  ) {
+    renderObject
+      ..gap = gap
+      ..lift = lift
+      ..textDirection = Directionality.of(context);
+  }
+}
+
+class _TitleRowParentData extends ContainerBoxParentData<RenderBox> {}
+
+/// Render object for [ProjectHeaderTitleRow]. Public so a widget test can
+/// address it directly.
+class RenderProjectHeaderTitleRow extends RenderBox
+    with
+        ContainerRenderObjectMixin<RenderBox, _TitleRowParentData>,
+        RenderBoxContainerDefaultsMixin<RenderBox, _TitleRowParentData> {
+  RenderProjectHeaderTitleRow({
+    required this._gap,
+    required this._lift,
+    required this._textDirection,
+  });
+
+  double get gap => _gap;
+  double _gap;
+
+  set gap(double value) {
+    if (_gap == value) return;
+    _gap = value;
+    markNeedsLayout();
+  }
+
+  double get lift => _lift;
+  double _lift;
+
+  set lift(double value) {
+    if (_lift == value) return;
+    _lift = value;
+    markNeedsLayout();
+  }
+
+  TextDirection get textDirection => _textDirection;
+  TextDirection _textDirection;
+
+  set textDirection(TextDirection value) {
+    if (_textDirection == value) return;
+    _textDirection = value;
+    markNeedsLayout();
+  }
+
+  RenderBox get _title => firstChild!;
+  RenderBox get _actions => lastChild!;
+
+  @override
+  void setupParentData(RenderBox child) {
+    if (child.parentData is! _TitleRowParentData) {
+      child.parentData = _TitleRowParentData();
+    }
+  }
+
+  /// The width the header can use. An unbounded parent gets the two children
+  /// side by side at their natural widths rather than an infinity.
+  double _availableWidth(BoxConstraints constraints) =>
+      constraints.hasBoundedWidth
+      ? constraints.maxWidth
+      : _title.getMaxIntrinsicWidth(double.infinity) +
+            gap +
+            _actions.getMaxIntrinsicWidth(double.infinity);
+
+  BoxConstraints _titleConstraints(
+    BoxConstraints constraints,
+    double actions,
+  ) => BoxConstraints(
+    maxWidth: math.max(0, _availableWidth(constraints) - actions - gap),
+  );
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) {
+    final actions = _actions.getDryLayout(constraints.loosen());
+    final title = _title.getDryLayout(
+      _titleConstraints(constraints, actions.width),
+    );
+    return constraints.constrain(
+      Size(_availableWidth(constraints), title.height),
+    );
+  }
+
+  @override
+  void performLayout() {
+    // Loosened rather than unbounded: a rail whose labels outgrow the header
+    // is squeezed by its own `Row` instead of painting past the right edge.
+    _actions.layout(constraints.loosen(), parentUsesSize: true);
+    final actionsSize = _actions.size;
+    _title.layout(
+      _titleConstraints(constraints, actionsSize.width),
+      parentUsesSize: true,
+    );
+    final titleSize = _title.size;
+    final width = _availableWidth(constraints);
+    size = constraints.constrain(Size(width, titleSize.height));
+
+    final rtl = textDirection == TextDirection.rtl;
+    (_title.parentData! as _TitleRowParentData).offset = Offset(
+      rtl ? size.width - titleSize.width : 0,
+      0,
+    );
+    (_actions.parentData! as _TitleRowParentData).offset = Offset(
+      rtl ? 0 : size.width - actionsSize.width,
+      -lift,
+    );
+  }
+
+  @override
+  double computeMinIntrinsicWidth(double height) =>
+      _title.getMinIntrinsicWidth(height) +
+      gap +
+      _actions.getMinIntrinsicWidth(height);
+
+  @override
+  double computeMaxIntrinsicWidth(double height) =>
+      _title.getMaxIntrinsicWidth(height) +
+      gap +
+      _actions.getMaxIntrinsicWidth(height);
+
+  // Height is the title's alone: that is the whole point of this layout.
+  @override
+  double computeMinIntrinsicHeight(double width) =>
+      _title.getMinIntrinsicHeight(
+        math.max(
+          0,
+          width - _actions.getMaxIntrinsicWidth(double.infinity) - gap,
+        ),
+      );
+
+  @override
+  double computeMaxIntrinsicHeight(double width) =>
+      _title.getMaxIntrinsicHeight(
+        math.max(
+          0,
+          width - _actions.getMaxIntrinsicWidth(double.infinity) - gap,
+        ),
+      );
+
+  @override
+  void paint(PaintingContext context, Offset offset) =>
+      defaultPaint(context, offset);
+
+  @override
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) =>
+      defaultHitTestChildren(result, position: position);
+
+  /// Accepts a pointer anywhere on the action rail, including the part that
+  /// hangs below the header.
+  ///
+  /// `RenderBox.hitTest` rejects a position outside the box before it reaches
+  /// any child, and the box is deliberately only as tall as the title — so
+  /// without this the bottom third of two 48 pt controls would be dead, which
+  /// is below the touch target the design system asks for. Sizing the box to
+  /// the rail instead is what opens the empty band this layout exists to
+  /// avoid, so the rail keeps its own bounds for hit testing while the header
+  /// keeps the title's for layout.
+  ///
+  /// Only the rail's own rectangle is claimed. Everything below the header
+  /// outside it still falls through to the siblings underneath, which are
+  /// hit-tested first anyway.
+  @override
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    if (super.hitTest(result, position: position)) return true;
+
+    final actionsData = _actions.parentData! as _TitleRowParentData;
+    if (!(actionsData.offset & _actions.size).contains(position)) return false;
+
+    final hit = result.addWithPaintOffset(
+      offset: actionsData.offset,
+      position: position,
+      hitTest: (BoxHitTestResult result, Offset transformed) =>
+          _actions.hitTest(result, position: transformed),
+    );
+    if (hit) result.add(BoxHitTestEntry(this, position));
+    return hit;
+  }
+}

--- a/lib/features/projects/ui/widgets/project_mobile_detail_content.dart
+++ b/lib/features/projects/ui/widgets/project_mobile_detail_content.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_icon_action.dart';
 import 'package:lotti/features/design_system/components/cards/design_system_section_card.dart';
 import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
 import 'package:lotti/features/design_system/components/context_menus/design_system_context_menu.dart';
@@ -16,6 +17,7 @@ import 'package:lotti/features/keyboard/ui/list_detail_focus_traversal.dart';
 import 'package:lotti/features/projects/ui/model/project_list_detail_models.dart';
 import 'package:lotti/features/projects/ui/model/project_task_list_options.dart';
 import 'package:lotti/features/projects/ui/widgets/project_agent_summary_card.dart';
+import 'package:lotti/features/projects/ui/widgets/project_header_title_row.dart';
 import 'package:lotti/features/projects/ui/widgets/project_tasks_panel.dart';
 import 'package:lotti/features/projects/ui/widgets/shared_widgets.dart';
 import 'package:lotti/features/projects/ui/widgets/showcase/showcase_palette.dart';
@@ -65,6 +67,18 @@ class ProjectMobileDetailContent extends StatefulWidget {
     this.onTaskListOptionsChanged,
     super.key,
   });
+
+  /// Below this header width the title row's Explore project action drops
+  /// its label and shows the map glyph alone.
+  ///
+  /// A 430 pt phone leaves the header about 400 pt; the narrowest desktop
+  /// detail pane the showcases use leaves it 516 pt, which fits the label
+  /// beside a title.
+  static const double compactHeaderWidth = 460;
+
+  /// From this text scale the Explore project action drops its label at any
+  /// width — the same threshold the task panel header uses.
+  static const double largeTextScale = 1.2;
 
   final ProjectRecord record;
   final DateTime currentTime;
@@ -264,6 +278,7 @@ class _ProjectMobileDetailContentState
                                 onCategoryTap: widget.onCategoryTap,
                                 onTargetDateTap: widget.onTargetDateTap,
                                 onStatusTap: widget.onStatusTap,
+                                onOpenPlaza: widget.onOpenPlaza,
                                 isInteractive: !isMutating,
                                 trailing: menuItems.isEmpty || isMutating
                                     ? null
@@ -281,24 +296,6 @@ class _ProjectMobileDetailContentState
                             SliverToBoxAdapter(
                               child: SizedBox(height: tokens.spacing.step4),
                             ),
-                            if (widget.onOpenPlaza != null) ...[
-                              SliverToBoxAdapter(
-                                child: Align(
-                                  alignment: AlignmentDirectional.centerStart,
-                                  child: DesignSystemButton(
-                                    label: context.messages.plazaExploreProject,
-                                    variant: DesignSystemButtonVariant.outlined,
-                                    leadingIcon: LottiIcons.map,
-                                    onPressed: isMutating
-                                        ? null
-                                        : widget.onOpenPlaza,
-                                  ),
-                                ),
-                              ),
-                              SliverToBoxAdapter(
-                                child: SizedBox(height: tokens.spacing.step4),
-                              ),
-                            ],
                             if (description.isNotEmpty) ...[
                               SliverToBoxAdapter(
                                 child: _ProjectDescription(
@@ -407,6 +404,7 @@ class _ProjectMobileHeader extends StatelessWidget {
     this.onCategoryTap,
     this.onTargetDateTap,
     this.onStatusTap,
+    this.onOpenPlaza,
     this.isInteractive = true,
     this.trailing,
   });
@@ -415,8 +413,42 @@ class _ProjectMobileHeader extends StatelessWidget {
   final VoidCallback? onCategoryTap;
   final VoidCallback? onTargetDateTap;
   final VoidCallback? onStatusTap;
+
+  /// Opens the plaza on this project. Rendered in the title row's action
+  /// rail; omitted entirely when the host has nowhere to send the user.
+  final VoidCallback? onOpenPlaza;
   final bool isInteractive;
   final Widget? trailing;
+
+  /// The title row's trailing rail: Explore project, then whatever the host
+  /// passed as [trailing] (the overflow menu). [compact] drops the explore
+  /// label so a narrow pane or large text keeps the title readable.
+  List<Widget> _actions(BuildContext context, {required bool compact}) {
+    final tokens = context.designTokens;
+    final label = context.messages.plazaExploreProject;
+    final onExplore = isInteractive ? onOpenPlaza : null;
+    return [
+      if (onOpenPlaza != null)
+        if (compact)
+          DesignSystemIconAction(
+            icon: LottiIcons.map,
+            tooltip: label,
+            onPressed: onExplore,
+          )
+        else
+          DesignSystemButton(
+            label: label,
+            variant: DesignSystemButtonVariant.outlined,
+            size: DesignSystemButtonSize.dense,
+            tapTargetSize: MaterialTapTargetSize.padded,
+            leadingIcon: LottiIcons.map,
+            onPressed: onExplore,
+          ),
+      if (onOpenPlaza != null && trailing != null)
+        SizedBox(width: tokens.spacing.step2),
+      ?trailing,
+    ];
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -444,30 +476,34 @@ class _ProjectMobileHeader extends StatelessWidget {
           ),
           SizedBox(height: tokens.spacing.step2),
         ],
-        Stack(
-          clipBehavior: Clip.none,
-          children: [
-            Padding(
-              padding: EdgeInsetsDirectional.only(
-                end: trailing == null
-                    ? 0
-                    : tokens.spacing.step9 + tokens.spacing.step2,
+        // Title and the action rail share one row, so Explore project sits in
+        // the top-right corner beside the overflow menu instead of taking a
+        // band of its own under the heading.
+        LayoutBuilder(
+          builder: (context, constraints) {
+            final actions = _actions(
+              context,
+              compact:
+                  constraints.maxWidth <
+                      ProjectMobileDetailContent.compactHeaderWidth ||
+                  MediaQuery.textScalerOf(context).scale(1) >=
+                      ProjectMobileDetailContent.largeTextScale,
+            );
+            final title = Semantics(
+              header: true,
+              child: Text(
+                record.project.data.title,
+                style: titleStyle,
               ),
-              child: Semantics(
-                header: true,
-                child: Text(
-                  record.project.data.title,
-                  style: titleStyle,
-                ),
-              ),
-            ),
-            if (trailing != null)
-              PositionedDirectional(
-                top: -tokens.spacing.step2,
-                end: 0,
-                child: trailing!,
-              ),
-          ],
+            );
+            if (actions.isEmpty) return title;
+            return ProjectHeaderTitleRow(
+              gap: tokens.spacing.step3,
+              lift: tokens.spacing.step2,
+              title: title,
+              actions: Row(mainAxisSize: MainAxisSize.min, children: actions),
+            );
+          },
         ),
         SizedBox(height: tokens.spacing.step2),
         Wrap(

--- a/lib/features/projects/ui/widgets/project_tasks_panel.dart
+++ b/lib/features/projects/ui/widgets/project_tasks_panel.dart
@@ -16,6 +16,7 @@ import 'package:lotti/features/projects/ui/widgets/project_task_list_options_she
 import 'package:lotti/features/projects/ui/widgets/shared_widgets.dart';
 import 'package:lotti/features/projects/ui/widgets/showcase/showcase_palette.dart';
 import 'package:lotti/features/projects/ui/widgets/showcase/showcase_status_helpers.dart';
+import 'package:lotti/features/tasks/ui/cover_art_thumbnail.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:sliver_tools/sliver_tools.dart';
@@ -647,7 +648,19 @@ class _ProjectTaskGroupHeader extends StatelessWidget {
 Key projectTaskRowKey(TaskSummary summary) =>
     ValueKey('project-task-row-${summary.task.meta.id}');
 
-/// A row displaying a single task's title, estimated duration, and status.
+/// The cover-art id [summary] should render a thumbnail for, or `null` when
+/// the task carries none.
+///
+/// A task whose `coverArtId` is absent — or is whitespace a sync or an
+/// import left behind — has nothing to draw, and the row keeps the full
+/// width it has always had.
+String? _coverArtId(TaskSummary summary) {
+  final id = summary.task.data.coverArtId?.trim();
+  return (id == null || id.isEmpty) ? null : id;
+}
+
+/// A row displaying a single task's cover art, title, estimated duration, and
+/// status.
 ///
 /// [highlighted] paints the hover wash without a pointer, for the row the
 /// list was just asked to bring into view.
@@ -704,6 +717,7 @@ class _TaskSummaryRowSurfaceState extends State<_TaskSummaryRowSurface> {
   @override
   Widget build(BuildContext context) {
     final oneLiner = widget.summary.oneLiner;
+    final coverArtId = _coverArtId(widget.summary);
 
     final tokens = context.designTokens;
     final backgroundColor = _hovered || widget.highlighted
@@ -734,7 +748,24 @@ class _TaskSummaryRowSurfaceState extends State<_TaskSummaryRowSurface> {
             vertical: tokens.spacing.step3,
           ),
           child: Row(
+            // The thumbnail lines up with the title rather than floating in
+            // the middle of a row whose height is set by the one-liner and
+            // the metadata beneath it.
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              if (coverArtId != null) ...[
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(tokens.radii.s),
+                  child: CoverArtThumbnail(
+                    imageId: coverArtId,
+                    // The same square the day planner's agenda card draws, so
+                    // a task is the same size wherever it is listed.
+                    size: tokens.spacing.step9,
+                    cropX: widget.summary.task.data.coverArtCropX,
+                  ),
+                ),
+                SizedBox(width: tokens.spacing.step4),
+              ],
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,

--- a/test/features/agents/workflow/project_agent_context_builder_test.dart
+++ b/test/features/agents/workflow/project_agent_context_builder_test.dart
@@ -7,6 +7,10 @@ import 'package:lotti/classes/project_data.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/agents/model/proposal_ledger.dart';
+import 'package:lotti/features/agents/tools/project_tool_definitions.dart';
 import 'package:lotti/features/agents/workflow/project_agent_context_builder.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
@@ -105,6 +109,27 @@ void main() {
       expect(prompt, contains('## Health Assessment'));
       expect(prompt, isNot(contains('## Your Personality')));
       expect(prompt, isNot(contains('## Report Directive')));
+    });
+
+    test('states the three rules that keep the proposal band clean', () {
+      // The deterministic guards drop duplicates whatever the model does, but
+      // an agent that is never told stays in a loop of proposing them.
+      final prompt = builder.buildSystemPrompt(
+        version: null,
+        soulVersion: null,
+      );
+
+      expect(prompt, contains('## Your Own Open Proposals'));
+      expect(
+        prompt,
+        contains('Never propose something that is already open'),
+      );
+      expect(
+        prompt,
+        contains('Never propose a status the project already has'),
+      );
+      expect(prompt, contains(ProjectAgentToolNames.retractSuggestions));
+      expect(prompt, contains('## Open Proposal Guard'));
     });
 
     test('appends legacy combined heading when only directives is set', () {
@@ -320,6 +345,115 @@ void main() {
       for (final tool in tools) {
         expect(tool.type, ChatCompletionToolType.function);
       }
+    });
+
+    test('withholds retract_suggestions when nothing is open', () {
+      // Offering it with nothing to withdraw invites a hallucinated
+      // fingerprint and a wasted turn.
+      expect(
+        builder.buildToolDefinitions().map((t) => t.function.name),
+        isNot(contains(ProjectAgentToolNames.retractSuggestions)),
+      );
+    });
+
+    test('offers retract_suggestions when proposals are open', () {
+      final tools = builder.buildToolDefinitions(hasOpenProposals: true);
+      expect(
+        tools.map((t) => t.function.name),
+        contains(ProjectAgentToolNames.retractSuggestions),
+      );
+      final retract = tools.firstWhere(
+        (t) => t.function.name == ProjectAgentToolNames.retractSuggestions,
+      );
+      final parameters = retract.function.parameters!;
+      expect(parameters['required'], ['proposals']);
+      final proposals = (parameters['properties']! as Map)['proposals']! as Map;
+      expect(
+        (proposals['items']! as Map)['required']! as List,
+        containsAll(<String>['fingerprint', 'reason']),
+        reason: 'a retraction without a reason leaves no audit trail',
+      );
+    });
+  });
+
+  group('open proposal guard', () {
+    LedgerEntry entry(String summary, {String status = 'active'}) {
+      final item = ChangeItem(
+        toolName: ProjectAgentToolNames.updateProjectStatus,
+        args: {'status': status},
+        humanSummary: summary,
+      );
+      return LedgerEntry(
+        changeSetId: 'set-1',
+        itemIndex: 0,
+        toolName: item.toolName,
+        args: item.args,
+        humanSummary: item.humanSummary,
+        fingerprint: ChangeItem.fingerprint(item),
+        status: ChangeItemStatus.pending,
+        createdAt: DateTime(2026, 9),
+      );
+    }
+
+    test('renders nothing when no proposal is open', () {
+      expect(
+        ProjectAgentContextBuilder.formatOpenProposalGuard(
+          const ProposalLedger.empty(),
+        ),
+        isEmpty,
+      );
+    });
+
+    test(
+      'lists each open proposal with the fingerprint it is retracted by',
+      () {
+        final open = entry('Update project status to Active');
+        final guard = ProjectAgentContextBuilder.formatOpenProposalGuard(
+          ProposalLedger(open: [open], resolved: const []),
+        );
+
+        expect(guard, contains('## Open Proposal Guard'));
+        expect(guard, contains('fp=${open.fingerprint}'));
+        expect(guard, contains('Update project status to Active'));
+        expect(
+          guard,
+          contains(ProjectAgentToolNames.retractSuggestions),
+          reason: 'the guard must name the tool that acts on it',
+        );
+      },
+    );
+
+    test('the wake message carries the guard for the model to compare', () {
+      final open = entry('Update project status to Active');
+      final result = builder.buildUserMessage(
+        projectEntity: projectEntity(),
+        lastReport: null,
+        observations: const [],
+        observationPayloads: const {},
+        linkedTasksContext: '{}',
+        triggerTokens: const {'entity-a'},
+        ledger: ProposalLedger(open: [open], resolved: const []),
+      );
+
+      expect(result.text, contains('fp=${open.fingerprint}'));
+      expect(
+        result.text.indexOf('## Open Proposal Guard'),
+        greaterThan(result.text.indexOf('## Project Context')),
+        reason: 'the guard is the freshest thing before the model proposes',
+      );
+    });
+
+    test('a wake with no open proposals carries no guard', () {
+      final result = builder.buildUserMessage(
+        projectEntity: projectEntity(),
+        lastReport: null,
+        observations: const [],
+        observationPayloads: const {},
+        linkedTasksContext: '{}',
+        triggerTokens: const {},
+      );
+
+      expect(result.text, isNot(contains('Open Proposal Guard')));
     });
   });
 

--- a/test/features/agents/workflow/project_agent_strategy_test.dart
+++ b/test/features/agents/workflow/project_agent_strategy_test.dart
@@ -1,8 +1,13 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/project_data.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/model/observation_record.dart';
+import 'package:lotti/features/agents/model/proposal_ledger.dart';
+import 'package:lotti/features/agents/service/suggestion_retraction_service.dart';
 import 'package:lotti/features/agents/tools/project_tool_definitions.dart';
 import 'package:lotti/features/agents/workflow/project_agent_strategy.dart';
 import 'package:lotti/features/ai/conversation/conversation_manager.dart';
@@ -15,6 +20,7 @@ import '../../../mocks/mocks.dart';
 const _agentId = 'agent-001';
 const _threadId = 'thread-001';
 const _runKey = 'run-key-001';
+const _projectId = 'project-001';
 
 ChatCompletionMessageToolCall _makeToolCall({
   required String name,
@@ -775,6 +781,328 @@ void main() {
         final deferred = strategy.extractDeferredItems();
         expect(
           () => deferred.add({'extra': true}),
+          throwsUnsupportedError,
+        );
+      });
+    });
+
+    group('redundant status proposals', () {
+      /// The strategy as the wake builds it: told what the project's status
+      /// is, so it can refuse a proposal that would change nothing.
+      ProjectAgentStrategy withStatus(ProjectStatus status) =>
+          ProjectAgentStrategy(
+            syncService: mockSyncService,
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            projectId: _projectId,
+            currentProjectStatus: status,
+          );
+
+      test('refuses a status the project already has, and says why', () async {
+        final active = ProjectStatus.active(
+          id: 's1',
+          createdAt: DateTime(2026, 9),
+          utcOffset: 0,
+        );
+        final strategy = withStatus(active);
+
+        await strategy.processToolCalls(
+          toolCalls: [
+            _makeToolCall(
+              name: ProjectAgentToolNames.updateProjectStatus,
+              // The alias the reported bug came in as.
+              args: {'status': 'on_track', 'reason': 'All tasks progressing'},
+            ),
+          ],
+          manager: mockManager,
+        );
+
+        expect(
+          strategy.extractDeferredItems(),
+          isEmpty,
+          reason: 'a no-op proposal must never reach the user',
+        );
+        final response = verify(
+          () => mockManager.addToolResponse(
+            toolCallId: 'call-1',
+            response: captureAny(named: 'response'),
+          ),
+        ).captured.single;
+        expect(response, contains('already Active'));
+
+        // Recorded as an ordinary result, not an error: `errorMessage` shows
+        // in the agent's activity log in the error colour, and the guard
+        // working is not a failure.
+        final toolResult =
+            verify(
+              () => mockSyncService.upsertEntity(captureAny()),
+            ).captured.whereType<AgentMessageEntity>().singleWhere(
+              (message) => message.kind == AgentMessageKind.toolResult,
+            );
+        expect(toolResult.metadata.errorMessage, isNull);
+      });
+
+      test('queues a status that would actually change the project', () async {
+        final strategy = withStatus(
+          ProjectStatus.active(
+            id: 's1',
+            createdAt: DateTime(2026, 9),
+            utcOffset: 0,
+          ),
+        );
+
+        await strategy.processToolCalls(
+          toolCalls: [
+            _makeToolCall(
+              name: ProjectAgentToolNames.updateProjectStatus,
+              args: {'status': 'completed', 'reason': 'Shipped'},
+            ),
+          ],
+          manager: mockManager,
+        );
+
+        expect(strategy.extractDeferredItems(), hasLength(1));
+      });
+
+      test('queues everything when the wake did not supply a status', () async {
+        // A strategy built without the project's status has nothing to compare
+        // against; it must not start dropping proposals on a guess.
+        await strategy.processToolCalls(
+          toolCalls: [
+            _makeToolCall(
+              name: ProjectAgentToolNames.updateProjectStatus,
+              args: {'status': 'active', 'reason': 'Work resumed'},
+            ),
+          ],
+          manager: mockManager,
+        );
+
+        expect(strategy.extractDeferredItems(), hasLength(1));
+      });
+
+      test('leaves create_task alone', () async {
+        final strategy = withStatus(
+          ProjectStatus.active(
+            id: 's1',
+            createdAt: DateTime(2026, 9),
+            utcOffset: 0,
+          ),
+        );
+
+        await strategy.processToolCalls(
+          toolCalls: [
+            _makeToolCall(
+              name: ProjectAgentToolNames.createTask,
+              args: {'title': 'Ship it'},
+            ),
+          ],
+          manager: mockManager,
+        );
+
+        expect(strategy.extractDeferredItems(), hasLength(1));
+      });
+    });
+
+    group('retract_suggestions', () {
+      late MockAgentRepository repository;
+      late ProjectAgentStrategy strategy;
+
+      /// One open proposal on the project, so a retraction has a target.
+      ChangeSetEntity openSet(ChangeItem item) =>
+          AgentDomainEntity.changeSet(
+                id: 'set-1',
+                agentId: _agentId,
+                taskId: _projectId,
+                threadId: _threadId,
+                runKey: _runKey,
+                status: ChangeSetStatus.pending,
+                items: [item],
+                createdAt: DateTime(2026, 9),
+                vectorClock: null,
+              )
+              as ChangeSetEntity;
+
+      const staleItem = ChangeItem(
+        toolName: ProjectAgentToolNames.updateProjectStatus,
+        args: {'status': 'active', 'reason': 'stale'},
+        humanSummary: 'Update project status to active',
+      );
+
+      setUp(() {
+        repository = MockAgentRepository();
+        when(() => mockSyncService.repository).thenReturn(repository);
+        when(
+          () => repository.getPendingChangeSets(_agentId, taskId: _projectId),
+        ).thenAnswer((_) async => [openSet(staleItem)]);
+        when(
+          () => repository.getProposalLedger(_agentId, taskId: _projectId),
+        ).thenAnswer((_) async => const ProposalLedger.empty());
+
+        strategy = ProjectAgentStrategy(
+          syncService: mockSyncService,
+          agentId: _agentId,
+          threadId: _threadId,
+          runKey: _runKey,
+          projectId: _projectId,
+          retractionService: SuggestionRetractionService(
+            syncService: mockSyncService,
+          ),
+        );
+      });
+
+      Future<void> retract(Object proposals) => strategy.processToolCalls(
+        toolCalls: [
+          _makeToolCall(
+            name: ProjectAgentToolNames.retractSuggestions,
+            args: {'proposals': proposals},
+          ),
+        ],
+        manager: mockManager,
+      );
+
+      String capturedResponse() =>
+          verify(
+                () => mockManager.addToolResponse(
+                  toolCallId: 'call-1',
+                  response: captureAny(named: 'response'),
+                ),
+              ).captured.single
+              as String;
+
+      test('stages a matching open proposal without writing it yet', () async {
+        await retract([
+          {
+            'fingerprint': ChangeItem.fingerprint(staleItem),
+            'reason': 'the project is already Active',
+          },
+        ]);
+
+        final staged = strategy.extractStagedRetractions();
+        expect(staged, hasLength(1));
+        expect(staged.single.item, staleItem);
+        expect(staged.single.reason, 'the project is already Active');
+        expect(capturedResponse(), contains('retracted'));
+        // Nothing is written here: the wake applies staged retractions with
+        // the proposals that replace them, so the band never reads empty.
+        verifyNever(
+          () => mockSyncService.upsertEntity(
+            any(that: isA<ChangeDecisionEntity>()),
+          ),
+        );
+        verifyNever(
+          () => mockSyncService.upsertEntity(any(that: isA<ChangeSetEntity>())),
+        );
+      });
+
+      test('reports a fingerprint that matches nothing', () async {
+        await retract([
+          {'fingerprint': 'not-a-real-fingerprint', 'reason': 'gone stale'},
+        ]);
+
+        expect(strategy.extractStagedRetractions(), isEmpty);
+        expect(capturedResponse(), contains('not_found'));
+      });
+
+      test('stages the same fingerprint only once', () async {
+        final request = {
+          'fingerprint': ChangeItem.fingerprint(staleItem),
+          'reason': 'already covered',
+        };
+        await retract([request]);
+        await retract([request]);
+
+        expect(strategy.extractStagedRetractions(), hasLength(1));
+      });
+
+      test('rejects a malformed proposals argument', () async {
+        await retract('not a list');
+
+        expect(strategy.extractStagedRetractions(), isEmpty);
+        expect(capturedResponse(), contains('non-empty array'));
+      });
+
+      test('rejects entries missing a fingerprint or a reason', () async {
+        await retract([
+          {'reason': 'no fingerprint'},
+          {'fingerprint': 'abc'},
+          'not an object',
+        ]);
+
+        expect(strategy.extractStagedRetractions(), isEmpty);
+        final response = capturedResponse();
+        expect(response, contains('fingerprint missing'));
+        expect(response, contains('reason missing'));
+        expect(response, contains('is not an object'));
+      });
+
+      test('reports the malformed entries alongside the good ones', () async {
+        // A model that gets one entry wrong should still have its valid
+        // retraction applied, and be told exactly what it got wrong.
+        await retract([
+          {
+            'fingerprint': ChangeItem.fingerprint(staleItem),
+            'reason': 'the project is already Active',
+          },
+          {'reason': 'no fingerprint here'},
+        ]);
+
+        expect(strategy.extractStagedRetractions(), hasLength(1));
+        final response = capturedResponse();
+        expect(response, contains('retracted'));
+        expect(response, contains('Skipped malformed entries'));
+      });
+
+      test('a failed read reports back instead of failing the wake', () async {
+        // Retraction is the least valuable thing a wake produces; losing the
+        // report and the observations with it would be disproportionate.
+        when(
+          () => repository.getPendingChangeSets(_agentId, taskId: _projectId),
+        ).thenThrow(Exception('database unavailable'));
+
+        await expectLater(
+          retract([
+            {
+              'fingerprint': ChangeItem.fingerprint(staleItem),
+              'reason': 'stale',
+            },
+          ]),
+          completes,
+        );
+
+        expect(strategy.extractStagedRetractions(), isEmpty);
+        expect(capturedResponse(), contains('could not be read'));
+      });
+
+      test('says so when the tool is not wired up', () async {
+        final unwired = ProjectAgentStrategy(
+          syncService: mockSyncService,
+          agentId: _agentId,
+          threadId: _threadId,
+          runKey: _runKey,
+        );
+
+        await unwired.processToolCalls(
+          toolCalls: [
+            _makeToolCall(
+              name: ProjectAgentToolNames.retractSuggestions,
+              args: {
+                'proposals': [
+                  {'fingerprint': 'abc', 'reason': 'stale'},
+                ],
+              },
+            ),
+          ],
+          manager: mockManager,
+        );
+
+        expect(unwired.extractStagedRetractions(), isEmpty);
+        expect(capturedResponse(), contains('not wired up'));
+      });
+
+      test('the staged list is unmodifiable', () async {
+        expect(
+          () => strategy.extractStagedRetractions().clear(),
           throwsUnsupportedError,
         );
       });

--- a/test/features/agents/workflow/project_agent_workflow_test.dart
+++ b/test/features/agents/workflow/project_agent_workflow_test.dart
@@ -12,6 +12,8 @@ import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/agents/model/proposal_ledger.dart';
 import 'package:lotti/features/agents/projection/content_digest.dart';
 import 'package:lotti/features/agents/projection/input_capture.dart';
 import 'package:lotti/features/agents/service/project_agent_service.dart';
@@ -215,6 +217,14 @@ void main() {
         taskId: any(named: 'taskId'),
       ),
     ).thenAnswer((_) async => []);
+    when(
+      () => mockAgentRepository.getProposalLedger(
+        any(),
+        taskId: any(named: 'taskId'),
+        changeSetFetchLimit: any(named: 'changeSetFetchLimit'),
+        resolvedLimit: any(named: 'resolvedLimit'),
+      ),
+    ).thenAnswer((_) async => const ProposalLedger.empty());
     when(() => mockSyncService.upsertEntity(any())).thenAnswer((_) async {});
     stubAppendMilestone(mockSyncService);
     stubReconciledAgentState(mockSyncService, mockAgentRepository);
@@ -2135,7 +2145,11 @@ void main() {
           changeSet.items[1].toolName,
           ProjectAgentToolNames.updateProjectStatus,
         );
-        expect(changeSet.items[1].humanSummary, contains('at_risk'));
+        // `at_risk` is an alias the apply path and the row both collapse to
+        // On Hold, so the stored args and summary carry the canonical status:
+        // the alias spelling would compare as a different proposal.
+        expect(changeSet.items[1].args['status'], 'on_hold');
+        expect(changeSet.items[1].humanSummary, contains('on_hold'));
       });
 
       test('does not create change set when no deferred items', () async {
@@ -3213,7 +3227,7 @@ void main() {
         expect(result.success, isTrue);
       });
 
-      test('builds default human summary for unknown deferred tool', () async {
+      test('builds a human summary for a status proposal', () async {
         mockConversationRepository.sendMessageDelegate =
             ({
               required conversationId,
@@ -3233,9 +3247,12 @@ void main() {
                     type: ChatCompletionMessageToolCallType.function,
                     function: ChatCompletionMessageFunctionCall(
                       name: ProjectAgentToolNames.updateProjectStatus,
+                      // Not `on_track`: that canonicalizes to the status the
+                      // fixture project already has, which the wake now
+                      // refuses rather than queues.
                       arguments: jsonEncode({
-                        'status': 'on_track',
-                        'reason': 'All tasks progressing',
+                        'status': 'monitoring',
+                        'reason': 'Nothing is scheduled this cycle',
                       }),
                     ),
                   ),
@@ -3274,7 +3291,7 @@ void main() {
         expect(changeSets, hasLength(1));
         expect(
           changeSets.first.items.first.humanSummary,
-          contains('on_track'),
+          contains('monitoring'),
         );
       });
 
@@ -3854,6 +3871,325 @@ void main() {
           expect(captured.whereType<ProjectRecommendationEntity>(), isEmpty);
         },
       );
+
+      group('proposals the user has not decided yet', () {
+        /// One `create_task` proposal, phrased identically every wake — the
+        /// shape the accumulating "Proposed changes" band came in as.
+        const proposal = ChangeItem(
+          toolName: ProjectAgentToolNames.createTask,
+          args: {'title': 'Define Launch Roadmap and Milestones'},
+          humanSummary: 'Create task: Define Launch Roadmap and Milestones',
+        );
+
+        LedgerEntry openEntry(ChangeItem item) => LedgerEntry(
+          changeSetId: 'set-previous',
+          itemIndex: 0,
+          toolName: item.toolName,
+          args: item.args,
+          humanSummary: item.humanSummary,
+          fingerprint: ChangeItem.fingerprint(item),
+          status: ChangeItemStatus.pending,
+          createdAt: DateTime(2026, 3, 19),
+        );
+
+        ChangeSetEntity pendingSet(ChangeItem item) =>
+            AgentDomainEntity.changeSet(
+                  id: 'set-previous',
+                  agentId: agentId,
+                  taskId: projectId,
+                  threadId: 'thread-previous',
+                  runKey: 'run-previous',
+                  status: ChangeSetStatus.pending,
+                  items: [item],
+                  createdAt: DateTime(2026, 3, 19),
+                  vectorClock: null,
+                )
+                as ChangeSetEntity;
+
+        void stubLedger(ProposalLedger ledger) {
+          when(
+            () => mockAgentRepository.getProposalLedger(
+              any(),
+              taskId: any(named: 'taskId'),
+              changeSetFetchLimit: any(named: 'changeSetFetchLimit'),
+              resolvedLimit: any(named: 'resolvedLimit'),
+            ),
+          ).thenAnswer((_) async => ledger);
+        }
+
+        /// Runs a wake in which the model issues [toolCalls], and returns
+        /// everything the wake persisted.
+        Future<List<Object?>> runWake(
+          List<ChatCompletionMessageToolCall> toolCalls, {
+          void Function(List<ChatCompletionTool>? tools)? onTools,
+        }) async {
+          mockConversationRepository.sendMessageDelegate =
+              ({
+                required conversationId,
+                required message,
+                required model,
+                required provider,
+                required inferenceRepo,
+                tools,
+                toolChoice,
+                temperature = 0.7,
+                strategy,
+              }) async {
+                onTools?.call(tools);
+                if (strategy != null) {
+                  final manager = mockConversationRepository.getConversation(
+                    conversationId,
+                  )!;
+                  when(
+                    () => manager.addToolResponse(
+                      toolCallId: any(named: 'toolCallId'),
+                      response: any(named: 'response'),
+                    ),
+                  ).thenReturn(null);
+                  await strategy.processToolCalls(
+                    toolCalls: toolCalls,
+                    manager: manager,
+                  );
+                }
+                return null;
+              };
+
+          await workflow.execute(
+            agentIdentity: testAgentIdentity,
+            runKey: runKey,
+            triggerTokens: {'entity-a'},
+            threadId: threadId,
+          );
+
+          return verify(
+            () => mockSyncService.upsertEntity(captureAny()),
+          ).captured;
+        }
+
+        ChatCompletionMessageToolCall createTaskCall(String title) =>
+            ChatCompletionMessageToolCall(
+              id: 'call-create',
+              type: ChatCompletionMessageToolCallType.function,
+              function: ChatCompletionMessageFunctionCall(
+                name: ProjectAgentToolNames.createTask,
+                arguments: jsonEncode({'title': title}),
+              ),
+            );
+
+        test('writes a proposal that is genuinely new', () async {
+          final captured = await runWake([
+            createTaskCall('Define Launch Roadmap and Milestones'),
+          ]);
+
+          expect(captured.whereType<ChangeSetEntity>(), hasLength(1));
+        });
+
+        test('does not write one the user is already looking at', () async {
+          // The bug: every wake wrote a fresh identical row, and the band grew
+          // to thirteen copies of the same suggestion.
+          stubLedger(
+            ProposalLedger(open: [openEntry(proposal)], resolved: const []),
+          );
+
+          final captured = await runWake([
+            createTaskCall('Define Launch Roadmap and Milestones'),
+          ]);
+
+          expect(captured.whereType<ChangeSetEntity>(), isEmpty);
+        });
+
+        test('does not write one the user already rejected', () async {
+          stubLedger(
+            ProposalLedger(
+              open: const [],
+              resolved: [
+                LedgerEntry(
+                  changeSetId: 'set-previous',
+                  itemIndex: 0,
+                  toolName: proposal.toolName,
+                  args: proposal.args,
+                  humanSummary: proposal.humanSummary,
+                  fingerprint: ChangeItem.fingerprint(proposal),
+                  status: ChangeItemStatus.rejected,
+                  createdAt: DateTime(2026, 3, 19),
+                  verdict: ChangeDecisionVerdict.rejected,
+                ),
+              ],
+            ),
+          );
+
+          final captured = await runWake([
+            createTaskCall('Define Launch Roadmap and Milestones'),
+          ]);
+
+          expect(captured.whereType<ChangeSetEntity>(), isEmpty);
+        });
+
+        test('still writes the other proposals of the same wake', () async {
+          stubLedger(
+            ProposalLedger(open: [openEntry(proposal)], resolved: const []),
+          );
+
+          final captured = await runWake([
+            createTaskCall('Define Launch Roadmap and Milestones'),
+            ChatCompletionMessageToolCall(
+              id: 'call-create-2',
+              type: ChatCompletionMessageToolCallType.function,
+              function: ChatCompletionMessageFunctionCall(
+                name: ProjectAgentToolNames.createTask,
+                arguments: jsonEncode({'title': 'Book the launch venue'}),
+              ),
+            ),
+          ]);
+
+          final sets = captured.whereType<ChangeSetEntity>();
+          expect(sets, hasLength(1));
+          expect(
+            sets.single.items.single.args['title'],
+            'Book the launch venue',
+          );
+        });
+
+        test('withholds retract_suggestions when nothing is open', () async {
+          List<ChatCompletionTool>? offered;
+          await runWake(const [], onTools: (tools) => offered = tools);
+
+          expect(offered, isNotNull);
+          expect(
+            offered!.map((tool) => tool.function.name),
+            isNot(contains(ProjectAgentToolNames.retractSuggestions)),
+          );
+        });
+
+        test('offers retract_suggestions when a proposal is open', () async {
+          stubLedger(
+            ProposalLedger(open: [openEntry(proposal)], resolved: const []),
+          );
+          List<ChatCompletionTool>? offered;
+          await runWake(const [], onTools: (tools) => offered = tools);
+
+          expect(offered, isNotNull);
+          expect(
+            offered!.map((tool) => tool.function.name),
+            contains(ProjectAgentToolNames.retractSuggestions),
+          );
+        });
+
+        test('applies a retraction the agent staged during the wake', () async {
+          stubLedger(
+            ProposalLedger(
+              open: [openEntry(proposal)],
+              resolved: const [],
+              pendingSets: [pendingSet(proposal)],
+            ),
+          );
+          when(
+            () => mockAgentRepository.getPendingChangeSets(
+              any(),
+              taskId: any(named: 'taskId'),
+            ),
+          ).thenAnswer((_) async => [pendingSet(proposal)]);
+          when(
+            () => mockAgentRepository.getEntity('set-previous'),
+          ).thenAnswer((_) async => pendingSet(proposal));
+
+          final captured = await runWake([
+            ChatCompletionMessageToolCall(
+              id: 'call-retract',
+              type: ChatCompletionMessageToolCallType.function,
+              function: ChatCompletionMessageFunctionCall(
+                name: ProjectAgentToolNames.retractSuggestions,
+                arguments: jsonEncode({
+                  'proposals': [
+                    {
+                      'fingerprint': ChangeItem.fingerprint(proposal),
+                      'reason': 'the user created this task by hand',
+                    },
+                  ],
+                }),
+              ),
+            ),
+          ]);
+
+          final decision = captured.whereType<ChangeDecisionEntity>().single;
+          expect(decision.verdict, ChangeDecisionVerdict.retracted);
+          expect(decision.actor, DecisionActor.agent);
+          expect(decision.retractionReason, contains('by hand'));
+          final rewritten = captured.whereType<ChangeSetEntity>().firstWhere(
+            (set) => set.id == 'set-previous',
+          );
+          expect(rewritten.items.single.status, ChangeItemStatus.retracted);
+        });
+
+        test(
+          'leaves a proposal the agent retracted and re-proposed open',
+          () async {
+            // Retract-then-re-add is churn: the row would vanish and reappear
+            // under the user's finger. The re-proposal is dropped as a duplicate
+            // and the original is left exactly where it was.
+            stubLedger(
+              ProposalLedger(
+                open: [openEntry(proposal)],
+                resolved: const [],
+                pendingSets: [pendingSet(proposal)],
+              ),
+            );
+            when(
+              () => mockAgentRepository.getPendingChangeSets(
+                any(),
+                taskId: any(named: 'taskId'),
+              ),
+            ).thenAnswer((_) async => [pendingSet(proposal)]);
+            when(
+              () => mockAgentRepository.getEntity('set-previous'),
+            ).thenAnswer((_) async => pendingSet(proposal));
+
+            final captured = await runWake([
+              ChatCompletionMessageToolCall(
+                id: 'call-retract',
+                type: ChatCompletionMessageToolCallType.function,
+                function: ChatCompletionMessageFunctionCall(
+                  name: ProjectAgentToolNames.retractSuggestions,
+                  arguments: jsonEncode({
+                    'proposals': [
+                      {
+                        'fingerprint': ChangeItem.fingerprint(proposal),
+                        'reason': 'superseded',
+                      },
+                    ],
+                  }),
+                ),
+              ),
+              createTaskCall('Define Launch Roadmap and Milestones'),
+            ]);
+
+            expect(captured.whereType<ChangeDecisionEntity>(), isEmpty);
+            expect(captured.whereType<ChangeSetEntity>(), isEmpty);
+          },
+        );
+
+        test(
+          'a ledger the database cannot produce does not fail the wake',
+          () async {
+            when(
+              () => mockAgentRepository.getProposalLedger(
+                any(),
+                taskId: any(named: 'taskId'),
+                changeSetFetchLimit: any(named: 'changeSetFetchLimit'),
+                resolvedLimit: any(named: 'resolvedLimit'),
+              ),
+            ).thenThrow(Exception('ledger read failed'));
+
+            final captured = await runWake([
+              createTaskCall('Define Launch Roadmap and Milestones'),
+            ]);
+
+            // Degraded, not dead: the guard is gone for this wake, the proposal
+            // is still written, and the report still lands.
+            expect(captured.whereType<ChangeSetEntity>(), hasLength(1));
+          },
+        );
+      });
     });
   });
 }

--- a/test/features/agents/workflow/project_proposal_reconciler_test.dart
+++ b/test/features/agents/workflow/project_proposal_reconciler_test.dart
@@ -1,0 +1,450 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/project_data.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/agents/model/proposal_ledger.dart';
+import 'package:lotti/features/agents/tools/project_tool_definitions.dart';
+import 'package:lotti/features/agents/workflow/project_proposal_reconciler.dart';
+
+/// The wake's clock. Fixed: nothing here reads a real one.
+final _now = DateTime(2026, 9, 9, 10);
+
+ProjectStatus _active() =>
+    ProjectStatus.active(id: 's-active', createdAt: _now, utcOffset: 0);
+
+ProjectStatus _onHold(String reason) => ProjectStatus.onHold(
+  id: 's-hold',
+  createdAt: _now,
+  utcOffset: 0,
+  reason: reason,
+);
+
+ChangeItem _statusItem(String status, {String summary = 'Update status'}) =>
+    ChangeItem(
+      toolName: ProjectAgentToolNames.updateProjectStatus,
+      args: {'status': status, 'reason': 'because'},
+      humanSummary: summary,
+    );
+
+ChangeItem _taskItem(String title) => ChangeItem(
+  toolName: ProjectAgentToolNames.createTask,
+  args: {'title': title},
+  humanSummary: 'Create task: $title',
+);
+
+LedgerEntry _entry(
+  ChangeItem item, {
+  ChangeItemStatus status = ChangeItemStatus.pending,
+  ChangeDecisionVerdict? verdict,
+}) => LedgerEntry(
+  changeSetId: 'set-1',
+  itemIndex: 0,
+  toolName: item.toolName,
+  args: item.args,
+  humanSummary: item.humanSummary,
+  fingerprint: ChangeItem.fingerprint(item),
+  status: status,
+  createdAt: _now,
+  verdict: verdict,
+);
+
+void main() {
+  group('projectStatusProposalIsRedundant', () {
+    test('is redundant when the canonical status matches the current one', () {
+      expect(
+        projectStatusProposalIsRedundant(
+          current: _active(),
+          args: {'status': 'active'},
+        ),
+        isTrue,
+      );
+    });
+
+    test('resolves aliases before comparing, so on_track means active', () {
+      // The exact shape of the reported bug: the agent proposed `on_track` on
+      // an already-active project, wake after wake.
+      expect(
+        projectStatusProposalIsRedundant(
+          current: _active(),
+          args: {'status': 'on_track', 'reason': 'All tasks progressing'},
+        ),
+        isTrue,
+      );
+    });
+
+    test('is not redundant when the status would actually change', () {
+      expect(
+        projectStatusProposalIsRedundant(
+          current: _active(),
+          args: {'status': 'completed'},
+        ),
+        isFalse,
+      );
+    });
+
+    test('is not redundant for a word outside the vocabulary', () {
+      // Invalid input belongs to the apply path, which explains what the
+      // vocabulary is. Swallowing it here would lose that feedback.
+      expect(
+        projectStatusProposalIsRedundant(
+          current: _active(),
+          args: {'status': 'vibing'},
+        ),
+        isFalse,
+      );
+    });
+
+    test('is not redundant when status is missing or not a string', () {
+      expect(
+        projectStatusProposalIsRedundant(current: _active(), args: {}),
+        isFalse,
+      );
+      expect(
+        projectStatusProposalIsRedundant(
+          current: _active(),
+          args: {'status': 7},
+        ),
+        isFalse,
+      );
+    });
+
+    test('on hold with the same reason is redundant', () {
+      expect(
+        projectStatusProposalIsRedundant(
+          current: _onHold('Waiting on legal'),
+          args: {'status': 'on_hold', 'reason': '  Waiting on legal  '},
+        ),
+        isTrue,
+      );
+    });
+
+    test('on hold with a new reason is a real change', () {
+      // The reason is user-facing text, so changing it changes what the user
+      // reads even though the status word is the same.
+      expect(
+        projectStatusProposalIsRedundant(
+          current: _onHold('Waiting on legal'),
+          args: {'status': 'on_hold', 'reason': 'Waiting on the supplier'},
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+      'on hold without a reason cannot change the reason, so is redundant',
+      () {
+        expect(
+          projectStatusProposalIsRedundant(
+            current: _onHold('Waiting on legal'),
+            args: {'status': 'on_hold'},
+          ),
+          isTrue,
+        );
+      },
+    );
+  });
+
+  group('normalizeProjectProposalArgs', () {
+    test('replaces a status alias with the status it means', () {
+      // `on_track` renders and applies as Active, so storing the alias made
+      // "Update project status to Active" compare as two different
+      // proposals and the band accumulated both.
+      expect(
+        normalizeProjectProposalArgs(
+          ProjectAgentToolNames.updateProjectStatus,
+          {'status': 'on_track', 'reason': 'progressing'},
+        ),
+        {'status': 'active', 'reason': 'progressing'},
+      );
+    });
+
+    test('normalizes case, spaces and hyphens through the alias table', () {
+      for (final raw in ['ON HOLD', 'on-hold', ' Blocked ']) {
+        expect(
+          normalizeProjectProposalArgs(
+            ProjectAgentToolNames.updateProjectStatus,
+            {'status': raw},
+          )['status'],
+          'on_hold',
+          reason: '$raw should normalize like the apply path does',
+        );
+      }
+    });
+
+    test('leaves a word outside the vocabulary verbatim', () {
+      // The apply path reports what the vocabulary is; swallowing the word
+      // here would lose that.
+      expect(
+        normalizeProjectProposalArgs(
+          ProjectAgentToolNames.updateProjectStatus,
+          {'status': 'vibing'},
+        ),
+        {'status': 'vibing'},
+      );
+    });
+
+    test('returns the same map when nothing needs changing', () {
+      final args = {'status': 'active'};
+      expect(
+        identical(
+          normalizeProjectProposalArgs(
+            ProjectAgentToolNames.updateProjectStatus,
+            args,
+          ),
+          args,
+        ),
+        isTrue,
+      );
+    });
+
+    test('leaves a non-string or missing status alone', () {
+      expect(
+        normalizeProjectProposalArgs(
+          ProjectAgentToolNames.updateProjectStatus,
+          {'status': 7},
+        ),
+        {'status': 7},
+      );
+      expect(
+        normalizeProjectProposalArgs(
+          ProjectAgentToolNames.updateProjectStatus,
+          const {},
+        ),
+        isEmpty,
+      );
+    });
+
+    test('leaves every other tool untouched', () {
+      final args = {'title': 'on_track'};
+      expect(
+        identical(
+          normalizeProjectProposalArgs(
+            ProjectAgentToolNames.createTask,
+            args,
+          ),
+          args,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('reconcileProjectProposals', () {
+    test('keeps everything when nothing is open', () {
+      final proposed = [_statusItem('completed'), _taskItem('Ship it')];
+      expect(
+        reconcileProjectProposals(
+          proposed: proposed,
+          ledger: const ProposalLedger.empty(),
+        ),
+        proposed,
+      );
+    });
+
+    test('drops a proposal identical to one already open', () {
+      final open = _statusItem('active');
+      final result = reconcileProjectProposals(
+        proposed: [open, _taskItem('Ship it')],
+        ledger: ProposalLedger(open: [_entry(open)], resolved: const []),
+      );
+      expect(result.map((item) => item.toolName), [
+        ProjectAgentToolNames.createTask,
+      ]);
+    });
+
+    test('drops a proposal that only reads identically to an open one', () {
+      // Different args, same rendered summary: the user would see two rows
+      // saying exactly the same thing.
+      final open = _statusItem('active', summary: 'Update project status');
+      const restated = ChangeItem(
+        toolName: ProjectAgentToolNames.updateProjectStatus,
+        args: {'status': 'active', 'reason': 'a different rationale'},
+        humanSummary: 'Update project status',
+      );
+      expect(
+        reconcileProjectProposals(
+          proposed: [restated],
+          ledger: ProposalLedger(open: [_entry(open)], resolved: const []),
+        ),
+        isEmpty,
+      );
+    });
+
+    test('drops a proposal the user already rejected', () {
+      final rejected = _taskItem('Write the launch roadmap');
+      expect(
+        reconcileProjectProposals(
+          proposed: [rejected],
+          ledger: ProposalLedger(
+            open: const [],
+            resolved: [
+              _entry(
+                rejected,
+                status: ChangeItemStatus.rejected,
+                verdict: ChangeDecisionVerdict.rejected,
+              ),
+            ],
+          ),
+        ),
+        isEmpty,
+      );
+    });
+
+    test(
+      'keeps a proposal the user confirmed — that one is done, not vetoed',
+      () {
+        final confirmed = _taskItem('Write the launch roadmap');
+        expect(
+          reconcileProjectProposals(
+            proposed: [confirmed],
+            ledger: ProposalLedger(
+              open: const [],
+              resolved: [
+                _entry(
+                  confirmed,
+                  status: ChangeItemStatus.confirmed,
+                  verdict: ChangeDecisionVerdict.confirmed,
+                ),
+              ],
+            ),
+          ),
+          hasLength(1),
+        );
+      },
+    );
+
+    test('collapses duplicates proposed twice inside one wake', () {
+      final item = _taskItem('Ship it');
+      expect(
+        reconcileProjectProposals(
+          proposed: [item, item],
+          ledger: const ProposalLedger.empty(),
+        ),
+        hasLength(1),
+      );
+    });
+
+    test('collapses same-wake proposals that render the same row', () {
+      // Same title, different optional args: different fingerprints, one
+      // rendered summary. Keeping both would let the user confirm each and
+      // create the task twice.
+      const first = ChangeItem(
+        toolName: ProjectAgentToolNames.createTask,
+        args: {'title': 'Ship it', 'description': 'the long way'},
+        humanSummary: 'Create task: Ship it',
+      );
+      const second = ChangeItem(
+        toolName: ProjectAgentToolNames.createTask,
+        args: {'title': 'Ship it', 'priority': 'HIGH'},
+        humanSummary: 'Create task: Ship it',
+      );
+      final result = reconcileProjectProposals(
+        proposed: [first, second],
+        ledger: const ProposalLedger.empty(),
+      );
+
+      expect(result, [first], reason: 'the first occurrence wins');
+    });
+
+    test('a status alias no longer survives as a second row', () {
+      // The end-to-end shape of the accumulation bug, once the args are
+      // normalized at the boundary: both spellings reduce to one proposal.
+      final open = _statusItem('active', summary: 'Update status to active');
+      final alias = ChangeItem(
+        toolName: ProjectAgentToolNames.updateProjectStatus,
+        args: normalizeProjectProposalArgs(
+          ProjectAgentToolNames.updateProjectStatus,
+          {'status': 'on_track', 'reason': 'because'},
+        ),
+        humanSummary: 'Update status to active',
+      );
+      expect(
+        reconcileProjectProposals(
+          proposed: [alias],
+          ledger: ProposalLedger(open: [_entry(open)], resolved: const []),
+        ),
+        isEmpty,
+      );
+    });
+
+    test('two on-hold proposals with different reasons both survive', () {
+      // The reason is user-facing and the apply path treats a new one as a
+      // real change, so normalization must not collapse them.
+      final first = ChangeItem(
+        toolName: ProjectAgentToolNames.updateProjectStatus,
+        args: normalizeProjectProposalArgs(
+          ProjectAgentToolNames.updateProjectStatus,
+          {'status': 'blocked', 'reason': 'waiting on legal'},
+        ),
+        humanSummary: 'Put on hold: waiting on legal',
+      );
+      final second = ChangeItem(
+        toolName: ProjectAgentToolNames.updateProjectStatus,
+        args: normalizeProjectProposalArgs(
+          ProjectAgentToolNames.updateProjectStatus,
+          {'status': 'on_hold', 'reason': 'waiting on the supplier'},
+        ),
+        humanSummary: 'Put on hold: waiting on the supplier',
+      );
+      expect(
+        reconcileProjectProposals(
+          proposed: [second],
+          ledger: ProposalLedger(open: [_entry(first)], resolved: const []),
+        ),
+        [second],
+      );
+    });
+
+    test('preserves the order of what survives', () {
+      final open = _statusItem('active');
+      final first = _taskItem('First');
+      final second = _taskItem('Second');
+      final result = reconcileProjectProposals(
+        proposed: [first, open, second],
+        ledger: ProposalLedger(open: [_entry(open)], resolved: const []),
+      );
+      expect(
+        result.map((item) => item.args['title']),
+        ['First', 'Second'],
+      );
+    });
+
+    test('an empty proposal list is returned untouched', () {
+      expect(
+        reconcileProjectProposals(
+          proposed: const [],
+          ledger: const ProposalLedger.empty(),
+        ),
+        isEmpty,
+      );
+    });
+  });
+
+  group('canonicalProjectStatusOf', () {
+    test('round-trips every status through the alias table', () {
+      // The two tables must agree, or the redundancy check silently never
+      // fires for whichever status they disagree on.
+      final statuses = <ProjectStatus>[
+        ProjectStatus.open(id: 'o', createdAt: _now, utcOffset: 0),
+        _active(),
+        ProjectStatus.monitoring(id: 'm', createdAt: _now, utcOffset: 0),
+        _onHold('reason'),
+        ProjectStatus.completed(id: 'c', createdAt: _now, utcOffset: 0),
+        ProjectStatus.archived(id: 'a', createdAt: _now, utcOffset: 0),
+      ];
+      for (final status in statuses) {
+        final canonical = canonicalProjectStatusOf(status);
+        expect(
+          canonicalProjectStatus(canonical),
+          canonical,
+          reason: '$canonical is not a value the wire vocabulary accepts',
+        );
+      }
+      expect(
+        statuses.map(canonicalProjectStatusOf).toSet(),
+        hasLength(statuses.length),
+        reason: 'two statuses must never share a canonical value',
+      );
+    });
+  });
+}

--- a/test/features/onboarding/services/onboarding_capture_to_task_service_test.dart
+++ b/test/features/onboarding/services/onboarding_capture_to_task_service_test.dart
@@ -816,10 +816,16 @@ void main() {
     late MockPersistenceLogic wiredPersistence;
     late MockOnboardingMetricsRepository wiredMetrics;
 
-    setUp(() {
+    setUp(() async {
       wiredStructuring = MockOnboardingTaskStructuringService();
       wiredPersistence = MockPersistenceLogic();
       wiredMetrics = MockOnboardingMetricsRepository();
+      // Reset first: these are bare registrations, so anything a preceding
+      // file in the same shard left behind makes them throw
+      // "already registered". Shard membership shifts whenever a test file is
+      // added anywhere in the suite, so relying on an empty GetIt here is an
+      // ordering dependency that fails at a distance.
+      await getIt.reset();
       // The provider resolves PersistenceLogic and the metrics repo from getIt,
       // with no explicit clock.
       getIt

--- a/test/features/projects/ui/pages/projects_manual_screenshots_test.dart
+++ b/test/features/projects/ui/pages/projects_manual_screenshots_test.dart
@@ -12,6 +12,7 @@
 library;
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -45,12 +46,16 @@ import 'package:lotti/features/projects/ui/pages/project_details_page.dart';
 import 'package:lotti/features/projects/ui/pages/projects_tab_page.dart';
 import 'package:lotti/features/projects/ui/widgets/project_create_modal.dart';
 import 'package:lotti/features/projects/ui/widgets/project_mobile_detail_content.dart';
+import 'package:lotti/features/tasks/ui/cover_art_thumbnail.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/themes/legacy_material_bridge.dart';
+import 'package:lotti/widgets/media/thumb_hash_image.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -64,6 +69,13 @@ import '../../test_utils.dart';
 
 const _subdir = 'projects';
 const _projectWaddleId = 'project-waddle';
+
+/// The covers worn by the three tasks linked to Project Waddle.
+final Set<String> _taskCoverIds = {
+  manualHabitatCoverImageId,
+  manualFishFeederCoverImageId,
+  manualSardineCargoCoverImageId,
+};
 String _t(String en, String de) => manualScreenshotText(en: en, de: de);
 
 final AiConfigModel _manualProjectAgentModel = manualDemoAiModels.firstWhere(
@@ -178,9 +190,26 @@ void main() {
   late List<ProjectRecord> records;
   late List<ProjectCategoryGroup> groups;
   late ValueNotifier<String?> selectedProjectId;
+  late Directory documentsDirectory;
 
   setUp(() async {
     world = ManualDemoWorld.penguinLogistics();
+    // The project task list draws each task's cover art, so this suite needs
+    // the catalog pixels on disk the way the tasks and day-plan suites do.
+    documentsDirectory = Directory.systemTemp.createTempSync(
+      'lotti-manual-projects-',
+    );
+    // Only the three covers the project's tasks show: installing, transcoding
+    // and priming the whole catalog runs once per case and doubled the suite.
+    // Transcoded to PNG because the headless engine can leave a resized WebP
+    // decode pending forever, which is what an empty cover square is.
+    await transcodeManualDemoMediaToPng(
+      await installManualDemoMedia(
+        world,
+        documentsDirectory,
+        images: _taskCoverIds.map(world.coverImageById),
+      ),
+    );
     final missionControl = CategoryTestUtils.createTestCategory(
       id: 'manual-mission-control',
       name: _t('Mission Control', 'Missionskontrolle'),
@@ -473,6 +502,10 @@ void main() {
     final navService = MockNavService();
     final userActivityService = MockUserActivityService();
     final entitiesCache = MockEntitiesCacheService();
+    final editorStateService = MockEditorStateService();
+    when(
+      () => editorStateService.getUnsavedStream(any(), any()),
+    ).thenAnswer((_) => const Stream.empty());
 
     when(userActivityService.updateActivity).thenReturn(null);
     when(() => navService.desktopSelectedProjectId).thenReturn(
@@ -491,19 +524,36 @@ void main() {
       },
     );
 
-    await setUpTestGetIt(
+    final mocks = await setUpTestGetIt(
       additionalSetup: () {
         getIt
+          ..registerSingleton<Directory>(documentsDirectory)
+          ..registerSingleton<EditorStateService>(editorStateService)
+          ..registerSingleton<PersistenceLogic>(MockPersistenceLogic())
           ..registerSingleton<NavService>(navService)
           ..registerSingleton<UserActivityService>(userActivityService)
           ..registerSingleton<EntitiesCacheService>(entitiesCache);
       },
     );
+    // The task rows resolve their cover art through `EntryController`, which
+    // reads the image entry out of the journal.
+    when(
+      () => mocks.journalDb.journalEntityById(any()),
+    ).thenAnswer((invocation) async {
+      final id = invocation.positionalArguments.first as String;
+      // A full event-loop turn, the way a real Drift lookup crosses a timer
+      // boundary — controllers that chain on this only settle correctly then.
+      await Future<void>.delayed(Duration.zero);
+      return world.entityById(id);
+    });
   });
 
   tearDown(() async {
     selectedProjectId.dispose();
     await tearDownTestGetIt();
+    if (documentsDirectory.existsSync()) {
+      documentsDirectory.deleteSync(recursive: true);
+    }
   });
 
   List<Override> overrides() => [
@@ -555,6 +605,16 @@ void main() {
     String? selectedId,
   }) async {
     applyScreenshotDevice(tester, device);
+    // Seeded before the first frame so the cover squares paint the same
+    // bitmap every run; the headless engine can otherwise leave a resized
+    // decode pending forever.
+    await primeManualDemoCoverArt(
+      tester,
+      documentsDirectory: documentsDirectory,
+      world: world,
+      imageIds: _taskCoverIds,
+      extents: const [48, 96, 144, 216],
+    );
     selectedProjectId.value = selectedId;
     final platform = device.isPhone
         ? TargetPlatform.android
@@ -692,6 +752,28 @@ void main() {
           ),
           findsOneWidget,
         );
+        // The three linked tasks carry catalog cover art, and the capture is
+        // only evidence of the thumbnails if their pictures actually painted.
+        expect(find.byType(CoverArtThumbnail), findsNWidgets(3));
+        expect(
+          tester
+              .widgetList<CoverArtThumbnail>(find.byType(CoverArtThumbnail))
+              .map((thumbnail) => thumbnail.imageId)
+              .toSet(),
+          _taskCoverIds,
+        );
+        // Each square cross-fades its ThumbHash stand-in into the real file,
+        // so both are in the tree; the capture is only evidence once the
+        // artwork itself has resolved.
+        final painted = tester
+            .widgetList<Image>(
+              find.descendant(
+                of: find.byType(CoverArtThumbnail),
+                matching: find.byType(Image),
+              ),
+            )
+            .where((image) => image.image is! ThumbHashImage);
+        expect(painted, hasLength(3));
         await captureScreenshot(
           tester,
           'projects_tasks_${viewport}_$theme',

--- a/test/features/projects/ui/widgets/project_header_title_row_test.dart
+++ b/test/features/projects/ui/widgets/project_header_title_row_test.dart
@@ -1,0 +1,353 @@
+// Every geometry argument is stated even when it matches a default: the
+// numbers are what the assertions below are about.
+// ignore_for_file: avoid_redundant_argument_values
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/projects/ui/widgets/project_header_title_row.dart';
+import 'package:material_ui/material_ui.dart';
+
+import '../../../../widget_test_utils.dart';
+
+/// A stand-in for the real action rail: the same fixed 48 pt tap target the
+/// overflow menu is, without pulling a menu into a layout test.
+const _railSize = 48.0;
+const _titleHeight = 30.0;
+
+void main() {
+  Future<void> pump(
+    WidgetTester tester, {
+    double width = 400,
+    double railWidth = _railSize,
+    double gap = 8,
+    double lift = 4,
+    TextDirection direction = TextDirection.ltr,
+    Widget? title,
+  }) async {
+    await tester.pumpWidget(
+      makeTestableWidget2(
+        Directionality(
+          textDirection: direction,
+          child: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              width: width,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ProjectHeaderTitleRow(
+                    gap: gap,
+                    lift: lift,
+                    title:
+                        title ??
+                        const SizedBox(
+                          key: Key('title'),
+                          height: _titleHeight,
+                          width: 120,
+                        ),
+                    actions: SizedBox(
+                      key: const Key('actions'),
+                      height: _railSize,
+                      width: railWidth,
+                    ),
+                  ),
+                  const SizedBox(key: Key('below'), height: 10),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  group('ProjectHeaderTitleRow', () {
+    testWidgets('is exactly as tall as its title, not its action rail', (
+      tester,
+    ) async {
+      // The regression this layout exists for: a `Row` would be 48 pt tall
+      // and open an empty toolbar band under the project title.
+      await pump(tester);
+      expect(
+        tester.getSize(find.byType(ProjectHeaderTitleRow)).height,
+        _titleHeight,
+      );
+    });
+
+    testWidgets('the content below starts right under the title', (
+      tester,
+    ) async {
+      await pump(tester);
+      expect(
+        tester.getTopLeft(find.byKey(const Key('below'))).dy -
+            tester.getTopLeft(find.byKey(const Key('title'))).dy,
+        _titleHeight,
+      );
+    });
+
+    testWidgets('pins the rail to the trailing corner, lifted', (
+      tester,
+    ) async {
+      await pump(tester, width: 400, lift: 4);
+      final row = tester.getRect(find.byType(ProjectHeaderTitleRow));
+      final actions = tester.getRect(find.byKey(const Key('actions')));
+      expect(actions.right, row.right);
+      expect(actions.top, row.top - 4);
+    });
+
+    testWidgets('mirrors both slots under right-to-left text', (tester) async {
+      await pump(tester, direction: TextDirection.rtl);
+      final row = tester.getRect(find.byType(ProjectHeaderTitleRow));
+      expect(tester.getRect(find.byKey(const Key('actions'))).left, row.left);
+      expect(tester.getRect(find.byKey(const Key('title'))).right, row.right);
+    });
+
+    testWidgets('leaves the title the width the rail and gap do not take', (
+      tester,
+    ) async {
+      // A title that would fill any width it is given, so the constraint it
+      // received is what its rendered width reports.
+      await pump(
+        tester,
+        width: 400,
+        railWidth: 100,
+        gap: 8,
+        title: const SizedBox(
+          key: Key('title'),
+          height: _titleHeight,
+          width: double.infinity,
+        ),
+      );
+      expect(
+        tester.getSize(find.byKey(const Key('title'))).width,
+        400 - 100 - 8,
+      );
+    });
+
+    testWidgets('a rail wider than the row is bounded, not overflowed', (
+      tester,
+    ) async {
+      // Clamped rather than negative, and the rail is laid out against the
+      // header's own constraints, so it cannot paint past the right edge.
+      await pump(
+        tester,
+        width: 60,
+        railWidth: 100,
+        title: const SizedBox(
+          key: Key('title'),
+          height: _titleHeight,
+          width: double.infinity,
+        ),
+      );
+
+      expect(tester.getSize(find.byKey(const Key('title'))).width, 0);
+      final row = tester.getRect(find.byType(ProjectHeaderTitleRow));
+      final actions = tester.getRect(find.byKey(const Key('actions')));
+      expect(actions.width, lessThanOrEqualTo(row.width));
+      expect(actions.left, greaterThanOrEqualTo(row.left));
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('an unbounded width falls back to both natural widths', (
+      tester,
+    ) async {
+      // A horizontally scrolling host offers infinite width; the header must
+      // size to what its two children actually want.
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: ProjectHeaderTitleRow(
+              gap: 8,
+              lift: 4,
+              title: const SizedBox(
+                key: Key('title'),
+                height: _titleHeight,
+                width: 120,
+              ),
+              actions: const SizedBox(
+                key: Key('actions'),
+                height: _railSize,
+                width: _railSize,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        tester.getSize(find.byType(ProjectHeaderTitleRow)).width,
+        120 + 8 + _railSize,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets("reports intrinsics: both widths, the title's height", (
+      tester,
+    ) async {
+      await pump(tester, width: 400, railWidth: 60, gap: 8);
+      final render = tester.renderObject<RenderProjectHeaderTitleRow>(
+        find.byType(ProjectHeaderTitleRow),
+      );
+
+      expect(render.getMinIntrinsicWidth(double.infinity), 120 + 8 + 60);
+      expect(render.getMaxIntrinsicWidth(double.infinity), 120 + 8 + 60);
+      expect(
+        render.getMinIntrinsicHeight(400),
+        _titleHeight,
+        reason: "the rail must not raise the header's intrinsic height",
+      );
+      expect(render.getMaxIntrinsicHeight(400), _titleHeight);
+    });
+
+    testWidgets('a dry layout matches the layout it performs', (tester) async {
+      await pump(tester, width: 400, railWidth: 60, gap: 8);
+      final render = tester.renderObject<RenderProjectHeaderTitleRow>(
+        find.byType(ProjectHeaderTitleRow),
+      );
+
+      expect(
+        render.getDryLayout(const BoxConstraints(maxWidth: 400)),
+        render.size,
+      );
+    });
+
+    testWidgets('re-laying out on changed gap, lift and direction', (
+      tester,
+    ) async {
+      await pump(tester, gap: 8, lift: 4);
+      final first = tester.getRect(find.byKey(const Key('actions')));
+
+      // Same values: the setters short-circuit and nothing moves.
+      await pump(tester, gap: 8, lift: 4);
+      expect(tester.getRect(find.byKey(const Key('actions'))), first);
+
+      await pump(tester, gap: 20, lift: 10);
+      expect(tester.getRect(find.byKey(const Key('actions'))).top, -10);
+
+      await pump(tester, gap: 20, lift: 10, direction: TextDirection.rtl);
+      expect(
+        tester.getRect(find.byKey(const Key('actions'))).left,
+        tester.getRect(find.byType(ProjectHeaderTitleRow)).left,
+      );
+    });
+
+    testWidgets('the whole rail is tappable, overhang included', (
+      tester,
+    ) async {
+      // The rail hangs below a title-height header, the way it does under the
+      // real header's `Column`. Without the hit-test override the header's own
+      // bounds would swallow that overhang and leave a 48 pt control with a
+      // ~26 pt target.
+      var taps = 0;
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          Align(
+            alignment: Alignment.topLeft,
+            // Inset, so the lifted top of the rail is still on screen.
+            child: Padding(
+              padding: const EdgeInsets.only(top: 20),
+              child: SizedBox(
+                width: 400,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ProjectHeaderTitleRow(
+                      gap: 8,
+                      lift: 4,
+                      title: const SizedBox(height: _titleHeight, width: 120),
+                      actions: GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onTap: () => taps++,
+                        child: const SizedBox(
+                          key: Key('actions'),
+                          height: _railSize,
+                          width: _railSize,
+                        ),
+                      ),
+                    ),
+                    // The metadata band the header sits above.
+                    const SizedBox(height: 40),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final actions = tester.getRect(find.byKey(const Key('actions')));
+      final row = tester.getRect(find.byType(ProjectHeaderTitleRow));
+      expect(
+        actions.bottom,
+        greaterThan(row.bottom),
+        reason: 'the fixture must actually overhang, or this proves nothing',
+      );
+
+      await tester.tapAt(Offset(actions.center.dx, row.top + 2));
+      expect(taps, 1, reason: 'inside the header band');
+
+      await tester.tapAt(actions.center);
+      expect(taps, 2, reason: 'below the header already');
+
+      await tester.tapAt(Offset(actions.center.dx, actions.bottom - 2));
+      expect(taps, 3, reason: 'the bottom edge, well below the header');
+    });
+
+    testWidgets('a pointer beside the rail is not claimed by the header', (
+      tester,
+    ) async {
+      // The override must not turn the whole band under the header into a
+      // catch-all: only the rail's own rectangle is claimed.
+      var railTaps = 0;
+      var belowTaps = 0;
+      await tester.pumpWidget(
+        makeTestableWidget2(
+          Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              width: 400,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ProjectHeaderTitleRow(
+                    gap: 8,
+                    lift: 4,
+                    title: const SizedBox(height: _titleHeight, width: 120),
+                    actions: GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: () => railTaps++,
+                      child: const SizedBox(
+                        key: Key('actions'),
+                        height: _railSize,
+                        width: _railSize,
+                      ),
+                    ),
+                  ),
+                  GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: () => belowTaps++,
+                    child: const SizedBox(
+                      key: Key('below'),
+                      height: 40,
+                      width: double.infinity,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final actions = tester.getRect(find.byKey(const Key('actions')));
+      await tester.tapAt(Offset(actions.left - 20, actions.bottom - 2));
+
+      expect(railTaps, 0);
+      expect(belowTaps, 1);
+    });
+  });
+}

--- a/test/features/projects/ui/widgets/project_mobile_detail_content_test.dart
+++ b/test/features/projects/ui/widgets/project_mobile_detail_content_test.dart
@@ -180,6 +180,134 @@ void main() {
       );
     });
 
+    group('Explore project', () {
+      testWidgets('sits in the title row, at the trailing edge', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          wrap(
+            ProjectMobileDetailContent(
+              record: makeTestProjectRecord(),
+              currentTime: DateTime(2026, 3, 28, 1, 18),
+              onOpenPlaza: () {},
+              onEdit: () {},
+            ),
+            size: const Size(1200, 900),
+          ),
+        );
+        await tester.pump();
+
+        final explore = tester.getRect(
+          find.widgetWithText(DesignSystemButton, 'Explore project'),
+        );
+        final title = tester.getRect(find.text('Test Project'));
+        final menu = tester.getRect(find.byType(DesignSystemContextMenuButton));
+
+        expect(
+          explore.center.dy,
+          closeTo(title.center.dy, title.height),
+          reason: 'it shares the title row rather than a band beneath it',
+        );
+        expect(
+          explore.left,
+          greaterThan(title.right),
+          reason: 'it sits after the title, not under it',
+        );
+        expect(
+          explore.right,
+          lessThanOrEqualTo(menu.left),
+          reason: 'the overflow menu stays the outermost control',
+        );
+      });
+
+      testWidgets('drops its label on a narrow pane', (tester) async {
+        // The surface itself, not just the MediaQuery: the header decides
+        // from the width it is actually laid out in.
+        tester.view.physicalSize = const Size(430, 900);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+        await tester.pumpWidget(
+          wrap(
+            ProjectMobileDetailContent(
+              record: makeTestProjectRecord(),
+              currentTime: DateTime(2026, 3, 28, 1, 18),
+              onOpenPlaza: () {},
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Explore project'), findsNothing);
+        expect(
+          find.byIcon(LottiIcons.map),
+          findsOneWidget,
+          reason: 'the glyph carries the action when the label will not fit',
+        );
+      });
+
+      testWidgets('drops its label at large text on a wide pane', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          wrap(
+            ProjectMobileDetailContent(
+              record: makeTestProjectRecord(),
+              currentTime: DateTime(2026, 3, 28, 1, 18),
+              onOpenPlaza: () {},
+            ),
+            size: const Size(1200, 900),
+            textScaler: const TextScaler.linear(
+              ProjectMobileDetailContent.largeTextScale,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Explore project'), findsNothing);
+        expect(find.byIcon(LottiIcons.map), findsOneWidget);
+      });
+
+      testWidgets('is absent when the host offers no plaza', (tester) async {
+        await tester.pumpWidget(
+          wrap(
+            ProjectMobileDetailContent(
+              record: makeTestProjectRecord(),
+              currentTime: DateTime(2026, 3, 28, 1, 18),
+            ),
+            size: const Size(1200, 900),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Explore project'), findsNothing);
+        expect(find.byIcon(LottiIcons.map), findsNothing);
+      });
+
+      testWidgets('keeps the metadata close to the title', (tester) async {
+        // The same guard the lone overflow menu has: adding a control to the
+        // title row must not open an empty band above the status pills.
+        await tester.pumpWidget(
+          wrap(
+            ProjectMobileDetailContent(
+              record: makeTestProjectRecord(),
+              currentTime: DateTime(2026, 3, 28, 1, 18),
+              onOpenPlaza: () {},
+              onEdit: () {},
+            ),
+            size: const Size(1200, 900),
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          tester.getTopLeft(find.text('Open')).dy -
+              tester.getTopLeft(find.text('Test Project')).dy,
+          lessThan(48),
+        );
+      });
+    });
+
     testWidgets('hides the overflow menu while an inline save runs', (
       tester,
     ) async {

--- a/test/features/projects/ui/widgets/project_mobile_detail_content_test.dart
+++ b/test/features/projects/ui/widgets/project_mobile_detail_content_test.dart
@@ -20,6 +20,7 @@ import 'package:lotti/features/projects/state/project_health_metrics.dart';
 import 'package:lotti/features/projects/ui/model/project_list_detail_models.dart';
 import 'package:lotti/features/projects/ui/model/project_task_list_options.dart';
 import 'package:lotti/features/projects/ui/widgets/project_agent_summary_card.dart';
+import 'package:lotti/features/projects/ui/widgets/project_header_title_row.dart';
 import 'package:lotti/features/projects/ui/widgets/project_mobile_detail_content.dart';
 import 'package:lotti/features/projects/ui/widgets/project_task_list_options_sheet.dart';
 import 'package:lotti/features/projects/ui/widgets/project_tasks_panel.dart';
@@ -282,6 +283,54 @@ void main() {
 
         expect(find.text('Explore project'), findsNothing);
         expect(find.byIcon(LottiIcons.map), findsNothing);
+      });
+
+      testWidgets('no metadata pill sits under the action rail', (
+        tester,
+      ) async {
+        // A single-line title leaves the header shorter than the 48 pt rail,
+        // so the rail hangs into the band the status pills occupy. The pills
+        // are laid out after the header, so a pill that reached under the
+        // rail would win the pointer — the rail's own hit-test override only
+        // claims what nothing later covers. They are left-aligned and the
+        // rail is right-aligned, and this pins that they stay apart.
+        tester.view.physicalSize = const Size(430, 1400);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+        await tester.pumpWidget(
+          wrap(
+            ProjectMobileDetailContent(
+              record: makeTestProjectRecord(
+                project: makeTestProject(title: 'Ab'),
+              ),
+              currentTime: DateTime(2026, 3, 28, 1, 18),
+              onOpenPlaza: () {},
+              onEdit: () {},
+              onStatusTap: () {},
+              onTargetDateTap: () {},
+              onCategoryTap: () {},
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final rail = tester.getRect(find.byType(DesignSystemContextMenuButton));
+        final header = tester.getRect(find.byType(ProjectHeaderTitleRow));
+        expect(
+          rail.bottom,
+          greaterThan(header.bottom),
+          reason: 'the fixture must overhang, or this pins nothing',
+        );
+
+        for (final pill in tester.widgetList<DsPill>(find.byType(DsPill))) {
+          final rect = tester.getRect(find.byWidget(pill));
+          expect(
+            rect.overlaps(rail),
+            isFalse,
+            reason: '"${pill.label}" reaches under the action rail',
+          );
+        }
       });
 
       testWidgets('keeps the metadata close to the title', (tester) async {

--- a/test/features/projects/ui/widgets/project_tasks_panel_test.dart
+++ b/test/features/projects/ui/widgets/project_tasks_panel_test.dart
@@ -1,5 +1,6 @@
 import 'package:clock/clock.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
@@ -14,8 +15,11 @@ import 'package:lotti/features/projects/ui/widgets/project_task_list_options_she
 import 'package:lotti/features/projects/ui/widgets/project_tasks_panel.dart';
 import 'package:lotti/features/projects/ui/widgets/shared_tag_widgets.dart';
 import 'package:lotti/features/projects/ui/widgets/showcase/showcase_palette.dart';
+import 'package:lotti/features/tasks/ui/cover_art_thumbnail.dart';
 import 'package:material_ui/material_ui.dart';
 
+import '../../../../helpers/fake_entry_controller.dart';
+import '../../../../helpers/journal_image_fixtures.dart';
 import '../../../../test_utils/material_ui_finders.dart';
 import '../../../../widget_test_utils.dart';
 import '../../test_utils.dart';
@@ -282,6 +286,120 @@ void main() {
       expect(backgroundRect.right, rowRect.right);
       expect(backgroundRect.top, lessThan(rowRect.top));
       expect(backgroundRect.bottom, greaterThan(rowRect.bottom));
+    });
+
+    group('cover art', () {
+      final image = buildJournalImage();
+
+      /// A task summary carrying [coverArtId], since the shared factory
+      /// builds plain tasks.
+      TaskSummary withCoverArt(String? coverArtId, {double cropX = 0.5}) {
+        final task = makeTestTask(id: 't1', title: 'Build feature');
+        return makeTestTaskSummary(
+          task: task.copyWith(
+            data: task.data.copyWith(
+              coverArtId: coverArtId,
+              coverArtCropX: cropX,
+            ),
+          ),
+          oneLiner: 'Implementation phase done, release next',
+        );
+      }
+
+      Future<void> pumpRow(WidgetTester tester, TaskSummary summary) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [createEntryControllerOverride(image)],
+            child: wrap(TaskSummaryRow(summary: summary)),
+          ),
+        );
+        await tester.pump();
+      }
+
+      testWidgets('renders the task cover art with its stored crop', (
+        tester,
+      ) async {
+        await pumpRow(tester, withCoverArt('image-1', cropX: 0.25));
+
+        final thumbnail = tester.widget<CoverArtThumbnail>(
+          find.byType(CoverArtThumbnail),
+        );
+        expect(thumbnail.imageId, 'image-1');
+        expect(
+          thumbnail.cropX,
+          0.25,
+          reason: 'the row must honour the crop the user chose on the task',
+        );
+      });
+
+      testWidgets('draws no thumbnail when the task has no cover art', (
+        tester,
+      ) async {
+        await pumpRow(tester, withCoverArt(null));
+        expect(find.byType(CoverArtThumbnail), findsNothing);
+      });
+
+      testWidgets('treats a blank cover art id as no cover art', (
+        tester,
+      ) async {
+        // Sync and import have both been seen leaving whitespace behind; a
+        // blank id resolves to nothing and would reserve an empty square.
+        await pumpRow(tester, withCoverArt('   '));
+        expect(find.byType(CoverArtThumbnail), findsNothing);
+      });
+
+      testWidgets('the thumbnail is a square that leads the row', (
+        tester,
+      ) async {
+        await pumpRow(tester, withCoverArt('image-1'));
+
+        final thumbRect = tester.getRect(find.byType(CoverArtThumbnail));
+        final titleRect = tester.getRect(find.text('Build feature'));
+        expect(thumbRect.width, thumbRect.height);
+        expect(
+          thumbRect.right,
+          lessThanOrEqualTo(titleRect.left),
+          reason: 'the thumbnail leads the text, never overlaps it',
+        );
+        expect(
+          thumbRect.top,
+          closeTo(titleRect.top, thumbRect.height),
+          reason: 'the thumbnail aligns with the title, not the row centre',
+        );
+      });
+
+      testWidgets('the text column gives up exactly the thumbnail width', (
+        tester,
+      ) async {
+        await pumpRow(tester, withCoverArt(null));
+        final withoutArt = tester.getRect(find.text('Build feature')).left;
+
+        await pumpRow(tester, withCoverArt('image-1'));
+        final withArt = tester.getRect(find.text('Build feature')).left;
+        final thumbRect = tester.getRect(find.byType(CoverArtThumbnail));
+
+        expect(
+          withArt - withoutArt,
+          closeTo(thumbRect.width + 12, 0.5),
+          reason:
+              'the text starts after the square plus one spacing step — the '
+              'row gives the thumbnail real space rather than overlapping',
+        );
+        expect(tester.takeException(), isNull);
+      });
+
+      testWidgets('the thumbnail takes its size from the spacing scale', (
+        tester,
+      ) async {
+        // Same square as the day planner's agenda card, so a task is the
+        // same size wherever it is listed.
+        await pumpRow(tester, withCoverArt('image-1'));
+        final tokens = DesignSystemTheme.dark().extension<DsTokens>()!;
+        expect(
+          tester.getRect(find.byType(CoverArtThumbnail)).width,
+          tokens.spacing.step9,
+        );
+      });
     });
   });
 


### PR DESCRIPTION
Three changes to the project detail surface and the project agent behind it.

## Task cover art in the project task list

A task with a picture was recognisable everywhere except inside its own
project, where the list was text only. `TaskSummaryRow` now leads with the same
`CoverArtThumbnail` square the day planner's agenda card draws — `spacing.step9`,
the crop stored on the task — so a picture identifies a task the same way in a
project as in the tasks list. `projectTaskCoverArtId` decides: a missing **or
blank** `coverArtId` reserves nothing and leaves the row exactly the width it had.

## The agent's proposals no longer accumulate

A pending `ChangeSet` outlives the wake that wrote it — it sits in **Proposed
changes** until the user decides it. Wakes were blind to that and wrote a fresh
set every time, so a project the agent believed should be Active collected
"Update project status to Active" over and over. The report that prompted this
carried **thirteen** of them, none of which the agent could take back.

Three guards, deliberately separate, because each catches a different mistake:

| Guard | Where | Catches |
|---|---|---|
| `projectStatusProposalIsRedundant` | `ProjectAgentStrategy`, at the tool call | a status the project already has — applying it is a no-op, and the model is told so **inside** the wake rather than losing the call silently |
| `reconcileProjectProposals` | `project_agent_execute.dart`, at persist time | a proposal matching one still open (by structural fingerprint **or** rendered summary), one the user already rejected, and a duplicate proposed twice in one wake |
| `retract_suggestions` | `SuggestionRetractionService`, shared with the task agent | one the *agent* judges stale — the project moved on, the user did it by hand |

The first two are deterministic and hold whatever the model does. The third
needs the model to know what is open, so the wake reads
`getProposalLedger(agentId, taskId: projectId)` before the conversation and
renders an **Open Proposal Guard** — one line per open proposal carrying the
`fp=…` fingerprint `retract_suggestions` addresses it by — as the last block of
the user message. The tool is **withheld when nothing is open**, so an agent
with nothing to withdraw cannot hallucinate a fingerprint. A ledger read that
fails is non-fatal: the wake runs without the guard rather than not at all.

`canonicalProjectStatusOf` reverses the existing `canonicalProjectStatus` alias
table, so `on_track` is recognised as the `active` the project already is.
`on_hold` also compares its reason, which is user-facing text: the same reason
is redundant, a new one is a real change.

Retractions are **staged, not written**, while the conversation runs, and
applied inside the wake's persistence transaction alongside the proposals that
replace them — the band never reads empty between a withdrawal and its
replacement. A fingerprint the agent retracts *and* re-proposes in the same wake
is skipped: the re-proposal has already been dropped as a duplicate, so applying
the retraction would make a stable row vanish and reappear under the user's finger.

## Explore project moved into the title row

It sat in a band of its own under the title, pushing the description and the
report down the page. A plain `Row` would have made the header as tall as the
48 pt overflow menu and reopened the "empty toolbar row" the header has always
avoided (there is a test guarding exactly that), so `ProjectHeaderTitleRow` is a
small render object that sizes the header to its **title** and lays the action
rail out in the trailing corner, where the overflow menu already hung. The
action drops to its map glyph on a narrow pane or at large text.

## Before / after

Captured with the shared harness from the penguin demo world; `before/` comes
from a `main` worktree running the **same** harness, so the pair differs only by
`lib/`.

| Surface | Before | After |
|---|---|---|
| Project tasks · phone dark — thumbnails | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d068167199fd4386dcf6c4280433fe2aeb0baa03/pr-screenshots/project-task-thumbnails-proposal-retraction/before/projects_tasks_mobile_dark.png" width="300"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d068167199fd4386dcf6c4280433fe2aeb0baa03/pr-screenshots/project-task-thumbnails-proposal-retraction/after/projects_tasks_mobile_dark.png" width="300"> |
| Project tasks · phone light | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d068167199fd4386dcf6c4280433fe2aeb0baa03/pr-screenshots/project-task-thumbnails-proposal-retraction/before/projects_tasks_mobile_light.png" width="300"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d068167199fd4386dcf6c4280433fe2aeb0baa03/pr-screenshots/project-task-thumbnails-proposal-retraction/after/projects_tasks_mobile_light.png" width="300"> |
| Project tasks · desktop dark | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d068167199fd4386dcf6c4280433fe2aeb0baa03/pr-screenshots/project-task-thumbnails-proposal-retraction/before/projects_tasks_desktop_dark.png" width="480"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d068167199fd4386dcf6c4280433fe2aeb0baa03/pr-screenshots/project-task-thumbnails-proposal-retraction/after/projects_tasks_desktop_dark.png" width="480"> |
| Project tasks · desktop light | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d068167199fd4386dcf6c4280433fe2aeb0baa03/pr-screenshots/project-task-thumbnails-proposal-retraction/before/projects_tasks_desktop_light.png" width="480"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d068167199fd4386dcf6c4280433fe2aeb0baa03/pr-screenshots/project-task-thumbnails-proposal-retraction/after/projects_tasks_desktop_light.png" width="480"> |
| Project detail · desktop — Explore project moves into the title corner | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d068167199fd4386dcf6c4280433fe2aeb0baa03/pr-screenshots/project-task-thumbnails-proposal-retraction/before/projects_detail_desktop_dark.png" width="480"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d068167199fd4386dcf6c4280433fe2aeb0baa03/pr-screenshots/project-task-thumbnails-proposal-retraction/after/projects_detail_desktop_dark.png" width="480"> |
| Project detail · phone | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d068167199fd4386dcf6c4280433fe2aeb0baa03/pr-screenshots/project-task-thumbnails-proposal-retraction/before/projects_detail_mobile_dark.png" width="300"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d068167199fd4386dcf6c4280433fe2aeb0baa03/pr-screenshots/project-task-thumbnails-proposal-retraction/after/projects_detail_mobile_dark.png" width="300"> |

The capture suite now installs and primes the demo cover art, and each tasks
case asserts that three squares resolved their **file** image rather than
stopping at the ThumbHash stand-in — otherwise the screenshot is not evidence
of anything.

## Tests

100 % line coverage on every file this branch adds or changes, with one
exception: the `default:` arm of `_buildHumanSummary`, which is unreachable
(the only deferred tool that is not `update_project_status` or `create_task` is
filtered out before it) and which `main` does not cover either.

Every new regression test was re-run **with its fix reverted** and fails there:
the dedup (4 failures), the redundancy refusal (1), the thumbnail (4) and the
Explore project placement (3).

- `project_proposal_reconciler_test.dart` — the two pure rules, including the
  `on_track`→`active` alias, the on-hold reason, sticky rejections, and that a
  *confirmed* proposal is not vetoed.
- `project_agent_strategy_test.dart` — the refusal and its message; staging,
  `not_found`, repeat fingerprints, malformed entries, mixed valid/invalid, and
  that **nothing** is written at tool-call time.
- `project_agent_workflow_test.dart` — end to end: a new proposal is written, an
  open or rejected one is not, the *other* proposals of the same wake still are,
  the tool is gated on open proposals, a staged retraction lands as a
  `ChangeDecisionEntity` with the item flipped, churn is left alone, and a
  failed ledger read still writes the proposal.
- `project_header_title_row_test.dart` — the header stays title-height, the rail
  is in the corner, RTL mirrors, the title gets the width that is left, a
  pathological rail does not throw, intrinsics and dry layout agree.

One existing test changed: `builds default human summary for unknown deferred
tool` proposed `on_track` on an already-active fixture project, which is now
refused. It proposes `monitoring` instead and keeps its assertion; the name was
already wrong for what it did.

Docs: `lib/features/projects/README.md`, `knowledge/features/projects.md` and
`knowledge/features/agents/project-and-event-agents.md` (new *Proposals do not
accumulate* section with a state diagram). `make okf_check`,
`make knowledge_check` and `make changelog_check` pass; analyzer is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gKHVRnjRJQ746Ufnn8Aiz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project task lists now display each task’s cover-art thumbnail when available.
  * The Explore project action now appears beside the project title and switches to a map icon on narrow layouts or with larger text.
  * Project agents can withdraw stale suggestions and avoid repeating proposals already awaiting a decision.

* **Bug Fixes**
  * Duplicate and redundant project proposals are now filtered out, including proposals matching the current project status or visible changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->