### PR TITLE
feat(plaza): walk the project world in daylight

### DIFF
--- a/changelog.d/2026-09-10-plaza-daylight.md
+++ b/changelog.d/2026-09-10-plaza-daylight.md
@@ -1,0 +1,18 @@
+### Added
+- **The project world can now be walked in daylight.** The district was built
+  for one hour of the day: a neon city at night, where a task's health was told
+  in lit windows, roof lanterns and pools of lamplight. A **Night | Day** switch
+  in the world's controls now rebuilds it under a clear mid-morning sky —
+  concrete and asphalt at their real colours, glass that mirrors the sky,
+  buildings and benches standing in their own shade — and the choice is
+  remembered the next time you go in. What each task is doing still reads: by
+  day the signs, the shutters, the hoardings and the flames over an overdue
+  job carry it instead of the lights.
+
+### Changed
+- **Explore category moved into the category header.** In the Projects list the
+  way into a category's world was a button on a row of its own under every
+  category, repeated down the pane, and it disappeared whenever the category was
+  folded. It now sits in the header's trailing corner beside the fold control,
+  where the list's other row actions are, and stays reachable when the category
+  is closed.

--- a/docs/plaza/HANDOVER.md
+++ b/docs/plaza/HANDOVER.md
@@ -16,6 +16,9 @@ same renderer and generator configuration as the app:
 fvm flutter run -d macos -t lib/features/plaza/dev_main.dart
 ```
 
+`PLAZA_DAY=1` boots it in daylight; the HUD's Night / Day toggle switches at
+any time.
+
 The macOS, Linux and Windows runners enable Flutter GPU at engine startup.
 The fixture can also be built without opening a window:
 
@@ -45,6 +48,7 @@ provide the GPU context needed to render the scene.
 | Escape | Close the demo panel and end the walk. |
 | Backtick | Toggle rendering diagnostics. |
 | Penguins / Meerkats checkboxes | Hide or show each species without moving the camera. |
+| Night / Day toggle | Rebuild the district under the other sky, keeping the camera where it stands. |
 
 Any manual movement exits the Morning walk. App task facades persist checklist
 edits and open the normal task details page; category facades enter their
@@ -75,6 +79,23 @@ captures and raster completion before announcing a settled stop. These images
 are useful for Linux geometry and UI review; frame times from a VM do not
 establish macOS GPU performance. Target-device runs still need a real display
 and should only be launched when a visible window is welcome.
+
+## Frame captures without a display server
+
+`PLAZA_SHOT_DIR` writes one PNG per settled tour stop from inside the harness,
+read back out of the widget tree rather than off the screen. It needs no X11, no
+window manager and no macOS screen-recording permission, and both skies are
+framed identically — which is what a before/after pair needs.
+
+```sh
+PLAZA_TOUR=1 PLAZA_TOUR_ONLY=home,overview,attention-closeup \
+  PLAZA_SHOT_DIR=/tmp/lotti-pr-screenshots/plaza/after \
+  build/macos/Build/Products/Debug/LottiDev.app/Contents/MacOS/LottiDev
+```
+
+On macOS the debug app is sandboxed: point `PLAZA_SHOT_DIR` inside its own
+container (`~/Library/Containers/com.matthiasn.lotti.dev/Data/...`) and copy the
+frames out, or the writes fail with `Operation not permitted`.
 
 ## Review captures
 
@@ -108,6 +129,13 @@ pacer. Compare the same build mode, fixture, display scale, viewport and frame
 cap, including the Penguins checkbox state. Penguins start hidden; enable them
 when comparing against older runs with companions on. Normal idle caps deliberately reduce FPS, so idle FPS is not a throughput
 measurement. `PLAZA_HIDE=fire,life` isolates the new animation layers.
+
+Switching the sky throws the scene away and builds a new one — geometry,
+materials and a second set of wall textures — the same path the layout knobs
+take, but reachable from the shipped HUD rather than only from the debug
+overlay. `flutter_scene` exposes no explicit teardown for geometry or textures,
+so if you are chasing memory growth, toggling Night / Day repeatedly is the
+path to watch.
 
 The integration's measurement record and hardware limitations are kept in
 [the implementation notes](../implementation_plans/2026-09-07_plaza_integration.md).

--- a/knowledge/features/plaza.md
+++ b/knowledge/features/plaza.md
@@ -104,6 +104,22 @@ sources:
   - id: traffic-tests
     resource: ../../test/features/plaza/domain/character_traffic_test.dart
     title: Crossings, mixed cadences, lookout clearance and reappearance
+  - id: palette
+    resource: ../../lib/features/plaza/ui/plaza_palette.dart
+    title: Sky, haze, surfaces and emitter behaviour per hour
+    last_modified: 2026-09-10
+  - id: sky-mode
+    resource: ../../lib/features/plaza/state/plaza_sky_mode_controller.dart
+    title: The remembered sky
+    last_modified: 2026-09-10
+  - id: wall-swap
+    resource: ../../lib/features/plaza/ui/plaza_wall_swap.dart
+    title: Which painted texture set to load, and when it settles
+    last_modified: 2026-09-10
+  - id: wall-ink
+    resource: ../../lib/features/plaza/scene/wall_textures.dart
+    title: Painted walls per hour, and the shadow mask
+    last_modified: 2026-09-10
   - id: penguin-model
     resource: ../../tool/plaza/build_penguin.py
     title: Original penguin mesh and skin generator
@@ -504,6 +520,74 @@ remain visible from altitude. Chase bulbs share a draw per lightbox.
 nearest-source budget in one instance buffer. Conservative bounds are reserved
 once, and distant sources fade out. The shared procedural texture forms flame
 tongues above overdue facades and billboards; no completed/cancelled item burns.
+
+# The hour the world is built under
+
+Every material in the scene is unlit: nothing is a light and nothing is lit.
+The hour is *painted*, and `PlazaPalette` is where it lives — sky, haze, bloom
+and vignette, every flat surface colour, the lantern set, how far emitters are
+pushed past white, and where the sun stands. `PlazaSceneController` holds one
+palette and reads every colour and atmospheric number from it. **No file under
+`scene/` keeps a colour constant of its own**: a value that is not in the
+palette cannot change with the sky, which is the defect the type exists to
+prevent. The one exception is signage — `PlazaStyle` — which keeps the night
+register in both skies, because a sign is a sign at noon.
+
+Night and day are separate palettes, not a blend, so a switch is a rebuild:
+`PlazaView` throws the scene away and builds it again under the new palette,
+keeping the camera pose. Materials are shared and immutable, so there is
+nothing to repaint in place; this is the same path the layout knobs use.
+
+Painted textures cannot be shared. The window and shopfront tiles are opaque —
+the texture *is* the wall — so each hour has its own set, painted from a
+`WallInk` and uploaded asynchronously. The set on screen stays until the new
+one lands, and a result that is no longer wanted (the locale moved on, or the
+walker switched back) is dropped rather than attached.
+
+`PlazaWallSwap` owns that decision — what is on the walls, what is on its way,
+and whether the set that just landed is still wanted — because a paint takes
+long enough for the walker to change their mind twice. Every load settles it,
+whether it was attached, dropped or thrown: a marker left standing would make
+its sky unloadable for the rest of the session, and the district would keep the
+other hour's windows with nothing scheduled to correct it. It is a plain object
+rather than fields on the renderer so that sequence is a unit test. The paving and grain
+overlays are translucent and serve both skies unchanged.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Night: stored preference, or none
+  Night --> Day: Day
+  Day --> Night: Night
+  state Night {
+    [*] --> NightScene: palette night
+    NightScene --> NightWalls: WallInk.night uploaded
+  }
+  state Day {
+    [*] --> DayScene: palette day, camera kept
+    DayScene --> DayWalls: WallInk.day uploaded
+    DayScene --> Shade: sun angle casts contact and streak
+  }
+```
+
+Daylight has no light to spend, so it spends shade. `PlazaSky.shadowLength`
+turns a volume's height into a ground distance from the sun's elevation,
+clamped so a tower does not drag its shadow across the district; night returns
+zero and no shadow geometry is created at all. Each caster gets two quads: a
+contact pad on its footprint, which is what says it meets the ground from any
+camera angle, and a streak away from the sun, which is what says where the sun
+is. One offset quad cannot be both — its falloff peaks half a shadow-length
+out and leaves the wall's own foot at a third of the density.
+
+Shade uses its own mask, not the light pool's. The pool is a hot core with a
+long thin skirt, which is right for light and wrong for shade: the renderer
+blends premultiplied (`src + dst × (1 − srcAlpha)`), so a dark colour
+multiplied through that skirt darkens the paving by a percent or two and the
+shadow reads as a stain. `WallTextures.paintShadow` is opaque across the middle
+and feathers only at the rim.
+
+Chrome over a bright world needs help the night never asked for: in daylight
+the HUD's blocks sit on a scrim, because white type and tinted status pills
+drawn straight onto sunlit concrete do not read.
 
 # Ambient companions
 

--- a/lib/features/plaza/README.md
+++ b/lib/features/plaza/README.md
@@ -22,6 +22,18 @@ project. Entering a project opens its own task world; Back returns to the
 category. Completed projects occupy the more distant avenues. Category worlds
 only show projects within the selected category and the current privacy scope.
 
+**Night** and **Day** switch the hour the district is built under. Night is the
+neon city the world was designed in. Day is a clear mid-morning: a blue sky with
+a sun in it, pale aerial haze instead of indigo fog, concrete and asphalt at
+their daylight values, glass that mirrors the sky rather than glowing, and soft
+shade under every building, sign and bench. Emitters fall back to their
+housings — the lamps go out, the ground keeps no pools of light, and only the
+sun blooms. Status still reads: the signs, the shutters, the hoardings and the
+flames over an overdue task carry it where the lights did. Switching rebuilds
+the scene where the camera stands and repaints the wall textures in the
+background, so the world never goes untextured. The choice is remembered
+between visits.
+
 Black-and-white penguin companions stroll through the streets and open square,
 alone or in pairs, with balancing flippers and orange webbed feet. Companions
 occasionally glance toward one another as if in conversation, with eyes leading
@@ -62,6 +74,10 @@ and widget textures belong to `flutter_scene`.
 - `state/project_plaza_provider.dart` refreshes snapshots and the attention clock.
 - `scene/project_world_generator.dart` and `category_world_generator.dart`
   generate task timelines and project avenues.
+- `ui/plaza_palette.dart` is the hour: sky, haze, surfaces, how far emitters
+  are pushed and where the sun stands. Scene code keeps no colour of its own.
+- `state/plaza_sky_mode_controller.dart` remembers the chosen sky, and
+  `ui/plaza_wall_swap.dart` decides which painted texture set to load for it.
 - `domain/` holds geometry, attention, routes, collisions and the Morning walk.
 - `scene/` builds geometry, manages facade detail and captures, and animates
   status lights, flames and ambient life.

--- a/lib/features/plaza/dev_main.dart
+++ b/lib/features/plaza/dev_main.dart
@@ -11,6 +11,7 @@ import 'package:lotti/features/plaza/scene/plaza_world.dart';
 import 'package:lotti/features/plaza/scene/project_world_generator.dart';
 import 'package:lotti/features/plaza/ui/debug_overlay.dart';
 import 'package:lotti/features/plaza/ui/plaza_copy.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
 import 'package:lotti/features/plaza/ui/plaza_view.dart';
 import 'package:lotti/l10n/app_localizations.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -49,7 +50,9 @@ class PlazaDevApp extends StatelessWidget {
           hidden: {...?env['PLAZA_HIDE']?.split(',')},
           trace: env['PLAZA_TRACE'] == '1',
           tourOnly: env['PLAZA_TOUR_ONLY']?.split(',').toSet(),
+          shotDir: env['PLAZA_SHOT_DIR'],
           initialFrameRate: PlazaFrameRate.fromEnvironment(env),
+          initialSkyMode: PlazaSkyMode.fromEnvironment(env),
         ),
       ),
     );

--- a/lib/features/plaza/scene/plaza_billboards.dart
+++ b/lib/features/plaza/scene/plaza_billboards.dart
@@ -51,7 +51,7 @@ extension _PlazaBillboardsBuilder on PlazaSceneController {
           root,
           Vector3(side * slot.width * 0.4, slot.bottom - 0.25, -0.3),
           Vector3(0.25, 0.5, 0.25),
-          PlazaSceneController._postMaterial,
+          _postMaterial,
         );
       }
     }
@@ -64,26 +64,26 @@ extension _PlazaBillboardsBuilder on PlazaSceneController {
           root,
           Vector3(px, slot.bottom / 2, -pylonPostSetback),
           Vector3(pylonPostSize, slot.bottom, pylonPostSize),
-          PlazaSceneController._postMaterial,
+          _postMaterial,
         );
         _box(
           root,
           Vector3(px, 0.3, -pylonPostSetback),
           Vector3(pylonFootingSize, 0.6, pylonFootingSize),
-          PlazaSceneController._postMaterial,
+          _postMaterial,
         );
       }
       _box(
         root,
         Vector3(0, slot.bottom * 0.55, -0.6),
         Vector3(slot.width * 0.8, 0.25, 0.25),
-        PlazaSceneController._postMaterial,
+        _postMaterial,
       );
       _box(
         root,
         Vector3(0, slot.bottom - 0.3, 0.5),
         Vector3(slot.width + 0.8, 0.12, 1.2),
-        PlazaSceneController._postMaterial,
+        _postMaterial,
       );
       // Light pool on the ground in the state colour, and a wide faint
       // wash in front of it so the panel connects to the paving.
@@ -105,6 +105,15 @@ extension _PlazaBillboardsBuilder on PlazaSceneController {
         color: frame,
         alpha: 0.07,
       );
