### PR TITLE
fix: give query chat the current local date and time

### DIFF
--- a/changelog.d/2026-09-13-query-chat-current-time.md
+++ b/changelog.d/2026-09-13-query-chat-current-time.md
@@ -1,0 +1,4 @@
+### Fixed
+- **Chat now receives the current local date and time.** Questions about today,
+  yesterday or tomorrow get a fresh device timestamp with its UTC offset,
+  rather than leaving the model to infer today from old reports or messages.

--- a/knowledge/features/agents/query-chat.md
+++ b/knowledge/features/agents/query-chat.md
@@ -5,7 +5,7 @@ description: Task, project and category conversations with isolated source check
 resource: ../../../lib/features/agents/query
 tags: [agents, chat, retrieval, evidence, privacy, sync]
 status: stable
-generated: { by: codex/gpt-6, at: 2026-09-12T20:00:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-13T00:00:00Z }
 stale_after: 2026-10-12
 sources:
   - id: controller
@@ -27,7 +27,7 @@ sources:
   - id: builder
     resource: ../../../lib/features/agents/query/query_answer_builder.dart
     title: Summary-first routing and home-entry evidence verification
-    last_modified: 2026-09-12
+    last_modified: 2026-09-13
   - id: summary-reader
     resource: ../../../lib/features/agents/query/query_summary_reader.dart
     title: Maintained task and project report layers
@@ -35,7 +35,11 @@ sources:
   - id: summary-answer
     resource: ../../../lib/features/agents/query/query_summary_answer_builder.dart
     title: TLDR selection and attributed summary answers
-    last_modified: 2026-09-12
+    last_modified: 2026-09-13
+  - id: inference
+    resource: ../../../lib/features/agents/query/query_text_inference.dart
+    title: Profile routing and fresh device clock context
+    last_modified: 2026-09-13
   - id: access
     resource: ../../../lib/features/agents/query/query_source_access.dart
     title: Live visibility gate
@@ -313,6 +317,20 @@ count excluded recordings as missing transcripts. Binary audio and
 images are not inspected by this crawler.
 
 # Request lifecycle and context
+
+Every `QueryTextInference.complete` request appends a fresh `currentTime` object
+with the device's `localDate` and a seconds-resolution `localTimestamp` including
+its explicit UTC offset. Shared system guidance anchors relative dates to that
+clock, not to dates in reports or prior messages. The clock refreshes for every
+completion, including retries and chats left open across midnight. It is request
+metadata, not evidence or a durable task conclusion. Injection preserves caller
+input and replaces any stale top-level clock value.
+
+The changing clock follows the existing source/context payload, preserving the
+stable source prefix. `QueryTextInference.requestBytes` counts both the guidance
+and clock metadata in summary-selection, full-summary and home-batch budgets.
+No extra inference call is needed. This remains a read-only query pipeline:
+owning-agent mutation tools, including time recording, are not exposed here.
 
 `QueryChatController` maintains separate drafts, narrowing choices, cancellation
 tokens and request status for each chat. Requests in different chats can run

--- a/lib/features/agents/query/query_answer_builder.dart
+++ b/lib/features/agents/query/query_answer_builder.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/query_chat_models.dart';
 import 'package:lotti/features/agents/query/query_chat_projection.dart';
