### PR TITLE
test: repair AI model screenshots after settings header changes

### DIFF
--- a/test/features/ai/ui/settings/ai_settings_manual_screenshots_test.dart
+++ b/test/features/ai/ui/settings/ai_settings_manual_screenshots_test.dart
@@ -493,13 +493,30 @@ void main() {
             find.text(_t('Sardine Logistics 14B', 'Sardinenlogistik 14B')),
             findsOneWidget,
           );
+          final coverArtist = find.text(
+            _t('Project Waddle Cover Artist', 'Project-Waddle-Titelkünstler'),
+          );
+          final settingsScrollable = find
+              .descendant(
+                of: find.byType(AiSettingsPage),
+                matching: find.byType(Scrollable),
+              )
+              .first;
+          // The settings header can push later models beyond the lazy list's
+          // built rows. Verify that they are reachable, then capture the top.
+          await tester.scrollUntilVisible(
+            coverArtist,
+            200,
+            scrollable: settingsScrollable,
+          );
+          await settleFrames(tester, 4);
+          expect(coverArtist.hitTestable(), findsOneWidget);
+          tester.state<ScrollableState>(settingsScrollable).position.jumpTo(0);
+          await settleFrames(tester, 4);
           expect(
-            find.text(
-              _t(
-                'Project Waddle Cover Artist',
-                'Project-Waddle-Titelkünstler',
-              ),
-            ),
+            find
+                .text(_t('Waddle Command 70B', 'Watschelkommando 70B'))
+                .hitTestable(),
             findsOneWidget,
           );
           await captureScreenshot(


### PR DESCRIPTION
The taller AI settings header leaves later model cards outside the lazy list’s built rows. The German manual capture job therefore fails in all four mobile/desktop and light/dark model cases when it looks for Project Waddle Cover Artist.

Scroll to the model and verify it is reachable, then restore the scroll position and verify the first model is visible before capturing the page. This repairs the screenshot CI failure following #4243, observed on #4245 and #4246.

Validation: all four German model cases reproduce the failure before the fix; all 32 German AI-settings captures and all four English model captures pass with the fix. Full Dart analysis reports no errors. Test-only change; no app behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated AI settings screenshot coverage to scroll through the model list before validating model visibility.
  * Improved test reliability when settings content extends beyond the initially rendered area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->