### PR TITLE
chore(release): clarify 1.1.10 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,15 +52,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Relationship agents now honor the model chosen in their settings.**
   Missing configuration retries less often and resumes when a usable profile
   becomes available.
-- **Reduce background agent work.** Wakes reuse prepared memory when no
-  compaction is needed, deferred jobs avoid unnecessary queue checks, and
-  project recommendations are retired once per replacement.
+- **Reduced background activity from agents.** Agents avoid repeating
+  preparation and checks when no new work is needed.
 - **Image analysis no longer fails when its short summary is invalid.** The
   full analysis is preserved when an AI response has an overlong one-line
   summary or an invalid TLDR, instead of reporting an empty response.
-- **Startup does less database work when many agents are present.** Clearing
-  old wake countdowns now shares a bulk read and transaction instead of
-  opening a separate transaction for every agent, including idle ones.
+- **Less startup overhead with many agents.** Lotti clears old agent
+  countdowns together, reducing the work needed to open your journal.
 - **Daily digests have more room to finish.** Raised the response limit from
   4,096 to 16,384 tokens to reduce failures caused by truncated responses.
 

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -51,9 +51,9 @@
         <p>Changed: inspect query answers with clearer evidence and accessible controls. Citations open their saved passages, excerpt boundaries and transcript dates are clearer, and shared conclusions show when they were saved. Empty memory disclosures disappear. Long voice transcripts expand without hiding Cancel, and audio setup details stay behind a short explanation.</p>
         <p>Fixed: larger text stays inside task controls and chat inputs. Task actions wrap when needed, and long input hints stay on one line without vertical clipping.</p>
         <p>Fixed: relationship agents now honor the model chosen in their settings. Missing configuration retries less often and resumes when a usable profile becomes available.</p>
-        <p>Fixed: reduce background agent work. Wakes reuse prepared memory when no compaction is needed, deferred jobs avoid unnecessary queue checks, and project recommendations are retired once per replacement.</p>
+        <p>Fixed: reduced background activity from agents. Agents avoid repeating preparation and checks when no new work is needed.</p>
         <p>Fixed: image analysis no longer fails when its short summary is invalid. The full analysis is preserved when an AI response has an overlong one-line summary or an invalid TLDR, instead of reporting an empty response.</p>
-        <p>Fixed: startup does less database work when many agents are present. Clearing old wake countdowns now shares a bulk read and transaction instead of opening a separate transaction for every agent, including idle ones.</p>
+        <p>Fixed: less startup overhead with many agents. Lotti clears old agent countdowns together, reducing the work needed to open your journal.</p>
         <p>Fixed: daily digests have more room to finish. Raised the response limit from 4,096 to 16,384 tokens to reduce failures caused by truncated responses.</p>
       </description>
     </release>


### PR DESCRIPTION
Release-workflow follow-up to #4249, addressing its late review feedback. This corrects two descriptions in the existing 1.1.10 release and keeps the changelog and AppStream text aligned. It adds no release entries, version bump, or tag change.

Describe reduced agent background activity and startup overhead in user-facing terms, keeping the 1.1.10 changelog and Flathub notes aligned. Addresses the review comment that arrived after #4249 merged.

Validation: release-note consistency check, XML parsing, clean diff check, and zero Dart analyzer diagnostics.
