### PR TITLE
feat: stream query answers with provisional validation

### DIFF
--- a/changelog.d/2026-09-12-query-synthesis-streaming.md
+++ b/changelog.d/2026-09-12-query-synthesis-streaming.md
@@ -1,0 +1,4 @@
+### Changed
+- **Query answers can appear while they are being written.** Draft text is
+  visibly marked until its checks finish. If verification fails, the draft is
+  removed and you can retry the question. Cancel also stops the active stream.

--- a/integration_test/tutorial/task_coding_prompt_tutorial_test.dart
+++ b/integration_test/tutorial/task_coding_prompt_tutorial_test.dart
@@ -79,6 +79,7 @@ class _FakeCloudInferenceRepository extends CloudInferenceRepository {
     GeminiThinkingMode? geminiThinkingMode,
     ReasoningEffort? reasoningEffort,
     InferenceImpactCollector? impactCollector,
+    bool preferStreaming = false,
   }) {
     return Stream<CreateChatCompletionStreamResponse>.fromFuture(
       Future<CreateChatCompletionStreamResponse>.delayed(

--- a/knowledge/features/agents/query-chat.md
+++ b/knowledge/features/agents/query-chat.md
@@ -210,6 +210,23 @@ inspection and resets after inspection. Saved `coverage.expanded` records
 whether any outside-home source was checked; it is separate from current
 activity. The transient `answering` flag resets on each Send or Retry.
 
+Synthesis alone can display a provisional answer. `QueryTextInference` decodes
+only the leading JSON `answer` string incrementally, buffering incomplete
+escapes and surrogate pairs; other field orders stay buffered. Inspection,
+reasoning and the durable conclusion are never rendered. The draft uses plain
+text with a visible unverified label, so citations and URLs are inert. The final
+parsed text must extend the displayed prefix without changing it; existing
+citation and live-access checks still run before transactional publication.
+
+`QueryChatLocal.provisional` holds the answer's dependencies and text only in
+memory. Active history notifications recheck those dependencies and category
+membership, including sources not yet in persisted history. Privacy/lockdown
+changes, unavailable access, forgotten recalled memory and chat deletion cancel
+the request and clear the draft. Normal publication keeps it only until the
+saved answer is visible in the history projection. A failed draft is removed
+and a content-free verification message appears beside the same question's
+Retry action. Nothing starts audio playback or TTS from provisional text.
+
 A single activity bubble groups phase, visible checked-source count and Cancel,
 with a live-region announcement. The query composer omits the duplicate helper
 status. The switcher exposes running/unread indicators, last-message previews,
@@ -263,6 +280,7 @@ stateDiagram-v2
   state running {
     [*] --> searching
     searching --> answering: Verified evidence ready for synthesis
+    answering --> provisional: First decoded answer text
   }
   idle --> running: Send
   running --> idle: answer committed
@@ -292,7 +310,10 @@ flowchart TD
   Plan --> Windows
   Windows --> Evidence
   Evidence --> Answer["Synthesis from accepted evidence, selected memory and chat context"]
-  Answer --> Gate["Live access and citation validation"]
+  Answer --> Draft["Provisional answer text only; inert citations"]
+  Draft --> Gate["Live access and citation validation"]
+  Draft -->|cancel or visibility loss| Clear["Clear transient text"]
+  Gate -->|invalid| Retract["Retract draft and offer Retry"]
   Gate --> Commit["Transactional answer and useful conclusion"]
   Batch -->|invalid response| Retry["Recoverable failure; no publication"]
   BatchMore -->|invalid response| Retry
@@ -311,9 +332,16 @@ and mark coverage incomplete; batch response validation rejects malformed or
 foreign passages as a whole. Evidence summaries are interpretations, not quotes.
 
 `QueryTextInference` uses the profile's thinking route through the existing
-cloud inference repository. The optional registered `AiInteractionCapture`
+cloud inference repository. Synthesis requests `preferStreaming`; inspection
+retains the accounting-oriented buffered path. The transport fallback and the
+absence of streamed Melious cost/energy fields are described in
+[provider routing](../ai/provider-routing.md#melious-reports-cost-and-impact-only-off-the-streaming-path).
+The optional registered `AiInteractionCapture`
 records agent/chat attribution, route IDs, usage and request/response digests;
-it does not retain an additional raw prompt log.
+it does not retain an additional raw prompt log. The live query evaluator
+records first synthesis content-token time, first decoded visible-answer time
+and total built-answer time separately. Streamed-answer equality is an explicit
+quality gate; a missing provider cost is unavailable, never zero.
 
 # Evidence, memory and deletion
 

--- a/knowledge/features/ai/provider-routing.md
+++ b/knowledge/features/ai/provider-routing.md
@@ -46,8 +46,8 @@ handles local providers such as Ollama, Whisper, Voxtral and oMLX.
 It is a thin **facade**: every public method delegates to
 `CloudInferenceGenerate` (text + image) or `CloudInferenceGenerateMore` (audio,
 multi-turn, image generation, model install/cleanup), both sharing one
-`CloudInferenceRequestHelpers`. The mockable surface and all call sites are
-unchanged.
+`CloudInferenceRequestHelpers`. The facade remains the mockable surface. Its `generate` method can request
+streaming while keeping an impact collector for buffered fallback.
 
 | Operation | Dedicated branches | Fallback |
 |-----------|--------------------|----------|
@@ -200,7 +200,7 @@ endpoint has to opt in:
 
 | Endpoint | How it buffers | Impact captured |
 |----------|----------------|-----------------|
-| `POST /chat/completions` | `_nonStreamingChat` when a collector is supplied — deliberately forfeiting incremental deltas, since Melious reports impact only when not streaming | Yes |
+| `POST /chat/completions` | `_nonStreamingChat` when a collector is supplied, unless `generateText` requests `preferStreaming` | Buffered responses only |
 | `POST /audio/transcriptions` (whisper-class ids) | Always one buffered POST | Yes, via `executeTranscription`'s `onSuccessResponse` hook |
 | `POST /chat/completions` with temporary-MP3 audio (Voxtral ids) | Always buffered | Yes |
 | `POST /images/generations` | Always buffered | Yes |
@@ -210,6 +210,21 @@ that ignores the parameter silently records nothing — the call still succeeds
 and the transcript still arrives, which is why the gap is invisible until the
 consumption charts come up short. Fields Melious omits leave the collector
 untouched rather than writing zeros.
+
+Scoped query synthesis opts into `preferStreaming` and requests a trailing token
+usage event. Its collector remains available, but the streamed responses tested
+with GLM-5.3 and DeepSeek Flash v4.1 omit billing and environmental impact.
+Streaming cost/energy therefore remains unavailable. An initial HTTP 400/422
+whose structured error names `stream` or `stream_options` permits one buffered
+fallback with identical model and reasoning settings. Authentication, overload,
+timeout, unrelated malformed requests and streams that already emitted data do
+not trigger fallback. Buffered fallback retains returned usage and impact.
+
+The ping filter subscribes lazily and owns upstream cancellation. The Melious
+SDK adapter and generic text compatibility route also close their own client
+on cancellation/completion; an injected caller-owned compatibility client is
+not closed. Cancelling the last broadcast listener cancels its owned upstream
+subscription, including while waiting for the first token.
 
 A small curated static catalog exists for immediate setup before live-catalog
 rows are installed: `deepseek-v4-pro`, `glm-5.2`, `gemma-4-26b-a4b`,

--- a/lib/features/agents/query/query_answer_builder.dart
+++ b/lib/features/agents/query/query_answer_builder.dart
@@ -66,6 +66,9 @@ class QueryAnswerBuilder {
     required QueryCancellation cancellation,
     required QueryProgress onProgress,
     void Function()? onAnswering,
+    void Function(QueryChatAnswer)? onSynthesisReady,
+    void Function(String)? onAnswerText,
+    void Function()? onFirstSynthesisToken,
     bool homeOnly = false,
     QuerySourceKind? kind,
   }) async {
@@ -503,6 +506,17 @@ class QueryAnswerBuilder {
       incomplete: incomplete,
     );
     onAnswering?.call();
+    onSynthesisReady?.call(
+      QueryChatAnswer(
+        questionId: question.id,
+        text: '',
+        coverage: coverage,
+        evidence: evidence,
+        dependencies: dependencies.values.toList(),
+        recalledMemoryIds: recalled.map((event) => event.id).toList(),
+        private: initial.showPrivate,
+      ),
+    );
     final result = await inference.complete(
       system:
           '${_untrusted}Answer from the supplied evidence and relevant memories only. '
@@ -531,6 +545,8 @@ class QueryAnswerBuilder {
         'coverage': coverage.toJson(),
       },
       cancellation: cancellation,
+      onAnswerText: onAnswerText,
+      onFirstToken: onFirstSynthesisToken,
     );
     final text = result['answer'];
     if (text is! String ||

--- a/lib/features/agents/query/query_chat_controller.dart
+++ b/lib/features/agents/query/query_chat_controller.dart
@@ -225,7 +225,14 @@ class QueryChatController extends Notifier<QueryChatSession> {
   }
 
   void _cancelAll() {
-    _runs.keys.toList().forEach(cancel);
+    // Publication can finish before its history projection arrives. Those
+    // retained drafts still need clearing when access becomes unavailable.
+    <String>{
+      ..._runs.keys,
+      for (final entry in state.chats.entries)
+        if (entry.value.provisional != null) entry.key,
+    }.forEach(cancel);
+    _releaseIdleHistory();
   }
 
   void select(String? id) =>

--- a/lib/features/agents/query/query_chat_controller.dart
+++ b/lib/features/agents/query/query_chat_controller.dart
@@ -227,11 +227,12 @@ class QueryChatController extends Notifier<QueryChatSession> {
   void _cancelAll() {
     // Publication can finish before its history projection arrives. Those
     // retained drafts still need clearing when access becomes unavailable.
-    <String>{
-      ..._runs.keys,
-      for (final entry in state.chats.entries)
-        if (entry.value.provisional != null) entry.key,
-    }.forEach(cancel);
+    _runs.keys.toList().forEach(cancel);
+    for (final entry in state.chats.entries.toList()) {
+      if (entry.value.provisional != null && !_runs.containsKey(entry.key)) {
+        _set(entry.key, entry.value.copyWith(clearProvisional: true));
+      }
+    }
     _releaseIdleHistory();
   }
 

--- a/lib/features/agents/query/query_chat_controller.dart
+++ b/lib/features/agents/query/query_chat_controller.dart
@@ -26,6 +26,8 @@ class QueryChatLocal {
     this.kind,
     this.answering = false,
     this.requestQuestionId,
+    this.provisional,
+    this.draftRetracted = false,
   });
   final String draft;
   final bool draftPrivate;
@@ -35,6 +37,10 @@ class QueryChatLocal {
   final bool homeOnly;
   final QuerySourceKind? kind;
   final bool answering;
+
+  /// Ephemeral synthesis only; never persisted before validation.
+  final QueryChatAnswer? provisional;
+  final bool draftRetracted;
 
   /// The saved question for the current/last attempt; null before persistence.
   final String? requestQuestionId;
@@ -51,6 +57,9 @@ class QueryChatLocal {
     bool? answering,
     String? requestQuestionId,
     bool clearRequestQuestion = false,
+    QueryChatAnswer? provisional,
+    bool clearProvisional = false,
+    bool? draftRetracted,
   }) => QueryChatLocal(
     draft: draft ?? this.draft,
     draftPrivate: draftPrivate ?? this.draftPrivate,
@@ -60,6 +69,8 @@ class QueryChatLocal {
     homeOnly: homeOnly ?? this.homeOnly,
     kind: clearKind ? null : kind ?? this.kind,
     answering: answering ?? this.answering,
+    provisional: clearProvisional ? null : provisional ?? this.provisional,
+    draftRetracted: draftRetracted ?? this.draftRetracted,
     requestQuestionId: clearRequestQuestion
         ? null
         : requestQuestionId ?? this.requestQuestionId,
@@ -117,7 +128,37 @@ class QueryChatController extends Notifier<QueryChatSession> {
   void _watchRunningHistory() {
     _runningHistory ??= ref.listen(queryChatDataProvider(key), (_, next) {
       final projection = next.value?.projection;
-      if (projection == null) return;
+      if (projection == null) {
+        if (next.hasError) _cancelAll();
+        return;
+      }
+      for (final entry in state.chats.entries.toList()) {
+        final draft = entry.value.provisional;
+        if (draft == null) continue;
+        final chat = projection.chats
+            .where((c) => c.id == entry.key)
+            .firstOrNull;
+        if (chat == null) {
+          _runs.remove(entry.key)?.cancel();
+          state = QueryChatSession(
+            selectedId: state.selectedId == entry.key ? null : state.selectedId,
+            chats: {...state.chats}..remove(entry.key),
+          );
+          continue;
+        }
+        if (chat.answerFor(draft.questionId) != null &&
+            entry.value.status != QueryTurnStatus.running) {
+          _set(entry.key, entry.value.copyWith(clearProvisional: true));
+        } else if (_runs[entry.key] case final run?) {
+          if (draft.recalledMemoryIds.any(
+            (id) => !projection.memories.any((m) => m.id == id),
+          )) {
+            cancel(entry.key);
+          } else {
+            unawaited(_recheckProvisional(entry.key, draft, run));
+          }
+        }
+      }
       final live = projection.chats.map((c) => c.id).toSet();
       for (final removed in _observed.difference(live)) {
         _runs.remove(removed)?.cancel();
@@ -130,14 +171,49 @@ class QueryChatController extends Notifier<QueryChatSession> {
       _observed
         ..clear()
         ..addAll(live);
+      _releaseIdleHistory();
     });
   }
 
   void _releaseIdleHistory() {
-    if (_runs.isNotEmpty) return;
+    if (_runs.isNotEmpty ||
+        state.chats.values.any((c) => c.provisional != null)) {
+      return;
+    }
     _runningHistory?.close();
     _runningHistory = null;
     _observed.clear();
+  }
+
+  Future<void> _recheckProvisional(
+    String id,
+    QueryChatAnswer draft,
+    QueryCancellation run,
+  ) async {
+    try {
+      final access = await ref
+          .read(queryChatStoreProvider)
+          .access
+          .load(
+            draft.dependencies.map((source) => source.id),
+          );
+      if (!ref.mounted || run.isCancelled || !identical(_runs[id], run)) return;
+      final scoped = [
+        ...draft.evidence.map((e) => e.source),
+        ...draft.coverage.unreadableSources,
+        ...draft.dependencies.where((s) => s.id == key.scope.id),
+      ];
+      if (!access.allowsContent(draft.dependencies, private: draft.private) ||
+          scoped.any(
+            (s) => access.entries[s.id]?.meta.categoryId != s.categoryId,
+          ) ||
+          (key.scope.kind == QueryScopeKind.category &&
+              !access.allowsCategory(key.scope.id))) {
+        cancel(id);
+      }
+    } catch (_) {
+      if (ref.mounted && identical(_runs[id], run)) cancel(id);
+    }
   }
 
   void _set(String id, QueryChatLocal local) {
@@ -210,6 +286,12 @@ class QueryChatController extends Notifier<QueryChatSession> {
 
   Future<void> delete(String id, {required bool forget}) async {
     _runs.remove(id)?.cancel();
+    _set(
+      id,
+      state
+          .local(id)
+          .copyWith(status: QueryTurnStatus.cancelled, clearProvisional: true),
+    );
     _releaseIdleHistory();
     await ref
         .read(queryChatStoreProvider)
@@ -226,7 +308,12 @@ class QueryChatController extends Notifier<QueryChatSession> {
     _runs[id]?.cancel();
     // Keep the slot occupied until cleanup completes, preventing a retry from
     // racing a cancelled request's terminal event.
-    _set(id, state.local(id).copyWith(status: QueryTurnStatus.cancelled));
+    _set(
+      id,
+      state
+          .local(id)
+          .copyWith(status: QueryTurnStatus.cancelled, clearProvisional: true),
+    );
   }
 
   Future<void> send(String id, {String? retryQuestionId}) async {
@@ -246,6 +333,8 @@ class QueryChatController extends Notifier<QueryChatSession> {
         checked: 0,
         expanded: false,
         answering: false,
+        clearProvisional: true,
+        draftRetracted: false,
         requestQuestionId: retryQuestionId,
         clearRequestQuestion: retryQuestionId == null,
       ),
@@ -300,6 +389,23 @@ class QueryChatController extends Notifier<QueryChatSession> {
         cancellation: cancellation,
         homeOnly: local.homeOnly,
         kind: local.kind,
+        onSynthesisReady: (answer) {
+          cancellation.check();
+          _set(id, state.local(id).copyWith(provisional: answer));
+        },
+        onAnswerText: (text) {
+          cancellation.check();
+          if (!ref.mounted || !identical(_runs[id], cancellation)) return;
+          final current = state.local(id).provisional;
+          if (current != null) {
+            _set(
+              id,
+              state
+                  .local(id)
+                  .copyWith(provisional: current.copyWith(text: text)),
+            );
+          }
+        },
         onAnswering: () {
           if (!cancellation.isCancelled) {
             stage = 'answer';
@@ -320,9 +426,38 @@ class QueryChatController extends Notifier<QueryChatSession> {
       final published = await store.publish(key.agentId, id, result);
       if (!published) throw const QueryCancelled();
       if (ref.mounted) {
-        _set(id, state.local(id).copyWith(status: QueryTurnStatus.idle));
+        final visible = ref
+            .read(queryChatDataProvider(key))
+            .value
+            ?.projection
+            .chats
+            .where((c) => c.id == id)
+            .firstOrNull
+            ?.answerFor(question.id);
+        _set(
+          id,
+          state
+              .local(id)
+              .copyWith(
+                status: QueryTurnStatus.idle,
+                clearProvisional: visible != null,
+              ),
+        );
       }
     } catch (error, stack) {
+      if (ref.mounted && identical(_runs[id], cancellation)) {
+        final local = state.local(id);
+        _set(
+          id,
+          local.copyWith(
+            draftRetracted:
+                local.provisional?.text.isNotEmpty == true &&
+                error is! QueryCancelled &&
+                error is! QueryScopeUnavailable,
+            clearProvisional: true,
+          ),
+        );
+      }
       if (error is! QueryCancelled &&
           error is! QueryScopeUnavailable &&
           error is! QueryInferenceUnavailable) {

--- a/lib/features/agents/query/query_text_inference.dart
+++ b/lib/features/agents/query/query_text_inference.dart
@@ -44,7 +44,10 @@ class QueryCancellation {
     return () => _callbacks.remove(callback);
   }
 
-  Future<String> collect(Stream<String> stream) async {
+  Future<String> collect(
+    Stream<String> stream, {
+    void Function(String)? onText,
+  }) async {
     check();
     final result = Completer<String>();
     final buffer = StringBuffer();
@@ -56,11 +59,19 @@ class QueryCancellation {
 
     subscription = stream.listen(
       (text) {
+        if (result.isCompleted || _cancelled) return;
         buffer.write(text);
         if (buffer.length > 64000 && !result.isCompleted) {
           result.completeError(
             const FormatException('Query response too large'),
           );
+          unawaited(subscription.cancel());
+          return;
+        }
+        try {
+          onText?.call(buffer.toString());
+        } catch (error, stack) {
+          if (!result.isCompleted) result.completeError(error, stack);
           unawaited(subscription.cancel());
         }
       },
@@ -88,7 +99,10 @@ typedef QueryTextStream = Stream<String> Function(String system, String prompt);
 /// Each completion has a fresh context. Inference accounting records hashes
 /// and usage through the existing capture boundary, never a second chat log.
 class QueryTextInference {
-  const QueryTextInference({required this._generate});
+  const QueryTextInference({
+    required this._generate,
+    this._generateSynthesis,
+  });
 
   factory QueryTextInference.forProfile({
     required CloudInferenceRepository cloud,
@@ -98,8 +112,12 @@ class QueryTextInference {
     String? categoryId,
     String? taskId,
     AiInteractionCapture? capture,
-  }) => QueryTextInference(
-    generate: (system, prompt) {
+  }) {
+    Stream<String> generate(
+      String system,
+      String prompt, {
+      bool synthesis = false,
+    }) {
       final provider = profile.thinkingProvider;
       final model = profile.thinkingModel;
       final impact = InferenceImpactCollector();
@@ -114,6 +132,7 @@ class QueryTextInference {
         maxCompletionTokens: model?.maxCompletionTokens,
         geminiThinkingMode: model?.geminiThinkingMode,
         impactCollector: impact,
+        preferStreaming: synthesis,
       );
       final stream = capture == null
           ? raw()
@@ -154,19 +173,47 @@ class QueryTextInference {
       return stream.map(
         (chunk) => chunk.choices?.firstOrNull?.delta?.content ?? '',
       );
-    },
-  );
+    }
+
+    return QueryTextInference(
+      generate: generate,
+      generateSynthesis: (system, prompt) =>
+          generate(system, prompt, synthesis: true),
+    );
+  }
 
   final QueryTextStream _generate;
+  final QueryTextStream? _generateSynthesis;
 
   Future<Map<String, dynamic>> complete({
     required String system,
     required Map<String, Object?> input,
     required QueryCancellation cancellation,
+    void Function(String)? onAnswerText,
+    void Function()? onFirstToken,
   }) async {
     cancellation.check();
+    var shown = '';
+    var received = false;
     final response = await cancellation.collect(
-      _generate(system, jsonEncode(input)),
+      (onAnswerText == null ? _generate : _generateSynthesis ?? _generate)(
+        system,
+        jsonEncode(input),
+      ),
+      onText: (raw) {
+        if (!received && raw.isNotEmpty) {
+          received = true;
+          onFirstToken?.call();
+        }
+        if (onAnswerText == null) return;
+        final prefix = _answerPrefix(raw);
+        if (prefix == null || prefix == shown) return;
+        if (!prefix.startsWith(shown)) {
+          throw const FormatException('Query draft changed');
+        }
+        shown = prefix;
+        onAnswerText(prefix);
+      },
     );
     var text = splitThinkingSegments(response)
         .where((segment) => !segment.isThinking)
@@ -182,6 +229,50 @@ class QueryTextInference {
     if (decoded is! Map<String, dynamic>) {
       throw const FormatException('Expected query object');
     }
+    if (decoded['answer'] case final String answer when onAnswerText != null) {
+      if (!answer.startsWith(shown)) {
+        throw const FormatException('Query draft changed');
+      }
+      if (answer != shown) onAnswerText(answer);
+    }
     return decoded;
   }
+}
+
+/// Only the first top-level answer string is rendered incrementally. Other
+/// field orders remain buffered. Incomplete escapes and surrogate pairs stay
+/// buffered too, so visible text never needs an in-place correction.
+String? _answerPrefix(String response) {
+  var text = splitThinkingSegments(response)
+      .where((part) => !part.isThinking)
+      .map((part) => part.text)
+      .join()
+      .trimLeft();
+  text = text.replaceFirst(RegExp(r'^```(?:json)?\s*'), '');
+  final start = RegExp(r'^\{\s*"answer"\s*:\s*"').firstMatch(text);
+  if (start == null) return null;
+  var end = start.end;
+  while (end < text.length) {
+    final unit = text.codeUnitAt(end);
+    if (unit == 34) break;
+    if (unit == 92) {
+      if (end + 1 >= text.length) break;
+      if (text.codeUnitAt(end + 1) == 117) {
+        if (end + 6 > text.length) break;
+        end += 6;
+      } else {
+        end += 2;
+      }
+    } else {
+      end++;
+    }
+  }
+  var answer = jsonDecode('"${text.substring(start.end, end)}"') as String;
+  if (answer.isNotEmpty) {
+    final last = answer.codeUnitAt(answer.length - 1);
+    if (last >= 0xd800 && last <= 0xdbff) {
+      answer = answer.substring(0, answer.length - 1);
+    }
+  }
+  return answer;
 }

--- a/lib/features/agents/ui/query/query_chat_pane.dart
+++ b/lib/features/agents/ui/query/query_chat_pane.dart
@@ -431,6 +431,13 @@ class _QueryChatPaneState extends ConsumerState<QueryChatPane> {
     final tokens = context.designTokens;
     final lastQuestion = chat?.questions.lastOrNull;
     final running = local.status == QueryTurnStatus.running;
+    final provisional = local.provisional;
+    final showProvisional =
+        provisional != null &&
+        provisional.text.isNotEmpty &&
+        (!provisional.private || showPrivate) &&
+        chat != null &&
+        chat.answerFor(provisional.questionId) == null;
     final lastAnswer = chat?.events
         .where((e) => e.data is QueryChatAnswer)
         .lastOrNull;
@@ -637,7 +644,7 @@ class _QueryChatPaneState extends ConsumerState<QueryChatPane> {
                       conversationId: id,
                       history: AsyncData(history),
                       draft: draft,
-                      isSending: running,
+                      isSending: running || showProvisional,
                       sendingLabel: _activityLabel(context, local),
                       onDraftChanged: (text) =>
                           controller.updateDraft(id, text),
@@ -676,50 +683,79 @@ class _QueryChatPaneState extends ConsumerState<QueryChatPane> {
                             color: tokens.colors.background.level02,
                             borderRadius: BorderRadius.circular(tokens.radii.l),
                           ),
-                          child: Row(
+                          child: Column(
                             mainAxisSize: MainAxisSize.min,
+                            crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              SizedBox.square(
-                                dimension: IconSizes.s,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: BorderWidths.emphasis,
-                                  color: tokens.colors.interactive.enabled,
+                              if (showProvisional) ...[
+                                Text(
+                                  messages.queryDraftProvisional,
+                                  style: tokens.typography.styles.others.caption
+                                      .copyWith(
+                                        color:
+                                            tokens.colors.text.mediumEmphasis,
+                                      ),
                                 ),
-                              ),
-                              SizedBox(width: tokens.spacing.step3),
-                              Flexible(
-                                child: Semantics(
-                                  liveRegion: true,
-                                  child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      Text(
-                                        _activityLabel(context, local),
-                                        style: tokens
-                                            .typography
-                                            .styles
-                                            .body
-                                            .bodySmall,
-                                      ),
-                                      Text(
-                                        messages.queryChecked(local.checked),
-                                        style: tokens
-                                            .typography
-                                            .styles
-                                            .others
-                                            .caption,
-                                      ),
-                                    ],
+                                SizedBox(height: tokens.spacing.step2),
+                                // Plain text keeps every draft citation and URL inert.
+                                SelectableText(
+                                  provisional.text,
+                                  key: ValueKey(
+                                    'query-provisional-${provisional.questionId}',
                                   ),
+                                  style:
+                                      tokens.typography.styles.body.bodySmall,
                                 ),
-                              ),
-                              SizedBox(width: tokens.spacing.step3),
-                              DesignSystemButton(
-                                label: messages.cancelButton,
-                                onPressed: () => controller.cancel(id),
-                                variant: DesignSystemButtonVariant.tertiary,
-                                size: DesignSystemButtonSize.dense,
+                                SizedBox(height: tokens.spacing.step3),
+                              ],
+                              Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  SizedBox.square(
+                                    dimension: IconSizes.s,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: BorderWidths.emphasis,
+                                      color: tokens.colors.interactive.enabled,
+                                    ),
+                                  ),
+                                  SizedBox(width: tokens.spacing.step3),
+                                  Flexible(
+                                    child: Semantics(
+                                      liveRegion: true,
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: [
+                                          Text(
+                                            _activityLabel(context, local),
+                                            style: tokens
+                                                .typography
+                                                .styles
+                                                .body
+                                                .bodySmall,
+                                          ),
+                                          Text(
+                                            messages.queryChecked(
+                                              local.checked,
+                                            ),
+                                            style: tokens
+                                                .typography
+                                                .styles
+                                                .others
+                                                .caption,
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ),
+                                  SizedBox(width: tokens.spacing.step3),
+                                  DesignSystemButton(
+                                    label: messages.cancelButton,
+                                    onPressed: () => controller.cancel(id),
+                                    variant: DesignSystemButtonVariant.tertiary,
+                                    size: DesignSystemButtonSize.dense,
+                                  ),
+                                ],
                               ),
                             ],
                           ),
@@ -1113,6 +1149,8 @@ class _QueryChatPaneState extends ConsumerState<QueryChatPane> {
         Text(
           needsSetup
               ? messages.queryInferenceUnavailable
+              : local.draftRetracted && local.requestQuestionId == questionId
+              ? messages.queryDraftRetracted
               : terminal?.data is QueryChatCancelled
               ? messages.aiAttributionStatusCancelled
               : messages.queryFailed,

--- a/lib/features/ai/repository/cloud_inference_generate.dart
+++ b/lib/features/ai/repository/cloud_inference_generate.dart
@@ -52,6 +52,7 @@ class CloudInferenceGenerate {
     GeminiThinkingMode? geminiThinkingMode,
     ReasoningEffort? reasoningEffort,
     InferenceImpactCollector? impactCollector,
+    bool preferStreaming = false,
   }) {
     if (provider?.inferenceProviderType == InferenceProviderType.sherpa) {
       throw UnsupportedError('sherpa-onnx supports audio transcription only');
@@ -129,6 +130,7 @@ class CloudInferenceGenerate {
         toolChoice: toolChoice,
         reasoningEffort: reasoningEffort,
         impactCollector: impactCollector,
+        preferStreaming: preferStreaming,
       );
     }
 
@@ -164,7 +166,14 @@ class CloudInferenceGenerate {
       ),
     );
 
-    return _helpers.filterAnthropicPings(res).asBroadcastStream();
+    return _helpers
+        .filterAnthropicPings(
+          res,
+          onClose: overrideClient == null ? client.endSession : null,
+        )
+        .asBroadcastStream(
+          onCancel: (subscription) => unawaited(subscription.cancel()),
+        );
   }
 
   Stream<CreateChatCompletionStreamResponse> generateWithImages(

--- a/lib/features/ai/repository/cloud_inference_repository.dart
+++ b/lib/features/ai/repository/cloud_inference_repository.dart
@@ -110,6 +110,7 @@ class CloudInferenceRepository {
     GeminiThinkingMode? geminiThinkingMode,
     ReasoningEffort? reasoningEffort,
     InferenceImpactCollector? impactCollector,
+    bool preferStreaming = false,
   }) => _generate.generate(
     prompt,
     model: model,
@@ -125,6 +126,7 @@ class CloudInferenceRepository {
     geminiThinkingMode: geminiThinkingMode,
     reasoningEffort: reasoningEffort,
     impactCollector: impactCollector,
+    preferStreaming: preferStreaming,
   );
 
   Stream<CreateChatCompletionStreamResponse> generateWithImages(

--- a/lib/features/ai/repository/cloud_inference_request_helpers.dart
+++ b/lib/features/ai/repository/cloud_inference_request_helpers.dart
@@ -54,38 +54,48 @@ class CloudInferenceRequestHelpers {
 
   /// Filters out Anthropic ping messages from the stream
   Stream<CreateChatCompletionStreamResponse> filterAnthropicPings(
-    Stream<CreateChatCompletionStreamResponse> stream,
-  ) {
-    // Use where to filter out errors instead of handleError
-    final controller = StreamController<CreateChatCompletionStreamResponse>();
+    Stream<CreateChatCompletionStreamResponse> stream, {
+    void Function()? onClose,
+  }) {
+    late StreamController<CreateChatCompletionStreamResponse> controller;
+    StreamSubscription<CreateChatCompletionStreamResponse>? subscription;
+    var closed = false;
+    void closeResource() {
+      if (closed) return;
+      closed = true;
+      onClose?.call();
+    }
 
-    stream.listen(
-      controller.add,
-      onError: (Object error, StackTrace stackTrace) {
-        // Check if this is specifically an Anthropic ping message error
-        final errorString = error.toString();
-
-        // Anthropic ping messages cause a specific null subtype error when parsing choices
-        final isAnthropicPingError =
-            errorString.contains(
-              "type 'Null' is not a subtype of type 'List<dynamic>'",
-            ) &&
-            errorString.contains('choices');
-
-        if (isAnthropicPingError) {
-          // Log but don't propagate the error
-          developer.log(
-            'Skipping Anthropic ping message',
-            name: 'CloudInferenceRepository',
-            error: error,
-            stackTrace: stackTrace,
-          );
-          return;
-        }
-        // Propagate other errors
-        controller.addError(error, stackTrace);
+    controller = StreamController<CreateChatCompletionStreamResponse>(
+      onListen: () {
+        subscription = stream.listen(
+          controller.add,
+          onError: (Object error, StackTrace stackTrace) {
+            final message = error.toString();
+            if (message.contains(
+                  "type 'Null' is not a subtype of type 'List<dynamic>'",
+                ) &&
+                message.contains('choices')) {
+              developer.log(
+                'Skipping Anthropic ping message',
+                name: 'CloudInferenceRepository',
+              );
+            } else {
+              controller.addError(error, stackTrace);
+            }
+          },
+          onDone: () {
+            closeResource();
+            unawaited(controller.close());
+          },
+        );
       },
-      onDone: controller.close,
+      onCancel: () {
+        closeResource();
+        return subscription?.cancel();
+      },
+      onPause: () => subscription?.pause(),
+      onResume: () => subscription?.resume(),
     );
 
     return controller.stream;

--- a/lib/features/ai/repository/melious_inference_repository.dart
+++ b/lib/features/ai/repository/melious_inference_repository.dart
@@ -390,7 +390,9 @@ class MeliousInferenceRepository extends TranscriptionRepository {
           reasoningEffort: resolveReasoningEffort(model, reasoningEffort),
         )
         .copyWith(
-          streamOptions: const ChatCompletionStreamOptions(includeUsage: true),
+          streamOptions: preferStreaming
+              ? const ChatCompletionStreamOptions(includeUsage: true)
+              : null,
         );
     late StreamController<CreateChatCompletionStreamResponse> controller;
     StreamSubscription<CreateChatCompletionStreamResponse>? subscription;

--- a/lib/features/ai/repository/melious_inference_repository.dart
+++ b/lib/features/ai/repository/melious_inference_repository.dart
@@ -340,8 +340,10 @@ class MeliousInferenceRepository extends TranscriptionRepository {
   /// Melious returns `environment_impact` + `billing_cost` (only present on
   /// non-streaming responses); the parsed impact is written to the collector and
   /// the buffered reply is re-emitted as a single synthetic stream chunk so
-  /// existing consumers are unchanged. Without a collector the original
-  /// streaming path is used verbatim.
+  /// existing consumers are unchanged. [preferStreaming] retains the collector
+  /// but requests incremental text and token usage. Only an explicit initial
+  /// rejection of a streaming parameter permits one same-model buffered
+  /// fallback; other errors and partial responses are never retried here.
   Stream<CreateChatCompletionStreamResponse> generateText({
     required String prompt,
     required String model,
@@ -354,6 +356,7 @@ class MeliousInferenceRepository extends TranscriptionRepository {
     ChatCompletionToolChoiceOption? toolChoice,
     ReasoningEffort? reasoningEffort,
     InferenceImpactCollector? impactCollector,
+    bool preferStreaming = false,
   }) {
     final messages = [
       if (systemMessage != null)
@@ -362,7 +365,7 @@ class MeliousInferenceRepository extends TranscriptionRepository {
         content: ChatCompletionUserMessageContent.string(prompt),
       ),
     ];
-    if (impactCollector != null) {
+    if (impactCollector != null && !preferStreaming) {
       return _nonStreamingChat(
         messages: messages,
         model: model,
@@ -376,21 +379,111 @@ class MeliousInferenceRepository extends TranscriptionRepository {
         impactCollector: impactCollector,
       );
     }
-    final stream = _chatCompletionStreamFactory(
-      baseUrl: baseUrl,
-      apiKey: apiKey,
-      request: _helpers.createBaseRequest(
-        messages: messages,
-        model: model,
-        temperature: temperature,
-        maxCompletionTokens: maxCompletionTokens,
-        tools: tools,
-        toolChoice: resolveToolChoice(model, tools, toolChoice),
-        reasoningEffort: resolveReasoningEffort(model, reasoningEffort),
-      ),
-    );
+    final request = _helpers
+        .createBaseRequest(
+          messages: messages,
+          model: model,
+          temperature: temperature,
+          maxCompletionTokens: maxCompletionTokens,
+          tools: tools,
+          toolChoice: resolveToolChoice(model, tools, toolChoice),
+          reasoningEffort: resolveReasoningEffort(model, reasoningEffort),
+        )
+        .copyWith(
+          streamOptions: const ChatCompletionStreamOptions(includeUsage: true),
+        );
+    late StreamController<CreateChatCompletionStreamResponse> controller;
+    StreamSubscription<CreateChatCompletionStreamResponse>? subscription;
+    var emitted = false;
+    var cancelled = false;
+    bool permitsFallback(Object error) {
+      if (!preferStreaming ||
+          emitted ||
+          error is! OpenAIClientException ||
+          (error.code != 400 && error.code != 422)) {
+        return false;
+      }
+      var body = error.body;
+      if (body is String) {
+        try {
+          body = jsonDecode(body);
+        } catch (_) {
+          return false;
+        }
+      }
+      final detail = body is Map ? body['error'] : null;
+      final parameter = detail is Map ? detail['param'] : null;
+      return parameter == 'stream' || parameter == 'stream_options';
+    }
 
-    return _helpers.filterAnthropicPings(stream).asBroadcastStream();
+    void finishError(Object error, StackTrace stack) {
+      if (cancelled) return;
+      controller.addError(error, stack);
+      unawaited(controller.close());
+    }
+
+    void listen(
+      Stream<CreateChatCompletionStreamResponse> source, {
+      required bool fallback,
+    }) {
+      subscription = source.listen(
+        (chunk) {
+          if (cancelled) return;
+          emitted = true;
+          controller.add(chunk);
+        },
+        onError: (Object error, StackTrace stack) {
+          if (cancelled) return;
+          if (!fallback && permitsFallback(error)) {
+            listen(
+              _nonStreamingChat(
+                messages: messages,
+                model: model,
+                baseUrl: baseUrl,
+                apiKey: apiKey,
+                temperature: temperature,
+                maxCompletionTokens: maxCompletionTokens,
+                tools: tools,
+                toolChoice: toolChoice,
+                reasoningEffort: reasoningEffort,
+                impactCollector: impactCollector ?? InferenceImpactCollector(),
+              ),
+              fallback: true,
+            );
+          } else {
+            finishError(error, stack);
+          }
+        },
+        onDone: () => unawaited(controller.close()),
+        cancelOnError: true,
+      );
+    }
+
+    controller = StreamController<CreateChatCompletionStreamResponse>(
+      onListen: () {
+        try {
+          listen(
+            _helpers.filterAnthropicPings(
+              _chatCompletionStreamFactory(
+                baseUrl: baseUrl,
+                apiKey: apiKey,
+                request: request,
+              ),
+            ),
+            fallback: false,
+          );
+        } catch (error, stack) {
+          finishError(error, stack);
+        }
+      },
+      onCancel: () {
+        cancelled = true;
+        return subscription?.cancel();
+      },
+    );
+    return controller.stream.asBroadcastStream(
+      onCancel: (subscription) => unawaited(subscription.cancel()),
+    );
   }
 
   /// Generates with full conversation history through Melious' OpenAI-compatible
@@ -504,7 +597,10 @@ class MeliousInferenceRepository extends TranscriptionRepository {
     required CreateChatCompletionRequest request,
   }) {
     final client = OpenAIClient(baseUrl: baseUrl, apiKey: apiKey);
-    return client.createChatCompletionStream(request: request);
+    return const CloudInferenceRequestHelpers().filterAnthropicPings(
+      client.createChatCompletionStream(request: request),
+      onClose: client.endSession,
+    );
   }
 
   /// Non-streaming Melious chat: one raw POST that returns the full body

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4257,6 +4257,8 @@
   "queryDeleteForget": "Smazat a zapomenout závěry",
   "queryDeleteKeep": "Smazat a ponechat závěry",
   "queryDictated": "Přepis můžeš upravit před odesláním otázky. Zvuk už mohl být odeslán tvému poskytovateli přepisu.",
+  "queryDraftProvisional": "Návrh · zatím neověřený",
+  "queryDraftRetracted": "Návrh odpovědi se nepodařilo ověřit. Zkus to znovu.",
   "queryEarlierTextOmitted": "[Dřívější text není zobrazen]",
   "queryEmptyBody": "Zeptej se na dřívější poznámky a schůzky. Odpovědi obsahují přesné pasáže, které si můžeš prohlédnout.",
   "queryExactStoredText": "Přesný uložený text",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4724,6 +4724,8 @@
   "queryDeleteForget": "Slet og glem konklusioner",
   "queryDeleteKeep": "Slet og behold konklusioner",
   "queryDictated": "Du kan redigere transskriptionen, før du sender dit spørgsmål. Lyden kan allerede være sendt til din transskriptionsudbyder.",
+  "queryDraftProvisional": "Udkast · endnu ikke verificeret",
+  "queryDraftRetracted": "Udkastet til svaret kunne ikke verificeres. Prøv igen.",
   "queryEarlierTextOmitted": "[Tidligere tekst vises ikke]",
   "queryEmptyBody": "Spørg til tidligere noter og møder. Svarene indeholder de præcise passager, du kan læse.",
   "queryExactStoredText": "Præcis gemt tekst",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -4250,6 +4250,8 @@
   "queryDeleteForget": "Löschen und Erkenntnisse vergessen",
   "queryDeleteKeep": "Löschen und Erkenntnisse behalten",
   "queryDictated": "Du kannst das Transkript bearbeiten, bevor du deine Frage sendest. Das Audio wurde möglicherweise bereits an deinen Transkriptionsanbieter gesendet.",
+  "queryDraftProvisional": "Entwurf · noch nicht geprüft",
+  "queryDraftRetracted": "Der Antwortentwurf konnte nicht geprüft werden. Versuch es erneut.",
   "queryEarlierTextOmitted": "[Vorheriger Text nicht angezeigt]",
   "queryEmptyBody": "Frag nach früheren Notizen und Besprechungen. Die Antworten enthalten die genauen Textstellen zum Nachlesen.",
   "queryExactStoredText": "Exakter gespeicherter Text",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6363,6 +6363,8 @@
   "queryDeleteForget": "Delete and forget conclusions",
   "queryDeleteKeep": "Delete and keep conclusions",
   "queryDictated": "You can edit the transcript before sending your question. Audio may already have been sent to your transcription provider.",
+  "queryDraftProvisional": "Draft · not yet verified",
+  "queryDraftRetracted": "The draft answer could not be verified. Try again.",
   "queryEarlierTextOmitted": "[Earlier text not shown]",
   "queryEmptyBody": "Ask about earlier notes and meetings. Answers include the exact passages you can inspect.",
   "queryExactStoredText": "Exact stored text",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4250,6 +4250,8 @@
   "queryDeleteForget": "Eliminar y olvidar las conclusiones",
   "queryDeleteKeep": "Eliminar y conservar las conclusiones",
   "queryDictated": "Puedes editar la transcripción antes de enviar tu pregunta. Es posible que el audio ya se haya enviado a tu proveedor de transcripción.",
+  "queryDraftProvisional": "Borrador · aún sin verificar",
+  "queryDraftRetracted": "No se pudo verificar el borrador de la respuesta. Inténtalo de nuevo.",
   "queryEarlierTextOmitted": "[Texto anterior no mostrado]",
   "queryEmptyBody": "Pregunta sobre notas y reuniones anteriores. Las respuestas incluyen los pasajes exactos que puedes consultar.",
   "queryExactStoredText": "Texto exacto guardado",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4250,6 +4250,8 @@
   "queryDeleteForget": "Supprimer et oublier les conclusions",
   "queryDeleteKeep": "Supprimer et garder les conclusions",
   "queryDictated": "Tu peux modifier la transcription avant d’envoyer ta question. L’audio a peut-être déjà été envoyé à ton fournisseur de transcription.",
+  "queryDraftProvisional": "Brouillon · pas encore vérifié",
+  "queryDraftRetracted": "Le brouillon de la réponse n’a pas pu être vérifié. Réessaie.",
   "queryEarlierTextOmitted": "[Texte précédent non affiché]",
   "queryEmptyBody": "Pose des questions sur tes notes et réunions passées. Les réponses incluent les passages exacts que tu peux consulter.",
   "queryExactStoredText": "Texte exact enregistré",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4724,6 +4724,8 @@
   "queryDeleteForget": "Elimina e dimentica le conclusioni",
   "queryDeleteKeep": "Elimina e conserva le conclusioni",
   "queryDictated": "Puoi modificare la trascrizione prima di inviare la domanda. L’audio potrebbe essere già stato inviato al tuo servizio di trascrizione.",
+  "queryDraftProvisional": "Bozza · non ancora verificata",
+  "queryDraftRetracted": "Non è stato possibile verificare la bozza della risposta. Riprova.",
   "queryEarlierTextOmitted": "[Testo precedente non mostrato]",
   "queryEmptyBody": "Chiedi informazioni su note e riunioni precedenti. Le risposte includono i passaggi esatti che puoi consultare.",
   "queryExactStoredText": "Testo esatto salvato",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -25708,6 +25708,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Skip'**
   String get whatsNewSkipButton;
+
+  /// No description provided for @queryDraftProvisional.
+  ///
+  /// In en, this message translates to:
+  /// **'Draft · not yet verified'**
+  String get queryDraftProvisional;
+
+  /// No description provided for @queryDraftRetracted.
+  ///
+  /// In en, this message translates to:
+  /// **'The draft answer could not be verified. Try again.'**
+  String get queryDraftRetracted;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -15619,4 +15619,11 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Přeskočit';
+
+  @override
+  String get queryDraftProvisional => 'Návrh · zatím neověřený';
+
+  @override
+  String get queryDraftRetracted =>
+      'Návrh odpovědi se nepodařilo ověřit. Zkus to znovu.';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -15419,4 +15419,11 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Spring over';
+
+  @override
+  String get queryDraftProvisional => 'Udkast · endnu ikke verificeret';
+
+  @override
+  String get queryDraftRetracted =>
+      'Udkastet til svaret kunne ikke verificeres. Prøv igen.';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -15535,4 +15535,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Überspringen';
+
+  @override
+  String get queryDraftProvisional => 'Entwurf · noch nicht geprüft';
+
+  @override
+  String get queryDraftRetracted =>
+      'Der Antwortentwurf konnte nicht geprüft werden. Versuch es erneut.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -15328,6 +15328,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Skip';
+
+  @override
+  String get queryDraftProvisional => 'Draft · not yet verified';
+
+  @override
+  String get queryDraftRetracted =>
+      'The draft answer could not be verified. Try again.';
 }
 
 /// The translations for English, as used in the United Kingdom (`en_GB`).

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -15627,4 +15627,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Omitir';
+
+  @override
+  String get queryDraftProvisional => 'Borrador · aún sin verificar';
+
+  @override
+  String get queryDraftRetracted =>
+      'No se pudo verificar el borrador de la respuesta. Inténtalo de nuevo.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -15679,4 +15679,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Ignorer';
+
+  @override
+  String get queryDraftProvisional => 'Brouillon · pas encore vérifié';
+
+  @override
+  String get queryDraftRetracted =>
+      'Le brouillon de la réponse n’a pas pu être vérifié. Réessaie.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -15616,4 +15616,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Salta!';
+
+  @override
+  String get queryDraftProvisional => 'Bozza · non ancora verificata';
+
+  @override
+  String get queryDraftRetracted =>
+      'Non è stato possibile verificare la bozza della risposta. Riprova.';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -15462,4 +15462,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Overslaan';
+
+  @override
+  String get queryDraftProvisional => 'Concept · nog niet geverifieerd';
+
+  @override
+  String get queryDraftRetracted =>
+      'Het conceptantwoord kon niet worden geverifieerd. Probeer het opnieuw.';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -15557,4 +15557,11 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Pular';
+
+  @override
+  String get queryDraftProvisional => 'Rascunho · ainda não verificado';
+
+  @override
+  String get queryDraftRetracted =>
+      'Não foi possível verificar o rascunho da resposta. Tenta novamente.';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -15729,4 +15729,11 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Omite';
+
+  @override
+  String get queryDraftProvisional => 'Ciornă · încă neverificată';
+
+  @override
+  String get queryDraftRetracted =>
+      'Ciorna răspunsului nu a putut fi verificată. Încercați din nou.';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -15437,4 +15437,11 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get whatsNewSkipButton => 'Hoppa över';
+
+  @override
+  String get queryDraftProvisional => 'Utkast · ännu inte verifierat';
+
+  @override
+  String get queryDraftRetracted =>
+      'Svarsutkastet kunde inte verifieras. Försök igen.';
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4723,6 +4723,8 @@
   "queryDeleteForget": "Verwijderen en conclusies vergeten",
   "queryDeleteKeep": "Verwijderen en conclusies bewaren",
   "queryDictated": "Je kunt de transcriptie bewerken voordat je je vraag verstuurt. De audio kan al naar je transcriptieaanbieder zijn verstuurd.",
+  "queryDraftProvisional": "Concept · nog niet geverifieerd",
+  "queryDraftRetracted": "Het conceptantwoord kon niet worden geverifieerd. Probeer het opnieuw.",
   "queryEarlierTextOmitted": "[Eerdere tekst niet getoond]",
   "queryEmptyBody": "Stel vragen over eerdere notities en vergaderingen. Antwoorden bevatten de exacte passages die je kunt nalezen.",
   "queryExactStoredText": "Exact opgeslagen tekst",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4723,6 +4723,8 @@
   "queryDeleteForget": "Eliminar e esquecer as conclusões",
   "queryDeleteKeep": "Eliminar e manter as conclusões",
   "queryDictated": "Podes editar a transcrição antes de enviares a pergunta. O áudio pode já ter sido enviado ao teu fornecedor de transcrição.",
+  "queryDraftProvisional": "Rascunho · ainda não verificado",
+  "queryDraftRetracted": "Não foi possível verificar o rascunho da resposta. Tenta novamente.",
   "queryEarlierTextOmitted": "[Texto anterior não apresentado]",
   "queryEmptyBody": "Pergunta sobre notas e reuniões anteriores. As respostas incluem as passagens exatas que podes consultar.",
   "queryExactStoredText": "Texto exato guardado",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4250,6 +4250,8 @@
   "queryDeleteForget": "Ștergeți și eliminați concluziile",
   "queryDeleteKeep": "Ștergeți și păstrați concluziile",
   "queryDictated": "Puteți edita transcrierea înainte de a trimite întrebarea. Este posibil ca sunetul să fi fost deja trimis furnizorului dvs. de transcriere.",
+  "queryDraftProvisional": "Ciornă · încă neverificată",
+  "queryDraftRetracted": "Ciorna răspunsului nu a putut fi verificată. Încercați din nou.",
   "queryEarlierTextOmitted": "[Textul anterior nu este afișat]",
   "queryEmptyBody": "Întrebați despre notițe și întâlniri anterioare. Răspunsurile includ pasajele exacte pe care le puteți consulta.",
   "queryExactStoredText": "Textul exact salvat",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4724,6 +4724,8 @@
   "queryDeleteForget": "Radera och glöm slutsatser",
   "queryDeleteKeep": "Radera och behåll slutsatser",
   "queryDictated": "Du kan redigera transkriptionen innan du skickar din fråga. Ljudet kan redan ha skickats till din transkriberingsleverantör.",
+  "queryDraftProvisional": "Utkast · ännu inte verifierat",
+  "queryDraftRetracted": "Svarsutkastet kunde inte verifieras. Försök igen.",
   "queryEarlierTextOmitted": "[Tidigare text visas inte]",
   "queryEmptyBody": "Fråga om tidigare anteckningar och möten. Svaren innehåller de exakta avsnitten som du kan läsa.",
   "queryExactStoredText": "Exakt sparad text",

--- a/test/features/agents/query/query_chat_controller_test.dart
+++ b/test/features/agents/query/query_chat_controller_test.dart
@@ -36,6 +36,7 @@ void main() {
   late MockDomainLogger logger;
   Exception? setupError;
   Stream<String>? synthesis;
+  var recall = false;
   var malformed = false;
   var unavailable = false;
   final now = DateTime(2026, 9, 10, 12);
@@ -47,6 +48,7 @@ void main() {
     bench = QueryPersistenceBench()..add('task');
     inspect = (_) async {};
     compose = (_) async {};
+    recall = false;
     malformed = false;
     synthesis = null;
     unavailable = false;
@@ -85,7 +87,11 @@ void main() {
                     'terms': ['feeder'],
                     'sufficient': sources.isNotEmpty,
                     'searchCategory': false,
-                    'memoryIds': <String>[],
+                    'memoryIds': <String>[
+                      if (recall)
+                        for (final memory in input['memories'] as List)
+                          (memory as Map<String, dynamic>)['id'] as String,
+                    ],
                     'passages': [
                       for (final source in sources)
                         {
@@ -158,6 +164,7 @@ void main() {
       await container.pump();
 
       expect(container.read(provider).local(id).provisional, isNull);
+      expect(container.read(provider).local(id).status, QueryTurnStatus.idle);
       expect(
         (await bench.store.load('agent')).chats.single.answerFor(
           local.requestQuestionId!,
@@ -167,11 +174,29 @@ void main() {
     });
   });
 
-  for (final outcome in ['publish', 'invalid citation', 'cancel', 'privacy']) {
+  for (final outcome in [
+    'publish',
+    'refresh',
+    'invalid citation',
+    'cancel',
+    'privacy',
+    'moved',
+    'load failure',
+    'deleted',
+    'forgotten',
+    'history error',
+  ]) {
     test(
       'provisional synthesis $outcome preserves the publication boundary',
       () async {
         await withClock(Clock.fixed(now), () async {
+          String? memoryChat;
+          if (outcome == 'forgotten') {
+            memoryChat = await controller.create('Earlier feeder discussion');
+            controller.updateDraft(memoryChat, 'What did we record?');
+            await controller.send(memoryChat);
+            recall = true;
+          }
           var stopped = false;
           final stream = StreamController<String>(
             onCancel: () => stopped = true,
@@ -202,43 +227,97 @@ void main() {
           final draft = container.read(provider).local(chatId).provisional!;
           expect(draft.text, text);
           final before = await bench.store.load('agent');
-          expect(before.chats.single.answerFor(draft.questionId), isNull);
-          if (outcome == 'privacy') {
+          expect(
+            before.chats
+                .firstWhere((c) => c.id == chatId)
+                .answerFor(draft.questionId),
+            isNull,
+          );
+          final initialAccess = await bench.crawler.access.load(['task']);
+          if (outcome == 'privacy' || outcome == 'moved') {
             final task = bench.entries['task']!;
             bench.entries['task'] = task.copyWith(
-              meta: task.meta.copyWith(private: true),
+              meta: outcome == 'privacy'
+                  ? task.meta.copyWith(private: true)
+                  : task.meta.copyWith(categoryId: bench.categories.first.id),
             );
+          }
+          if (outcome == 'load failure') {
+            when(
+              bench.db.getAllCategories,
+            ).thenThrow(StateError('Access unavailable'));
+          }
+          if (outcome == 'deleted') {
+            await bench.store.delete('agent', chatId, forget: true);
+          }
+          if (outcome == 'forgotten') {
+            expect(draft.recalledMemoryIds, isNotEmpty);
+            await bench.store.delete('agent', memoryChat!, forget: true);
+          }
+          if (outcome == 'history error') {
+            history.addError(StateError('History unavailable'));
+            await container.pump();
+          } else if ([
+            'privacy',
+            'moved',
+            'load failure',
+            'deleted',
+            'forgotten',
+            'refresh',
+          ].contains(outcome)) {
             history.add(
               QueryChatData(
-                projection: before,
-                access: await bench.crawler.access.load(['task']),
+                projection: ['deleted', 'forgotten'].contains(outcome)
+                    ? await bench.store.load('agent')
+                    : before,
+                access: initialAccess,
               ),
             );
             await container.pump();
-            expect(container.read(provider).local(chatId).provisional, isNull);
-          } else if (outcome == 'cancel') {
-            controller.cancel(chatId);
-            expect(container.read(provider).local(chatId).provisional, isNull);
-          } else {
+          }
+          if (outcome == 'load failure') {
+            when(
+              bench.db.getAllCategories,
+            ).thenAnswer((_) async => bench.categories);
+          }
+          if (outcome == 'cancel') controller.cancel(chatId);
+          if (['publish', 'refresh', 'invalid citation'].contains(outcome)) {
             stream.add('","conclusion":""}');
             await stream.close();
+          } else {
+            expect(container.read(provider).local(chatId).provisional, isNull);
           }
           await request;
           final after = await bench.store.load('agent');
           final local = container.read(provider).local(chatId);
-          if (outcome == 'publish') {
+          final savedChat = after.chats
+              .where((c) => c.id == chatId)
+              .firstOrNull;
+          if (outcome == 'publish' || outcome == 'refresh') {
             expect(
-              (after.chats.single.answerFor(draft.questionId)!.data
-                      as QueryChatAnswer)
+              (savedChat!.answerFor(draft.questionId)!.data as QueryChatAnswer)
                   .text,
               draft.text,
             );
             expect(local.draftRetracted, isFalse);
+            history.add(
+              QueryChatData(projection: after, access: initialAccess),
+            );
+            await container.pump();
+            expect(container.read(provider).local(chatId).provisional, isNull);
           } else {
             expect(local.provisional, isNull);
-            expect(after.chats.single.answerFor(draft.questionId), isNull);
+            expect(savedChat?.answerFor(draft.questionId), isNull);
             expect(local.draftRetracted, outcome == 'invalid citation');
-            expect(local.requestQuestionId, draft.questionId);
+            if (outcome == 'deleted') {
+              expect(
+                container.read(provider).chats.containsKey(chatId),
+                isFalse,
+              );
+              expect(savedChat, isNull);
+            } else {
+              expect(local.requestQuestionId, draft.questionId);
+            }
             expect(stopped, isTrue);
           }
           subscription.close();

--- a/test/features/agents/query/query_chat_controller_test.dart
+++ b/test/features/agents/query/query_chat_controller_test.dart
@@ -34,6 +34,7 @@ void main() {
   late Future<void> Function(String chatId) compose;
   late MockDomainLogger logger;
   Exception? setupError;
+  Stream<String>? synthesis;
   var malformed = false;
   var unavailable = false;
   final now = DateTime(2026, 9, 10, 12);
@@ -46,6 +47,7 @@ void main() {
     inspect = (_) async {};
     compose = (_) async {};
     malformed = false;
+    synthesis = null;
     unavailable = false;
     history = StreamController<QueryChatData>.broadcast();
     container = ProviderContainer(
@@ -104,6 +106,10 @@ void main() {
                   yield '{"ids":[]}';
                 } else {
                   await compose(chatId);
+                  if (synthesis case final stream?) {
+                    yield* stream;
+                    return;
+                  }
                   yield malformed
                       ? 'invalid'
                       : jsonEncode({
@@ -124,6 +130,87 @@ void main() {
     await history.close();
     await bench.close();
   });
+
+  for (final outcome in ['publish', 'invalid citation', 'cancel', 'privacy']) {
+    test(
+      'provisional synthesis $outcome preserves the publication boundary',
+      () async {
+        await withClock(Clock.fixed(now), () async {
+          var stopped = false;
+          final stream = StreamController<String>(
+            onCancel: () => stopped = true,
+          );
+          synthesis = stream.stream;
+          addTearDown(() {
+            container.read(provider).chats.keys.forEach(controller.cancel);
+            unawaited(stream.close());
+          });
+          final started = Completer<void>();
+          compose = (_) async => started.complete();
+          final chatId = await controller.create('Synthetic habitat');
+          controller.updateDraft(chatId, 'What was recorded?');
+          final seen = Completer<void>();
+          final subscription = container.listen(provider, (_, next) {
+            if (next.local(chatId).provisional?.text.isNotEmpty == true &&
+                !seen.isCompleted) {
+              seen.complete();
+            }
+          });
+          final request = controller.send(chatId);
+          await started.future;
+          final text = outcome == 'invalid citation'
+              ? 'Unsupported [999]'
+              : 'Recorded [1]';
+          stream.add('{"answer":"$text');
+          await seen.future;
+          final draft = container.read(provider).local(chatId).provisional!;
+          expect(draft.text, text);
+          final before = await bench.store.load('agent');
+          expect(before.chats.single.answerFor(draft.questionId), isNull);
+          if (outcome == 'privacy') {
+            final task = bench.entries['task']!;
+            bench.entries['task'] = task.copyWith(
+              meta: task.meta.copyWith(private: true),
+            );
+            history.add(
+              QueryChatData(
+                projection: before,
+                access: await bench.crawler.access.load(['task']),
+              ),
+            );
+            await container.pump();
+            expect(container.read(provider).local(chatId).provisional, isNull);
+          } else if (outcome == 'cancel') {
+            controller.cancel(chatId);
+            expect(container.read(provider).local(chatId).provisional, isNull);
+          } else {
+            stream.add('","conclusion":""}');
+            await stream.close();
+          }
+          await request;
+          final after = await bench.store.load('agent');
+          final local = container.read(provider).local(chatId);
+          if (outcome == 'publish') {
+            expect(
+              (after.chats.single.answerFor(draft.questionId)!.data
+                      as QueryChatAnswer)
+                  .text,
+              draft.text,
+            );
+            expect(local.draftRetracted, isFalse);
+          } else {
+            expect(local.provisional, isNull);
+            expect(after.chats.single.answerFor(draft.questionId), isNull);
+            expect(local.draftRetracted, outcome == 'invalid citation');
+            expect(local.requestQuestionId, draft.questionId);
+            expect(stopped, isTrue);
+          }
+          subscription.close();
+          await stream.close();
+        });
+      },
+    );
+  }
 
   test(
     'searching changes to answering only at synthesis and resets on retry',

--- a/test/features/agents/query/query_chat_controller_test.dart
+++ b/test/features/agents/query/query_chat_controller_test.dart
@@ -30,6 +30,7 @@ void main() {
   late ProviderContainer container;
   late QueryChatController controller;
   late StreamController<QueryChatData> history;
+  late StreamController<bool> privacy;
   late Future<void> Function(String chatId) inspect;
   late Future<void> Function(String chatId) compose;
   late MockDomainLogger logger;
@@ -50,6 +51,7 @@ void main() {
     synthesis = null;
     unavailable = false;
     history = StreamController<QueryChatData>.broadcast();
+    privacy = StreamController<bool>.broadcast();
     container = ProviderContainer(
       overrides: [
         domainLoggerProvider.overrideWithValue(logger),
@@ -57,7 +59,10 @@ void main() {
         queryChatDataProvider(key).overrideWith((ref) => history.stream),
         configFlagProvider(
           'private',
-        ).overrideWith((ref) => Stream.value(false)),
+        ).overrideWith((ref) async* {
+          yield false;
+          yield* privacy.stream;
+        }),
         queryBuilderFactoryProvider.overrideWithValue((
           scope,
           agentId,
@@ -128,7 +133,38 @@ void main() {
   tearDown(() async {
     container.dispose();
     await history.close();
+    await privacy.close();
     await bench.close();
+  });
+
+  test('privacy change clears a published draft awaiting projection', () async {
+    await withClock(Clock.fixed(now), () async {
+      final subscription = container.listen(provider, (_, _) {});
+      addTearDown(subscription.close);
+      await container.read(configFlagProvider('private').future);
+      final id = await controller.create('Feeder');
+      controller.updateDraft(id, 'What was recorded?');
+      await controller.send(id);
+      final local = container.read(provider).local(id);
+      expect(local.status, QueryTurnStatus.idle);
+      expect(local.provisional?.text, 'Answer for $id [1]');
+      final saved = await bench.store.load('agent');
+      expect(saved.chats.single.answerFor(local.requestQuestionId!), isNotNull);
+
+      privacy.add(true);
+      await container.pump();
+      expect(container.read(configFlagProvider('private')).value, isTrue);
+      privacy.add(false);
+      await container.pump();
+
+      expect(container.read(provider).local(id).provisional, isNull);
+      expect(
+        (await bench.store.load('agent')).chats.single.answerFor(
+          local.requestQuestionId!,
+        ),
+        saved.chats.single.answerFor(local.requestQuestionId!),
+      );
+    });
   });
 
   for (final outcome in ['publish', 'invalid citation', 'cancel', 'privacy']) {

--- a/test/features/agents/query/query_text_inference_test.dart
+++ b/test/features/agents/query/query_text_inference_test.dart
@@ -15,6 +15,138 @@ import '../test_data/ai_config_factories.dart';
 
 void main() {
   setUpAll(registerAllFallbackValues);
+  for (final fenced in [false, true]) {
+    test('synthesis decodes character-sized escapes fenced=$fenced', () async {
+      const answer = 'Line\n"quoted" 🐧 [1]';
+      final json = jsonEncode({'answer': answer, 'conclusion': 'hidden'});
+      final raw = fenced ? '```json\n$json\n```' : json;
+      final shown = <String>[];
+      var firstTokens = 0;
+      final inference = QueryTextInference(
+        generate: (_, _) => Stream.fromIterable(raw.split('')),
+      );
+      final result = await inference.complete(
+        system: 'answer',
+        input: {},
+        cancellation: QueryCancellation(),
+        onAnswerText: shown.add,
+        onFirstToken: () => firstTokens++,
+      );
+      expect(firstTokens, 1);
+      expect(result['answer'], answer);
+      expect(shown.last, answer);
+      expect(shown.length, greaterThan(1));
+      expect(shown.every(answer.startsWith), isTrue);
+      expect(shown, isNot(contains('hidden')));
+    });
+  }
+
+  test('duplicate answer cannot rewrite already displayed text', () async {
+    final shown = <String>[];
+    final inference = QueryTextInference(
+      generate: (_, _) => Stream.fromIterable([
+        '{"answer":"first',
+        '","answer":"different"}',
+      ]),
+    );
+    await expectLater(
+      inference.complete(
+        system: 'answer',
+        input: {},
+        cancellation: QueryCancellation(),
+        onAnswerText: shown.add,
+      ),
+      throwsFormatException,
+    );
+    expect(shown, ['first']);
+  });
+  test('synthesis reveals stable answer text before completion', () async {
+    final source = StreamController<String>();
+    final shown = <String>[];
+    var inspected = 0;
+    final inference = QueryTextInference(
+      generate: (_, _) {
+        inspected++;
+        return Stream.value('{"passages":[]}');
+      },
+      generateSynthesis: (_, _) => source.stream,
+    );
+    final token = QueryCancellation();
+    final future = inference.complete(
+      system: 'synthesis',
+      input: {},
+      cancellation: token,
+      onAnswerText: shown.add,
+    );
+    addTearDown(() async {
+      token.cancel();
+      try {
+        await future;
+      } catch (_) {}
+      await source.close();
+    });
+    source.add('<think>private reasoning');
+    await Future<void>.value();
+    expect(shown, isEmpty);
+    source.add('</think>{"answer":"Penguins: ');
+    await Future<void>.value();
+    expect(shown, ['Penguins: ']);
+    source.add(r'\uD83D');
+    await Future<void>.value();
+    expect(shown.last, 'Penguins: ');
+    source.add(r'\uDC27 [1]","conclusion":"never rendered"}');
+    await source.close();
+    final result = await future;
+    expect(shown.last, 'Penguins: 🐧 [1]');
+    expect(shown.last, result['answer']);
+    expect(shown.join(), isNot(contains('never rendered')));
+    expect(inspected, 0);
+    await inference.complete(
+      system: 'inspect',
+      input: {},
+      cancellation: QueryCancellation(),
+    );
+    expect(inspected, 1);
+  });
+
+  test('other field order buffers without showing conclusion', () async {
+    final shown = <String>[];
+    final inference = QueryTextInference(
+      generate: (_, _) => Stream.fromIterable([
+        '{"conclusion":"secret",',
+        '"answer":"Recorded [1]"}',
+      ]),
+    );
+    final result = await inference.complete(
+      system: 'answer',
+      input: {},
+      cancellation: QueryCancellation(),
+      onAnswerText: shown.add,
+    );
+    expect(shown, ['Recorded [1]']);
+    expect(result['answer'], shown.single);
+  });
+
+  test('draft callback failure cancels the provider stream', () async {
+    var cancelled = false;
+    final source = StreamController<String>(onCancel: () => cancelled = true);
+    final inference = QueryTextInference(generate: (_, _) => source.stream);
+    final future = inference.complete(
+      system: 'answer',
+      input: {},
+      cancellation: QueryCancellation(),
+      onAnswerText: (_) => throw StateError('no access'),
+    );
+    final assertion = expectLater(future, throwsStateError);
+    addTearDown(source.close);
+    source.add('{"answer":"must be removed"}');
+    await Future<void>.value();
+    expect(cancelled, isTrue);
+    await source.close();
+    await assertion;
+    expect(cancelled, isTrue);
+    await source.close();
+  });
   test(
     'owned resources cancel immediately and can detach after completion',
     () {
@@ -120,96 +252,99 @@ void main() {
     },
   );
 
-  test(
-    'profile routing records per-chat usage while retaining isolated prompts',
-    () async {
-      final cloud = MockCloudInferenceRepository();
-      final provider = testInferenceProvider();
-      final attribution = AiInteractionCaptureTestBench.create();
-      final prompts = <String>[];
-      when(
-        () => cloud.generate(
-          any(),
-          model: 'query-model',
-          temperature: 0.2,
-          baseUrl: provider.baseUrl,
-          apiKey: provider.apiKey,
-          provider: provider,
-          systemMessage: 'inspect',
-          maxCompletionTokens: any(named: 'maxCompletionTokens'),
-          geminiThinkingMode: any(named: 'geminiThinkingMode'),
-          impactCollector: any(named: 'impactCollector'),
-        ),
-      ).thenAnswer((call) {
-        prompts.add(call.positionalArguments.first as String);
-        return Stream.fromIterable([
-          const CreateChatCompletionStreamResponse(
-            id: 'chunk',
-            object: 'chat.completion.chunk',
-            created: 0,
-            choices: [
-              ChatCompletionStreamResponseChoice(
-                index: 0,
-                delta: ChatCompletionStreamResponseDelta(
-                  content: '{"passages":[]}',
+  for (final synthesis in [false, true]) {
+    test(
+      'profile routing records usage with synthesis=$synthesis',
+      () async {
+        final cloud = MockCloudInferenceRepository();
+        final provider = testInferenceProvider();
+        final attribution = AiInteractionCaptureTestBench.create();
+        final prompts = <String>[];
+        when(
+          () => cloud.generate(
+            any(),
+            model: 'query-model',
+            temperature: 0.2,
+            baseUrl: provider.baseUrl,
+            apiKey: provider.apiKey,
+            provider: provider,
+            systemMessage: 'inspect',
+            maxCompletionTokens: any(named: 'maxCompletionTokens'),
+            geminiThinkingMode: any(named: 'geminiThinkingMode'),
+            impactCollector: any(named: 'impactCollector'),
+            preferStreaming: synthesis,
+          ),
+        ).thenAnswer((call) {
+          prompts.add(call.positionalArguments.first as String);
+          return Stream.fromIterable([
+            const CreateChatCompletionStreamResponse(
+              id: 'chunk',
+              object: 'chat.completion.chunk',
+              created: 0,
+              choices: [
+                ChatCompletionStreamResponseChoice(
+                  index: 0,
+                  delta: ChatCompletionStreamResponseDelta(
+                    content: '{"passages":[]}',
+                  ),
+                ),
+              ],
+            ),
+            const CreateChatCompletionStreamResponse(
+              id: 'usage',
+              object: 'chat.completion.chunk',
+              created: 0,
+              choices: [],
+              usage: CompletionUsage(
+                promptTokens: 60,
+                completionTokens: 15,
+                totalTokens: 75,
+                promptTokensDetails: PromptTokensDetails(cachedTokens: 10),
+                completionTokensDetails: CompletionTokensDetails(
+                  reasoningTokens: 4,
                 ),
               ),
-            ],
-          ),
-          const CreateChatCompletionStreamResponse(
-            id: 'usage',
-            object: 'chat.completion.chunk',
-            created: 0,
-            choices: [],
-            usage: CompletionUsage(
-              promptTokens: 60,
-              completionTokens: 15,
-              totalTokens: 75,
-              promptTokensDetails: PromptTokensDetails(cachedTokens: 10),
-              completionTokensDetails: CompletionTokensDetails(
-                reasoningTokens: 4,
-              ),
             ),
+          ]);
+        });
+        final inference = QueryTextInference.forProfile(
+          cloud: cloud,
+          profile: ResolvedProfile(
+            thinkingModelId: 'query-model',
+            thinkingProvider: provider,
+            thinkingModel: testAiModel(id: 'query-config'),
           ),
+          agentId: 'agent',
+          chatId: 'chat',
+          taskId: 'task',
+          categoryId: 'category',
+          capture: attribution.capture,
+        );
+        expect(
+          await inference.complete(
+            system: 'inspect',
+            input: {'source': 'Only this meeting'},
+            cancellation: QueryCancellation(),
+            onAnswerText: synthesis ? (_) {} : null,
+          ),
+          {'passages': <Object>[]},
+        );
+        expect(prompts, [
+          jsonEncode({'source': 'Only this meeting'}),
         ]);
-      });
-      final inference = QueryTextInference.forProfile(
-        cloud: cloud,
-        profile: ResolvedProfile(
-          thinkingModelId: 'query-model',
-          thinkingProvider: provider,
-          thinkingModel: testAiModel(id: 'query-config'),
-        ),
-        agentId: 'agent',
-        chatId: 'chat',
-        taskId: 'task',
-        categoryId: 'category',
-        capture: attribution.capture,
-      );
-      expect(
-        await inference.complete(
-          system: 'inspect',
-          input: {'source': 'Only this meeting'},
-          cancellation: QueryCancellation(),
-        ),
-        {'passages': <Object>[]},
-      );
-      expect(prompts, [
-        jsonEncode({'source': 'Only this meeting'}),
-      ]);
-      final event = attribution.recordedInteractions.single;
-      expect(event.providerModelId, 'query-model');
-      expect(event.configId, provider.id);
-      expect(event.modelId, 'query-config');
-      expect(event.agentId, 'agent');
-      expect(event.threadId, 'chat');
-      expect(event.inputTokens, 60);
-      expect(event.outputTokens, 15);
-      expect(event.cachedInputTokens, 10);
-      expect(event.thoughtsTokens, 4);
-    },
-  );
-
+        final event = attribution.recordedInteractions.single;
+        expect(event.providerModelId, 'query-model');
+        expect(event.configId, provider.id);
+        expect(event.modelId, 'query-config');
+        expect(event.agentId, 'agent');
+        expect(event.threadId, 'chat');
+        expect(event.inputTokens, 60);
+        expect(event.outputTokens, 15);
+        expect(event.cachedInputTokens, 10);
+        expect(event.thoughtsTokens, 4);
+      },
+    );
+  }
   test(
     'oversized and failed streams reject the response and release subscriptions',
     () async {

--- a/test/features/agents/ui/query/query_chat_pane_test.dart
+++ b/test/features/agents/ui/query/query_chat_pane_test.dart
@@ -585,6 +585,71 @@ void main() {
     await tester.pump();
   }
 
+  for (final retracted in [false, true]) {
+    testWidgets('query synthesis provisional retracted=$retracted is honest', (
+      tester,
+    ) async {
+      events.add(
+        event(
+          'question',
+          'feeder',
+          const QueryChatEventData.question(text: 'What was recorded?'),
+        ),
+      );
+      if (retracted) {
+        events.add(
+          event(
+            'failure',
+            'feeder',
+            const QueryChatEventData.failed(questionId: 'question'),
+          ),
+        );
+      }
+      await pump(
+        tester,
+        session: QueryChatSession(
+          selectedId: 'feeder',
+          chats: {
+            'feeder': QueryChatLocal(
+              status: retracted
+                  ? QueryTurnStatus.failed
+                  : QueryTurnStatus.running,
+              answering: true,
+              requestQuestionId: 'question',
+              draftRetracted: retracted,
+              provisional: retracted
+                  ? null
+                  : const QueryChatAnswer(
+                      questionId: 'question',
+                      text: 'Recorded 37 penguins [1]',
+                      coverage: QueryCoverage(checked: 1),
+                    ),
+            ),
+          },
+        ),
+      );
+      if (retracted) {
+        expect(
+          find.text('The draft answer could not be verified. Try again.'),
+          findsOneWidget,
+        );
+        expect(find.text('Recorded 37 penguins [1]'), findsNothing);
+        expect(find.text('Try Again'), findsOneWidget);
+      } else {
+        expect(find.text('Draft · not yet verified'), findsOneWidget);
+        expect(
+          tester
+              .widget<SelectableText>(
+                find.byKey(const ValueKey('query-provisional-question')),
+              )
+              .data,
+          'Recorded 37 penguins [1]',
+        );
+        expect(find.byType(AgentMarkdownView), findsNothing);
+      }
+    });
+  }
+
   for (final answering in [false, true]) {
     testWidgets(
       'query activity reports the actual answering=$answering phase',

--- a/test/features/ai/eval/penguin_query_eval_live_test.dart
+++ b/test/features/ai/eval/penguin_query_eval_live_test.dart
@@ -113,6 +113,7 @@ void main() {
       final answers = <String, QueryBuiltAnswer>{};
       final questionEvents = <String, AgentQueryChatEventEntity>{};
       final homeOnly = env['QUERY_EVAL_HOME_ONLY'] == '1';
+      final streamSynthesis = env['QUERY_EVAL_STREAM_SYNTHESIS'] == '1';
       final legacyFlow = env['QUERY_EVAL_LEGACY_FLOW'] == '1';
       final batchInputBytes = legacyFlow
           ? 1
@@ -213,9 +214,11 @@ void main() {
           'case': scenario.id,
           'question': scenario.question,
           'memoryCandidateCount': turn.memories.length,
+          'streamSynthesis': streamSynthesis,
           'calls': measured.calls,
         };
         artifacts.add(artifact);
+        var streamedText = '';
         var checked = 0;
         var authorizationFailed = false;
         try {
@@ -244,6 +247,21 @@ void main() {
                 onProgress: (count, {required expanded}) {
                   checked = count;
                 },
+                onFirstSynthesisToken: () {
+                  artifact['firstSynthesisTokenMs'] =
+                      clock.elapsedMicroseconds / 1000;
+                },
+                onAnswerText: !streamSynthesis
+                    ? null
+                    : (text) {
+                        if (text.isNotEmpty) {
+                          artifact.putIfAbsent(
+                            'firstVisibleAnswerMs',
+                            () => clock.elapsedMicroseconds / 1000,
+                          );
+                        }
+                        streamedText = text;
+                      },
                 onAnswering: () {
                   artifact['answeringStartsMs'] =
                       clock.elapsedMicroseconds / 1000;
@@ -260,6 +278,8 @@ void main() {
             r'\[(\d+)\]',
           ).allMatches(answer.text).map((m) => int.parse(m.group(1)!)).toList();
           final checks = <String, bool>{
+            if (streamSynthesis)
+              'streamedAnswerUnchanged': streamedText == answer.text,
             'answerFacts': scenario.answerTerms.every(
               (terms) => containsAnyEvalTerm(answer.text, terms),
             ),

--- a/test/features/ai/eval/penguin_query_eval_test.dart
+++ b/test/features/ai/eval/penguin_query_eval_test.dart
@@ -14,6 +14,30 @@ void main() {
   setUp(setUpTestGetIt);
   tearDown(tearDownTestGetIt);
 
+  test('measurement forwards synthesis text and first-token events', () async {
+    final measured = MeasuredQueryInference(
+      QueryTextInference(
+        generate: (_, _) =>
+            Stream.fromIterable(['{"answer":"recorded', ' [1]"}']),
+      ),
+    );
+    final shown = <String>[];
+    var tokens = 0;
+    final result = await measured.complete(
+      system: 'Answer from the supplied evidence',
+      input: {},
+      cancellation: QueryCancellation(),
+      onAnswerText: shown.add,
+      onFirstToken: () => tokens++,
+    );
+    expect(shown, ['recorded', 'recorded [1]']);
+    expect(tokens, 1);
+    expect(result['answer'], shown.last);
+    expect(measured.calls.single['firstTokenMs'], isA<num>());
+    expect(measured.calls.single['milliseconds'], isA<num>());
+    expect(measured.calls.single['stage'], 'answer');
+  });
+
   test('eval credentials require HTTPS except on explicit loopback hosts', () {
     for (final endpoint in [
       'https://inference.example/v1',

--- a/test/features/ai/eval/support/penguin_query_eval.dart
+++ b/test/features/ai/eval/support/penguin_query_eval.dart
@@ -171,6 +171,8 @@ class MeasuredQueryInference implements QueryTextInference {
     required String system,
     required Map<String, Object?> input,
     required QueryCancellation cancellation,
+    void Function(String)? onAnswerText,
+    void Function()? onFirstToken,
   }) async {
     if (calls.length >= 12) {
       throw StateError('Query eval completion cap reached');
@@ -200,6 +202,11 @@ class MeasuredQueryInference implements QueryTextInference {
         system: system,
         input: input,
         cancellation: cancellation,
+        onAnswerText: onAnswerText,
+        onFirstToken: () {
+          record['firstTokenMs'] = clock.elapsedMicroseconds / 1000;
+          onFirstToken?.call();
+        },
       );
       record['outputCharacters'] = jsonEncode(result).length;
       record['status'] = 'complete';

--- a/test/features/ai/repository/cloud_inference_generate_test.dart
+++ b/test/features/ai/repository/cloud_inference_generate_test.dart
@@ -27,6 +27,7 @@ class _FakeMeliousInferenceRepository extends MeliousInferenceRepository {
           String model,
           String baseUrl,
           ReasoningEffort? reasoningEffort,
+          bool preferStreaming,
         })
       >[];
   final imageCalls =
@@ -45,12 +46,14 @@ class _FakeMeliousInferenceRepository extends MeliousInferenceRepository {
     ChatCompletionToolChoiceOption? toolChoice,
     ReasoningEffort? reasoningEffort,
     InferenceImpactCollector? impactCollector,
+    bool preferStreaming = false,
   }) {
     textCalls.add((
       prompt: prompt,
       model: model,
       baseUrl: baseUrl,
       reasoningEffort: reasoningEffort,
+      preferStreaming: preferStreaming,
     ));
     return Stream.value(_chunk('melious text'));
   }
@@ -369,11 +372,13 @@ void main() {
             systemMessage: 'be brief',
             maxCompletionTokens: 512,
             reasoningEffort: ReasoningEffort.high,
+            preferStreaming: true,
           )
           .toList();
 
       expect(chunks.single.choices?.single.delta?.content, 'melious text');
       expect(fakeMeliousRepo.textCalls, hasLength(1));
+      expect(fakeMeliousRepo.textCalls.single.preferStreaming, isTrue);
       expect(fakeMeliousRepo.textCalls.single.prompt, prompt);
       expect(fakeMeliousRepo.textCalls.single.model, 'qwen/qwen3-vl-plus');
       expect(

--- a/test/features/ai/repository/cloud_inference_request_helpers_test.dart
+++ b/test/features/ai/repository/cloud_inference_request_helpers_test.dart
@@ -128,6 +128,26 @@ void main() {
   });
 
   group('filterAnthropicPings', () {
+    test('listens lazily and cancels the owned idle source', () async {
+      var listened = false;
+      var cancelled = false;
+      var closed = 0;
+      final source = StreamController<CreateChatCompletionStreamResponse>(
+        onListen: () => listened = true,
+        onCancel: () => cancelled = true,
+      );
+      final stream = helpers.filterAnthropicPings(
+        source.stream,
+        onClose: () => closed++,
+      );
+      expect(listened, isFalse);
+      final subscription = stream.listen((_) {});
+      expect(listened, isTrue);
+      await subscription.cancel();
+      expect(cancelled, isTrue);
+      expect(closed, 1);
+      await source.close();
+    });
     test('swallows Anthropic ping errors and keeps valid chunks', () async {
       final source = Stream<CreateChatCompletionStreamResponse>.multi((c) {
         c

--- a/test/features/ai/repository/cloud_inference_request_helpers_test.dart
+++ b/test/features/ai/repository/cloud_inference_request_helpers_test.dart
@@ -128,6 +128,30 @@ void main() {
   });
 
   group('filterAnthropicPings', () {
+    test('pause and resume reach the upstream subscription', () async {
+      var paused = false;
+      var resumed = false;
+      final source = StreamController<CreateChatCompletionStreamResponse>(
+        onPause: () => paused = true,
+        onResume: () => resumed = true,
+      );
+      final received = Completer<CreateChatCompletionStreamResponse>();
+      final subscription =
+          helpers.filterAnthropicPings(source.stream).listen(received.complete)
+            ..pause();
+      expect(paused, isTrue);
+      source.add(chunk('resumed answer'));
+      expect(received.isCompleted, isFalse);
+      subscription.resume();
+      expect(
+        (await received.future).choices?.single.delta?.content,
+        'resumed answer',
+      );
+      expect(resumed, isTrue);
+      await subscription.cancel();
+      await source.close();
+    });
+
     test('listens lazily and cancels the owned idle source', () async {
       var listened = false;
       var cancelled = false;

--- a/test/features/ai/repository/melious_inference_repository_test.dart
+++ b/test/features/ai/repository/melious_inference_repository_test.dart
@@ -19,6 +19,8 @@ import 'package:lotti/features/ai/util/image_processing_utils.dart';
 import 'package:lotti/features/ai_consumption/model/ai_attribution.dart';
 import 'package:lotti/features/ai_consumption/model/ai_consumption_enums.dart';
 import 'package:openai_dart/openai_dart.dart';
+// The SDK exception requires an enum omitted from its public barrel.
+import 'package:openai_dart/src/generated/client.dart' show HttpMethod;
 
 import '../../../helpers/fallbacks.dart';
 import '../../ai_consumption/test_utils.dart';
@@ -630,6 +632,165 @@ void main() {
         expect(models.single.isReasoningModel, isTrue);
       },
     );
+
+    test(
+      'preferred streaming retains collector and cancels before first token',
+      () async {
+        var stopped = false;
+        CreateChatCompletionRequest? sent;
+        final source = StreamController<CreateChatCompletionStreamResponse>(
+          onCancel: () => stopped = true,
+        );
+        final repository = MeliousInferenceRepository(
+          httpClient: MockClient(
+            (_) async => http.Response('{"choices":[]}', 200),
+          ),
+          chatCompletionStreamFactory:
+              ({required baseUrl, required apiKey, required request}) {
+                sent = request;
+                return source.stream;
+              },
+        );
+        addTearDown(repository.close);
+        final impact = InferenceImpactCollector();
+        final subscription = repository
+            .generateText(
+              prompt: 'synthetic',
+              model: 'deepseek-v4.1-flash',
+              baseUrl: baseUrl,
+              apiKey: apiKey,
+              preferStreaming: true,
+              impactCollector: impact,
+            )
+            .listen((_) {});
+        expect(sent?.stream, isTrue);
+        expect(sent?.streamOptions?.includeUsage, isTrue);
+        await subscription.cancel();
+        expect(stopped, isTrue);
+        expect(impact.impact, isNull);
+        await source.close();
+      },
+    );
+
+    test(
+      'explicit stream rejection falls back with the identical model',
+      () async {
+        final requests = <Map<String, dynamic>>[];
+        final repository = MeliousInferenceRepository(
+          httpClient: MockClient((request) async {
+            requests.add(jsonDecode(request.body) as Map<String, dynamic>);
+            return http.Response(
+              jsonEncode({
+                'choices': [
+                  {
+                    'message': {'content': 'Recorded [1]'},
+                  },
+                ],
+              }),
+              200,
+            );
+          }),
+          chatCompletionStreamFactory:
+              ({required baseUrl, required apiKey, required request}) =>
+                  Stream.error(
+                    OpenAIClientException(
+                      message: 'unsupported',
+                      uri: Uri.parse(baseUrl),
+                      method: HttpMethod.post,
+                      code: 400,
+                      body: {
+                        'error': {'param': 'stream'},
+                      },
+                    ),
+                  ),
+        );
+        addTearDown(repository.close);
+        final chunks = await repository
+            .generateText(
+              prompt: 'synthetic',
+              model: 'glm-5.3-flash',
+              baseUrl: baseUrl,
+              apiKey: apiKey,
+              preferStreaming: true,
+              impactCollector: InferenceImpactCollector(),
+            )
+            .toList();
+        expect(chunks.first.choices?.first.delta?.content, 'Recorded [1]');
+        expect(requests.single['model'], 'glm-5.3-flash');
+        expect(requests.single['stream'], isFalse);
+      },
+    );
+
+    for (final shape in [
+      'overload',
+      'other parameter',
+      'invalid body',
+      'no detail',
+      'partial',
+      'sync error',
+    ]) {
+      test('stream failure $shape never silently reruns inference', () async {
+        var bufferedCalls = 0;
+        final error = shape == 'sync error'
+            ? StateError('synthetic failure')
+            : OpenAIClientException(
+                message: 'synthetic failure',
+                uri: Uri.parse(baseUrl),
+                method: HttpMethod.post,
+                code: shape == 'overload' ? 503 : 400,
+                body: switch (shape) {
+                  'other parameter' => {
+                    'error': {'param': 'model'},
+                  },
+                  'invalid body' => 'invalid JSON',
+                  'no detail' => <String, dynamic>{},
+                  _ => {
+                    'error': {'param': 'stream'},
+                  },
+                },
+              );
+        final repository = MeliousInferenceRepository(
+          httpClient: MockClient((_) async {
+            bufferedCalls++;
+            return http.Response('{}', 200);
+          }),
+          chatCompletionStreamFactory:
+              ({required baseUrl, required apiKey, required request}) {
+                if (error is StateError) throw error;
+                return Stream.multi((controller) {
+                  if (shape == 'partial') {
+                    controller.add(
+                      const CreateChatCompletionStreamResponse(
+                        id: 'partial',
+                        object: 'chat.completion.chunk',
+                        created: 0,
+                        choices: [],
+                      ),
+                    );
+                  }
+                  controller
+                    ..addError(error)
+                    ..close();
+                });
+              },
+        );
+        addTearDown(repository.close);
+        await expectLater(
+          repository
+              .generateText(
+                prompt: 'synthetic',
+                model: 'deepseek-v4.1-flash',
+                baseUrl: baseUrl,
+                apiKey: apiKey,
+                preferStreaming: true,
+                impactCollector: InferenceImpactCollector(),
+              )
+              .toList(),
+          throwsA(same(error)),
+        );
+        expect(bufferedCalls, 0);
+      });
+    }
 
     test('generateText streams text and sends prompt request body', () async {
       final probe = _ChatStreamProbe(content: 'melious response');

--- a/test/features/ai/repository/melious_inference_repository_test.dart
+++ b/test/features/ai/repository/melious_inference_repository_test.dart
@@ -818,6 +818,7 @@ void main() {
       final request = probe.requests.single;
       expect(request.model.toString(), contains('minimax-m2.7'));
       expect(request.stream, isTrue);
+      expect(request.streamOptions, isNull);
       expect(request.temperature, 0.2);
       expect(request.maxCompletionTokens, 128);
       expect(request.messages, hasLength(2));

--- a/test/features/ai/repository/melious_inference_repository_test.dart
+++ b/test/features/ai/repository/melious_inference_repository_test.dart
@@ -18,11 +18,13 @@ import 'package:lotti/features/ai/skills/entry_summary_tool.dart';
 import 'package:lotti/features/ai/util/image_processing_utils.dart';
 import 'package:lotti/features/ai_consumption/model/ai_attribution.dart';
 import 'package:lotti/features/ai_consumption/model/ai_consumption_enums.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
 // The SDK exception requires an enum omitted from its public barrel.
 import 'package:openai_dart/src/generated/client.dart' show HttpMethod;
 
 import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
 import '../../ai_consumption/test_utils.dart';
 
 class _ChatStreamProbe {
@@ -712,7 +714,6 @@ void main() {
               baseUrl: baseUrl,
               apiKey: apiKey,
               preferStreaming: true,
-              impactCollector: InferenceImpactCollector(),
             )
             .toList();
         expect(chunks.first.choices?.first.delta?.content, 'Recorded [1]');
@@ -791,6 +792,70 @@ void main() {
         expect(bufferedCalls, 0);
       });
     }
+
+    test(
+      'default SDK streaming decodes text and usage through the HTTP boundary',
+      () async {
+        final sent = <Map<String, dynamic>>[];
+        final transport = MockClient((request) async {
+          sent.add(jsonDecode(request.body) as Map<String, dynamic>);
+          return http.Response(
+            'data: ${jsonEncode({
+              'id': 'synthetic-stream',
+              'object': 'chat.completion.chunk',
+              'created': 0,
+              'model': 'glm-5.3',
+              'choices': [
+                {
+                  'index': 0,
+                  'delta': {'content': 'Recorded penguins'},
+                },
+              ],
+            })}\n\n'
+            'data: ${jsonEncode({
+              'id': 'synthetic-stream',
+              'object': 'chat.completion.chunk',
+              'created': 0,
+              'model': 'glm-5.3',
+              'choices': <Object?>[],
+              'usage': {'prompt_tokens': 8, 'completion_tokens': 2, 'total_tokens': 10},
+            })}\n\ndata: [DONE]\n\n',
+            200,
+            headers: {'content-type': 'text/event-stream'},
+          );
+        });
+        final repository = MeliousInferenceRepository(httpClient: transport);
+        addTearDown(repository.close);
+        final sdkClient = MockHttpClient();
+        when(() => sdkClient.send(any())).thenAnswer(
+          (call) => transport.send(
+            call.positionalArguments.single as http.BaseRequest,
+          ),
+        );
+        final chunks = await http.runWithClient(
+          () => repository
+              .generateText(
+                prompt: 'Synthetic penguin question',
+                model: 'glm-5.3',
+                baseUrl: baseUrl,
+                apiKey: apiKey,
+                preferStreaming: true,
+                impactCollector: InferenceImpactCollector(),
+              )
+              .toList(),
+          () => sdkClient,
+        );
+        expect(
+          chunks.first.choices?.single.delta?.content,
+          'Recorded penguins',
+        );
+        expect(chunks.last.usage?.totalTokens, 10);
+        expect(sent.single['stream'], isTrue);
+        expect(sent.single['stream_options'], {'include_usage': true});
+        expect(sent.single['model'], 'glm-5.3');
+        verify(sdkClient.close).called(1);
+      },
+    );
 
     test('generateText streams text and sends prompt request body', () async {
       final probe = _ChatStreamProbe(content: 'melious response');

--- a/test/helpers/fallbacks.dart
+++ b/test/helpers/fallbacks.dart
@@ -4,6 +4,7 @@ import 'dart:ui' show Locale;
 
 import 'package:a2ui_core/a2ui_core.dart' show CreateSurfaceMessage;
 import 'package:drift/drift.dart' as drift;
+import 'package:http/http.dart' as http;
 import 'package:lotti/classes/check_in_data.dart';
 import 'package:lotti/classes/checklist_data.dart';
 import 'package:lotti/classes/checklist_item_data.dart';
@@ -249,6 +250,7 @@ FutureOr<AgentStateEntity?> _fallbackAgentStateUpdate(
 /// `registerFallbackValue()` calls across test files. Safe to call multiple
 /// times — mocktail deduplicates internally.
 void registerAllFallbackValues() {
+  registerFallbackValue(http.Request('GET', Uri.parse('https://example.test')));
   // Sealed union / abstract class fallbacks (need real instances)
   registerFallbackValue(fallbackJournalEntity);
   registerFallbackValue(fallbackProjectEntry);

--- a/tool/penguin_query_eval.py
+++ b/tool/penguin_query_eval.py
@@ -78,6 +78,7 @@ def main():
     parser.add_argument("--output", required=True, type=Path, help="JSON artifact outside the repository")
     parser.add_argument("--cases", default="local,follow_up,wider_category,absent,category_boundary")
     parser.add_argument("--home-only", action="store_true")
+    parser.add_argument("--stream-synthesis", action="store_true")
     parser.add_argument("--legacy-flow", action="store_true", help="Force the original preview/window path for a matched control")
     parser.add_argument("--variant", required=True, help="Explicit code/comparison variant")
     args = parser.parse_args()
@@ -112,6 +113,7 @@ def main():
         "QUERY_EVAL_VARIANT": args.variant,
         "QUERY_EVAL_LEGACY_FLOW": "1" if args.legacy_flow else "0",
         "QUERY_EVAL_PYTHON": sys.executable,
+        "QUERY_EVAL_STREAM_SYNTHESIS": "1" if args.stream_synthesis else "0",
     })
     output.parent.mkdir(parents=True, exist_ok=True)
     # Keep compiler/provider output beside the synthetic artifact; credentials

--- a/tool/penguin_query_eval_test.py
+++ b/tool/penguin_query_eval_test.py
@@ -55,6 +55,14 @@ class PenguinQueryEvalTest(unittest.TestCase):
         self.assertEqual(kwargs["env"]["QUERY_EVAL_OUTPUT"], str(self.output))
         process.wait.assert_called_once_with(timeout=900)
 
+    def test_streaming_control_is_explicit(self):
+        self.args.append("--stream-synthesis")
+        process = Mock(pid=12345)
+        process.wait.return_value = 0
+        result, start = self.run_main(process)
+        self.assertEqual(result, 0)
+        self.assertEqual(start.call_args.kwargs["env"]["QUERY_EVAL_STREAM_SYNTHESIS"], "1")
+
     def test_legacy_control_is_explicit(self):
         self.args.append("--legacy-flow")
         process = Mock(pid=12345)


### PR DESCRIPTION
Query chat previously waited for the complete synthesis response before showing any answer. It now displays decoded answer text as a clearly marked provisional draft, then replaces it with the saved answer and evidence after validation. Invalid drafts are removed with Retry beside the original question.

- Stream only the answer field; keep reasoning, inspection output and shared conclusions out of the preview. Draft citations and URLs stay inactive.
- Preserve per-chat cancellation, current visibility checks, deletion/forgetting rules and transactional publication. Retain the draft during the handoff to persisted history.
- Request streaming for synthesis while source inspection remains buffered. Melious falls back once to the same model only for an explicit initial rejection of a streaming parameter. Cancellation closes owned upstream requests.
- Record first synthesis token and first visible answer timings in the penguin evaluation. This PR makes no measured end-to-end speedup claim; retrieval batching shipped separately in #4238. Streaming Melious cost/energy fields remain unavailable when omitted by the provider.

Validation: 220 targeted Dart tests and 10 Python tests passed; full Dart MCP analysis is clean. Existing reversal checks cover decoding, cancellation, routing, privacy, provisional/retraction rendering and evaluation forwarding. After review and coverage follow-ups, the three affected test files pass 141 tests; reversal checks also cover delayed publication, deletion, forgotten memory, source moves, access failures, pause/resume and SDK client cleanup. Full tests, coverage and platform builds run in CI.

Screenshots use shared synthetic fixtures and penguin content. Eight before/after pairs cover provisional synthesis and verification failure on mobile/desktop in both themes. Seeded UI states demonstrate presentation, not live provider performance.

| State | Before | After |
|---|---|---|
| desktop dark retracted | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/before/query_desktop_dark_retracted.png) | [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/after/query_desktop_dark_retracted.png) |
| desktop dark streaming | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/before/query_desktop_dark_streaming.png) | [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/after/query_desktop_dark_streaming.png) |
| desktop light retracted | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/before/query_desktop_light_retracted.png) | [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/after/query_desktop_light_retracted.png) |
| desktop light streaming | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/before/query_desktop_light_streaming.png) | [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/after/query_desktop_light_streaming.png) |
| mobile dark retracted | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/before/query_mobile_dark_retracted.png) | [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/after/query_mobile_dark_retracted.png) |
| mobile dark streaming | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/before/query_mobile_dark_streaming.png) | [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/after/query_mobile_dark_streaming.png) |
| mobile light retracted | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/before/query_mobile_light_retracted.png) | [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/after/query_mobile_light_retracted.png) |
| mobile light streaming | [Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/before/query_mobile_light_streaming.png) | [After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/after/query_mobile_light_streaming.png) |

| Mobile synthesis before | Mobile synthesis after |
|---|---|
| ![Before](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/before/query_mobile_dark_streaming.png) | ![After](https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-synthesis-streaming/9cf13810c29d6e0478732e36d394980d4cfa1204/after/query_mobile_dark_streaming.png) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query answers now appear progressively while being generated and are clearly labeled as unverified drafts.
  * Drafts are removed when verification fails, with an option to retry.
  * Canceling a query stops the active response stream.
  * Drafts remain privacy-aware and are cleared when access or required source information changes.
* **Localization**
  * Added draft-status messages across supported languages.
* **Documentation**
  * Documented streaming behavior, verification states, fallback handling, and evaluation metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->