+      // What the panel keeps off the paving: the shade of a sign standing
+      // in the sun, which is what gives the open square any relief at all.
+      _addShadow(
+        Vector3(slot.x, 0, slot.z),
+        width: slot.width,
+        depth: 1.5,
+        height: slot.bottom + slot.height,
+        contact: false,
+      );
       // The panel's reflection: a streak on the paving toward the walker.
       _addWash(
         Vector3(slot.x + sinF * 1.2, 0, slot.z + cosF * 1.2),
@@ -124,7 +133,7 @@ extension _PlazaBillboardsBuilder on PlazaSceneController {
       root,
       Vector3(0, slot.centerY, -depth / 2 - 0.02),
       Vector3(slot.width + 0.5, slot.height + 0.5, depth),
-      PlazaSceneController._towerMaterial,
+      _towerMaterial,
     );
     // A pylon's or a roof panel's back is open to the street: the same
     // capture shows through, mirrored ([backQuad] keeps the front's UVs

--- a/lib/features/plaza/scene/plaza_buildings.dart
+++ b/lib/features/plaza/scene/plaza_buildings.dart
@@ -21,15 +21,14 @@ extension _PlazaBuildingsBuilder on PlazaSceneController {
     );
     final parade = stableIndex(task.id, 'parade', WallTextures.paradeVariants);
     final kit = stableIndex(task.id, 'kit', WallTextures.tileFamilies);
-    final colors = dsTokensDark.colors;
-    final wallTint = linearColor(PlazaStyle.categoryWall(task));
+    final wallTint = linearColor(palette.categoryWall(task));
     final stone = _boxes.solid(wallTint);
-    final cornice = _boxes.solid(linearColor(colors.background.level03));
+    final cornice = _boxes.solid(linearColor(palette.surfaces.cornice));
     final structure = PlazaArchitecture(_boxes).build(
       architecture,
       wall: stone,
       trim: cornice,
-      light: _boxes.solid(linearColor(PlazaStyle.taskColor(attention))),
+      light: _boxes.solid(linearColor(palette.taskColor(attention))),
       onVolume: (tier, volume, {required groundFloor}) {
         if (!_shown('walls')) return;
         _windowedBox(
@@ -47,11 +46,17 @@ extension _PlazaBuildingsBuilder on PlazaSceneController {
       },
     )..localTransform = Matrix4.translation(Vector3(0, -h / 2, 0));
     node.add(structure);
+    _addShadow(
+      Vector3(placement.x, 0, placement.z),
+      width: w,
+      depth: d,
+      height: h,
+    );
     _box(
       node,
       Vector3(0, -h / 2 + 0.02, 0),
       Vector3(w + 3, 0.04, d + 3),
-      PlazaSceneController._pavementMaterial,
+      _pavementMaterial,
     );
     // A canopy shadows the recessed entrances without entering the street.
     _box(
@@ -68,7 +73,7 @@ extension _PlazaBuildingsBuilder on PlazaSceneController {
         attention.lantern == LanternState.blocked ||
         attention.lantern == LanternState.overdue;
     if (alarm) {
-      final spill = PlazaStyle.taskColor(attention);
+      final spill = palette.taskColor(attention);
       final sinF = math.sin(facing);
       final cosF = math.cos(facing);
       final cx = placement.x + normal.x * setback;
@@ -93,7 +98,7 @@ extension _PlazaBuildingsBuilder on PlazaSceneController {
       node,
       Vector3(0, -h / 2 + 0.35, 0),
       Vector3(w + 0.1, 0.7, d + 0.1),
-      _boxes.solid(linearColor(const Color(0xFF0A0910))),
+      _boxes.solid(linearColor(palette.surfaces.plotBase)),
     );
 
     final facadeW = architecture.facadeWidth;
@@ -151,7 +156,7 @@ extension _PlazaBuildingsBuilder on PlazaSceneController {
           architecture.front + 0.12,
         ),
         Vector3(facadeW * pct, 0.28, 0.12),
-        _boxes.solid(linearColor(PlazaStyle.lightBar(attention))),
+        _boxes.solid(linearColor(palette.taskColor(attention))),
       );
     }
     // Quarter ticks so the bar has a scale.
@@ -160,7 +165,7 @@ extension _PlazaBuildingsBuilder on PlazaSceneController {
         node,
         Vector3(facadeW / 2 - facadeW * q, plinthY, architecture.front + 0.16),
         Vector3(0.06, 0.28, 0.04),
-        _boxes.solid(linearColor(const Color(0xFF07060D))),
+        _boxes.solid(linearColor(palette.surfaces.plotRim)),
       );
     }
 
@@ -177,23 +182,23 @@ extension _PlazaBuildingsBuilder on PlazaSceneController {
     };
     final categoryNeon = PlazaStyle.neon(PlazaStyle.categoryBright(task));
     final neonColor = Color.lerp(
-      const Color(0xFF0B0A14),
+      palette.surfaces.unlitNeon,
       categoryNeon,
       emissive,
     )!;
     // One colour rule: on an anomaly the state owns the brightest register
     // (the two verticals and their glow burn in the lantern colour); the
     // category survives on the roofline at half power.
-    final stateNeon = PlazaStyle.taskColor(attention);
+    final stateNeon = palette.taskColor(attention);
     // Lit neon goes past white so the bloom pass carries it; a dark shop's
     // strips stay under the threshold.
-    final boost = emissive >= 0.7 ? PlazaSceneController.neonBoost : 1.0;
+    final boost = emissive >= 0.7 ? neonBoost : 1.0;
     final vertical = UnlitMaterial()
       ..baseColorFactor = emissiveColor(alarm ? stateNeon : neonColor, boost);
     final roofline = UnlitMaterial()
       ..baseColorFactor = emissiveColor(
         alarm
-            ? Color.lerp(const Color(0xFF0B0A14), categoryNeon, 0.5)!
+            ? Color.lerp(palette.surfaces.unlitNeon, categoryNeon, 0.5)!
             : neonColor,
         boost,
       );
@@ -241,7 +246,7 @@ extension _PlazaBuildingsBuilder on PlazaSceneController {
         width: facadeW * (alarm ? 0.8 : 1),
         length: alarm ? facadeH * 1.2 : 3,
         yaw: facing,
-        color: alarm ? stateNeon : const Color(0xFFFFC46B),
+        color: alarm ? stateNeon : palette.lights.parade,
         alpha: alarm ? 0.09 : 0.07,
       );
     }
@@ -250,7 +255,7 @@ extension _PlazaBuildingsBuilder on PlazaSceneController {
     // remains above it and supplies a second, screen-sized status cue.
     final crown = architecture.volumes.last;
     final statusRoof = _boxes.solid(
-      linearColor(PlazaStyle.taskColor(attention)),
+      linearColor(palette.taskColor(attention)),
     );
     _box(
       node,
@@ -269,7 +274,7 @@ extension _PlazaBuildingsBuilder on PlazaSceneController {
           placement.z + normal.z * (placement.depth / 2 + facadeW * 0.3),
         ),
         radius: facadeW * 0.55,
-        color: PlazaStyle.taskColor(attention),
+        color: palette.taskColor(attention),
         alpha: attention.lantern == LanternState.open ? 0.13 : 0.26,
       );
     }
@@ -285,8 +290,8 @@ extension _PlazaBuildingsBuilder on PlazaSceneController {
     // the far-tier colour language on arrival.
     final ringMaterial = UnlitMaterial()
       ..baseColorFactor = emissiveColor(
-        PlazaStyle.taskColor(attention),
-        PlazaSceneController.neonBoost,
+        palette.taskColor(attention),
+        neonBoost,
       )
       ..depthBias = PlazaSceneController.glowDepthBias;
     const t = 0.12;
@@ -345,7 +350,7 @@ extension _PlazaBuildingsBuilder on PlazaSceneController {
     scene.add(
       _boxes.node(
         Vector3(placement.width, 0.5, placement.depth),
-        _boxes.solid(linearColor(const Color(0xFF14161C))),
+        _boxes.solid(linearColor(palette.surfaces.riser)),
         transform: Matrix4.translation(
           Vector3(placement.x, 0.25, placement.z),
         )..rotateY(placement.facingRadians),

--- a/lib/features/plaza/scene/plaza_cables.dart
+++ b/lib/features/plaza/scene/plaza_cables.dart
@@ -8,6 +8,7 @@ import 'package:lotti/features/plaza/domain/street_layout.dart';
 import 'package:lotti/features/plaza/scene/plaza_primitives.dart';
 import 'package:lotti/features/plaza/scene/plaza_static_meshes.dart';
 import 'package:lotti/features/plaza/scene/plaza_world.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
 import 'package:lotti/features/plaza/ui/plaza_style.dart';
 import 'package:vector_math/vector_math.dart';
 
@@ -277,19 +278,23 @@ class PlazaCables {
     required Scene scene,
     required PlazaWorld world,
     required TextureSource glowTexture,
+    PlazaPalette palette = PlazaPalette.night,
   }) {
+    // Cables read as dark catenaries against either sky; only how far
+    // their travelling lights are pushed past white changes with the hour.
+    final boost = palette.lights.emissiveBoost;
     scene.add(root);
     final stationary = Node()..raycastable = false;
     root.add(stationary);
     final body = UnlitMaterial()
-      ..baseColorFactor = linearColor(dsTokensDark.colors.background.level03);
+      ..baseColorFactor = linearColor(palette.surfaces.cable);
     final lit = UnlitMaterial()
       ..baseColorFactor = emissiveColor(
         dsTokensDark.colors.text.highEmphasis,
-        1.6,
+        boost,
       );
     final selected = UnlitMaterial()
-      ..baseColorFactor = emissiveColor(PlazaStyle.teal, 1.6);
+      ..baseColorFactor = emissiveColor(PlazaStyle.teal, boost);
     _selection = PlazaCableSelection(
       paths: world.cablePaths,
       root: root,

--- a/lib/features/plaza/scene/plaza_furniture.dart
+++ b/lib/features/plaza/scene/plaza_furniture.dart
@@ -6,15 +6,24 @@ extension _PlazaFurnitureBuilder on PlazaSceneController {
   /// are the collider's, the dressing is here.
   void _buildPlazaFurniture() {
     final seat = UnlitMaterial()
-      ..baseColorFactor = linearColor(const Color(0xFF4A3A2E));
+      ..baseColorFactor = linearColor(palette.surfaces.timber);
     final soil = UnlitMaterial()
-      ..baseColorFactor = linearColor(const Color(0xFF1E1A1C));
+      ..baseColorFactor = linearColor(palette.surfaces.ironwork);
     final leaves = UnlitMaterial()
-      ..baseColorFactor = linearColor(const Color(0xFF1F3A28));
+      ..baseColorFactor = linearColor(palette.surfaces.foliage);
     for (final f in world.scenery.furniture) {
       final root = Node(
         localTransform: Matrix4.translation(Vector3(f.x, 0, f.z))
           ..rotateY(f.yawRadians),
+      );
+      // A bench in the sun is what tells the walker the square has a sun:
+      // the towers' shade lands at the far edge of an open plaza, but the
+      // furniture stands where the camera does.
+      _addShadow(
+        Vector3(f.x, 0, f.z),
+        width: f.width,
+        depth: f.depth,
+        height: f.height,
       );
       switch (f.kind) {
         case FurnitureKind.bench:
@@ -31,7 +40,7 @@ extension _PlazaFurnitureBuilder on PlazaSceneController {
             root,
             Vector3(0, f.height * 0.46, 0),
             Vector3(f.width * 0.9, 0.04, f.depth * 0.9),
-            PlazaSceneController._postMaterial,
+            _postMaterial,
           );
           _box(
             root,
@@ -44,14 +53,14 @@ extension _PlazaFurnitureBuilder on PlazaSceneController {
               root,
               Vector3(0, f.height * 0.25, dz),
               Vector3(f.width * 0.9, f.height * 0.5, 0.08),
-              PlazaSceneController._postMaterial,
+              _postMaterial,
             );
           }
         case FurnitureKind.planter:
           root.add(
             _boxes.node(
               Vector3(f.width, f.height, f.depth),
-              PlazaSceneController._postMaterial,
+              _postMaterial,
               transform: Matrix4.translation(Vector3(0, f.height / 2, 0)),
               shaded: true,
             ),
@@ -79,17 +88,17 @@ extension _PlazaFurnitureBuilder on PlazaSceneController {
             Vector3(f.width + 0.06, 0.03, f.depth + 0.06),
             _boxes.solid(
               linearColor(
-                const Color(0xFFFFC46B),
+                palette.lights.parade,
                 alpha: 0.8,
               ),
             ),
           );
         case FurnitureKind.kiosk:
           final sign = UnlitMaterial()
-            ..baseColorFactor = linearColor(const Color(0xFFFFC46B));
+            ..baseColorFactor = linearColor(palette.lights.parade);
           final window = UnlitMaterial()
             ..baseColorFactor = linearColor(
-              const Color(0xFFFFD08A),
+              palette.lights.lamp,
               alpha: 0.75,
             )
             ..alphaMode = AlphaMode.blend;
@@ -97,7 +106,7 @@ extension _PlazaFurnitureBuilder on PlazaSceneController {
           root.add(
             _boxes.node(
               Vector3(f.width, f.height, f.depth),
-              PlazaSceneController._towerMaterial,
+              _towerMaterial,
               transform: Matrix4.translation(Vector3(0, f.height / 2, 0)),
               shaded: true,
             ),
@@ -121,7 +130,7 @@ extension _PlazaFurnitureBuilder on PlazaSceneController {
             root,
             Vector3(0, f.height + 0.05, 0),
             Vector3(f.width + 0.4, 0.1, f.depth + 0.4),
-            PlazaSceneController._postMaterial,
+            _postMaterial,
           );
           _addPool(
             Vector3(
@@ -130,7 +139,7 @@ extension _PlazaFurnitureBuilder on PlazaSceneController {
               f.z + math.cos(f.yawRadians) * 2,
             ),
             radius: 3,
-            color: const Color(0xFFFFD08A),
+            color: palette.lights.lamp,
             alpha: 0.16,
           );
       }
@@ -147,14 +156,14 @@ extension _PlazaFurnitureBuilder on PlazaSceneController {
         scene.root,
         Vector3(x, lampPostHeight / 2, z),
         Vector3(lampPostSize, lampPostHeight, lampPostSize),
-        PlazaSceneController._postMaterial,
+        _postMaterial,
       );
       // Housing: a small dark head the bulb hangs under.
       _box(
         pole,
         Vector3(0, 2.7, 0),
         Vector3(0.7, 0.28, 0.7),
-        PlazaSceneController._postMaterial,
+        _postMaterial,
       );
       final lantern = Node(
         localTransform: Matrix4.translation(Vector3(0, 2.45, 0)),
@@ -164,7 +173,7 @@ extension _PlazaFurnitureBuilder on PlazaSceneController {
       _addPool(
         Vector3(x, 0, z),
         radius: 5,
-        color: const Color(0xFFFFE2B8),
+        color: palette.lights.interior,
         alpha: 0.3,
       );
     }
@@ -176,7 +185,7 @@ extension _PlazaFurnitureBuilder on PlazaSceneController {
         scene.root,
         Vector3(beacon.markerX, beacon.markerY / 2, beacon.markerZ),
         Vector3(0.08, beacon.markerY, 0.08),
-        PlazaSceneController._postMaterial,
+        _postMaterial,
       );
       _addPool(
         Vector3(beacon.markerX, 0, beacon.markerZ),
@@ -214,7 +223,7 @@ extension _PlazaFurnitureBuilder on PlazaSceneController {
           root,
           Vector3(side * gantry.width / 2, top / 2, 0),
           Vector3(gantryLegSize, top, gantryLegSize),
-          PlazaSceneController._postMaterial,
+          _postMaterial,
         );
       }
       _box(
@@ -225,7 +234,7 @@ extension _PlazaFurnitureBuilder on PlazaSceneController {
           gantryBeamThickness,
           gantryBeamDepth,
         ),
-        PlazaSceneController._postMaterial,
+        _postMaterial,
       );
       root.add(
         _glowQuad(gantry.width + 2, gantry.height + 2.5, PlazaStyle.teal, 0.2)
@@ -272,12 +281,10 @@ extension _PlazaFurnitureBuilder on PlazaSceneController {
           )..add(
             PlazaArchitecture(_boxes).build(
               architecture,
-              wall: PlazaSceneController._towerMaterial,
-              trim: _boxes.solid(
-                linearColor(dsTokensDark.colors.background.level03),
-              ),
+              wall: _towerMaterial,
+              trim: _boxes.solid(linearColor(palette.surfaces.cornice)),
               light: _boxes.solid(
-                emissiveColor(PlazaStyle.teal, PlazaSceneController.neonBoost),
+                emissiveColor(PlazaStyle.teal, neonBoost),
               ),
               onVolume: (tier, volume, {required groundFloor}) {
                 _windowedBox(
@@ -287,7 +294,7 @@ extension _PlazaFurnitureBuilder on PlazaSceneController {
                   d: volume.depth,
                   height: volume.height,
                   state: LanternState.inProgress,
-                  tint: PlazaSceneController._tower,
+                  tint: _tower,
                   groundFloor: groundFloor,
                   family: 2,
                 );
@@ -298,7 +305,7 @@ extension _PlazaFurnitureBuilder on PlazaSceneController {
       // border is the one teal frame on the tower.
       final corner = UnlitMaterial()
         ..baseColorFactor = linearColor(
-          Color.lerp(const Color(0xFF0B0A14), PlazaStyle.teal, 0.3)!,
+          Color.lerp(palette.surfaces.unlitNeon, PlazaStyle.teal, 0.3)!,
         );
       for (final side in [-1.0, 1.0]) {
         _box(

--- a/lib/features/plaza/scene/plaza_ground.dart
+++ b/lib/features/plaza/scene/plaza_ground.dart
@@ -12,7 +12,7 @@ extension _PlazaGroundBuilder on PlazaSceneController {
       scene.root,
       Vector3(centerX, -0.06, centerZ),
       Vector3(6000, 0.1, 6000),
-      _boxes.solid(PlazaSceneController._ground),
+      _boxes.solid(_ground),
     );
     if (buildSkyline) {
       _buildSkyline();
@@ -29,9 +29,7 @@ extension _PlazaGroundBuilder on PlazaSceneController {
       final roadNode = _boxes.node(
         Vector3(layout.roadWidth, 0.08, segment.length + 0.4),
         _boxes.solid(
-          segment.isGap
-              ? PlazaSceneController._gap
-              : PlazaSceneController._road,
+          segment.isGap ? _gap : _road,
         ),
         transform: Matrix4.translation(mid)..rotateY(segment.headingRadians),
       );
@@ -42,7 +40,7 @@ extension _PlazaGroundBuilder on PlazaSceneController {
           roadNode,
           Vector3(side * (layout.roadWidth / 2 - 1.5), 0.05, 0),
           Vector3(3, 0.1, segment.length + 0.4),
-          PlazaSceneController._pavementMaterial,
+          _pavementMaterial,
         );
         // A kerb you could stub a toe on: a raised stone edge between the
         // road and the pavement.
@@ -50,7 +48,7 @@ extension _PlazaGroundBuilder on PlazaSceneController {
           roadNode,
           Vector3(side * (layout.roadWidth / 2 - 3), 0.09, 0),
           Vector3(0.35, 0.18, segment.length + 0.4),
-          PlazaSceneController._kerbMaterial,
+          _kerbMaterial,
         );
       }
       // The map layer: a teal ribbon down the axis of every segment,
@@ -73,7 +71,7 @@ extension _PlazaGroundBuilder on PlazaSceneController {
             roadNode,
             Vector3(0, 0.045, along),
             Vector3(0.18, 0.01, 2.2),
-            _boxes.solid(PlazaSceneController._centreLine),
+            _boxes.solid(_centreLine),
           );
         }
       }
@@ -116,7 +114,7 @@ extension _PlazaGroundBuilder on PlazaSceneController {
     if (plaza != null) {
       final slab = _boxes.node(
         Vector3(plaza.width, 0.1, plaza.depth),
-        _boxes.solid(PlazaSceneController._ground),
+        _boxes.solid(_ground),
         transform: Matrix4.translation(
           Vector3(plaza.centerX, 0.01, plaza.centerZ),
         )..rotateY(plaza.headingRadians),
@@ -159,7 +157,7 @@ extension _PlazaGroundBuilder on PlazaSceneController {
       _addPool(
         Vector3(plaza.home.x, 0, plaza.home.z),
         radius: 7,
-        color: const Color(0xFFFFE2B8),
+        color: palette.lights.interior,
         alpha: 0.14,
       );
       _buildPlazaKerb(plaza);
@@ -214,7 +212,7 @@ extension _PlazaGroundBuilder on PlazaSceneController {
         root,
         Vector3(dx, 0, dz),
         Vector3(sx, kerbH, sz),
-        PlazaSceneController._kerbMaterial,
+        _kerbMaterial,
       );
     }
     // The threshold: a flush band across the opening, so the step from
@@ -223,7 +221,7 @@ extension _PlazaGroundBuilder on PlazaSceneController {
       root,
       Vector3(0, -kerbH / 2 + 0.05, -hd),
       Vector3(mouth, 0.02, 0.7),
-      PlazaSceneController._kerbMaterial,
+      _kerbMaterial,
     );
     scene.add(root);
   }

--- a/lib/features/plaza/scene/plaza_lights.dart
+++ b/lib/features/plaza/scene/plaza_lights.dart
@@ -11,10 +11,13 @@ extension _PlazaLightsBuilder on PlazaSceneController {
     required Color color,
     required double alpha,
   }) {
+    // Every pool passes through the hour's ground-light scale, so daylight
+    // takes them all out at once rather than each caller remembering to.
+    final lit = _groundLight(alpha);
     final material = UnlitMaterial()
-      ..baseColorFactor = linearColor(color, alpha: alpha)
+      ..baseColorFactor = linearColor(color, alpha: lit)
       ..alphaMode = AlphaMode.blend;
-    _pools.add((material, alpha));
+    _pools.add((material, lit));
     scene.add(
       Node(
         localTransform: Matrix4.translation(
@@ -37,10 +40,11 @@ extension _PlazaLightsBuilder on PlazaSceneController {
     required Color color,
     required double alpha,
   }) {
+    final lit = _groundLight(alpha);
     final material = UnlitMaterial()
-      ..baseColorFactor = linearColor(color, alpha: alpha)
+      ..baseColorFactor = linearColor(color, alpha: lit)
       ..alphaMode = AlphaMode.blend;
-    _washes.add((material, alpha));
+    _washes.add((material, lit));
     scene.add(
       Node(
         localTransform:
@@ -58,6 +62,95 @@ extension _PlazaLightsBuilder on PlazaSceneController {
     );
   }
 
+  /// The shadow a [height]-metre volume standing on [at] throws across the
+  /// paving, [width] by [depth] at its foot.
+  ///
+  /// There is no light in this scene and nothing casts anything: this is
+  /// two soft dark quads on the ground. It is the one thing that makes an
+  /// unlit daylight city read as standing on its street rather than pasted
+  /// onto it, which is why the day palette carries a sun angle at all.
+  /// Night has no sun, so [PlazaSky.shadowLength] returns zero and nothing
+  /// is added.
+  ///
+  /// Two quads, not one, because they do different jobs. The **contact**
+  /// pad sits on the footprint and is what says the building meets the
+  /// ground — it has to be there from every camera angle, including the one
+  /// looking straight down the sun. The **cast** streak runs away from the
+  /// sun and is what says where the sun is. One offset quad cannot be both:
+  /// its falloff peaks half a shadow-length out, leaving the wall's own
+  /// foot at a third of the density, which reads as a smudge on the paving
+  /// rather than as contact.
+  ///
+  /// Both are square to the sun rather than to the building: a facade
+  /// turned off-axis gets the larger of its two footprint sides, which at
+  /// this softness reads correctly and costs no solve.
+  void _addShadow(
+    Vector3 at, {
+    required double width,
+    required double depth,
+    required double height,
+    bool contact = true,
+  }) {
+    final alpha = palette.lights.shadowAlpha;
+    final length = palette.sky.shadowLength(height);
+    if (alpha <= 0 || length <= 0) return;
+    // Away from the sun, along the ground.
+    final cast = palette.sky.sunAzimuth + math.pi;
+    final lateral = math.max(width, depth);
+    // A sign on two thin posts meets the ground at two thin posts: it
+    // gets the streak its panel throws and no pad, or the pad would read
+    // as a slab of shade the structure does not have.
+    if (contact) {
+      _shadowQuad(
+        at,
+        width: lateral * 1.25,
+        length: lateral * 1.25,
+        yaw: 0,
+        alpha: alpha,
+      );
+    }
+    _shadowQuad(
+      Vector3(
+        at.x + math.sin(cast) * length / 2,
+        0,
+        at.z + math.cos(cast) * length / 2,
+      ),
+      width: lateral * 1.1,
+      length: lateral + length,
+      yaw: cast,
+      alpha: alpha * castShare,
+    );
+  }
+
+  /// How much of the contact pad's density the cast streak carries. A
+  /// shadow thrown across open paving is lighter than the dark under the
+  /// wall itself, and the two overlap where they meet.
+  static const castShare = 0.7;
+
+  void _shadowQuad(
+    Vector3 at, {
+    required double width,
+    required double length,
+    required double yaw,
+    required double alpha,
+  }) {
+    final material = UnlitMaterial()
+      ..baseColorFactor = linearColor(palette.lights.shadow, alpha: alpha)
+      ..alphaMode = AlphaMode.blend;
+    _shadows.add(material);
+    scene.add(
+      Node(
+        localTransform:
+            Matrix4.translation(
+                Vector3(at.x, PlazaSceneController._groundTop, at.z),
+              )
+              ..rotateY(yaw)
+              ..rotateX(-math.pi / 2),
+        mesh: Mesh(ccwQuad(width, length), material),
+      ),
+    );
+  }
+
   Node _glowQuad(
     double width,
     double height,
@@ -65,11 +158,15 @@ extension _PlazaLightsBuilder on PlazaSceneController {
     double alpha, {
     double depthBias = 0,
   }) {
+    // The faux bloom behind an emitter. Daylight leaves a quarter of it:
+    // enough that a lit sign still separates from its wall, not so much
+    // that a haze hangs on a facade the sun is already on.
+    final lit = alpha * glowScale;
     final material = UnlitMaterial()
-      ..baseColorFactor = linearColor(color, alpha: alpha)
+      ..baseColorFactor = linearColor(color, alpha: lit)
       ..alphaMode = AlphaMode.blend
       ..depthBias = depthBias;
-    _pools.add((material, alpha));
+    _pools.add((material, lit));
     return Node(mesh: Mesh(ccwQuad(width, height), material));
   }
 
@@ -87,7 +184,7 @@ extension _PlazaLightsBuilder on PlazaSceneController {
       parent,
       Vector3(base.x, base.y + height / 2, base.z),
       Vector3(size, height, size),
-      PlazaSceneController._postMaterial,
+      _postMaterial,
     );
     final light = Node(
       localTransform: Matrix4.translation(

--- a/lib/features/plaza/scene/plaza_scene.dart
+++ b/lib/features/plaza/scene/plaza_scene.dart
@@ -16,6 +16,7 @@ import 'package:lotti/features/plaza/scene/plaza_scene_records.dart';
 import 'package:lotti/features/plaza/scene/plaza_static_meshes.dart';
 import 'package:lotti/features/plaza/scene/plaza_world.dart';
 import 'package:lotti/features/plaza/scene/wall_textures.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
 import 'package:lotti/features/plaza/ui/plaza_style.dart';
 import 'package:vector_math/vector_math.dart' hide Colors;
 
@@ -37,12 +38,20 @@ enum _Face { front, back, right, left }
 /// Widget surfaces (facades, billboards, tickers, block markers) and the
 /// screen-clamped sprites are attached by the other scene classes.
 class PlazaSceneController {
-  PlazaSceneController({required this.world, this.hidden = const {}})
-    : pxPerMeter = world.layout.pxPerMeter {
+  PlazaSceneController({
+    required this.world,
+    this.palette = PlazaPalette.night,
+    this.hidden = const {},
+  }) : pxPerMeter = world.layout.pxPerMeter {
     _build();
   }
 
   final PlazaWorld world;
+
+  /// The hour this scene is built under. Every colour and atmospheric
+  /// number below comes from it, which is why none of them is static: two
+  /// scenes under different skies must not share a material.
+  final PlazaPalette palette;
   final double pxPerMeter;
 
   /// Dev-only: pieces left out of the scene (`gantry`, `jumbotron`,
@@ -65,21 +74,21 @@ class PlazaSceneController {
 
   /// The ground plane, and the plaza slab flush with it: the paving
   /// joints set the square apart, not its colour.
-  static final Vector4 _ground = linearColor(const Color(0xFF15131E));
-  static final Vector4 _road = linearColor(const Color(0xFF1A1D2B));
-  static final Vector4 _gap = linearColor(const Color(0xFF15171F));
-  static final Vector4 _post = linearColor(const Color(0xFF14171F));
-  static final Vector4 _tower = linearColor(const Color(0xFF0E0B18));
+  late final Vector4 _ground = linearColor(palette.surfaces.ground);
+  late final Vector4 _road = linearColor(palette.surfaces.road);
+  late final Vector4 _gap = linearColor(palette.surfaces.gap);
+  late final Vector4 _post = linearColor(palette.surfaces.post);
+  late final Vector4 _tower = linearColor(palette.surfaces.tower);
 
-  static final Vector4 _pavement = linearColor(const Color(0xFF232532));
-  static final Vector4 _kerb = linearColor(const Color(0xFF5A5E72));
+  late final Vector4 _pavement = linearColor(palette.surfaces.pavement);
+  late final Vector4 _kerb = linearColor(palette.surfaces.kerb);
 
   /// One material per solid colour, shared by every box in it: only the
   /// pools and washes are ever rewritten by [updateForCamera].
-  static final _postMaterial = UnlitMaterial()..baseColorFactor = _post;
-  static final _towerMaterial = UnlitMaterial()..baseColorFactor = _tower;
-  static final _pavementMaterial = UnlitMaterial()..baseColorFactor = _pavement;
-  static final _kerbMaterial = UnlitMaterial()..baseColorFactor = _kerb;
+  late final _postMaterial = UnlitMaterial()..baseColorFactor = _post;
+  late final _towerMaterial = UnlitMaterial()..baseColorFactor = _tower;
+  late final _pavementMaterial = UnlitMaterial()..baseColorFactor = _pavement;
+  late final _kerbMaterial = UnlitMaterial()..baseColorFactor = _kerb;
 
   /// The map layer: road ribbons shown from altitude, in the ticker teal.
   static final Vector4 _ribbon = linearColor(PlazaStyle.teal, alpha: 0.55);
@@ -87,7 +96,7 @@ class PlazaSceneController {
 
   /// Washes fade to nothing with altitude, unlike the pools.
   final List<(UnlitMaterial, double)> _washes = [];
-  static final Vector4 _centreLine = linearColor(const Color(0xFF7A7050));
+  late final Vector4 _centreLine = linearColor(palette.surfaces.centreLine);
 
   /// Top of the pavement; every ground light pool sits above this.
   static const _groundTop = 0.11;
@@ -99,6 +108,13 @@ class PlazaSceneController {
   /// Light pools: (material, full alpha). Their alpha fades with camera
   /// altitude so the overview is carried by lanterns, not discs.
   final List<(UnlitMaterial, double)> _pools = [];
+
+  /// Contact shadows. Unlike the pools they do not fade with altitude — a
+  /// city seen from above is read by its shadows more than from the street.
+  final List<UnlitMaterial> _shadows = [];
+
+  /// How many shadow quads this hour put on the ground. Night has none.
+  int get shadowCount => _shadows.length;
 
   /// Ground surfaces that take the asphalt grain.
   final List<UnlitMaterial> _grainMaterials = [];
@@ -156,6 +172,12 @@ class PlazaSceneController {
     for (final (material, _) in [..._pools, ..._washes]) {
       material.baseColorTexture = textures.pool;
     }
+    // A shadow takes the shadow mask, not the light pool's falloff: the
+    // pool is a hot core with a long skirt, and a dark colour multiplied
+    // through that skirt darkens the paving by almost nothing.
+    for (final material in _shadows) {
+      material.baseColorTexture = textures.shadow;
+    }
     // Billboard glows have their own animation owner, but still need the
     // falloff texture. An untextured blended quad reads as a coloured sheet.
     for (final billboard in bindings.billboards) {
@@ -186,22 +208,10 @@ class PlazaSceneController {
   /// still shows a lit street, not so much that the discs read as discs.
   static const poolFloor = 0.15;
 
-  /// Fog at eye level and from the air: the street haze thins as the
-  /// camera climbs, so the map shot sees a lit district instead of a
-  /// purple wash.
-  static const fogDensityLow = 0.0055;
-  static const fogDensityHigh = 0.002;
-  static const fogOpacityLow = 0.92;
-  static const fogOpacityHigh = 0.6;
-
-  /// HDR brightness above which a pixel blooms, and how much of the bloom
-  /// is added back. Widget whites sit at 1.0, so screens bloom a little;
-  /// neon and chase heads are pushed past it with [emissiveColor].
-  static const bloomThreshold = 1.0;
-  static const bloomIntensity = 0.3;
-
-  /// How far past white the neon and the lit rooflines go.
-  static const neonBoost = 1.6;
+  /// How far past white the neon and the lit rooflines go, and how much of
+  /// a ground pool or emitter glow survives this hour.
+  double get neonBoost => palette.lights.emissiveBoost;
+  double get glowScale => palette.lights.glowScale;
 
   /// The altitude fade last applied, so a camera that has not climbed
   /// does not rewrite every pool and wash material each frame.
@@ -236,9 +246,12 @@ class PlazaSceneController {
     final last = _lastFadeT;
     if (last != null && (t - last).abs() < 1e-6) return;
     _lastFadeT = t;
+    final air = palette.air;
     scene.fog
-      ..density = fogDensityLow + (fogDensityHigh - fogDensityLow) * t
-      ..maxOpacity = fogOpacityLow + (fogOpacityHigh - fogOpacityLow) * t;
+      ..density =
+          air.fogDensityLow + (air.fogDensityHigh - air.fogDensityLow) * t
+      ..maxOpacity =
+          air.fogOpacityLow + (air.fogOpacityHigh - air.fogOpacityLow) * t;
     void fade(List<(UnlitMaterial, double)> materials, double factor) {
       for (final (material, alpha) in materials) {
         material.baseColorFactor = Vector4(
@@ -262,9 +275,9 @@ class PlazaSceneController {
   /// parade on the street face; a shorter one is all sign.
   static const paradeWallHeight = 12.0;
 
-  /// The cornice band: the wall's own dark, a shade above the night.
-  static final _corniceMaterial = UnlitMaterial()
-    ..baseColorFactor = linearColor(const Color(0xFF141220));
+  /// The cornice band: the wall's own colour, a shade along from it.
+  late final _corniceMaterial = UnlitMaterial()
+    ..baseColorFactor = linearColor(palette.surfaces.cornice);
 
   /// A shared unit box scaled to [size], with an unscaled anchor centred
   /// at [at] under [parent] so attached decorations retain their placement.
@@ -309,6 +322,10 @@ class PlazaSceneController {
   }
 
   static final Vector4 _panelBack = linearColor(PlazaStyle.panel);
+
+  /// A ground pool or wash at this hour's strength. Daylight scales them to
+  /// nothing: a disc of lamplight on sunlit paving reads as a stain.
+  double _groundLight(double alpha) => alpha * palette.lights.groundLightScale;
 
   /// A soft glow quad behind an emitter: the faux bloom that makes neon
   /// and lightboxes read as lit rather than painted.

--- a/lib/features/plaza/scene/plaza_skyline.dart
+++ b/lib/features/plaza/scene/plaza_skyline.dart
@@ -3,43 +3,55 @@ part of 'plaza_scene.dart';
 /// Builds this fixture family using the scene's shared resources.
 extension _PlazaSkylineBuilder on PlazaSceneController {
   void _buildSky() {
+    final sky = palette.sky;
+    final air = palette.air;
+    final sun = sky.sunDirection;
     scene.skybox = Skybox(
       GradientSkySource(
-        zenithColor: linearColor(const Color(0xFF03030B)).xyz,
-        horizonColor: linearColor(const Color(0xFF2A2446)).xyz,
-        groundColor: linearColor(const Color(0xFF090A16)).xyz,
-        sunColor: Vector3.zero(),
+        zenithColor: linearColor(sky.zenith).xyz,
+        horizonColor: linearColor(sky.horizon).xyz,
+        groundColor: linearColor(sky.ground).xyz,
+        // The disk's HDR value: hue times intensity, so a daylight sun sits
+        // well past white and blooms while night's stays at zero.
+        sunColor: linearColor(sky.sun).xyz * sky.sunIntensity,
+        sunDirection: Vector3(sun.x, sun.y, sun.z),
+        sunSharpness: sky.sunSharpness,
       ),
     );
     // Ground-hugging haze in the horizon's own colour: the street dissolves
     // into the sky instead of hitting a seam, and it thins with altitude
-    // so the overview still sees the district. The night is a desaturated
-    // indigo so amber signage sits warm against it; the magenta lives in
-    // the hero towers' domes alone.
-    // Real bloom: the emitters (neon, screens, chase heads, rooflines)
-    // bleed into the night the way a lightbox does, and a soft vignette
-    // pulls the eye to the centre of every frame.
+    // so the overview still sees the district. At night the haze is a
+    // desaturated indigo so amber signage sits warm against it; by day it
+    // is the sky's own pale blue, and distance reads as aerial perspective
+    // rather than as a wall two blocks out.
+    //
+    // Bloom is real: at night the emitters (neon, screens, chase heads,
+    // rooflines) bleed into the dark the way a lightbox does, and a soft
+    // vignette pulls the eye to the centre of every frame. Daylight raises
+    // the threshold above the sky's own brightness — only the sun disk is
+    // left to bloom — and drops the vignette, which would read as a dirty
+    // lens rather than as night closing in.
     scene.postProcess.bloom
-      ..enabled = true
-      ..threshold = PlazaSceneController.bloomThreshold
-      ..intensity = PlazaSceneController.bloomIntensity
-      ..scatter = 0.6;
+      ..enabled = air.hasBloom
+      ..threshold = air.bloomThreshold
+      ..intensity = air.bloomIntensity
+      ..scatter = air.bloomScatter;
     scene.postProcess.vignette
-      ..enabled = true
-      ..intensity = 0.32
-      ..radius = 0.82
-      ..smoothness = 0.6;
+      ..enabled = air.hasVignette
+      ..intensity = air.vignetteIntensity
+      ..radius = air.vignetteRadius
+      ..smoothness = air.vignetteSmoothness;
     scene.fog
       ..enabled = true
       ..mode = FogMode.exponential
-      ..density = PlazaSceneController.fogDensityLow
+      ..density = air.fogDensityLow
       ..start = 8
       ..height = 0
       ..heightFalloff = 0.028
-      ..maxOpacity = PlazaSceneController.fogOpacityLow
+      ..maxOpacity = air.fogOpacityLow
       // Between the ground and the horizon: the haze never outshines the
       // paving the walker stands on.
-      ..color = linearColor(const Color(0xFF181727)).xyz;
+      ..color = linearColor(air.fog).xyz;
   }
 
   /// City fabric behind the plots (`Scenery.fillers`): dark windowed
@@ -64,6 +76,12 @@ extension _PlazaSkylineBuilder on PlazaSceneController {
             ..localTransform = (Matrix4.translation(
               Vector3(block.x, 0, block.z),
             )..rotateY(block.yawRadians));
+      _addShadow(
+        Vector3(block.x, 0, block.z),
+        width: bw,
+        depth: bd,
+        height: bh,
+      );
       // The parade's light on the pavement, on the street side.
       {
         final yaw = block.yawRadians + (side < 0 ? math.pi / 2 : -math.pi / 2);
@@ -76,7 +94,7 @@ extension _PlazaSkylineBuilder on PlazaSceneController {
           width: bw,
           length: 2.5,
           yaw: yaw,
-          color: const Color(0xFFFFC46B),
+          color: palette.lights.parade,
           alpha: 0.06,
         );
       }
@@ -164,7 +182,7 @@ extension _PlazaSkylineBuilder on PlazaSceneController {
         );
       }
       root.add(
-        _glowQuad(w * 9, height * 1.4, const Color(0xFFFF7A4A), 0.11)
+        _glowQuad(w * 9, height * 1.4, palette.lights.skyGlow, 0.11)
           ..localTransform = Matrix4.translation(
             Vector3(0, height * 0.35, -bd / 2 - 24),
           ),
@@ -248,14 +266,14 @@ extension _PlazaSkylineBuilder on PlazaSceneController {
     };
     return PlazaArchitecture(_boxes).build(
       architecture,
-      wall: PlazaSceneController._towerMaterial,
+      wall: _towerMaterial,
       trim: _boxes.solid(
         linearColor(
           landmark ? colors.background.level03 : colors.background.level02,
         ),
       ),
       light: _boxes.solid(
-        emissiveColor(glow, landmark ? PlazaSceneController.neonBoost : 1),
+        emissiveColor(glow, landmark ? neonBoost : 1),
       ),
       detailed: detailed,
       onVolume: (tier, volume, {required groundFloor}) {
@@ -266,7 +284,7 @@ extension _PlazaSkylineBuilder on PlazaSceneController {
           d: volume.depth,
           height: volume.height,
           state: state,
-          tint: PlazaSceneController._tower,
+          tint: _tower,
           groundFloor: shops && groundFloor,
           shops: LanternState.inProgress,
           variant: variant,

--- a/lib/features/plaza/scene/plaza_sprites.dart
+++ b/lib/features/plaza/scene/plaza_sprites.dart
@@ -10,6 +10,7 @@ import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/features/plaza/scene/plaza_primitives.dart';
 import 'package:lotti/features/plaza/scene/plaza_scene_records.dart';
 import 'package:lotti/features/plaza/scene/plaza_world.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
 import 'package:lotti/features/plaza/ui/plaza_style.dart';
 import 'package:vector_math/vector_math.dart' hide Colors;
 
@@ -27,15 +28,20 @@ class PlazaSprites {
     required this.scene,
     required this.world,
     required PlazaSceneBindings bindings,
+    this.palette = PlazaPalette.night,
   }) {
-    for (final anchor in bindings.lampAnchors) {
+    // Street lamps stand in both hours; only at night do they burn. A
+    // daylight lamp keeps its post and loses its bulb and halo, so nothing
+    // hangs a glowing dot over sunlit paving.
+    for (final anchor
+        in palette.lights.lampsLit ? bindings.lampAnchors : const <Node>[]) {
       final bulb = Sprite(
-        color: linearColor(PlazaStyle.lamp),
+        color: linearColor(palette.lights.lamp),
         width: lampBulbSize,
         height: lampBulbSize,
       );
       final halo = Sprite(
-        color: linearColor(PlazaStyle.lamp, alpha: 0.35),
+        color: linearColor(palette.lights.lamp, alpha: 0.35),
         width: lampHaloSize,
         height: lampHaloSize,
       );
@@ -54,7 +60,7 @@ class PlazaSprites {
     }
     for (final anchor in bindings.spireAnchors) {
       final sprite = Sprite(
-        color: linearColor(PlazaStyle.warning),
+        color: linearColor(palette.lights.warning),
         width: spireLightSize,
         height: spireLightSize,
       );
@@ -85,7 +91,7 @@ class PlazaSprites {
       );
     }
     for (final building in bindings.buildings) {
-      final color = PlazaStyle.taskColor(building.attention);
+      final color = palette.taskColor(building.attention);
       final sprite = Sprite(color: linearColor(color));
       final node = Node(mesh: sprite.mesh)..raycastable = false;
       building.lanternAnchor.add(node);
@@ -107,7 +113,9 @@ class PlazaSprites {
       );
     }
     for (final beacon in world.beacons) {
-      final teal = linearColor(PlazaStyle.beaconColor(beacon, world));
+      final teal = linearColor(
+        PlazaStyle.beaconColor(beacon, world, palette: palette),
+      );
       final position = Vector3(beacon.markerX, beacon.markerY, beacon.markerZ);
       final dot = Sprite(color: teal);
       final dotNode = Node(
@@ -139,6 +147,10 @@ class PlazaSprites {
   }
 
   final Scene scene;
+
+  /// The hour the sprites burn in. It decides whether the street lamps are
+  /// lit at all, and what colour a roof lantern reads as against the sky.
+  final PlazaPalette palette;
   final PlazaWorld world;
   final List<_Lantern> _lanterns = [];
   final List<_BeaconSprite> _beacons = [];

--- a/lib/features/plaza/scene/plaza_surfaces.dart
+++ b/lib/features/plaza/scene/plaza_surfaces.dart
@@ -1,5 +1,4 @@
 import 'dart:math' as math;
-import 'dart:ui' show Color;
 
 import 'package:flutter/foundation.dart' show ValueListenable, ValueNotifier;
 import 'package:flutter_scene/scene.dart';
@@ -301,7 +300,7 @@ class PlazaSurfaces {
       final rim = UnlitMaterial()
         ..baseColorFactor = linearColor(PlazaStyle.teal, alpha: 0.8);
       final track = UnlitMaterial()
-        ..baseColorFactor = linearColor(const Color(0xFF0B0D14));
+        ..baseColorFactor = linearColor(PlazaStyle.housing);
       anchor.add(
         Node(
           localTransform: Matrix4.translation(Vector3(0, 0, -0.22)),

--- a/lib/features/plaza/scene/plaza_walls.dart
+++ b/lib/features/plaza/scene/plaza_walls.dart
@@ -134,7 +134,7 @@ extension _PlazaWallsBuilder on PlazaSceneController {
           )..rotateY(yaw),
           mesh: Mesh(
             ccwQuad(width, cornice),
-            PlazaSceneController._corniceMaterial,
+            _corniceMaterial,
           ),
         ),
       );

--- a/lib/features/plaza/scene/wall_textures.dart
+++ b/lib/features/plaza/scene/wall_textures.dart
@@ -1,11 +1,153 @@
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
-import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter/foundation.dart' show immutable, visibleForTesting;
 import 'package:flutter_scene/scene.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/plaza/domain/attention.dart';
 import 'package:lotti/features/plaza/ui/plaza_copy.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
+
+/// The inks a painted wall is made of, per hour.
+///
+/// The window and shopfront tiles are opaque: the texture *is* the wall, so
+/// unlike the paving and grain overlays they cannot be reused across skies.
+/// Everything the two painters draw the building itself with lives here;
+/// what they draw *inside* a lit shop does not, because a shop lights its
+/// interior at noon as well.
+@immutable
+class WallInk {
+  const WallInk({
+    required this.mode,
+    required this.wall,
+    required this.officeWall,
+    required this.frame,
+    required this.reveal,
+    required this.mullion,
+    required this.board,
+    required this.riser,
+    required this.leaf,
+    required this.signOff,
+    required this.shutter,
+    required this.blind,
+    required this.slabEdge,
+    required this.skyHigh,
+    required this.skyLow,
+    required this.interior,
+  });
+
+  final PlazaSkyMode mode;
+
+  /// The wall between the windows, and a shopfront parade's surround.
+  final ui.Color wall;
+
+  /// The curtain-wall family's spandrel, which is glass rather than render.
+  final ui.Color officeWall;
+
+  /// Around glass and doors.
+  final ui.Color frame;
+
+  /// The window reveal: the wall's own thickness around a pane.
+  final ui.Color reveal;
+  final ui.Color mullion;
+
+  /// Fascia board, stair riser, door leaf, an unlit sign, a closed shutter.
+  final ui.Color board;
+  final ui.Color riser;
+  final ui.Color leaf;
+  final ui.Color signOff;
+  final ui.Color shutter;
+
+  /// A blind pulled part-way down.
+  final ui.Color blind;
+
+  /// The lit top edge of a floor slab, the relief that makes a storey read
+  /// as a storey: catching the city at night, catching the sun by day.
+  final ui.Color slabEdge;
+
+  /// Daylight only: what a pane reflects, top and bottom, and the interior
+  /// that shows through the reflection where someone is in.
+  final ui.Color skyHigh;
+  final ui.Color skyLow;
+  final ui.Color interior;
+
+  /// Whether panes mirror the sky rather than glowing.
+  bool get reflectsSky => mode == PlazaSkyMode.day;
+
+  /// The two gradient stops of one pane.
+  ///
+  /// At night a pane is a light source: [tint] at an alpha that says whether
+  /// anyone is in. By day it is a mirror — the sky, top to bottom — and
+  /// occupancy shows as an interior behind the reflection instead. Either
+  /// way an [on] pane is the one with somebody in it, so the same lit ratio
+  /// drives both.
+  (ui.Color, ui.Color) pane({
+    required ui.Color tint,
+    required bool on,
+    required double roll,
+  }) {
+    if (reflectsSky) {
+      if (!on) return (skyHigh, skyLow);
+      // The reflection survives at the top of the glass, where the sky is
+      // steepest in it; the room shows through lower down.
+      return (
+        ui.Color.lerp(skyHigh, interior, 0.35 + roll * 0.2)!,
+        ui.Color.lerp(skyLow, interior, 0.6 + roll * 0.25)!,
+      );
+    }
+    final glow = on ? 0.4 + roll * 0.4 : 0.14 + roll * 0.1;
+    return (
+      tint.withValues(alpha: glow),
+      tint.withValues(alpha: glow * 0.55),
+    );
+  }
+
+  static WallInk of(PlazaSkyMode mode) =>
+      mode == PlazaSkyMode.day ? day : night;
+
+  /// The register the district was painted in: a dark city carrying its own
+  /// light.
+  static const night = WallInk(
+    mode: PlazaSkyMode.night,
+    wall: ui.Color(0xFF0B0A14),
+    officeWall: ui.Color(0xFF121722),
+    frame: ui.Color(0xFF07060D),
+    reveal: ui.Color(0xFF050409),
+    mullion: ui.Color(0xFF07060D),
+    board: ui.Color(0xFF15131F),
+    riser: ui.Color(0xFF0A0910),
+    leaf: ui.Color(0xFF15131F),
+    signOff: ui.Color(0xFF2B2836),
+    shutter: ui.Color(0xFF232230),
+    blind: ui.Color(0xB30B0A14),
+    slabEdge: ui.Color(0xFF1C1A2A),
+    // Unused at night: nothing reflects a sky this dark.
+    skyHigh: ui.Color(0xFF0B0A14),
+    skyLow: ui.Color(0xFF0B0A14),
+    interior: ui.Color(0xFF0B0A14),
+  );
+
+  /// Mid-morning: render and concrete in the sun, glass that mirrors the
+  /// sky, and reveals that read as shade rather than as holes.
+  static const day = WallInk(
+    mode: PlazaSkyMode.day,
+    wall: ui.Color(0xFFB3ADA3),
+    officeWall: ui.Color(0xFF9FA8B4),
+    frame: ui.Color(0xFF6B665E),
+    reveal: ui.Color(0xFF8A857C),
+    mullion: ui.Color(0xFF7C776E),
+    board: ui.Color(0xFFC7C1B5),
+    riser: ui.Color(0xFF9A948A),
+    leaf: ui.Color(0xFF8E8577),
+    signOff: ui.Color(0xFFA8A296),
+    shutter: ui.Color(0xFF9EA2A8),
+    blind: ui.Color(0xCCE9E3D6),
+    slabEdge: ui.Color(0xFFD6D0C4),
+    skyHigh: ui.Color(0xFFBBD3EA),
+    skyLow: ui.Color(0xFF8098AE),
+    interior: ui.Color(0xFF4A4740),
+  );
+}
 
 /// Window-grid textures for the side and back walls, one per lantern
 /// state, tiled across every wall: the cheapest way to turn a cuboid into
@@ -13,9 +155,13 @@ import 'package:lotti/features/plaza/ui/plaza_copy.dart';
 /// as repeating textures; walls pick a tile offset from the task id so no
 /// two facades share the same lit windows.
 class WallTextures {
-  WallTextures._(this._byState);
+  WallTextures._(this._byState, this.mode);
 
   final Map<(LanternState, int), Texture2D> _byState;
+
+  /// The hour these were painted for. A scene must not be handed a set
+  /// from the other sky.
+  final PlazaSkyMode mode;
 
   /// How many window-tile families there are: the same lit ratio in
   /// three occupancies (mixed flats, a residential stack with dark floors
@@ -73,25 +219,35 @@ class WallTextures {
   };
 
   /// Paints and uploads the fifteen window tiles, fifteen shopfront strips,
-  /// the light-pool falloff, the asphalt grain and the plaza paving.
-  static Future<WallTextures> load({PlazaCopy? copy}) async {
+  /// the light-pool falloff, the asphalt grain and the plaza paving, in
+  /// [mode]'s inks.
+  ///
+  /// The set belongs to one hour: switching skies loads a second set rather
+  /// than repainting this one, so the world on screen keeps its textures
+  /// until the new ones are on the GPU.
+  static Future<WallTextures> load({
+    PlazaCopy? copy,
+    PlazaSkyMode mode = PlazaSkyMode.night,
+  }) async {
     final map = <(LanternState, int), Texture2D>{};
     final shops = <(LanternState, int), Texture2D>{};
+    final ink = WallInk.of(mode);
     for (final state in LanternState.values) {
       for (var f = 0; f < tileFamilies; f++) {
         map[(state, f)] = await _upload(
-          paintWindows(state, family: f),
+          paintWindows(state, family: f, ink: ink),
         );
       }
       for (var v = 0; v < paradeVariants; v++) {
         shops[(state, v)] = await _upload(
-          paintShopfront(state, variant: v, copy: copy),
+          paintShopfront(state, variant: v, copy: copy, ink: ink),
         );
       }
     }
-    final textures = WallTextures._(map)
-      ..pool = await _upload(_paintPool())
-      ..grain = await _upload(_paintGrain())
+    final textures = WallTextures._(map, mode)
+      ..pool = await _upload(paintPool())
+      ..shadow = await _upload(paintShadow())
+      ..grain = await _upload(paintGrain())
       ..paving = await _upload(paintPaving())
       .._shopfronts = shops;
     return textures;
@@ -116,6 +272,9 @@ class WallTextures {
   /// Asphalt grain: a near-black noise tile with faint lighter grit.
   late final Texture2D grain;
 
+  /// The contact-shadow mask; see [paintShadow].
+  late final Texture2D shadow;
+
   /// Plaza paving: slab joints and a little wear, blended over the slab.
   late final Texture2D paving;
 
@@ -133,14 +292,11 @@ class WallTextures {
 
   static double _m(double meters) => meters * _px;
 
-  static const _night = ui.Color(0xFF0B0A14);
-  static const _frame = ui.Color(0xFF07060D);
-  static const _board = ui.Color(0xFF15131F);
-  static const _riser = ui.Color(0xFF0A0910);
-  static const _leaf = ui.Color(0xFF15131F);
-  static const _signOff = ui.Color(0xFF2B2836);
-  static const _shutter = ui.Color(0xFF232230);
   static const _warmLight = ui.Color(0xFFFFE2B8);
+
+  /// A fixed dark for what the sky never reaches: the shade inside a lit
+  /// interior, and the dark stripe on a painted canvas awning.
+  static const _shade = ui.Color(0xFF0B0A14);
 
   /// The alarm colours match the lanterns.
   static const _alarm = ui.Color(0xFFE4655F);
@@ -160,6 +316,7 @@ class WallTextures {
     LanternState state, {
     int variant = 0,
     PlazaCopy? copy,
+    WallInk ink = WallInk.night,
   }) {
     const w = shopfrontWidth * _px;
     const h = shopfrontHeight * _px;
@@ -168,7 +325,7 @@ class WallTextures {
       ..scale(_textureScale)
       ..drawRect(
         const ui.Rect.fromLTWH(0, 0, w, h),
-        ui.Paint()..color = _night,
+        ui.Paint()..color = ink.wall,
       );
     final rng = math.Random(31337 + state.index * 7 + variant);
     final dressing = _Dressing.forState(state);
@@ -182,6 +339,7 @@ class WallTextures {
         _m(shop.width),
         dressing,
         copy ?? PlazaCopy.english,
+        ink,
       );
       left += _m(shop.width);
     }
@@ -245,6 +403,7 @@ class WallTextures {
     double width,
     _Dressing dressing,
     PlazaCopy copy,
+    WallInk ink,
   ) {
     const h = shopfrontHeight * _px;
     final lit = dressing.lit;
@@ -255,7 +414,7 @@ class WallTextures {
     // it is still fitting out.
     canvas.drawRect(
       ui.Rect.fromLTWH(left, 0, width, _m(_fasciaM)),
-      ui.Paint()..color = ui.Color.lerp(_board, shop.colour, 0.12)!,
+      ui.Paint()..color = ui.Color.lerp(ink.board, shop.colour, 0.12)!,
     );
     if (dressing != _Dressing.fittingOut) {
       final signW = width * (0.5 + rng.nextDouble() * 0.15);
@@ -316,7 +475,7 @@ class WallTextures {
         // is on the wall where the walker reads it.
         final alarm = dressing == _Dressing.shuttered;
         canvas
-          ..drawRect(sign, ui.Paint()..color = _signOff)
+          ..drawRect(sign, ui.Paint()..color = ink.signOff)
           ..drawRect(
             sign.deflate(2),
             ui.Paint()
@@ -390,7 +549,7 @@ class WallTextures {
       case _Dressing.trading when vacant:
       case _Dressing.late when vacant:
       case _Dressing.fittingOut:
-        _paintPapered(canvas, rng, glass);
+        _paintPapered(canvas, rng, glass, ink);
         _paintDoor(
           canvas,
           door,
@@ -398,8 +557,9 @@ class WallTextures {
           lit: false,
           dressing: dressing,
           copy: copy,
+          ink: ink,
         );
-        canvas.drawRect(riser, ui.Paint()..color = _riser);
+        canvas.drawRect(riser, ui.Paint()..color = ink.riser);
       case _Dressing.trading:
       case _Dressing.late:
         _paintInterior(
@@ -408,6 +568,7 @@ class WallTextures {
           glass,
           shop,
           late: dressing == _Dressing.late,
+          ink: ink,
         );
         _paintDoor(
           canvas,
@@ -416,8 +577,9 @@ class WallTextures {
           lit: true,
           dressing: dressing,
           copy: copy,
+          ink: ink,
         );
-        canvas.drawRect(riser, ui.Paint()..color = _riser);
+        canvas.drawRect(riser, ui.Paint()..color = ink.riser);
         if (shop.awning) _paintAwning(canvas, glass, accent);
       case _Dressing.shuttered:
       case _Dressing.closed:
@@ -427,12 +589,13 @@ class WallTextures {
           door,
           alarm: dressing == _Dressing.shuttered,
           copy: copy,
+          ink: ink,
         );
     }
-    // Pilaster: the dark column between one shop and the next.
+    // Pilaster: the column between one shop and the next.
     canvas.drawRect(
       ui.Rect.fromLTWH(left, _m(_fasciaM), _m(_pilasterM), h - _m(_fasciaM)),
-      ui.Paint()..color = _frame,
+      ui.Paint()..color = ink.frame,
     );
   }
 
@@ -442,6 +605,7 @@ class WallTextures {
     ui.Rect glass,
     _Shop shop, {
     required bool late,
+    required WallInk ink,
   }) {
     final (interior, glow) = switch (shop.trade) {
       _Trade.cafe => (const ui.Color(0xFFFFD08A), 0.6),
@@ -454,7 +618,7 @@ class WallTextures {
       _Trade.vacant => (const ui.Color(0xFF8A8598), 0.2),
     };
     canvas
-      ..drawRect(glass.inflate(_m(0.05)), ui.Paint()..color = _frame)
+      ..drawRect(glass.inflate(_m(0.05)), ui.Paint()..color = ink.frame)
       ..drawRect(
         glass,
         ui.Paint()
@@ -490,13 +654,13 @@ class WallTextures {
       // Trading late: the whole interior flooded in the alarm amber.
       canvas.drawRect(glass, ui.Paint()..color = _amber.withValues(alpha: 0.3));
     }
-    _paintMullions(canvas, glass);
+    _paintMullions(canvas, glass, ink);
   }
 
   /// Vertical mullions about every 1.4 m and a transom under the fanlight.
-  static void _paintMullions(ui.Canvas canvas, ui.Rect glass) {
+  static void _paintMullions(ui.Canvas canvas, ui.Rect glass, WallInk ink) {
     final panes = math.max(1, (glass.width / _m(1.4)).round());
-    final paint = ui.Paint()..color = _frame;
+    final paint = ui.Paint()..color = ink.mullion;
     for (var i = 1; i < panes; i++) {
       final x = glass.left + glass.width * i / panes;
       canvas.drawRect(
@@ -540,8 +704,9 @@ class WallTextures {
     required bool lit,
     required _Dressing dressing,
     required PlazaCopy copy,
+    required WallInk ink,
   }) {
-    canvas.drawRect(door.inflate(_m(0.06)), ui.Paint()..color = _frame);
+    canvas.drawRect(door.inflate(_m(0.06)), ui.Paint()..color = ink.frame);
     if (lit) {
       canvas
         ..drawRect(
@@ -559,7 +724,7 @@ class WallTextures {
         )
         ..drawRect(
           ui.Rect.fromLTWH(door.left, door.top + _m(0.38), door.width, 3),
-          ui.Paint()..color = _frame,
+          ui.Paint()..color = ink.frame,
         );
     } else {
       // A notice taped to the door at eye height, with the words on it.
@@ -570,7 +735,7 @@ class WallTextures {
         _m(0.42),
       );
       canvas
-        ..drawRect(door, ui.Paint()..color = _leaf)
+        ..drawRect(door, ui.Paint()..color = ink.leaf)
         ..drawRect(notice, ui.Paint()..color = const ui.Color(0xFFEDE6D6));
       _paintWord(
         canvas,
@@ -590,8 +755,13 @@ class WallTextures {
   }
 
   /// Not open yet: sheets of paper taped inside the glass, seams between.
-  static void _paintPapered(ui.Canvas canvas, math.Random rng, ui.Rect glass) {
-    canvas.drawRect(glass.inflate(_m(0.05)), ui.Paint()..color = _frame);
+  static void _paintPapered(
+    ui.Canvas canvas,
+    math.Random rng,
+    ui.Rect glass,
+    WallInk ink,
+  ) {
+    canvas.drawRect(glass.inflate(_m(0.05)), ui.Paint()..color = ink.frame);
     var x = glass.left;
     while (x < glass.right) {
       final sheet = math.min(_m(0.6 + rng.nextDouble() * 0.5), glass.right - x);
@@ -626,7 +796,7 @@ class WallTextures {
           ..maskFilter = ui.MaskFilter.blur(ui.BlurStyle.normal, _m(0.3)),
       );
     }
-    _paintMullions(canvas, glass);
+    _paintMullions(canvas, glass, ink);
   }
 
   /// Shutters down over the glass and the door; alarm tape across them
@@ -638,6 +808,7 @@ class WallTextures {
     ui.Rect door, {
     required bool alarm,
     required PlazaCopy copy,
+    required WallInk ink,
   }) {
     const h = shopfrontHeight * _px;
     final span = ui.Rect.fromLTRB(
@@ -646,7 +817,7 @@ class WallTextures {
       math.max(glass.right, door.right) + _m(0.06),
       h,
     );
-    canvas.drawRect(span, ui.Paint()..color = _shutter);
+    canvas.drawRect(span, ui.Paint()..color = ink.shutter);
     final light = ui.Paint()..color = const ui.Color(0xFF3B3A4A);
     final dark = ui.Paint()..color = const ui.Color(0xFF14131C);
     for (var y = span.top + _m(0.18); y < span.bottom; y += _m(0.18)) {
@@ -741,7 +912,7 @@ class WallTextures {
       _m(0.32),
     );
     canvas.drawRect(band, ui.Paint()..color = accent);
-    final stripe = ui.Paint()..color = _night.withValues(alpha: 0.7);
+    final stripe = ui.Paint()..color = _shade.withValues(alpha: 0.7);
     for (var x = band.left + _m(0.15); x < band.right; x += _m(0.3)) {
       canvas.drawRect(
         ui.Rect.fromLTWH(
@@ -755,7 +926,7 @@ class WallTextures {
     }
     canvas.drawRect(
       ui.Rect.fromLTWH(band.left, band.bottom - 3, band.width, 3),
-      ui.Paint()..color = ui.Color.lerp(accent, _night, 0.5)!,
+      ui.Paint()..color = ui.Color.lerp(accent, _shade, 0.5)!,
     );
   }
 
@@ -1052,7 +1223,7 @@ class WallTextures {
           ..drawRect(screen, ui.Paint()..color = colour)
           ..drawRect(
             screen.deflate(_m(0.05)),
-            ui.Paint()..color = _night.withValues(alpha: 0.45),
+            ui.Paint()..color = _shade.withValues(alpha: 0.45),
           );
         i++;
       }
@@ -1143,7 +1314,11 @@ class WallTextures {
     return recorder.endRecording().toImageSync(size, size);
   }
 
-  static ui.Image _paintPool() {
+  /// The radial falloff every ground light — and, in daylight, every
+  /// contact shadow — is drawn with. White; the material colour tints it.
+  /// Public so its shape can be checked without a GPU.
+  @visibleForTesting
+  static ui.Image paintPool() {
     const size = 256;
     final recorder = ui.PictureRecorder();
     ui.Canvas(recorder).drawCircle(
@@ -1169,7 +1344,43 @@ class WallTextures {
     return recorder.endRecording().toImageSync(size, size);
   }
 
-  static ui.Image _paintGrain() {
+  /// The mask a contact shadow is drawn with: opaque across the middle,
+  /// feathered at the rim.
+  ///
+  /// Deliberately not the light pool's falloff. A pool is a hot core with a
+  /// long thin skirt, which is right for light — the ground is brightest
+  /// under the lamp — but wrong for shade: multiplied into a dark colour,
+  /// that skirt darkens the paving by a percent or two and the shadow reads
+  /// as a stain. Shade is flat in the middle and soft only at its edge.
+  /// Public so its shape can be checked without a GPU.
+  @visibleForTesting
+  static ui.Image paintShadow() {
+    const size = 256;
+    final recorder = ui.PictureRecorder();
+    ui.Canvas(recorder).drawCircle(
+      const ui.Offset(size / 2, size / 2),
+      size / 2,
+      ui.Paint()
+        ..shader = ui.Gradient.radial(
+          const ui.Offset(size / 2, size / 2),
+          size / 2,
+          const [
+            ui.Color(0xFFFFFFFF),
+            ui.Color(0xFFFFFFFF),
+            ui.Color(0x8CFFFFFF),
+            ui.Color(0x00FFFFFF),
+          ],
+          const [0, 0.55, 0.82, 1],
+        ),
+    );
+    return recorder.endRecording().toImageSync(size, size);
+  }
+
+  /// Asphalt grain: a transparent tile of dark grit with the odd light
+  /// fleck, blended over whichever road colour the hour supplies. Public so
+  /// it can be checked without a GPU.
+  @visibleForTesting
+  static ui.Image paintGrain() {
     const size = 128;
     final recorder = ui.PictureRecorder();
     final canvas = ui.Canvas(recorder)
@@ -1200,7 +1411,11 @@ class WallTextures {
   /// Paints the window tile for [state] in tile [family]; public so the
   /// occupancy contract can be checked without a GPU.
   @visibleForTesting
-  static ui.Image paintWindows(LanternState state, {int family = 0}) {
+  static ui.Image paintWindows(
+    LanternState state, {
+    int family = 0,
+    WallInk ink = WallInk.night,
+  }) {
     const w = bays * _px;
     const h = floors * _px;
     final recorder = ui.PictureRecorder();
@@ -1208,10 +1423,7 @@ class WallTextures {
       ..scale(_textureScale)
       ..drawRect(
         ui.Rect.fromLTWH(0, 0, w.toDouble(), h.toDouble()),
-        ui.Paint()
-          ..color = family == 2
-              ? dsTokensDark.colors.aiCard.background
-              : _night,
+        ui.Paint()..color = family == 2 ? ink.officeWall : ink.wall,
       );
     final rng = math.Random(state.index * 7919 + 17 + family * 101);
     final tint = _tints[state]!;
@@ -1242,32 +1454,28 @@ class WallTextures {
         final roll = rng.nextDouble() < lit;
         final on = floor != darkFloor && (floor == litFloor || roll);
         // Two tints per state: most windows warm, a few the cooler one,
-        // and a sill-to-lintel gradient so the pane has depth.
+        // and a sill-to-lintel gradient so the pane has depth. By day the
+        // tint gives way to the sky the glass mirrors, and occupancy shows
+        // as the room behind the reflection.
         final cool = rng.nextDouble() < coolShare;
         final base = cool ? _coolTint : tint;
-        // Lit panes top out below full white so screens and signs stay
-        // the brightest things on a wall.
-        final glow = on
-            ? 0.4 + rng.nextDouble() * 0.4
-            : 0.14 + rng.nextDouble() * 0.1;
-        // Reveal: a dark frame around the pane; then the pane with a
-        // sill-to-lintel gradient; then mullion and transom.
-        final mullion = ui.Paint()..color = _frame;
+        final (paneTop, paneBottom) = ink.pane(
+          tint: base,
+          on: on,
+          roll: rng.nextDouble(),
+        );
+        // Reveal: the wall's thickness around the pane — a hole at night,
+        // a band of shade by day; then the pane; then mullion and transom.
+        final mullion = ui.Paint()..color = ink.mullion;
         canvas
-          ..drawRect(
-            rect.inflate(_px * 0.03),
-            ui.Paint()..color = const ui.Color(0xFF050409),
-          )
+          ..drawRect(rect.inflate(_px * 0.03), ui.Paint()..color = ink.reveal)
           ..drawRect(
             rect,
             ui.Paint()
               ..shader = ui.Gradient.linear(
                 rect.topCenter,
                 rect.bottomCenter,
-                [
-                  base.withValues(alpha: glow),
-                  base.withValues(alpha: glow * 0.55),
-                ],
+                [paneTop, paneBottom],
               ),
           )
           ..drawRect(
@@ -1292,7 +1500,7 @@ class WallTextures {
               rect.width,
               rect.height * (0.25 + rng.nextDouble() * 0.35),
             ),
-            ui.Paint()..color = const ui.Color(0xB30B0A14),
+            ui.Paint()..color = ink.blind,
           );
         }
         if (office) {
@@ -1304,19 +1512,19 @@ class WallTextures {
               _px * 0.025,
               _px.toDouble(),
             ),
-            ui.Paint()..color = dsTokensDark.colors.background.level03,
+            ui.Paint()..color = ink.mullion,
           );
         }
       }
-      // Floor slab: a lit edge over a dark band, the relief of a storey.
+      // Floor slab: an edge over a band, the relief of a storey.
       canvas
         ..drawRect(
           ui.Rect.fromLTWH(0, floor * _px.toDouble(), w.toDouble(), 6),
-          ui.Paint()..color = _frame,
+          ui.Paint()..color = ink.frame,
         )
         ..drawRect(
           ui.Rect.fromLTWH(0, floor * _px.toDouble() + 6, w.toDouble(), 3),
-          ui.Paint()..color = const ui.Color(0xFF1C1A2A),
+          ui.Paint()..color = ink.slabEdge,
         );
     }
     return recorder.endRecording().toImageSync(

--- a/lib/features/plaza/state/plaza_sky_mode_controller.dart
+++ b/lib/features/plaza/state/plaza_sky_mode_controller.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/domain_logging.dart';
+
+/// SettingsDb key for the sky the plaza is entered under.
+const plazaSkyModeSettingsKey = 'PLAZA_SKY_MODE';
+
+/// Remembers whether the walker last left the district in daylight or at
+/// night, so entering it again does not undo the choice.
+///
+/// Loads once from [SettingsDb], holds the mode in memory and persists every
+/// change. SettingsDb writes emit no `UpdateNotifications` token, so the
+/// world watches this provider rather than re-reading the database. A
+/// missing, unreadable or unrecognised preference yields night — the hour
+/// the district was designed in — a failed write keeps the in-memory choice,
+/// and a still-in-flight initial load never clobbers a choice just made.
+class PlazaSkyModeController extends Notifier<PlazaSkyMode> {
+  bool _chosen = false;
+
+  @override
+  PlazaSkyMode build() {
+    unawaited(_load());
+    return PlazaSkyMode.night;
+  }
+
+  Future<void> _load() async {
+    if (!getIt.isRegistered<SettingsDb>()) return;
+    final String? raw;
+    try {
+      raw = await getIt<SettingsDb>().itemByKey(plazaSkyModeSettingsKey);
+    } catch (error, stackTrace) {
+      _report('load', error, stackTrace);
+      return;
+    }
+    if (!ref.mounted || _chosen || raw == null) return;
+    state = PlazaSkyMode.fromName(raw);
+  }
+
+  /// Switches the sky and remembers it in the background. A failed write is
+  /// logged and swallowed: the choice stands for this session.
+  void set(PlazaSkyMode mode) {
+    _chosen = true;
+    if (state == mode) return;
+    state = mode;
+    unawaited(_persist(mode));
+  }
+
+  Future<void> _persist(PlazaSkyMode mode) async {
+    if (!getIt.isRegistered<SettingsDb>()) return;
+    try {
+      await getIt<SettingsDb>().saveSettingsItem(
+        plazaSkyModeSettingsKey,
+        mode.name,
+      );
+    } catch (error, stackTrace) {
+      _report('persist', error, stackTrace);
+    }
+  }
+
+  /// Both database paths run fire-and-forget, so a thrown error would
+  /// surface as an unhandled asynchronous error; it is logged instead.
+  void _report(String operation, Object error, StackTrace stackTrace) {
+    if (!getIt.isRegistered<DomainLogger>()) return;
+    getIt<DomainLogger>().error(
+      LogDomain.settings,
+      error,
+      stackTrace: stackTrace,
+      subDomain: 'plazaSkyMode.$operation',
+    );
+  }
+}
+
+/// The remembered sky for every plaza world.
+final NotifierProvider<PlazaSkyModeController, PlazaSkyMode>
+plazaSkyModeProvider = NotifierProvider<PlazaSkyModeController, PlazaSkyMode>(
+  PlazaSkyModeController.new,
+  name: 'plazaSkyModeProvider',
+);

--- a/lib/features/plaza/ui/category_plaza_page.dart
+++ b/lib/features/plaza/ui/category_plaza_page.dart
@@ -3,6 +3,7 @@ import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/plaza/data/plaza_repository.dart';
 import 'package:lotti/features/plaza/scene/category_world_generator.dart';
 import 'package:lotti/features/plaza/scene/plaza_world.dart';
+import 'package:lotti/features/plaza/state/plaza_sky_mode_controller.dart';
 import 'package:lotti/features/plaza/state/project_plaza_provider.dart';
 import 'package:lotti/features/plaza/ui/checklist_ticks.dart';
 import 'package:lotti/features/plaza/ui/plaza_copy.dart';
@@ -106,6 +107,8 @@ class _CategoryPlazaPageState extends ConsumerState<CategoryPlazaPage> {
               );
             },
             onExit: () => Navigator.of(context).pop(),
+            initialSkyMode: ref.watch(plazaSkyModeProvider),
+            onSkyModeChanged: ref.read(plazaSkyModeProvider.notifier).set,
           );
         },
       ),

--- a/lib/features/plaza/ui/plaza_hud.dart
+++ b/lib/features/plaza/ui/plaza_hud.dart
@@ -5,6 +5,7 @@ import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/plaza/domain/attention.dart';
 import 'package:lotti/features/plaza/ui/debug_overlay.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
 import 'package:lotti/features/plaza/ui/plaza_style.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:material_ui/material_ui.dart';
@@ -22,6 +23,8 @@ class PlazaHud extends StatelessWidget {
     required this.onHome,
     required this.frameRate,
     required this.onFrameRateChanged,
+    required this.skyMode,
+    required this.onSkyModeChanged,
     required this.showPenguins,
     required this.onShowPenguinsChanged,
     required this.showMeerkats,
@@ -29,6 +32,7 @@ class PlazaHud extends StatelessWidget {
     required this.showDebug,
     required this.onShowDebugChanged,
     this.onExit,
+    this.palette = PlazaPalette.night,
     this.showConnections = true,
     this.onShowConnectionsChanged,
     this.isCategory = false,
@@ -50,6 +54,15 @@ class PlazaHud extends StatelessWidget {
   final ValueChanged<bool>? onShowConnectionsChanged;
   final PlazaFrameRate frameRate;
   final ValueChanged<PlazaFrameRate> onFrameRateChanged;
+
+  /// The sky the world is under, and the control that changes it.
+  final PlazaSkyMode skyMode;
+  final ValueChanged<PlazaSkyMode> onSkyModeChanged;
+
+  /// The active palette. The status legend reads its lantern colours from
+  /// here, so the key under the street always shows the colours the roofs
+  /// are actually wearing.
+  final PlazaPalette palette;
   final bool showMeerkats;
   final ValueChanged<bool>? onShowMeerkatsChanged;
   final bool showPenguins;
@@ -70,120 +83,136 @@ class PlazaHud extends StatelessWidget {
             alignment: Alignment.topCenter,
             child: Padding(
               padding: EdgeInsets.all(tokens.spacing.step4),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Wrap(
-                    spacing: tokens.spacing.step4,
-                    runSpacing: tokens.spacing.step2,
-                    crossAxisAlignment: WrapCrossAlignment.center,
-                    children: [
-                      if (onExit != null)
-                        DesignSystemButton(
-                          label: messages.designSystemBackLabel,
-                          variant: DesignSystemButtonVariant.secondary,
-                          onPressed: onExit,
+              child: _Legible(
+                palette: palette,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Wrap(
+                      spacing: tokens.spacing.step4,
+                      runSpacing: tokens.spacing.step2,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: [
+                        if (onExit != null)
+                          DesignSystemButton(
+                            label: messages.designSystemBackLabel,
+                            variant: DesignSystemButtonVariant.secondary,
+                            onPressed: onExit,
+                          ),
+                        IgnorePointer(
+                          child: Text(
+                            '$projectLabel — ${messages.plazaTitle}',
+                            style: tokens.typography.styles.subtitle.subtitle2,
+                          ),
                         ),
-                      IgnorePointer(
-                        child: Text(
-                          '$projectLabel — ${messages.plazaTitle}',
-                          style: tokens.typography.styles.subtitle.subtitle2,
-                        ),
-                      ),
-                      IgnorePointer(
-                        child: Text(
-                          isCategory
-                              ? '${messages.projectCountSummary(taskCount)} · ${messages.plazaNeedsAttention(attentionCount)}'
-                              : messages.plazaStats(
-                                  taskCount,
-                                  weekCount,
-                                  attentionCount,
+                        IgnorePointer(
+                          child: Text(
+                            isCategory
+                                ? '${messages.projectCountSummary(taskCount)} · ${messages.plazaNeedsAttention(attentionCount)}'
+                                : messages.plazaStats(
+                                    taskCount,
+                                    weekCount,
+                                    attentionCount,
+                                  ),
+                            style: tokens.typography.styles.others.caption
+                                .copyWith(
+                                  color: tokens.colors.text.mediumEmphasis,
                                 ),
-                          style: tokens.typography.styles.others.caption
-                              .copyWith(
-                                color: tokens.colors.text.mediumEmphasis,
-                              ),
+                          ),
                         ),
-                      ),
-                    ],
-                  ),
-                  SizedBox(height: tokens.spacing.step3),
-                  Wrap(
-                    spacing: tokens.spacing.step3,
-                    runSpacing: tokens.spacing.step2,
-                    crossAxisAlignment: WrapCrossAlignment.center,
-                    children: [
-                      DesignSystemButton(
-                        label: messages.plazaMorningWalk,
-                        onPressed: onMorningWalk,
-                      ),
-                      DesignSystemButton(
-                        label: messages.plazaOverview,
-                        variant: DesignSystemButtonVariant.secondary,
-                        onPressed: onOverview,
-                      ),
-                      DesignSystemButton(
-                        label: messages.designSystemBreadcrumbHomeLabel,
-                        variant: DesignSystemButtonVariant.secondary,
-                        onPressed: onHome,
-                      ),
-                      DsSegmentedToggle<PlazaFrameRate>(
-                        segments: [
-                          for (final rate in PlazaFrameRate.values)
+                      ],
+                    ),
+                    SizedBox(height: tokens.spacing.step3),
+                    Wrap(
+                      spacing: tokens.spacing.step3,
+                      runSpacing: tokens.spacing.step2,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: [
+                        DesignSystemButton(
+                          label: messages.plazaMorningWalk,
+                          onPressed: onMorningWalk,
+                        ),
+                        DesignSystemButton(
+                          label: messages.plazaOverview,
+                          variant: DesignSystemButtonVariant.secondary,
+                          onPressed: onOverview,
+                        ),
+                        DesignSystemButton(
+                          label: messages.designSystemBreadcrumbHomeLabel,
+                          variant: DesignSystemButtonVariant.secondary,
+                          onPressed: onHome,
+                        ),
+                        DsSegmentedToggle<PlazaSkyMode>(
+                          segments: [
                             DsSegment(
-                              rate,
-                              rate == PlazaFrameRate.auto
-                                  ? messages.habitAutoPillLabel
-                                  : rate.label,
+                              PlazaSkyMode.night,
+                              messages.plazaSkyNight,
                             ),
-                        ],
-                        selected: frameRate,
-                        onChanged: onFrameRateChanged,
-                      ),
-                      DesignSystemCheckbox(
-                        value: showPenguins,
-                        label: messages.plazaShowPenguins,
-                        onChanged: onShowPenguinsChanged == null
-                            ? null
-                            : (value) => onShowPenguinsChanged!(value ?? false),
-                      ),
-                      if (onShowConnectionsChanged != null)
-                        DesignSystemCheckbox(
-                          value: showConnections,
-                          label: messages.knowledgeGraphViewConnections,
-                          onChanged: (value) =>
-                              onShowConnectionsChanged!(value ?? false),
+                            DsSegment(PlazaSkyMode.day, messages.plazaSkyDay),
+                          ],
+                          selected: skyMode,
+                          onChanged: onSkyModeChanged,
                         ),
-                      DesignSystemCheckbox(
-                        value: showMeerkats,
-                        label: messages.plazaMeerkats,
-                        onChanged: onShowMeerkatsChanged == null
-                            ? null
-                            : (value) => onShowMeerkatsChanged!(value ?? false),
-                      ),
-                      DesignSystemCheckbox(
-                        value: showDebug,
-                        label: messages.plazaDebug,
-                        onChanged: (value) =>
-                            onShowDebugChanged(value ?? false),
-                      ),
-                    ],
-                  ),
-                  if (toast != null)
-                    Padding(
-                      padding: EdgeInsets.only(top: tokens.spacing.step3),
-                      child: IgnorePointer(
-                        child: Center(
-                          child: DsPill(
-                            variant: DsPillVariant.filled,
-                            shape: DsPillShape.tag,
-                            label: toast,
+                        DsSegmentedToggle<PlazaFrameRate>(
+                          segments: [
+                            for (final rate in PlazaFrameRate.values)
+                              DsSegment(
+                                rate,
+                                rate == PlazaFrameRate.auto
+                                    ? messages.habitAutoPillLabel
+                                    : rate.label,
+                              ),
+                          ],
+                          selected: frameRate,
+                          onChanged: onFrameRateChanged,
+                        ),
+                        DesignSystemCheckbox(
+                          value: showPenguins,
+                          label: messages.plazaShowPenguins,
+                          onChanged: onShowPenguinsChanged == null
+                              ? null
+                              : (value) =>
+                                    onShowPenguinsChanged!(value ?? false),
+                        ),
+                        if (onShowConnectionsChanged != null)
+                          DesignSystemCheckbox(
+                            value: showConnections,
+                            label: messages.knowledgeGraphViewConnections,
+                            onChanged: (value) =>
+                                onShowConnectionsChanged!(value ?? false),
+                          ),
+                        DesignSystemCheckbox(
+                          value: showMeerkats,
+                          label: messages.plazaMeerkats,
+                          onChanged: onShowMeerkatsChanged == null
+                              ? null
+                              : (value) =>
+                                    onShowMeerkatsChanged!(value ?? false),
+                        ),
+                        DesignSystemCheckbox(
+                          value: showDebug,
+                          label: messages.plazaDebug,
+                          onChanged: (value) =>
+                              onShowDebugChanged(value ?? false),
+                        ),
+                      ],
+                    ),
+                    if (toast != null)
+                      Padding(
+                        padding: EdgeInsets.only(top: tokens.spacing.step3),
+                        child: IgnorePointer(
+                          child: Center(
+                            child: DsPill(
+                              variant: DsPillVariant.filled,
+                              shape: DsPillShape.tag,
+                              label: toast,
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),
@@ -192,67 +221,104 @@ class PlazaHud extends StatelessWidget {
             child: IgnorePointer(
               child: Padding(
                 padding: EdgeInsets.all(tokens.spacing.step4),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    if (walkChip != null)
-                      Padding(
-                        padding: EdgeInsets.only(bottom: tokens.spacing.step3),
-                        child: DsPill(
-                          variant: DsPillVariant.filled,
-                          shape: DsPillShape.tag,
-                          label: walkChip,
+                child: _Legible(
+                  palette: palette,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (walkChip != null)
+                        Padding(
+                          padding: EdgeInsets.only(
+                            bottom: tokens.spacing.step3,
+                          ),
+                          child: DsPill(
+                            variant: DsPillVariant.filled,
+                            shape: DsPillShape.tag,
+                            label: walkChip,
+                          ),
+                        ),
+                      Wrap(
+                        spacing: tokens.spacing.step3,
+                        runSpacing: tokens.spacing.step2,
+                        alignment: WrapAlignment.center,
+                        children: [
+                          for (final (label, color) in [
+                            (
+                              messages.taskStatusInProgress,
+                              palette.lanterns.of(LanternState.inProgress),
+                            ),
+                            (
+                              messages.taskStatusOpen,
+                              palette.lanterns.of(LanternState.open),
+                            ),
+                            (
+                              messages.taskStatusBlocked,
+                              palette.lanterns.of(LanternState.blocked),
+                            ),
+                            (
+                              messages.projectTasksDueOverdue,
+                              palette.lanterns.of(LanternState.overdue),
+                            ),
+                            (
+                              messages.taskStatusDone,
+                              tokens.colors.alert.success.defaultColor,
+                            ),
+                          ])
+                            DsPill(
+                              variant: DsPillVariant.tinted,
+                              shape: DsPillShape.tag,
+                              label: label,
+                              color: color,
+                            ),
+                        ],
+                      ),
+                      SizedBox(height: tokens.spacing.step3),
+                      Text(
+                        messages.plazaControls,
+                        textAlign: TextAlign.center,
+                        style: tokens.typography.styles.others.caption.copyWith(
+                          color: tokens.colors.text.mediumEmphasis,
                         ),
                       ),
-                    Wrap(
-                      spacing: tokens.spacing.step3,
-                      runSpacing: tokens.spacing.step2,
-                      alignment: WrapAlignment.center,
-                      children: [
-                        for (final (label, color) in [
-                          (
-                            messages.taskStatusInProgress,
-                            PlazaStyle.lantern(LanternState.inProgress),
-                          ),
-                          (
-                            messages.taskStatusOpen,
-                            PlazaStyle.lantern(LanternState.open),
-                          ),
-                          (
-                            messages.taskStatusBlocked,
-                            PlazaStyle.lantern(LanternState.blocked),
-                          ),
-                          (
-                            messages.projectTasksDueOverdue,
-                            PlazaStyle.lantern(LanternState.overdue),
-                          ),
-                          (
-                            messages.taskStatusDone,
-                            tokens.colors.alert.success.defaultColor,
-                          ),
-                        ])
-                          DsPill(
-                            variant: DsPillVariant.tinted,
-                            shape: DsPillShape.tag,
-                            label: label,
-                            color: color,
-                          ),
-                      ],
-                    ),
-                    SizedBox(height: tokens.spacing.step3),
-                    Text(
-                      messages.plazaControls,
-                      textAlign: TextAlign.center,
-                      style: tokens.typography.styles.others.caption.copyWith(
-                        color: tokens.colors.text.mediumEmphasis,
-                      ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Keeps the HUD readable over whatever the world is doing behind it.
+///
+/// The chrome is dark: white type and tinted status pills, drawn straight
+/// onto the scene. Against a night street that works — the street is
+/// darker than the type. Against a sunlit one it does not, so daylight
+/// puts the chrome on a scrim and night leaves the view unobstructed.
+class _Legible extends StatelessWidget {
+  const _Legible({required this.palette, required this.child});
+
+  final PlazaPalette palette;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!palette.isDay) return child;
+    final tokens = context.designTokens;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: PlazaStyle.panel.withValues(alpha: SurfaceAlphas.linework),
+        borderRadius: BorderRadius.circular(tokens.radii.sectionCards),
+      ),
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: tokens.spacing.step3,
+          vertical: tokens.spacing.step2,
+        ),
+        child: child,
       ),
     );
   }

--- a/lib/features/plaza/ui/plaza_palette.dart
+++ b/lib/features/plaza/ui/plaza_palette.dart
@@ -1,0 +1,535 @@
+import 'dart:math' as math;
+import 'dart:ui' show Color;
+
+import 'package:flutter/foundation.dart' show immutable;
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/plaza/domain/attention.dart';
+import 'package:lotti/features/plaza/domain/plaza_task.dart';
+import 'package:material_ui/material_ui.dart' show Colors;
+
+/// Which sky the world is built under.
+///
+/// The plaza renders with unlit materials, so nothing here is a light: the
+/// hour is *painted*. A mode selects a whole [PlazaPalette] — sky, haze,
+/// paving, walls, and how far emitters are pushed — and the scene is rebuilt
+/// with it. There is no blend between the two; a switch is a rebuild.
+enum PlazaSkyMode {
+  night,
+  day;
+
+  /// `PLAZA_DAY=1` boots the fixture into daylight.
+  static PlazaSkyMode fromEnvironment(Map<String, String> env) =>
+      env['PLAZA_DAY'] == '1' ? day : night;
+
+  /// The stored preference. An unknown or missing name is night, the mode
+  /// the world was designed in.
+  static PlazaSkyMode fromName(String? name) => PlazaSkyMode.values.firstWhere(
+    (mode) => mode.name == name,
+    orElse: () => night,
+  );
+}
+
+/// The dome: a zenith-to-horizon gradient with a sun disk in it.
+///
+/// Both modes use the same gradient source, so the only difference is its
+/// numbers. Night's sun is black at zero intensity, which is what makes
+/// [hasSun] — and with it every sun-derived effect, shading and shadows —
+/// false without a second code path.
+@immutable
+class PlazaSky {
+  const PlazaSky({
+    required this.zenith,
+    required this.horizon,
+    required this.ground,
+    required this.sun,
+    required this.sunIntensity,
+    required this.sunAzimuth,
+    required this.sunElevation,
+    required this.sunSharpness,
+  });
+
+  /// Straight up.
+  final Color zenith;
+
+  /// Where the sky meets the district.
+  final Color horizon;
+
+  /// Below the horizon; the fog resolves into it at eye level.
+  final Color ground;
+
+  /// The disk's hue. Multiplied by [sunIntensity] into the HDR value the
+  /// bloom pass sees, so a sun above 1.0 blooms and a night sky does not.
+  final Color sun;
+  final double sunIntensity;
+
+  /// Where the sun stands. Azimuth is measured from +Z toward +X, the way
+  /// the street's yaws are; elevation rises from the horizon.
+  final double sunAzimuth;
+  final double sunElevation;
+
+  /// Disk tightness; higher is a smaller, harder sun.
+  final double sunSharpness;
+
+  /// Whether anything is up there to cast light. Night has a sun in the
+  /// data (a black one at zero intensity) so the shader binding stays one
+  /// shape; this is the question the scene actually asks.
+  bool get hasSun => sunIntensity > 0;
+
+  /// Unit vector toward the sun.
+  ({double x, double y, double z}) get sunDirection => (
+    x: math.cos(sunElevation) * math.sin(sunAzimuth),
+    y: math.sin(sunElevation),
+    z: math.cos(sunElevation) * math.cos(sunAzimuth),
+  );
+
+  /// How far a [height]-metre wall throws its shadow across the paving.
+  /// Clamped because a low sun would otherwise stretch a tower's shadow
+  /// across the whole district and swallow the street.
+  double shadowLength(double height) {
+    if (!hasSun) return 0;
+    final tangent = math.tan(sunElevation);
+    if (tangent <= 0) return maxShadowLength;
+    return math.min(height / tangent, maxShadowLength);
+  }
+
+  /// Metres. A shadow longer than this reads as a stain, not a shadow.
+  static const maxShadowLength = 26.0;
+}
+
+/// What the air does between the camera and the district: haze, bloom and
+/// vignette. Every value the sky pass and the scene controller write per
+/// frame lives here rather than as a scene constant, so the hour owns them.
+@immutable
+class PlazaAir {
+  const PlazaAir({
+    required this.fog,
+    required this.fogDensityLow,
+    required this.fogDensityHigh,
+    required this.fogOpacityLow,
+    required this.fogOpacityHigh,
+    required this.bloomThreshold,
+    required this.bloomIntensity,
+    required this.bloomScatter,
+    required this.vignetteIntensity,
+    required this.vignetteRadius,
+    required this.vignetteSmoothness,
+  });
+
+  /// The haze's own colour: between the ground and the horizon, so it never
+  /// outshines the paving the walker stands on.
+  final Color fog;
+
+  /// Haze at eye level and from the air. It thins as the camera climbs so
+  /// the overview sees a district rather than a wash.
+  final double fogDensityLow;
+  final double fogDensityHigh;
+  final double fogOpacityLow;
+  final double fogOpacityHigh;
+
+  /// HDR brightness above which a pixel blooms, how much comes back, and
+  /// how wide it spreads.
+  final double bloomThreshold;
+  final double bloomIntensity;
+  final double bloomScatter;
+
+  /// A zero intensity disables the vignette outright.
+  final double vignetteIntensity;
+  final double vignetteRadius;
+  final double vignetteSmoothness;
+
+  bool get hasVignette => vignetteIntensity > 0;
+
+  /// The bloom is worth running when something can exceed its threshold.
+  bool get hasBloom => bloomIntensity > 0;
+}
+
+/// The flat colours of the built world. Under unlit materials these are the
+/// final pixels, not albedos waiting for a light — which is why the day set
+/// is mid-toned rather than white: a sunlit concrete slab photographs
+/// around 70 % grey, and painting it white leaves nothing for the sun.
+@immutable
+class PlazaSurfaceColors {
+  const PlazaSurfaceColors({
+    required this.ground,
+    required this.road,
+    required this.gap,
+    required this.post,
+    required this.tower,
+    required this.pavement,
+    required this.kerb,
+    required this.centreLine,
+    required this.cornice,
+    required this.plotBase,
+    required this.plotRim,
+    required this.unlitNeon,
+    required this.riser,
+    required this.timber,
+    required this.ironwork,
+    required this.foliage,
+    required this.wallBase,
+    required this.roofBase,
+    required this.doneWallBase,
+    required this.cable,
+  });
+
+  /// The ground plane and the plaza slab flush with it.
+  final Color ground;
+  final Color road;
+  final Color gap;
+
+  /// Lamp posts, pylons and other slender structure.
+  final Color post;
+
+  /// The far skyline's towers, already half lost in haze.
+  final Color tower;
+
+  final Color pavement;
+  final Color kerb;
+  final Color centreLine;
+
+  /// The band under a roofline: the wall's own colour, a shade along.
+  final Color cornice;
+
+  /// A plot's plinth and the rim around it.
+  final Color plotBase;
+  final Color plotRim;
+
+  /// What a neon strip is made of before it is lit — the housing. Night
+  /// lerps its neon out of this; by day the strips never leave it.
+  final Color unlitNeon;
+
+  /// Stair and balcony risers on the filler blocks.
+  final Color riser;
+
+  /// Benches, planters and their foliage.
+  final Color timber;
+  final Color ironwork;
+  final Color foliage;
+
+  /// What a category's colour is mixed into for a task's walls and roof.
+  final Color wallBase;
+  final Color roofBase;
+
+  /// A connection cable strung between two roofs. Near-black reads as a
+  /// wire against the night; against a pale sky it reads as ink, so
+  /// daylight lifts it to the grey of a real span.
+  final Color cable;
+
+  /// What the success green is mixed into for a finished task's walls.
+  /// Separate from [wallBase] because a done block is not a tinted category
+  /// block: it is set back, quiet, and reads green rather than coloured.
+  final Color doneWallBase;
+}
+
+/// How light behaves in this hour: how far emitters are pushed past white,
+/// whether the ground carries pools of it, and what the sun leaves behind.
+@immutable
+class PlazaLightSettings {
+  const PlazaLightSettings({
+    required this.emissiveBoost,
+    required this.groundLightScale,
+    required this.glowScale,
+    required this.lampsLit,
+    required this.shadowAlpha,
+    required this.shadow,
+    required this.lamp,
+    required this.interior,
+    required this.parade,
+    required this.skyGlow,
+    required this.warning,
+  });
+
+  /// How far past display white a lit emitter goes, so the bloom pass picks
+  /// it up. Daylight is 1.0: nothing outshines the sky, so nothing blooms.
+  final double emissiveBoost;
+
+  /// Multiplies every ground pool and wash. Zero removes them, which is
+  /// what daylight wants — a pool of lamplight on sunlit paving is a smudge.
+  final double groundLightScale;
+
+  /// Multiplies the soft glow quads behind emitters (neon, signage, roof
+  /// lanterns).
+  final double glowScale;
+
+  /// Whether the street lamps burn. Their posts stand either way.
+  final bool lampsLit;
+
+  /// The opacity of a building's contact shadow. Zero means no shadows,
+  /// which is the only honest option when there is no sun.
+  final double shadowAlpha;
+
+  /// The shadow's colour, multiplied onto the paving beneath it.
+  final Color shadow;
+
+  /// Warm sodium-vapour lamp light.
+  final Color lamp;
+
+  /// Light spilling out of a window or a doorway.
+  final Color interior;
+
+  /// The amber a lit shopfront parade throws onto the pavement.
+  final Color parade;
+
+  /// The warm bloom a city throws onto its own horizon.
+  final Color skyGlow;
+
+  /// Aircraft warning light on the spires. It blinks by day too — that is
+  /// what it is for.
+  final Color warning;
+
+  bool get hasShadows => shadowAlpha > 0;
+}
+
+/// The roof lantern's colour per state, and with it the facade light bar,
+/// the billboard frame and every sprite that carries a task's health.
+///
+/// Night states are lights in the dark. The day set answers a different
+/// question — what reads as a coloured mark against a bright sky — so the
+/// hues hold but the values drop; a pale cream lantern that glows at
+/// midnight disappears at noon.
+@immutable
+class PlazaLanterns {
+  const PlazaLanterns({
+    required this.blocked,
+    required this.overdue,
+    required this.inProgress,
+    required this.open,
+    required this.off,
+  });
+
+  final Color blocked;
+  final Color overdue;
+  final Color inProgress;
+  final Color open;
+  final Color off;
+
+  Color of(LanternState state) => switch (state) {
+    LanternState.blocked => blocked,
+    LanternState.overdue => overdue,
+    LanternState.inProgress => inProgress,
+    LanternState.open => open,
+    LanternState.off => off,
+  };
+}
+
+/// Everything the hour decides, in one value.
+///
+/// The scene holds one of these and reads every colour and atmospheric
+/// number from it. Nothing in `scene/` may keep a colour constant of its
+/// own: a value that is not here cannot change with the sky, and that is
+/// exactly the bug this type exists to prevent.
+@immutable
+class PlazaPalette {
+  const PlazaPalette({
+    required this.mode,
+    required this.sky,
+    required this.air,
+    required this.surfaces,
+    required this.lights,
+    required this.lanterns,
+  });
+
+  final PlazaSkyMode mode;
+  final PlazaSky sky;
+  final PlazaAir air;
+  final PlazaSurfaceColors surfaces;
+  final PlazaLightSettings lights;
+  final PlazaLanterns lanterns;
+
+  bool get isDay => mode == PlazaSkyMode.day;
+
+  static PlazaPalette of(PlazaSkyMode mode) => switch (mode) {
+    PlazaSkyMode.night => night,
+    PlazaSkyMode.day => day,
+  };
+
+  /// A task's own colour: done is the success green, everything else is its
+  /// lantern. The facade light bar, the sprite and the sign frame share it.
+  Color taskColor(TaskAttention attention) =>
+      attention.task.state == PlazaTaskState.done
+      ? dsTokensDark.colors.alert.success.defaultColor
+      : lanterns.of(attention.lantern);
+
+  /// The dim wall tint: the category's colour mixed into this hour's wall
+  /// base. A finished task's walls take the success green instead, at the
+  /// same strength, so a done block reads as done before its sign is legible.
+  Color categoryWall(PlazaTask task) => task.state == PlazaTaskState.done
+      ? Color.lerp(
+          surfaces.doneWallBase,
+          dsTokensDark.colors.alert.success.defaultColor,
+          _doneMix,
+        )!
+      : Color.lerp(surfaces.wallBase, Color(task.categoryColor), _wallMix)!;
+
+  /// The roof: the same mix, a step darker, and the surface the aerial
+  /// overview actually reads.
+  Color categoryRoof(PlazaTask task) => task.state == PlazaTaskState.done
+      ? dsTokensDark.colors.alert.success.defaultColor
+      : Color.lerp(surfaces.roofBase, Color(task.categoryColor), _roofMix)!;
+
+  static const _wallMix = 0.28;
+  static const _roofMix = 0.22;
+
+  /// How much success green a finished task's walls take. Night borrowed
+  /// the design system's muted alpha; daylight needs more of it, because a
+  /// pale wall swallows a tint that reads fine against a dark one.
+  double get _doneMix => isDay ? 0.5 : SurfaceAlphas.muted;
+
+  /// The night the district was designed in: a desaturated indigo dusk, so
+  /// amber signage sits warm against it and the magenta lives in the hero
+  /// towers' domes alone.
+  static const night = PlazaPalette(
+    mode: PlazaSkyMode.night,
+    sky: PlazaSky(
+      zenith: Color(0xFF03030B),
+      horizon: Color(0xFF2A2446),
+      ground: Color(0xFF090A16),
+      sun: Colors.black,
+      sunIntensity: 0,
+      sunAzimuth: 0,
+      sunElevation: 0,
+      sunSharpness: 400,
+    ),
+    air: PlazaAir(
+      fog: Color(0xFF181727),
+      fogDensityLow: 0.0055,
+      fogDensityHigh: 0.002,
+      fogOpacityLow: 0.92,
+      fogOpacityHigh: 0.6,
+      bloomThreshold: 1,
+      bloomIntensity: 0.3,
+      bloomScatter: 0.6,
+      vignetteIntensity: 0.32,
+      vignetteRadius: 0.82,
+      vignetteSmoothness: 0.6,
+    ),
+    surfaces: PlazaSurfaceColors(
+      ground: Color(0xFF15131E),
+      road: Color(0xFF1A1D2B),
+      gap: Color(0xFF15171F),
+      post: Color(0xFF14171F),
+      tower: Color(0xFF0E0B18),
+      pavement: Color(0xFF232532),
+      kerb: Color(0xFF5A5E72),
+      centreLine: Color(0xFF7A7050),
+      cornice: Color(0xFF141220),
+      plotBase: Color(0xFF0A0910),
+      plotRim: Color(0xFF07060D),
+      unlitNeon: Color(0xFF0B0A14),
+      riser: Color(0xFF14161C),
+      timber: Color(0xFF4A3A2E),
+      ironwork: Color(0xFF1E1A1C),
+      foliage: Color(0xFF1F3A28),
+      wallBase: Color(0xFF3B3F4A),
+      roofBase: Color(0xFF262A33),
+      // `dsTokensDark.colors.background.level01`, which is not a constant
+      // and so cannot be named here; a palette test pins the two together.
+      doneWallBase: Color(0xFF181818),
+      // `dsTokensDark.colors.background.level03`; pinned by a palette test.
+      cable: Color(0xFF535353),
+    ),
+    lights: PlazaLightSettings(
+      emissiveBoost: 1.6,
+      groundLightScale: 1,
+      glowScale: 1,
+      lampsLit: true,
+      shadowAlpha: 0,
+      shadow: Colors.black,
+      lamp: Color(0xFFFFD08A),
+      interior: Color(0xFFFFE2B8),
+      parade: Color(0xFFFFC46B),
+      skyGlow: Color(0xFFFF7A4A),
+      warning: Color(0xFFFF3B30),
+    ),
+    lanterns: PlazaLanterns(
+      blocked: Color(0xFFE4655F),
+      overdue: Color(0xFFFBA336),
+      inProgress: Color(0xFF4AB6E8),
+      open: Color(0xFFD0C2A0),
+      off: Color(0xFF3A3F48),
+    ),
+  );
+
+  /// Clear mid-morning: a high sun across the avenue, concrete and asphalt
+  /// at their real values, and light that is in the sky rather than in the
+  /// buildings. Every emitter falls back to its housing, the ground pools
+  /// go out, and what a task is doing has to survive on paint, shadow and
+  /// signage instead.
+  static const day = PlazaPalette(
+    mode: PlazaSkyMode.day,
+    sky: PlazaSky(
+      zenith: Color(0xFF2F6FD0),
+      horizon: Color(0xFFC4DCF2),
+      ground: Color(0xFF7E7A6E),
+      sun: Color(0xFFFFF3D6),
+      sunIntensity: 7,
+      // Across the avenue rather than down it, and behind the district
+      // rather than behind the walker: facades keep their relief, and the
+      // shade the signs throw falls toward the camera instead of hiding
+      // behind them.
+      sunAzimuth: 5.34,
+      sunElevation: 0.72,
+      sunSharpness: 900,
+    ),
+    air: PlazaAir(
+      fog: Color(0xFFBFD3E6),
+      // Thinner than night: distance should read as aerial perspective,
+      // not as a wall of haze two blocks out.
+      fogDensityLow: 0.0026,
+      fogDensityHigh: 0.0011,
+      fogOpacityLow: 0.7,
+      fogOpacityHigh: 0.42,
+      // Above the sky's own brightness, so only the sun disk blooms.
+      bloomThreshold: 1.4,
+      bloomIntensity: 0.1,
+      bloomScatter: 0.5,
+      vignetteIntensity: 0,
+      vignetteRadius: 0.9,
+      vignetteSmoothness: 0.6,
+    ),
+    surfaces: PlazaSurfaceColors(
+      ground: Color(0xFF8E8B84),
+      road: Color(0xFF6E7079),
+      gap: Color(0xFF7A7C85),
+      post: Color(0xFF5A5E68),
+      tower: Color(0xFF9AA3B4),
+      pavement: Color(0xFFB4B0A6),
+      kerb: Color(0xFFD6D2C6),
+      centreLine: Color(0xFFE8D9A0),
+      cornice: Color(0xFFA9A296),
+      plotBase: Color(0xFF6B6A66),
+      plotRim: Color(0xFF4E4D4A),
+      unlitNeon: Color(0xFF8C93A3),
+      riser: Color(0xFF7C8089),
+      timber: Color(0xFF8A6A4E),
+      ironwork: Color(0xFF3E3A3C),
+      foliage: Color(0xFF4E7A46),
+      wallBase: Color(0xFFB9BEC8),
+      roofBase: Color(0xFF9AA0AC),
+      doneWallBase: Color(0xFFC8CCC4),
+      cable: Color(0xFF6E727A),
+    ),
+    lights: PlazaLightSettings(
+      emissiveBoost: 1,
+      groundLightScale: 0,
+      glowScale: 0.25,
+      lampsLit: false,
+      shadowAlpha: 0.72,
+      shadow: Color(0xFF2A3038),
+      // Unchanged from night, and unused: daylight scales every pool and
+      // wash they colour to nothing.
+      lamp: Color(0xFFFFD08A),
+      interior: Color(0xFFFFE2B8),
+      parade: Color(0xFFFFC46B),
+      skyGlow: Color(0xFFFF7A4A),
+      warning: Color(0xFFFF3B30),
+    ),
+    lanterns: PlazaLanterns(
+      blocked: Color(0xFFC0332C),
+      overdue: Color(0xFFD9781B),
+      inProgress: Color(0xFF1F7FBF),
+      open: Color(0xFF6E6350),
+      off: Color(0xFF5A5F68),
+    ),
+  );
+}

--- a/lib/features/plaza/ui/plaza_style.dart
+++ b/lib/features/plaza/ui/plaza_style.dart
@@ -3,6 +3,7 @@ import 'package:lotti/features/plaza/domain/attention.dart';
 import 'package:lotti/features/plaza/domain/plaza_layout.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/features/plaza/scene/plaza_world.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
 import 'package:material_ui/material_ui.dart';
 
 /// Dev-harness palette and type for the plaza's scene content.
@@ -16,6 +17,9 @@ import 'package:material_ui/material_ui.dart';
 abstract final class PlazaStyle {
   /// Facade and billboard panel background.
   static const panel = Color(0xFF0A0E16);
+
+  /// The dark track a ticker band runs in: the fixture behind the type.
+  static const housing = Color(0xFF0B0D14);
 
   /// `--lotti-teal-light`: beacons, focus ring, OPEN, ticker text.
   static const teal = Color(0xFF5ED4B7);
@@ -82,18 +86,15 @@ abstract final class PlazaStyle {
   }
 
   /// The roof lantern colour; also the billboard frame and light pool.
-  static Color lantern(LanternState state) => switch (state) {
-    LanternState.blocked => const Color(0xFFE4655F),
-    LanternState.overdue => const Color(0xFFFBA336),
-    LanternState.inProgress => const Color(0xFF4AB6E8),
-    LanternState.open => const Color(0xFFD0C2A0),
-    LanternState.off => const Color(0xFF3A3F48),
-  };
+  ///
+  /// Signage keeps the night register in both skies — a sign is a sign at
+  /// noon — so this and everything derived from it read the night palette
+  /// by name. Scene geometry asks its own [PlazaPalette] instead.
+  static Color lantern(LanternState state) =>
+      PlazaPalette.night.lanterns.of(state);
 
   /// The progress light bar along the facade base.
-  static Color taskColor(TaskAttention a) => a.task.state == PlazaTaskState.done
-      ? dsTokensDark.colors.alert.success.defaultColor
-      : lantern(a.lantern);
+  static Color taskColor(TaskAttention a) => PlazaPalette.night.taskColor(a);
 
   static Color lightBar(TaskAttention a) => taskColor(a);
 
@@ -110,14 +111,21 @@ abstract final class PlazaStyle {
   }
 
   /// Beacon colour by kind: navigation stops are teal, home is white, an
-  /// attention beacon takes its task's state colour.
-  static Color beaconColor(Beacon beacon, PlazaWorld world) {
+  /// attention beacon takes its task's state colour — in [palette]'s
+  /// register, so a daylight beacon is not a night lantern on a bright sky.
+  static Color beaconColor(
+    Beacon beacon,
+    PlazaWorld world, {
+    PlazaPalette palette = PlazaPalette.night,
+  }) {
     switch (beacon.kind) {
       case BeaconKind.home:
         return const Color(0xFFF2FFFA);
       case BeaconKind.attention:
         final attention = world.attention[beacon.taskId];
-        return attention == null ? teal : lantern(attention.lantern);
+        return attention == null
+            ? teal
+            : palette.lanterns.of(attention.lantern);
       case BeaconKind.block:
       case BeaconKind.corner:
         return teal;
@@ -130,18 +138,6 @@ abstract final class PlazaStyle {
   /// Aircraft warning light on the spires.
   static const warning = Color(0xFFFF3B30);
 
-  /// Category colours: the bright bar on the facade, the dim wall tint, the
-  /// darker roof tint. Derived from the task's category colour so the demo
-  /// world's categories tint their own blocks.
+  /// The bright bar on the facade, in the task's own category colour.
   static Color categoryBright(PlazaTask task) => Color(task.categoryColor);
-  static Color categoryWall(PlazaTask task) => task.state == PlazaTaskState.done
-      ? Color.lerp(
-          dsTokensDark.colors.background.level01,
-          dsTokensDark.colors.alert.success.defaultColor,
-          SurfaceAlphas.muted,
-        )!
-      : Color.lerp(const Color(0xFF3B3F4A), Color(task.categoryColor), 0.28)!;
-  static Color categoryRoof(PlazaTask task) => task.state == PlazaTaskState.done
-      ? dsTokensDark.colors.alert.success.defaultColor
-      : Color.lerp(const Color(0xFF262A33), Color(task.categoryColor), 0.22)!;
 }

--- a/lib/features/plaza/ui/plaza_view.dart
+++ b/lib/features/plaza/ui/plaza_view.dart
@@ -1,7 +1,9 @@
 import 'dart:async' show unawaited;
+import 'dart:io' show File;
 import 'dart:math' as math;
-import 'dart:ui' show FramePhase, FrameTiming;
+import 'dart:ui' show FramePhase, FrameTiming, ImageByteFormat;
 
+import 'package:flutter/rendering.dart' show RenderRepaintBoundary;
 import 'package:flutter/scheduler.dart' show SchedulerBinding;
 import 'package:flutter/services.dart';
 import 'package:flutter_gpu/gpu.dart' as gpu;
@@ -34,10 +36,12 @@ import 'package:lotti/features/plaza/ui/plaza_copy.dart';
 import 'package:lotti/features/plaza/ui/plaza_frame_pacer.dart';
 import 'package:lotti/features/plaza/ui/plaza_frame_window.dart';
 import 'package:lotti/features/plaza/ui/plaza_hud.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
 import 'package:lotti/features/plaza/ui/plaza_pointer_controller.dart';
 import 'package:lotti/features/plaza/ui/plaza_repaint.dart';
 import 'package:lotti/features/plaza/ui/plaza_search_sheet.dart';
 import 'package:lotti/features/plaza/ui/plaza_tour.dart';
+import 'package:lotti/features/plaza/ui/plaza_wall_swap.dart';
 import 'package:lotti/features/plaza/ui/task_side_panel.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/ui/error_state_widget.dart';
@@ -55,7 +59,10 @@ class PlazaView extends StatefulWidget {
     this.hidden = const {},
     this.trace = false,
     this.tourOnly,
+    this.shotDir,
     this.initialFrameRate = PlazaFrameRate.auto,
+    this.initialSkyMode = PlazaSkyMode.night,
+    this.onSkyModeChanged,
     super.key,
   });
 
@@ -67,7 +74,21 @@ class PlazaView extends StatefulWidget {
   final Set<String> hidden;
   final bool trace;
   final Set<String>? tourOnly;
+
+  /// Fixture-only: where a settled tour stop writes its PNG.
+  ///
+  /// The frame is read back from the widget tree rather than off the screen,
+  /// so a capture needs no display server, no window manager and no screen
+  /// recording permission — and both skies are framed identically, which is
+  /// the whole point of a before/after pair.
+  final String? shotDir;
   final PlazaFrameRate initialFrameRate;
+
+  /// The sky the world boots under.
+  final PlazaSkyMode initialSkyMode;
+
+  /// Told when the walker changes the sky, so a host can remember it.
+  final ValueChanged<PlazaSkyMode>? onSkyModeChanged;
 
   @override
   State<PlazaView> createState() => _PlazaViewState();
@@ -96,6 +117,13 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
   Set<String> get _hidden => widget.hidden;
   bool get _traceMode => widget.trace;
   late PlazaFrameRate _frameRate = widget.initialFrameRate;
+  late PlazaSkyMode _skyMode = widget.initialSkyMode;
+  PlazaPalette get _palette => PlazaPalette.of(_skyMode);
+
+  /// Which painted texture set is on its way, so a walker who flips back and
+  /// forth lands on their last choice rather than on whichever paint
+  /// finished last.
+  final PlazaWallSwap _wallSwap = PlazaWallSwap();
   PlazaFramePacer? _pacer;
 
   Duration? _lastPaint;
@@ -160,6 +188,9 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
   // Tap-versus-drag.
   final _pointer = PlazaPointerController();
 
+  /// The subtree a fixture capture reads back: the world and its chrome.
+  final GlobalKey _shotKey = GlobalKey();
+
   // Rolling frame-time window.
   final _frameMs = PlazaFrameWindow();
   double _statsAge = 0;
@@ -203,7 +234,7 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
     // backend without GPU support; those child futures otherwise escape it.
     await Future.sync(() => gpu.gpuContext);
     await Scene.initializeStaticResources();
-    _walls = await WallTextures.load(copy: widget.world.copy);
+    _walls = await WallTextures.load(copy: widget.world.copy, mode: _skyMode);
     await _ensureCharacterModels();
     if (!mounted) return;
     _load();
@@ -258,6 +289,35 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
       _tourReadyReport = null;
       _tourAnnounced = true;
       _tourClock = _tourSettleSeconds;
+      final stop = _tourStop;
+      if (widget.shotDir != null && stop >= 0) {
+        unawaited(
+          _writeShot(plazaTourStops[stop].name).catchError((Object error) {
+            debugPrint('PLAZA_SHOT failed: $error');
+          }),
+        );
+      }
+    }
+  }
+
+  /// Reads the settled frame back out of the widget tree and writes it to
+  /// [PlazaView.shotDir] as `<stop>.png`.
+  Future<void> _writeShot(String name) async {
+    final boundary =
+        _shotKey.currentContext?.findRenderObject() as RenderRepaintBoundary?;
+    if (boundary == null) return;
+    final image = await boundary.toImage(
+      pixelRatio: MediaQuery.devicePixelRatioOf(context),
+    );
+    try {
+      final bytes = await image.toByteData(format: ImageByteFormat.png);
+      if (bytes == null) return;
+      final file = File('${widget.shotDir}/$name.png')
+        ..parent.createSync(recursive: true)
+        ..writeAsBytesSync(bytes.buffer.asUint8List());
+      debugPrint('PLAZA_SHOT wrote ${file.path}');
+    } finally {
+      image.dispose();
     }
   }
 
@@ -349,7 +409,11 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
         maxBuildingHeight: _knobs.maxHeight,
       ),
     );
-    _sceneController = PlazaSceneController(world: _world, hidden: _hidden);
+    _sceneController = PlazaSceneController(
+      world: _world,
+      palette: _palette,
+      hidden: _hidden,
+    );
     final walls = _walls;
     if (walls != null) _sceneController.attachWallTextures(walls);
     _lod = FacadeLodManager(
@@ -370,6 +434,7 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
       scene: _sceneController.scene,
       world: _world,
       bindings: _sceneController.bindings,
+      palette: _palette,
     );
     // Fire and forget: sprites are square dots until the glow lands.
     unawaited(_sprites.loadGlow().catchError(_reportTextureError));
@@ -390,11 +455,13 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
             scene: _sceneController.scene,
             world: _world,
             glowTexture: walls.pool,
+            palette: _palette,
           );
     _cables?.root.visible = _showConnections;
     _attachCharacters();
     debugPrint(
-      'PLAZA_BATCHES meshes=${batches.meshes} batches=${batches.batches}',
+      'PLAZA_BATCHES meshes=${batches.meshes} batches=${batches.batches} '
+      'shadows=${_sceneController.shadowCount}',
     );
     debugPrint(
       'PLAZA_CABLES edges=${_world.connections.length} '
@@ -519,7 +586,9 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
       if (oldWidget.world.copy.messages.localeName !=
           widget.world.copy.messages.localeName) {
         unawaited(
-          _reloadWalls(widget.world.copy).catchError(_reportTextureError),
+          _reloadWalls(widget.world.copy, _skyMode).catchError(
+            _reportTextureError,
+          ),
         );
       }
     }
@@ -537,14 +606,56 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
     );
   }
 
-  Future<void> _reloadWalls(PlazaCopy copy) async {
-    final walls = await WallTextures.load(copy: copy);
-    if (!mounted ||
-        copy.messages.localeName != widget.world.copy.messages.localeName) {
-      return;
+  /// Paints and uploads a texture set for [mode] and hands it to the scene.
+  ///
+  /// The set on screen stays until this one lands, so neither a locale
+  /// change nor a sky switch ever shows an untextured city. A result that
+  /// is no longer wanted — the locale moved on, or the walker switched
+  /// back — is dropped rather than attached.
+  Future<void> _reloadWalls(PlazaCopy copy, PlazaSkyMode mode) async {
+    try {
+      final walls = await WallTextures.load(copy: copy, mode: mode);
+      if (!mounted ||
+          copy.messages.localeName != widget.world.copy.messages.localeName ||
+          mode != _skyMode) {
+        return;
+      }
+      _walls = walls;
+      _sceneController.attachWallTextures(walls);
+      _wakeForInput();
+    } finally {
+      // Whatever happened to it — attached, dropped, or thrown — this set is
+      // no longer on its way, and its sky must stay askable.
+      _wallSwap.settled(mode);
     }
-    _walls = walls;
-    _sceneController.attachWallTextures(walls);
+  }
+
+  /// Switches the sky.
+  ///
+  /// The scene is rebuilt under the new palette at once — geometry, air and
+  /// every solid colour — keeping the camera where it stands, and the
+  /// painted walls follow when their set finishes uploading. Rebuilding is
+  /// what a mode change *is*: the materials are shared and immutable, so
+  /// there is nothing to repaint in place.
+  void _setSkyMode(PlazaSkyMode mode) {
+    if (mode == _skyMode) return;
+    final pose = _camera.pose;
+    _lod.dispose();
+    setState(() {
+      _skyMode = mode;
+      _load(pose: pose);
+    });
+    widget.onSkyModeChanged?.call(mode);
+    final pending = _wallSwap.request(wanted: mode, attached: _walls?.mode);
+    if (pending != null) {
+      unawaited(
+        _reloadWalls(
+          widget.world.copy,
+          pending,
+        ).catchError(_reportTextureError),
+      );
+    }
+    _frameCamera = null;
     _wakeForInput();
   }
 
@@ -920,137 +1031,148 @@ class _PlazaViewState extends State<PlazaView> with WidgetsBindingObserver {
       );
     }
     final panel = _panel;
+    // The capture boundary is a full-window compositing layer that exists
+    // only so a fixture can read the frame back; shipping runs never pay
+    // for it. [_writeShot] already tolerates its absence.
+    Widget capturable(Widget world) => widget.shotDir == null
+        ? world
+        : RepaintBoundary(key: _shotKey, child: world);
     return Scaffold(
       backgroundColor: context.designTokens.colors.background.level01,
       body: Focus(
         autofocus: true,
         onKeyEvent: _onKey,
-        child: Stack(
-          children: [
-            Positioned.fill(
-              child: Listener(
-                onPointerDown: _onPointerDown,
-                onPointerMove: _onPointerMove,
-                onPointerUp: _onPointerUp,
-                onPointerCancel: (event) => _pointer.cancel(event.pointer),
-                child: LayoutBuilder(
-                  builder: (context, constraints) {
-                    _viewSize = constraints.biggest;
-                    // The frame clock invalidates paint, leaving hosted
-                    // widget elements out of the per-frame build path.
-                    return PlazaRepaint(
-                      frames: _frame,
-                      child: SceneView(
-                        _sceneController.scene,
-                        cameraBuilder: (_) =>
-                            _frameCamera ??
-                            _camera.camera(
-                              farClip: math.max(
-                                1400,
-                                (_world.plaza?.overview.y ?? 0) * 4,
+        child: capturable(
+          Stack(
+            children: [
+              Positioned.fill(
+                child: Listener(
+                  onPointerDown: _onPointerDown,
+                  onPointerMove: _onPointerMove,
+                  onPointerUp: _onPointerUp,
+                  onPointerCancel: (event) => _pointer.cancel(event.pointer),
+                  child: LayoutBuilder(
+                    builder: (context, constraints) {
+                      _viewSize = constraints.biggest;
+                      // The frame clock invalidates paint, leaving hosted
+                      // widget elements out of the per-frame build path.
+                      return PlazaRepaint(
+                        frames: _frame,
+                        child: SceneView(
+                          _sceneController.scene,
+                          cameraBuilder: (_) =>
+                              _frameCamera ??
+                              _camera.camera(
+                                farClip: math.max(
+                                  1400,
+                                  (_world.plaza?.overview.y ?? 0) * 4,
+                                ),
                               ),
-                            ),
-                        autoTick: false,
-                      ),
-                    );
-                  },
-                ),
-              ),
-            ),
-            PlazaHud(
-              projectLabel: _world.projectLabel,
-              isCategory: _world.isCategory,
-              taskCount: _world.liveTaskCount,
-              weekCount: _world.builtWeeks,
-              attentionCount: _world.anomalies.length,
-              onMorningWalk: _startWalk,
-              onOverview: _flyOverview,
-              onHome: _flyHome,
-              onExit: widget.onExit,
-              frameRate: _frameRate,
-              onFrameRateChanged: (rate) {
-                setState(() => _frameRate = rate);
-                _wakeForInput();
-              },
-              showPenguins:
-                  _showPenguins &&
-                  _penguinModel != null &&
-                  _world.ambientCreatures > 0,
-              onShowPenguinsChanged:
-                  _penguinModel == null || _world.ambientCreatures == 0
-                  ? null
-                  : (show) {
-                      setState(() => _showPenguins = show);
-                      _characters?.enabled = show;
-                      _wakeForInput();
+                          autoTick: false,
+                        ),
+                      );
                     },
-              showConnections: _showConnections,
-              onShowConnectionsChanged: _world.connections.isEmpty
-                  ? null
-                  : (show) {
-                      setState(() => _showConnections = show);
-                      _cables?.root.visible = show;
-                      _wakeForInput();
-                    },
-              showMeerkats:
-                  _showMeerkats &&
-                  _meerkatModel != null &&
-                  _world.ambientCreatures >= 4,
-              onShowMeerkatsChanged:
-                  _meerkatModel == null || _world.ambientCreatures < 4
-                  ? null
-                  : (show) {
-                      setState(() => _showMeerkats = show);
-                      _wakeForInput();
-                    },
-              showDebug: _showDebug,
-              onShowDebugChanged: (show) => setState(() => _showDebug = show),
-              toast: _toast,
-              walkChip: _walk == null
-                  ? null
-                  : '${context.messages.plazaMorningWalk} · ${_walk!.index + 1}/${_walk!.stops.length} · ${_walk!.paused ? context.messages.plazaPaused : context.messages.plazaTourControls}',
-            ),
-            if (_searchOpen)
-              PlazaSearchSheet(
-                tasks: _world.tasks,
-                attentionOf: _world.attentionOf,
-                weekOf: _world.weekOf,
-                onPick: (task) {
-                  setState(() => _searchOpen = false);
-                  _flyToTask(task);
-                },
-                onClose: () => setState(() => _searchOpen = false),
-              ),
-            if (panel != null)
-              TaskSidePanel(
-                attention: panel.attention,
-                categoryLabel: _world.categoryLabelOf(panel.task),
-                ticks: _ticks,
-                onClose: () => setState(() => _panel = null),
-              ),
-            if (_showDebug)
-              SafeArea(
-                child: Align(
-                  alignment: Alignment.topRight,
-                  child: Padding(
-                    padding: EdgeInsets.fromLTRB(
-                      context.designTokens.spacing.step3,
-                      context.designTokens.spacing.step10,
-                      context.designTokens.spacing.step3,
-                      context.designTokens.spacing.step3,
-                    ),
-                    child: PlazaDebugOverlay(
-                      stats: _stats,
-                      config: _config,
-                      knobs: _knobs,
-                      datasetLabel: _world.projectLabel,
-                      onConfigChanged: () => setState(() {}),
-                      onKnobsApplied: _applyKnobs,
-                    ),
                   ),
                 ),
               ),
-          ],
+              PlazaHud(
+                projectLabel: _world.projectLabel,
+                isCategory: _world.isCategory,
+                taskCount: _world.liveTaskCount,
+                weekCount: _world.builtWeeks,
+                attentionCount: _world.anomalies.length,
+                onMorningWalk: _startWalk,
+                onOverview: _flyOverview,
+                onHome: _flyHome,
+                onExit: widget.onExit,
+                skyMode: _skyMode,
+                onSkyModeChanged: _setSkyMode,
+                palette: _palette,
+                frameRate: _frameRate,
+                onFrameRateChanged: (rate) {
+                  setState(() => _frameRate = rate);
+                  _wakeForInput();
+                },
+                showPenguins:
+                    _showPenguins &&
+                    _penguinModel != null &&
+                    _world.ambientCreatures > 0,
+                onShowPenguinsChanged:
+                    _penguinModel == null || _world.ambientCreatures == 0
+                    ? null
+                    : (show) {
+                        setState(() => _showPenguins = show);
+                        _characters?.enabled = show;
+                        _wakeForInput();
+                      },
+                showConnections: _showConnections,
+                onShowConnectionsChanged: _world.connections.isEmpty
+                    ? null
+                    : (show) {
+                        setState(() => _showConnections = show);
+                        _cables?.root.visible = show;
+                        _wakeForInput();
+                      },
+                showMeerkats:
+                    _showMeerkats &&
+                    _meerkatModel != null &&
+                    _world.ambientCreatures >= 4,
+                onShowMeerkatsChanged:
+                    _meerkatModel == null || _world.ambientCreatures < 4
+                    ? null
+                    : (show) {
+                        setState(() => _showMeerkats = show);
+                        _wakeForInput();
+                      },
+                showDebug: _showDebug,
+                onShowDebugChanged: (show) => setState(() => _showDebug = show),
+                toast: _toast,
+                walkChip: _walk == null
+                    ? null
+                    : '${context.messages.plazaMorningWalk} · ${_walk!.index + 1}/${_walk!.stops.length} · ${_walk!.paused ? context.messages.plazaPaused : context.messages.plazaTourControls}',
+              ),
+              if (_searchOpen)
+                PlazaSearchSheet(
+                  tasks: _world.tasks,
+                  attentionOf: _world.attentionOf,
+                  weekOf: _world.weekOf,
+                  onPick: (task) {
+                    setState(() => _searchOpen = false);
+                    _flyToTask(task);
+                  },
+                  onClose: () => setState(() => _searchOpen = false),
+                ),
+              if (panel != null)
+                TaskSidePanel(
+                  attention: panel.attention,
+                  categoryLabel: _world.categoryLabelOf(panel.task),
+                  ticks: _ticks,
+                  onClose: () => setState(() => _panel = null),
+                ),
+              if (_showDebug)
+                SafeArea(
+                  child: Align(
+                    alignment: Alignment.topRight,
+                    child: Padding(
+                      padding: EdgeInsets.fromLTRB(
+                        context.designTokens.spacing.step3,
+                        context.designTokens.spacing.step10,
+                        context.designTokens.spacing.step3,
+                        context.designTokens.spacing.step3,
+                      ),
+                      child: PlazaDebugOverlay(
+                        stats: _stats,
+                        config: _config,
+                        knobs: _knobs,
+                        datasetLabel: _world.projectLabel,
+                        onConfigChanged: () => setState(() {}),
+                        onKnobsApplied: _applyKnobs,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/plaza/ui/plaza_wall_swap.dart
+++ b/lib/features/plaza/ui/plaza_wall_swap.dart
@@ -1,0 +1,43 @@
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
+
+/// Decides when a change of sky needs a new set of painted wall textures.
+///
+/// The window and shopfront tiles are opaque — the texture *is* the wall — so
+/// each hour has its own set and a switch has to paint and upload one. That
+/// takes long enough for the walker to change their mind twice, which is the
+/// whole reason this is a type rather than two fields: the state is "what is
+/// on the walls, what is on its way, and is the set that just landed still
+/// wanted", and getting it wrong leaves the district wearing the other sky's
+/// windows with nothing scheduled to correct it.
+///
+/// Kept out of the renderer so it can be tested without a GPU.
+class PlazaWallSwap {
+  PlazaSkyMode? _inFlight;
+
+  /// The set being painted right now, if any.
+  PlazaSkyMode? get inFlight => _inFlight;
+
+  /// The set to load so the world can wear [wanted], or null when there is
+  /// nothing to do — the walls already show it, or it is already on its way.
+  ///
+  /// A request for the sky already on the walls does **not** cancel a load in
+  /// flight for the other one: that load will settle on its own, and only
+  /// then is its mode free to be asked for again.
+  PlazaSkyMode? request({
+    required PlazaSkyMode wanted,
+    required PlazaSkyMode? attached,
+  }) {
+    if (wanted == attached || wanted == _inFlight) return null;
+    return _inFlight = wanted;
+  }
+
+  /// Marks the load for [mode] as finished, however it ended — attached,
+  /// dropped as no longer wanted, or failed.
+  ///
+  /// Every one of those has to clear the marker. A load that failed or was
+  /// dropped and left it standing would make [request] believe that set is
+  /// still coming, and the sky it belongs to could never be loaded again.
+  void settled(PlazaSkyMode mode) {
+    if (_inFlight == mode) _inFlight = null;
+  }
+}

--- a/lib/features/plaza/ui/project_plaza_page.dart
+++ b/lib/features/plaza/ui/project_plaza_page.dart
@@ -6,9 +6,11 @@ import 'package:lotti/features/plaza/data/plaza_repository.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/features/plaza/scene/plaza_world.dart';
 import 'package:lotti/features/plaza/scene/project_world_generator.dart';
+import 'package:lotti/features/plaza/state/plaza_sky_mode_controller.dart';
 import 'package:lotti/features/plaza/state/project_plaza_provider.dart';
 import 'package:lotti/features/plaza/ui/checklist_ticks.dart';
 import 'package:lotti/features/plaza/ui/plaza_copy.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
 import 'package:lotti/features/plaza/ui/plaza_view.dart';
 import 'package:lotti/features/tasks/ui/pages/task_details_page.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -22,6 +24,8 @@ typedef ProjectPlazaSceneBuilder =
       required ChecklistTicks ticks,
       required ValueChanged<PlazaTask> onOpenTask,
       required VoidCallback onExit,
+      PlazaSkyMode initialSkyMode,
+      ValueChanged<PlazaSkyMode>? onSkyModeChanged,
     });
 
 /// A live project world. The current scene remains mounted across background
@@ -151,6 +155,8 @@ class _ProjectPlazaPageState extends ConsumerState<ProjectPlazaPage> {
               ),
             ),
             onExit: () => Navigator.of(context).pop(),
+            initialSkyMode: ref.watch(plazaSkyModeProvider),
+            onSkyModeChanged: ref.read(plazaSkyModeProvider.notifier).set,
           );
         },
       ),

--- a/lib/features/projects/ui/widgets/project_list_shared.dart
+++ b/lib/features/projects/ui/widgets/project_list_shared.dart
@@ -1,7 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:lotti/features/categories/domain/category_icon.dart';
-import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_icon_action.dart';
 import 'package:lotti/features/design_system/components/lists/grouped_card_row_interactions.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/projects/model/projects_overview_models.dart';
@@ -116,6 +116,20 @@ class _ProjectGroupSectionState extends State<ProjectGroupSection> {
                 children: [
                   Expanded(child: ProjectGroupHeader(group: widget.group)),
                   SizedBox(width: tokens.spacing.step2),
+                  // The world is entered from the header's trailing corner,
+                  // where this list's other row-level actions sit, rather
+                  // than from a button on a row of its own under every
+                  // category. It handles its own tap, so the header's
+                  // InkWell never folds the group behind it.
+                  if (widget.onExplorePlaza != null &&
+                      widget.group.category != null) ...[
+                    DesignSystemIconAction(
+                      icon: LottiIcons.map,
+                      tooltip: context.messages.plazaExploreCategory,
+                      onPressed: widget.onExplorePlaza,
+                    ),
+                    SizedBox(width: tokens.spacing.step2),
+                  ],
                   Icon(
                     _expanded ? LottiIcons.collapse : LottiIcons.expand,
                     color: ShowcasePalette.mediumText(context),
@@ -127,17 +141,6 @@ class _ProjectGroupSectionState extends State<ProjectGroupSection> {
         ),
         if (_expanded) ...[
           SizedBox(height: tokens.spacing.step2),
-          if (widget.onExplorePlaza != null &&
-              widget.group.category != null) ...[
-            DesignSystemButton(
-              label: context.messages.plazaExploreCategory,
-              leadingIcon: LottiIcons.map,
-              size: DesignSystemButtonSize.dense,
-              variant: DesignSystemButtonVariant.secondary,
-              onPressed: widget.onExplorePlaza,
-            ),
-            SizedBox(height: tokens.spacing.step2),
-          ],
           DecoratedBox(
             key: ValueKey(
               'project-group-card-${widget.group.categoryId ?? 'unassigned'}',

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -3875,6 +3875,8 @@
   "plazaProjectOverdue": "Úkoly po termínu: {count}",
   "plazaSearchHint": "Hledej úkoly, Enter pro přelet",
   "plazaShowPenguins": "Tučňáci",
+  "plazaSkyDay": "Den",
+  "plazaSkyNight": "Noc",
   "plazaStaleReason": "bez aktivity {days} dní — vrať se k tomu",
   "plazaStats": "{tasks} úkolů · {weeks} týdnů · {attention} vyžaduje pozornost",
   "plazaTaskCount": "Úkoly: {count}",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4342,6 +4342,8 @@
   "plazaProjectOverdue": "Forsinkede opgaver: {count}",
   "plazaSearchHint": "Søg efter opgaver, Enter for at flyve",
   "plazaShowPenguins": "Pingviner",
+  "plazaSkyDay": "Dag",
+  "plazaSkyNight": "Nat",
   "plazaStaleReason": "stille i {days} dage — tag fat igen",
   "plazaStats": "{tasks} opgaver · {weeks} uger · {attention} kræver opmærksomhed",
   "plazaTaskCount": "Opgaver: {count}",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3868,6 +3868,8 @@
   "plazaProjectOverdue": "Überfällige Aufgaben: {count}",
   "plazaSearchHint": "Aufgaben suchen, Enter zum Hinfliegen",
   "plazaShowPenguins": "Pinguine",
+  "plazaSkyDay": "Tag",
+  "plazaSkyNight": "Nacht",
   "plazaStaleReason": "seit {days} Tagen ruhig — nimm es wieder auf",
   "plazaStats": "{tasks} Aufgaben · {weeks} Wochen · {attention} brauchen Aufmerksamkeit",
   "plazaTaskCount": "Aufgaben: {count}",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5889,6 +5889,14 @@
   },
   "plazaSearchHint": "Search tasks, Enter to fly",
   "plazaShowPenguins": "Penguins",
+  "plazaSkyDay": "Day",
+  "@plazaSkyDay": {
+    "description": "Segment label for the daylight sky in the Plaza world."
+  },
+  "plazaSkyNight": "Night",
+  "@plazaSkyNight": {
+    "description": "Segment label for the night sky in the Plaza world."
+  },
   "plazaStaleReason": "quiet for {days} days — pick it back up",
   "@plazaStaleReason": {
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -3868,6 +3868,8 @@
   "plazaProjectOverdue": "Tareas vencidas: {count}",
   "plazaSearchHint": "Busca tareas, Intro para volar",
   "plazaShowPenguins": "Pingüinos",
+  "plazaSkyDay": "Día",
+  "plazaSkyNight": "Noche",
   "plazaStaleReason": "sin actividad desde hace {days} días — retómala",
   "plazaStats": "{tasks} tareas · {weeks} semanas · {attention} requieren atención",
   "plazaTaskCount": "Tareas: {count}",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3868,6 +3868,8 @@
   "plazaProjectOverdue": "Tâches en retard : {count}",
   "plazaSearchHint": "Cherche une tâche, Entrée pour y aller",
   "plazaShowPenguins": "Manchots",
+  "plazaSkyDay": "Jour",
+  "plazaSkyNight": "Nuit",
   "plazaStaleReason": "sans activité depuis {days} jours — reprends-la",
   "plazaStats": "{tasks} tâches · {weeks} semaines · {attention} demandent ton attention",
   "plazaTaskCount": "Tâches : {count}",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4342,6 +4342,8 @@
   "plazaProjectOverdue": "Attività scadute: {count}",
   "plazaSearchHint": "Cerca attività, Invio per volare",
   "plazaShowPenguins": "Pinguini",
+  "plazaSkyDay": "Giorno",
+  "plazaSkyNight": "Notte",
   "plazaStaleReason": "ferma da {days} giorni — riprendila",
   "plazaStats": "{tasks} attività · {weeks} settimane · {attention} richiedono attenzione",
   "plazaTaskCount": "Attività: {count}",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -17359,6 +17359,18 @@ abstract class AppLocalizations {
   /// **'Penguins'**
   String get plazaShowPenguins;
 
+  /// Segment label for the daylight sky in the Plaza world.
+  ///
+  /// In en, this message translates to:
+  /// **'Day'**
+  String get plazaSkyDay;
+
+  /// Segment label for the night sky in the Plaza world.
+  ///
+  /// In en, this message translates to:
+  /// **'Night'**
+  String get plazaSkyNight;
+
   /// No description provided for @plazaStaleReason.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -10364,6 +10364,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get plazaShowPenguins => 'Tučňáci';
 
   @override
+  String get plazaSkyDay => 'Den';
+
+  @override
+  String get plazaSkyNight => 'Noc';
+
+  @override
   String plazaStaleReason(int days) {
     return 'bez aktivity $days dní — vrať se k tomu';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -10236,6 +10236,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get plazaShowPenguins => 'Pingviner';
 
   @override
+  String get plazaSkyDay => 'Dag';
+
+  @override
+  String get plazaSkyNight => 'Nat';
+
+  @override
   String plazaStaleReason(int days) {
     return 'stille i $days dage — tag fat igen';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -10305,6 +10305,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get plazaShowPenguins => 'Pinguine';
 
   @override
+  String get plazaSkyDay => 'Tag';
+
+  @override
+  String get plazaSkyNight => 'Nacht';
+
+  @override
   String plazaStaleReason(int days) {
     return 'seit $days Tagen ruhig — nimm es wieder auf';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -10187,6 +10187,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get plazaShowPenguins => 'Penguins';
 
   @override
+  String get plazaSkyDay => 'Day';
+
+  @override
+  String get plazaSkyNight => 'Night';
+
+  @override
   String plazaStaleReason(int days) {
     return 'quiet for $days days — pick it back up';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -10385,6 +10385,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get plazaShowPenguins => 'Pingüinos';
 
   @override
+  String get plazaSkyDay => 'Día';
+
+  @override
+  String get plazaSkyNight => 'Noche';
+
+  @override
   String plazaStaleReason(int days) {
     return 'sin actividad desde hace $days días — retómala';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -10410,6 +10410,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get plazaShowPenguins => 'Manchots';
 
   @override
+  String get plazaSkyDay => 'Jour';
+
+  @override
+  String get plazaSkyNight => 'Nuit';
+
+  @override
   String plazaStaleReason(int days) {
     return 'sans activité depuis $days jours — reprends-la';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -10367,6 +10367,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get plazaShowPenguins => 'Pinguini';
 
   @override
+  String get plazaSkyDay => 'Giorno';
+
+  @override
+  String get plazaSkyNight => 'Notte';
+
+  @override
   String plazaStaleReason(int days) {
     return 'ferma da $days giorni — riprendila';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -10253,6 +10253,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get plazaShowPenguins => 'Pinguïns';
 
   @override
+  String get plazaSkyDay => 'Dag';
+
+  @override
+  String get plazaSkyNight => 'Nacht';
+
+  @override
   String plazaStaleReason(int days) {
     return 'al $days dagen stil — pak het weer op';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -10331,6 +10331,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get plazaShowPenguins => 'Pinguins';
 
   @override
+  String get plazaSkyDay => 'Dia';
+
+  @override
+  String get plazaSkyNight => 'Noite';
+
+  @override
   String plazaStaleReason(int days) {
     return 'sem atividade há $days dias — retoma-a';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -10432,6 +10432,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get plazaShowPenguins => 'Pinguini';
 
   @override
+  String get plazaSkyDay => 'Zi';
+
+  @override
+  String get plazaSkyNight => 'Noapte';
+
+  @override
   String plazaStaleReason(int days) {
     return 'fără activitate de $days zile — reluați-o';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -10245,6 +10245,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get plazaShowPenguins => 'Pingviner';
 
   @override
+  String get plazaSkyDay => 'Dag';
+
+  @override
+  String get plazaSkyNight => 'Natt';
+
+  @override
   String plazaStaleReason(int days) {
     return 'ingen aktivitet på $days dagar — ta upp den igen';
   }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4341,6 +4341,8 @@
   "plazaProjectOverdue": "Achterstallige taken: {count}",
   "plazaSearchHint": "Zoek taken, Enter om erheen te vliegen",
   "plazaShowPenguins": "Pinguïns",
+  "plazaSkyDay": "Dag",
+  "plazaSkyNight": "Nacht",
   "plazaStaleReason": "al {days} dagen stil — pak het weer op",
   "plazaStats": "{tasks} taken · {weeks} weken · {attention} vragen aandacht",
   "plazaTaskCount": "Taken: {count}",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4341,6 +4341,8 @@
   "plazaProjectOverdue": "Tarefas em atraso: {count}",
   "plazaSearchHint": "Procura tarefas, Enter para voar",
   "plazaShowPenguins": "Pinguins",
+  "plazaSkyDay": "Dia",
+  "plazaSkyNight": "Noite",
   "plazaStaleReason": "sem atividade há {days} dias — retoma-a",
   "plazaStats": "{tasks} tarefas · {weeks} semanas · {attention} precisam de atenção",
   "plazaTaskCount": "Tarefas: {count}",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -3868,6 +3868,8 @@
   "plazaProjectOverdue": "Sarcini întârziate: {count}",
   "plazaSearchHint": "Căutați sarcini, Enter pentru a zbura",
   "plazaShowPenguins": "Pinguini",
+  "plazaSkyDay": "Zi",
+  "plazaSkyNight": "Noapte",
   "plazaStaleReason": "fără activitate de {days} zile — reluați-o",
   "plazaStats": "{tasks} sarcini · {weeks} săptămâni · {attention} necesită atenție",
   "plazaTaskCount": "Sarcini: {count}",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4342,6 +4342,8 @@
   "plazaProjectOverdue": "Försenade uppgifter: {count}",
   "plazaSearchHint": "Sök uppgifter, Enter för att flyga",
   "plazaShowPenguins": "Pingviner",
+  "plazaSkyDay": "Dag",
+  "plazaSkyNight": "Natt",
   "plazaStaleReason": "ingen aktivitet på {days} dagar — ta upp den igen",
   "plazaStats": "{tasks} uppgifter · {weeks} veckor · {attention} kräver uppmärksamhet",
   "plazaTaskCount": "Uppgifter: {count}",

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -80,7 +80,7 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - sherpa_onnx_macos (1.13.7):
+  - sherpa_onnx_macos (1.13.4):
     - FlutterMacOS
   - sqflite_darwin (0.0.4):
     - Flutter
@@ -254,7 +254,7 @@ SPEC CHECKSUMS:
   screen_retriever_macos: c5508cc3c66ff0d4db650480cf0ab691e220d933
   share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  sherpa_onnx_macos: c5f2ac756922aa50ee4e1b887e55c46183eae68a
+  sherpa_onnx_macos: e648c8a9f1a02ec1d7e2788a2963bc86e67e2dd7
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   super_native_extensions: c2795d6d9aedf4a79fae25cb6160b71b50549189
   url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd
@@ -263,4 +263,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 481248ab00d30452d8c6bfe642a8daa6f28d838c
 
-COCOAPODS: 1.17.0
+COCOAPODS: 1.16.2

--- a/test/features/plaza/scene/wall_textures_test.dart
+++ b/test/features/plaza/scene/wall_textures_test.dart
@@ -5,6 +5,7 @@ import 'dart:ui' as ui;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/plaza/domain/attention.dart';
 import 'package:lotti/features/plaza/scene/wall_textures.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
 
 /// The strip as raw RGBA, sampled in world metres from its top-left.
 class _Strip {
@@ -15,6 +16,18 @@ class _Strip {
   final ByteData bytes;
 
   double get pxPerMeter => width / WallTextures.shopfrontWidth;
+
+  /// The pixel at [x], [y] in texels, for tiles that are not measured in
+  /// shopfront metres.
+  ui.Color atPixel(int x, int y) {
+    final i = (y.clamp(0, height - 1) * width + x.clamp(0, width - 1)) * 4;
+    return ui.Color.fromARGB(
+      bytes.getUint8(i + 3),
+      bytes.getUint8(i),
+      bytes.getUint8(i + 1),
+      bytes.getUint8(i + 2),
+    );
+  }
 
   ui.Color at(double xMeters, double yMeters) {
     final x = (xMeters * pxPerMeter).floor().clamp(0, width - 1);
@@ -48,10 +61,38 @@ class _Strip {
   }
 }
 
-Future<_Strip> _paint(LanternState state, {int variant = 0}) async {
-  final image = WallTextures.paintShopfront(state, variant: variant);
+Future<_Strip> _paint(
+  LanternState state, {
+  int variant = 0,
+  WallInk ink = WallInk.night,
+}) async {
+  final image = WallTextures.paintShopfront(state, variant: variant, ink: ink);
   final bytes = await image.toByteData();
   return _Strip(image.width, image.height, bytes!);
+}
+
+/// A window tile as raw RGBA, addressed in bays and floors.
+Future<_Strip> _paintTile(
+  LanternState state, {
+  int family = 0,
+  WallInk ink = WallInk.night,
+}) async {
+  final image = WallTextures.paintWindows(state, family: family, ink: ink);
+  final bytes = await image.toByteData();
+  return _Strip(image.width, image.height, bytes!);
+}
+
+/// Mean brightness of every pixel in an image, the one number that says
+/// whether a wall is painted for the dark or for the sun.
+Future<double> _meanBrightness(ui.Image image) async {
+  final bytes = (await image.toByteData())!;
+  var total = 0.0;
+  for (var i = 0; i < bytes.lengthInBytes; i += 4) {
+    total +=
+        (bytes.getUint8(i) + bytes.getUint8(i + 1) + bytes.getUint8(i + 2)) /
+        (3 * 255);
+  }
+  return total / (bytes.lengthInBytes / 4);
 }
 
 int _count(Iterable<ui.Color> colors, bool Function(ui.Color) test) =>
@@ -368,5 +409,292 @@ void main() {
     );
     expect(slats, greaterThan(10));
     expect(slats, lessThan(80));
+  });
+
+  group('WallInk', () {
+    test('the painters default to the sky the district was designed in', () {
+      expect(WallInk.of(PlazaSkyMode.night), same(WallInk.night));
+      expect(WallInk.of(PlazaSkyMode.day), same(WallInk.day));
+      expect(WallInk.night.mode, PlazaSkyMode.night);
+      expect(WallInk.day.mode, PlazaSkyMode.day);
+      expect(WallInk.night.reflectsSky, isFalse);
+      expect(WallInk.day.reflectsSky, isTrue);
+    });
+
+    test('a night pane is a light: occupied glows, empty barely shows', () {
+      const tint = ui.Color(0xFFFFE2B0);
+      final (litTop, litBottom) = WallInk.night.pane(
+        tint: tint,
+        on: true,
+        roll: 0.5,
+      );
+      final (darkTop, _) = WallInk.night.pane(
+        tint: tint,
+        on: false,
+        roll: 0.5,
+      );
+      expect(litTop.a, greaterThan(darkTop.a));
+      expect(
+        litBottom.a,
+        lessThan(litTop.a),
+        reason: 'a pane is brighter at the lintel than at the sill',
+      );
+      expect((litTop.r, litTop.g, litTop.b), (tint.r, tint.g, tint.b));
+    });
+
+    test('a day pane is a mirror: the empty one is pure sky', () {
+      final (top, bottom) = WallInk.day.pane(
+        tint: const ui.Color(0xFFFFE2B0),
+        on: false,
+        roll: 0.5,
+      );
+      expect(top, WallInk.day.skyHigh);
+      expect(bottom, WallInk.day.skyLow);
+      expect(
+        _sum(top),
+        greaterThan(_sum(bottom)),
+        reason: 'glass mirrors more sky the higher up the pane you look',
+      );
+    });
+
+    test('a day pane with someone in shows the room through the sky', () {
+      const tint = ui.Color(0xFFFFE2B0);
+      final (top, bottom) = WallInk.day.pane(tint: tint, on: true, roll: 0.5);
+      final (emptyTop, emptyBottom) = WallInk.day.pane(
+        tint: tint,
+        on: false,
+        roll: 0.5,
+      );
+      expect(_sum(top), lessThan(_sum(emptyTop)));
+      expect(_sum(bottom), lessThan(_sum(emptyBottom)));
+      expect(
+        _sum(bottom),
+        lessThan(_sum(top)),
+        reason: 'the reflection survives at the top, the room shows below',
+      );
+      expect(top.a, 1.0, reason: 'daylight glass is opaque, not a glow');
+    });
+
+    test('a day pane never out-brightens the sky it reflects', () {
+      for (final on in [true, false]) {
+        for (final roll in [0.0, 0.5, 1.0]) {
+          final (top, bottom) = WallInk.day.pane(
+            tint: const ui.Color(0xFFFFFFFF),
+            on: on,
+            roll: roll,
+          );
+          expect(_sum(top), lessThanOrEqualTo(_sum(WallInk.day.skyHigh)));
+          expect(_sum(bottom), lessThanOrEqualTo(_sum(WallInk.day.skyLow)));
+        }
+      }
+    });
+  });
+
+  group('daylight wall textures', () {
+    test('the wall between the windows is painted for the sun', () async {
+      final nightImage = WallTextures.paintWindows(LanternState.open);
+      final dayImage = WallTextures.paintWindows(
+        LanternState.open,
+        ink: WallInk.day,
+      );
+      addTearDown(nightImage.dispose);
+      addTearDown(dayImage.dispose);
+      expect(
+        await _meanBrightness(dayImage),
+        greaterThan(await _meanBrightness(nightImage) + 0.25),
+        reason: 'a night tile under a blue sky is the bug this prevents',
+      );
+      expect(
+        (dayImage.width, dayImage.height),
+        (nightImage.width, nightImage.height),
+        reason: 'both sets tile the same walls, so the atlas cannot move',
+      );
+    });
+
+    test('a day tile is wall where a night tile is wall', () async {
+      // 15 % across a bay is solid wall on the residential family: the day
+      // set must paint the render there, not glass.
+      final day = await _paintTile(LanternState.open, ink: WallInk.day);
+      for (var floor = 0; floor < WallTextures.floors; floor++) {
+        for (var bay = 0; bay < WallTextures.bays; bay++) {
+          final x = (bay + 0.15) * day.width / WallTextures.bays;
+          final y = (floor + 0.65) * day.height / WallTextures.floors;
+          expect(
+            day.atPixel(x.floor(), y.floor()),
+            WallInk.day.wall,
+            reason: 'floor $floor bay $bay is not the day wall',
+          );
+        }
+      }
+    });
+
+    test('the shopfront parade is dressed for the sun too', () async {
+      final nightImage = WallTextures.paintShopfront(LanternState.inProgress);
+      final dayImage = WallTextures.paintShopfront(
+        LanternState.inProgress,
+        ink: WallInk.day,
+      );
+      addTearDown(nightImage.dispose);
+      addTearDown(dayImage.dispose);
+      expect(
+        await _meanBrightness(dayImage),
+        greaterThan(await _meanBrightness(nightImage)),
+      );
+      expect((dayImage.width, dayImage.height), (1584, 192));
+    });
+
+    test(
+      'daylight keeps the state vocabulary the walker has learned',
+      () async {
+        // The parade still says what the task is doing: blocked is taped,
+        // in progress is lit, not started is papered over.
+        final blocked = await _paint(LanternState.blocked, ink: WallInk.day);
+        final trading = await _paint(LanternState.inProgress, ink: WallInk.day);
+        final open = await _paint(LanternState.open, ink: WallInk.day);
+        expect(_count(blocked.along(_tapeRow), _isRed), greaterThan(30));
+        expect(_count(trading.along(_tapeRow), _isRed), lessThan(5));
+        expect(_count(trading.along(_signRow), _isLitSign), greaterThan(10));
+        expect(_count(open.along(_glassRow), _isPaper), greaterThan(20));
+      },
+    );
+
+    test(
+      'busy walls are more occupied than sleeping ones, in both skies',
+      () async {
+        // The lit ratio still says how busy a task is when the panes are
+        // mirrors: a day tile with more rooms showing is a busier building.
+        for (final ink in [WallInk.night, WallInk.day]) {
+          final byState = <LanternState, double>{};
+          for (final state in LanternState.values) {
+            for (var family = 0; family < WallTextures.tileFamilies; family++) {
+              final image = WallTextures.paintWindows(
+                state,
+                family: family,
+                ink: ink,
+              );
+              addTearDown(image.dispose);
+              byState[state] =
+                  (byState[state] ?? 0) + await _meanBrightness(image);
+            }
+          }
+          final busy = byState[LanternState.inProgress]!;
+          final asleep = byState[LanternState.off]!;
+          expect(
+            WallTextures.litRatio(LanternState.inProgress),
+            greaterThan(WallTextures.litRatio(LanternState.off)),
+          );
+          expect(
+            ink.reflectsSky ? asleep : busy,
+            greaterThan(ink.reflectsSky ? busy : asleep),
+            reason: ink.reflectsSky
+                // Occupied glass shows a dark room where empty glass mirrors
+                // a bright sky, so by day a busy wall is the darker one.
+                ? 'a day wall with more rooms showing should darken'
+                : 'a night wall with more lights on should brighten',
+          );
+        }
+      },
+    );
+
+    test('the five states stay five different pictures by day', () async {
+      final signatures = <double>{};
+      for (final state in LanternState.values) {
+        final image = WallTextures.paintShopfront(state, ink: WallInk.day);
+        addTearDown(image.dispose);
+        signatures.add(
+          double.parse((await _meanBrightness(image)).toStringAsFixed(4)),
+        );
+      }
+      expect(signatures, hasLength(LanternState.values.length));
+    });
+  });
+
+  group('the ground overlays serve both skies', () {
+    test('the falloff is a hot core with a feathered skirt', () async {
+      // Every ground light is drawn with this, and so is every daylight
+      // contact shadow: a hard-edged quad would read as a painted
+      // rectangle rather than as contact with the paving.
+      final image = WallTextures.paintPool();
+      addTearDown(image.dispose);
+      final pixels = (await image.toByteData())!;
+      int alphaAt(int x, int y) =>
+          pixels.getUint8((y * image.width + x) * 4 + 3);
+      final centre = image.width ~/ 2;
+      expect(
+        alphaAt(centre, centre),
+        greaterThan(240),
+        reason: 'the core is all but opaque; the gradient samples it at 250',
+      );
+      final ring = [
+        for (final r in [0.1, 0.25, 0.4, 0.49])
+          alphaAt(centre + (image.width * r).round(), centre),
+      ];
+      for (var i = 1; i < ring.length; i++) {
+        expect(
+          ring[i],
+          lessThan(ring[i - 1]),
+          reason: 'the skirt has to fall away, not step down',
+        );
+      }
+      expect(alphaAt(0, 0), 0, reason: 'the corners must not clip a square');
+    });
+
+    test(
+      'the shadow mask is flat in the middle where the pool is not',
+      () async {
+        // This is the difference the daylight shadows live on. Multiplied
+        // into a dark colour, the pool's long thin skirt darkens the paving
+        // by a percent or two; shade needs a mask that is opaque across the
+        // shape and soft only at its rim. Swapping the two back makes every
+        // contact shadow disappear, which is exactly what happened once.
+        final shadowImage = WallTextures.paintShadow();
+        final poolImage = WallTextures.paintPool();
+        addTearDown(shadowImage.dispose);
+        addTearDown(poolImage.dispose);
+        final shadow = (await shadowImage.toByteData())!;
+        final pool = (await poolImage.toByteData())!;
+        int alphaAt(ByteData pixels, int width, int x, int y) =>
+            pixels.getUint8((y * width + x) * 4 + 3);
+        final centre = shadowImage.width ~/ 2;
+        // Half way out to the rim the shadow is still solid and the pool has
+        // already fallen away to a fraction of itself.
+        final half = centre + (shadowImage.width * 0.25).round();
+        expect(alphaAt(shadow, shadowImage.width, half, centre), 255);
+        expect(
+          alphaAt(pool, poolImage.width, half, centre),
+          lessThan(120),
+          reason: 'if the pool ever flattens, this test is measuring nothing',
+        );
+        // And it still feathers rather than ending in a hard disc edge.
+        final rim = centre + (shadowImage.width * 0.45).round();
+        expect(
+          alphaAt(shadow, shadowImage.width, rim, centre),
+          inExclusiveRange(0, 255),
+        );
+        expect(alphaAt(shadow, shadowImage.width, 0, 0), 0);
+      },
+    );
+
+    test('the grain is a transparent overlay, so both roads take it', () async {
+      // It is blended over the road colour rather than replacing it, which
+      // is why the day road needs no grain tile of its own.
+      final image = WallTextures.paintGrain();
+      addTearDown(image.dispose);
+      final pixels = (await image.toByteData())!;
+      var opaque = 0;
+      var marked = 0;
+      for (var i = 0; i < pixels.lengthInBytes; i += 4) {
+        final alpha = pixels.getUint8(i + 3);
+        if (alpha == 255) opaque++;
+        if (alpha > 0) marked++;
+      }
+      expect(opaque, 0, reason: 'an opaque grain tile would repaint the road');
+      expect(marked, greaterThan(500), reason: 'and it has to be visible');
+      expect(
+        marked,
+        lessThan(image.width * image.height),
+        reason: 'grit, not a wash',
+      );
+    });
   });
 }

--- a/test/features/plaza/state/plaza_sky_mode_controller_test.dart
+++ b/test/features/plaza/state/plaza_sky_mode_controller_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/features/plaza/state/plaza_sky_mode_controller.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/domain_logging.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
+import '../../../widget_test_utils.dart';
+
+void main() {
+  late TestGetItMocks mocks;
+  late ProviderContainer container;
+
+  setUpAll(registerAllFallbackValues);
+
+  setUp(() async {
+    mocks = await setUpTestGetIt();
+    when(
+      () => mocks.settingsDb.itemByKey(any<String>()),
+    ).thenAnswer((_) async => null);
+    when(
+      () => mocks.settingsDb.saveSettingsItem(any<String>(), any<String>()),
+    ).thenAnswer((_) async => 1);
+    container = ProviderContainer();
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await tearDownTestGetIt();
+  });
+
+  /// Drains the pending microtasks of the controller's async load.
+  Future<void> awaitHydration() async {
+    for (var i = 0; i < 16; i++) {
+      await Future<void>.value();
+    }
+  }
+
+  PlazaSkyMode read() => container.read(plazaSkyModeProvider);
+  PlazaSkyModeController notifier() =>
+      container.read(plazaSkyModeProvider.notifier);
+
+  /// Swaps a mock logger into getIt and returns it.
+  MockDomainLogger installMockLogger() {
+    final logger = MockDomainLogger();
+    when(
+      () => logger.error(
+        any<LogDomain>(),
+        any<Object>(),
+        stackTrace: any<StackTrace>(named: 'stackTrace'),
+        subDomain: any<String>(named: 'subDomain'),
+        message: any<String>(named: 'message'),
+      ),
+    ).thenReturn(null);
+    getIt
+      ..unregister<DomainLogger>()
+      ..registerSingleton<DomainLogger>(logger);
+    return logger;
+  }
+
+  test('the district opens at night until told otherwise', () async {
+    expect(read(), PlazaSkyMode.night);
+    await awaitHydration();
+    expect(read(), PlazaSkyMode.night);
+    verify(() => mocks.settingsDb.itemByKey(plazaSkyModeSettingsKey)).called(1);
+  });
+
+  test('a remembered daylight preference is restored', () async {
+    when(
+      () => mocks.settingsDb.itemByKey(plazaSkyModeSettingsKey),
+    ).thenAnswer((_) async => PlazaSkyMode.day.name);
+    expect(read(), PlazaSkyMode.night, reason: 'before the read resolves');
+    await awaitHydration();
+    expect(read(), PlazaSkyMode.day);
+  });
+
+  test('a preference written by another build falls back to night', () async {
+    when(
+      () => mocks.settingsDb.itemByKey(plazaSkyModeSettingsKey),
+    ).thenAnswer((_) async => 'golden-hour');
+    await awaitHydration();
+    expect(read(), PlazaSkyMode.night);
+  });
+
+  test('switching the sky persists it under the shared key', () async {
+    await awaitHydration();
+    notifier().set(PlazaSkyMode.day);
+    expect(read(), PlazaSkyMode.day);
+    await awaitHydration();
+    verify(
+      () => mocks.settingsDb.saveSettingsItem(
+        plazaSkyModeSettingsKey,
+        PlazaSkyMode.day.name,
+      ),
+    ).called(1);
+  });
+
+  test('switching to the mode already showing writes nothing', () async {
+    await awaitHydration();
+    notifier().set(PlazaSkyMode.night);
+    await awaitHydration();
+    verifyNever(
+      () => mocks.settingsDb.saveSettingsItem(any<String>(), any<String>()),
+    );
+  });
+
+  test('a choice made mid-load is not undone by the stored one', () async {
+    // The walker switches to daylight while the initial read is still in
+    // flight; the night that comes back must not overwrite it.
+    when(
+      () => mocks.settingsDb.itemByKey(plazaSkyModeSettingsKey),
+    ).thenAnswer((_) async => PlazaSkyMode.night.name);
+    notifier().set(PlazaSkyMode.day);
+    await awaitHydration();
+    expect(read(), PlazaSkyMode.day);
+  });
+
+  test(
+    'an unreadable preference is logged and leaves night standing',
+    () async {
+      final logger = installMockLogger();
+      when(
+        () => mocks.settingsDb.itemByKey(plazaSkyModeSettingsKey),
+      ).thenThrow(Exception('settings unavailable'));
+      await awaitHydration();
+      expect(read(), PlazaSkyMode.night);
+      verify(
+        () => logger.error(
+          LogDomain.settings,
+          any<Object>(),
+          stackTrace: any<StackTrace>(named: 'stackTrace'),
+          subDomain: 'plazaSkyMode.load',
+        ),
+      ).called(1);
+    },
+  );
+
+  test('a failed write keeps the choice for this session', () async {
+    final logger = installMockLogger();
+    when(
+      () => mocks.settingsDb.saveSettingsItem(any<String>(), any<String>()),
+    ).thenThrow(Exception('disk full'));
+    await awaitHydration();
+    notifier().set(PlazaSkyMode.day);
+    await awaitHydration();
+    expect(read(), PlazaSkyMode.day);
+    verify(
+      () => logger.error(
+        LogDomain.settings,
+        any<Object>(),
+        stackTrace: any<StackTrace>(named: 'stackTrace'),
+        subDomain: 'plazaSkyMode.persist',
+      ),
+    ).called(1);
+  });
+
+  test('without a settings database the sky still switches', () async {
+    getIt.unregister<SettingsDb>();
+    await awaitHydration();
+    expect(read(), PlazaSkyMode.night);
+    notifier().set(PlazaSkyMode.day);
+    await awaitHydration();
+    expect(read(), PlazaSkyMode.day);
+  });
+}

--- a/test/features/plaza/ui/category_plaza_page_test.dart
+++ b/test/features/plaza/ui/category_plaza_page_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/features/plaza/data/plaza_repository.dart';
 import 'package:lotti/features/plaza/scene/plaza_world.dart';
 import 'package:lotti/features/plaza/state/project_plaza_provider.dart';
 import 'package:lotti/features/plaza/ui/category_plaza_page.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
 import 'package:lotti/features/plaza/ui/project_plaza_page.dart';
 import 'package:lotti/widgets/ui/error_state_widget.dart';
 import 'package:material_ui/material_ui.dart';
@@ -41,6 +42,8 @@ void main() {
             required ticks,
             required onOpenTask,
             required onExit,
+            initialSkyMode = PlazaSkyMode.night,
+            onSkyModeChanged,
           }) {
             if (world.isCategory) {
               categoryWorld = world;

--- a/test/features/plaza/ui/plaza_hud_test.dart
+++ b/test/features/plaza/ui/plaza_hud_test.dart
@@ -2,8 +2,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/components/checkboxes/design_system_checkbox.dart';
 import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/plaza/domain/attention.dart';
 import 'package:lotti/features/plaza/ui/debug_overlay.dart';
 import 'package:lotti/features/plaza/ui/plaza_hud.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
+import 'package:lotti/features/plaza/ui/plaza_style.dart';
 import 'package:material_ui/material_ui.dart';
 
 import '../../../widget_test_utils.dart';
@@ -18,6 +21,7 @@ void main() {
   late bool showPenguins;
   late bool showMeerkats;
   late bool showConnections;
+  PlazaSkyMode? skyMode;
 
   setUp(() {
     walks = 0;
@@ -29,6 +33,7 @@ void main() {
     showPenguins = true;
     showMeerkats = true;
     showConnections = true;
+    skyMode = null;
   });
 
   Widget host({
@@ -38,6 +43,7 @@ void main() {
     bool penguinsAvailable = true,
     bool meerkatsAvailable = true,
     bool connectionsAvailable = false,
+    PlazaSkyMode sky = PlazaSkyMode.night,
   }) => makeTestableWidget2(
     Scaffold(
       body: PlazaHud(
@@ -52,6 +58,9 @@ void main() {
         onExit: () => exits++,
         frameRate: frameRate,
         onFrameRateChanged: (rate) => frameRate = rate,
+        skyMode: sky,
+        palette: PlazaPalette.of(sky),
+        onSkyModeChanged: (mode) => skyMode = mode,
         showMeerkats: showMeerkats,
         onShowMeerkatsChanged: meerkatsAvailable
             ? (show) => showMeerkats = show
@@ -251,5 +260,88 @@ void main() {
     expect(disabled.onChanged, isNull);
     await tester.tap(find.text('Meerkats'));
     expect(showMeerkats, isFalse);
+  });
+
+  testWidgets('the sky control offers both hours and reports the switch', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1400, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(host());
+    // Each segment draws its label twice: once visible, once as the ghost
+    // that reserves the selected width.
+    expect(find.text('Night'), findsNWidgets(2));
+    expect(find.text('Day'), findsNWidgets(2));
+    expect(skyMode, isNull, reason: 'nothing reported before a tap');
+    await tester.tap(find.text('Day').hitTestable().first);
+    await tester.pump();
+    expect(skyMode, PlazaSkyMode.day);
+    await tester.pumpWidget(host(sky: PlazaSkyMode.day));
+    await tester.tap(find.text('Night').hitTestable().first);
+    await tester.pump();
+    expect(skyMode, PlazaSkyMode.night);
+  });
+
+  testWidgets('the status legend wears the colours the roofs do', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1400, 1000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    Color? pillColor(String label) => tester
+        .widgetList<DsPill>(find.byType(DsPill))
+        .where((pill) => pill.label == label)
+        .map((pill) => pill.color)
+        .firstOrNull;
+
+    await tester.pumpWidget(host());
+    const open = 'Open';
+    expect(pillColor(open), PlazaPalette.night.lanterns.of(LanternState.open));
+    await tester.pumpWidget(host(sky: PlazaSkyMode.day));
+    await tester.pump();
+    expect(
+      pillColor(open),
+      PlazaPalette.day.lanterns.of(LanternState.open),
+      reason: 'a key that shows night colours over a daylit street is a lie',
+    );
+  });
+
+  testWidgets('daylight puts the chrome on a scrim and night does not', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1400, 1000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    // White type and tinted pills drawn straight onto sunlit concrete do
+    // not read; over the night street they do, and a scrim there would
+    // obstruct the view for nothing.
+    Iterable<Color?> scrims() => tester
+        .widgetList<DecoratedBox>(find.byType(DecoratedBox))
+        .map((box) => box.decoration)
+        .whereType<BoxDecoration>()
+        .map((decoration) => decoration.color)
+        .where((color) => color?.withValues(alpha: 1) == PlazaStyle.panel);
+
+    await tester.pumpWidget(host());
+    expect(scrims(), isEmpty);
+
+    await tester.pumpWidget(host(sky: PlazaSkyMode.day));
+    await tester.pump();
+    expect(
+      scrims(),
+      hasLength(2),
+      reason: 'the controls above and the legend below each get one',
+    );
+    expect(
+      scrims().first!.a,
+      closeTo(SurfaceAlphas.linework, 0.001),
+      reason: 'the scrim opacity is a design-system step, not a local number',
+    );
   });
 }

--- a/test/features/plaza/ui/plaza_palette_test.dart
+++ b/test/features/plaza/ui/plaza_palette_test.dart
@@ -1,0 +1,487 @@
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/plaza/domain/attention.dart';
+import 'package:lotti/features/plaza/domain/plaza_task.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
+import 'package:material_ui/material_ui.dart';
+
+PlazaTask _task(PlazaTaskState state, {int color = 0xFF3366FF}) => PlazaTask(
+  id: 'palette-${state.name}',
+  createdAt: DateTime.utc(2026, 7),
+  title: 'Palette probe',
+  state: state,
+  progress: 0,
+  checklistItems: 0,
+  linkedTaskIds: const [],
+  categoryColor: color,
+);
+
+/// Perceived brightness, so "daylight is lighter than night" can be asserted
+/// on a colour rather than eyeballed.
+double _luminance(Color color) =>
+    0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b;
+
+/// The states that are lights at night: everything except the unlit
+/// fixture, which is exempt from the legibility rules on purpose.
+const _liveStates = <LanternState>[
+  LanternState.blocked,
+  LanternState.overdue,
+  LanternState.inProgress,
+  LanternState.open,
+];
+
+void main() {
+  final now = DateTime.utc(2026, 7, 15);
+
+  group('PlazaSkyMode', () {
+    test('PLAZA_DAY=1 boots the fixture into daylight', () {
+      expect(
+        PlazaSkyMode.fromEnvironment({'PLAZA_DAY': '1'}),
+        PlazaSkyMode.day,
+      );
+    });
+
+    test('any other environment stays at night', () {
+      expect(PlazaSkyMode.fromEnvironment(const {}), PlazaSkyMode.night);
+      expect(
+        PlazaSkyMode.fromEnvironment({'PLAZA_DAY': '0'}),
+        PlazaSkyMode.night,
+      );
+      expect(
+        PlazaSkyMode.fromEnvironment({'PLAZA_DAY': 'true'}),
+        PlazaSkyMode.night,
+        reason: 'only the literal 1 opts in, as with the other PLAZA_ knobs',
+      );
+    });
+
+    test('a stored name round-trips', () {
+      for (final mode in PlazaSkyMode.values) {
+        expect(PlazaSkyMode.fromName(mode.name), mode);
+      }
+    });
+
+    test('a missing or unreadable preference falls back to night', () {
+      expect(PlazaSkyMode.fromName(null), PlazaSkyMode.night);
+      expect(PlazaSkyMode.fromName(''), PlazaSkyMode.night);
+      expect(PlazaSkyMode.fromName('dusk'), PlazaSkyMode.night);
+    });
+  });
+
+  group('PlazaSky', () {
+    test('night has no sun; day does', () {
+      expect(PlazaPalette.night.sky.hasSun, isFalse);
+      expect(PlazaPalette.day.sky.hasSun, isTrue);
+    });
+
+    test('the sun direction is a unit vector at its stated azimuth', () {
+      final sky = PlazaPalette.day.sky;
+      final direction = sky.sunDirection;
+      final length = math.sqrt(
+        direction.x * direction.x +
+            direction.y * direction.y +
+            direction.z * direction.z,
+      );
+      expect(length, closeTo(1, 1e-12));
+      expect(direction.y, closeTo(math.sin(sky.sunElevation), 1e-12));
+      // atan2 answers in (-pi, pi]; an azimuth past half a turn is the
+      // same bearing, so compare them on the circle.
+      expect(
+        math.atan2(direction.x, direction.z) % (2 * math.pi),
+        closeTo(sky.sunAzimuth % (2 * math.pi), 1e-12),
+      );
+    });
+
+    test('the sun stands above the horizon and off the street axis', () {
+      final sky = PlazaPalette.day.sky;
+      expect(
+        sky.sunElevation,
+        inInclusiveRange(math.pi / 8, math.pi / 2 - math.pi / 12),
+        reason:
+            'a sun at the zenith leaves no shadow, one at the horizon '
+            'leaves nothing but shadow',
+      );
+      expect(sky.sunDirection.y, greaterThan(0));
+    });
+
+    test('a night wall casts nothing, whatever its height', () {
+      expect(PlazaPalette.night.sky.shadowLength(1), 0);
+      expect(PlazaPalette.night.sky.shadowLength(80), 0);
+    });
+
+    test('a daylight shadow grows with the wall until it is clamped', () {
+      final sky = PlazaPalette.day.sky;
+      final low = sky.shadowLength(4);
+      final tall = sky.shadowLength(12);
+      expect(low, greaterThan(0));
+      expect(tall, greaterThan(low));
+      expect(low, closeTo(4 / math.tan(sky.sunElevation), 1e-9));
+    });
+
+    test('a tower does not drag its shadow across the district', () {
+      final sky = PlazaPalette.day.sky;
+      expect(sky.shadowLength(400), PlazaSky.maxShadowLength);
+      expect(
+        sky.shadowLength(400),
+        greaterThanOrEqualTo(sky.shadowLength(40)),
+        reason: 'the clamp is a ceiling, never a reversal',
+      );
+    });
+
+    test('a sun on the horizon clamps instead of dividing by zero', () {
+      const horizon = PlazaSky(
+        zenith: Colors.blue,
+        horizon: Colors.white,
+        ground: Colors.brown,
+        sun: Colors.white,
+        sunIntensity: 5,
+        sunAzimuth: 0,
+        sunElevation: 0,
+        sunSharpness: 400,
+      );
+      expect(horizon.shadowLength(10), PlazaSky.maxShadowLength);
+    });
+  });
+
+  group('PlazaAir', () {
+    test('night carries both bloom and vignette', () {
+      expect(PlazaPalette.night.air.hasBloom, isTrue);
+      expect(PlazaPalette.night.air.hasVignette, isTrue);
+    });
+
+    test('daylight keeps a trace of bloom and drops the vignette', () {
+      expect(PlazaPalette.day.air.hasVignette, isFalse);
+      expect(
+        PlazaPalette.day.air.bloomThreshold,
+        greaterThan(PlazaPalette.night.air.bloomThreshold),
+        reason: 'nothing in a daylit street should outshine the sky',
+      );
+      expect(
+        PlazaPalette.day.air.bloomIntensity,
+        lessThan(PlazaPalette.night.air.bloomIntensity),
+      );
+    });
+
+    test('haze thins with altitude in both skies', () {
+      for (final palette in [PlazaPalette.night, PlazaPalette.day]) {
+        final air = palette.air;
+        expect(
+          air.fogDensityHigh,
+          lessThan(air.fogDensityLow),
+          reason: '${palette.mode.name}: the overview must see the district',
+        );
+        expect(air.fogOpacityHigh, lessThan(air.fogOpacityLow));
+      }
+    });
+
+    test('daylight haze is thinner and paler than the night indigo', () {
+      expect(
+        PlazaPalette.day.air.fogDensityLow,
+        lessThan(PlazaPalette.night.air.fogDensityLow),
+      );
+      expect(
+        _luminance(PlazaPalette.day.air.fog),
+        greaterThan(_luminance(PlazaPalette.night.air.fog)),
+      );
+    });
+  });
+
+  group('PlazaLanterns', () {
+    test('every state has its own colour, in both skies', () {
+      for (final palette in [PlazaPalette.night, PlazaPalette.day]) {
+        final colours = {
+          for (final state in LanternState.values)
+            state: palette.lanterns.of(state),
+        };
+        expect(
+          colours.values.toSet(),
+          hasLength(LanternState.values.length),
+          reason:
+              '${palette.mode.name}: two states reading the same colour '
+              'is a state the walker cannot tell apart',
+        );
+      }
+    });
+
+    test('a live state keeps its hue and changes only its value', () {
+      // The four states that are lights at night have to survive as marks
+      // by day. The hue is the thing the walker has learned; the value is
+      // what has to change to carry it against a bright sky.
+      for (final state in _liveStates) {
+        final night = HSLColor.fromColor(PlazaPalette.night.lanterns.of(state));
+        final day = HSLColor.fromColor(PlazaPalette.day.lanterns.of(state));
+        expect(
+          day.lightness,
+          lessThan(night.lightness),
+          reason: '$state should darken for a bright sky',
+        );
+        if (night.saturation > 0.2) {
+          expect(
+            day.hue,
+            closeTo(night.hue, 12),
+            reason: '$state must stay recognisably the same colour',
+          );
+        }
+      }
+    });
+
+    test('a live state reads better by day than its night colour would', () {
+      // The point of a second lantern set: against the day sky, each of
+      // these separates further than the night colour it replaces.
+      final sky = _luminance(PlazaPalette.day.sky.horizon);
+      for (final state in _liveStates) {
+        final asNight =
+            (sky - _luminance(PlazaPalette.night.lanterns.of(state))).abs();
+        final asDay = (sky - _luminance(PlazaPalette.day.lanterns.of(state)))
+            .abs();
+        expect(
+          asDay,
+          greaterThan(asNight),
+          reason: '$state gains nothing from the day set',
+        );
+      }
+    });
+
+    test('the off state is the only lantern without a hue', () {
+      // Nothing to report should not shout. It cannot be said in luminance
+      // — a grey mark separates from a pale sky more than an amber one
+      // does — so the rule is chroma: every live state carries a hue and
+      // the unlit fixture is the one neutral among them.
+      for (final palette in [PlazaPalette.night, PlazaPalette.day]) {
+        final off = HSLColor.fromColor(
+          palette.lanterns.of(LanternState.off),
+        ).saturation;
+        expect(
+          off,
+          lessThan(0.15),
+          reason: '${palette.mode.name}: off should read as grey metal',
+        );
+        for (final state in _liveStates) {
+          expect(
+            HSLColor.fromColor(palette.lanterns.of(state)).saturation,
+            greaterThan(off),
+            reason: '${palette.mode.name}: $state has no more hue than off',
+          );
+        }
+      }
+    });
+
+    test('the day lanterns are darker than the sky behind them', () {
+      final sky = _luminance(PlazaPalette.day.sky.horizon);
+      for (final state in LanternState.values) {
+        expect(
+          _luminance(PlazaPalette.day.lanterns.of(state)),
+          lessThan(sky),
+          reason: '$state has to read as a mark, not vanish into the sky',
+        );
+      }
+    });
+  });
+
+  group('PlazaPalette', () {
+    test('of() returns the palette for the mode, and knows which it is', () {
+      expect(PlazaPalette.of(PlazaSkyMode.night), same(PlazaPalette.night));
+      expect(PlazaPalette.of(PlazaSkyMode.day), same(PlazaPalette.day));
+      expect(PlazaPalette.night.isDay, isFalse);
+      expect(PlazaPalette.day.isDay, isTrue);
+      expect(PlazaPalette.night.mode, PlazaSkyMode.night);
+      expect(PlazaPalette.day.mode, PlazaSkyMode.day);
+    });
+
+    test('a finished task is the success green, whatever the hour', () {
+      final done = attentionFor(_task(PlazaTaskState.done), now);
+      final success = dsTokensDark.colors.alert.success.defaultColor;
+      expect(PlazaPalette.night.taskColor(done), success);
+      expect(PlazaPalette.day.taskColor(done), success);
+    });
+
+    test('every other task takes its lantern in the active register', () {
+      final open = attentionFor(_task(PlazaTaskState.open), now);
+      expect(
+        PlazaPalette.night.taskColor(open),
+        PlazaPalette.night.lanterns.of(open.lantern),
+      );
+      expect(
+        PlazaPalette.day.taskColor(open),
+        PlazaPalette.day.lanterns.of(open.lantern),
+      );
+      expect(
+        PlazaPalette.day.taskColor(open),
+        isNot(PlazaPalette.night.taskColor(open)),
+      );
+    });
+
+    test('walls and roofs keep the category hue in both skies', () {
+      final task = _task(PlazaTaskState.open, color: 0xFFFF0000);
+      for (final palette in [PlazaPalette.night, PlazaPalette.day]) {
+        final wall = HSLColor.fromColor(palette.categoryWall(task));
+        final roof = HSLColor.fromColor(palette.categoryRoof(task));
+        bool red(double hue) => hue < 12 || hue > 348;
+        expect(red(wall.hue), isTrue, reason: '${palette.mode}: ${wall.hue}');
+        expect(red(roof.hue), isTrue, reason: '${palette.mode}: ${roof.hue}');
+      }
+    });
+
+    test('a daylight wall and roof are lit, not merely tinted dark', () {
+      final task = _task(PlazaTaskState.open);
+      expect(
+        _luminance(PlazaPalette.day.categoryWall(task)),
+        greaterThan(_luminance(PlazaPalette.night.categoryWall(task)) + 0.2),
+      );
+      expect(
+        _luminance(PlazaPalette.day.categoryRoof(task)),
+        greaterThan(_luminance(PlazaPalette.night.categoryRoof(task)) + 0.2),
+      );
+    });
+
+    test('the roof stays a step down from the wall it caps', () {
+      final task = _task(PlazaTaskState.open);
+      for (final palette in [PlazaPalette.night, PlazaPalette.day]) {
+        expect(
+          _luminance(palette.categoryRoof(task)),
+          lessThan(_luminance(palette.categoryWall(task))),
+          reason: '${palette.mode.name}: a roof reads as a top surface',
+        );
+      }
+    });
+
+    test('the night done wall still starts from the design system ground', () {
+      // The value is copied into the palette because a token is not a
+      // constant; if the token moves, this is what says so.
+      expect(
+        PlazaPalette.night.surfaces.doneWallBase,
+        dsTokensDark.colors.background.level01,
+      );
+    });
+
+    test('a finished block reads green before its sign is legible', () {
+      final done = _task(PlazaTaskState.done, color: 0xFFFF0000);
+      final success = dsTokensDark.colors.alert.success.defaultColor;
+      for (final palette in [PlazaPalette.night, PlazaPalette.day]) {
+        expect(
+          palette.categoryRoof(done),
+          success,
+          reason: '${palette.mode.name}: the roof is the aerial read',
+        );
+        final wall = HSLColor.fromColor(palette.categoryWall(done));
+        expect(
+          wall.hue,
+          closeTo(HSLColor.fromColor(success).hue, 6),
+          reason: '${palette.mode.name}: the walls go green too, not red',
+        );
+      }
+    });
+
+    test(
+      'the daylight done wall takes more green than the night one, because '
+      'a pale wall swallows the tint a dark one shows',
+      () {
+        final done = _task(PlazaTaskState.done, color: 0xFFFF0000);
+        final success = dsTokensDark.colors.alert.success.defaultColor;
+        double distanceToSuccess(Color wall) {
+          final hsl = HSLColor.fromColor(wall);
+          return (hsl.saturation - HSLColor.fromColor(success).saturation)
+              .abs();
+        }
+
+        expect(
+          distanceToSuccess(PlazaPalette.day.categoryWall(done)),
+          lessThan(distanceToSuccess(PlazaPalette.night.categoryWall(done))),
+        );
+      },
+    );
+  });
+
+  group('the two skies differ where it matters', () {
+    test('daylight puts the light in the sky, not in the buildings', () {
+      final night = PlazaPalette.night.lights;
+      final day = PlazaPalette.day.lights;
+      expect(
+        day.emissiveBoost,
+        lessThan(night.emissiveBoost),
+        reason: 'nothing is pushed past white when the sky already is',
+      );
+      expect(day.groundLightScale, 0, reason: 'no pools of lamplight at noon');
+      expect(day.glowScale, lessThan(night.glowScale));
+      expect(day.lampsLit, isFalse);
+      expect(night.lampsLit, isTrue);
+    });
+
+    test('only daylight casts shadows, and they are dark', () {
+      expect(PlazaPalette.night.lights.hasShadows, isFalse);
+      expect(PlazaPalette.night.lights.shadowAlpha, 0);
+      expect(PlazaPalette.day.lights.hasShadows, isTrue);
+      expect(
+        _luminance(PlazaPalette.day.lights.shadow),
+        lessThan(_luminance(PlazaPalette.day.surfaces.pavement)),
+        reason: 'a shadow has to darken the paving it lies on',
+      );
+    });
+
+    test('every built surface is lighter by day than by night', () {
+      final night = PlazaPalette.night.surfaces;
+      final day = PlazaPalette.day.surfaces;
+      final pairs = <String, (Color, Color)>{
+        'ground': (night.ground, day.ground),
+        'road': (night.road, day.road),
+        'gap': (night.gap, day.gap),
+        'post': (night.post, day.post),
+        'tower': (night.tower, day.tower),
+        'pavement': (night.pavement, day.pavement),
+        'kerb': (night.kerb, day.kerb),
+        'centreLine': (night.centreLine, day.centreLine),
+        'cornice': (night.cornice, day.cornice),
+        'plotBase': (night.plotBase, day.plotBase),
+        'plotRim': (night.plotRim, day.plotRim),
+        'unlitNeon': (night.unlitNeon, day.unlitNeon),
+        'riser': (night.riser, day.riser),
+        'timber': (night.timber, day.timber),
+        'ironwork': (night.ironwork, day.ironwork),
+        'foliage': (night.foliage, day.foliage),
+        'wallBase': (night.wallBase, day.wallBase),
+        'roofBase': (night.roofBase, day.roofBase),
+      };
+      for (final MapEntry(key: name, value: (dark, lit)) in pairs.entries) {
+        expect(
+          _luminance(lit),
+          greaterThan(_luminance(dark)),
+          reason:
+              '$name is unlit geometry: if it does not lighten, that '
+              'surface stays a night surface under a blue sky',
+        );
+      }
+    });
+
+    test('the kerb still separates itself from the paving by day', () {
+      for (final palette in [PlazaPalette.night, PlazaPalette.day]) {
+        expect(
+          _luminance(palette.surfaces.kerb),
+          greaterThan(_luminance(palette.surfaces.pavement)),
+          reason: '${palette.mode.name}: the kerb line carries the street',
+        );
+        expect(
+          _luminance(palette.surfaces.pavement),
+          greaterThan(_luminance(palette.surfaces.road)),
+          reason: '${palette.mode.name}: pavement reads against asphalt',
+        );
+      }
+    });
+
+    test('the day sky is brighter overhead than the night sky', () {
+      expect(
+        _luminance(PlazaPalette.day.sky.horizon),
+        greaterThan(_luminance(PlazaPalette.night.sky.horizon)),
+      );
+      expect(
+        _luminance(PlazaPalette.day.sky.zenith),
+        greaterThan(_luminance(PlazaPalette.night.sky.zenith)),
+      );
+      expect(
+        _luminance(PlazaPalette.day.sky.horizon),
+        greaterThan(_luminance(PlazaPalette.day.sky.zenith)),
+        reason: 'a clear sky is palest where it meets the ground',
+      );
+    });
+  });
+}

--- a/test/features/plaza/ui/plaza_style_test.dart
+++ b/test/features/plaza/ui/plaza_style_test.dart
@@ -5,6 +5,7 @@ import 'package:lotti/features/plaza/domain/plaza_layout.dart';
 import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/features/plaza/domain/street_layout.dart';
 import 'package:lotti/features/plaza/scene/plaza_world.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
 import 'package:lotti/features/plaza/ui/plaza_style.dart';
 import 'package:material_ui/material_ui.dart';
 
@@ -31,8 +32,8 @@ void main() {
       final cancelled = _task(PlazaTaskState.cancelled);
       final success = dsTokensDark.colors.alert.success.defaultColor;
       expect(PlazaStyle.chip(attentionFor(done, now)).fill, success);
-      expect(PlazaStyle.categoryRoof(done), success);
-      final wall = HSLColor.fromColor(PlazaStyle.categoryWall(done));
+      expect(PlazaPalette.night.categoryRoof(done), success);
+      final wall = HSLColor.fromColor(PlazaPalette.night.categoryWall(done));
       final roof = HSLColor.fromColor(success);
       expect(wall.hue, closeTo(roof.hue, 2));
       expect(wall.lightness, lessThan(roof.lightness));
@@ -112,8 +113,8 @@ void main() {
   test('category colours: the category itself, then two darker tints', () {
     final task = _task(PlazaTaskState.open, color: 0xFFFF0000);
     expect(PlazaStyle.categoryBright(task), const Color(0xFFFF0000));
-    final wall = HSLColor.fromColor(PlazaStyle.categoryWall(task));
-    final roof = HSLColor.fromColor(PlazaStyle.categoryRoof(task));
+    final wall = HSLColor.fromColor(PlazaPalette.night.categoryWall(task));
+    final roof = HSLColor.fromColor(PlazaPalette.night.categoryRoof(task));
     // Still red: the hue sits at the top or the bottom of the wheel.
     bool red(double hue) => hue < 10 || hue > 350;
     expect(red(wall.hue), isTrue, reason: 'wall hue ${wall.hue}');
@@ -121,4 +122,31 @@ void main() {
     expect(wall.lightness, greaterThan(roof.lightness));
     expect(wall.lightness, lessThan(0.5));
   });
+
+  test(
+    'an attention beacon takes its lantern from the palette it is given',
+    () {
+      final tasks = syntheticPlazaTasks();
+      final world = PlazaWorld(
+        tasks: tasks,
+        now: syntheticNow(tasks),
+        projectLabel: 'Test',
+        layout: StreetLayout(projectSeed: 1337),
+      );
+      final beacon = world.beacons.firstWhere(
+        (b) => b.kind == BeaconKind.attention,
+      );
+      final attention = world.attention[beacon.taskId]!;
+      expect(
+        PlazaStyle.beaconColor(beacon, world),
+        PlazaPalette.night.lanterns.of(attention.lantern),
+        reason: 'the default is the sky the district was designed in',
+      );
+      expect(
+        PlazaStyle.beaconColor(beacon, world, palette: PlazaPalette.day),
+        PlazaPalette.day.lanterns.of(attention.lantern),
+        reason: 'a daylight beacon must not be a night lantern on a bright sky',
+      );
+    },
+  );
 }

--- a/test/features/plaza/ui/plaza_wall_swap_test.dart
+++ b/test/features/plaza/ui/plaza_wall_swap_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
+import 'package:lotti/features/plaza/ui/plaza_wall_swap.dart';
+
+void main() {
+  late PlazaWallSwap swap;
+
+  setUp(() => swap = PlazaWallSwap());
+
+  test('a world with no walls yet asks for the sky it wants', () {
+    expect(
+      swap.request(wanted: PlazaSkyMode.night, attached: null),
+      PlazaSkyMode.night,
+    );
+    expect(swap.inFlight, PlazaSkyMode.night);
+  });
+
+  test('the sky already on the walls needs nothing', () {
+    expect(
+      swap.request(wanted: PlazaSkyMode.night, attached: PlazaSkyMode.night),
+      isNull,
+    );
+    expect(swap.inFlight, isNull);
+  });
+
+  test('switching sky asks for that sky exactly once', () {
+    expect(
+      swap.request(wanted: PlazaSkyMode.day, attached: PlazaSkyMode.night),
+      PlazaSkyMode.day,
+    );
+    expect(
+      swap.request(wanted: PlazaSkyMode.day, attached: PlazaSkyMode.night),
+      isNull,
+      reason: 'the same set must not be painted twice over',
+    );
+  });
+
+  test('switching back does not cancel the set already on its way', () {
+    swap.request(wanted: PlazaSkyMode.day, attached: PlazaSkyMode.night);
+    expect(
+      swap.request(wanted: PlazaSkyMode.night, attached: PlazaSkyMode.night),
+      isNull,
+      reason: 'night is already on the walls; nothing to load',
+    );
+    expect(
+      swap.inFlight,
+      PlazaSkyMode.day,
+      reason: 'the day paint is still running and will settle itself',
+    );
+  });
+
+  test('a dropped set can be asked for again', () {
+    // The regression: switch to day, switch back before it lands, then
+    // switch to day again. The dropped load used to leave its mode marked
+    // as in flight forever, so nothing was ever scheduled and the district
+    // wore night windows under a day sky until the page was rebuilt.
+    expect(
+      swap.request(wanted: PlazaSkyMode.day, attached: PlazaSkyMode.night),
+      PlazaSkyMode.day,
+    );
+    swap
+      ..request(wanted: PlazaSkyMode.night, attached: PlazaSkyMode.night)
+      ..settled(PlazaSkyMode.day); // arrived unwanted, dropped
+    expect(
+      swap.request(wanted: PlazaSkyMode.day, attached: PlazaSkyMode.night),
+      PlazaSkyMode.day,
+    );
+  });
+
+  test('a failed load leaves its sky askable', () {
+    swap
+      ..request(wanted: PlazaSkyMode.day, attached: PlazaSkyMode.night)
+      ..settled(PlazaSkyMode.day); // threw
+    expect(
+      swap.request(wanted: PlazaSkyMode.day, attached: PlazaSkyMode.night),
+      PlazaSkyMode.day,
+      reason: 'one failed paint must not disable that sky for the session',
+    );
+  });
+
+  test('an attached set stops being asked for', () {
+    swap
+      ..request(wanted: PlazaSkyMode.day, attached: PlazaSkyMode.night)
+      ..settled(PlazaSkyMode.day);
+    expect(
+      swap.request(wanted: PlazaSkyMode.day, attached: PlazaSkyMode.day),
+      isNull,
+    );
+    expect(swap.inFlight, isNull);
+  });
+
+  test('settling a set that is not in flight changes nothing', () {
+    swap
+      ..request(wanted: PlazaSkyMode.day, attached: PlazaSkyMode.night)
+      ..settled(PlazaSkyMode.night);
+    expect(
+      swap.inFlight,
+      PlazaSkyMode.day,
+      reason: 'a locale reload settling night must not free the day marker',
+    );
+  });
+}

--- a/test/features/plaza/ui/project_plaza_page_test.dart
+++ b/test/features/plaza/ui/project_plaza_page_test.dart
@@ -12,6 +12,7 @@ import 'package:lotti/features/plaza/domain/plaza_task.dart';
 import 'package:lotti/features/plaza/scene/plaza_world.dart';
 import 'package:lotti/features/plaza/state/project_plaza_provider.dart';
 import 'package:lotti/features/plaza/ui/checklist_ticks.dart';
+import 'package:lotti/features/plaza/ui/plaza_palette.dart';
 import 'package:lotti/features/plaza/ui/project_plaza_page.dart';
 import 'package:lotti/features/tasks/ui/pages/task_details_page.dart';
 import 'package:lotti/widgets/ui/error_state_widget.dart';
@@ -46,6 +47,8 @@ void main() {
   late PlazaWorld renderedWorld;
   late ChecklistTicks renderedTicks;
   late ValueChanged<PlazaTask> openTask;
+  PlazaSkyMode? renderedSky;
+  ValueChanged<PlazaSkyMode>? reportSky;
 
   setUp(() {
     snapshots = StreamController<ProjectPlazaData?>();
@@ -67,10 +70,14 @@ void main() {
               required ticks,
               required onOpenTask,
               required onExit,
+              initialSkyMode = PlazaSkyMode.night,
+              onSkyModeChanged,
             }) {
               renderedWorld = world;
               renderedTicks = ticks;
               openTask = onOpenTask;
+              renderedSky = initialSkyMode;
+              reportSky = onSkyModeChanged;
               return Scaffold(
                 body: Text(world.projectLabel, key: const ValueKey('scene')),
               );
@@ -366,5 +373,34 @@ void main() {
     expect(renderedWorld.projectLabel, 'Project Waddle');
     expect(find.byType(ErrorStateWidget), findsNothing);
     await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('the world opens under the remembered sky and reports a switch', (
+    tester,
+  ) async {
+    await withClock(Clock.fixed(manualDemoNow), () async {
+      await tester.pumpWidget(page());
+      snapshots.add(snapshot);
+      await tester.pump();
+      await tester.pump();
+      expect(
+        renderedSky,
+        PlazaSkyMode.night,
+        reason: 'nothing remembered yet: the district opens at night',
+      );
+
+      reportSky!(PlazaSkyMode.day);
+      await tester.pump();
+      expect(
+        renderedSky,
+        PlazaSkyMode.day,
+        reason: 'the page holds the choice the world reported back',
+      );
+
+      // And the next world entered opens under it, without asking again.
+      await tester.pumpWidget(page(projectId: project.meta.id));
+      await tester.pump();
+      expect(renderedSky, PlazaSkyMode.day);
+    });
   });
 }

--- a/test/features/projects/ui/pages/projects_tab_page_test.dart
+++ b/test/features/projects/ui/pages/projects_tab_page_test.dart
@@ -222,7 +222,9 @@ void main() {
         .element(find.byType(ProjectsTabPage))
         .messages
         .plazaExploreCategory;
-    await tester.tap(find.text(label).first);
+    // The way in is the map glyph in the category header's trailing
+    // corner; its tooltip and semantics carry the label.
+    await tester.tap(find.byTooltip(label).first);
     await tester.pumpAndSettle();
     expect(
       tester

--- a/test/features/projects/ui/widgets/project_list_shared_test.dart
+++ b/test/features/projects/ui/widgets/project_list_shared_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_icon_action.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/keyboard/ui/app_command_host.dart';
@@ -174,6 +175,135 @@ void main() {
       await tester.pump();
       expect(find.text('Project Alpha'), findsOneWidget);
       expect(find.byIcon(LottiIcons.collapse), findsOneWidget);
+    });
+
+    testWidgets("docks Explore category in the header's trailing corner", (
+      tester,
+    ) async {
+      // It used to sit on a row of its own under every category header,
+      // left-aligned, repeated down a narrow pane. It belongs where this
+      // list's other row-level actions are: the trailing corner.
+      final group = makeGroupedProjectsSection();
+      var explored = 0;
+      await tester.pumpWidget(
+        wrap(
+          ProjectGroupSection(
+            group: group,
+            selectedProjectId: null,
+            onProjectSelected: (_) {},
+            onExplorePlaza: () => explored++,
+          ),
+        ),
+      );
+
+      final action = find.byType(DesignSystemIconAction);
+      expect(action, findsOneWidget);
+      final headerRect = tester.getRect(find.byType(InkWell).first);
+      final actionRect = tester.getRect(action);
+      final labelRect = tester.getRect(find.text('Work'));
+      expect(
+        actionRect.center.dx,
+        greaterThan(labelRect.right),
+        reason: 'the action sits after the category name, not under it',
+      );
+      expect(
+        actionRect.center.dy,
+        closeTo(headerRect.center.dy, 0.1),
+        reason: 'and on the header row, not on a row of its own',
+      );
+      expect(
+        tester.getRect(find.byIcon(LottiIcons.collapse)).center.dx,
+        greaterThan(actionRect.center.dx),
+        reason: 'the fold chevron keeps the outermost corner',
+      );
+      expect(explored, 0);
+    });
+
+    testWidgets('entering the world does not fold the group behind it', (
+      tester,
+    ) async {
+      final group = makeGroupedProjectsSection();
+      var explored = 0;
+      await tester.pumpWidget(
+        wrap(
+          ProjectGroupSection(
+            group: group,
+            selectedProjectId: null,
+            onProjectSelected: (_) {},
+            onExplorePlaza: () => explored++,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(DesignSystemIconAction));
+      await tester.pump();
+      expect(explored, 1);
+      expect(
+        find.text('Project Alpha'),
+        findsOneWidget,
+        reason: "the header InkWell must not receive the action's tap",
+      );
+      expect(find.byIcon(LottiIcons.collapse), findsOneWidget);
+    });
+
+    testWidgets('the way in survives folding the group', (tester) async {
+      // On its old row it disappeared with the projects, so a folded
+      // category could not be entered at all.
+      final group = makeGroupedProjectsSection();
+      await tester.pumpWidget(
+        wrap(
+          ProjectGroupSection(
+            group: group,
+            selectedProjectId: null,
+            onProjectSelected: (_) {},
+            onExplorePlaza: () {},
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Work'));
+      await tester.pump();
+      expect(find.text('Project Alpha'), findsNothing);
+      expect(find.byType(DesignSystemIconAction), findsOneWidget);
+    });
+
+    testWidgets('a category with nowhere to go shows no action', (
+      tester,
+    ) async {
+      final group = makeGroupedProjectsSection();
+      await tester.pumpWidget(
+        wrap(
+          ProjectGroupSection(
+            group: group,
+            selectedProjectId: null,
+            onProjectSelected: (_) {},
+          ),
+        ),
+      );
+      expect(
+        find.byType(DesignSystemIconAction),
+        findsNothing,
+        reason: 'no callback means the host has no world to open',
+      );
+    });
+
+    testWidgets('the unassigned group has no world of its own', (tester) async {
+      final group = ProjectCategoryGroup(
+        categoryId: null,
+        category: null,
+        projects: makeGroupedProjectsSection().projects,
+      );
+      await tester.pumpWidget(
+        wrap(
+          ProjectGroupSection(
+            group: group,
+            selectedProjectId: null,
+            onProjectSelected: (_) {},
+            onExplorePlaza: () {},
+          ),
+        ),
+      );
+      expect(find.byType(DesignSystemIconAction), findsNothing);
     });
 
     testWidgets('centers the visible group header inside its 48dp tap target', (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Night | Day** switch to the Plaza world, with daylight visuals, shadows, and readable task status indicators.
  * The selected sky mode is remembered when returning to the Plaza.
  * Added localized Day and Night labels across supported languages.
  * Moved the category **Explore** action into the header, where it remains available when folded.
* **Documentation**
  * Added guidance for sky modes, frame captures, and monitoring repeated mode changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->