### PR TITLE
fix: play and transcribe each task recording independently

### DIFF
--- a/changelog.d/2026-09-09-audio-plays-wrong-recording.md
+++ b/changelog.d/2026-09-09-audio-plays-wrong-recording.md
@@ -1,0 +1,15 @@
+### Fixed
+- **A second recording added to a task played the first one instead of
+  itself.** Once one voice note in a task had been played through, every
+  recording tapped after it started the earlier one's audio — the card lit up
+  as the one you had picked, but the wrong recording came out of it, and
+  transcribing from that card handed the model the wrong audio too. The only
+  way around it was to start a fresh task for every recording. Selecting a
+  recording and starting playback are now a single ordered step, so each one
+  plays and transcribes on its own.
+- **Importing a recording could overwrite one already in the journal.**
+  Dropped audio was filed under a name derived purely from its timestamp, and
+  a name that was merely *close* to Lotti's own — `…-203 2.m4a`, or a copy —
+  was read as that exact timestamp. Two such files landed on one path, the
+  second silently replacing the first while the first entry kept pointing at
+  it. Imports now keep every recording as its own file.

--- a/knowledge/features/speech/overview.md
+++ b/knowledge/features/speech/overview.md
@@ -11,7 +11,7 @@ sources:
   - id: src
     resource: ../../../lib/features/speech
     title: Speech feature source
-    last_modified: 2026-08-05
+    last_modified: 2026-09-09
   - id: vu
     resource: ../../../lib/features/speech/state/vu_meter.dart
     title: VuMeter — sliding-window RMS→VU
@@ -162,6 +162,46 @@ subscribes to `media_kit` position, buffer and completion streams.
 
 Because it is app-wide, starting a recording pauses active playback rather than
 letting the two compete for the output device.
+
+## One player, one queue
+
+There is a single `media_kit.Player` behind every audio card on screen, so the
+controller **serializes every player-mutating call** — `playAudioNote`,
+`setAudioNote`, `play`, `pause`, `seek`, `setSpeed` — onto one queue. Each
+operation observes the finished state of the one before it; none of them can
+interleave across an `await` and issue `open`/`play` in an order neither chose.
+
+`playAudioNote(note)` is **the** entry point for "play this recording": it
+queues selection and playback as one operation. Calling `setAudioNote` and then
+`play` as two separate un-awaited calls is what made a second recording in a
+task play the first one — `play` ran while `setAudioNote` was still resolving
+the new path, took its reopen branch against the not-yet-replaced
+`state.audioNote`, and re-opened the previous file on top of the new one.
+
+Teardown does not go through that queue: the completion timer and provider
+disposal dispose the `Player` directly. A generation counter, bumped on every
+note change and every teardown, lets an operation suspended on an `await`
+detect that its player is gone and abandon the rest of its work rather than
+issue it against a disposed player.
+
+The states below are the **`media_kit.Player`'s** lifecycle — whether a native
+player exists and what it has loaded. They are not `AudioPlayerStatus`
+(`initializing`, `playing`, `paused`, `stopped`), which `AudioPlayerState`
+tracks separately and which the UI reads for its play/pause glyph.
+
+```mermaid
+stateDiagram-v2
+  [*] --> NoPlayer: build()
+  NoPlayer --> Opening: playAudioNote / setAudioNote — _ensurePlayer + open
+  Opening --> Loaded: open completed, generation unchanged
+  Opening --> NoPlayer: superseded — teardown won the race
+  Loaded --> Playing: play()
+  Playing --> Paused: pause()
+  Paused --> Playing: play() — media still loaded
+  Playing --> NoPlayer: completed → completion timer tears the Player down
+  Loaded --> Opening: playAudioNote(other note)
+  NoPlayer --> Opening: play() reopens state.audioNote
+```
 
 Waveforms are extracted by `AudioWaveformService` and exposed through
 `audioWaveformProvider`, which caches them so scrubbing does not re-analyse the

--- a/lib/features/speech/README.md
+++ b/lib/features/speech/README.md
@@ -17,7 +17,8 @@ check-in.
   agent is woken.
 - **Plays recordings back properly.** Progress, playback speed, and a waveform to
   scrub through — with one player for the whole app, so a recording never plays
-  over another.
+  over another, and each recording in a task plays and transcribes as itself
+  however many others sit beside it.
 - **Turns speech into text.** Transcription runs after the recording is saved,
   using whichever model the user configured, including local ones. There is no
   live "watch the words appear" mode — the recording is always saved first.

--- a/lib/features/speech/state/audio_player_controller.dart
+++ b/lib/features/speech/state/audio_player_controller.dart
@@ -18,6 +18,20 @@ class AudioPlayerConstants {
 
   /// Delay before updating progress when playback completes
   static const int completionDelayMs = 50;
+
+  /// How long a queued operation waits for the one ahead of it before giving
+  /// up on the [Player] they were both going to share.
+  ///
+  /// mpv can hang: `AudioMetadataExtractor.extractDuration` already bounds
+  /// its own `open` for that reason. Without a bound here a single stuck
+  /// call would wedge the queue for the rest of the session, taking `pause`,
+  /// `seek` and every later `play` down with it. Waiting it out is not an
+  /// option either — a Player stuck inside `open` will not play anything for
+  /// the next operation either, so running that operation against it would
+  /// only let the stuck native call land *after* the newer one and leave the
+  /// wrong recording loaded. The timeout therefore abandons the player rather
+  /// than sharing it; see [AudioPlayerController._abandonStuckPlayer].
+  static const Duration operationQueueTimeout = Duration(seconds: 10);
 }
 
 /// Factory function type for creating Player instances.
