### PR TITLE
fix: isolate throttle persistence notifications

### DIFF
--- a/knowledge/features/agents/wake-orchestration.md
+++ b/knowledge/features/agents/wake-orchestration.md
@@ -11,7 +11,7 @@ sources:
   - id: wake
     resource: ../../../lib/features/agents/wake
     title: WakeOrchestrator, WakeQueue, WakeRunner, drain engine
-    last_modified: 2026-08-16
+    last_modified: 2026-09-12
   - id: enums
     resource: ../../../lib/features/agents/model/agent_enums.dart
     title: WakeReason
@@ -185,6 +185,7 @@ single-agent batch uses its direct state lookup; a multi-agent batch uses the
 existing chunked pending-wake query and only decodes states with pending wakes.
 States carrying only `scheduledWakeAt` are left untouched. Only states whose
 `nextWakeAt` is still set are written, and change callbacks run after commit.
+Each callback failure is logged separately and leaves later notifications running.
 A microtask starts the worker, which runs at most one clear batch at a time;
 requests arriving during that batch wait for the next one. Failed transactions
 produce no change callbacks and release requests so a later clear can retry.

--- a/knowledge/features/ai/execution-paths.md
+++ b/knowledge/features/ai/execution-paths.md
@@ -11,7 +11,7 @@ sources:
   - id: runner
     resource: ../../../lib/features/ai/services/skill_inference_runner.dart
     title: SkillInferenceRunner
-    last_modified: 2026-08-09
+    last_modified: 2026-09-12
   - id: skill-modal
     resource: ../../../lib/features/ai/ui/unified_ai_skills_modal.dart
     title: Unified AI skills modal

--- a/lib/features/agents/wake/wake_throttle_coordinator.dart
+++ b/lib/features/agents/wake/wake_throttle_coordinator.dart
@@ -200,7 +200,19 @@ class WakeThrottleCoordinator with AgentErrorLogging {
           });
         }
         final onChanged = onPersistedStateChanged;
-        if (onChanged != null) changed.forEach(onChanged);
+        if (onChanged != null) {
+          for (final agentId in changed) {
+            try {
+              onChanged(agentId);
+            } catch (e, s) {
+              logError(
+                'failed to notify persisted throttle change',
+                error: e,
+                stackTrace: s,
+              );
+            }
+          }
+        }
       } catch (e, s) {
         logError(
           'failed to clear persisted throttle batch (${agentIds.length} agents)',

--- a/test/features/agents/wake/wake_throttle_coordinator_test.dart
+++ b/test/features/agents/wake/wake_throttle_coordinator_test.dart
@@ -522,6 +522,70 @@ void main() {
       });
     });
 
+    test('a failing callback preserves later post-commit notifications', () {
+      fakeAsync((async) {
+        final transactionRepository = _TransactionCheckingAgentRepository();
+        final now = DateTime(2026, 9, 12, 10);
+        when(
+          () => transactionRepository.getAgentStatesWithPendingWakes(any()),
+        ).thenAnswer((_) async {
+          return {
+            for (final id in ['agent-1', 'agent-2'])
+              id: makeTestState(agentId: id, nextWakeAt: now),
+          };
+        });
+        when(
+          () => transactionRepository.upsertEntity(any()),
+        ).thenAnswer((_) async {});
+        final logger = MockDomainLogger();
+        final failure = StateError('notification failed');
+        final changed = <String>[];
+        final coordinator = WakeThrottleCoordinator(
+          repository: transactionRepository,
+          onDrainRequested: () async {},
+          onPersistedStateChanged: (id) {
+            expect(transactionRepository.insideTransaction, isFalse);
+            changed.add(id);
+            if (id == 'agent-1') throw failure;
+          },
+          throttleWindow: _generatedThrottleWindow,
+          domainLogger: logger,
+        );
+        addTearDown(coordinator.dispose);
+
+        coordinator
+          ..clearThrottle('agent-1')
+          ..clearThrottle('agent-2');
+        async.flushMicrotasks();
+
+        expect(changed, ['agent-1', 'agent-2']);
+        final saved = verify(
+          () => transactionRepository.upsertEntity(captureAny()),
+        ).captured.cast<AgentStateEntity>();
+        expect(saved.map((state) => state.agentId), changed);
+        expect(saved.every((state) => state.nextWakeAt == null), isTrue);
+        verify(
+          () => logger.error(
+            LogDomain.agentRuntime,
+            failure,
+            message: 'failed to notify persisted throttle change',
+            stackTrace: any<StackTrace>(named: 'stackTrace'),
+          ),
+        ).called(1);
+        verifyNever(
+          () => logger.error(
+            any<LogDomain>(),
+            any<Object>(),
+            message: any<String>(
+              named: 'message',
+              that: contains('failed to clear persisted throttle batch'),
+            ),
+            stackTrace: any<StackTrace>(named: 'stackTrace'),
+          ),
+        );
+      });
+    });
+
     test('serializes clear batches and preserves a re-armed bulk-read row', () {
       fakeAsync((async) {
         final read = Completer<Map<String, AgentStateEntity>>();


### PR DESCRIPTION
A throwing persisted-state callback could stop notifications for later agents after a throttle-clear transaction had already committed, while incorrectly logging the batch as a persistence failure. Each callback now has its own error handling, so later notifications still run and callback errors are reported separately.

Also refreshes the two source dates identified during review of #4240. This follow-up addresses the review feedback left when that PR merged.

Validation:
- Full repository analysis via Dart MCP: no errors, warnings, or infos.
- All 16 coordinator tests pass, including generated state-machine scenarios.
- New regression fails against the merged implementation and passes with the fix; checks committed state, later notifications, and distinct error logging.
- `make knowledge_check`: passes, including all 554 Mermaid diagrams.
- Changed Dart files formatted; repository-wide formatting is blocked by the existing unreadable `integration_test/docker/config/media_store` directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved persisted wake-state notifications so a failure in one callback no longer prevents subsequent notifications from being delivered.
  - Callback failures are logged while the remaining state-clearing process continues.

- **Documentation**
  - Updated feature documentation metadata and clarified notification failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->