### PR TITLE
fix: raise digest output limit to 16K and log usage above 4K

### DIFF
--- a/changelog.d/2026-09-12-digest-output-budget.md
+++ b/changelog.d/2026-09-12-digest-output-budget.md
@@ -1,0 +1,3 @@
+### Fixed
+- **Daily digests have more room to finish.** Raised the response limit from
+  4,096 to 16,384 tokens to reduce failures caused by truncated responses.

--- a/knowledge/features/daily_os_next/evaluation.md
+++ b/knowledge/features/daily_os_next/evaluation.md
@@ -864,17 +864,17 @@ Historical pre-ceiling Melious full journeys established the positive-path
 output distribution before choosing caps. The capped GLM/Qwen run on 2026-07-29
 then observed successful provider turns at:
 
-| Wake | Observed successful output tokens | Ceiling |
+| Wake | Observed successful output tokens | Ceiling on 2026-07-29 |
 |---|---:|---:|
 | Parse | 511–1,640 | 4,096 |
 | Draft | 571–2,173 | 8,192 |
 | Digest | 122–1,553 | 4,096 |
 | Refine | 73 in the deterministic full-workflow fixture | 4,096 |
 
-The draft ceiling deliberately leaves the most headroom because a complete plan
-is the largest artifact. Ceiling enforcement is per provider turn; a multi-turn
-digest may legitimately use more than 4,096 tokens in total while no individual
-response can run away.
+These are historical limits; current ceilings are documented in
+[wake context and prompt](wake-prompt.md#the-system-prompt-matches-the-wake-mode).
+Ceiling enforcement is per provider turn, so a multi-turn digest may legitimately
+use more tokens in total while each individual response remains bounded.
 
 Using nearest-rank percentiles over the available realistic full-journey
 reports, pre-limit versus current capped-stack total wake p50/p95 was

--- a/knowledge/features/daily_os_next/wake-prompt.md
+++ b/knowledge/features/daily_os_next/wake-prompt.md
@@ -15,7 +15,7 @@ sources:
   - id: inference-boundaries
     resource: ../../../lib/features/daily_os_next/agents/workflow/day_agent_workflow_models.dart
     title: Per-mode inference deadlines and output ceilings
-    last_modified: 2026-07-29
+    last_modified: 2026-09-12
   - id: sections
     resource: ../../../lib/features/daily_os_next/agents/prompt/day_agent_prompt_sections.dart
     title: Prompt section tags
@@ -79,13 +79,22 @@ Every provider turn also receives a mode-specific output ceiling:
 | Capture parse | 4,096 |
 | Day draft | 8,192 |
 | Refine | 4,096 |
-| Coordinator digest | 4,096 |
+| Coordinator digest | 16,384 |
 | Other day-agent wake | 4,096 |
 
 The draft ceiling is larger because its terminal tool serializes the complete
-block list. The others produce smaller artifacts. These are injected through
+block list. Digests receive extra headroom after repeated truncation at the
+previous ceiling. The others produce smaller artifacts. These are injected through
 `DayAgentOutputTokenBudgetPolicy`, then clamped around the resolved provider
 repository, so a caller may request less but cannot bypass the Daily OS maximum.
+
+When reported effective completion usage exceeds 4,096 tokens, the wrapper logs
+one `outputBudget` entry in `agentWorkflow` per provider turn. It records the
+wake kind, peak completion and reasoning counts, effective total, threshold, and
+applied ceiling, without response content. Gemini reasoning is added to its
+completion count; OpenAI-compatible totals already include it. Duplicate usage
+chunks are not summed, and a later stream failure still logs any reported peak.
+The usual domain logging flag controls these diagnostic entries.
 
 A response ending with `finish_reason: length` is truncated. Providers that omit
 that reason are treated the same when reported completion usage reaches the

--- a/knowledge/features/daily_os_next/wake-prompt.md
+++ b/knowledge/features/daily_os_next/wake-prompt.md
@@ -86,7 +86,9 @@ The draft ceiling is larger because its terminal tool serializes the complete
 block list. Digests receive extra headroom after repeated truncation at the
 previous ceiling. The others produce smaller artifacts. These are injected through
 `DayAgentOutputTokenBudgetPolicy`, then clamped around the resolved provider
-repository, so a caller may request less but cannot bypass the Daily OS maximum.
+repository. A lower `AiConfigModel.maxCompletionTokens` on the selected thinking
+model further reduces the ceiling; callers can request less but cannot bypass
+either maximum.
 
 When reported effective completion usage exceeds 4,096 tokens, the wrapper logs
 one `outputBudget` entry in `agentWorkflow` per provider turn. It records the

--- a/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
@@ -558,6 +558,7 @@ class DayAgentWorkflow {
         delegate: cloudInferenceRepo,
         wakeKind: wakeKind,
         maxCompletionTokens: outputTokenBudgets.forKind(wakeKind),
+        domainLogger: domainLogger,
       );
       inferenceRepo = DayAgentTimeoutInferenceRepository(
         delegate: outputBudgetRepo,

--- a/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math' as math;
 
 import 'package:clock/clock.dart';
 import 'package:lotti/classes/day_agent_identity.dart';
@@ -557,7 +558,11 @@ class DayAgentWorkflow {
       final outputBudgetRepo = DayAgentOutputBudgetInferenceRepository(
         delegate: cloudInferenceRepo,
         wakeKind: wakeKind,
-        maxCompletionTokens: outputTokenBudgets.forKind(wakeKind),
+        maxCompletionTokens: math.min(
+          outputTokenBudgets.forKind(wakeKind),
+          resolvedProfile.thinkingModel?.maxCompletionTokens ??
+              outputTokenBudgets.forKind(wakeKind),
+        ),
         domainLogger: domainLogger,
       );
       inferenceRepo = DayAgentTimeoutInferenceRepository(

--- a/lib/features/daily_os_next/agents/workflow/day_agent_workflow_models.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_workflow_models.dart
@@ -11,6 +11,7 @@ import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/gemini_tool_call.dart';
 import 'package:lotti/features/ai/repository/inference_repository_interface.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_reconcile_models.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:openai_dart/openai_dart.dart';
 import 'package:uuid/uuid.dart';
 
@@ -48,8 +49,9 @@ class DayAgentInferenceTimeoutPolicy {
 
 /// Per-provider-turn output ceilings selected from measured Daily OS wakes.
 ///
-/// Drafts receive more headroom because they serialize a complete block list.
-/// Capture, refine, and digest turns produce smaller bounded artifacts. The
+/// Drafts receive more headroom because they serialize a complete block list;
+/// digests receive additional headroom after repeated output-limit failures.
+/// Capture, refine, and general turns produce smaller bounded artifacts. The
 /// policy is injected into the day-agent workflow, so tests and future provider
 /// profiles can tune it without bypassing the truncation safety boundary.
 class DayAgentOutputTokenBudgetPolicy {
@@ -57,7 +59,7 @@ class DayAgentOutputTokenBudgetPolicy {
     this.capture = 4096,
     this.draft = 8192,
     this.refine = 4096,
-    this.digest = 4096,
+    this.digest = 16384,
     this.general = 4096,
   });
 
@@ -99,12 +101,15 @@ class DayAgentOutputLimitExceededException implements Exception {
 /// adapters can omit that signal, so reported completion usage at the ceiling
 /// is treated equivalently. The error is emitted only after the provider stream
 /// ends, before the conversation repository can execute a collected tool call.
+/// Reported usage above 4,096 tokens is logged once per provider turn, including
+/// when the stream fails after reporting usage, without recording its content.
 class DayAgentOutputBudgetInferenceRepository
     implements InferenceRepositoryInterface {
   DayAgentOutputBudgetInferenceRepository({
     required this.delegate,
     required this.wakeKind,
     required this.maxCompletionTokens,
+    this.domainLogger,
   }) {
     if (maxCompletionTokens <= 0) {
       throw ArgumentError.value(
@@ -118,6 +123,9 @@ class DayAgentOutputBudgetInferenceRepository
   final InferenceRepositoryInterface delegate;
   final DayAgentWakeKind wakeKind;
   final int maxCompletionTokens;
+  final DomainLogger? domainLogger;
+
+  static const _outputLoggingThreshold = 4096;
 
   int _effectiveLimit(int? requested) =>
       requested == null || requested > maxCompletionTokens
@@ -130,28 +138,54 @@ class DayAgentOutputBudgetInferenceRepository
     InferenceProviderType providerType,
   ) async* {
     var reachedLimit = false;
-    await for (final response in source) {
-      final choices = response.choices;
-      if (choices != null &&
-          choices.any(
-            (choice) =>
-                choice.finishReason == ChatCompletionFinishReason.length,
-          )) {
-        reachedLimit = true;
+    var peakCompletionTokens = 0;
+    var peakReasoningTokens = 0;
+    var peakEffectiveTokens = 0;
+    try {
+      await for (final response in source) {
+        final choices = response.choices;
+        if (choices != null &&
+            choices.any(
+              (choice) =>
+                  choice.finishReason == ChatCompletionFinishReason.length,
+            )) {
+          reachedLimit = true;
+        }
+        final usage = response.usage;
+        final completionTokens = usage?.completionTokens;
+        final reasoningTokens =
+            usage?.completionTokensDetails?.reasoningTokens ?? 0;
+        final effectiveCompletionTokens = completionTokens == null
+            ? null
+            : completionTokens +
+                  (providerType == InferenceProviderType.gemini
+                      ? reasoningTokens
+                      : 0);
+        if (effectiveCompletionTokens != null &&
+            effectiveCompletionTokens >= effectiveLimit) {
+          reachedLimit = true;
+        }
+        if (effectiveCompletionTokens != null &&
+            effectiveCompletionTokens > peakEffectiveTokens) {
+          peakCompletionTokens = completionTokens!;
+          peakReasoningTokens = reasoningTokens;
+          peakEffectiveTokens = effectiveCompletionTokens;
+        }
+        yield response;
       }
-      final usage = response.usage;
-      final completionTokens = usage?.completionTokens;
-      final effectiveCompletionTokens = completionTokens == null
-          ? null
-          : completionTokens +
-                (providerType == InferenceProviderType.gemini
-                    ? usage?.completionTokensDetails?.reasoningTokens ?? 0
-                    : 0);
-      if (effectiveCompletionTokens != null &&
-          effectiveCompletionTokens >= effectiveLimit) {
-        reachedLimit = true;
+    } finally {
+      if (peakEffectiveTokens > _outputLoggingThreshold) {
+        domainLogger?.log(
+          LogDomain.agentWorkflow,
+          'high output usage: wakeKind=${wakeKind.name} '
+          'completionTokens=$peakCompletionTokens '
+          'reasoningTokens=$peakReasoningTokens '
+          'effectiveCompletionTokens=$peakEffectiveTokens '
+          'threshold=$_outputLoggingThreshold '
+          'maxCompletionTokens=$effectiveLimit',
+          subDomain: 'outputBudget',
+        );
       }
-      yield response;
     }
     if (reachedLimit) {
       throw DayAgentOutputLimitExceededException(

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_coordination_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_coordination_test.dart
@@ -978,6 +978,7 @@ void main() {
             timeoutRepo.delegate as DayAgentOutputBudgetInferenceRepository;
         expect(outputBudget.wakeKind, DayAgentWakeKind.digest);
         expect(outputBudget.maxCompletionTokens, 2304);
+        expect(outputBudget.domainLogger, same(domainLogger));
       });
 
       test('re-arms the next digest when provider execution fails', () async {

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_coordination_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_coordination_test.dart
@@ -953,33 +953,52 @@ void main() {
         });
       });
 
-      test('uses the configured digest output ceiling', () async {
-        final result = await executeDigest(
-          workflow(
-            directiveService: directiveService,
-            outputTokenBudgets: const DayAgentOutputTokenBudgetPolicy(
-              digest: 2304,
+      for (final (modelLimit, wakeLimit, expectedLimit) in [
+        (null, 2304, 2304),
+        (8192, 16384, 8192),
+        (32768, 16384, 16384),
+      ]) {
+        test('uses the configured digest output ceiling '
+            '(model $modelLimit, wake $wakeLimit)', () async {
+          when(
+            () => aiConfigRepository.getConfigsByType(AiConfigType.model),
+          ).thenAnswer(
+            (_) async => [
+              testAiModel(
+                id: 'model-day',
+                providerModelId: 'models/day',
+                inferenceProviderId: 'provider-day',
+              ).copyWith(maxCompletionTokens: modelLimit),
+            ],
+          );
+          final result = await executeDigest(
+            workflow(
+              directiveService: directiveService,
+              outputTokenBudgets: DayAgentOutputTokenBudgetPolicy(
+                digest: wakeLimit,
+              ),
             ),
-          ),
-        );
+          );
 
-        expect(result.success, isTrue, reason: result.error);
-        final inferenceRepo =
-            conversationRepository.sendMessageCalls.single.inferenceRepo;
-        expect(inferenceRepo, isA<DayAgentTimeoutInferenceRepository>());
-        final timeoutRepo = inferenceRepo as DayAgentTimeoutInferenceRepository;
-        expect(timeoutRepo.wakeKind, DayAgentWakeKind.digest);
-        expect(timeoutRepo.timeout, const Duration(seconds: 60));
-        expect(
-          timeoutRepo.delegate,
-          isA<DayAgentOutputBudgetInferenceRepository>(),
-        );
-        final outputBudget =
-            timeoutRepo.delegate as DayAgentOutputBudgetInferenceRepository;
-        expect(outputBudget.wakeKind, DayAgentWakeKind.digest);
-        expect(outputBudget.maxCompletionTokens, 2304);
-        expect(outputBudget.domainLogger, same(domainLogger));
-      });
+          expect(result.success, isTrue, reason: result.error);
+          final inferenceRepo =
+              conversationRepository.sendMessageCalls.single.inferenceRepo;
+          expect(inferenceRepo, isA<DayAgentTimeoutInferenceRepository>());
+          final timeoutRepo =
+              inferenceRepo as DayAgentTimeoutInferenceRepository;
+          expect(timeoutRepo.wakeKind, DayAgentWakeKind.digest);
+          expect(timeoutRepo.timeout, const Duration(seconds: 60));
+          expect(
+            timeoutRepo.delegate,
+            isA<DayAgentOutputBudgetInferenceRepository>(),
+          );
+          final outputBudget =
+              timeoutRepo.delegate as DayAgentOutputBudgetInferenceRepository;
+          expect(outputBudget.wakeKind, DayAgentWakeKind.digest);
+          expect(outputBudget.maxCompletionTokens, expectedLimit);
+          expect(outputBudget.domainLogger, same(domainLogger));
+        });
+      }
 
       test('re-arms the next digest when provider execution fails', () async {
         conversationRepository.errorToThrow = Exception('model failed');

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_models_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_models_test.dart
@@ -10,8 +10,11 @@ import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/gemini_tool_call.dart';
 import 'package:lotti/features/ai/repository/inference_repository_interface.dart';
 import 'package:lotti/features/daily_os_next/agents/workflow/day_agent_workflow_models.dart';
+import 'package:lotti/services/domain_logging.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
 
+import '../../../../mocks/mocks.dart';
 import '../../../agents/test_utils.dart';
 
 // The rest of day_agent_workflow_models.dart (tool exceptions, observation
@@ -742,7 +745,7 @@ void main() {
       expect(policy.forKind(DayAgentWakeKind.capture), 4096);
       expect(policy.forKind(DayAgentWakeKind.draft), 8192);
       expect(policy.forKind(DayAgentWakeKind.refine), 4096);
-      expect(policy.forKind(DayAgentWakeKind.digest), 4096);
+      expect(policy.forKind(DayAgentWakeKind.digest), 16384);
       expect(policy.forKind(DayAgentWakeKind.general), 4096);
     });
 
@@ -938,15 +941,20 @@ void main() {
       },
     );
 
-    test('a natural response below the ceiling completes normally', () async {
+    test('a digest above the former ceiling completes normally', () async {
       final chunks = [
         _textChunk(finishReason: ChatCompletionFinishReason.stop),
-        _usageChunk(outputTokens: 1200),
+        _usageChunk(outputTokens: 12000),
       ];
+      final delegate = _RecordingInferenceRepository([
+        Stream.fromIterable(chunks),
+      ]);
       final repository = DayAgentOutputBudgetInferenceRepository(
-        delegate: _StreamInferenceRepository(Stream.fromIterable(chunks)),
+        delegate: delegate,
         wakeKind: DayAgentWakeKind.digest,
-        maxCompletionTokens: 4096,
+        maxCompletionTokens: const DayAgentOutputTokenBudgetPolicy().forKind(
+          DayAgentWakeKind.digest,
+        ),
       );
 
       expect(
@@ -960,6 +968,117 @@ void main() {
             .toList(),
         chunks,
       );
+      expect(delegate.maxCompletionTokens, [16384]);
+    });
+
+    for (final scenario in [
+      (
+        provider: InferenceProviderType.melious,
+        completion: 4096,
+        reasoning: 0,
+        effective: 4096,
+      ),
+      (
+        provider: InferenceProviderType.melious,
+        completion: 4097,
+        reasoning: 0,
+        effective: 4097,
+      ),
+      (
+        provider: InferenceProviderType.gemini,
+        completion: 3000,
+        reasoning: 1097,
+        effective: 4097,
+      ),
+      (
+        provider: InferenceProviderType.melious,
+        completion: 3000,
+        reasoning: 1097,
+        effective: 3000,
+      ),
+    ]) {
+      test('logs usage above 4K for ${scenario.provider.name} '
+          '${scenario.completion}/${scenario.reasoning}', () async {
+        final logger = MockDomainLogger();
+        final usage = _usageChunk(
+          outputTokens: scenario.completion,
+          reasoningTokens: scenario.reasoning,
+        );
+        final repository = DayAgentOutputBudgetInferenceRepository(
+          delegate: _StreamInferenceRepository(
+            Stream.fromIterable([usage, usage]),
+          ),
+          wakeKind: DayAgentWakeKind.digest,
+          maxCompletionTokens: const DayAgentOutputTokenBudgetPolicy().digest,
+          domainLogger: logger,
+        );
+
+        await repository
+            .generateTextWithMessages(
+              messages: const [],
+              model: 'test-model',
+              temperature: 0.3,
+              provider: testInferenceProvider(
+                inferenceProviderType: scenario.provider,
+              ),
+            )
+            .drain<void>();
+
+        if (scenario.effective > 4096) {
+          verify(
+            () => logger.log(
+              LogDomain.agentWorkflow,
+              'high output usage: wakeKind=digest '
+              'completionTokens=${scenario.completion} '
+              'reasoningTokens=${scenario.reasoning} '
+              'effectiveCompletionTokens=${scenario.effective} '
+              'threshold=4096 maxCompletionTokens=16384',
+              subDomain: 'outputBudget',
+            ),
+          ).called(1);
+        }
+        verifyNoMoreInteractions(logger);
+      });
+    }
+
+    test('logs peak usage even when the provider subsequently fails', () async {
+      final logger = MockDomainLogger();
+      final failure = StateError('provider disconnected');
+      Stream<CreateChatCompletionStreamResponse> source() async* {
+        yield _usageChunk(outputTokens: 7000);
+        yield _usageChunk(outputTokens: 5000);
+        throw failure;
+      }
+
+      final repository = DayAgentOutputBudgetInferenceRepository(
+        delegate: _StreamInferenceRepository(source()),
+        wakeKind: DayAgentWakeKind.digest,
+        maxCompletionTokens: const DayAgentOutputTokenBudgetPolicy().digest,
+        domainLogger: logger,
+      );
+
+      await expectLater(
+        repository
+            .generateTextWithMessages(
+              messages: const [],
+              model: 'test-model',
+              temperature: 0.3,
+              provider: testInferenceProvider(),
+            )
+            .drain<void>(),
+        throwsA(same(failure)),
+      );
+      verify(
+        () => logger.log(
+          LogDomain.agentWorkflow,
+          'high output usage: wakeKind=digest '
+          'completionTokens=7000 reasoningTokens=0 '
+          'effectiveCompletionTokens=7000 '
+          'threshold=4096 maxCompletionTokens=16384',
+          subDomain: 'outputBudget',
+        ),
+      ).called(1);
+      verifyNoMoreInteractions(logger);
     });
   });
 

--- a/test/features/daily_os_next/benchmark/day_agent_wake_benchmark_test.dart
+++ b/test/features/daily_os_next/benchmark/day_agent_wake_benchmark_test.dart
@@ -60,7 +60,7 @@ void main() {
     expect(report['parse']!.outputTokenCeiling, 4096);
     expect(report['draft']!.outputTokenCeiling, 8192);
     expect(report['refine']!.outputTokenCeiling, 4096);
-    expect(report['digest']!.outputTokenCeiling, 4096);
+    expect(report['digest']!.outputTokenCeiling, 16384);
     expect(report['parse']!.providerTurns, 1);
     expect(report['draft']!.providerTurns, 1);
     expect(report['refine']!.providerTurns, 2);


### PR DESCRIPTION
Daily digest turns repeatedly exhausted the 4,096-token response ceiling. Raise the digest limit to **16,384 tokens** and log reported effective completion usage **above 4,096 tokens** in `agentWorkflow` (`outputBudget`). The effective ceiling also respects a lower `maxCompletionTokens` saved on the selected thinking model. The existing per-wake deadline and truncation guard remain in force.

Each provider turn emits at most one diagnostic with peak completion, reasoning and effective token counts plus the applied ceiling. Gemini reasoning contributes to its effective total; OpenAI-compatible completion totals already include reasoning. Duplicate usage chunks are not summed, and known usage is still logged if the stream subsequently fails. Diagnostics contain no response content and use the existing domain logging switch.

Validation: 86 targeted tests pass (one opt-in benchmark skipped) through Dart MCP; the full analyzer reports no diagnostics. Regression checks fail with the changes reverted and pass after restoration, including a 12,000-token digest, threshold boundaries, reasoning accounting, duplicate usage, error teardown, and workflow logger wiring. Knowledge validation parses all 554 Mermaid diagrams; changelog validation passes.
