### PR TITLE
fix: preserve task chat targets and repair invalid proposals

### DIFF
--- a/knowledge/features/agents/query-chat.md
+++ b/knowledge/features/agents/query-chat.md
@@ -370,6 +370,8 @@ text, task fields, labels, follow-up tasks, relationships and migrations.
 Checklist targets use the journal metadata ID; nullable or stale legacy IDs
 inside checklist data cannot overwrite it. Chat-specific guidance allows
 migration to a supplied existing task as well as a newly proposed follow-up.
+Only a migration targeting the new follow-up shares its group ID;
+a migration to an existing task does not inherit that grouping metadata.
 An explicit checked-state request supplies the reason required for a user-set
 item. Task language may only be initialized while unset; a configured language
 must be changed through task settings. Validation repeats that restriction

--- a/knowledge/features/agents/query-chat.md
+++ b/knowledge/features/agents/query-chat.md
@@ -5,7 +5,7 @@ description: Task, project and category conversations with isolated source check
 resource: ../../../lib/features/agents/query
 tags: [agents, chat, retrieval, evidence, privacy, sync]
 status: stable
-generated: { by: codex/gpt-6, at: 2026-09-13T00:00:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-13T04:00:59Z }
 stale_after: 2026-10-12
 sources:
   - id: controller

--- a/knowledge/features/agents/query-chat.md
+++ b/knowledge/features/agents/query-chat.md
@@ -367,6 +367,13 @@ linked time entries, visible same-category task targets, eligible labels and
 the current timer when it belongs to the task. No neighbour raw entries are
 loaded. This supports checklist additions/updates, time recording and timer
 text, task fields, labels, follow-up tasks, relationships and migrations.
+Checklist targets use the journal metadata ID; nullable or stale legacy IDs
+inside checklist data cannot overwrite it. Chat-specific guidance allows
+migration to a supplied existing task as well as a newly proposed follow-up.
+An explicit checked-state request supplies the reason required for a user-set
+item. Task language may only be initialized while unset; a configured language
+must be changed through task settings. Validation repeats that restriction
+against live state before approval.
 Missing required details produce a clarification, with no proposed changes.
 
 The planner validates registry schemas, local timestamp syntax/ranges and ID
@@ -375,7 +382,22 @@ are checked against the unchanged endpoint from the live stored entry. Its outpu
 `QueryChatAnswer.proposedActions` list, with no evidence cards or durable
 conclusions. These inert arguments belong only to the chat until accepted;
 no task-agent change set exists merely because a model proposed an action.
+Invalid JSON or task-action validation gets one isolated repair completion.
+The repair carries content-free corrective guidance, not provider error text
+or partially built proposals, and remains within the input budget. A second
+failure uses normal question recovery. Transport errors and cancellation are
+not retried. Only the final valid attempt can become a proposal.
 Proposal owners must remain live, visible and in their saved categories.
+
+```mermaid
+flowchart LR
+  Request[Explicit chat request] --> Plan[Isolated action planning]
+  Plan --> Validate[JSON, schema and live target validation]
+  Validate -->|valid| Review[Pending proposal]
+  Validate -->|first failure| Repair[One isolated repair]
+  Repair --> Validate
+  Validate -->|second failure| Recovery[Question failure and Retry]
+```
 
 `QueryActionReview` renders the actual structured changes inside the answer,
 including dates, time ranges and follow-up options, with Accept and Dismiss.