@@ -69,8 +83,85 @@ class AudioPlayerController extends Notifier<AudioPlayerState> {
   StreamSubscription<bool>? _completedSubscription;
   Timer? _completionTimer;
 
+  /// Tail of the queue every player-mutating operation runs on.
+  ///
+  /// The media_kit [Player] is a single shared device: two operations that
+  /// interleave across their `await`s issue their `open`/`play` calls in an
+  /// order neither of them chose. Chaining them makes each one observe the
+  /// finished state of the previous, so `play` can never act on the
+  /// half-applied result of a `setAudioNote` that is still in flight.
+  Future<void> _operationQueue = Future<void>.value();
+
+  /// Incremented whenever the selected note is replaced or the live [Player]
+  /// is torn down.
+  ///
+  /// An operation captures this on entry and compares it after every `await`
+  /// (see [_isSuperseded]): the completion timer and provider disposal both
+  /// tear the player down without going through [_operationQueue], so an
+  /// in-flight operation can find its player gone — or its note replaced —
+  /// halfway through, and must abandon its remaining work rather than issue
+  /// it against a disposed player or clobber a newer selection.
+  int _generation = 0;
+
   @visibleForTesting
   StreamSubscription<bool>? get completedSubscription => _completedSubscription;
+
+  /// Runs [operation] once every previously queued operation has settled, or
+  /// after [AudioPlayerConstants.operationQueueTimeout] if one of them hangs.
+  ///
+  /// The returned future carries [operation]'s own outcome. The queue tail is
+  /// a separate completer that is always finished normally, so one operation
+  /// failing reports to its own caller and cannot wedge every later request
+  /// behind an unhandled error.
+  ///
+  /// **Not re-entrant.** [operation] must call the private `_`-prefixed
+  /// bodies ([_setAudioNote], [_play], …), never the public wrappers: a
+  /// public method invoked from inside a running operation would wait on a
+  /// queue tail that only completes once that same operation returns, and
+  /// hang until the timeout above rescues it.
+  Future<void> _serialize(Future<void> Function() operation) async {
+    final previous = _operationQueue;
+    final stuckPlayer = _audioPlayer;
+    final finished = Completer<void>();
+    _operationQueue = finished.future;
+    await previous.timeout(
+      AudioPlayerConstants.operationQueueTimeout,
+      onTimeout: () => _abandonStuckPlayer(stuckPlayer),
+    );
+    try {
+      await operation();
+    } finally {
+      finished.complete();
+    }
+  }
+
+  /// Gives up on [player] after the operation holding it stopped responding.
+  ///
+  /// Disposing it — rather than handing it to the operation that has been
+  /// waiting — is what keeps the timeout from reintroducing the race this
+  /// queue exists to prevent: the stuck native call cannot be cancelled, so
+  /// sharing the instance would let it land after the newer `open` and leave
+  /// the wrong recording loaded. Teardown bumps the generation instead, so
+  /// every continuation of the stuck operation is superseded and returns
+  /// without touching anything, and the waiting operation builds itself a
+  /// fresh [Player] through [_ensurePlayer]. State (the selected note, the
+  /// position) survives, so playback resumes on the next tap.
+  ///
+  /// No-op once [player] is no longer the live instance: with several
+  /// operations queued behind one stuck call, each waits on its own timer, and
+  /// only the first to fire should act. The rest would otherwise tear down the
+  /// healthy player their predecessor just built.
+  void _abandonStuckPlayer(Player? player) {
+    if (player == null || !identical(_audioPlayer, player)) return;
+    _completionTimer?.cancel();
+    _completionTimer = null;
+    _tearDownActivePlayer();
+  }
+
+  /// Whether the work started at [generation] against [player] is still the
+  /// current work. Once it is not, the caller must stop touching the player.
+  bool _isSuperseded(int generation, Player player) =>
+      _generation != generation || !identical(_audioPlayer, player);
 
   @override
   AudioPlayerState build() {
@@ -156,6 +247,9 @@ class AudioPlayerController extends Notifier<AudioPlayerState> {
   void _tearDownActivePlayer() {
     final player = _audioPlayer;
     if (player == null) return;
+    // Any operation currently suspended on an await holds a reference to this
+    // player; bumping the generation is what tells it to stop.
+    _generation++;
     _positionSubscription?.cancel();
     _positionSubscription = null;
     _bufferSubscription?.cancel();
@@ -212,8 +306,28 @@ class AudioPlayerController extends Notifier<AudioPlayerState> {
     state = state.copyWith(buffered: clamped);
   }
 
+  /// Selects [audioNote] and starts playing it.
+  ///
+  /// Selection and playback are queued as a **single** operation. Calling
+  /// `setAudioNote(note)` and `play()` as two separate un-awaited calls is
+  /// what used to make a freshly opened note play the previous one: `play`
+  /// ran while `setAudioNote` was still suspended on its first `await`, read
+  /// the not-yet-replaced `state.audioNote`, and re-opened the old file
+  /// *after* `setAudioNote` had opened the new one. Every play-this-note
+  /// caller must go through here rather than sequencing the two by hand.
+  Future<void> playAudioNote(JournalAudio audioNote) => _serialize(() async {
+    await _setAudioNote(audioNote);
+    await _play();
+  });
+
   /// Sets the audio note to play and opens the media file.
-  Future<void> setAudioNote(JournalAudio audioNote) async {
+  Future<void> setAudioNote(JournalAudio audioNote) =>
+      _serialize(() => _setAudioNote(audioNote));
+
+  /// Starts or resumes playback.
+  Future<void> play() => _serialize(_play);
+
+  Future<void> _setAudioNote(JournalAudio audioNote) async {
     try {
       if (state.audioNote == audioNote && _hasOpenAudio) {
         return;
@@ -226,6 +340,7 @@ class AudioPlayerController extends Notifier<AudioPlayerState> {
       final player = _ensurePlayer();
       if (player == null) return;
 
+      final generation = ++_generation;
       final localPath = await AudioUtils.getFullAudioPath(audioNote);
       final newState = AudioPlayerState(
         status: AudioPlayerStatus.stopped,
@@ -234,6 +349,7 @@ class AudioPlayerController extends Notifier<AudioPlayerState> {
       );
       state = newState;
       await player.open(Media(localPath), play: false);
+      if (_isSuperseded(generation, player)) return;
       _hasOpenAudio = true;
       final totalDuration = player.state.duration;
       state = state.copyWith(totalDuration: totalDuration);
@@ -247,8 +363,7 @@ class AudioPlayerController extends Notifier<AudioPlayerState> {
     }
   }
 
-  /// Starts or resumes playback.
-  Future<void> play() async {
+  Future<void> _play() async {
     try {
       // If a completion-delay timer from the previous run is still pending
       // it would otherwise fire mid-replay, tearing down the freshly
@@ -259,6 +374,8 @@ class AudioPlayerController extends Notifier<AudioPlayerState> {
       final player = _ensurePlayer();
       if (player == null) return;
 
+      final generation = _generation;
+
       // After a completion-driven teardown the Player will have been
       // recreated above without any media loaded. Reopen the previously
       // selected audio note so the user can transparently replay.
@@ -267,6 +384,7 @@ class AudioPlayerController extends Notifier<AudioPlayerState> {
         if (audioNote != null) {
           final localPath = await AudioUtils.getFullAudioPath(audioNote);
           await player.open(Media(localPath), play: false);
+          if (_isSuperseded(generation, player)) return;
           _hasOpenAudio = true;
 
           // Sync total duration from the actual media file in case it
@@ -286,6 +404,7 @@ class AudioPlayerController extends Notifier<AudioPlayerState> {
       }
 
       await player.setRate(state.speed);
+      if (_isSuperseded(generation, player)) return;
       await player.play();
       state = state.copyWith(status: AudioPlayerStatus.playing);
     } catch (exception, stackTrace) {
@@ -299,32 +418,50 @@ class AudioPlayerController extends Notifier<AudioPlayerState> {
   }
 
   /// Seeks to the specified position.
-  Future<void> seek(Duration newPosition) async {
+  ///
+  /// The position bookkeeping needs no [Player], so it lands *before* the
+  /// queue: `setAudioNote` publishes the new note (making its card active,
+  /// and its waveform scrubbable) before `open` resolves, so a scrub started
+  /// in that window would otherwise leave the thumb pinned until the file
+  /// finished loading. Only the seek on the player itself is queued.
+  Future<void> seek(Duration newPosition) {
+    _recordSeekPosition(newPosition);
+    return _serialize(() => _seek(newPosition));
+  }
+
+  /// Applies a requested [newPosition] to state, and nothing else.
+  ///
+  /// This is also the only record of a seek that arrived while no file was
+  /// loaded: `play`'s reopen branch restores the position from here.
+  void _recordSeekPosition(Duration newPosition) {
+    final newBuffered = newPosition > state.buffered
+        ? newPosition
+        : state.buffered;
+
+    if (newPosition == state.progress &&
+        newPosition == state.pausedAt &&
+        newBuffered == state.buffered) {
+      return;
+    }
+    state = state.copyWith(
+      progress: newPosition,
+      pausedAt: newPosition,
+      buffered: newBuffered,
+    );
+  }
+
+  Future<void> _seek(Duration newPosition) async {
     try {
       final player = _ensurePlayer();
       if (player == null) return;
 
       // After a completion-driven teardown the Player has no media loaded
       // yet; calling player.seek before player.open is undefined. The
-      // requested position is still recorded in state and will be applied
+      // requested position is already recorded in state and will be applied
       // when play() reopens the file (see the reopen branch in play).
       if (_hasOpenAudio) {
         await player.seek(newPosition);
       }
-      final newBuffered = newPosition > state.buffered
-          ? newPosition
-          : state.buffered;
-
-      if (newPosition == state.progress &&
-          newPosition == state.pausedAt &&
-          newBuffered == state.buffered) {
-        return;
-      }
-      state = state.copyWith(
-        progress: newPosition,
-        pausedAt: newPosition,
-        buffered: newBuffered,
-      );
     } catch (exception, stackTrace) {
       _loggingService?.error(
         LogDomain.speech,
@@ -336,7 +473,9 @@ class AudioPlayerController extends Notifier<AudioPlayerState> {
   }
 
   /// Sets the playback speed.
-  Future<void> setSpeed(double speed) async {
+  Future<void> setSpeed(double speed) => _serialize(() => _setSpeed(speed));
+
+  Future<void> _setSpeed(double speed) async {
     try {
       final player = _ensurePlayer();
       if (player == null) return;
@@ -354,7 +493,9 @@ class AudioPlayerController extends Notifier<AudioPlayerState> {
   }
 
   /// Pauses playback.
-  Future<void> pause() async {
+  Future<void> pause() => _serialize(_pause);
+
+  Future<void> _pause() async {
     try {
       final player = _ensurePlayer();
       if (player == null) return;

--- a/lib/features/speech/ui/widgets/audio_player.dart
+++ b/lib/features/speech/ui/widgets/audio_player.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -110,9 +112,11 @@ class _PlayerBody extends StatelessWidget {
 
     void handleTap() {
       if (!isActive) {
-        controller
-          ..setAudioNote(journalAudio)
-          ..play();
+        // One queued operation, not two un-awaited calls: `play()` used to run
+        // while `setAudioNote()` was still resolving this entry's path, so it
+        // re-opened the *previously* selected recording and every card after
+        // the first played the first one's audio.
+        unawaited(controller.playAudioNote(journalAudio));
         return;
       }
 

--- a/lib/logic/audio_import.dart
+++ b/lib/logic/audio_import.dart
@@ -81,15 +81,22 @@ Future<void> importAudioXFiles(
         timestamp,
       );
       final directory = await createAssetDirectory(relativePath);
-      final targetFileName = AudioMetadataExtractor.computeTargetFileName(
-        timestamp,
-        fileExtension,
+      // Never reuse an occupied name: the copy below would overwrite an
+      // earlier recording that an existing journal entry still points at.
+      // The claim creates the file, so it is already this import's to clean
+      // up before the copy has written a single byte into it.
+      final targetFileName = AudioMetadataExtractor.claimAvailableFileName(
+        directory: directory,
+        preferredFileName: AudioMetadataExtractor.computeTargetFileName(
+          timestamp,
+          fileExtension,
+        ),
       );
       final targetFilePath = path.join(directory, targetFileName);
+      copiedFilePath = targetFilePath;
 
       // Copy file first
       await File(srcPath).copy(targetFilePath);
-      copiedFilePath = targetFilePath;
 
       // Extract audio duration
       var duration = Duration.zero;

--- a/lib/logic/media/audio_metadata_extractor.dart
+++ b/lib/logic/media/audio_metadata_extractor.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:lotti/features/speech/repository/audio_recorder_repository.dart';
 import 'package:lotti/get_it.dart';
 import 'package:media_kit/media_kit.dart';
+import 'package:path/path.dart' as p;
 
 /// Function type for reading audio duration from a file.
 typedef AudioMetadataReader = Future<Duration> Function(String filePath);
@@ -62,10 +63,18 @@ class AudioMetadataExtractor {
   /// Returns the parsed DateTime if successful, null otherwise.
   /// The parsed timestamp is converted to local time.
   ///
+  /// Parsing is **strict**: the whole name must be the timestamp. Lenient
+  /// parsing accepts trailing characters, so `…-203 2.m4a` and
+  /// `…-203-copy.m4a` both read back as the timestamp of `…-203.m4a` and
+  /// therefore compute the same storage path — three different recordings
+  /// overwriting one file. A name that is only *nearly* a Lotti timestamp is
+  /// not one, and falls back to the file's modification time instead.
+  ///
   /// Examples:
   /// - `2024-01-15_10-30-45-123.m4a` → DateTime(2024, 1, 15, 10, 30, 45, 123)
   /// - `invalid-format.m4a` → null
   /// - `2024-01-15.m4a` → null (missing time components)
+  /// - `2024-01-15_10-30-45-123 2.m4a` → null (trailing characters)
   static DateTime? parseFilenameTimestamp(String filename) {
     try {
       // Remove file extension before parsing
@@ -74,7 +83,7 @@ class AudioMetadataExtractor {
       // Try to parse using Lotti's audio filename format
       return DateFormat(
         AudioRecorderConstants.fileNameDateFormat,
-      ).parse(nameWithoutExtension, true).toLocal();
+      ).parseStrict(nameWithoutExtension, true).toLocal();
     } on FormatException {
       // Return null if parsing fails (expected for non-Lotti filenames)
       return null;
@@ -100,6 +109,65 @@ class AudioMetadataExtractor {
       AudioRecorderConstants.fileNameDateFormat,
     ).format(timestamp);
     return '$base.$extension';
+  }
+
+  /// Claims a free name under [directory], starting from [preferredFileName]
+  /// and appending `-1`, `-2`, … before the extension until one is taken.
+  ///
+  /// **Creates the file**, empty, as it claims it — the caller is expected to
+  /// write over it, and to delete it if the import then fails. Claiming is a
+  /// single atomic `create(exclusive: true)` rather than an existence check
+  /// followed by a copy, because two imports can overlap: duration extraction
+  /// holds each one open for seconds, which is more than enough for a second
+  /// drop to check the same name, find it free, and overwrite the first.
+  ///
+  /// Import target names are derived purely from the recording's timestamp,
+  /// so two distinct sources can compute the same name — two recorders that
+  /// stamped the same millisecond, or two files whose modification times
+  /// agree because they were unpacked from the same archive. Copying over an
+  /// occupied name destroys the earlier recording while its journal entry
+  /// keeps pointing at the path, so that entry silently starts playing (and
+  /// transcribing) the newer recording's audio.
+  ///
+  /// The loop terminates: every iteration probes a name no earlier iteration
+  /// probed, and a directory holds finitely many files.
+  static String claimAvailableFileName({
+    required String directory,
+    required String preferredFileName,
+  }) {
+    final extension = p.extension(preferredFileName);
+    final base = p.basenameWithoutExtension(preferredFileName);
+    var candidate = preferredFileName;
+    var suffix = 0;
+    while (!_claimFile(p.join(directory, candidate))) {
+      suffix++;
+      candidate = '$base-$suffix$extension';
+    }
+    return candidate;
+  }
+
+  /// Creates [path] and reports whether this caller is the one that made it.
+  /// `false` means the name was already taken.
+  ///
+  /// `createSync(exclusive: true)` raises the same [FileSystemException] for
+  /// an occupied name and for a failure that has nothing to do with the name
+  /// — a read-only or full volume, a missing or unwritable directory. Only
+  /// the first is a reason to try the next suffix; treating the rest as
+  /// "taken" would spin [claimAvailableFileName] forever on a failure that
+  /// repeats for every candidate, blocking the isolate outright. So anything
+  /// that did not leave a file behind is rethrown, and `importAudioXFiles`
+  /// logs it and moves on to the next file.
+  ///
+  /// This also keeps the loop finite: it only advances when the candidate
+  /// really does exist, and a directory holds finitely many entries.
+  static bool _claimFile(String path) {
+    try {
+      File(path).createSync(exclusive: true);
+      return true;
+    } on FileSystemException {
+      if (!File(path).existsSync()) rethrow;
+      return false;
+    }
   }
 
   /// Selects the appropriate audio metadata reader based on environment.

--- a/test/features/speech/state/audio_player_controller_test.dart
+++ b/test/features/speech/state/audio_player_controller_test.dart
@@ -11,6 +11,7 @@ import 'package:lotti/features/speech/model/audio_player_state.dart';
 import 'package:lotti/features/speech/state/audio_player_controller.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/domain_logging.dart';
+import 'package:media_kit/media_kit.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
@@ -1423,6 +1424,504 @@ void main() {
 
       // Verify player was disposed (via _cleanup → _disposeActivePlayer).
       verify(() => mockPlayer.dispose()).called(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Switching the selected note.
+  //
+  // The regression these cover: `setAudioNote` and `play` were issued as two
+  // un-awaited calls, so `play` ran while `setAudioNote` was still resolving
+  // the new note's path, took its "reopen after teardown" branch against the
+  // *previous* `state.audioNote`, and re-opened that file after the new one
+  // had already been opened. Every card after the first therefore played (and
+  // handed the transcriber) the first recording's audio.
+  //
+  // Each test records the exact `open`/`play` sequence the media_kit Player
+  // receives, because the media that is loaded when `play()` lands is the
+  // thing the user actually hears — state alone cannot show it.
+  // ---------------------------------------------------------------------
+  group('AudioPlayerController - switching between audio notes', () {
+    JournalAudio buildNote(String id, String file) => JournalAudio(
+      meta: Metadata(
+        id: id,
+        createdAt: DateTime(2024, 1, 15),
+        updatedAt: DateTime(2024, 1, 15),
+        dateFrom: DateTime(2024, 1, 15),
+        dateTo: DateTime(2024, 1, 15),
+      ),
+      data: AudioData(
+        audioFile: file,
+        audioDirectory: '/audio/2024-01-15/',
+        duration: const Duration(minutes: 3),
+        dateTo: DateTime(2024, 1, 15),
+        dateFrom: DateTime(2024, 1, 15),
+      ),
+    );
+
+    final audioOne = buildNote('audio-one-id', 'audio-one.m4a');
+    final audioTwo = buildNote('audio-two-id', 'audio-two.m4a');
+    final audioThree = buildNote('audio-three-id', 'audio-three.m4a');
+
+    late List<String> calls;
+    String? loaded;
+
+    setUp(() {
+      calls = <String>[];
+      loaded = null;
+      when(() => mockPlayer.open(any(), play: any(named: 'play'))).thenAnswer((
+        invocation,
+      ) async {
+        final media = invocation.positionalArguments.first as Media;
+        loaded = media.uri.split('/').last;
+        calls.add('open:$loaded');
+      });
+      when(() => mockPlayer.play()).thenAnswer((_) async {
+        calls.add('play:$loaded');
+      });
+    });
+
+    /// Runs the current note to its natural end so the controller's completion
+    /// handler tears the Player down — the state every following tap starts
+    /// from.
+    void completePlayback(FakeAsync async) {
+      completedController.add(true);
+      async
+        ..flushMicrotasks()
+        ..elapse(const Duration(milliseconds: 20));
+    }
+
+    test(
+      'a note played after an earlier one completed plays its own audio',
+      () {
+        fakeAsync((async) {
+          final controller = container.read(
+            audioPlayerControllerProvider.notifier,
+          )..completionDelayForTest = const Duration(milliseconds: 10);
+
+          controller.playAudioNote(audioOne);
+          async.flushMicrotasks();
+
+          completePlayback(async);
+
+          controller.playAudioNote(audioTwo);
+          async.flushMicrotasks();
+
+          expect(calls, [
+            'open:audio-one.m4a',
+            'play:audio-one.m4a',
+            'open:audio-two.m4a',
+            'play:audio-two.m4a',
+          ]);
+        });
+      },
+    );
+
+    test('a third note plays its own audio, not an earlier one', () {
+      fakeAsync((async) {
+        final controller = container.read(
+          audioPlayerControllerProvider.notifier,
+        )..completionDelayForTest = const Duration(milliseconds: 10);
+
+        controller.playAudioNote(audioOne);
+        async.flushMicrotasks();
+        completePlayback(async);
+
+        controller.playAudioNote(audioTwo);
+        async.flushMicrotasks();
+        completePlayback(async);
+
+        controller.playAudioNote(audioThree);
+        async.flushMicrotasks();
+
+        expect(calls.last, 'play:audio-three.m4a');
+        expect(calls.sublist(calls.length - 2), [
+          'open:audio-three.m4a',
+          'play:audio-three.m4a',
+        ]);
+      });
+    });
+
+    test('the note reported in state is the one the player loaded', () {
+      fakeAsync((async) {
+        final controller = container.read(
+          audioPlayerControllerProvider.notifier,
+        )..completionDelayForTest = const Duration(milliseconds: 10);
+
+        controller.playAudioNote(audioOne);
+        async.flushMicrotasks();
+        completePlayback(async);
+        controller.playAudioNote(audioTwo);
+        async.flushMicrotasks();
+
+        // The visible symptom was exactly this pair disagreeing: the card for
+        // audio two lit up as active while audio one was coming out.
+        expect(
+          container
+              .read(audioPlayerControllerProvider)
+              .audioNote
+              ?.data
+              .audioFile,
+          loaded,
+        );
+      });
+    });
+
+    test('replaying the already-loaded note does not reopen the file', () {
+      fakeAsync((async) {
+        final controller = container.read(
+          audioPlayerControllerProvider.notifier,
+        );
+
+        controller.playAudioNote(audioOne);
+        async.flushMicrotasks();
+        controller.playAudioNote(audioOne);
+        async.flushMicrotasks();
+
+        expect(calls, [
+          'open:audio-one.m4a',
+          'play:audio-one.m4a',
+          'play:audio-one.m4a',
+        ]);
+      });
+    });
+
+    test('a hand-sequenced setAudioNote + play pair is ordered correctly', () {
+      fakeAsync((async) {
+        // Not the call shape the widget uses any more, but the serialization
+        // has to hold for any caller that still sequences the two by hand —
+        // otherwise the same interleaving comes back through a new call site.
+        final controller = container.read(
+          audioPlayerControllerProvider.notifier,
+        )..completionDelayForTest = const Duration(milliseconds: 10);
+
+        controller.playAudioNote(audioOne);
+        async.flushMicrotasks();
+        completePlayback(async);
+
+        controller
+          ..setAudioNote(audioTwo)
+          ..play();
+        async.flushMicrotasks();
+
+        expect(calls.sublist(calls.length - 2), [
+          'open:audio-two.m4a',
+          'play:audio-two.m4a',
+        ]);
+      });
+    });
+  });
+
+  group('AudioPlayerController - operation serialization', () {
+    final audioNote = JournalAudio(
+      meta: Metadata(
+        id: 'queued-audio-id',
+        createdAt: DateTime(2024, 1, 15),
+        updatedAt: DateTime(2024, 1, 15),
+        dateFrom: DateTime(2024, 1, 15),
+        dateTo: DateTime(2024, 1, 15),
+      ),
+      data: AudioData(
+        audioFile: 'queued.m4a',
+        audioDirectory: '/audio/2024-01-15/',
+        duration: const Duration(minutes: 3),
+        dateTo: DateTime(2024, 1, 15),
+        dateFrom: DateTime(2024, 1, 15),
+      ),
+    );
+
+    test('a later operation waits for the one already in flight', () {
+      fakeAsync((async) {
+        final openGate = Completer<void>();
+        when(
+          () => mockPlayer.open(any(), play: any(named: 'play')),
+        ).thenAnswer((_) => openGate.future);
+
+        final controller = container.read(
+          audioPlayerControllerProvider.notifier,
+        )..setAudioNote(audioNote);
+        async.flushMicrotasks();
+
+        controller.setSpeed(2);
+        async.flushMicrotasks();
+
+        verifyNever(() => mockPlayer.setRate(2));
+
+        openGate.complete();
+        async.flushMicrotasks();
+
+        verify(() => mockPlayer.setRate(2)).called(1);
+        expect(container.read(audioPlayerControllerProvider).speed, 2);
+      });
+    });
+
+    test('operations queued behind each other all run, in call order', () {
+      fakeAsync((async) {
+        final order = <String>[];
+        when(
+          () => mockPlayer.open(any(), play: any(named: 'play')),
+        ).thenAnswer((_) async => order.add('open'));
+        when(
+          () => mockPlayer.play(),
+        ).thenAnswer((_) async => order.add('play'));
+        when(() => mockPlayer.pause()).thenAnswer((_) async {
+          order.add('pause');
+        });
+
+        container.read(audioPlayerControllerProvider.notifier)
+          ..setAudioNote(audioNote)
+          ..play()
+          ..pause();
+        async.flushMicrotasks();
+
+        expect(order, ['open', 'play', 'pause']);
+      });
+    });
+
+    test('a hung operation does not wedge the queue forever', () {
+      fakeAsync((async) {
+        // mpv can hang; without a bound on the wait, one stuck native call
+        // would take every later pause/seek/play down with it for the rest
+        // of the session.
+        when(
+          () => mockPlayer.open(any(), play: any(named: 'play')),
+        ).thenAnswer((_) => Completer<void>().future);
+
+        final controller = container.read(
+          audioPlayerControllerProvider.notifier,
+        )..setAudioNote(audioNote);
+        async.flushMicrotasks();
+
+        controller.pause();
+        async.flushMicrotasks();
+        verifyNever(() => mockPlayer.pause());
+
+        async.elapse(AudioPlayerConstants.operationQueueTimeout);
+
+        verify(() => mockPlayer.pause()).called(1);
+        expect(
+          container.read(audioPlayerControllerProvider).status,
+          AudioPlayerStatus.paused,
+        );
+      });
+    });
+
+    test('the stuck player is abandoned rather than shared with the next '
+        'operation', () {
+      fakeAsync((async) {
+        final stuckOpen = Completer<void>();
+        when(
+          () => mockPlayer.open(any(), play: any(named: 'play')),
+        ).thenAnswer((_) => stuckOpen.future);
+
+        final controller = container.read(
+          audioPlayerControllerProvider.notifier,
+        )..setAudioNote(audioNote);
+        async.flushMicrotasks();
+
+        controller.pause();
+        async.flushMicrotasks();
+        async.elapse(AudioPlayerConstants.operationQueueTimeout);
+
+        // A Player wedged inside open() will not play for the next operation
+        // either, so handing it over buys nothing and lets the stuck native
+        // call land after a newer open — the wrong-recording race again. It
+        // is disposed instead, and the waiter builds a fresh one.
+        verify(() => mockPlayer.dispose()).called(1);
+
+        // When the stuck call finally returns it must write nothing: the
+        // player's 5-minute duration never reaches state, which keeps the
+        // note's own 3-minute metadata.
+        stuckOpen.complete();
+        async.flushMicrotasks();
+        expect(
+          container.read(audioPlayerControllerProvider).totalDuration,
+          const Duration(minutes: 3),
+        );
+      });
+    });
+
+    test('a scrub lands in state before the queue drains', () {
+      fakeAsync((async) {
+        final openGate = Completer<void>();
+        when(
+          () => mockPlayer.open(any(), play: any(named: 'play')),
+        ).thenAnswer((_) => openGate.future);
+
+        final controller = container.read(
+          audioPlayerControllerProvider.notifier,
+        )..setAudioNote(audioNote);
+        async.flushMicrotasks();
+
+        controller.seek(const Duration(seconds: 42));
+        async.flushMicrotasks();
+
+        // setAudioNote publishes the note — and so makes the card active and
+        // its waveform scrubbable — before `open` resolves. Queueing the
+        // position bookkeeping too would pin the thumb until the file loaded.
+        expect(
+          container.read(audioPlayerControllerProvider).progress,
+          const Duration(seconds: 42),
+        );
+        verifyNever(() => mockPlayer.seek(any()));
+
+        openGate.complete();
+        async.flushMicrotasks();
+
+        // The call on the player itself still waits its turn.
+        verify(() => mockPlayer.seek(const Duration(seconds: 42))).called(1);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Teardown does not go through the operation queue: the completion timer
+  // (and provider disposal) can dispose the Player while an operation is
+  // suspended on an await. The generation guard is what stops that operation
+  // from finishing its work against a player that no longer exists.
+  // ---------------------------------------------------------------------
+  group('AudioPlayerController - superseded operations', () {
+    final audioNote = JournalAudio(
+      meta: Metadata(
+        id: 'superseded-audio-id',
+        createdAt: DateTime(2024, 1, 15),
+        updatedAt: DateTime(2024, 1, 15),
+        dateFrom: DateTime(2024, 1, 15),
+        dateTo: DateTime(2024, 1, 15),
+      ),
+      data: AudioData(
+        audioFile: 'superseded.m4a',
+        audioDirectory: '/audio/2024-01-15/',
+        duration: const Duration(minutes: 3),
+        dateTo: DateTime(2024, 1, 15),
+        dateFrom: DateTime(2024, 1, 15),
+      ),
+    );
+
+    /// Fires the completion handler and lets its delay elapse, which tears the
+    /// live Player down mid-operation.
+    void tearDownPlayerMidFlight(
+      FakeAsync async,
+      AudioPlayerController controller,
+    ) {
+      controller.handleCompletedForTest(isCompleted: true);
+      async.elapse(const Duration(milliseconds: 20));
+    }
+
+    test('setAudioNote abandons its open when the player is torn down', () {
+      fakeAsync((async) {
+        final openGate = Completer<void>();
+        when(
+          () => mockPlayer.open(any(), play: any(named: 'play')),
+        ).thenAnswer((_) => openGate.future);
+
+        final controller = container.read(
+          audioPlayerControllerProvider.notifier,
+        )..completionDelayForTest = const Duration(milliseconds: 10);
+
+        controller.setAudioNote(audioNote);
+        async.flushMicrotasks();
+
+        tearDownPlayerMidFlight(async, controller);
+        openGate.complete();
+        async.flushMicrotasks();
+
+        // The player's 5-minute duration must NOT be written back: that value
+        // came from a Player this operation no longer owns. The note's own
+        // 3-minute metadata stands.
+        expect(
+          container.read(audioPlayerControllerProvider).totalDuration,
+          const Duration(minutes: 3),
+        );
+      });
+    });
+
+    test('play abandons its reopen when the player is torn down', () {
+      fakeAsync((async) {
+        final openGate = Completer<void>();
+        when(
+          () => mockPlayer.open(any(), play: any(named: 'play')),
+        ).thenAnswer((_) => openGate.future);
+
+        final controller = container.read(
+          audioPlayerControllerProvider.notifier,
+        )..completionDelayForTest = const Duration(milliseconds: 10);
+        // The post-teardown shape play()'s reopen branch exists for: a note is
+        // selected but no file is loaded.
+        controller.stateForTest = AudioPlayerState(
+          status: AudioPlayerStatus.stopped,
+          totalDuration: const Duration(minutes: 3),
+          audioNote: audioNote,
+        );
+
+        controller.play();
+        async.flushMicrotasks();
+
+        tearDownPlayerMidFlight(async, controller);
+        openGate.complete();
+        async.flushMicrotasks();
+
+        verifyNever(() => mockPlayer.play());
+        expect(
+          container.read(audioPlayerControllerProvider).status,
+          isNot(AudioPlayerStatus.playing),
+        );
+      });
+    });
+
+    test(
+      'play does not start on a player torn down while setting the rate',
+      () {
+        fakeAsync((async) {
+          final rateGate = Completer<void>();
+          when(
+            () => mockPlayer.setRate(any()),
+          ).thenAnswer((_) => rateGate.future);
+
+          final controller =
+              container.read(
+                  audioPlayerControllerProvider.notifier,
+                )
+                ..completionDelayForTest = const Duration(milliseconds: 10)
+                ..hasOpenAudioForTest = true;
+          controller.stateForTest = AudioPlayerState(
+            status: AudioPlayerStatus.stopped,
+            totalDuration: const Duration(minutes: 3),
+            audioNote: audioNote,
+          );
+
+          controller.play();
+          async.flushMicrotasks();
+
+          tearDownPlayerMidFlight(async, controller);
+          rateGate.complete();
+          async.flushMicrotasks();
+
+          verifyNever(() => mockPlayer.play());
+          expect(
+            container.read(audioPlayerControllerProvider).status,
+            isNot(AudioPlayerStatus.playing),
+          );
+        });
+      },
+    );
+
+    test('an operation that keeps its player runs to completion', () {
+      fakeAsync((async) {
+        // The other side of the guard: with nothing tearing the player down,
+        // setAudioNote must still write the player-reported duration.
+        container
+            .read(audioPlayerControllerProvider.notifier)
+            .setAudioNote(
+              audioNote,
+            );
+        async.flushMicrotasks();
+
+        expect(
+          container.read(audioPlayerControllerProvider).totalDuration,
+          const Duration(minutes: 5),
+        );
+      });
     });
   });
 }

--- a/test/features/speech/ui/widgets/audio_player_widget_test.dart
+++ b/test/features/speech/ui/widgets/audio_player_widget_test.dart
@@ -46,9 +46,15 @@ class _FakeAudioPlayerController extends AudioPlayerController {
   Duration? lastSeekPosition;
   double? lastSpeedSet;
   JournalAudio? lastAudioNoteSet;
+  JournalAudio? lastPlayedAudioNote;
 
   @override
   AudioPlayerState build() => _state;
+
+  @override
+  Future<void> playAudioNote(JournalAudio audioNote) async {
+    lastPlayedAudioNote = audioNote;
+  }
 
   @override
   Future<void> play() async {
@@ -343,9 +349,36 @@ void main() {
     await tester.tap(find.bySemanticsLabel('Play audio'));
     await tester.pump();
 
-    expect(controller.lastAudioNoteSet?.meta.id, journalAudio.meta.id);
-    expect(controller.playWasCalled, isTrue);
+    expect(controller.lastPlayedAudioNote?.meta.id, journalAudio.meta.id);
   });
+
+  testWidgets(
+    'tapping play on an inactive card never sequences setAudioNote and play '
+    'as two separate calls',
+    (WidgetTester tester) async {
+      // The regression this guards: as two un-awaited calls, `play()` ran
+      // while `setAudioNote()` was still resolving the path, re-opened the
+      // previously selected recording and played *that* instead. The widget
+      // must hand the controller one atomic request.
+      final journalAudio = buildJournalAudio();
+      final state = buildState(
+        status: AudioPlayerStatus.stopped,
+        totalDuration: journalAudio.data.duration,
+        progress: Duration.zero,
+        pausedAt: Duration.zero,
+        speed: 1,
+      );
+
+      await pumpPlayer(tester, journalAudio: journalAudio, state: state);
+
+      await tester.tap(find.bySemanticsLabel('Play audio'));
+      await tester.pump();
+
+      expect(controller.lastAudioNoteSet, isNull);
+      expect(controller.playWasCalled, isFalse);
+      expect(controller.lastPlayedAudioNote, same(journalAudio));
+    },
+  );
 
   testWidgets('tapping pause button when playing calls pause', (
     WidgetTester tester,

--- a/test/logic/audio_import_test.dart
+++ b/test/logic/audio_import_test.dart
@@ -422,4 +422,158 @@ void main() {
       expect(captured.data.dateFrom, equals(expectedTimestamp));
     });
   });
+
+  group('importDroppedAudio target-name collisions', () {
+    /// Writes [content] into `<tempDir>/<sourceDir>/<name>` and returns it as
+    /// a droppable [XFile]. Two sources sharing [name] compute the same
+    /// timestamp, and therefore the same storage path.
+    Future<XFile> sourceNamed({
+      required String sourceDir,
+      required String name,
+      required String content,
+    }) async {
+      final file = File(path.join(tempDir.path, sourceDir, name));
+      await file.create(recursive: true);
+      await file.writeAsString(content);
+      return XFile(file.path);
+    }
+
+    List<JournalAudio> capturedEntries() => verify(
+      () => mockPersistenceLogic.createDbEntity(
+        captureAny(that: isA<JournalAudio>()),
+        linkedId: any(named: 'linkedId'),
+        shouldAddGeolocation: any(named: 'shouldAddGeolocation'),
+        enqueueSync: any(named: 'enqueueSync'),
+      ),
+    ).captured.cast<JournalAudio>();
+
+    File storedFileFor(JournalAudio entry) => File(
+      path.join(
+        tempDir.path,
+        entry.data.audioDirectory.replaceFirst('/', ''),
+        entry.data.audioFile,
+      ),
+    );
+
+    const sharedName = '2025-10-20_16-49-32-203.m4a';
+
+    test('a second source with the same timestamp gets its own file', () async {
+      await importAudioXFiles([
+        await sourceNamed(
+          sourceDir: 'first',
+          name: sharedName,
+          content: 'audio-one',
+        ),
+      ]);
+      await importAudioXFiles([
+        await sourceNamed(
+          sourceDir: 'second',
+          name: sharedName,
+          content: 'audio-two',
+        ),
+      ]);
+
+      final entries = capturedEntries();
+      expect(entries, hasLength(2));
+      expect(
+        entries[1].data.audioFile,
+        isNot(entries[0].data.audioFile),
+        reason: "the second import must not reuse the first entry's path",
+      );
+    });
+
+    test('the first recording survives a colliding second import', () async {
+      await importAudioXFiles([
+        await sourceNamed(
+          sourceDir: 'first',
+          name: sharedName,
+          content: 'audio-one',
+        ),
+      ]);
+      await importAudioXFiles([
+        await sourceNamed(
+          sourceDir: 'second',
+          name: sharedName,
+          content: 'audio-two',
+        ),
+      ]);
+
+      // The reported symptom, at the storage layer: before the fix the copy
+      // overwrote the first file, so entry one played (and transcribed) the
+      // second recording's audio.
+      final entries = capturedEntries();
+      expect(storedFileFor(entries[0]).readAsStringSync(), 'audio-one');
+      expect(storedFileFor(entries[1]).readAsStringSync(), 'audio-two');
+    });
+
+    test(
+      'a third colliding import is distinct from both earlier ones',
+      () async {
+        for (final content in ['audio-one', 'audio-two', 'audio-three']) {
+          await importAudioXFiles([
+            await sourceNamed(
+              sourceDir: content,
+              name: sharedName,
+              content: content,
+            ),
+          ]);
+        }
+
+        final entries = capturedEntries();
+        expect(entries.map((e) => e.data.audioFile).toSet(), hasLength(3));
+        expect(
+          entries.map((e) => storedFileFor(e).readAsStringSync()),
+          ['audio-one', 'audio-two', 'audio-three'],
+        );
+      },
+    );
+
+    test('a claimed name is cleaned up when the import fails', () async {
+      // The claim creates the file before the copy runs, so a failure between
+      // the two must not leave a zero-byte squatter blocking that name.
+      when(
+        () => mockPersistenceLogic.createDbEntity(
+          any(that: isA<JournalAudio>()),
+          linkedId: any(named: 'linkedId'),
+          shouldAddGeolocation: any(named: 'shouldAddGeolocation'),
+          enqueueSync: any(named: 'enqueueSync'),
+        ),
+      ).thenThrow(Exception('DB creation failed'));
+
+      await importAudioXFiles([
+        await sourceNamed(
+          sourceDir: 'first',
+          name: sharedName,
+          content: 'audio-one',
+        ),
+      ]);
+
+      final audioDir = Directory(path.join(tempDir.path, 'audio'));
+      expect(
+        audioDir.existsSync()
+            ? audioDir.listSync(recursive: true).whereType<File>().toList()
+            : <File>[],
+        isEmpty,
+      );
+    });
+
+    test('an uncontested import keeps the plain timestamp name', () async {
+      await importAudioXFiles([
+        await sourceNamed(
+          sourceDir: 'only',
+          name: sharedName,
+          content: 'audio-one',
+        ),
+      ]);
+
+      final entry = capturedEntries().single;
+      final timestamp = AudioMetadataExtractor.parseFilenameTimestamp(
+        sharedName,
+      )!;
+      expect(
+        entry.data.audioFile,
+        AudioMetadataExtractor.computeTargetFileName(timestamp, 'm4a'),
+      );
+    });
+  });
 }

--- a/test/logic/media/audio_metadata_extractor_test.dart
+++ b/test/logic/media/audio_metadata_extractor_test.dart
@@ -10,6 +10,7 @@ import 'package:lotti/logic/media/audio_metadata_extractor.dart';
 import 'package:lotti/utils/platform.dart' as lotti_platform;
 import 'package:media_kit/media_kit.dart';
 import 'package:mocktail/mocktail.dart' as mt;
+import 'package:path/path.dart' as p;
 
 import '../../helpers/fallbacks.dart';
 import '../../mocks/mocks.dart';
@@ -255,6 +256,214 @@ void main() {
           reason: '$scenario',
         );
       }, tags: 'glados');
+
+      // Lenient parsing accepted anything *after* a valid timestamp, so a
+      // duplicated or renamed export resolved to the timestamp of the file it
+      // was copied from — and therefore to that file's storage path, which
+      // the import then overwrote.
+      group('rejects names that only start with a Lotti timestamp', () {
+        test('returns null for a Finder-style " 2" duplicate suffix', () {
+          expect(
+            AudioMetadataExtractor.parseFilenameTimestamp(
+              '2024-01-15_10-30-45-123 2.m4a',
+            ),
+            isNull,
+          );
+        });
+
+        test('returns null for a "-copy" suffix', () {
+          expect(
+            AudioMetadataExtractor.parseFilenameTimestamp(
+              '2024-01-15_10-30-45-123-copy.m4a',
+            ),
+            isNull,
+          );
+        });
+
+        test('returns null for a numeric disambiguation suffix', () {
+          // The suffix claimAvailableFileName itself appends must not read
+          // back as a timestamp, or a re-import would collide all over again.
+          expect(
+            AudioMetadataExtractor.parseFilenameTimestamp(
+              '2024-01-15_10-30-45-123-1.m4a',
+            ),
+            isNull,
+          );
+        });
+
+        test('returns null for trailing whitespace', () {
+          expect(
+            AudioMetadataExtractor.parseFilenameTimestamp(
+              '2024-01-15_10-30-45-123 ',
+            ),
+            isNull,
+          );
+        });
+
+        test('still parses the exact recorder filename', () {
+          expect(
+            AudioMetadataExtractor.parseFilenameTimestamp(
+              '2024-01-15_10-30-45-123.m4a',
+            ),
+            isNotNull,
+          );
+        });
+      });
+
+      test('returns null for an out-of-range month', () {
+        expect(
+          AudioMetadataExtractor.parseFilenameTimestamp(
+            '2024-13-15_10-30-45-123.m4a',
+          ),
+          isNull,
+        );
+      });
+
+      test('returns null for an out-of-range day', () {
+        expect(
+          AudioMetadataExtractor.parseFilenameTimestamp(
+            '2024-02-30_10-30-45-123.m4a',
+          ),
+          isNull,
+        );
+      });
+    });
+
+    group('claimAvailableFileName', () {
+      late Directory dir;
+
+      setUp(() async {
+        dir = await Directory.systemTemp.createTemp('resolve_target_name_');
+      });
+
+      tearDown(() async {
+        if (dir.existsSync()) {
+          await dir.delete(recursive: true);
+        }
+      });
+
+      void occupy(String name) {
+        File(
+          '${dir.path}${Platform.pathSeparator}$name',
+        ).writeAsStringSync('x');
+      }
+
+      test('returns the preferred name when nothing occupies it', () {
+        expect(
+          AudioMetadataExtractor.claimAvailableFileName(
+            directory: dir.path,
+            preferredFileName: '2024-01-15_10-30-45-123.m4a',
+          ),
+          '2024-01-15_10-30-45-123.m4a',
+        );
+      });
+
+      test('appends -1 when the preferred name is taken', () {
+        occupy('2024-01-15_10-30-45-123.m4a');
+
+        expect(
+          AudioMetadataExtractor.claimAvailableFileName(
+            directory: dir.path,
+            preferredFileName: '2024-01-15_10-30-45-123.m4a',
+          ),
+          '2024-01-15_10-30-45-123-1.m4a',
+        );
+      });
+
+      test('walks past every taken suffix', () {
+        occupy('2024-01-15_10-30-45-123.m4a');
+        occupy('2024-01-15_10-30-45-123-1.m4a');
+        occupy('2024-01-15_10-30-45-123-2.m4a');
+
+        expect(
+          AudioMetadataExtractor.claimAvailableFileName(
+            directory: dir.path,
+            preferredFileName: '2024-01-15_10-30-45-123.m4a',
+          ),
+          '2024-01-15_10-30-45-123-3.m4a',
+        );
+      });
+
+      test('claims the name, so a second caller cannot be handed it', () {
+        // The check-then-act version returned the same free name to both
+        // callers; two imports overlapping (duration extraction holds each
+        // open for seconds) then copied over one another.
+        final first = AudioMetadataExtractor.claimAvailableFileName(
+          directory: dir.path,
+          preferredFileName: 'clash.m4a',
+        );
+        final second = AudioMetadataExtractor.claimAvailableFileName(
+          directory: dir.path,
+          preferredFileName: 'clash.m4a',
+        );
+
+        expect(first, 'clash.m4a');
+        expect(second, 'clash-1.m4a');
+      });
+
+      test('leaves the claimed name on disk for the caller to write over', () {
+        final claimed = AudioMetadataExtractor.claimAvailableFileName(
+          directory: dir.path,
+          preferredFileName: 'claimed.m4a',
+        );
+
+        final file = File('${dir.path}${Platform.pathSeparator}$claimed');
+        expect(file.existsSync(), isTrue);
+        expect(file.lengthSync(), 0);
+      });
+
+      test('keeps the extension on the end, not the suffix', () {
+        occupy('note.wav');
+
+        expect(
+          AudioMetadataExtractor.claimAvailableFileName(
+            directory: dir.path,
+            preferredFileName: 'note.wav',
+          ),
+          'note-1.wav',
+        );
+      });
+
+      test('handles a preferred name with no extension', () {
+        occupy('extensionless');
+
+        expect(
+          AudioMetadataExtractor.claimAvailableFileName(
+            directory: dir.path,
+            preferredFileName: 'extensionless',
+          ),
+          'extensionless-1',
+        );
+      });
+
+      // createSync(exclusive: true) raises the same exception for "name is
+      // taken" and for "this volume will not take any file at all". Treating
+      // the second as the first would advance the suffix, fail identically on
+      // every candidate, and spin the loop forever with the isolate blocked.
+      test('rethrows when the directory cannot hold a file at all', () {
+        expect(
+          () => AudioMetadataExtractor.claimAvailableFileName(
+            directory: p.join(dir.path, 'no', 'such', 'directory'),
+            preferredFileName: '2024-01-15_10-30-45-123.m4a',
+          ),
+          throwsA(isA<FileSystemException>()),
+        );
+      });
+
+      test('rethrows when a directory occupies the name', () {
+        // A directory where an audio file belongs is a corrupted asset store,
+        // not a naming collision — failing loudly beats quietly filing the
+        // recording under a suffixed name.
+        Directory(p.join(dir.path, 'blocked.m4a')).createSync();
+
+        expect(
+          () => AudioMetadataExtractor.claimAvailableFileName(
+            directory: dir.path,
+            preferredFileName: 'blocked.m4a',
+          ),
+          throwsA(isA<FileSystemException>()),
+        );
+      });
     });
 
     group('computeRelativePath', () {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed playback and transcription so each recording uses its own audio, including when switching between recordings.
  * Prevented imported recordings with matching timestamps from overwriting existing files.
  * Improved playback reliability by preserving operation order and safely stopping outdated actions.

* **Documentation**
  * Updated speech feature documentation to clarify recording playback behavior and audio player lifecycle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->