### PR TITLE
fix: preserve image analyses and batch startup throttle clears

### DIFF
--- a/changelog.d/2026-09-12-analysis-and-startup-fixes.md
+++ b/changelog.d/2026-09-12-analysis-and-startup-fixes.md
@@ -1,0 +1,7 @@
+### Fixed
+- **Image analysis no longer fails when its short summary is invalid.** The
+  full analysis is preserved when an AI response has an overlong one-line
+  summary or an invalid TLDR, instead of reporting an empty response.
+- **Startup does less database work when many agents are present.** Clearing
+  old wake countdowns now shares a bulk read and transaction instead of
+  opening a separate transaction for every agent, including idle ones.

--- a/knowledge/features/agents/wake-orchestration.md
+++ b/knowledge/features/agents/wake-orchestration.md
@@ -5,7 +5,7 @@ description: How a local change becomes an agent wake — subscription matching,
 resource: ../../../lib/features/agents/wake
 tags: [agents, wake, scheduling, concurrency]
 status: stable
-generated: { by: codex/gpt-6, at: 2026-09-05T15:15:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-12T14:39:00Z }
 stale_after: 2026-10-12
 sources:
   - id: wake
@@ -175,16 +175,26 @@ runner acquisition, content gating, run persistence, and the pre-wake hook, so
 an automatic job already removed from the queue cannot race a late opt-out into
 paid inference.
 
-Persisted throttle set/clear operations re-read and write the state inside the
-same repository transaction as other partial state writers. This keeps the
-device-local `nextWakeAt` mutation from restoring a consumed project marker or
-erasing activity that was persisted by the project monitor concurrently.
-Repeated clears for one agent share their pending transaction/read. Completion
-releases that sharing state, so a later clear still checks the database for
-unhydrated stale deadlines. Setting or hydrating a new deadline starts a new
-generation: its later clear cannot join an older operation, and an older
-completion cannot remove a newer pending clear. The existing deadline checks
-before and after the state read continue to protect re-armed cooldowns.
+Persisted throttle set/clear operations read and write state inside the same
+repository transaction as other partial state writers. This keeps the
+local `nextWakeAt` mutation from restoring a consumed project marker or
+erasing activity persisted by the project monitor concurrently.
+
+Clear requests made in the same synchronous burst share one transaction. A
+single-agent batch uses its direct state lookup; a multi-agent batch uses the
+existing chunked pending-wake query and only decodes states with pending wakes.
+States carrying only `scheduledWakeAt` are left untouched. Only states whose
+`nextWakeAt` is still set are written, and change callbacks run after commit.
+A microtask starts the worker, which runs at most one clear batch at a time;
+requests arriving during that batch wait for the next one. Failed transactions
+produce no change callbacks and release requests so a later clear can retry.
+
+Repeated clears for one agent share their pending completion. Setting or
+hydrating a new deadline starts a new generation: its later clear cannot join
+an older request, and completing that older request cannot evict the newer one.
+Completion releases the sharing state, so later clears still check for
+unhydrated stale deadlines. The worker checks in-memory deadlines before the
+transaction and again after the state read, preserving re-armed cooldowns.
 Routine clear diagnostics use counted sampling rather than one line per call.
 
 A subscription can instead opt **out of the window entirely** with

--- a/knowledge/features/ai/execution-paths.md
+++ b/knowledge/features/ai/execution-paths.md
@@ -5,7 +5,7 @@ description: The legacy prompt path, the skill/profile path, the category consen
 resource: ../../../lib/features/ai/services/skill_inference_runner.dart
 tags: [ai, skills, automation, consent, overrides, diagnostics]
 status: stable
-generated: { by: codex/gpt-6, at: 2026-09-06T12:00:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-12T14:24:03Z }
 stale_after: 2026-10-19
 sources:
   - id: runner
@@ -336,20 +336,24 @@ Image analysis publishes the same three tiers through the same
 from analysis being the older, load-bearing artifact:
 
 - **Tiers are conditional on the model.** They are requested only when the
