### PR TITLE
feat: keep project and category details beside chat

### DIFF
--- a/changelog.d/2026-09-13-project-category-chat-companion.md
+++ b/changelog.d/2026-09-13-project-category-chat-companion.md
@@ -1,0 +1,4 @@
+### Changed
+- **Project and category chats keep their details in place.** Chat opens beside
+  the detail on wide screens or in an expandable sheet on smaller screens.
+  Category edits stay intact, and the project list returns after closing chat.

--- a/knowledge/features/agents/query-chat.md
+++ b/knowledge/features/agents/query-chat.md
@@ -97,15 +97,16 @@ not reopen a pane. Existing task-agent improvement chats are unaffected.
 
 The **Ask** action opens a discussion without running inference. Task headers
 and task/project summary cards expose the action; the task action bar remains
-reserved for time tracking and capture. Project and saved-category details still
-open `QueryChatPane` in place of their detail page.
+reserved for time tracking and capture. Projects and saved categories use the same companion as tasks, preserving their
+detail content and pending form edits while chat is open.
 
-Tasks use `QueryCompanion`, keeping the detail subtree mounted and usable.
+Task, project and saved-category pages use `QueryCompanion`, keeping the detail
+subtree mounted and usable.
 The companion wraps data-dependent loading/missing-task branches as well, so
 a sync deletion cannot remove the chat Close control or strand its open flag. With
 enough width, chat docks on the right with a keyboard- and pointer-resizable
 divider. Fit uses the existing chat/detail reading measures at the current text
-scale. `TasksRootPage` temporarily hides the mounted task list when both reading
+scale. `TasksRootPage` and `ProjectsTabPage` temporarily hide their mounted lists when both reading
 columns would otherwise be squeezed, and suppresses the metadata column.
 `AppScreen` hides its mounted day-view column while the selected task's chat is
 open. Neither suppression writes the saved pane preferences. Close restores the

--- a/knowledge/features/design_system/component-contracts.md
+++ b/knowledge/features/design_system/component-contracts.md
@@ -117,6 +117,8 @@ contiguous selected band per option. Checkbox-first lists can set
 `showSelectedBackground: false` when the checkmark is the deliberate sole state
 indicator; checked semantics and the full-row action remain unchanged.
 
+`ResizableDivider.layoutWidth` exposes its reserved row width for fit
+calculations; its wider pointer hit target overflows without consuming space.
 `ResizableDivider.reverse` controls a pane on the divider's right: dragging or
 pressing Left grows that pane, while the semantic Increase action always grows
 the announced width. Pointer direction and value direction are separate.

--- a/knowledge/features/keyboard.md
+++ b/knowledge/features/keyboard.md
@@ -46,3 +46,19 @@ The original command-system rationale is recorded in
 [ADR 0030](../../docs/adr/0030-desktop-keyboard-command-system.md). The catalog's
 deliberately lean metadata contract is recorded in
 [ADR 0047](../../docs/adr/0047-lean-keyboard-command-catalog-metadata.md).
+
+# List and detail focus
+
+`ListDetailFocusTraversal` keeps hidden list content mounted and moves focus
+into details when hiding the list. Hosts can disable `focusListOnExternalReveal`
+when a layout-driven reveal must preserve a companion's return focus. The
+controller's explicit Show list action still transfers focus into the list.
+
+```mermaid
+flowchart LR
+  Hide[Hide list] --> Detail[Focus detail region]
+  Show[Explicit Show list] --> List[Focus list region]
+  Reveal[Host reveals list] --> Policy{focusListOnExternalReveal}
+  Policy -->|true| List
+  Policy -->|false| Keep[Preserve focus]
+```

