### PR TITLE
fix: resume relationship retries after inference route edits

### DIFF
--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -8,6 +8,10 @@ status: stable
 generated: { by: codex/gpt-6, at: 2026-09-12T20:00:00Z }
 stale_after: 2027-03-01
 sources:
+  - id: sync-runtime
+    resource: ../../lib/features/sync/matrix/sync_event_processor_agent_handlers.dart
+    title: Runtime restoration after synced relationship prerequisites arrive
+    last_modified: 2026-09-12
   - id: src
     resource: ../../lib/features/relationships
     title: Relationships feature source
@@ -699,8 +703,10 @@ removed:
   inference picker emits `AgentNotificationScopes.inferenceSetup` after a
   changed setup commits; maintenance listens to that scope rather than ordinary
   agent writes, so its own repairs cannot create a scan loop. An unchanged
-  setup emits no route notification. A repaired route need not wait out the
-  backoff. Cadence
+  setup emits no route notification. Sync re-offers the identity after a
+  relationship link, scheduled-wake record, or failed agent state arrives,
+  covering creation bundles whose identity precedes those prerequisites.
+  A repaired route need not wait out the backoff. Cadence
   repair runs independently before the configuration check. Configuration read
   exceptions also re-arm the episode; an unreadable failure counter uses the
   initial one-hour delay rather than discarding the retry.

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -693,8 +693,14 @@ removed:
   The normal scheduled manager still elects a device before inference. A
   concurrent consume/replacement observed during resolution is left alone;
   the final check and reschedule share a transaction.
-  Saving the Settings default or changing profile/model/provider catalogs
-  requests a scan, so a repaired route need not wait out the backoff. Cadence
+  Saving the Settings default, changing profile/model/provider catalogs,
+  editing a person's profile/category or its category default, and receiving
+  an active relationship identity through sync all request a scan. The shared
+  inference picker emits `AgentNotificationScopes.inferenceSetup` after a
+  changed setup commits; maintenance listens to that scope rather than ordinary
+  agent writes, so its own repairs cannot create a scan loop. An unchanged
+  setup emits no route notification. A repaired route need not wait out the
+  backoff. Cadence
   repair runs independently before the configuration check. Configuration read
   exceptions also re-arm the episode; an unreadable failure counter uses the
   initial one-hour delay rather than discarding the retry.

--- a/knowledge/features/sync/receive-path.md
+++ b/knowledge/features/sync/receive-path.md
@@ -27,7 +27,7 @@ sources:
   - id: agent-resolution
     resource: ../../../lib/features/sync/matrix/sync_event_processor_agent_handlers.dart
     title: Exact file-backed payload resolution
-    last_modified: 2026-08-06
+    last_modified: 2026-09-12
   - id: journal-resolution
     resource: ../../../lib/features/sync/matrix/smart_journal_entity_loader.dart
     title: Exact journal payload resolution