-  resolved vision model's `supportsFunctionCalling` is true. Many capable
+  resolved vision model's `supportsFunctionCalling` is true and the provider's
+  image route supports tools. Many capable
   vision models cannot call tools, and this skill shipped on a free-text
   contract long before the tiers existed — so tool support *upgrades* the
   output rather than gating it. Without it, no tool is attached, no tier
   instruction is appended (`SkillPromptBuilder`'s `requestTieredSummary`), and
   the result is byte-for-byte what it is today.
-- **A rejected tool call is not a failure and buys no retry.** A model that
-  answers in prose despite the pin simply lands on the untiered path with its
-  analysis intact. Losing an analysis to reclaim a one-liner would be a bad
-  trade — the inverse of the audio summary, where the tiers *are* the artifact
-  and a failed run costs nothing already persisted.
+- **Invalid shorter tiers do not discard a valid analysis or trigger a retry.**
+  If full tier validation fails, `parseEntrySummaryToolBody` recovers the
+  non-empty string `summary` from the first matching tool call's JSON object.
+  It saves that body without `oneLiner` or `tldr`. If the tool body is also
+  invalid or absent, streamed prose is the fallback. With neither a valid tool
+  body nor non-empty prose, the run fails as an empty analysis. Audio summaries
+  continue to require all three tiers and retry failed validation.
 
-When tiers do come back, the tool's `summary` argument becomes the analysis
-body; `response` is never the raw streamed prose in that case.
+The tool's valid `summary` argument takes precedence over streamed prose,
+whether all tiers validated or only the body was recovered. The consumption
+record hashes that same body before it is persisted, preserving provenance.
 
 The collapsed image card leads with a **thumbnail**, not a text line: an
 image's payload is the picture, so collapsing it to text alone would be harder

--- a/lib/features/agents/wake/wake_throttle_coordinator.dart
+++ b/lib/features/agents/wake/wake_throttle_coordinator.dart
@@ -32,6 +32,8 @@ class WakeThrottleCoordinator with AgentErrorLogging {
   final _throttleDeadlines = <String, DateTime>{};
   final _deferredDrainTimers = <String, Timer>{};
   final _pendingClears = <String, Future<void>>{};
+  final _queuedClears = <({String agentId, Completer<void> completion})>[];
+  bool _clearWorkerScheduled = false;
 
   void _log(String message, {String? subDomain}) {
     domainLogger?.log(LogDomain.agentRuntime, message, subDomain: subDomain);
@@ -121,8 +123,9 @@ class WakeThrottleCoordinator with AgentErrorLogging {
   /// Cancels [agentId]'s cooldown: drops the in-memory deadline, cancels the
   /// deferred drain timer, and clears the persisted `nextWakeAt`. Used when a
   /// wake is forced (e.g. manual re-analysis) and the countdown is moot.
-  /// Concurrent clears share the persisted read until it completes. Even when
-  /// no deadline was hydrated, the first clear retires stale persisted state.
+  /// Concurrent clears share a bulk read and transaction. Repeated clears for
+  /// one agent share their completion until that deadline generation changes.
+  /// Even unhydrated persisted deadlines are retired.
   void clearThrottle(String agentId) {
     _throttleDeadlines.remove(agentId);
     _deferredDrainTimers[agentId]?.cancel();
@@ -145,52 +148,80 @@ class WakeThrottleCoordinator with AgentErrorLogging {
     _deferredDrainTimers.clear();
   }
 
-  /// Clears the persisted `nextWakeAt` on the agent's state entity.
-  ///
-  /// Writes directly to repository (bypassing AgentSyncService) because
-  /// throttle state is per-device and should NOT be synced to other devices.
+  /// Queues device-local clears for one bulk read per burst. The worker keeps
+  /// at most one clear transaction in flight; new requests join the next batch.
   Future<void> _clearPersistedThrottle(String agentId) {
     final pending = _pendingClears[agentId];
     if (pending != null) return pending;
-    final clear = _persistThrottleClear(agentId);
-    _pendingClears[agentId] = clear;
-    unawaited(
-      clear.whenComplete(() {
-        if (identical(_pendingClears[agentId], clear)) {
-          _pendingClears.remove(agentId);
-        }
-      }),
-    );
-    return clear;
+    final completion = Completer<void>();
+    _pendingClears[agentId] = completion.future;
+    _queuedClears.add((agentId: agentId, completion: completion));
+    if (!_clearWorkerScheduled) {
+      _clearWorkerScheduled = true;
+      scheduleMicrotask(() => unawaited(_flushPersistedClears()));
+    }
+    return completion.future;
   }
 
-  Future<void> _persistThrottleClear(String agentId) async {
-    try {
-      if (_throttleDeadlines.containsKey(agentId)) return;
-
-      var changed = false;
-      await repository.runInTransaction(() async {
-        if (_throttleDeadlines.containsKey(agentId)) return;
-        final state = await repository.getAgentState(agentId);
-        if (_throttleDeadlines.containsKey(agentId) ||
-            state == null ||
-            state.nextWakeAt == null) {
-          return;
+  Future<void> _flushPersistedClears() async {
+    while (_queuedClears.isNotEmpty) {
+      final batch = List.of(_queuedClears);
+      _queuedClears.clear();
+      final agentIds = batch
+          .map((request) => request.agentId)
+          .toSet()
+          .where((id) => !_throttleDeadlines.containsKey(id))
+          .toList();
+      try {
+        final changed = <String>[];
+        if (agentIds.isNotEmpty) {
+          // Read and write inside the same transaction as other partial state
+          // writers. Only pending rows are decoded; idle agents cost no writes.
+          await repository.runInTransaction(() async {
+            final states = agentIds.length == 1
+                ? {
+                    agentIds.single: await repository.getAgentState(
+                      agentIds.single,
+                    ),
+                  }
+                : await repository.getAgentStatesWithPendingWakes(agentIds);
+            for (final agentId in agentIds) {
+              final state = states[agentId];
+              if (_throttleDeadlines.containsKey(agentId) ||
+                  state == null ||
+                  state.nextWakeAt == null) {
+                continue;
+              }
+              await repository.upsertEntity(
+                state.copyWith(nextWakeAt: null, updatedAt: clock.now()),
+              );
+              changed.add(agentId);
+            }
+          });
         }
-        await repository.upsertEntity(
-          state.copyWith(nextWakeAt: null, updatedAt: clock.now()),
+        final onChanged = onPersistedStateChanged;
+        if (onChanged != null) changed.forEach(onChanged);
+      } catch (e, s) {
+        logError(
+          'failed to clear persisted throttle batch (${agentIds.length} agents)',
+          error: e,
+          stackTrace: s,
         );
-        changed = true;
-      });
-      if (changed) onPersistedStateChanged?.call(agentId);
-    } catch (e, s) {
-      logError(
-        'failed to clear persisted throttle '
-        'for ${DomainLogger.sanitizeId(agentId)}',
-        error: e,
-        stackTrace: s,
-      );
+      } finally {
+        for (final request in batch) {
+          // A newly armed deadline can queue another clear while this batch
+          // awaits storage. Completing the older batch must not evict it.
+          if (identical(
+            _pendingClears[request.agentId],
+            request.completion.future,
+          )) {
+            unawaited(_pendingClears.remove(request.agentId));
+          }
+          request.completion.complete();
+        }
+      }
     }
+    _clearWorkerScheduled = false;
   }
 
   void _scheduleDeferredDrain(String agentId, DateTime deadline) {

--- a/lib/features/ai/services/skill_inference_runner.dart
+++ b/lib/features/ai/services/skill_inference_runner.dart
@@ -514,12 +514,11 @@ class SkillInferenceRunner {
         final collected = await _collectStream(responseStream);
 
         // Decode the tiers when we asked for them. Unlike the audio summary,
-        // a rejected tool call does NOT fail the run and buys no retry: the
-        // analysis is the artifact users have always got, the tiers only make
-        // it easier to scan, and losing an analysis to reclaim a one-liner
-        // would be a bad trade. A model that answered in prose instead simply
-        // lands on the untiered path below.
+        // invalid shorter tiers must not discard the full analysis. Recover
+        // the tool's summary on its own before falling back to streamed prose.
+        // Audio summaries still require all three tiers and retry on failure.
         EntrySummary? tiers;
+        String? recoveredSummary;
         if (useTieredSummary) {
           try {
             tiers = parseEntrySummaryToolCall(collected.toolCalls);
@@ -527,19 +526,26 @@ class SkillInferenceRunner {
             _loggingService.log(
               LogDomain.ai,
               'Image analysis tiers unavailable for $imageEntryId '
-              '(${e.reason}) — falling back to the prose analysis',
+              '(${e.reason}) — trying analysis without tiers',
               subDomain: 'runImageAnalysis',
             );
+            try {
+              recoveredSummary = parseEntrySummaryToolBody(collected.toolCalls);
+            } on EntrySummaryToolException {
+              // Malformed/missing tool content cannot supply an analysis;
+              // streamed prose remains usable, if the model supplied any.
+            }
           }
         }
 
-        // The tool's `summary` argument IS the analysis when tiers came back;
-        // otherwise the streamed prose is, exactly as before. Resolved BEFORE
+        // Prefer the tool's valid summary, with or without shorter tiers, then
+        // streamed prose. Resolve the body BEFORE
         // the consumption record, because that record hashes the response for
         // provenance: a tool call leaves `collected.content` empty, so hashing
         // it would stamp every tiered analysis with the digest of an empty
         // string and break the link to the `AiResponseEntry` it describes.
-        final response = tiers?.summary ?? collected.content.trim();
+        final response =
+            tiers?.summary ?? recoveredSummary ?? collected.content.trim();
         if (response.isEmpty) {
           throw StateError(
             'Empty image analysis response for $imageEntryId',

--- a/lib/features/ai/skills/entry_summary_tool.dart
+++ b/lib/features/ai/skills/entry_summary_tool.dart
@@ -142,6 +142,39 @@ const ChatCompletionToolChoiceOption entrySummaryToolChoice =
 EntrySummary parseEntrySummaryToolCall(
   List<ChatCompletionMessageToolCall> toolCalls,
 ) {
+  final args = _decodeEntrySummaryToolCall(toolCalls);
+
+  final oneLiner = _requireSummaryField(args, EntrySummaryToolArgs.oneLiner);
+  if (oneLiner.length > entrySummaryOneLinerMaxChars) {
+    throw EntrySummaryToolException(
+      '"${EntrySummaryToolArgs.oneLiner}" is ${oneLiner.length} chars, '
+      'over the $entrySummaryOneLinerMaxChars limit',
+    );
+  }
+
+  return EntrySummary(
+    oneLiner: oneLiner,
+    tldr: _requireSummaryField(args, EntrySummaryToolArgs.tldr),
+    summary: _requireSummaryField(args, EntrySummaryToolArgs.summary),
+  );
+}
+
+/// Recovers the full analysis when an image response's shorter tiers are invalid.
+///
+/// Only the first matching tool call is considered, just as for the strict
+/// parser. Its arguments must be valid JSON and its summary a non-empty string.
+/// Missing or invalid shorter tiers are ignored; audio summaries continue to
+/// use [parseEntrySummaryToolCall] to require all three tiers.
+String parseEntrySummaryToolBody(
+  List<ChatCompletionMessageToolCall> toolCalls,
+) => _requireSummaryField(
+  _decodeEntrySummaryToolCall(toolCalls),
+  EntrySummaryToolArgs.summary,
+);
+
+Map<String, dynamic> _decodeEntrySummaryToolCall(
+  List<ChatCompletionMessageToolCall> toolCalls,
+) {
   final call = toolCalls
       .where((toolCall) => toolCall.function.name == entrySummaryToolName)
       .firstOrNull;
@@ -165,33 +198,19 @@ EntrySummary parseEntrySummaryToolCall(
   if (decoded is! Map<String, dynamic>) {
     throw const EntrySummaryToolException('arguments are not a JSON object');
   }
-  final args = decoded;
+  return decoded;
+}
 
-  String requireField(String key) {
-    final value = args[key];
-    if (value is! String) {
-      throw EntrySummaryToolException(
-        value == null ? 'missing "$key"' : '"$key" is not a string',
-      );
-    }
-    final trimmed = value.trim();
-    if (trimmed.isEmpty) {
-      throw EntrySummaryToolException('"$key" is empty');
-    }
-    return trimmed;
-  }
-
-  final oneLiner = requireField(EntrySummaryToolArgs.oneLiner);
-  if (oneLiner.length > entrySummaryOneLinerMaxChars) {
+String _requireSummaryField(Map<String, dynamic> args, String key) {
+  final value = args[key];
+  if (value is! String) {
     throw EntrySummaryToolException(
-      '"${EntrySummaryToolArgs.oneLiner}" is ${oneLiner.length} chars, '
-      'over the $entrySummaryOneLinerMaxChars limit',
+      value == null ? 'missing "$key"' : '"$key" is not a string',
     );
   }
-
-  return EntrySummary(
-    oneLiner: oneLiner,
-    tldr: requireField(EntrySummaryToolArgs.tldr),
-    summary: requireField(EntrySummaryToolArgs.summary),
-  );
+  final trimmed = value.trim();
+  if (trimmed.isEmpty) {
+    throw EntrySummaryToolException('"$key" is empty');
+  }
+  return trimmed;
 }

--- a/test/features/agents/wake/wake_orchestrator_throttle_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_throttle_test.dart
@@ -545,6 +545,14 @@ void main() {
               return stateByAgent[agentId];
             });
             when(
+              () => generatedRepository.getAgentStatesWithPendingWakes(any()),
+            ).thenAnswer((invocation) async {
+              final ids = invocation.positionalArguments.single as List<String>;
+              return {
+                for (final id in ids) id: ?stateByAgent[id],
+              };
+            });
+            when(
               () => generatedRepository.upsertEntity(any()),
             ).thenAnswer((invocation) async {
               final entity =

--- a/test/features/agents/wake/wake_throttle_coordinator_test.dart
+++ b/test/features/agents/wake/wake_throttle_coordinator_test.dart
@@ -332,8 +332,28 @@ void main() {
 
   late MockAgentRepository repository;
 
+  // Existing state-machine scenarios drive individual persisted rows. Adapt
+  // those fixtures to the bulk query while dedicated cost tests count calls.
+  void stubPendingWakeStates(MockAgentRepository repo) {
+    when(() => repo.getAgentStatesWithPendingWakes(any())).thenAnswer((
+      invocation,
+    ) async {
+      final ids = invocation.positionalArguments.single as List<String>;
+      final states = <String, AgentStateEntity>{};
+      for (final id in ids) {
+        final state = await repo.getAgentState(id);
+        if (state != null &&
+            (state.nextWakeAt != null || state.scheduledWakeAt != null)) {
+          states[id] = state;
+        }
+      }
+      return states;
+    });
+  }
+
   setUp(() {
     repository = MockAgentRepository();
+    stubPendingWakeStates(repository);
     when(() => repository.getAgentState(any())).thenAnswer((invocation) async {
       final agentId = invocation.positionalArguments.first as String;
       return makeTestState(agentId: agentId);
@@ -436,6 +456,172 @@ void main() {
       });
     });
 
+    test('clears a startup burst with one transaction and one bulk read', () {
+      fakeAsync((async) {
+        final transactionRepository = _TransactionCheckingAgentRepository();
+        final activityAt = DateTime(2026, 9, 12, 10);
+        final stale = makeTestState(
+          agentId: 'agent-7',
+          nextWakeAt: activityAt,
+          slots: AgentSlots(pendingProjectActivityAt: activityAt),
+        );
+        final scheduled = makeTestState(
+          agentId: 'agent-8',
+          scheduledWakeAt: activityAt,
+        );
+        when(
+          () => transactionRepository.getAgentStatesWithPendingWakes(any()),
+        ).thenAnswer((_) async {
+          expect(transactionRepository.insideTransaction, isTrue);
+          return {'agent-7': stale, 'agent-8': scheduled};
+        });
+        when(
+          () => transactionRepository.getAgentState(any()),
+        ).thenAnswer((invocation) async {
+          final id = invocation.positionalArguments.single as String;
+          return id == 'agent-7' ? stale : makeTestState(agentId: id);
+        });
+        when(
+          () => transactionRepository.upsertEntity(any()),
+        ).thenAnswer((_) async {
+          expect(transactionRepository.insideTransaction, isTrue);
+        });
+        final changed = <String>[];
+        final coordinator = WakeThrottleCoordinator(
+          repository: transactionRepository,
+          onDrainRequested: () async {},
+          onPersistedStateChanged: changed.add,
+          throttleWindow: _generatedThrottleWindow,
+        );
+        addTearDown(coordinator.dispose);
+
+        for (var i = 0; i < 1600; i++) {
+          coordinator.clearThrottle('agent-$i');
+        }
+        async.flushMicrotasks();
+
+        expect(transactionRepository.transactionCount, 1);
+        final ids =
+            verify(
+                  () => transactionRepository.getAgentStatesWithPendingWakes(
+                    captureAny(),
+                  ),
+                ).captured.single
+                as List<String>;
+        expect(ids.toSet(), {for (var i = 0; i < 1600; i++) 'agent-$i'});
+        verifyNever(() => transactionRepository.getAgentState(any()));
+        final saved =
+            verify(
+                  () => transactionRepository.upsertEntity(captureAny()),
+                ).captured.single
+                as AgentStateEntity;
+        expect(saved.agentId, 'agent-7');
+        expect(saved.nextWakeAt, isNull);
+        expect(saved.slots.pendingProjectActivityAt, activityAt);
+        expect(changed, ['agent-7']);
+      });
+    });
+
+    test('serializes clear batches and preserves a re-armed bulk-read row', () {
+      fakeAsync((async) {
+        final read = Completer<Map<String, AgentStateEntity>>();
+        final now = DateTime(2026, 9, 12, 10);
+        var bulkReads = 0;
+        when(
+          () => repository.getAgentStatesWithPendingWakes(any()),
+        ).thenAnswer((invocation) {
+          bulkReads++;
+          if (bulkReads == 1) return read.future;
+          final ids = invocation.positionalArguments.single as List<String>;
+          return Future.value({
+            for (final id in ids)
+              id: makeTestState(agentId: id, nextWakeAt: now),
+          });
+        });
+        final changed = <String>[];
+        final coordinator = createCoordinator(
+          onDrainRequested: () async {},
+          onPersistedStateChanged: changed.add,
+        );
+        addTearDown(coordinator.dispose);
+        withClock(Clock.fixed(now), () {
+          coordinator
+            ..clearThrottle('agent-1')
+            ..clearThrottle('agent-2');
+          async.flushMicrotasks();
+          coordinator
+            ..setDeadlineFromHydration(
+              'agent-1',
+              now.add(const Duration(hours: 1)),
+            )
+            ..clearThrottle('agent-3')
+            ..clearThrottle('agent-4');
+          async.flushMicrotasks();
+          expect(bulkReads, 1, reason: 'no overlapping clear batch');
+          read.complete({
+            for (final id in ['agent-1', 'agent-2'])
+              id: makeTestState(agentId: id, nextWakeAt: now),
+          });
+          async.flushMicrotasks();
+          expect(bulkReads, 2);
+          final saved = verify(
+            () => repository.upsertEntity(captureAny()),
+          ).captured.cast<AgentStateEntity>();
+          expect(saved.map((s) => s.agentId), [
+            'agent-2',
+            'agent-3',
+            'agent-4',
+          ]);
+          expect(saved.every((s) => s.nextWakeAt == null), isTrue);
+          expect(changed, ['agent-2', 'agent-3', 'agent-4']);
+          expect(
+            coordinator.deadlineFor('agent-1'),
+            now.add(const Duration(hours: 1)),
+          );
+        });
+      });
+    });
+
+    test('a failed bulk read releases its clears for a later retry', () {
+      fakeAsync((async) {
+        var fail = true;
+        final now = DateTime(2026, 9, 12, 10);
+        when(
+          () => repository.getAgentStatesWithPendingWakes(any()),
+        ).thenAnswer((_) async {
+          if (fail) throw StateError('read failed');
+          return {
+            'agent-1': makeTestState(agentId: 'agent-1', nextWakeAt: now),
+          };
+        });
+        final changed = <String>[];
+        final coordinator = createCoordinator(
+          onDrainRequested: () async {},
+          onPersistedStateChanged: changed.add,
+        );
+        addTearDown(coordinator.dispose);
+        coordinator
+          ..clearThrottle('agent-1')
+          ..clearThrottle('agent-2');
+        async.flushMicrotasks();
+        verifyNever(() => repository.upsertEntity(any()));
+        expect(changed, isEmpty);
+        fail = false;
+        coordinator
+          ..clearThrottle('agent-1')
+          ..clearThrottle('agent-2');
+        async.flushMicrotasks();
+        final saved =
+            verify(
+                  () => repository.upsertEntity(captureAny()),
+                ).captured.single
+                as AgentStateEntity;
+        expect(saved.agentId, 'agent-1');
+        expect(saved.nextWakeAt, isNull);
+        expect(changed, ['agent-1']);
+      });
+    });
+
     test('coalesces repeated clears while the same state read is pending', () {
       fakeAsync((async) {
         final read = Completer<AgentStateEntity?>();
@@ -490,7 +676,7 @@ void main() {
         async.flushMicrotasks();
         coordinator.clearThrottle('agent-1');
         async.flushMicrotasks();
-        expect(reads, hasLength(3));
+        expect(reads, hasLength(2), reason: 'the next clear batch waits');
 
         reads[0].complete(makeTestState(agentId: 'agent-1'));
         async.flushMicrotasks();
@@ -545,6 +731,7 @@ void main() {
     test('serializes persisted throttle set and clear mutations', () {
       final now = DateTime(2024, 3, 15, 10, 30);
       final transactionRepository = _TransactionCheckingAgentRepository();
+      stubPendingWakeStates(transactionRepository);
       var state = makeTestState(
         agentId: 'agent-1',
         slots: AgentSlots(

--- a/test/features/ai/services/skill_inference_runner_test.dart
+++ b/test/features/ai/services/skill_inference_runner_test.dart
@@ -1815,36 +1815,38 @@ void main() {
           ).thenAnswer((_) => Stream.fromIterable(chunks));
         }
 
-        CreateChatCompletionStreamResponse tierChunk() =>
-            CreateChatCompletionStreamResponse(
-              id: 'resp-img',
-              choices: [
-                ChatCompletionStreamResponseChoice(
-                  delta: ChatCompletionStreamResponseDelta(
-                    toolCalls: [
-                      ChatCompletionStreamMessageToolCallChunk(
-                        index: 0,
-                        id: 'call-1',
-                        function: ChatCompletionStreamMessageFunctionCall(
-                          name: entrySummaryToolName,
-                          arguments: jsonEncode({
-                            EntrySummaryToolArgs.oneLiner:
-                                'Dashboard shows the error rate flat at 0.2%.',
-                            EntrySummaryToolArgs.tldr:
-                                'The rollout has not moved the error rate.',
-                            EntrySummaryToolArgs.summary:
-                                '## Observed\n- Error rate 0.2%',
-                          }),
-                        ),
-                      ),
-                    ],
+        CreateChatCompletionStreamResponse tierChunk({
+          Map<String, Object?> overrides = const {},
+        }) => CreateChatCompletionStreamResponse(
+          id: 'resp-img',
+          choices: [
+            ChatCompletionStreamResponseChoice(
+              delta: ChatCompletionStreamResponseDelta(
+                toolCalls: [
+                  ChatCompletionStreamMessageToolCallChunk(
+                    index: 0,
+                    id: 'call-1',
+                    function: ChatCompletionStreamMessageFunctionCall(
+                      name: entrySummaryToolName,
+                      arguments: jsonEncode({
+                        EntrySummaryToolArgs.oneLiner:
+                            'Dashboard shows the error rate flat at 0.2%.',
+                        EntrySummaryToolArgs.tldr:
+                            'The rollout has not moved the error rate.',
+                        EntrySummaryToolArgs.summary:
+                            '## Observed\n- Error rate 0.2%',
+                        ...overrides,
+                      }),
+                    ),
                   ),
-                  index: 0,
-                ),
-              ],
-              object: 'chat.completion.chunk',
-              created: DateTime(2024).millisecondsSinceEpoch ~/ 1000,
-            );
+                ],
+              ),
+              index: 0,
+            ),
+          ],
+          object: 'chat.completion.chunk',
+          created: DateTime(2024).millisecondsSinceEpoch ~/ 1000,
+        );
 
         setUp(() {
           when(
@@ -1911,6 +1913,62 @@ void main() {
             expect(data.type, AiResponseType.imageAnalysis);
           },
         );
+
+        for (final invalidTier in <String, Map<String, Object?>>{
+          'overlong one-liner': {
+            EntrySummaryToolArgs.oneLiner: 'x' * 149,
+          },
+          'empty TLDR': {EntrySummaryToolArgs.tldr: '   '},
+        }.entries) {
+          test(
+            'preserves image analysis with an ${invalidTier.key} '
+            'and no streamed prose',
+            () async {
+              final attribution = _registerInteractionCapture();
+              await stubImageOnDisk();
+              stubImageInference([tierChunk(overrides: invalidTier.value)]);
+              when(
+                () => mockAiInputRepo.createAiResponseEntry(
+                  id: any(named: 'id'),
+                  data: any(named: 'data'),
+                  start: any(named: 'start'),
+                  linkedId: any(named: 'linkedId'),
+                  categoryId: any(named: 'categoryId'),
+                ),
+              ).thenAnswer(
+                (invocation) async => makePersistedResponse(invocation),
+              );
+              stubLoggingEvent();
+
+              await runner.runImageAnalysis(
+                imageEntryId: 'img-1',
+                automationResult: resultWithVisionModel(
+                  model: toolCapableVisionModel(),
+                ),
+              );
+
+              final data =
+                  verify(
+                        () => mockAiInputRepo.createAiResponseEntry(
+                          id: any(named: 'id'),
+                          data: captureAny(named: 'data'),
+                          start: any(named: 'start'),
+                          linkedId: 'img-1',
+                          categoryId: any(named: 'categoryId'),
+                        ),
+                      ).captured.single
+                      as AiResponseData;
+              expect(data.response, '## Observed\n- Error rate 0.2%');
+              expect(data.oneLiner, isNull);
+              expect(data.tldr, isNull);
+              expect(data.type, AiResponseType.imageAnalysis);
+              expect(
+                _capturedEvents(attribution).single.responseDigest,
+                sha256.convert(utf8.encode(data.response)).toString(),
+              );
+            },
+          );
+        }
 
         test(
           'attaches the publishing tool and pins the model to it only when '

--- a/test/features/ai/skills/entry_summary_tool_test.dart
+++ b/test/features/ai/skills/entry_summary_tool_test.dart
@@ -228,6 +228,61 @@ void main() {
     });
   });
 
+  group('parseEntrySummaryToolBody', () {
+    test('recovers and trims the body without requiring shorter tiers', () {
+      expect(
+        parseEntrySummaryToolBody([
+          _call(_args(oneLiner: null, tldr: null, summary: '  ## Analysis\n')),
+        ]),
+        '## Analysis',
+      );
+    });
+
+    test('recovers the body rejected by strict one-liner validation', () {
+      final calls = [_call(_args(oneLiner: 'x' * 149))];
+      expect(
+        () => parseEntrySummaryToolCall(calls),
+        throwsA(isA<EntrySummaryToolException>()),
+      );
+      expect(
+        parseEntrySummaryToolBody(calls),
+        '## Decisions\n- Ship behind a flag',
+      );
+    });
+
+    test('selects the first matching call and ignores unrelated calls', () {
+      expect(
+        parseEntrySummaryToolBody([
+          _call(_args(summary: 'Unrelated'), name: 'other_tool'),
+          _call(_args(summary: 'First analysis')),
+          _call(_args(summary: 'Echoed analysis'), id: 'call-2'),
+        ]),
+        'First analysis',
+      );
+    });
+
+    for (final invalid in <String, List<ChatCompletionMessageToolCall>>{
+      'missing tool': [],
+      'wrong tool': [_call(_args(), name: 'other_tool')],
+      'malformed JSON': [_call('{')],
+      'non-object JSON': [_call('[]')],
+      'missing summary': [_call(_args(summary: null))],
+      'empty summary': [_call(_args(summary: '  \n '))],
+      'non-string summary': [_call('{"summary":42}')],
+      'invalid first matching call': [
+        _call('{}'),
+        _call(_args(), id: 'call-2'),
+      ],
+    }.entries) {
+      test('rejects ${invalid.key}', () {
+        expect(
+          () => parseEntrySummaryToolBody(invalid.value),
+          throwsA(isA<EntrySummaryToolException>()),
+        );
+      });
+    }
+  });
+
   group('entrySummaryTool schema', () {
     test('requires exactly the three tiers and forbids extra properties', () {
       final parameters = entrySummaryTool.function.parameters!;


### PR DESCRIPTION
Image analysis could discard a valid full analysis when the model's one-line summary exceeded 140 characters or its TLDR was invalid. The image path now recovers the valid tool summary before falling back to prose, saves it without invalid tiers, and hashes the saved body for provenance. Audio-summary validation remains strict.

Startup also opened a separate transaction for every agent whose countdown was cleared, including idle agents. The regression fixture reproduces a 1,600-agent burst; clears now share one transaction and one bulk pending-state lookup (chunked by the existing repository), writing only stale countdowns. Batches run sequentially, preserve re-armed deadlines and unrelated state, and release failed requests for a later retry.

Validation:
- Full repository analysis through Dart MCP: no errors, warnings, or infos.
- 223 targeted tests pass across the two AI and two wake test files, including generated state-machine scenarios.
- Image-analysis and throttle regressions fail with their respective fixes reverted and pass after restoration.
- Changed Dart files formatted; `git diff --check`, `make knowledge_check`, and `make changelog_check` pass.

Updates the runtime documentation and adds one release-note fragment. The startup regression proves reduced database operation counts; end-to-end startup timing still needs fresh runtime measurements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Image analysis now preserves a valid summary when an AI response contains an overlong one-line summary or invalid TLDR, instead of returning an empty result.
  - Recovered summaries are saved consistently, including when structured tier details are unavailable.

- **Performance & Reliability**
  - Startup cleanup of expired wake countdowns now processes agents in shared batches, improving efficiency for large numbers of agents.
  - Wake-clear operations are serialized safely, skip active countdowns, and can retry after failed persistence operations.

- **Documentation**
  - Updated guidance describing wake countdown batching and image-analysis recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->