@@ -677,7 +675,10 @@ class QueryAnswerBuilder {
       'Choose relevant memories in this same inspection; a memory is not fresh evidence. '
       'Do not write the final answer. Never invent a missing fact.';
 
-  static final int _batchSystemBytes = utf8.encode(_batchSystem).length;
+  static final int _batchSystemBytes = QueryTextInference.requestBytes(
+    _batchSystem,
+    const {},
+  );
 
   _QueryBatchResult? _matchingBatch(
     QuerySourceDocument document,
@@ -734,14 +735,10 @@ class QueryAnswerBuilder {
             (length, source) => length + source.text.length,
           ) <=
           12000 &&
-      _batchSystemBytes +
-              utf8
-                  .encode(
-                    jsonEncode(
-                      _batchInput(corpus, question, context, memories),
-                    ),
-                  )
-                  .length <=
+      QueryTextInference.requestBytes(
+            _batchSystem,
+            _batchInput(corpus, question, context, memories),
+          ) <=
           maxBatchBytes;
 
   /// Verifies the whole supplied batch at both model boundaries. Only exact

--- a/lib/features/agents/query/query_summary_answer_builder.dart
+++ b/lib/features/agents/query/query_summary_answer_builder.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:lotti/features/agents/model/query_chat_models.dart';
 import 'package:lotti/features/agents/query/query_journal_crawler.dart';
 import 'package:lotti/features/agents/query/query_source_access.dart';
@@ -117,8 +115,7 @@ class QuerySummaryAnswerBuilder {
     };
     var incomplete = catalog.incomplete || kind != null;
     bool fits(String system, Map<String, Object?> input) =>
-        utf8.encode(system).length + utf8.encode(jsonEncode(input)).length <=
-        maxInputBytes;
+        QueryTextInference.requestBytes(system, input) <= maxInputBytes;
     if (!fits(_selectionSystem, orientation) ||
         !fits(_answerSystem, {...context, 'summaries': const []})) {
       throw const FormatException('Summary question exceeds input budget');

--- a/lib/features/agents/query/query_text_inference.dart
+++ b/lib/features/agents/query/query_text_inference.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:clock/clock.dart';
 import 'package:lotti/features/agents/ui/chat/thinking_parser.dart';
 import 'package:lotti/features/ai/model/ai_call_impact.dart';
 import 'package:lotti/features/ai/model/resolved_profile.dart';
@@ -188,6 +189,40 @@ class QueryTextInference {
   final QueryTextStream _generate;
   final QueryTextStream? _generateSynthesis;
 
+  static const _clockGuidance =
+      ' The top-level currentTime is the device clock for this request. '
+      'Use its localDate and localTimestamp to resolve today, yesterday, '
+      'tomorrow and other relative dates. Dates in sources, reports and prior '
+      'conversation are historical; never use them as the current date. '
+      'The clock is request metadata, not source evidence or a durable task '
+      'conclusion. Do not invent a different current date.';
+
+  /// Includes the same clock guidance and metadata sent to the provider, so
+  /// retrieval budgets still bound the complete request. Timestamps use seconds
+  /// and a fixed-width UTC offset, keeping their size stable across calls.
+  static int requestBytes(String system, Map<String, Object?> input) =>
+      utf8.encode('$system$_clockGuidance').length +
+      utf8.encode(jsonEncode(_withCurrentTime(input))).length;
+
+  static Map<String, Object?> _withCurrentTime(Map<String, Object?> input) {
+    final now = clock.now();
+    final local = now.toIso8601String().split('.').first;
+    final minutes = now.timeZoneOffset.inMinutes;
+    final hours = (minutes.abs() ~/ 60).toString().padLeft(2, '0');
+    final remainder = (minutes.abs() % 60).toString().padLeft(2, '0');
+    final offset = '${minutes < 0 ? '-' : '+'}$hours:$remainder';
+    return {
+      for (final entry in input.entries)
+        if (entry.key != 'currentTime') entry.key: entry.value,
+      // Append volatile clock data after stable sources and replace any stale
+      // caller-supplied clock. Never cache this at profile/chat construction.
+      'currentTime': {
+        'localDate': local.split('T').first,
+        'localTimestamp': '$local$offset',
+      },
+    };
+  }
+
   Future<Map<String, dynamic>> complete({
     required String system,
     required Map<String, Object?> input,
@@ -200,8 +235,8 @@ class QueryTextInference {
     var received = false;
     final response = await cancellation.collect(
       (onAnswerText == null ? _generate : _generateSynthesis ?? _generate)(
-        system,
-        jsonEncode(input),
+        '$system$_clockGuidance',
+        jsonEncode(_withCurrentTime(input)),
       ),
       onText: (raw) {
         if (!received && raw.isNotEmpty) {

--- a/test/features/agents/query/query_answer_builder_test.dart
+++ b/test/features/agents/query/query_answer_builder_test.dart
@@ -202,6 +202,7 @@ void main() {
     late List<String> stages;
     late List<Map<String, dynamic>> batchInputs;
     late List<String> batchPrompts;
+    late List<int> batchSizes;
     late List<(int, bool)> progress;
     late QueryCancellation cancellation;
     var wanted = 'source-1';
@@ -223,6 +224,7 @@ void main() {
       stages = [];
       batchInputs = [];
       batchPrompts = [];
+      batchSizes = [];
       progress = [];
       cancellation = QueryCancellation();
       wanted = 'source-1';
@@ -237,12 +239,14 @@ void main() {
     Future<QueryBuiltAnswer> build({
       bool homeOnly = false,
       int sourceCalls = 90,
+      int maxBytes = QueryAnswerBuilder.defaultBatchInputBytes,
       AgentQueryChatEventEntity? askedQuestion,
     }) =>
         QueryAnswerBuilder(
           crawler: bench.crawler,
           access: bench.crawler.access,
           maxSourceCalls: sourceCalls,
+          maxBatchBytes: maxBytes,
           inference: QueryTextInference(
             generate: (system, prompt) {
               final input = jsonDecode(prompt) as Map<String, dynamic>;
@@ -251,6 +255,9 @@ void main() {
                 stages.add('batch');
                 batchInputs.add(input);
                 batchPrompts.add(prompt);
+                batchSizes.add(
+                  utf8.encode(system).length + utf8.encode(prompt).length,
+                );
                 duringBatch?.call();
                 final sources = (input['sources'] as List)
                     .cast<Map<String, dynamic>>();
@@ -369,6 +376,16 @@ void main() {
         expect(batchPrompts.last, isNot(first));
       },
     );
+
+    test('home batch budget includes the clock sent to the provider', () async {
+      await build(homeOnly: true);
+      final budget = batchSizes.single - 1;
+      stages.clear();
+      await build(homeOnly: true, maxBytes: budget);
+      expect(stages, isNot(contains('batch')));
+      expect(stages, contains('extract'));
+      expect(batchSizes, hasLength(1));
+    });
 
     test('one inspection budget still counts every batched source', () async {
       final result = await build(sourceCalls: 1);

--- a/test/features/agents/query/query_chat_providers_test.dart
+++ b/test/features/agents/query/query_chat_providers_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:clock/clock.dart';
 import 'package:drift/drift.dart' hide isNull;
@@ -182,27 +183,39 @@ void main() {
               baseUrl: provider.baseUrl,
               apiKey: provider.apiKey,
               provider: provider,
-              systemMessage: 'inspect',
+              systemMessage: any(named: 'systemMessage'),
               maxCompletionTokens: any(named: 'maxCompletionTokens'),
               geminiThinkingMode: any(named: 'geminiThinkingMode'),
               impactCollector: any(named: 'impactCollector'),
             ),
           ).thenAnswer(
-            (_) => Stream.value(
-              const CreateChatCompletionStreamResponse(
-                id: 'response',
-                object: 'chat.completion.chunk',
-                created: 0,
-                choices: [
-                  ChatCompletionStreamResponseChoice(
-                    index: 0,
-                    delta: ChatCompletionStreamResponseDelta(
-                      content: '{"passages":[]}',
+            (invocation) {
+              expect(
+                invocation.namedArguments[#systemMessage],
+                allOf(startsWith('inspect'), contains('device clock')),
+              );
+              final input =
+                  jsonDecode(invocation.positionalArguments.single as String)
+                      as Map<String, dynamic>;
+              expect(input['source'], 'Only the feeder note');
+              expect(input['currentTime'], isA<Map<String, dynamic>>());
+              expect(input.keys, unorderedEquals(['source', 'currentTime']));
+              return Stream.value(
+                const CreateChatCompletionStreamResponse(
+                  id: 'response',
+                  object: 'chat.completion.chunk',
+                  created: 0,
+                  choices: [
+                    ChatCompletionStreamResponseChoice(
+                      index: 0,
+                      delta: ChatCompletionStreamResponseDelta(
+                        content: '{"passages":[]}',
+                      ),
                     ),
-                  ),
-                ],
-              ),
-            ),
+                  ],
+                ),
+              );
+            },
           );
           bench.categories[0] = bench.categories.single.copyWith(
             defaultProfileId: 'category-profile',

--- a/test/features/agents/query/query_summary_answer_builder_test.dart
+++ b/test/features/agents/query/query_summary_answer_builder_test.dart
@@ -384,6 +384,34 @@ void main() {
     },
   );
 
+  test('full-summary budget includes the clock sent to the provider', () async {
+    reports['other'] = reports['other']!.copyWith(content: 'x' * 10000);
+    await build();
+    final fullBytes =
+        utf8.encode(systems.last).length +
+        utf8.encode(jsonEncode(prompts.last)).length;
+    final budget = fullBytes - 1;
+    prompts.clear();
+    systems.clear();
+
+    final answer = await build(maxBytes: budget);
+
+    expect(answer!.coverage.incomplete, isTrue);
+    expect(
+      ((prompts.last['summaries'] as List).single as Map).containsKey(
+        'content',
+      ),
+      isFalse,
+    );
+    for (var i = 0; i < prompts.length; i++) {
+      expect(
+        utf8.encode(systems[i]).length +
+            utf8.encode(jsonEncode(prompts[i])).length,
+        lessThanOrEqualTo(budget),
+      );
+    }
+  });
+
   test('selection cannot request a TLDR omitted by the input budget', () async {
     reports['other'] = reports['other']!.copyWith(
       tldr: List.filled(30000, 'x').join(),

--- a/test/features/agents/query/query_text_inference_test.dart
+++ b/test/features/agents/query/query_text_inference_test.dart
@@ -1,12 +1,14 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:clock/clock.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/query/query_text_inference.dart';
 import 'package:lotti/features/ai/model/resolved_profile.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
+import 'package:timezone/timezone.dart' as tz;
 
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
@@ -15,6 +17,106 @@ import '../test_data/ai_config_factories.dart';
 
 void main() {
   setUpAll(registerAllFallbackValues);
+  for (final (minutes, offset) in [
+    (120, '+02:00'),
+    (345, '+05:45'),
+    (-210, '-03:30'),
+  ]) {
+    test(
+      'current clock preserves device wall date and offset $offset',
+      () async {
+        final location = tz.Location('test', [], [], [
+          tz.TimeZone(
+            Duration(minutes: minutes),
+            isDst: false,
+            abbreviation: 'test',
+          ),
+        ]);
+        final now = tz.TZDateTime(location, 2026, 9, 13, 0, 5, 6);
+        await withClock(Clock.fixed(now), () async {
+          final input = <String, Object?>{
+            'sources': [
+              {'date': '2025-01-01', 'text': 'Old 🐧 report'},
+            ],
+            'currentTime': {'localDate': '2024-01-01'},
+          };
+          final original = jsonEncode(input);
+          final measured = QueryTextInference.requestBytes('Inspect', input);
+          final inference = QueryTextInference(
+            generate: (system, prompt) {
+              final supplied = jsonDecode(prompt) as Map<String, dynamic>;
+              expect(supplied['currentTime'], {
+                'localDate': '2026-09-13',
+                'localTimestamp': '2026-09-13T00:05:06$offset',
+              });
+              expect(supplied['sources'], input['sources']);
+              expect(supplied.keys.last, 'currentTime');
+              expect(system, contains('never use them as the current date'));
+              expect(
+                measured,
+                utf8.encode(system).length + utf8.encode(prompt).length,
+              );
+              return Stream.value('{}');
+            },
+          );
+          await inference.complete(
+            system: 'Inspect',
+            input: input,
+            cancellation: QueryCancellation(),
+          );
+          expect(
+            jsonEncode(input),
+            original,
+            reason: 'Clock injection must not mutate caller context',
+          );
+        });
+      },
+    );
+  }
+
+  test(
+    'reused inference refreshes today across midnight for both routes',
+    () async {
+      var now = DateTime.utc(2026, 9, 12, 23, 59, 59);
+      final calls = <Map<String, dynamic>>[];
+      final systems = <String>[];
+      Stream<String> generate(String system, String prompt) {
+        calls.add(jsonDecode(prompt) as Map<String, dynamic>);
+        systems.add(system);
+        return Stream.value('{"answer":"done"}');
+      }
+
+      final inference = QueryTextInference(
+        generate: generate,
+        generateSynthesis: generate,
+      );
+      await withClock(Clock(() => now), () async {
+        for (final synthesis in [false, true]) {
+          await inference.complete(
+            system: 'Answer',
+            input: const {},
+            cancellation: QueryCancellation(),
+            onAnswerText: synthesis ? (_) {} : null,
+          );
+          now = now.add(const Duration(seconds: 2));
+        }
+      });
+      expect(calls.map((c) => (c['currentTime'] as Map)['localDate']), [
+        '2026-09-12',
+        '2026-09-13',
+      ]);
+      expect(
+        (calls.last['currentTime'] as Map)['localTimestamp'],
+        '2026-09-13T00:00:01+00:00',
+      );
+      expect(
+        systems.first,
+        systems.last,
+        reason: 'Clock must not churn the system prefix',
+      );
+    },
+  );
+
   for (final fenced in [false, true]) {
     test('synthesis decodes character-sized escapes fenced=$fenced', () async {
       const answer = 'Line\n"quoted" 🐧 [1]';
@@ -188,10 +290,10 @@ void main() {
         cancellation: QueryCancellation(),
       );
       expect(first['quote'], 'Keep the feeder.');
-      expect(inputs, [
-        {'source': 'first'},
-        {'source': 'second'},
-      ]);
+      expect(inputs.map((input) => input['source']), ['first', 'second']);
+      for (final input in inputs) {
+        expect(input.keys, unorderedEquals(['source', 'currentTime']));
+      }
     },
   );
 
@@ -296,7 +398,7 @@ void main() {
             baseUrl: provider.baseUrl,
             apiKey: provider.apiKey,
             provider: provider,
-            systemMessage: 'inspect',
+            systemMessage: any(named: 'systemMessage'),
             maxCompletionTokens: 321,
             geminiThinkingMode: any(named: 'geminiThinkingMode'),
             impactCollector: any(named: 'impactCollector'),
@@ -366,9 +468,10 @@ void main() {
           ),
           {'passages': <Object>[]},
         );
-        expect(prompts, [
-          jsonEncode({'source': 'Only this meeting'}),
-        ]);
+        expect(prompts, hasLength(1));
+        final supplied = jsonDecode(prompts.single) as Map<String, dynamic>;
+        expect(supplied['source'], 'Only this meeting');
+        expect(supplied['currentTime'], isA<Map<String, dynamic>>());
         final event = attribution.recordedInteractions.single;
         expect(event.providerModelId, 'query-model');
         expect(event.configId, provider.id);


### PR DESCRIPTION
Chat could infer “today” from an old report or message because query inference received no current clock. Every query completion now receives the device’s current local date, time and UTC offset, with guidance to use them for relative dates. The clock refreshes on each request, including streaming synthesis and chats left open across midnight.

Clock metadata follows the existing context to preserve the stable source prefix. Request-size budgets include the added guidance and metadata. Model routing, evidence validation and the number of inference calls are unchanged.

Validation:
- 108 targeted tests passed via Dart MCP; full analyzer clean.
- Regression tests cover local offsets, midnight rollover, stale clock replacement, caller isolation and actual request-byte limits. Each new regression failed with its relevant fix reverted.
- Knowledge and changelog validation passed.

This fixes request context; no new live-model latency or quality claim is made. Task-agent action tools remain a separate integration.