@@ -66,6 +66,11 @@ flowchart TD
 ```
 
 # Components
+
+Agent runtime restoration also runs when required rows arrive after their
+identity, so an early restoration pass does not strand work until a restart or
+periodic scan. The relationship retry contract is documented in
+[Relationships](../relationships.md).
 
 All under `lib/features/sync/queue/`:
 

--- a/lib/features/agents/model/agent_constants.dart
+++ b/lib/features/agents/model/agent_constants.dart
@@ -15,6 +15,9 @@ abstract final class AgentKinds {
 
 /// Notification scopes that carry meaning beyond a single agent entity ID.
 abstract final class AgentNotificationScopes {
+  /// A committed inference setup edit can unblock scheduled agent work.
+  static const inferenceSetup = 'AGENT_INFERENCE_SETUP_CHANGED';
+
   /// Forces the Projects overview to refresh agent-authored one-liners.
   static const projectOverview = 'PROJECT_AGENT_OVERVIEW_CHANGED';
 }

--- a/lib/features/agents/service/task_agent_service.dart
+++ b/lib/features/agents/service/task_agent_service.dart
@@ -307,12 +307,13 @@ class TaskAgentService {
     return agentService.getAgent(agentId);
   }
 
-  /// Persist the complete inference setup for an existing task agent.
+  /// Persist the complete inference setup for an existing agent.
   ///
   /// Disabled setup is mirrored to the legacy-aware dormant lifecycle and
   /// cancels pending automatic work. Re-enabling a setup only reactivates an
   /// agent that was dormant because its previous typed setup was disabled;
   /// an independently paused legacy/configured agent stays paused.
+  /// Committed changes notify runtime route listeners without a content wake.
   Future<void> updateAgentInferenceSetup({
     required String agentId,
     required AgentInferenceSetup setup,
@@ -390,6 +391,14 @@ class TaskAgentService {
       } else {
         orchestrator.disableAutomaticUpdatesRuntime(agentId);
       }
+    }
+
+    if (previous.config != updated.config) {
+      updateNotifications?.notifyUiOnly({
+        agentId,
+        agentNotification,
+        AgentNotificationScopes.inferenceSetup,
+      });
     }
 
     if (postCommitSyncError != null) {

--- a/lib/features/relationships/runtime/relationship_runtime_maintenance.dart
+++ b/lib/features/relationships/runtime/relationship_runtime_maintenance.dart
@@ -31,6 +31,7 @@ class RelationshipRuntimeMaintenance implements AgentRuntimeMaintenance {
     required this._relationshipRepository,
     this._domainLogger,
     this.inferenceIsConfigured,
+    this.onIdentityRestored,
   });
 
   final AgentService _agentService;
@@ -42,6 +43,9 @@ class RelationshipRuntimeMaintenance implements AgentRuntimeMaintenance {
 
   /// Checks the same effective route as Phase B, including device settings.
   final Future<bool> Function(AgentIdentityEntity)? inferenceIsConfigured;
+
+  /// Rescans pending retries after an active identity arrives through sync.
+  final void Function()? onIdentityRestored;
 
   @override
   Future<void> restoreSubscriptions() async {
@@ -182,6 +186,7 @@ class RelationshipRuntimeMaintenance implements AgentRuntimeMaintenance {
         return;
       }
       await _relationshipAgentService.registerSubscription(identity.agentId);
+      onIdentityRestored?.call();
     } catch (error, stackTrace) {
       _log('onIdentityReceived', identity.agentId, error, stackTrace);
     }

--- a/lib/features/relationships/state/relationship_agent_providers.dart
+++ b/lib/features/relationships/state/relationship_agent_providers.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:lotti/classes/relationship_trigger_tokens.dart';
@@ -24,6 +26,7 @@ import 'package:lotti/features/relationships/service/relationship_reminder_servi
 import 'package:lotti/features/relationships/workflow/relationship_agent_workflow.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/providers/service_providers.dart' show journalDbProvider;
+import 'package:lotti/services/db_notification.dart';
 
 /// The OS-reminder projection of the cadence verdict (ADR 0039, plan v2
 /// phase 8) — durable inbox rows first, OS alarms second.
@@ -173,9 +176,23 @@ final relationshipRuntimeMaintenanceProvider =
           }
         }
 
-        ref.listen(defaultInferenceProfileControllerProvider, (previous, next) {
-          if (next.hasValue && previous?.value != next.value) requestCheck();
-        });
+        // Ordinary agent notifications include wake persistence itself;
+        // listening to those would turn each scan into another scan.
+        final subscription = ref
+            .watch(maybeUpdateNotificationsProvider)
+            ?.updateStream
+            .listen((ids) {
+              if (ids.contains(AgentNotificationScopes.inferenceSetup) ||
+                  ids.contains(relationshipNotification) ||
+                  ids.contains(categoriesNotification)) {
+                requestCheck();
+              }
+            });
+        ref
+          ..onDispose(() => unawaited(subscription?.cancel()))
+          ..listen(defaultInferenceProfileControllerProvider, (previous, next) {
+            if (next.hasValue && previous?.value != next.value) requestCheck();
+          });
         for (final type in [
           AiConfigType.inferenceProfile,
           AiConfigType.model,
@@ -192,6 +209,7 @@ final relationshipRuntimeMaintenanceProvider =
           relationshipAgentService: ref.watch(relationshipAgentServiceProvider),
           relationshipRepository: ref.watch(relationshipRepositoryProvider),
           domainLogger: ref.watch(domainLoggerProvider),
+          onIdentityRestored: requestCheck,
           inferenceIsConfigured: (identity) async {
             final relationshipId = await ref
                 .read(relationshipAgentServiceProvider)

--- a/lib/features/sync/matrix/sync_event_processor_agent_handlers.dart
+++ b/lib/features/sync/matrix/sync_event_processor_agent_handlers.dart
@@ -358,17 +358,28 @@ extension _AgentHandlers on SyncEventProcessor {
         if (identity is AgentIdentityEntity &&
             identity.kind == AgentKinds.projectAgent) {
           await _reconcileProjectAgentRuntime(identity);
+        } else if (identity is AgentIdentityEntity &&
+            identity.kind == AgentKinds.relationshipAgent &&
+            entityToApply.consecutiveFailureCount > 0) {
+          // A retry can arrive before the state that marks it as backed off.
+          await _offerIdentityToRuntimeMaintenance(identity);
         }
       }
       // Ordering: creation bundles emit the identity BEFORE its spec rows,
       // so the identity-time mirror can find no criteria yet. When the
       // spec head lands, offer the (already persisted) identity again —
       // this is what makes a goal synced in mid-session actually live.
-      if (wakeOrchestrator != null && entityToApply is GoalSpecHeadEntity) {
+      // Relationship retry/cadence rows can likewise follow their identity
+      // and link, so let maintenance see the now-persisted prerequisite.
+      if (wakeOrchestrator != null &&
+          (entityToApply is GoalSpecHeadEntity ||
+              entityToApply is ScheduledWakeEntity)) {
         final identity = await agentRepository!.getEntity(
           entityToApply.agentId,
         );
-        if (identity is AgentIdentityEntity) {
+        if (identity is AgentIdentityEntity &&
+            (entityToApply is GoalSpecHeadEntity ||
+                identity.kind == AgentKinds.relationshipAgent)) {
           await _offerIdentityToRuntimeMaintenance(identity);
         }
       }
@@ -520,6 +531,13 @@ extension _AgentHandlers on SyncEventProcessor {
               agent.kind == AgentKinds.projectAgent) {
             await _reconcileProjectAgentRuntime(agent);
           }
+        }
+      } else if (wakeOrchestrator != null &&
+          resolvedLink is AgentRelationshipLink) {
+        final identity = await agentRepository!.getEntity(resolvedLink.fromId);
+        if (identity is AgentIdentityEntity &&
+            identity.kind == AgentKinds.relationshipAgent) {
+          await _offerIdentityToRuntimeMaintenance(identity);
         }
       }
       _updateNotifications.notify(

--- a/test/features/agents/service/task_agent_service_test.dart
+++ b/test/features/agents/service/task_agent_service_test.dart
@@ -2173,6 +2173,13 @@ void main() {
         ).captured;
         final updated = captured.first as AgentIdentityEntity;
         expect(updated.config.profileId, 'new-profile-id');
+        verify(
+          () => mockUpdateNotifications.notifyUiOnly({
+            'agent-1',
+            agentNotification,
+            AgentNotificationScopes.inferenceSetup,
+          }),
+        ).called(1);
         expect(
           updated.config.inferenceSetup,
           const AgentInferenceSetup(
@@ -2233,6 +2240,29 @@ void main() {
     });
 
     group('persistent inference setup', () {
+      test('an unchanged setup does not request another route scan', () async {
+        const setup = AgentInferenceSetup(
+          mode: AgentInferenceSetupMode.configured,
+          origin: AgentInferenceSetupOrigin.user,
+          baseProfileId: 'profile-1',
+        );
+        when(() => mockAgentService.getAgent('agent-1')).thenAnswer(
+          (_) async => makeIdentity(
+            config: const AgentConfig(
+              profileId: 'profile-1',
+              inferenceSetup: setup,
+            ),
+          ),
+        );
+
+        await service.updateAgentInferenceSetup(
+          agentId: 'agent-1',
+          setup: setup,
+        );
+
+        verifyNever(() => mockUpdateNotifications.notifyUiOnly(any()));
+      });
+
       test('rejects configured setup without a profile or model', () async {
         await expectLater(
           () => service.updateAgentInferenceSetup(

--- a/test/features/relationships/runtime/relationship_runtime_maintenance_test.dart
+++ b/test/features/relationships/runtime/relationship_runtime_maintenance_test.dart
@@ -29,6 +29,7 @@ void main() {
   late MockRelationshipRepository relationshipRepository;
   late MockDomainLogger logger;
   late RelationshipRuntimeMaintenance maintenance;
+  late int scanRequests;
 
   const relationshipId = 'person-1';
 
@@ -84,6 +85,7 @@ void main() {
     relationshipAgentService = MockRelationshipAgentService();
     relationshipRepository = MockRelationshipRepository();
     logger = MockDomainLogger();
+    scanRequests = 0;
     maintenance = RelationshipRuntimeMaintenance(
       agentService: agentService,
       repository: repository,
@@ -91,6 +93,7 @@ void main() {
       relationshipAgentService: relationshipAgentService,
       relationshipRepository: relationshipRepository,
       domainLogger: logger,
+      onIdentityRestored: () => scanRequests++,
     );
     when(
       () => agentService.listAgents(lifecycle: AgentLifecycle.active),
@@ -436,6 +439,7 @@ void main() {
     test('an active synced-in identity subscribes immediately — no restart '
         'needed', () async {
       await maintenance.onIdentityReceived(identity());
+      expect(scanRequests, 1);
       verify(
         () => relationshipAgentService.registerSubscription(agentId),
       ).called(1);
@@ -449,6 +453,7 @@ void main() {
         () => relationshipAgentService.removeSubscription(agentId),
       ).called(1);
       verifyNever(() => relationshipAgentService.registerSubscription(any()));
+      expect(scanRequests, 0);
     });
 
     test('another kind is ignored entirely', () async {
@@ -456,6 +461,7 @@ void main() {
         identity(kind: AgentKinds.goalAgent),
       );
       verifyZeroInteractions(relationshipAgentService);
+      expect(scanRequests, 0);
     });
 
     test('a subscription failure is contained — the sync apply loop must '

--- a/test/features/relationships/state/relationship_agent_providers_test.dart
+++ b/test/features/relationships/state/relationship_agent_providers_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
@@ -27,6 +29,7 @@ import 'package:lotti/features/relationships/state/relationship_agent_providers.
 import 'package:lotti/features/relationships/workflow/relationship_agent_workflow.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/providers/service_providers.dart' show journalDbProvider;
+import 'package:lotti/services/db_notification.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
@@ -86,6 +89,47 @@ void main() {
     addTearDown(c.dispose);
     return c;
   }
+
+  test('route edits and synced identities request scans, ordinary agent writes '
+      'do not', () async {
+    final updates = StreamController<Set<String>>.broadcast(sync: true);
+    addTearDown(updates.close);
+    final notifications = MockUpdateNotifications();
+    when(() => notifications.updateStream).thenAnswer((_) => updates.stream);
+    final manager = MockScheduledWakeManager();
+    final agentService = MockRelationshipAgentService();
+    when(
+      () => agentService.registerSubscription(agentId),
+    ).thenAnswer((_) async {});
+    final c = container(
+      overrides: [
+        maybeUpdateNotificationsProvider.overrideWithValue(notifications),
+        scheduledWakeManagerProvider.overrideWithValue(manager),
+        relationshipAgentServiceProvider.overrideWithValue(agentService),
+        aiConfigRepositoryProvider.overrideWithValue(MockAiConfigRepository()),
+      ],
+    );
+    final maintenance = c
+        .listen(relationshipRuntimeMaintenanceProvider, (_, _) {})
+        .read();
+    await c.read(defaultInferenceProfileControllerProvider.future);
+
+    updates.add({agentId, agentNotification});
+    verifyNever(manager.requestCheck);
+    for (final token in [
+      AgentNotificationScopes.inferenceSetup,
+      relationshipNotification,
+      categoriesNotification,
+    ]) {
+      updates.add({token});
+      verify(manager.requestCheck).called(1);
+    }
+    await maintenance.onIdentityReceived(identity());
+    verify(manager.requestCheck).called(1);
+    c.dispose();
+    updates.add({AgentNotificationScopes.inferenceSetup});
+    verifyNoMoreInteractions(manager);
+  });
 
   test(
     'the relationship_agent kind resolves to ITS registered runner — '

--- a/test/features/sync/matrix/sync_event_processor_agent_handlers_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_agent_handlers_test.dart
@@ -29,6 +29,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as path;
 
 import '../../../mocks/mocks.dart';
+import '../../agents/test_data/entity_factories.dart';
 import 'sync_event_processor_test_helpers.dart';
 
 void main() {
@@ -2719,6 +2720,77 @@ void main() {
           () => mockOrchestrator.enableAutomaticUpdatesRuntime(any()),
         ).thenReturn(null);
       });
+
+      final prerequisiteDate = DateTime(2026, 9, 12);
+      final prerequisites = <String, SyncMessage>{
+        'relationship link': SyncMessage.agentLink(
+          agentLink: AgentLink.agentRelationship(
+            id: 'relationship-link',
+            fromId: 'relationship-agent',
+            toId: 'person-1',
+            createdAt: prerequisiteDate,
+            updatedAt: prerequisiteDate,
+            vectorClock: null,
+          ),
+          status: SyncEntryStatus.update,
+        ),
+        'scheduled retry': SyncMessage.agentEntity(
+          agentEntity: AgentDomainEntity.scheduledWake(
+            id: 'relationship-retry',
+            agentId: 'relationship-agent',
+            scheduledAt: prerequisiteDate,
+            status: ScheduledWakeStatus.pending,
+            reason: 'scheduled',
+            updatedAt: prerequisiteDate,
+            vectorClock: null,
+          ),
+          status: SyncEntryStatus.update,
+        ),
+        'failure state': SyncMessage.agentEntity(
+          agentEntity: makeTestState(
+            agentId: 'relationship-agent',
+            consecutiveFailureCount: 1,
+          ),
+          status: SyncEntryStatus.update,
+        ),
+      };
+      for (final prerequisite in prerequisites.entries) {
+        for (final kind in [
+          AgentKinds.relationshipAgent,
+          AgentKinds.taskAgent,
+          null,
+        ]) {
+          test('a late ${prerequisite.key} re-offers only its relationship '
+              'identity ($kind)', () async {
+            final seen = <String>[];
+            processor.runtimeMaintenance = [_RecordingMaintenance(seen)];
+            addTearDown(() => processor.runtimeMaintenance = const []);
+            when(
+              () => mockAgentRepo.getEntity('relationship-agent'),
+            ).thenAnswer(
+              (_) async => kind == null
+                  ? null
+                  : makeTestIdentity(
+                      id: 'relationship-agent',
+                      agentId: 'relationship-agent',
+                      kind: kind,
+                    ),
+            );
+            when(
+              () => event.text,
+            ).thenReturn(encodeMessage(prerequisite.value));
+
+            await processor.process(event: event, journalDb: journalDb);
+
+            expect(
+              seen,
+              kind == AgentKinds.relationshipAgent
+                  ? ['relationship-agent']
+                  : isEmpty,
+            );
+          });
+        }
+      }
 
       test('offers a synced-in identity to every runtime-maintenance '
           'contributor, containing a throwing one', () async {


### PR DESCRIPTION
Repairing a relationship agent through the shared inference picker could leave a backed-off escalation waiting until the next hourly scan. Request a scheduled-wake scan after a changed inference setup commits, when a person/category changes, and when an active relationship identity arrives through sync. Later relationship links, scheduled-wake rows, and failed agent states re-offer the identity after being applied, covering either sync arrival order.

Use a dedicated inference-setup notification instead of ordinary agent notifications, so wake persistence cannot trigger a scan loop. Unchanged setups emit no route notification, and the listener is disposed with the runtime provider. The existing maintenance transaction and lease election still govern retry execution.

Addresses the late review on #4243: https://github.com/matthiasn/lotti/pull/4243#discussion_r3997124494

Validation: 232 targeted tests pass across the runtime/service/provider and sync-handler files through Dart MCP, including notification filtering, local persistence, synced identity recovery, and subscription disposal. Both sets of three positive regression checks fail with the fixes reverted and pass after restoration. The full analyzer is clean, and knowledge validation parses all 554 Mermaid diagrams.
