### PR TITLE
fix: validate malformed image probe cases

### DIFF
--- a/tool/deepseek_image_probe.py
+++ b/tool/deepseek_image_probe.py
@@ -197,7 +197,7 @@ def main() -> int:
     opener = urllib.request.build_opener(NoRedirect)
     failed = False
     for case in args.cases:
-        source, choice = case.split("-", 1)
+        source, _, choice = case.partition("-")
         if source not in {"text", "image"} or choice not in {
             "absent",
             "forced",

--- a/tool/deepseek_image_probe.py
+++ b/tool/deepseek_image_probe.py
@@ -178,6 +178,17 @@ def main() -> int:
         "--declared-mime", help="Override MIME to probe app JPEG labeling"
     )
     args = parser.parse_args()
+    cases = []
+    for case in args.cases:
+        source, _, choice = case.partition("-")
+        if source not in {"text", "image"} or choice not in {
+            "absent",
+            "forced",
+            "auto",
+            "required",
+        }:
+            parser.error(f"Unsupported case: {case}")
+        cases.append((case, source, choice))
     key, base = credentials(args.env_file)
     endpoint = base.rstrip("/") + "/chat/completions"
     parsed = urllib.parse.urlparse(endpoint)
@@ -196,15 +207,7 @@ def main() -> int:
     args.output.mkdir(parents=True, exist_ok=True)
     opener = urllib.request.build_opener(NoRedirect)
     failed = False
-    for case in args.cases:
-        source, _, choice = case.partition("-")
-        if source not in {"text", "image"} or choice not in {
-            "absent",
-            "forced",
-            "auto",
-            "required",
-        }:
-            parser.error(f"Unsupported case: {case}")
+    for case, source, choice in cases:
         body = build_request(args.model, source, choice, image_url, args.stream)
         if args.temperature is not None:
             body["temperature"] = args.temperature

--- a/tool/deepseek_image_probe_test.py
+++ b/tool/deepseek_image_probe_test.py
@@ -147,32 +147,46 @@ class DeepseekImageProbeTest(unittest.TestCase):
             )
         )
 
-    def test_case_without_separator_reports_usage_error_before_inference(self):
-        with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            image_file = root / "sample.png"
-            image_file.write_bytes(b"synthetic-image-bytes")
-            argv = [
-                "probe",
-                "--image",
-                str(image_file),
-                "--output",
-                str(root / "results"),
-                "--cases",
-                "invalid",
-            ]
-            stderr = io.StringIO()
-            with (
-                patch("sys.argv", argv),
-                patch.dict(os.environ, {"MELIOUS_API_KEY": "test-key"}, clear=True),
-                patch.object(probe.urllib.request, "build_opener") as build_opener,
-                contextlib.redirect_stderr(stderr),
-                self.assertRaises(SystemExit) as raised,
-            ):
-                probe.main()
-            self.assertEqual(raised.exception.code, 2)
-            self.assertIn("Unsupported case: invalid", stderr.getvalue())
-            build_opener.return_value.open.assert_not_called()
+    def test_invalid_cases_report_usage_error_before_any_setup(self):
+        for cases in [
+            ["invalid"],
+            ["text-auto", "invalid"],
+            ["other-auto"],
+            ["image-unknown"],
+        ]:
+            with self.subTest(cases=cases):
+                argv = [
+                    "probe",
+                    "--image",
+                    "/missing/image.png",
+                    "--output",
+                    "/unused/results",
+                    "--cases",
+                    *cases,
+                ]
+                stderr = io.StringIO()
+                with (
+                    patch("sys.argv", argv),
+                    patch.object(
+                        probe,
+                        "credentials",
+                        return_value=("test-key", "https://api.melious.ai/v1"),
+                    ) as credentials,
+                    patch.object(
+                        Path,
+                        "read_bytes",
+                        side_effect=AssertionError("Image read before case validation"),
+                    ) as read_image,
+                    patch.object(probe.urllib.request, "build_opener") as build_opener,
+                    contextlib.redirect_stderr(stderr),
+                    self.assertRaises(SystemExit) as raised,
+                ):
+                    probe.main()
+                self.assertEqual(raised.exception.code, 2)
+                self.assertIn(f"Unsupported case: {cases[-1]}", stderr.getvalue())
+                credentials.assert_not_called()
+                read_image.assert_not_called()
+                build_opener.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tool/deepseek_image_probe_test.py
+++ b/tool/deepseek_image_probe_test.py
@@ -147,6 +147,33 @@ class DeepseekImageProbeTest(unittest.TestCase):
             )
         )
 
+    def test_case_without_separator_reports_usage_error_before_inference(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            image_file = root / "sample.png"
+            image_file.write_bytes(b"synthetic-image-bytes")
+            argv = [
+                "probe",
+                "--image",
+                str(image_file),
+                "--output",
+                str(root / "results"),
+                "--cases",
+                "invalid",
+            ]
+            stderr = io.StringIO()
+            with (
+                patch("sys.argv", argv),
+                patch.dict(os.environ, {"MELIOUS_API_KEY": "test-key"}, clear=True),
+                patch.object(probe.urllib.request, "build_opener") as build_opener,
+                contextlib.redirect_stderr(stderr),
+                self.assertRaises(SystemExit) as raised,
+            ):
+                probe.main()
+            self.assertEqual(raised.exception.code, 2)
+            self.assertIn("Unsupported case: invalid", stderr.getvalue())
+            build_opener.return_value.open.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Passing `--cases invalid` to the image-inference probe raised an unpacking `ValueError` instead of an argparse usage error. The probe now parses with `partition()` and validates every case immediately after argument parsing, before reading credentials or images, creating outputs, or sending any inference request. Invalid values exit with code 2 and a helpful message, including when an invalid case follows a valid one.

Follow-up to the review comment on #4234: that PR merged immediately before the corrective commit was pushed, so the correction was not included in its merge.

Validation: all seven Python probe tests and Ruff checks pass. The regression covers missing separators, invalid source/choice values, and a valid case followed by an invalid one. All four cases failed against the earlier validation order and pass with this change, asserting the exit code, error message, and absence of credential reads, image reads, and network setup. The app's Dart code is unchanged.