--- a/knowledge/features/projects.md
+++ b/knowledge/features/projects.md
@@ -244,7 +244,8 @@ Project chat uses the retained companion described in
 [query chat](agents/query-chat.md#ownership-and-entry-points). Opening it may
 temporarily hide the list to make room without changing its saved collapse
 preference; Show list or keyboard search restores browsing and closes chat when
-the list and discussion cannot both fit.
+the list and discussion cannot both fit. Automatic list restoration after Close
+keeps focus on the Ask control; an explicit Show list action focuses browsing.
 
 Project detail actions preserve workspace continuity. Edit uses the
 Projects-owned `/projects/<id>/edit` route on mobile and desktop, with an

--- a/knowledge/features/projects.md
+++ b/knowledge/features/projects.md
@@ -240,6 +240,12 @@ measure with its one standard horizontal gutter, keeping report lines and cards
 readable when the list releases a wide canvas without double-insetting mobile
 content.
 
+Project chat uses the retained companion described in
+[query chat](agents/query-chat.md#ownership-and-entry-points). Opening it may
+temporarily hide the list to make room without changing its saved collapse
+preference; Show list or keyboard search restores browsing and closes chat when
+the list and discussion cannot both fit.
+
 Project detail actions preserve workspace continuity. Edit uses the
 Projects-owned `/projects/<id>/edit` route on mobile and desktop, with an
 explicit return path back to the selected project. The editor owns the complete

--- a/lib/features/categories/ui/pages/category_details_page.dart
+++ b/lib/features/categories/ui/pages/category_details_page.dart
@@ -3,10 +3,9 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/query_chat_models.dart';
-import 'package:lotti/features/agents/query/query_chat_providers.dart';
 import 'package:lotti/features/agents/ui/profile_selector.dart';
 import 'package:lotti/features/agents/ui/query/query_ask_button.dart';
-import 'package:lotti/features/agents/ui/query/query_chat_pane.dart';
+import 'package:lotti/features/agents/ui/query/query_companion.dart';
 import 'package:lotti/features/agents/ui/template_selector.dart';
 import 'package:lotti/features/ai/state/profile_automation_providers.dart';
 import 'package:lotti/features/categories/domain/category_icon.dart';
@@ -52,7 +51,8 @@ part 'category_details_form_sections.dart';
 ///
 /// Both create and edit mode render inside the shared
 /// [SettingsDetailScaffold] (header with back affordance, Cmd/Ctrl+S,
-/// sticky glass [SettingsFormActionBar]).
+/// sticky glass [SettingsFormActionBar]). Saved categories keep that form
+/// mounted inside [QueryCompanion] while a scoped discussion is open.
 class CategoryDetailsPage extends ConsumerStatefulWidget {
   const CategoryDetailsPage({
     this.categoryId,
@@ -222,23 +222,16 @@ class _CategoryDetailsPageState extends ConsumerState<CategoryDetailsPage> {
       return _buildCreateMode(context);
     }
 
-    // Keep the editor's auto-disposed controller subscribed while its query
-    // pane is open so returning to the form preserves pending field edits.
     final state = ref.watch(
       categoryDetailsControllerProvider(widget.categoryId!),
     );
-    final queryScope = QueryScope(
-      kind: QueryScopeKind.category,
-      id: widget.categoryId!,
+    return QueryCompanion(
+      scope: QueryScope(kind: QueryScopeKind.category, id: widget.categoryId!),
+      child: _buildEditMode(context, state),
     );
-    if (ref.watch(queryPaneOpenProvider(queryScope))) {
-      return QueryChatPane(
-        scope: queryScope,
-        onClose: () =>
-            ref.read(queryPaneOpenProvider(queryScope).notifier).open = false,
-      );
-    }
+  }
 
+  Widget _buildEditMode(BuildContext context, CategoryDetailsState state) {
     final category = state.category;
 
     if (category == null && !state.isLoading) {

--- a/lib/features/design_system/components/navigation/resizable_divider.dart
+++ b/lib/features/design_system/components/navigation/resizable_divider.dart
@@ -26,6 +26,9 @@ class ResizableDivider extends StatefulWidget {
          'Provide all resize semantic values or none of them.',
        );
 
+  /// Reserved row width, independent of the overflowing pointer hit target.
+  static const layoutWidth = 3.0;
+
   /// Called with the change in pane width. Pointer and arrow-key deltas are
   /// reversed when [reverse] is true; semantic increase always grows the pane.
   /// Ignored while [enabled] is false.
@@ -90,13 +93,13 @@ class _ResizableDividerState extends State<ResizableDivider> {
     // 3 px width (hover/drag), while a wider invisible [OverflowBox] on top
     // preserves the full hitTargetWidth drag/hover area.
     final visual = SizedBox(
-      width: 3,
+      width: ResizableDivider.layoutWidth,
       child: OverflowBox(
         maxWidth: widget.hitTargetWidth,
         child: Center(
           child: AnimatedContainer(
             duration: const Duration(milliseconds: 150),
-            width: isActive ? 3 : 1,
+            width: isActive ? ResizableDivider.layoutWidth : 1,
             color: lineColor,
           ),
         ),

--- a/lib/features/keyboard/ui/list_detail_focus_traversal.dart
+++ b/lib/features/keyboard/ui/list_detail_focus_traversal.dart
@@ -52,6 +52,7 @@ class ListDetailFocusTraversal extends StatefulWidget {
     required this.divider,
     required this.detailPane,
     this.listPaneVisible = true,
+    this.focusListOnExternalReveal = true,
     this.canHideListPane = false,
     this.onListPaneVisibilityChanged,
     super.key,
@@ -62,6 +63,11 @@ class ListDetailFocusTraversal extends StatefulWidget {
   final Widget divider;
   final Widget detailPane;
   final bool listPaneVisible;
+
+  /// Whether a host-driven reveal transfers focus into the list. Disable when
+  /// restoring space after closing a companion that restores its own opener.
+  /// Explicit [ListDetailFocusTraversalController.showListPane] still focuses it.
+  final bool focusListOnExternalReveal;
   final bool canHideListPane;
   final ValueChanged<bool>? onListPaneVisibilityChanged;
 
@@ -83,7 +89,10 @@ class _ListDetailFocusTraversalState extends State<ListDetailFocusTraversal> {
     _focusDetails,
     () => widget.listPaneVisible,
     () => widget.canHideListPane,
-    (visible) => widget.onListPaneVisibilityChanged?.call(visible),
+    (visible) {
+      widget.onListPaneVisibilityChanged?.call(visible);
+      if (visible && !widget.focusListOnExternalReveal) _focusList();
+    },
   );
 
   void _focusList() => _focusRegion(_listRegionId);
@@ -104,7 +113,7 @@ class _ListDetailFocusTraversalState extends State<ListDetailFocusTraversal> {
     if (oldWidget.listPaneVisible == widget.listPaneVisible) return;
 
     if (widget.listPaneVisible) {
-      _focusList();
+      if (widget.focusListOnExternalReveal) _focusList();
     } else {
       _focusDetails();
     }

--- a/lib/features/projects/ui/pages/project_details_page.dart
+++ b/lib/features/projects/ui/pages/project_details_page.dart
@@ -7,12 +7,11 @@ import 'package:lotti/classes/project_data.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/query_chat_models.dart';
-import 'package:lotti/features/agents/query/query_chat_providers.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/project_agent_providers.dart';
 import 'package:lotti/features/agents/state/task_agent_providers.dart';
 import 'package:lotti/features/agents/ui/agent_creation_modal.dart';
-import 'package:lotti/features/agents/ui/query/query_chat_pane.dart';
+import 'package:lotti/features/agents/ui/query/query_companion.dart';
 import 'package:lotti/features/categories/ui/widgets/category_picker_sheet.dart';
 import 'package:lotti/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart';
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
@@ -72,6 +71,9 @@ final projectByIdResolverProvider = Provider<ProjectByIdResolver>(
 /// data instead of flashing a spinner. The initial spinner only shows while the
 /// [ProjectDetailController] is loading with no project yet.
 ///
+/// Query chat uses [QueryCompanion] so reports, task-list state and initial
+/// loading/error states remain mounted alongside the discussion.
+///
 /// Edits here are immediate-save inline pickers — category, target date, and
 /// status each open a sheet/picker, mutate [ProjectDetailController], and call
 /// `saveChanges()` right away (no explicit Save button). When the project has a
@@ -88,15 +90,13 @@ class ProjectDetailsPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final queryScope = QueryScope(kind: QueryScopeKind.project, id: projectId);
-    if (ref.watch(queryPaneOpenProvider(queryScope))) {
-      return QueryChatPane(
-        scope: queryScope,
-        onClose: () =>
-            ref.read(queryPaneOpenProvider(queryScope).notifier).open = false,
-      );
-    }
+    return QueryCompanion(
+      scope: QueryScope(kind: QueryScopeKind.project, id: projectId),
+      child: _buildDetail(context, ref),
+    );
+  }
 
+  Widget _buildDetail(BuildContext context, WidgetRef ref) {
     final detailState = ref.watch(projectDetailControllerProvider(projectId));
     final recordAsync = ref.watch(projectDetailRecordProvider(projectId));
     final currentTime = ref.watch(projectDetailNowProvider)();

--- a/lib/features/projects/ui/pages/projects_tab_page.dart
+++ b/lib/features/projects/ui/pages/projects_tab_page.dart
@@ -1,6 +1,9 @@
 import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/features/agents/model/query_chat_models.dart';
+import 'package:lotti/features/agents/query/query_chat_providers.dart';
+import 'package:lotti/features/agents/ui/query/query_companion.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
 import 'package:lotti/features/design_system/components/chips/active_filter_chip.dart';
 import 'package:lotti/features/design_system/components/chips/design_system_chip.dart';
@@ -42,7 +45,9 @@ import 'package:material_ui/material_ui.dart';
 /// and, on the right, [ProjectDetailsPage] for the project currently selected
 /// in `NavService.desktopSelectedProjectId`, falling back to an empty-state.
 /// With a selection, the list can move offstage into persisted focus mode while
-/// retaining its state. On mobile it shows only the list scaffold; tapping a
+/// retaining its state. Opening chat temporarily releases the list width when
+/// needed; closing chat restores the saved preference, and Show list/search
+/// closes a space-constrained chat before returning to browsing. On mobile it shows only the list scaffold; tapping a
 /// project beams to `/projects/<id>`.
 ///
 /// The list scaffold watches [visibleProjectGroupsProvider] (the raw
@@ -104,47 +109,84 @@ class _ProjectsTabPageState extends ConsumerState<ProjectsTabPage> {
         decoration: BoxDecoration(
           color: ShowcasePalette.page(context),
         ),
-        child: ValueListenableBuilder<String?>(
-          valueListenable: getIt<NavService>().desktopSelectedProjectId,
-          builder: (context, selectedProjectId, _) {
-            final canHideListPane = selectedProjectId != null;
-            final listPaneVisible =
-                !paneWidths.listPaneCollapsed || !canHideListPane;
+        child: LayoutBuilder(
+          builder: (context, constraints) => ValueListenableBuilder<String?>(
+            valueListenable: getIt<NavService>().desktopSelectedProjectId,
+            builder: (context, selectedProjectId, _) {
+              final canHideListPane = selectedProjectId != null;
+              final queryScope = selectedProjectId == null
+                  ? null
+                  : QueryScope(
+                      kind: QueryScopeKind.project,
+                      id: selectedProjectId,
+                    );
+              final queryOpen =
+                  queryScope != null &&
+                  ref.watch(queryPaneOpenProvider(queryScope));
+              // Fit-driven suppression keeps the saved list preference intact.
+              final queryNeedsListSpace =
+                  queryOpen &&
+                  constraints.maxWidth <
+                      listPaneWidth +
+                          QueryCompanion.minimumDockedWidth(context);
+              final listPaneVisible =
+                  !canHideListPane ||
+                  (!paneWidths.listPaneCollapsed && !queryNeedsListSpace);
 
-            return ListDetailFocusTraversal(
-              debugLabel: 'projects-split',
-              listPaneVisible: listPaneVisible,
-              canHideListPane: canHideListPane,
-              onListPaneVisibilityChanged: (visible) {
-                if (visible) {
-                  paneController.expandListPane();
-                } else {
-                  paneController.collapseListPane();
+              void showList() {
+                if (queryNeedsListSpace) {
+                  ref.read(queryPaneOpenProvider(queryScope).notifier).open =
+                      false;
                 }
-              },
-              listPane: SizedBox(
-                width: listPaneWidth,
-                child: _ProjectsListScaffold(
-                  scrollController: _scrollController,
-                  searchFocusNode: _searchFocusNode,
-                ),
-              ),
-              divider: ResizableDivider(
-                currentValue: listPaneWidth,
-                minValue: minListPaneWidth,
-                maxValue: maxListPaneWidth,
-                onDrag: resolvedListPane.onDrag,
-              ),
-              detailPane: selectedProjectId != null
-                  ? _ProjectsDetailPane(
-                      key: ValueKey(selectedProjectId),
-                      projectId: selectedProjectId,
-                    )
-                  : DesktopDetailEmptyState(
-                      message: context.messages.desktopEmptyStateSelectProject,
+                paneController.expandListPane();
+              }
+
+              return AppCommandScope(
+                handlers: {
+                  AppCommandId.focusSearch: AppCommandHandler(
+                    invoke: (_) {
+                      showList();
+                      _focusSearch(isDesktop: true);
+                    },
+                  ),
+                },
+                child: ListDetailFocusTraversal(
+                  debugLabel: 'projects-split',
+                  listPaneVisible: listPaneVisible,
+                  canHideListPane: canHideListPane,
+                  onListPaneVisibilityChanged: (visible) {
+                    if (visible) {
+                      showList();
+                    } else {
+                      paneController.collapseListPane();
+                    }
+                  },
+                  listPane: SizedBox(
+                    width: listPaneWidth,
+                    child: _ProjectsListScaffold(
+                      scrollController: _scrollController,
+                      searchFocusNode: _searchFocusNode,
                     ),
-            );
-          },
+                  ),
+                  divider: ResizableDivider(
+                    currentValue: listPaneWidth,
+                    minValue: minListPaneWidth,
+                    maxValue: maxListPaneWidth,
+                    onDrag: resolvedListPane.onDrag,
+                  ),
+                  detailPane: selectedProjectId != null
+                      ? _ProjectsDetailPane(
+                          key: ValueKey(selectedProjectId),
+                          projectId: selectedProjectId,
+                        )
+                      : DesktopDetailEmptyState(
+                          message:
+                              context.messages.desktopEmptyStateSelectProject,
+                        ),
+                ),
+              );
+            },
+          ),
         ),
       );
     } else {

--- a/lib/features/projects/ui/pages/projects_tab_page.dart
+++ b/lib/features/projects/ui/pages/projects_tab_page.dart
@@ -128,6 +128,7 @@ class _ProjectsTabPageState extends ConsumerState<ProjectsTabPage> {
                   queryOpen &&
                   constraints.maxWidth <
                       listPaneWidth +
+                          ResizableDivider.layoutWidth +
                           QueryCompanion.minimumDockedWidth(context);
               final listPaneVisible =
                   !canHideListPane ||

--- a/lib/features/projects/ui/pages/projects_tab_page.dart
+++ b/lib/features/projects/ui/pages/projects_tab_page.dart
@@ -152,6 +152,7 @@ class _ProjectsTabPageState extends ConsumerState<ProjectsTabPage> {
                 },
                 child: ListDetailFocusTraversal(
                   debugLabel: 'projects-split',
+                  focusListOnExternalReveal: !canHideListPane,
                   listPaneVisible: listPaneVisible,
                   canHideListPane: canHideListPane,
                   onListPaneVisibilityChanged: (visible) {

--- a/test/features/categories/ui/pages/category_details_page_test.dart
+++ b/test/features/categories/ui/pages/category_details_page_test.dart
@@ -129,55 +129,71 @@ void main() {
       }
     }
 
-    testWidgets('Ask preserves an unsaved category name when returning', (
-      tester,
-    ) async {
-      final scope = QueryScope(
-        kind: QueryScopeKind.category,
-        id: testCategoryId,
-      );
-      final category = CategoryTestUtils.createTestCategory(
-        id: testCategoryId,
-        name: 'Penguin habitat',
-      );
-      when(
-        () => mockRepository.watchCategory(testCategoryId),
-      ).thenAnswer((_) => Stream.value(category));
-      await pumpCategoryDetailsPage(
+    testWidgets(
+      'Ask keeps the category form mounted with unsaved text and selection',
+      (
         tester,
-        settle: true,
-        extraOverrides: [
-          queryChatEnabledProvider.overrideWithValue(true),
-          queryChatTargetProvider(scope).overrideWith(
-            (ref) async => QueryChatTarget(
-              scope: scope,
-              label: category.name,
-              agent: null,
+      ) async {
+        final scope = QueryScope(
+          kind: QueryScopeKind.category,
+          id: testCategoryId,
+        );
+        final category = CategoryTestUtils.createTestCategory(
+          id: testCategoryId,
+          name: 'Penguin habitat',
+        );
+        when(
+          () => mockRepository.watchCategory(testCategoryId),
+        ).thenAnswer((_) => Stream.value(category));
+        await pumpCategoryDetailsPage(
+          tester,
+          settle: true,
+          extraOverrides: [
+            queryChatEnabledProvider.overrideWithValue(true),
+            queryChatTargetProvider(scope).overrideWith(
+              (ref) async => QueryChatTarget(
+                scope: scope,
+                label: category.name,
+                agent: null,
+              ),
             ),
-          ),
-          configFlagProvider(
-            'private',
-          ).overrideWith((ref) => Stream.value(false)),
-          chatRecorderControllerProvider.overrideWith(
-            TranscriptEmittingController.new,
-          ),
-        ],
-      );
-      await tester.enterText(nameFieldFinder(), 'Unsaved habitat name');
-      await tester.tap(find.text('Ask about this category'));
-      await tester.pumpAndSettle();
-      expect(
-        tester.widget<QueryChatPane>(find.byType(QueryChatPane)).scope,
-        scope,
-      );
-      await tester.tap(find.byIcon(LottiIcons.back).first);
-      await tester.pumpAndSettle();
-      expect(find.byType(QueryChatPane), findsNothing);
-      expect(
-        tester.widget<TextField>(nameFieldFinder()).controller!.text,
-        'Unsaved habitat name',
-      );
-    });
+            configFlagProvider(
+              'private',
+            ).overrideWith((ref) => Stream.value(false)),
+            chatRecorderControllerProvider.overrideWith(
+              TranscriptEmittingController.new,
+            ),
+          ],
+        );
+        await tester.enterText(nameFieldFinder(), 'Unsaved habitat name');
+        final field = tester.element(nameFieldFinder());
+        final input = tester.widget<TextField>(nameFieldFinder()).controller!
+          ..selection = const TextSelection(baseOffset: 2, extentOffset: 7);
+        await tester.tap(find.text('Ask about this category'));
+        await tester.pumpAndSettle();
+        expect(
+          tester.widget<QueryChatPane>(find.byType(QueryChatPane)).scope,
+          scope,
+        );
+        expect(tester.element(nameFieldFinder()), same(field));
+        expect(
+          tester.widget<QueryChatPane>(find.byType(QueryChatPane)).companion,
+          isTrue,
+        );
+        expect(
+          input.selection,
+          const TextSelection(baseOffset: 2, extentOffset: 7),
+        );
+        await tester.tap(find.byIcon(LottiIcons.close).last);
+        await tester.pumpAndSettle();
+        expect(find.byType(QueryChatPane), findsNothing);
+        expect(tester.element(nameFieldFinder()), same(field));
+        expect(
+          tester.widget<TextField>(nameFieldFinder()).controller!.text,
+          'Unsaved habitat name',
+        );
+      },
+    );
 
     testWidgets(
       'name field does not reseed selection/text on rebuild during edit',

--- a/test/features/keyboard/ui/list_detail_focus_traversal_test.dart
+++ b/test/features/keyboard/ui/list_detail_focus_traversal_test.dart
@@ -225,61 +225,77 @@ void main() {
     },
   );
 
-  testWidgets('external pane visibility changes transfer focus', (
-    tester,
-  ) async {
-    final listPaneVisible = ValueNotifier(true);
-    final listFocusNode = FocusNode(debugLabel: 'external-list');
-    final detailFocusNode = FocusNode(debugLabel: 'external-detail');
-    addTearDown(listPaneVisible.dispose);
-    addTearDown(listFocusNode.dispose);
-    addTearDown(detailFocusNode.dispose);
+  for (final autoFocus in [true, false]) {
+    testWidgets('external reveal focus policy (automatic=$autoFocus)', (
+      tester,
+    ) async {
+      final listPaneVisible = ValueNotifier(true);
+      final listFocusNode = FocusNode(debugLabel: 'external-list');
+      final detailFocusNode = FocusNode(debugLabel: 'external-detail');
+      addTearDown(listPaneVisible.dispose);
+      addTearDown(listFocusNode.dispose);
+      addTearDown(detailFocusNode.dispose);
 
-    await tester.pumpWidget(
-      makeTestableWidgetNoScroll(
-        ValueListenableBuilder<bool>(
-          valueListenable: listPaneVisible,
-          builder: (context, visible, _) => ListDetailFocusTraversal(
-            debugLabel: 'external-split',
-            listPaneVisible: visible,
-            canHideListPane: true,
-            listPane: SizedBox(
-              width: 240,
-              child: TextButton(
-                focusNode: listFocusNode,
-                onPressed: () {},
-                child: const Text('External list row'),
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          ValueListenableBuilder<bool>(
+            valueListenable: listPaneVisible,
+            builder: (context, visible, _) => ListDetailFocusTraversal(
+              debugLabel: 'external-split',
+              listPaneVisible: visible,
+              focusListOnExternalReveal: autoFocus,
+              onListPaneVisibilityChanged: (value) =>
+                  listPaneVisible.value = value,
+              canHideListPane: true,
+              listPane: SizedBox(
+                width: 240,
+                child: TextButton(
+                  focusNode: listFocusNode,
+                  onPressed: () {},
+                  child: const Text('External list row'),
+                ),
               ),
-            ),
-            divider: const SizedBox(width: 3),
-            detailPane: Align(
-              alignment: Alignment.topLeft,
-              child: TextButton(
-                focusNode: detailFocusNode,
-                onPressed: () {},
-                child: const Text('External detail action'),
+              divider: const SizedBox(width: 3),
+              detailPane: Align(
+                alignment: Alignment.topLeft,
+                child: TextButton(
+                  focusNode: detailFocusNode,
+                  onPressed: () {},
+                  child: const Text('External detail action'),
+                ),
               ),
             ),
           ),
         ),
-      ),
-    );
+      );
 
-    listFocusNode.requestFocus();
-    await tester.pump();
-    listPaneVisible.value = false;
-    await tester.pump();
-    await tester.pump();
+      listFocusNode.requestFocus();
+      await tester.pump();
+      listPaneVisible.value = false;
+      await tester.pump();
+      await tester.pump();
 
-    expect(detailFocusNode.hasFocus, isTrue);
+      expect(detailFocusNode.hasFocus, isTrue);
 
-    listPaneVisible.value = true;
-    await tester.pump();
-    await tester.pump();
+      listPaneVisible.value = true;
+      await tester.pump();
+      await tester.pump();
 
-    expect(listFocusNode.hasFocus, isTrue);
-  });
-
+      expect(listFocusNode.hasFocus, autoFocus);
+      expect(detailFocusNode.hasFocus, !autoFocus);
+      if (!autoFocus) {
+        listPaneVisible.value = false;
+        await tester.pump();
+        await tester.pump();
+        ListDetailFocusTraversal.maybeOf(
+          tester.element(find.text('External detail action')),
+        )!.showListPane();
+        await tester.pump();
+        await tester.pump();
+        expect(listFocusNode.hasFocus, isTrue);
+      }
+    });
+  }
   testWidgets('refuses to hide the list without an actionable detail', (
     tester,
   ) async {

--- a/test/features/projects/ui/pages/project_details_page_test.dart
+++ b/test/features/projects/ui/pages/project_details_page_test.dart
@@ -275,7 +275,7 @@ void main() {
     await tester.pump();
   }
 
-  testWidgets('Ask opens the project scope and Back restores project details', (
+  testWidgets('Ask keeps project details mounted in a companion until Close', (
     tester,
   ) async {
     const scope = QueryScope(kind: QueryScopeKind.project, id: _projectId);
@@ -303,15 +303,28 @@ void main() {
         ),
       ],
     );
+    final detail = tester.element(find.byType(ProjectMobileDetailContent));
     await tester.tap(find.text('Ask'));
     await tester.pumpAndSettle();
     expect(
       tester.widget<QueryChatPane>(find.byType(QueryChatPane)).scope,
       scope,
     );
-    await tester.tap(find.byIcon(LottiIcons.back).first);
+    expect(
+      tester.element(find.byType(ProjectMobileDetailContent)),
+      same(detail),
+    );
+    expect(
+      tester.widget<QueryChatPane>(find.byType(QueryChatPane)).companion,
+      isTrue,
+    );
+    await tester.tap(find.byIcon(LottiIcons.close).last);
     await tester.pumpAndSettle();
     expect(find.byType(QueryChatPane), findsNothing);
+    expect(
+      tester.element(find.byType(ProjectMobileDetailContent)),
+      same(detail),
+    );
     expect(find.text(testProject.data.title), findsWidgets);
   });
 

--- a/test/features/projects/ui/pages/projects_tab_page_test.dart
+++ b/test/features/projects/ui/pages/projects_tab_page_test.dart
@@ -7,6 +7,9 @@ import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/project_data.dart';
 import 'package:lotti/database/state/config_flag_provider.dart';
+import 'package:lotti/features/agents/model/query_chat_models.dart';
+import 'package:lotti/features/agents/query/query_chat_providers.dart';
+import 'package:lotti/features/agents/ui/chat/chat_recorder_controller.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
 import 'package:lotti/features/design_system/components/checkboxes/design_system_checkbox.dart';
 import 'package:lotti/features/design_system/components/chips/active_filter_chip.dart';
@@ -44,6 +47,7 @@ import 'package:mocktail/mocktail.dart';
 import '../../../../helpers/test_finders.dart';
 import '../../../../mocks/mocks.dart';
 import '../../../../widget_test_utils.dart';
+import '../../../agents/ui/evolution/widgets/evolution_recorder_test_utils.dart';
 import '../../../categories/test_utils.dart';
 import '../../test_utils.dart';
 
@@ -1397,6 +1401,94 @@ void main() {
   });
 
   group('desktop split-view layout', () {
+    for (final useSearch in [false, true]) {
+      testWidgets('project companion restores its list (search=$useSearch)', (
+        tester,
+      ) async {
+        const scope = QueryScope(kind: QueryScopeKind.project, id: 'p1');
+        const size = Size(1200, 900);
+        tester.view.physicalSize = size;
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+        final nav = getIt<NavService>() as MockNavService;
+        final selected = ValueNotifier<String?>('p1');
+        addTearDown(selected.dispose);
+        when(() => nav.desktopSelectedProjectId).thenReturn(selected);
+        await pumpPage(
+          tester,
+          groups: [buildWorkGroup()],
+          mediaQueryData: const MediaQueryData(size: size),
+          extraOverrides: [
+            queryChatEnabledProvider.overrideWithValue(true),
+            queryChatTargetProvider(scope).overrideWith(
+              (ref) async => const QueryChatTarget(
+                scope: scope,
+                label: 'Penguin habitat',
+                agent: null,
+              ),
+            ),
+            chatRecorderControllerProvider.overrideWith(
+              TranscriptEmittingController.new,
+            ),
+            projectDetailControllerProvider(
+              'p1',
+            ).overrideWith(_StubProjectDetailController.new),
+            projectDetailRecordProvider('p1').overrideWith((ref) async => null),
+          ],
+        );
+        final context = tester.element(find.byType(ProjectsTabPage));
+        final container = ProviderScope.containerOf(context);
+        final list = tester.element(find.byType(ProjectsOverviewContent));
+        final detail = tester.element(find.byType(ProjectDetailsPage));
+        container.read(queryPaneOpenProvider(scope).notifier).open = true;
+        await tester.pump();
+        await tester.pump();
+        expect(find.text('Device Sync'), findsNothing);
+        expect(
+          tester.element(
+            find.byType(ProjectsOverviewContent, skipOffstage: false),
+          ),
+          same(list),
+        );
+        expect(
+          container.read(paneWidthControllerProvider).listPaneCollapsed,
+          isFalse,
+        );
+        if (useSearch) {
+          final commands = AppCommandControllerProvider.of(
+            tester.element(find.byType(ProjectDetailsPage)),
+          );
+          expect(
+            await commands.invoke(context, AppCommandId.focusSearch),
+            isTrue,
+          );
+        } else {
+          await tester.tap(
+            find.byKey(const ValueKey('projects-show-list-pane')),
+          );
+        }
+        await tester.pump();
+        await tester.pump();
+        expect(container.read(queryPaneOpenProvider(scope)), isFalse);
+        expect(find.text('Device Sync'), findsOneWidget);
+        expect(tester.element(find.byType(ProjectDetailsPage)), same(detail));
+        expect(
+          tester.element(find.byType(ProjectsOverviewContent)),
+          same(list),
+        );
+        if (useSearch) {
+          expect(
+            tester
+                .widget<TextField>(find.byType(TextField))
+                .focusNode!
+                .hasFocus,
+            isTrue,
+          );
+        }
+        await tester.pumpWidget(const SizedBox.shrink());
+      });
+    }
+
     testWidgets(
       'wide viewport renders list pane + divider + empty detail state',
       (tester) async {

--- a/test/features/projects/ui/pages/projects_tab_page_test.dart
+++ b/test/features/projects/ui/pages/projects_tab_page_test.dart
@@ -2,9 +2,11 @@
 
 import 'dart:async';
 
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/project_data.dart';
 import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/agents/model/query_chat_models.dart';
@@ -53,13 +55,15 @@ import '../../test_utils.dart';
 
 /// Loading-state detail controller stub for the split-view swap test.
 class _StubProjectDetailController extends ProjectDetailController {
-  _StubProjectDetailController() : super('p1');
+  _StubProjectDetailController({this.project}) : super('p1');
+
+  final ProjectEntry? project;
 
   @override
-  ProjectDetailState build() => const ProjectDetailState(
-    project: null,
+  ProjectDetailState build() => ProjectDetailState(
+    project: project,
     linkedTasks: [],
-    isLoading: true,
+    isLoading: project == null,
     isSaving: false,
     hasChanges: false,
   );
@@ -1401,6 +1405,66 @@ void main() {
   });
 
   group('desktop split-view layout', () {
+    testWidgets(
+      'closing project chat returns focus to Ask after restoring the list',
+      (tester) async {
+        const scope = QueryScope(kind: QueryScopeKind.project, id: 'p1');
+        const size = Size(1200, 900);
+        tester.view.physicalSize = size;
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+        final nav = getIt<NavService>() as MockNavService;
+        final selected = ValueNotifier<String?>('p1');
+        addTearDown(selected.dispose);
+        when(() => nav.desktopSelectedProjectId).thenReturn(selected);
+        final project = makeTestProject(
+          id: 'p1',
+          title: 'Penguin habitat',
+          categoryId: 'work',
+        );
+        await pumpPage(
+          tester,
+          groups: [buildWorkGroup()],
+          mediaQueryData: const MediaQueryData(size: size),
+          extraOverrides: [
+            queryChatEnabledProvider.overrideWithValue(true),
+            queryChatTargetProvider(scope).overrideWith(
+              (ref) async => const QueryChatTarget(
+                scope: scope,
+                label: 'Penguin habitat',
+                agent: null,
+              ),
+            ),
+            chatRecorderControllerProvider.overrideWith(
+              TranscriptEmittingController.new,
+            ),
+            projectDetailControllerProvider('p1').overrideWith(
+              () => _StubProjectDetailController(project: project),
+            ),
+            projectDetailRecordProvider('p1').overrideWith(
+              (ref) async => makeTestProjectRecord(project: project),
+            ),
+          ],
+        );
+        await tester.pump();
+        await tester.pump();
+        final opener = Focus.of(tester.element(find.text('Ask')))
+          ..requestFocus();
+        await tester.pump();
+        await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+        await tester.pump();
+        await tester.pump();
+        expect(find.text('Device Sync'), findsNothing);
+        expect(opener.hasFocus, isFalse);
+        await tester.tap(find.byIcon(LottiIcons.close).last);
+        await tester.pump();
+        await tester.pump();
+        expect(find.text('Device Sync'), findsOneWidget);
+        expect(opener.hasFocus, isTrue);
+        await tester.pumpWidget(const SizedBox.shrink());
+      },
+    );
+
     for (final useSearch in [false, true]) {
       testWidgets('project companion restores its list (search=$useSearch)', (
         tester,

--- a/test/features/projects/ui/pages/projects_tab_page_test.dart
+++ b/test/features/projects/ui/pages/projects_tab_page_test.dart
@@ -12,6 +12,7 @@ import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/agents/model/query_chat_models.dart';
 import 'package:lotti/features/agents/query/query_chat_providers.dart';
 import 'package:lotti/features/agents/ui/chat/chat_recorder_controller.dart';
+import 'package:lotti/features/agents/ui/query/query_companion.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
 import 'package:lotti/features/design_system/components/checkboxes/design_system_checkbox.dart';
 import 'package:lotti/features/design_system/components/chips/active_filter_chip.dart';
@@ -1464,6 +1465,78 @@ void main() {
         await tester.pumpWidget(const SizedBox.shrink());
       },
     );
+
+    testWidgets('project companion includes divider width at docking boundary', (
+      tester,
+    ) async {
+      const scope = QueryScope(kind: QueryScopeKind.project, id: 'p1');
+      const size = Size(1400, 900);
+      tester.view.physicalSize = size;
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      final nav = getIt<NavService>() as MockNavService;
+      final selected = ValueNotifier<String?>('p1');
+      addTearDown(selected.dispose);
+      when(() => nav.desktopSelectedProjectId).thenReturn(selected);
+      await pumpPage(
+        tester,
+        groups: [buildWorkGroup()],
+        mediaQueryData: const MediaQueryData(size: size),
+        extraOverrides: [
+          queryChatEnabledProvider.overrideWithValue(true),
+          queryChatTargetProvider(scope).overrideWith(
+            (ref) async => const QueryChatTarget(
+              scope: scope,
+              label: 'Penguin habitat',
+              agent: null,
+            ),
+          ),
+          chatRecorderControllerProvider.overrideWith(
+            TranscriptEmittingController.new,
+          ),
+          projectDetailControllerProvider(
+            'p1',
+          ).overrideWith(_StubProjectDetailController.new),
+          projectDetailRecordProvider('p1').overrideWith((ref) async => null),
+        ],
+      );
+      final context = tester.element(find.byType(ProjectsTabPage));
+      final container = ProviderScope.containerOf(context);
+      final panes = container.read(paneWidthControllerProvider.notifier);
+      final dividerWidth = tester.getSize(find.byType(ResizableDivider)).width;
+      final fittingListWidth =
+          size.width -
+          QueryCompanion.minimumDockedWidth(context) -
+          dividerWidth;
+      panes.updateListPaneWidth(
+        fittingListWidth -
+            container.read(paneWidthControllerProvider).listPaneWidth,
+      );
+      container.read(queryPaneOpenProvider(scope).notifier).open = true;
+      await tester.pump();
+      await tester.pump();
+      expect(find.text('Device Sync'), findsOneWidget);
+      expect(find.byType(DraggableScrollableSheet), findsNothing);
+
+      // One pixel less detail space must suppress the list, keeping chat docked.
+      panes.updateListPaneWidth(1);
+      await tester.pump();
+      await tester.pump();
+      expect(find.text('Device Sync'), findsNothing);
+      expect(find.byType(DraggableScrollableSheet), findsNothing);
+      expect(
+        container.read(paneWidthControllerProvider).listPaneCollapsed,
+        isFalse,
+      );
+
+      panes.updateListPaneWidth(-1);
+      await tester.pump();
+      await tester.pump();
+      expect(find.text('Device Sync'), findsOneWidget);
+      expect(find.byType(DraggableScrollableSheet), findsNothing);
+      expect(container.read(queryPaneOpenProvider(scope)), isTrue);
+      await tester.pumpWidget(const SizedBox.shrink());
+    });
 
     for (final useSearch in [false, true]) {
       testWidgets('project companion restores its list (search=$useSearch)', (


### PR DESCRIPTION
Opening project or category chat replaced the detail screen. Both now use the task chat companion: a resizable side panel on wide hosts and an expandable sheet on narrow hosts. Detail widgets remain mounted, preserving category draft text and selection as well as project browsing state.

On desktop, project chat temporarily hides the project list when it needs the width, without changing the saved list preference. Closing chat restores the list and returns keyboard focus to Ask; Show list and keyboard search close chat when needed to restore browsing. The existing default-off `enable_query_chat` flag still gates all entry points.

Validation: zero analyzer diagnostics; all 148 tests in the three touched page test files pass via Dart MCP. The four navigation/retention regressions fail against the previous implementation. The review fix also passes all 58 tests in the project host and shared focus traversal files, including regressions for Close returning focus to Ask and explicit Show list/search focusing the list. Those regressions fail without the fix. Knowledge and changelog checks pass. The divider fit regression checks exact fit and one pixel below it; all 72 project-host/divider tests pass, and the new regression fails without the correction. CI is validating the final update. The preceding run passed all ten unit/widget shards, property tests, and integration tests with 100% patch coverage and 99.38% overall coverage.

<details>
<summary>Before / after screenshots</summary>

Production widgets with shared synthetic test fixtures; desktop and phone viewports. Screenshots are stored outside the repository.

| Surface | Before | After |
|---|---|---|
| Project — desktop | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-companion-project-category/83254fb580bd6f36c6c1cbda27144b9bdf304358/before/project_1280_dark.png" width="260"> | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-companion-project-category/83254fb580bd6f36c6c1cbda27144b9bdf304358/after/project_1280_dark.png" width="260"> |
| Project — phone | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-companion-project-category/83254fb580bd6f36c6c1cbda27144b9bdf304358/before/project_390_dark.png" width="260"> | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-companion-project-category/83254fb580bd6f36c6c1cbda27144b9bdf304358/after/project_390_dark.png" width="260"> |
| Category — desktop | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-companion-project-category/83254fb580bd6f36c6c1cbda27144b9bdf304358/before/category_1280_light.png" width="260"> | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-companion-project-category/83254fb580bd6f36c6c1cbda27144b9bdf304358/after/category_1280_light.png" width="260"> |
| Category — phone | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-companion-project-category/83254fb580bd6f36c6c1cbda27144b9bdf304358/before/category_390_light.png" width="260"> | <img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/query-companion-project-category/83254fb580bd6f36c6c1cbda27144b9bdf304358/after/category_390_light.png" width="260"> |

</details>