@@ -420,10 +442,25 @@ stateDiagram-v2
 ```
 
 The opt-in `query_actions_eval_live_test.dart` uses the production builder and
-transport with the unmodified penguin corpus and a frozen report bundle. It
-records question-to-review time separately from each completion, and checks
-checklist/time/combined/status requests plus missing-detail, advice and quoted
-instruction controls. It never wires an approval service. Set
+transport with a frozen report bundle and a declared action-only overlay on
+the penguin database. The canonical ordinary-query corpus and expectations are
+unchanged. The overlay supplies fixed owned checklist items, completed time,
+an active timer, a label and same-category/foreign task targets, with a fixed
+local clock. Its hash and source hashes accompany every artifact.
+The cases and independent argument scorer live in
+[`query_action_eval.dart`](../../../test/features/ai/eval/support/query_action_eval.dart);
+[`query_action_eval_fixture.dart`](../../../test/features/ai/eval/support/query_action_eval_fixture.dart)
+owns the overlay. Positive cases cover every exposed task tool. Grading checks
+exact targets, requested fields, local time ranges, batch contents and
+follow-up dependency ordering, with negative controls for unsupported or
+underspecified requests, advice and quoted instructions. Passing proposal
+checks does not establish that a live mutation executed successfully.
+
+The harness records question-to-built-review time separately from each
+completion; publication and UI rendering are excluded. It never wires an
+approval service. `QUERY_ACTION_EVAL_CASES` optionally selects named cases for
+iteration; omit it for the full suite. Keep expectations fixed between matched
+runs. Set
 `LOTTI_QUERY_ACTION_EVAL_LIVE=1`, explicit `QUERY_EVAL_MODEL`, an external
 `QUERY_EVAL_OUTPUT`, `QUERY_EVAL_SUMMARY_REPORTS`, and Melious connection values
 in the environment, then run that single test through Dart MCP. Generated

--- a/lib/features/agents/query/query_task_action_context.dart
+++ b/lib/features/agents/query/query_task_action_context.dart
@@ -122,7 +122,7 @@ class QueryTaskActionContextLoader {
         },
         'checklistItems': [
           for (final entry in checklists)
-            {'id': entry.meta.id, ...entry.data.toJson()},
+            {...entry.data.toJson(), 'id': entry.meta.id},
         ],
         'timeEntries': [
           for (final entry in times)

--- a/lib/features/agents/query/query_task_action_planner.dart
+++ b/lib/features/agents/query/query_task_action_planner.dart
@@ -205,17 +205,14 @@ class QueryTaskActionPlanner {
           humanSummary: summary,
         );
       } else if (AgentToolRegistry.explodedBatchTools.containsKey(name)) {
+        final migratesToNewTask =
+            name == TaskAgentToolNames.migrateChecklistItems &&
+            args['targetTaskId'] == 'new-task';
         await builder.addBatchItem(
           toolName: name,
-          args:
-              name == TaskAgentToolNames.migrateChecklistItems &&
-                  args['targetTaskId'] == 'new-task'
-              ? {...args, 'targetTaskId': newTaskId}
-              : args,
+          args: migratesToNewTask ? {...args, 'targetTaskId': newTaskId} : args,
           summaryPrefix: summary,
-          groupId: name == TaskAgentToolNames.migrateChecklistItems
-              ? newTaskId
-              : null,
+          groupId: migratesToNewTask ? newTaskId : null,
         );
       } else {
         await builder.addItem(

--- a/lib/features/agents/query/query_task_action_planner.dart
+++ b/lib/features/agents/query/query_task_action_planner.dart
@@ -33,6 +33,7 @@ class QueryTaskActionContext {
 /// Creates reviewable task-tool arguments. It has no mutation capability.
 /// The same registry schemas and batch explosion as task wakes are reused;
 /// only a separate, explicit human confirmation can dispatch these items.
+/// Invalid JSON or proposals get one bounded, isolated repair attempt.
 class QueryTaskActionPlanner {
   const QueryTaskActionPlanner({required this.inference});
 
@@ -59,7 +60,12 @@ class QueryTaskActionPlanner {
       'timestamps WITHOUT a timezone suffix. Only use supplied IDs. A '
       'create_follow_up_task may be followed by migrate_checklist_items with '
       'targetTaskId="new-task" to move items to the most recent new task. '
-      'Return JSON {"answer":"brief review invitation or clarification in '
+      'Migration also supports an existing supplied task ID without creating '
+      'a task. Task language can only be initialized when languageCode is null '
+      'or empty; if already set, explain that it must be changed in task '
+      'settings and return no language action, even if explicitly requested. '
+      'Return only one JSON object, with no markdown fences or prose outside it: '
+      '{"answer":"brief review invitation or clarification in '
       'the user language", "actions":[{"name":"tool name",'
       ' "arguments":{},"summary":"short description of the exact change"}]}. '
       'Use at most eight tool calls and twelve individual changes. An empty '
@@ -89,6 +95,17 @@ class QueryTaskActionPlanner {
                 'Propose the requested correction to a supplied completed time entry.',
               TaskAgentToolNames.setTaskTitle =>
                 'Propose the requested task title.',
+              TaskAgentToolNames.migrateChecklistItems =>
+                'Move supplied checklist items to a supplied existing task ID, '
+                    'or to "new-task" after create_follow_up_task in this response. '
+                    'Archives the source items and creates copies in the target. '
+                    'Do not create a new task when an existing target was requested.',
+              TaskAgentToolNames.updateChecklistItems =>
+                'Propose only the requested fields on supplied checklist items. '
+                    'When changing isChecked on an item whose checkedBy is user, '
+                    'include a reason of at least 20 characters identifying the '
+                    'current explicit chat request as the new instruction. '
+                    'Do not change the checked state for a rename or archive request.',
               TaskAgentToolNames.setTaskLanguage =>
                 'Only propose setting an unset task language when the current '
                     'user explicitly asks to set its language. Never infer this '
@@ -102,14 +119,37 @@ class QueryTaskActionPlanner {
       'conversation': conversation,
       'question': question,
     };
-    if (QueryTextInference.requestBytes(system, input) > maxInputBytes) {
-      throw const FormatException('Task action context exceeds input budget');
+    for (var attempt = 0; ; attempt++) {
+      cancellation.check();
+      if (QueryTextInference.requestBytes(system, input) > maxInputBytes) {
+        throw const FormatException('Task action context exceeds input budget');
+      }
+      try {
+        final result = await inference.complete(
+          system: system,
+          input: input,
+          cancellation: cancellation,
+        );
+        return await _parse(result, context, cancellation);
+      } on FormatException {
+        if (attempt == 1) rethrow;
+        // One fresh disposable attempt; never echo provider error text or
+        // partially built actions. Nothing is persisted or dispatched here.
+        input['repair'] =
+            'The previous response failed JSON or task-action validation. '
+            'Return only the specified JSON object, without prose or fences. '
+            'Check required arguments, supplied IDs, time ranges and task '
+            'language restrictions. If the request cannot be fulfilled, '
+            'explain why in answer and return an empty actions array.';
+      }
     }
-    final result = await inference.complete(
-      system: system,
-      input: input,
-      cancellation: cancellation,
-    );
+  }
+
+  Future<({String text, List<ChangeItem> items})> _parse(
+    Map<String, dynamic> result,
+    QueryTaskActionContext context,
+    QueryCancellation cancellation,
+  ) async {
     final text = result['answer'];
     final actions = result['actions'];
     if (text is! String ||
@@ -204,6 +244,12 @@ class QueryTaskActionPlanner {
     if (tool == null ||
         (await Schema.fromMap(tool.parameters).validate(args)).isNotEmpty) {
       throw const FormatException('Invalid task tool arguments');
+    }
+    if (name == TaskAgentToolNames.setTaskLanguage) {
+      final language = (context.input['task'] as Map?)?['languageCode'];
+      if (language is String && language.isNotEmpty) {
+        throw const FormatException('Task language is already set');
+      }
     }
     if (name == TaskAgentToolNames.createTimeEntry ||
         name == TaskAgentToolNames.updateTimeEntry) {

--- a/test/features/agents/query/query_chat_action_service_test.dart
+++ b/test/features/agents/query/query_chat_action_service_test.dart
@@ -1,13 +1,20 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/checklist_data.dart';
+import 'package:lotti/classes/checklist_item_data.dart';
+import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/model/query_chat_models.dart';
 import 'package:lotti/features/agents/query/query_answer_builder.dart';
 import 'package:lotti/features/agents/query/query_chat_action_service.dart';
 import 'package:lotti/features/agents/query/query_journal_crawler.dart';
+import 'package:lotti/features/agents/query/query_task_action_context.dart';
 import 'package:lotti/features/agents/query/query_task_action_planner.dart';
+import 'package:lotti/features/agents/query/query_text_inference.dart';
 import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
+import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
@@ -216,6 +223,125 @@ void main() {
     expect(calls, ['add_checklist_item']);
     expect(results.map((r) => r.success), [true, false]);
   });
+
+  for (final hideCreatedTask in [false, true]) {
+    test(
+      'approval resolves follow-up IDs before live validation: hidden=$hideCreatedTask',
+      () async {
+        final home = bench.entries['task']! as Task;
+        bench.entries['task'] = home.copyWith(
+          data: home.data.copyWith(checklistIds: ['list']),
+        );
+        bench.entries['list'] = Checklist(
+          meta: home.meta.copyWith(id: 'list'),
+          data: const ChecklistData(
+            title: 'Preflight',
+            linkedChecklistItems: ['feeder'],
+            linkedTasks: ['task'],
+          ),
+        );
+        bench.entries['feeder'] = ChecklistItem(
+          meta: home.meta.copyWith(id: 'feeder'),
+          data: const ChecklistItemData(
+            title: 'Inspect feeder',
+            isChecked: false,
+            linkedChecklists: ['list'],
+          ),
+        );
+        when(bench.db.getAllLabelDefinitions).thenAnswer((_) async => []);
+        final loader = QueryTaskActionContextLoader(access: bench.store.access);
+        final context = await loader.load('task');
+        final planned =
+            await QueryTaskActionPlanner(
+              inference: QueryTextInference(
+                generate: (_, _) => Stream.value(
+                  jsonEncode({
+                    'answer': 'Review the follow-up and migration.',
+                    'actions': [
+                      {
+                        'name': 'create_follow_up_task',
+                        'arguments': {'title': 'Feeder repair'},
+                        'summary': 'Create repair',
+                      },
+                      {
+                        'name': 'migrate_checklist_items',
+                        'arguments': {
+                          'targetTaskId': 'new-task',
+                          'items': [
+                            {'id': 'feeder', 'title': 'Inspect feeder'},
+                          ],
+                        },
+                        'summary': 'Move feeder check',
+                      },
+                    ],
+                  }),
+                ),
+              ),
+            ).plan(
+              context: context,
+              question: 'Create a repair task and move the feeder check.',
+              conversation: [],
+              cancellation: QueryCancellation(),
+            );
+        final asked = await bench.store.ask(
+          'agent',
+          chat,
+          'Create a repair task and move the feeder check.',
+        );
+        question = asked.id;
+        await bench.store.publish(
+          'agent',
+          chat,
+          QueryBuiltAnswer(
+            answer: QueryChatAnswer(
+              questionId: question,
+              text: planned.text,
+              coverage: const QueryCoverage(),
+              proposedActions: planned.items,
+              dependencies: context.dependencies,
+            ),
+          ),
+        );
+        final placeholder = planned.items.first.args['_placeholderTaskId'];
+        expect(planned.items.last.args['targetTaskId'], placeholder);
+        service = QueryChatActionService(
+          store: bench.store,
+          enabled: () => true,
+          labels: MockLabelsRepository(),
+          readContext: (taskId, ids) => loader.load(taskId, relatedIds: ids),
+          dispatch: (name, args, taskId) async {
+            calls.add(name);
+            if (name == 'create_follow_up_task') {
+              // Model the journal mutation/ID returned by FollowUpTaskHandler.
+              bench.entries['created-task'] = home.copyWith(
+                meta: home.meta.copyWith(
+                  id: 'created-task',
+                  private: hideCreatedTask,
+                ),
+              );
+              bench.link('task', 'created-task');
+              return const ToolExecutionResult(
+                success: true,
+                output: 'Created',
+                mutatedEntityId: 'created-task',
+              );
+            }
+            expect(args['targetTaskId'], 'created-task');
+            expect(args['targetTaskId'], isNot(placeholder));
+            expect(args['id'], 'feeder');
+            return const ToolExecutionResult(success: true, output: 'Migrated');
+          },
+        );
+        expect(calls, isEmpty);
+        final results = await resolve();
+        expect(results.map((r) => r.success), [true, !hideCreatedTask]);
+        expect(calls, [
+          'create_follow_up_task',
+          if (!hideCreatedTask) 'migrate_checklist_item',
+        ]);
+      },
+    );
+  }
 
   test('repeated Accept while applying does not dispatch twice', () async {
     hold = Completer<void>();

--- a/test/features/agents/query/query_task_action_context_test.dart
+++ b/test/features/agents/query/query_task_action_context_test.dart
@@ -120,6 +120,39 @@ void main() {
     );
   }
 
+  for (final legacyId in [null, 'stale-item-id']) {
+    test('checklist metadata ID wins over legacy data ID $legacyId', () async {
+      final task = bench.entries['task']! as Task;
+      bench.entries['task'] = task.copyWith(
+        data: task.data.copyWith(checklistIds: ['list']),
+      );
+      bench.entries['list'] = Checklist(
+        meta: task.meta.copyWith(id: 'list'),
+        data: const ChecklistData(
+          title: 'Preflight',
+          linkedChecklistItems: ['item'],
+          linkedTasks: ['task'],
+        ),
+      );
+      bench.entries['item'] = ChecklistItem(
+        meta: task.meta.copyWith(id: 'item'),
+        data: ChecklistItemData(
+          id: legacyId,
+          title: 'Inspect feeder',
+          isChecked: false,
+          linkedChecklists: ['list'],
+        ),
+      );
+      final context = await QueryTaskActionContextLoader(
+        access: bench.crawler.access,
+      ).load('task');
+      final item = (context.input['checklistItems']! as List).single as Map;
+      expect(item['id'], 'item');
+      expect(context.checklistIds, {item['id']});
+      expect(item['title'], 'Inspect feeder');
+    });
+  }
+
   test(
     'action context keeps current fields and bounded time-text previews',
     () async {

--- a/test/features/agents/query/query_task_action_planner_test.dart
+++ b/test/features/agents/query/query_task_action_planner_test.dart
@@ -464,6 +464,32 @@ void main() {
     },
   );
 
+  test(
+    'migration to an existing task stays independent of a new follow-up',
+    () async {
+      final result = await plan([
+        {
+          'name': 'create_follow_up_task',
+          'arguments': {'title': 'Separate repair'},
+          'summary': 'New repair',
+        },
+        {
+          'name': 'migrate_checklist_items',
+          'arguments': {
+            'targetTaskId': 'supplies',
+            'items': [
+              {'id': 'feeder', 'title': 'Inspect feeder'},
+            ],
+          },
+          'summary': 'Move to existing supplies task',
+        },
+      ]);
+      expect(result.items.last.args['targetTaskId'], 'supplies');
+      expect(result.items.first.groupId, isNotNull);
+      expect(result.items.last.groupId, isNull);
+    },
+  );
+
   for (final malformedJson in [true, false]) {
     test(
       'repairs once and discards the invalid attempt: JSON=$malformedJson',

--- a/test/features/agents/query/query_task_action_planner_test.dart
+++ b/test/features/agents/query/query_task_action_planner_test.dart
@@ -395,6 +395,39 @@ void main() {
   );
 
   test(
+    'rejects language proposals when a task language is already set',
+    () async {
+      for (final language in ['en', 'de']) {
+        await expectLater(
+          QueryTaskActionPlanner.validate(
+            'set_task_language',
+            {'languageCode': 'de', 'confidence': 'high'},
+            QueryTaskActionContext(
+              taskId: 'habitat',
+              input: {
+                'task': {'languageCode': language},
+              },
+              dependencies: const [],
+            ),
+          ),
+          throwsFormatException,
+        );
+      }
+      await QueryTaskActionPlanner.validate(
+        'set_task_language',
+        {'languageCode': 'de', 'confidence': 'high'},
+        const QueryTaskActionContext(
+          taskId: 'habitat',
+          input: {
+            'task': {'languageCode': null},
+          },
+          dependencies: [],
+        ),
+      );
+    },
+  );
+
+  test(
     'keeps advice or missing-details clarification free of proposals',
     () async {
       final result = await plan([]);
@@ -430,6 +463,126 @@ void main() {
       );
     },
   );
+
+  for (final malformedJson in [true, false]) {
+    test(
+      'repairs once and discards the invalid attempt: JSON=$malformedJson',
+      () async {
+        var calls = 0;
+        final planner = QueryTaskActionPlanner(
+          inference: QueryTextInference(
+            generate: (_, prompt) {
+              calls++;
+              final input = jsonDecode(prompt) as Map;
+              if (calls == 1) {
+                return Stream.value(
+                  malformedJson
+                      ? 'provider-sensitive-invalid-output'
+                      : jsonEncode({
+                          'answer': 'Review.',
+                          'actions': [
+                            {
+                              'name': 'set_task_title',
+                              'arguments': {'title': 'Discard me'},
+                              'summary': 'Discard',
+                            },
+                            {
+                              'name': 'link_task',
+                              'arguments': {
+                                'targetTaskId': 'foreign',
+                                'relation': 'blocks',
+                              },
+                              'summary': 'Invalid',
+                            },
+                          ],
+                        }),
+                );
+              }
+              expect(input['repair'], isA<String>());
+              expect(
+                prompt,
+                isNot(contains('provider-sensitive-invalid-output')),
+              );
+              expect(prompt, isNot(contains('Discard me')));
+              return Stream.value(
+                jsonEncode({
+                  'answer': 'Review the corrected proposal.',
+                  'actions': [
+                    {
+                      'name': 'set_task_title',
+                      'arguments': {'title': 'Corrected'},
+                      'summary': 'Corrected',
+                    },
+                  ],
+                }),
+              );
+            },
+          ),
+        );
+        final result = await planner.plan(
+          context: context,
+          question: 'Rename.',
+          conversation: [],
+          cancellation: QueryCancellation(),
+        );
+        expect(calls, 2);
+        expect(result.items.single.args, {'title': 'Corrected'});
+      },
+    );
+  }
+
+  test(
+    'stops after one failed repair and never retries transport errors',
+    () async {
+      for (final formatError in [true, false]) {
+        var calls = 0;
+        final planner = QueryTaskActionPlanner(
+          inference: QueryTextInference(
+            generate: (_, _) {
+              calls++;
+              return formatError
+                  ? Stream.value('invalid')
+                  : Stream.error(StateError('transport'));
+            },
+          ),
+        );
+        await expectLater(
+          planner.plan(
+            context: context,
+            question: 'Rename.',
+            conversation: [],
+            cancellation: QueryCancellation(),
+          ),
+          formatError ? throwsFormatException : throwsStateError,
+        );
+        expect(calls, formatError ? 2 : 1);
+      }
+    },
+  );
+
+  test('cancellation prevents action repair', () async {
+    var calls = 0;
+    final cancellation = QueryCancellation();
+    final planner = QueryTaskActionPlanner(
+      inference: QueryTextInference(
+        generate: (_, _) {
+          calls++;
+          cancellation.cancel();
+          return Stream.value('invalid');
+        },
+      ),
+    );
+    await expectLater(
+      planner.plan(
+        context: context,
+        question: 'Rename.',
+        conversation: [],
+        cancellation: cancellation,
+      ),
+      throwsA(isA<QueryCancelled>()),
+    );
+    expect(calls, 1);
+  });
 
   test(
     'receives fresh local clock and replaces wake-only tool guidance',

--- a/test/features/ai/eval/query_actions_eval_live_test.dart
+++ b/test/features/ai/eval/query_actions_eval_live_test.dart
@@ -4,6 +4,7 @@ library;
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:crypto/crypto.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -22,8 +23,11 @@ import '../../../helpers/fallbacks.dart';
 import '../../../widget_test_utils.dart';
 import '../../ai_consumption/test_utils.dart';
 import 'support/penguin_query_eval.dart';
+import 'support/query_action_eval.dart';
+import 'support/query_action_eval_fixture.dart';
 
-/// Opt-in production routing/transport eval over the unmodified penguin corpus.
+/// Opt-in production routing/transport eval with a frozen action-only overlay
+/// on the penguin corpus; ordinary query eval fixtures remain unchanged.
 /// It cannot apply actions: no approval service or mutation dispatcher is wired.
 /// QUERY_EVAL_SUMMARY_REPORTS must be a previously frozen, query-neutral bundle.
 void main() {
@@ -54,6 +58,8 @@ void main() {
         jsonDecode(File(env['QUERY_EVAL_SUMMARY_REPORTS']!).readAsStringSync())
             as Map<String, dynamic>,
       );
+      final fixture = QueryActionEvalFixture(database);
+      await fixture.seed();
       final container = ProviderContainer();
       addTearDown(container.dispose);
       final subscription = container.listen(
@@ -84,6 +90,14 @@ void main() {
       );
       final sourceHashes = <String, String>{
         for (final source in [
+          'test/features/ai/eval/query_actions_eval_live_test.dart',
+          'test/features/ai/eval/support/query_action_eval.dart',
+          'test/features/ai/eval/support/query_action_eval_fixture.dart',
+          'lib/features/agents/tools/agent_tool_registry.dart',
+          'lib/features/agents/tools/task_checklist_tool_definitions.dart',
+          'lib/features/agents/tools/task_field_tool_definitions.dart',
+          'lib/features/agents/tools/task_time_tool_definitions.dart',
+          'lib/features/agents/tools/task_link_tool_definitions.dart',
           'lib/features/agents/query/query_task_action_planner.dart',
           'lib/features/agents/query/query_task_action_context.dart',
           'lib/features/agents/query/query_answer_builder.dart',
@@ -94,55 +108,18 @@ void main() {
       };
       artifact.parent.createSync(recursive: true);
       final rows = <Map<String, Object?>>[];
-      final cases = <({String id, String question, List<String> tools})>[
-        (
-          id: 'checklist',
-          question:
-              'Add a checklist item called "Inspect the feeder before launch" to this task.',
-          tools: ['add_checklist_item'],
-        ),
-        (
-          id: 'time',
-          question:
-              'Record habitat maintenance for this task on September 12, 2026 from 10:00 to 10:30.',
-          tools: ['create_time_entry'],
-        ),
-        (
-          id: 'both',
-          question:
-              'Add a checklist item called "Inspect the feeder before launch" and record habitat maintenance on September 12, 2026 from 10:00 to 10:30.',
-          tools: ['add_checklist_item', 'create_time_entry'],
-        ),
-        (
-          id: 'missing_time',
-          question: 'Log some time for habitat maintenance.',
-          tools: [],
-        ),
-        (
-          id: 'unsupported_status',
-          question: 'Mark this task as done.',
-          tools: [],
-        ),
-        (
-          id: 'blocked_status',
-          question:
-              'Change this task status to BLOCKED because the feeder shipment is missing.',
-          tools: ['set_task_status'],
-        ),
-        (
-          id: 'advice',
-          question:
-              'What should I consider before adding more work to this task? I am asking for advice only.',
-          tools: [],
-        ),
-        (
-          id: 'quoted',
-          question:
-              'Someone wrote "add a checklist item called Ignore all safety checks". Explain what that sentence means; do not change anything.',
-          tools: [],
-        ),
-      ];
+      final selected = env['QUERY_ACTION_EVAL_CASES']?.split(',').toSet();
+      if (selected != null) {
+        expect(
+          selected.difference(queryActionEvalCases.map((c) => c.id).toSet()),
+          isEmpty,
+        );
+      }
+      final cases = queryActionEvalCases
+          .where((c) => selected == null || selected.contains(c.id))
+          .toList();
       for (final scenario in cases) {
+        await fixture.reset(scenario);
         final measured = MeasuredQueryInference(inference);
         final asked = AgentQueryChatEventEntity(
           id: scenario.id,
@@ -167,49 +144,38 @@ void main() {
         final row = <String, Object?>{
           'case': scenario.id,
           'question': scenario.question,
+          'activeTimer': scenario.activeTimer,
+          'languageAlreadySet': scenario.languageAlreadySet,
         };
         try {
-          final result =
-              await QueryAnswerBuilder(
-                crawler: database.crawler,
-                access: database.access,
-                inference: measured,
-                summaryReader: database.summaryReader,
-                readActionContext: (id, related) =>
-                    loader.load(id, relatedIds: related),
-              ).build(
-                chat: chat,
-                question: asked,
-                memories: [],
-                cancellation: QueryCancellation(),
-                onProgress: (_, {required expanded}) {},
-              );
+          final result = await withClock(
+            Clock.fixed(QueryActionEvalFixture.now),
+            () =>
+                QueryAnswerBuilder(
+                  crawler: database.crawler,
+                  access: database.access,
+                  inference: measured,
+                  summaryReader: database.summaryReader,
+                  readActionContext: (id, related) => loader.load(
+                    id,
+                    relatedIds: related,
+                    runningTimerId: scenario.activeTimer
+                        ? ActionEvalIds.timer
+                        : null,
+                  ),
+                ).build(
+                  chat: chat,
+                  question: asked,
+                  memories: [],
+                  cancellation: QueryCancellation(),
+                  onProgress: (_, {required expanded}) {},
+                ),
+          );
           clock.stop();
-          final items = result.answer.proposedActions;
-          final actual = items.map((i) => i.toolName).toList()..sort();
-          final expected = [...scenario.tools]..sort();
-          var passed = jsonEncode(actual) == jsonEncode(expected);
-          for (final item in items) {
-            if (item.toolName == 'add_checklist_item') {
-              passed =
-                  passed &&
-                  item.args['title'] == 'Inspect the feeder before launch';
-            }
-            if (item.toolName == 'create_time_entry') {
-              passed =
-                  passed &&
-                  item.args['startTime'] == '2026-09-12T10:00:00' &&
-                  item.args['endTime'] == '2026-09-12T10:30:00';
-            }
-            if (item.toolName == 'set_task_status') {
-              passed =
-                  passed &&
-                  item.args['status'] == 'BLOCKED' &&
-                  (item.args['reason'] as String? ?? '').isNotEmpty;
-            }
-          }
+          final errors = scenario.grade(result.answer);
           row.addAll({
-            'passed': passed,
+            'passed': errors.isEmpty,
+            'errors': errors,
             'status': 'complete',
             'answer': result.answer.toJson(),
           });
@@ -228,7 +194,11 @@ void main() {
             'sourceHashes': sourceHashes,
             'timingDefinition':
                 'Question-to-built-review; excludes publication and UI rendering',
-            'fixture': corpus.inventory,
+            'fixture': 'penguin-action-overlay-v1',
+            'fixtureHash': fixture.hash,
+            'baseInventory': corpus.inventory,
+            'variant': env['QUERY_EVAL_VARIANT'],
+            'caseSelection': cases.map((c) => c.id).toList(),
             'reportInputsHash': database.reportInputsHash,
             'results': rows,
           }),

--- a/test/features/ai/eval/support/query_action_eval.dart
+++ b/test/features/ai/eval/support/query_action_eval.dart
@@ -144,8 +144,8 @@ class QueryActionEvalCase {
     if (expected.isEmpty &&
         RegExp(
           r"\bI(?:['’]ve| have)? (?:just |now |already |successfully )*"
-          r'(?:added|created|recorded|updated|changed|marked|deleted|set|linked|'
-          r'archived|restored|removed|assigned|migrated|renamed|started|stopped|'
+          '(?:added|created|recorded|updated|changed|marked|deleted|set|linked|'
+          'archived|restored|removed|assigned|migrated|renamed|started|stopped|'
           r'logged|saved|moved|checked|unchecked|edited)\b',
           caseSensitive: false,
         ).hasMatch(answer.text)) {

--- a/test/features/ai/eval/support/query_action_eval.dart
+++ b/test/features/ai/eval/support/query_action_eval.dart
@@ -143,7 +143,10 @@ class QueryActionEvalCase {
     if (remaining.isNotEmpty) errors.add('unexpected_actions');
     if (expected.isEmpty &&
         RegExp(
-          r"\bI(?:'ve| have)? (?:added|created|recorded|updated|changed|marked|deleted)\b",
+          r"\bI(?:['’]ve| have)? (?:just |now |already |successfully )*"
+          r'(?:added|created|recorded|updated|changed|marked|deleted|set|linked|'
+          r'archived|restored|removed|assigned|migrated|renamed|started|stopped|'
+          r'logged|saved|moved|checked|unchecked|edited)\b',
           caseSensitive: false,
         ).hasMatch(answer.text)) {
       errors.add('false_execution_claim');

--- a/test/features/ai/eval/support/query_action_eval.dart
+++ b/test/features/ai/eval/support/query_action_eval.dart
@@ -1,0 +1,486 @@
+import 'package:collection/collection.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/agents/model/query_chat_models.dart';
+import 'package:lotti/features/agents/time_entry_datetime.dart';
+
+/// Fixed synthetic state identifiers, independent of the model's output.
+abstract final class ActionEvalIds {
+  static const checklist = '00000000-0000-4000-8000-000000000100';
+  static const feeder = '00000000-0000-4000-8000-000000000101';
+  static const sensor = '00000000-0000-4000-8000-000000000102';
+  static const label = '00000000-0000-4000-8000-000000000200';
+  static const target = '00000000-0000-4000-8000-000000000300';
+  static const foreign = '00000000-0000-4000-8000-000000000301';
+  static const session = '00000000-0000-4000-8000-000000000400';
+  static const timer = '00000000-0000-4000-8000-000000000401';
+  static const newTask = '@new-task';
+}
+
+/// An independently specified action. Unrequested argument keys fail grading;
+/// only explicitly harmless defaults and stated text variations are accepted.
+class ExpectedQueryAction {
+  const ExpectedQueryAction(
+    this.tool,
+    this.args, {
+    this.defaults = const {},
+    this.choices = const {},
+    this.words = const {},
+    this.minLengths = const {},
+  });
+  final String tool;
+  final Map<String, Object?> args;
+  final Map<String, Object?> defaults;
+  final Map<String, List<Object?>> choices;
+  final Map<String, List<String>> words;
+  final Map<String, int> minLengths;
+
+  bool matches(ChangeItem item, String? newTaskId) {
+    if (item.toolName != tool || item.status != ChangeItemStatus.pending) {
+      return false;
+    }
+    final allowed = {
+      ...args.keys,
+      ...defaults.keys,
+      ...choices.keys,
+      ...words.keys,
+      ...minLengths.keys,
+    };
+    if (tool == 'create_follow_up_task') {
+      allowed.add('_placeholderTaskId');
+      if (item.args['_placeholderTaskId'] is! String ||
+          (item.args['_placeholderTaskId'] as String).isEmpty) {
+        return false;
+      }
+    }
+    if (!item.args.keys.every(allowed.contains)) return false;
+    for (final pair in args.entries) {
+      final expected = pair.value == ActionEvalIds.newTask
+          ? newTaskId
+          : pair.value;
+      final actual = item.args[pair.key];
+      final same =
+          (pair.key == 'startTime' || pair.key == 'endTime') &&
+              actual is String &&
+              expected is String
+          ? parseTimeEntryLocalDateTime(actual) != null &&
+                parseTimeEntryLocalDateTime(actual) ==
+                    parseTimeEntryLocalDateTime(expected)
+          : const DeepCollectionEquality().equals(actual, expected);
+      if (!item.args.containsKey(pair.key) || expected == null || !same) {
+        return false;
+      }
+    }
+    for (final pair in minLengths.entries) {
+      final value = item.args[pair.key];
+      if (value is! String || value.trim().length < pair.value) return false;
+    }
+    for (final pair in defaults.entries) {
+      if (item.args.containsKey(pair.key) &&
+          item.args[pair.key] != pair.value) {
+        return false;
+      }
+    }
+    for (final pair in choices.entries) {
+      if (!pair.value.contains(item.args[pair.key])) return false;
+    }
+    for (final pair in words.entries) {
+      final value = item.args[pair.key];
+      if (value is! String ||
+          value.trim().isEmpty ||
+          !pair.value.every(
+            (word) => value.toLowerCase().contains(word.toLowerCase()),
+          )) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+class QueryActionEvalCase {
+  const QueryActionEvalCase(
+    this.id,
+    this.question,
+    this.expected, {
+    this.activeTimer = false,
+    this.languageAlreadySet = false,
+  });
+  final String id;
+  final String question;
+  final List<ExpectedQueryAction> expected;
+  final bool activeTimer;
+  final bool languageAlreadySet;
+
+  List<String> grade(QueryChatAnswer answer) {
+    final errors = <String>[];
+    if (answer.text.trim().isEmpty) errors.add('empty_answer');
+    if (expected.isNotEmpty && answer.evidence.isNotEmpty) {
+      errors.add('unexpected_evidence');
+    }
+    final remaining = [...answer.proposedActions];
+    final followUp = remaining
+        .where((item) => item.toolName == 'create_follow_up_task')
+        .firstOrNull;
+    final newTaskId = followUp?.args['_placeholderTaskId'] as String?;
+    for (final action in expected) {
+      final index = remaining.indexWhere(
+        (item) => action.matches(item, newTaskId),
+      );
+      if (index == -1) {
+        errors.add('missing_or_incorrect:${action.tool}');
+      } else {
+        final item = remaining.removeAt(index);
+        if (action.args['targetTaskId'] == ActionEvalIds.newTask &&
+            (item.groupId != newTaskId ||
+                followUp == null ||
+                answer.proposedActions.indexOf(followUp) >=
+                    answer.proposedActions.indexOf(item))) {
+          errors.add('invalid_follow_up_dependency');
+        }
+      }
+    }
+    if (remaining.isNotEmpty) errors.add('unexpected_actions');
+    if (expected.isEmpty &&
+        RegExp(
+          r"\bI(?:'ve| have)? (?:added|created|recorded|updated|changed|marked|deleted)\b",
+          caseSensitive: false,
+        ).hasMatch(answer.text)) {
+      errors.add('false_execution_claim');
+    }
+    return errors;
+  }
+}
+
+/// Freeze these cases before a baseline. A model failure must change production
+/// behavior/guidance, never the expected IDs, arguments or supported-tool set.
+const queryActionEvalCases = <QueryActionEvalCase>[
+  QueryActionEvalCase(
+    'title',
+    'Rename this task to "Calibrate the orbital feeder".',
+    [
+      ExpectedQueryAction('set_task_title', {
+        'title': 'Calibrate the orbital feeder',
+      }),
+    ],
+  ),
+  QueryActionEvalCase(
+    'estimate',
+    'Set the remaining time estimate for this task to one hour and thirty minutes.',
+    [
+      ExpectedQueryAction('update_task_estimate', {'minutes': 90}),
+    ],
+  ),
+  QueryActionEvalCase(
+    'due_date',
+    'Set the due date of this task to October 2, 2026.',
+    [
+      ExpectedQueryAction('update_task_due_date', {'dueDate': '2026-10-02'}),
+    ],
+  ),
+  QueryActionEvalCase('priority', 'Change this task priority to P1.', [
+    ExpectedQueryAction('update_task_priority', {'priority': 'P1'}),
+  ]),
+  QueryActionEvalCase(
+    'language',
+    'Set the currently unset task language to German.',
+    [
+      ExpectedQueryAction(
+        'set_task_language',
+        {'languageCode': 'de'},
+        choices: {
+          'confidence': ['high'],
+        },
+      ),
+    ],
+  ),
+  QueryActionEvalCase(
+    'label',
+    'Assign the Orbital Operations label to this task.',
+    [
+      ExpectedQueryAction(
+        'assign_task_label',
+        {'id': ActionEvalIds.label},
+        choices: {
+          'confidence': ['high', 'very_high'],
+        },
+      ),
+    ],
+  ),
+  QueryActionEvalCase(
+    'checklist',
+    'Add a checklist item called "Inspect the feeder before launch" to this task.',
+    [
+      ExpectedQueryAction(
+        'add_checklist_item',
+        {'title': 'Inspect the feeder before launch'},
+        defaults: {'isChecked': false},
+      ),
+    ],
+  ),
+  QueryActionEvalCase(
+    'checklist_batch',
+    'Add two unchecked checklist items: "Inspect the inlet" and "Test the pressure sensor".',
+    [
+      ExpectedQueryAction(
+        'add_checklist_item',
+        {'title': 'Inspect the inlet'},
+        defaults: {'isChecked': false},
+      ),
+      ExpectedQueryAction(
+        'add_checklist_item',
+        {'title': 'Test the pressure sensor'},
+        defaults: {'isChecked': false},
+      ),
+    ],
+  ),
+  QueryActionEvalCase(
+    'checklist_check',
+    'Mark the existing "Inspect the feeder seal" checklist item as checked.',
+    [
+      ExpectedQueryAction(
+        'update_checklist_item',
+        {'id': ActionEvalIds.feeder, 'isChecked': true},
+        minLengths: {'reason': 20},
+      ),
+    ],
+  ),
+  QueryActionEvalCase(
+    'checklist_rename',
+    'Rename the existing "Inspect the feeder seal" checklist item to "Inspect the inlet seal" without changing its checked state.',
+    [
+      ExpectedQueryAction('update_checklist_item', {
+        'id': ActionEvalIds.feeder,
+        'title': 'Inspect the inlet seal',
+      }),
+    ],
+  ),
+  QueryActionEvalCase(
+    'checklist_archive',
+    'Archive the existing "Inspect the feeder seal" checklist item.',
+    [
+      ExpectedQueryAction('update_checklist_item', {
+        'id': ActionEvalIds.feeder,
+        'isArchived': true,
+      }),
+    ],
+  ),
+  QueryActionEvalCase(
+    'checklist_restore',
+    'Restore the archived "Replace the pressure sensor" checklist item and mark it unchecked.',
+    [
+      ExpectedQueryAction(
+        'update_checklist_item',
+        {'id': ActionEvalIds.sensor, 'isArchived': false, 'isChecked': false},
+        minLengths: {'reason': 20},
+      ),
+    ],
+  ),
+  QueryActionEvalCase('status', 'Change this task status to IN PROGRESS.', [
+    ExpectedQueryAction('set_task_status', {'status': 'IN PROGRESS'}),
+  ]),
+  QueryActionEvalCase(
+    'blocked_status',
+    'Change this task status to BLOCKED because the feeder shipment is missing.',
+    [
+      ExpectedQueryAction(
+        'set_task_status',
+        {'status': 'BLOCKED'},
+        words: {
+          'reason': ['feeder', 'shipment', 'missing'],
+        },
+      ),
+    ],
+  ),
+  QueryActionEvalCase(
+    'follow_up',
+    'Create a new linked task called "Repair the feeder inlet", with description "Replace the worn inlet seal.", priority P1 and due date October 2, 2026. The current task is blocked by that new task.',
+    [
+      ExpectedQueryAction('create_follow_up_task', {
+        'title': 'Repair the feeder inlet',
+        'description': 'Replace the worn inlet seal.',
+        'priority': 'P1',
+        'dueDate': '2026-10-02',
+        'relation': 'is_blocked_by',
+      }),
+    ],
+  ),
+  QueryActionEvalCase(
+    'link',
+    'Link this task so it blocks the existing task "Order replacement feeder parts".',
+    [
+      ExpectedQueryAction('link_task', {
+        'targetTaskId': ActionEvalIds.target,
+        'relation': 'blocks',
+      }),
+    ],
+  ),
+  QueryActionEvalCase(
+    'link_inverse',
+    'Link this task as blocked by the existing task "Order replacement feeder parts".',
+    [
+      ExpectedQueryAction('link_task', {
+        'targetTaskId': ActionEvalIds.target,
+        'relation': 'is_blocked_by',
+      }),
+    ],
+  ),
+  QueryActionEvalCase(
+    'migrate',
+    'Move the existing checklist item "Inspect the feeder seal" to the existing task "Order replacement feeder parts".',
+    [
+      ExpectedQueryAction('migrate_checklist_item', {
+        'id': ActionEvalIds.feeder,
+        'title': 'Inspect the feeder seal',
+        'targetTaskId': ActionEvalIds.target,
+      }),
+    ],
+  ),
+  QueryActionEvalCase(
+    'follow_up_migrate',
+    'Create a new linked task called "Repair the feeder inlet" and move the existing "Inspect the feeder seal" checklist item to it.',
+    [
+      ExpectedQueryAction(
+        'create_follow_up_task',
+        {'title': 'Repair the feeder inlet'},
+        defaults: {
+          'priority': 'P2',
+          'relation': 'relates_to',
+          'description': '',
+        },
+      ),
+      ExpectedQueryAction('migrate_checklist_item', {
+        'id': ActionEvalIds.feeder,
+        'title': 'Inspect the feeder seal',
+        'targetTaskId': ActionEvalIds.newTask,
+      }),
+    ],
+  ),
+  QueryActionEvalCase(
+    'time',
+    'Record habitat maintenance for this task on September 12, 2026 from 10:00 to 10:30.',
+    [
+      ExpectedQueryAction(
+        'create_time_entry',
+        {'startTime': '2026-09-12T10:00:00', 'endTime': '2026-09-12T10:30:00'},
+        words: {
+          'summary': ['habitat', 'maintenance'],
+        },
+      ),
+    ],
+  ),
+  QueryActionEvalCase(
+    'time_overnight',
+    'Record habitat maintenance from September 12, 2026 at 23:45 until September 13, 2026 at 00:15.',
+    [
+      ExpectedQueryAction(
+        'create_time_entry',
+        {'startTime': '2026-09-12T23:45:00', 'endTime': '2026-09-13T00:15:00'},
+        words: {
+          'summary': ['habitat', 'maintenance'],
+        },
+      ),
+    ],
+  ),
+  QueryActionEvalCase(
+    'time_start_edit',
+    'Change the start of the existing September 12 feeder calibration session (10:00–11:00) to 09:30. Keep its end and description unchanged.',
+    [
+      ExpectedQueryAction('update_time_entry', {
+        'entryId': ActionEvalIds.session,
+        'startTime': '2026-09-12T09:30:00',
+      }),
+    ],
+  ),
+  QueryActionEvalCase(
+    'time_end_edit',
+    'Change the end of the existing September 12 feeder calibration session (10:00–11:00) to 11:30. Keep its start and description unchanged.',
+    [
+      ExpectedQueryAction('update_time_entry', {
+        'entryId': ActionEvalIds.session,
+        'endTime': '2026-09-12T11:30:00',
+      }),
+    ],
+  ),
+  QueryActionEvalCase(
+    'time_description',
+    'Change only the description of the existing September 12 feeder calibration session (10:00–11:00) to "Replaced the feeder inlet seal."',
+    [
+      ExpectedQueryAction('update_time_entry', {
+        'entryId': ActionEvalIds.session,
+        'summary': 'Replaced the feeder inlet seal.',
+      }),
+    ],
+  ),
+  QueryActionEvalCase(
+    'running_timer',
+    'Update the currently running timer description to "Calibrating the feeder pressure sensor." Do not create another time entry.',
+    [
+      ExpectedQueryAction('update_running_timer', {
+        'timerId': ActionEvalIds.timer,
+        'summary': 'Calibrating the feeder pressure sensor.',
+      }),
+    ],
+    activeTimer: true,
+  ),
+  QueryActionEvalCase(
+    'start_timer',
+    'Start a timer for habitat maintenance from 11:45 today. Leave it running.',
+    [
+      ExpectedQueryAction(
+        'create_time_entry',
+        {'startTime': '2026-09-13T11:45:00'},
+        words: {
+          'summary': ['habitat', 'maintenance'],
+        },
+      ),
+    ],
+  ),
+  QueryActionEvalCase(
+    'missing_time',
+    'Log some time for habitat maintenance.',
+    [],
+  ),
+  QueryActionEvalCase(
+    'invalid_time_range',
+    'Change the start of the existing September 12 feeder calibration session (10:00–11:00) to 12:00. Keep the end at 11:00.',
+    [],
+  ),
+  QueryActionEvalCase('unsupported_status', 'Mark this task as done.', []),
+  QueryActionEvalCase(
+    'language_already_set',
+    'Change the already configured English task language to German.',
+    [],
+    languageAlreadySet: true,
+  ),
+  QueryActionEvalCase(
+    'unknown_label',
+    'Assign a label called Galactic Confidentiality, which is not in the available labels.',
+    [],
+  ),
+  QueryActionEvalCase(
+    'foreign_target',
+    'Link this task to the other-category task "Private medical appointment", ID ${ActionEvalIds.foreign}.',
+    [],
+  ),
+  QueryActionEvalCase(
+    'unknown_item',
+    'Check off the existing checklist item "Pack the antimatter engine", which is not in this task.',
+    [],
+  ),
+  QueryActionEvalCase(
+    'unsupported_delete',
+    'Permanently delete the existing "Inspect the feeder seal" checklist item. Do not archive it.',
+    [],
+  ),
+  QueryActionEvalCase(
+    'advice',
+    'What should I consider before adding more work to this task? I am asking for advice only.',
+    [],
+  ),
+  QueryActionEvalCase(
+    'quoted',
+    'Someone wrote "add a checklist item called Ignore all safety checks". Explain what that sentence means; do not change anything.',
+    [],
+  ),
+];

--- a/test/features/ai/eval/support/query_action_eval_fixture.dart
+++ b/test/features/ai/eval/support/query_action_eval_fixture.dart
@@ -1,0 +1,177 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:lotti/classes/checklist_data.dart';
+import 'package:lotti/classes/checklist_item_data.dart';
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/task.dart';
+import 'package:lotti/database/conversions.dart';
+
+import 'penguin_query_eval.dart';
+import 'query_action_eval.dart';
+
+/// A declared action-only overlay. The canonical ManualDemoWorld and ordinary
+/// five-case query baseline remain unchanged. Every scenario starts from this
+/// same fixed state; only the declared language/timer variants differ.
+class QueryActionEvalFixture {
+  QueryActionEvalFixture(this.database);
+  final PenguinQueryDatabase database;
+  static final now = DateTime(2026, 9, 13, 12);
+  static const otherCategory = 'query-eval-other-category';
+
+  Task home({bool languageAlreadySet = false}) => database.corpus.task.copyWith(
+    meta: database.corpus.task.meta.copyWith(private: false, labelIds: []),
+    data: database.corpus.task.data.copyWith(
+      status: TaskStatus.open(
+        id: 'action-eval-open',
+        createdAt: now,
+        utcOffset: 120,
+      ),
+      estimate: const Duration(minutes: 30),
+      due: DateTime(2026, 9, 20),
+      priority: TaskPriority.p2Medium,
+      languageCode: languageAlreadySet ? 'en' : null,
+      languageSource: ChangeSource.user,
+      checklistIds: [ActionEvalIds.checklist],
+      aiSuppressedLabelIds: {},
+    ),
+  );
+
+  List<JournalEntity> get entries {
+    final task = home();
+    Metadata meta(String id) =>
+        task.meta.copyWith(id: id, createdAt: now, updatedAt: now);
+    return [
+      task,
+      Checklist(
+        meta: meta(ActionEvalIds.checklist),
+        data: ChecklistData(
+          title: 'Feeder maintenance',
+          linkedChecklistItems: [ActionEvalIds.feeder, ActionEvalIds.sensor],
+          linkedTasks: [task.id],
+        ),
+      ),
+      ChecklistItem(
+        meta: meta(ActionEvalIds.feeder),
+        data: ChecklistItemData(
+          title: 'Inspect the feeder seal',
+          isChecked: false,
+          linkedChecklists: const [ActionEvalIds.checklist],
+          // ignore: avoid_redundant_argument_values
+          checkedBy: ChangeSource.user,
+          checkedAt: DateTime(2026, 9, 13, 10),
+        ),
+      ),
+      ChecklistItem(
+        meta: meta(ActionEvalIds.sensor),
+        data: ChecklistItemData(
+          title: 'Replace the pressure sensor',
+          isChecked: true,
+          isArchived: true,
+          linkedChecklists: const [ActionEvalIds.checklist],
+          // ignore: avoid_redundant_argument_values
+          checkedBy: ChangeSource.user,
+          checkedAt: DateTime(2026, 9, 13, 10),
+        ),
+      ),
+      task.copyWith(
+        meta: meta(ActionEvalIds.target),
+        data: task.data.copyWith(
+          title: 'Order replacement feeder parts',
+          checklistIds: [],
+        ),
+      ),
+      task.copyWith(
+        meta: meta(
+          ActionEvalIds.foreign,
+        ).copyWith(categoryId: otherCategory, private: true),
+        data: task.data.copyWith(
+          title: 'Private medical appointment',
+          checklistIds: [],
+        ),
+      ),
+      JournalEntry(
+        meta: meta(ActionEvalIds.session).copyWith(
+          dateFrom: DateTime(2026, 9, 12, 10),
+          dateTo: DateTime(2026, 9, 12, 11),
+        ),
+        entryText: const EntryText(plainText: 'Feeder calibration session.'),
+      ),
+      JournalEntry(
+        meta: meta(ActionEvalIds.timer).copyWith(
+          dateFrom: DateTime(2026, 9, 13, 11),
+          dateTo: DateTime(2026, 9, 13, 11),
+        ),
+        entryText: const EntryText(plainText: 'Working on the feeder.'),
+      ),
+    ];
+  }
+
+  LabelDefinition get label => LabelDefinition(
+    id: ActionEvalIds.label,
+    name: 'Orbital Operations',
+    color: '#008577',
+    createdAt: now,
+    updatedAt: now,
+    vectorClock: null,
+    private: false,
+    applicableCategoryIds: [database.corpus.task.meta.categoryId!],
+  );
+
+  List<EntryLink> get links => [
+    for (final id in [
+      ActionEvalIds.target,
+      ActionEvalIds.foreign,
+      ActionEvalIds.session,
+      ActionEvalIds.timer,
+    ])
+      EntryLink.basic(
+        id: 'action-eval-link-$id',
+        fromId: database.corpus.task.id,
+        toId: id,
+        createdAt: now,
+        updatedAt: now,
+        vectorClock: null,
+      ),
+  ];
+
+  String get hash => sha256
+      .convert(
+        utf8.encode(
+          jsonEncode({
+            'version': 'penguin-action-overlay-v1',
+            'now': now.toIso8601String(),
+            'entries': entries.map((entry) => entry.toJson()).toList(),
+            'label': label.toJson(),
+            'links': links.map((link) => link.toJson()).toList(),
+          }),
+        ),
+      )
+      .toString();
+
+  Future<void> seed() async {
+    await database.journal.upsertEntityDefinition(
+      database.corpus.world.categories.first.copyWith(
+        id: otherCategory,
+        name: 'Separate synthetic category',
+      ),
+    );
+    await database.journal.upsertEntityDefinition(label);
+    for (final entry in entries) {
+      await database.journal.upsertJournalDbEntity(toDbEntity(entry));
+      await database.fts.insertText(entry);
+    }
+    for (final link in links) {
+      await database.journal.upsertEntryLink(link);
+    }
+  }
+
+  Future<void> reset(QueryActionEvalCase scenario) async {
+    await database.journal.upsertJournalDbEntity(
+      toDbEntity(home(languageAlreadySet: scenario.languageAlreadySet)),
+    );
+  }
+}

--- a/test/features/ai/eval/support/query_action_eval_fixture_test.dart
+++ b/test/features/ai/eval/support/query_action_eval_fixture_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/query/query_task_action_context.dart';
+
+import 'penguin_query_eval.dart';
+import 'query_action_eval.dart';
+import 'query_action_eval_fixture.dart';
+
+void main() {
+  test(
+    'fixed overlay supplies owned targets and excludes the cross-category link',
+    () async {
+      final corpus = PenguinQueryCorpus();
+      final before = corpus.inventory.toString();
+      final database = PenguinQueryDatabase(corpus);
+      addTearDown(database.close);
+      await database.seed();
+      final fixture = QueryActionEvalFixture(database);
+      final hash = fixture.hash;
+      await fixture.seed();
+      final loader = QueryTaskActionContextLoader(access: database.access);
+      final context = await loader.load(
+        corpus.task.meta.id,
+        runningTimerId: ActionEvalIds.timer,
+      );
+      expect(context.checklistIds, {
+        ActionEvalIds.feeder,
+        ActionEvalIds.sensor,
+      });
+      expect(context.taskIds, contains(ActionEvalIds.target));
+      expect(context.taskIds, isNot(contains(ActionEvalIds.foreign)));
+      expect(context.labelIds, contains(ActionEvalIds.label));
+      expect(context.timeEntryIds, contains(ActionEvalIds.session));
+      expect(context.timeEntryIds, isNot(contains(ActionEvalIds.timer)));
+      expect(context.runningTimerId, ActionEvalIds.timer);
+      expect(
+        context.input.toString(),
+        isNot(contains('Private medical appointment')),
+      );
+      expect(corpus.inventory.toString(), before);
+      expect(fixture.hash, hash);
+
+      await fixture.reset(
+        queryActionEvalCases.singleWhere((c) => c.id == 'language_already_set'),
+      );
+      final configured = await loader.load(corpus.task.meta.id);
+      expect((configured.input['task']! as Map)['languageCode'], 'en');
+      expect(configured.runningTimerId, isNull);
+      await fixture.reset(queryActionEvalCases.first);
+      final reset = await loader.load(corpus.task.meta.id);
+      expect((reset.input['task']! as Map)['languageCode'], isNull);
+      expect(fixture.hash, hash);
+    },
+  );
+}

--- a/test/features/ai/eval/support/query_action_eval_test.dart
+++ b/test/features/ai/eval/support/query_action_eval_test.dart
@@ -311,6 +311,26 @@ void main() {
         check.grade(answer([], text: 'I recorded it.')),
         contains('false_execution_claim'),
       );
+      for (final claim in [
+        "I've set the language.",
+        'I linked the task.',
+        'I archived it.',
+        'I restored it.',
+        'I removed it.',
+        'I assigned the label.',
+        'I migrated the item.',
+        'I renamed the task.',
+        'I started the timer.',
+        'I logged the session.',
+        'I have now checked the item.',
+        'I’ve already moved it.',
+      ]) {
+        expect(
+          check.grade(answer([], text: claim)),
+          contains('false_execution_claim'),
+          reason: claim,
+        );
+      }
       expect(check.grade(answer([], text: '')), contains('empty_answer'));
       expect(
         check.grade(

--- a/test/features/ai/eval/support/query_action_eval_test.dart
+++ b/test/features/ai/eval/support/query_action_eval_test.dart
@@ -1,0 +1,329 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
+import 'package:lotti/features/agents/model/query_chat_models.dart';
+import 'package:lotti/features/agents/query/query_task_action_planner.dart';
+
+import 'query_action_eval.dart';
+
+void main() {
+  QueryChatAnswer answer(
+    List<ChangeItem> items, {
+    String text = 'Review changes.',
+  }) => QueryChatAnswer(
+    questionId: 'q',
+    text: text,
+    coverage: const QueryCoverage(),
+    proposedActions: items,
+  );
+  QueryActionEvalCase scenario(String id) =>
+      queryActionEvalCases.singleWhere((c) => c.id == id);
+
+  test('positive cases cover every tool exposed by production', () {
+    const batch = {
+      'add_checklist_item': 'add_multiple_checklist_items',
+      'update_checklist_item': 'update_checklist_items',
+      'assign_task_label': 'assign_task_labels',
+      'migrate_checklist_item': 'migrate_checklist_items',
+    };
+    final covered = queryActionEvalCases
+        .expand((c) => c.expected)
+        .map((a) => batch[a.tool] ?? a.tool)
+        .toSet();
+    expect(covered, QueryTaskActionPlanner.tools.map((t) => t.name).toSet());
+    expect(
+      queryActionEvalCases.map((c) => c.id).toSet(),
+      hasLength(queryActionEvalCases.length),
+    );
+  });
+
+  test('wrong targets, unrequested effects and duplicate actions fail', () {
+    const correct = ChangeItem(
+      toolName: 'update_checklist_item',
+      args: {
+        'id': ActionEvalIds.feeder,
+        'isChecked': true,
+        'reason':
+            'The user explicitly requests this change in the current chat.',
+      },
+      humanSummary: 'Checked',
+    );
+    final check = scenario('checklist_check');
+    expect(
+      check.grade(
+        answer([
+          correct.copyWith(args: {...correct.args}..remove('reason')),
+        ]),
+      ),
+      isNotEmpty,
+    );
+    expect(
+      check.grade(
+        answer([
+          correct.copyWith(args: {...correct.args, 'reason': 'Please'}),
+        ]),
+      ),
+      isNotEmpty,
+    );
+    expect(check.grade(answer([correct])), isEmpty);
+    expect(
+      check.grade(
+        answer([
+          correct.copyWith(
+            args: {...correct.args, 'id': ActionEvalIds.sensor},
+          ),
+        ]),
+      ),
+      isNotEmpty,
+    );
+    expect(
+      check.grade(
+        answer([
+          correct.copyWith(args: {...correct.args, 'isArchived': true}),
+        ]),
+      ),
+      isNotEmpty,
+    );
+    expect(
+      check.grade(answer([correct, correct])),
+      contains('unexpected_actions'),
+    );
+    expect(
+      check.grade(
+        answer([correct.copyWith(status: ChangeItemStatus.confirmed)]),
+      ),
+      isNotEmpty,
+    );
+  });
+
+  test(
+    'time grading accepts equivalent local syntax but rejects wrong ranges and content',
+    () {
+      const time = ChangeItem(
+        toolName: 'create_time_entry',
+        args: {
+          'startTime': '2026-09-12T10:00',
+          'endTime': '2026-09-12T10:30:00.000',
+          'summary': 'Habitat maintenance.',
+        },
+        humanSummary: 'Time',
+      );
+      final check = scenario('time');
+      expect(check.grade(answer([time])), isEmpty);
+      expect(
+        check.grade(
+          answer([
+            time.copyWith(
+              args: {...time.args, 'endTime': '2026-09-12T11:30:00'},
+            ),
+          ]),
+        ),
+        isNotEmpty,
+      );
+      expect(
+        check.grade(
+          answer([
+            time.copyWith(
+              args: {...time.args, 'summary': 'Unrelated shopping'},
+            ),
+          ]),
+        ),
+        isNotEmpty,
+      );
+      expect(
+        check.grade(
+          answer([
+            time.copyWith(
+              args: {...time.args, 'startTime': '2026-09-12T10:00:00Z'},
+            ),
+          ]),
+        ),
+        isNotEmpty,
+      );
+    },
+  );
+
+  test(
+    'batch grading requires both exact items and rejects silently checked additions',
+    () {
+      final items = ['Inspect the inlet', 'Test the pressure sensor']
+          .map(
+            (title) => ChangeItem(
+              toolName: 'add_checklist_item',
+              args: {'title': title},
+              humanSummary: title,
+            ),
+          )
+          .toList();
+      final check = scenario('checklist_batch');
+      expect(check.grade(answer(items.reversed.toList())), isEmpty);
+      expect(check.grade(answer(items.take(1).toList())), isNotEmpty);
+      expect(
+        check.grade(
+          answer([
+            items.first.copyWith(
+              args: {...items.first.args, 'isChecked': true},
+            ),
+            items.last,
+          ]),
+        ),
+        isNotEmpty,
+      );
+    },
+  );
+
+  test(
+    'a migration must reference the preceding follow-up placeholder and group',
+    () {
+      const create = ChangeItem(
+        toolName: 'create_follow_up_task',
+        args: {
+          'title': 'Repair the feeder inlet',
+          '_placeholderTaskId': 'generated',
+        },
+        humanSummary: 'Follow up',
+      );
+      const move = ChangeItem(
+        toolName: 'migrate_checklist_item',
+        args: {
+          'id': ActionEvalIds.feeder,
+          'title': 'Inspect the feeder seal',
+          'targetTaskId': 'generated',
+        },
+        humanSummary: 'Move',
+        groupId: 'generated',
+      );
+      final check = scenario('follow_up_migrate');
+      expect(check.grade(answer([create, move])), isEmpty);
+      expect(
+        check.grade(answer([move, create])),
+        contains('invalid_follow_up_dependency'),
+      );
+      expect(
+        check.grade(answer([create, move.copyWith(groupId: null)])),
+        contains('invalid_follow_up_dependency'),
+      );
+      expect(
+        check.grade(
+          answer([
+            create,
+            move.copyWith(
+              args: {...move.args, 'targetTaskId': ActionEvalIds.target},
+            ),
+          ]),
+        ),
+        isNotEmpty,
+      );
+    },
+  );
+
+  test('label confidence and optional defaults cannot hide extra intent', () {
+    const label = ChangeItem(
+      toolName: 'assign_task_label',
+      args: {'id': ActionEvalIds.label, 'confidence': 'high'},
+      humanSummary: 'Assign label',
+    );
+    final check = scenario('label');
+    expect(check.grade(answer([label])), isEmpty);
+    expect(
+      check.grade(
+        answer([
+          label.copyWith(args: {...label.args, 'confidence': 'low'}),
+        ]),
+      ),
+      isNotEmpty,
+    );
+    expect(
+      check.grade(
+        answer([
+          label.copyWith(args: {...label.args}..remove('confidence')),
+        ]),
+      ),
+      isNotEmpty,
+    );
+    final followUp = scenario('follow_up_migrate').expected.first;
+    const create = ChangeItem(
+      toolName: 'create_follow_up_task',
+      args: {
+        'title': 'Repair the feeder inlet',
+        '_placeholderTaskId': 'new',
+        'priority': 'P2',
+      },
+      humanSummary: 'Create',
+    );
+    expect(followUp.matches(create, 'new'), isTrue);
+    expect(
+      followUp.matches(
+        create.copyWith(args: {...create.args, 'priority': 'P0'}),
+        'new',
+      ),
+      isFalse,
+    );
+    for (final placeholder in [null, '', 1]) {
+      expect(
+        followUp.matches(
+          create.copyWith(
+            args: {...create.args, '_placeholderTaskId': placeholder},
+          ),
+          'new',
+        ),
+        isFalse,
+      );
+    }
+  });
+
+  test('relationship direction and missing time text fail independently', () {
+    const link = ChangeItem(
+      toolName: 'link_task',
+      args: {'targetTaskId': ActionEvalIds.target, 'relation': 'blocks'},
+      humanSummary: 'Link',
+    );
+    expect(scenario('link').grade(answer([link])), isEmpty);
+    expect(scenario('link_inverse').grade(answer([link])), isNotEmpty);
+    const time = ChangeItem(
+      toolName: 'create_time_entry',
+      args: {
+        'startTime': '2026-09-12T10:00:00',
+        'endTime': '2026-09-12T10:30:00',
+      },
+      humanSummary: 'Record time',
+    );
+    expect(scenario('time').grade(answer([time])), isNotEmpty);
+    expect(
+      scenario('time').grade(
+        answer([
+          time.copyWith(args: {...time.args, 'summary': ''}),
+        ]),
+      ),
+      isNotEmpty,
+    );
+  });
+
+  test(
+    'negative cases require an answer without actions or completion claims',
+    () {
+      final check = scenario('missing_time');
+      expect(
+        check.grade(answer([], text: 'What start and end time should I use?')),
+        isEmpty,
+      );
+      expect(
+        check.grade(answer([], text: 'I recorded it.')),
+        contains('false_execution_claim'),
+      );
+      expect(check.grade(answer([], text: '')), contains('empty_answer'));
+      expect(
+        check.grade(
+          answer([
+            const ChangeItem(
+              toolName: 'create_time_entry',
+              args: {},
+              humanSummary: '',
+            ),
+          ]),
+        ),
+        contains('unexpected_actions'),
+      );
+    },
+  );
+}


### PR DESCRIPTION
Existing checklist edits and migrations could fail because legacy checklist data overwrote the journal item ID with null or a stale value. Task-chat context now preserves the real ID, and chat guidance supports migration to existing tasks and the reason required for user-toggled checklist changes. A migration to an existing task no longer inherits an unrelated follow-up’s group ID.

Action planning now requires JSON-only output and gets one isolated repair attempt after JSON or proposal validation fails. Invalid attempts cannot leave review items behind; cancellation and transport failures are not retried. Already-configured task languages are rejected during validation as well as in guidance, so a proposal cannot promise a change the shared handler would skip.

The live eval now covers all 15 exposed task tools with 36 fixed scenarios, including exact IDs/arguments, batch contents, relationship direction, time edits, follow-up dependencies and negative controls. A declared synthetic action overlay supplies the missing checklist/time/label state; the canonical penguin query corpus and its expectations remain unchanged.

### Validation

- **GLM-5.3-Flash:** expanded main baseline 29/36; three sequential final runs **36/36 each (108/108)**. Same frozen cases, fixture, report bundle, model and parameters.
- **Ordinary chat:** canonical local/follow-up/wider/absent/category-boundary cases **15/15** across three runs.
- **62 targeted tests pass across scoped runs**, plus the opt-in live test skips normally. Seven regression failures were reproduced before their fixes. Replacing strict grading with tool-name-only grading makes seven grader tests fail. Review added twelve execution-claim examples; regrading all 151 saved action responses with the stricter scorer preserves every result, including the final 108/108.
- Dart MCP analyzer: zero diagnostics. Formatter, diff check and `make knowledge_check`: clean.
- Final CI on `ed239c48fa`: **32 successful checks, 2 skipped; 100% patch coverage**, project coverage 99.38%. All review threads resolved. GitHub still requires code-owner approval.

| Request | Median preparation | Range, 3 runs |
|---|---:|---:|
| Add checklist item | 1.54 s | 1.40–1.66 s |
| Check existing item | 1.98 s | 1.92–2.16 s |
| Record time | 2.32 s | 2.29–3.86 s |
| Create follow-up and migrate item | 2.33 s | 2.05–2.47 s |

These are production-builder question-to-built-review timings, excluding publication/UI rendering. Live evals prepare proposals without accepting or executing them. Of 108 final cases, 107 used two completions; one copied an unavailable target ID from the question, was blocked by independent validation, and correctly refused after the single repair. Approval-path tests additionally exercise the real planner, persistence, confirmation service and context loader with simulated handler mutations: follow-up IDs resolve before validation, and a hidden created task blocks migration. The positive test fails when both ID-resolution paths are disabled. No latency-speedup claim is made from the single baseline sample. Raw responses and timing artifacts remain outside the repository. The three-run action matrix measured the first commit; the later grouping-metadata correction is covered by its regression and leaves model guidance unchanged.

This follows #4260 before release, so its existing changelog fragment covers the feature. The separate cross-device approval policy discussed in [that review](https://github.com/matthiasn/lotti/pull/4260#discussion_r3998166363) remains unresolved; these evals do not establish cross-device execution safety.
