### PR TITLE
chore(release): 1.1.9+4387

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   live privacy checks. Skipped sources are reported as incomplete coverage.
 - **Query chat shows searching while it retrieves evidence.** It switches to
   preparing an answer only when the final response is being composed.
+- **DeepSeek V4.1 Flash image analysis could return tool markup instead of a
+  summary.** Melious requests with a single named tool now use the model's
+  working automatic tool mode, allowing image analyses and entry summaries
+  to return their content correctly.
+- **Agent conversations are easier to read and navigate.** A compact header,
+  centered starter questions, smaller answer text, and expandable source passages
+  keep the discussion together. The extra Ask action is removed from the task
+  details action bar.
+- **Chat dictation uses the category's default transcription setup.** It no
+  longer silently selects an installed local Sherpa model instead.
+- **Agent internals expand without a rendering assertion.** Conversation
+  disclosures now share the panel's Material surface.
 
 ## [1.1.8]
 

--- a/changelog.d/2026-09-12-deepseek-image-analysis.md
+++ b/changelog.d/2026-09-12-deepseek-image-analysis.md
@@ -1,5 +1,0 @@
-### Fixed
-- **DeepSeek V4.1 Flash image analysis could return tool markup instead of a
-  summary.** Melious requests with a single named tool now use the model's
-  working automatic tool mode, allowing image analyses and entry summaries
-  to return their content correctly.

--- a/changelog.d/2026-09-12-query-chat-design.md
+++ b/changelog.d/2026-09-12-query-chat-design.md
@@ -1,9 +1,0 @@
-### Fixed
-- **Agent conversations are easier to read and navigate.** A compact header,
-  centered starter questions, smaller answer text, and expandable source passages
-  keep the discussion together. The extra Ask action is removed from the task
-  details action bar.
-- **Chat dictation uses the category's default transcription setup.** It no
-  longer silently selects an installed local Sherpa model instead.
-- **Agent internals expand without a rendering assertion.** Conversation
-  disclosures now share the panel's Material surface.

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -49,6 +49,10 @@
         <p>Fixed: agent chat now opens with a direct invitation to ask about the current task, project or category. Its failure message no longer claims a question was saved when setup failed before saving it.</p>
         <p>Fixed: large agent searches shortlist sources together before inspecting matches. This reduces model round trips while keeping exact quotes and live privacy checks. Skipped sources are reported as incomplete coverage.</p>
         <p>Fixed: query chat shows searching while it retrieves evidence. It switches to preparing an answer only when the final response is being composed.</p>
+        <p>Fixed: DeepSeek V4.1 Flash image analysis could return tool markup instead of a summary. Melious requests with a single named tool now use the model's working automatic tool mode, allowing image analyses and entry summaries to return their content correctly.</p>
+        <p>Fixed: agent conversations are easier to read and navigate. A compact header, centered starter questions, smaller answer text, and expandable source passages keep the discussion together. The extra Ask action is removed from the task details action bar.</p>
+        <p>Fixed: chat dictation uses the category's default transcription setup. It no longer silently selects an installed local Sherpa model instead.</p>
+        <p>Fixed: agent internals expand without a rendering assertion. Conversation disclosures now share the panel's Material surface.</p>
       </description>
     </release>
     <release version="1.1.8" date="2026-09-11">

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.1.9+4386
+version: 1.1.9+4387
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
Prepare fix-only build **1.1.9+4387**. Append these notes to the existing 1.1.9 changelog and Flathub release, increment the build number, and consume the two unreleased fragments.

### Fixed

- **DeepSeek V4.1 Flash image analysis could return tool markup instead of a
  summary.** Melious requests with a single named tool now use the model's
  working automatic tool mode, allowing image analyses and entry summaries
  to return their content correctly.
- **Agent conversations are easier to read and navigate.** A compact header,
  centered starter questions, smaller answer text, and expandable source passages
  keep the discussion together. The extra Ask action is removed from the task
  details action bar.
- **Chat dictation uses the category's default transcription setup.** It no
  longer silently selects an installed local Sherpa model instead.
- **Agent internals expand without a rendering assertion.** Conversation
  disclosures now share the panel's Material surface.

### Validation

- Strict release-note validation and XML parsing.
- Flutter analysis.
- No Dart files changed. Repository-wide formatting was attempted but encountered an existing permission-denied Docker media directory.
- CI passed: all ten unit/widget test shards, Glados property tests, Matrix and journal persistence tests, Android/macOS builds, analysis, and documentation checks.
- Codecov patch and project checks passed; project coverage remains 99.35%.
- Automated reviews completed with no actionable findings.
