### PR TITLE
fix: align relationship briefing setup and check-in controls

### DIFF
--- a/changelog.d/2026-09-13-relationship-briefing-and-check-in.md
+++ b/changelog.d/2026-09-13-relationship-briefing-and-check-in.md
@@ -1,0 +1,8 @@
+### Fixed
+- **Relationship briefings now show the AI setup they actually use.** The
+  status and configuration sheet recognize the default profile from Settings.
+  Unavailable setups explain how to choose a working model, and new briefings
+  identify the model and provider that wrote them.
+- **Check-in time selection now matches the journal editor.** It follows your
+  12/24-hour preference. Audio check-ins use the person page's recorder;
+  the duplicate microphone beside the text field has been removed.

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -5,7 +5,7 @@ description: A personal CRM carried by two journal variants — why check-ins ar
 resource: ../../lib/features/relationships
 tags: [relationships, check-ins, journal-entity, privacy]
 status: stable
-generated: { by: codex/gpt-6, at: 2026-09-12T20:00:00Z }
+generated: { by: codex/gpt-6, at: 2026-09-13T12:00:00Z }
 stale_after: 2027-03-01
 sources:
   - id: sync-runtime
@@ -680,7 +680,7 @@ removed:
   completion stream (shutdown, runtime teardown) fails the turn rather than
   leaving the caller on a future that can no longer complete, which would
   strand the composer disabled.
-- **One resolution chain for runtime and disclosure.**
+- **One resolution chain for runtime, status and disclosure.**
   `resolveRelationshipAgentModel` honors the typed setup saved by the shared
   model picker, including direct thinking-model overrides. Disabled or broken
   typed setups do not fall through. Legacy agents try the person's profile,
@@ -688,6 +688,12 @@ removed:
   validated GLM built-in is used only if no Settings default was selected.
   A selected Settings default that cannot resolve is an error. The generic
   fallback contract is in [profile resolution](ai/profile-resolution.md).
+  `relationshipAgentResolvedSetupProvider` follows the agent's relationship
+  link and uses this same resolver. The shared setup provider dispatches
+  relationship identities there before asking for a task template. The card
+  and configuration sheet therefore show the route that will actually run,
+  including the Settings default, and refresh on identity, default-profile,
+  catalog, relationship and category changes.
 - **Missing configuration backs off without orphaning the episode.**
   Escalation retries keep their original workspace and trigger tokens, with
   delays of 1, 2, 4, 8, 16, then 24 hours based on the failure streak. Transient
@@ -716,8 +722,12 @@ removed:
   treated as cloud. The relationship read is unfiltered — Phase B resolves
   through the person's own profile whatever this device's private-entry
   display preference, so the dialog must see the same row — and a route that
-  resolves to nothing at all throws (the card surfaces the failure and logs
-  the reason) rather than reading as "local, proceed silently". A direct model
+  resolves to nothing throws `RelationshipInferenceSetupUnavailable`. Automatic
+  provider retries are disabled for this preflight: the card immediately shows
+  the unavailable setup, recovery guidance and a button opening `AgentModelSheet`.
+  Every explicit briefing attempt refreshes disclosure so a repaired setup is
+  reread before consent. The existing unavailable-status link opens the same
+  sheet. A direct model
   override checks its own provider locality, not its optional base profile.
 
 ## The briefing wears the shared AI panel
@@ -739,9 +749,17 @@ rather than from any relationship-specific code:
 * Retuning the wash, border or radius happens once in `ai_card_chrome.dart`
   and lands on all three surfaces together.
 
-What the briefing does NOT borrow is the task footer's settings zone. Its
-band carries only the two things this panel can do — the per-person chat and
-"Brief me".
+The footer includes the shared model identity row and a link to
+`AgentModelSheet`, alongside the relationship-specific briefing and check-in
+controls. Report freshness ("Up to date") describes the stored report; model
+availability describes the current configuration and is a separate signal.
+
+New relationship reports carry `ReportInferenceProvenance`, captured from the
+resolved route used by the wake, alongside health and consumption metadata.
+Model and provider names remain attributable after configuration changes.
+Older reports without that snapshot honestly retain "Attribution unavailable"
+until a new briefing is generated; changing the current setup cannot identify
+which model authored historical text.
 
 The health band pill (`DsPill`, tinted with the band colour) sits in the card
 **body**, above the prose it qualifies — deliberately not in the header's
@@ -925,8 +943,8 @@ tool does not create Daily OS blocks or OS reminders.
 `showCheckInCaptureSheet` and `showCheckInEditSheet` ([check_in_capture_sheet.dart](../../lib/features/relationships/ui/widgets/check_in_capture_sheet.dart))
 open one form (design 2026-09-06 §5) in the responsive modal — a bottom sheet
 on a phone, a dialog on desktop — in the order the design argued for: how it
-felt (the sentiment chips, optional) → what you talked about (the narrative,
-with *Speak instead* beside it) → when and how long (the type chips, a
+felt (the sentiment chips, optional) → what you talked about (the narrative)
+→ when and how long (the type chips, a
 *Started* tile and a *Duration* tile) → *More*, folded, for the topics and the
 two next-time fields; it opens unfolded when the check-in being edited already
 carries any of them. Save is pinned. The form has no actions of its own: after
@@ -946,7 +964,11 @@ sequenceDiagram
   H->>F: the published callback runs
 ```
 
-*Started* opens the date picker, then the time picker; the tile reads
+*Started* opens the date picker, then `DesignSystemTimeWheel`, the same control
+used by the journal date/time editor. It inherits the device's 12/24-hour
+preference and labels its semantics with the localized Started label. The
+chosen time preserves the selected day and is clamped to the current minute
+on today's date. The tile reads
 `Now · HH:mm` while the value is the current minute and the relative day plus
 the time otherwise. *Duration* opens `showCheckInDurationPicker`
 ([check_in_duration_picker.dart](../../lib/features/relationships/ui/widgets/check_in_duration_picker.dart)):
@@ -1043,9 +1065,12 @@ need.
 
 # Voice check-ins (plan v2 phase 6)
 
-The capture sheet's "Speak check-in" records through the shared recording
-sheet and hands the transcript back to the user to edit. The hard part is not
-the UI: it is that **automated transcription used to be task-shaped**.
+The person page's microphone opens the capture sheet with `startSpeaking`,
+which launches the shared recorder after the first frame and hands the
+transcript back to the user to edit. The narrative has no duplicate microphone;
+a live-region caption announces transcription while Save remains disabled.
+Automated transcription used to be task-shaped; the shared pipeline now
+resolves the relationship as its subject.
 
 `ProfileAutomationService.tryTranscribe` and `ProfileAutomationResolver` took
 a `taskId`, resolved the agent through `TaskAgentService.getTaskAgentForTask`,
@@ -1176,8 +1201,8 @@ Two invariants hold regardless of what comes back:
   the check-in exists only once the user presses save. This is the same rule
   that keeps `CheckInSentiment` user-set (ADR 0038).
 * **Speaking never destroys typing.** `mergeCheckInNarrative` appends below
-  existing text, blank-line separated, so a second recording adds to the
-  account rather than replacing it.
+  existing text, blank-line separated, including text entered while the
+  transcript was still arriving.
 
 Name accuracy comes from the **category's `speechDictionary`**, not from
 anything relationship-specific: the recording is created with the person's

--- a/lib/features/agents/state/task_agent_model_providers.dart
+++ b/lib/features/agents/state/task_agent_model_providers.dart
@@ -10,8 +10,10 @@ import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/state/ai_runtime_settings_controller.dart';
 import 'package:lotti/features/ai/state/profile_automation_providers.dart';
 import 'package:lotti/features/ai/util/known_models.dart';
+import 'package:lotti/features/relationships/state/relationship_agent_providers.dart';
 
-/// Shared detailed inference resolution used by the task-agent header.
+/// Shared detailed inference resolution used by agent headers and setup sheets.
+/// Relationship agents resolve their standalone defaults before template lookup.
 final FutureProviderFamily<ResolvedAgentSetup?, String>
 taskAgentResolvedSetupProvider = FutureProvider.autoDispose
     .family<ResolvedAgentSetup?, String>(
@@ -61,6 +63,9 @@ Future<ResolvedAgentSetup?> taskAgentResolvedSetup(
   final identityEntity = await ref.watch(agentIdentityProvider(agentId).future);
   final identity = identityEntity?.mapOrNull(agent: (value) => value);
   if (identity == null) return null;
+  if (identity.kind == AgentKinds.relationshipAgent) {
+    return ref.watch(relationshipAgentResolvedSetupProvider(agentId).future);
+  }
 
   final templateEntity = await ref.watch(
     templateForAgentProvider(agentId).future,

--- a/lib/features/relationships/state/relationship_agent_providers.dart
+++ b/lib/features/relationships/state/relationship_agent_providers.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/misc.dart';
 import 'package:lotti/classes/relationship_trigger_tokens.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/agent_runtime_registry.dart';
 import 'package:lotti/features/ai/conversation/conversation_repository.dart';
@@ -12,6 +13,7 @@ import 'package:lotti/features/ai/helpers/profile_automation_resolver.dart';
 import 'package:lotti/features/ai/helpers/profile_locality.dart';
 import 'package:lotti/features/ai/helpers/prompt_capability_filter.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/resolved_profile.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
 import 'package:lotti/features/ai/state/ai_runtime_settings_controller.dart';
@@ -81,6 +83,77 @@ final relationshipCategoryProfileLookupProvider =
       },
       name: 'relationshipCategoryProfileLookupProvider',
     );
+
+/// The setup shown by the briefing and shared configuration sheet. Uses the
+/// same person/category/Settings default chain as inference, without a template.
+final FutureProviderFamily<ResolvedAgentSetup?, String>
+relationshipAgentResolvedSetupProvider = FutureProvider.autoDispose
+    .family<ResolvedAgentSetup?, String>((ref, agentId) async {
+      final identity = await ref.watch(agentIdentityProvider(agentId).future);
+      if (identity is! AgentIdentityEntity) return null;
+      ref.watch(
+        defaultInferenceProfileControllerProvider.select((v) => v.value),
+      );
+      for (final type in [
+        AiConfigType.inferenceProfile,
+        AiConfigType.model,
+        AiConfigType.inferenceProvider,
+      ]) {
+        ref.watch(
+          aiConfigByTypeControllerProvider(type).select((v) => v.value),
+        );
+      }
+      final subscription = ref
+          .watch(maybeUpdateNotificationsProvider)
+          ?.updateStream
+          .listen((ids) {
+            if (ids.contains(relationshipNotification) ||
+                ids.contains(categoriesNotification)) {
+              ref.invalidateSelf();
+            }
+          });
+      ref.onDispose(() => unawaited(subscription?.cancel()));
+      // Capture dependencies before database reads: a Settings/catalog update
+      // can invalidate this resolution while those reads are still in flight.
+      final agentRepository = ref.watch(agentRepositoryProvider);
+      final relationshipRepository = ref.watch(relationshipRepositoryProvider);
+      final aiConfigRepository = ref.watch(aiConfigRepositoryProvider);
+      final categoryProfileLookup = ref.watch(
+        relationshipCategoryProfileLookupProvider,
+      );
+      final links = await agentRepository.getLinksFrom(
+        agentId,
+        type: AgentLinkTypes.agentRelationship,
+      );
+      final relationship = links.isEmpty
+          ? null
+          : await relationshipRepository.getRelationshipByIdUnfiltered(
+              links.first.toId,
+            );
+      final resolved = await resolveRelationshipAgentModel(
+        relationship: relationship,
+        agentIdentity: identity,
+        aiConfigRepository: aiConfigRepository,
+        categoryProfileLookup: categoryProfileLookup,
+      );
+      return resolved?.setup ??
+          ResolvedAgentSetup(
+            status:
+                identity.config.inferenceSetup?.mode ==
+                    AgentInferenceSetupMode.disabled
+                ? AgentSetupResolutionStatus.disabled
+                : AgentSetupResolutionStatus.broken,
+          );
+    }, name: 'relationshipAgentResolvedSetupProvider');
+
+/// A missing or unusable route needs a configuration action, not an AI retry.
+class RelationshipInferenceSetupUnavailable implements Exception {
+  const RelationshipInferenceSetupUnavailable();
+
+  @override
+  String toString() =>
+      'No inference provider resolves for the relationship agent';
+}
 
 /// Phase B — the lease-elected LLM tier (briefing, banner, chat).
 final relationshipAgentWorkflowProvider = Provider<RelationshipAgentWorkflow>(
@@ -246,45 +319,47 @@ final relationshipRuntimeMaintenanceProvider =
 /// trigger surface must surface the failure rather than proceed silently.
 final FutureProviderFamily<String?, String>
 relationshipBriefingDisclosureProvider = FutureProvider.autoDispose
-    .family<String?, String>((ref, relationshipId) async {
-      final aiConfigRepository = ref.watch(aiConfigRepositoryProvider);
-      ref.watch(
-        defaultInferenceProfileControllerProvider.select(
-          (value) => value.value,
-        ),
-      );
-      final relationship = await ref
-          .watch(relationshipRepositoryProvider)
-          .getRelationshipByIdUnfiltered(relationshipId);
-      final identity = await ref
-          .watch(agentRepositoryProvider)
-          .getEntity(relationshipAgentIdFor(relationshipId));
-      final resolved = await resolveRelationshipAgentModel(
-        relationship: relationship,
-        agentIdentity: identity is AgentIdentityEntity ? identity : null,
-        aiConfigRepository: aiConfigRepository,
-        categoryProfileLookup: ref.watch(
-          relationshipCategoryProfileLookupProvider,
-        ),
-      );
-      if (resolved == null) {
-        throw StateError(
-          'no inference provider resolves for the relationship agent',
+    .family<String?, String>(
+      (ref, relationshipId) async {
+        final aiConfigRepository = ref.watch(aiConfigRepositoryProvider);
+        ref.watch(
+          defaultInferenceProfileControllerProvider.select(
+            (value) => value.value,
+          ),
         );
-      }
-      final profileId = resolved.profileId;
-      if (profileId != null) {
-        final config = await aiConfigRepository.getConfigById(profileId);
-        if (config is AiConfigInferenceProfile &&
-            await profileIsLocal(config, aiConfigRepository)) {
+        final relationship = await ref
+            .watch(relationshipRepositoryProvider)
+            .getRelationshipByIdUnfiltered(relationshipId);
+        final identity = await ref
+            .watch(agentRepositoryProvider)
+            .getEntity(relationshipAgentIdFor(relationshipId));
+        final resolved = await resolveRelationshipAgentModel(
+          relationship: relationship,
+          agentIdentity: identity is AgentIdentityEntity ? identity : null,
+          aiConfigRepository: aiConfigRepository,
+          categoryProfileLookup: ref.watch(
+            relationshipCategoryProfileLookupProvider,
+          ),
+        );
+        if (resolved == null) {
+          throw const RelationshipInferenceSetupUnavailable();
+        }
+        final profileId = resolved.profileId;
+        if (profileId != null) {
+          final config = await aiConfigRepository.getConfigById(profileId);
+          if (config is AiConfigInferenceProfile &&
+              await profileIsLocal(config, aiConfigRepository)) {
+            return null;
+          }
+        }
+        if (profileId == null &&
+            PromptCapabilityFilter.isLocalOnlyProviderType(
+              resolved.provider.inferenceProviderType,
+            )) {
           return null;
         }
-      }
-      if (profileId == null &&
-          PromptCapabilityFilter.isLocalOnlyProviderType(
-            resolved.provider.inferenceProviderType,
-          )) {
-        return null;
-      }
-      return resolved.provider.name;
-    }, name: 'relationshipBriefingDisclosureProvider');
+        return resolved.provider.name;
+      },
+      name: 'relationshipBriefingDisclosureProvider',
+      retry: (_, _) => null,
+    );

--- a/lib/features/relationships/ui/widgets/check_in_capture_sheet.dart
+++ b/lib/features/relationships/ui/widgets/check_in_capture_sheet.dart
@@ -13,7 +13,7 @@ import 'package:lotti/features/design_system/components/buttons/design_system_bu
 import 'package:lotti/features/design_system/components/buttons/design_system_modal_action_bar.dart';
 import 'package:lotti/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart';
 import 'package:lotti/features/design_system/components/chips/design_system_chip.dart';
-import 'package:lotti/features/design_system/components/time_pickers/design_system_time_picker.dart';
+import 'package:lotti/features/design_system/components/time_pickers/design_system_picker_wheels.dart';
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
 import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -336,12 +336,6 @@ class _CheckInCaptureFormState extends ConsumerState<CheckInCaptureForm> {
   bool _isSaving = false;
   bool _isTranscribing = false;
 
-  /// Set synchronously the moment a spoken check-in starts and cleared once
-  /// the whole flow has ended, so the page's mic (`startSpeaking`) and a
-  /// press on *Speak* during the pre-flight awaits cannot open the recorder
-  /// twice. [_isTranscribing] only covers the wait that follows a recording.
-  bool _isSpeaking = false;
-
   /// The in-flight transcript wait, so dismissing the sheet stops it instead
   /// of leaving a database listener running out the timeout.
   CheckInTranscriptWait? _transcriptWait;
@@ -395,7 +389,7 @@ class _CheckInCaptureFormState extends ConsumerState<CheckInCaptureForm> {
         _avoidController.text.isNotEmpty;
     if (widget.startSpeaking) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) unawaited(_handleSpeak());
+        if (mounted) unawaited(_speak());
       });
     }
   }
@@ -492,10 +486,12 @@ class _CheckInCaptureFormState extends ConsumerState<CheckInCaptureForm> {
     return ModalUtils.showSinglePageModal<TimeOfDay>(
       context: context,
       title: context.messages.checkInStartedLabel,
-      builder: (modalContext) => DesignSystemTimePicker(
+      builder: (modalContext) => DesignSystemTimeWheel(
         key: const ValueKey('check-in-time-picker'),
-        initialTime: chosen,
-        onTimeChanged: (time) => chosen = time,
+        initialDateTime: _interactionTime,
+        use24hFormat: MediaQuery.alwaysUse24HourFormatOf(modalContext),
+        semanticsLabel: modalContext.messages.checkInStartedLabel,
+        onDateTimeChanged: (time) => chosen = TimeOfDay.fromDateTime(time),
       ),
       stickyActionBarBuilder: (modalContext) => DesignSystemModalActionBar(
         glass: true,
@@ -538,18 +534,6 @@ class _CheckInCaptureFormState extends ConsumerState<CheckInCaptureForm> {
   /// user's words and a five-minute spinner. Note the check is not the
   /// automatic-inference switch: this is a gesture, so it only needs a model,
   /// not the consent gate that governs unattended runs.
-  Future<void> _handleSpeak() async {
-    if (_isSaving || _isTranscribing || _isSpeaking) return;
-    setState(() => _isSpeaking = true);
-    try {
-      await _speak();
-    } finally {
-      // Whatever ended the flow — a refused pre-flight, a cancelled
-      // recording, a transcript, an error — the button comes back.
-      if (mounted) setState(() => _isSpeaking = false);
-    }
-  }
-
   Future<void> _speak() async {
     // Every provider is read up front: each `await` below can outlive this
     // widget, and reading through `ref` after that throws.
@@ -871,22 +855,13 @@ class _CheckInCaptureFormState extends ConsumerState<CheckInCaptureForm> {
           maxLines: 4,
           textCapitalization: TextCapitalization.sentences,
         ),
-        SizedBox(height: tokens.spacing.step3),
-        Align(
-          alignment: AlignmentDirectional.centerStart,
-          child: DesignSystemButton(
-            key: const Key('check_in_speak_button'),
-            label: _isTranscribing
-                ? messages.checkInTranscribingLabel
-                : messages.checkInSpeakInstead,
-            variant: DesignSystemButtonVariant.outlined,
-            leadingIcon: LottiIcons.mic,
-            isLoading: _isTranscribing,
-            onPressed: _isSaving || _isTranscribing || _isSpeaking
-                ? null
-                : _handleSpeak,
+        if (_isTranscribing) ...[
+          SizedBox(height: tokens.spacing.step3),
+          Semantics(
+            liveRegion: true,
+            child: caption(messages.checkInTranscribingLabel),
           ),
-        ),
+        ],
         SizedBox(height: tokens.spacing.step6),
         sectionLabel(messages.checkInWhenAndHowLong),
         Wrap(

--- a/lib/features/relationships/ui/widgets/relationship_briefing_card.dart
+++ b/lib/features/relationships/ui/widgets/relationship_briefing_card.dart
@@ -289,8 +289,11 @@ class _RelationshipBriefingCardState
         description: messages.relationshipAgentFailedNoModel,
         action: ToastAction(
           label: messages.inferenceProfileChooseModelTitle,
-          onPressed: () =>
-              AgentModelSheet.show(context: context, agentId: _agentId),
+          onPressed: () => AgentModelSheet.show(
+            context: context,
+            agentId: _agentId,
+            entityId: widget.relationship.meta.id,
+          ),
         ),
       );
     } catch (error, stackTrace) {

--- a/lib/features/relationships/ui/widgets/relationship_briefing_card.dart
+++ b/lib/features/relationships/ui/widgets/relationship_briefing_card.dart
@@ -241,7 +241,7 @@ class _RelationshipBriefingCardState
     try {
       // Name the provider BEFORE any cloud-bound trigger (ADR 0037): the
       // locality check fails closed, so an unresolvable profile discloses.
-      final providerName = await ref.read(
+      final providerName = await ref.refresh(
         relationshipBriefingDisclosureProvider(
           widget.relationship.meta.id,
         ).future,
@@ -280,6 +280,18 @@ class _RelationshipBriefingCardState
       context.showToast(
         tone: DesignSystemToastTone.success,
         title: messages.relationshipBriefingRequested,
+      );
+    } on RelationshipInferenceSetupUnavailable {
+      if (!mounted) return;
+      context.showToast(
+        tone: DesignSystemToastTone.error,
+        title: messages.taskAgentSetupBroken,
+        description: messages.relationshipAgentFailedNoModel,
+        action: ToastAction(
+          label: messages.inferenceProfileChooseModelTitle,
+          onPressed: () =>
+              AgentModelSheet.show(context: context, agentId: _agentId),
+        ),
       );
     } catch (error, stackTrace) {
       // Only what fails before the wake is queued lands here — disclosure,

--- a/lib/features/relationships/workflow/relationship_agent_workflow.dart
+++ b/lib/features/relationships/workflow/relationship_agent_workflow.dart
@@ -9,6 +9,7 @@ import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/agent_report_provenance.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/agents/util/agent_error_logging.dart';
@@ -72,12 +73,13 @@ String relationshipAdId(String agentId, String runKey) => const Uuid().v5(
 /// default model or a direct thinking-model override routes.
 typedef RelationshipModelResolution = ({
   String modelId,
+  ResolvedAgentSetup setup,
   AiConfigInferenceProvider provider,
   GeminiThinkingMode? geminiThinkingMode,
   String? profileId,
 });
 
-/// Shared by Phase B and briefing disclosure so consent names the route used.
+/// Shared by Phase B, setup status and disclosure so each names the same route.
 /// An explicit typed setup is authoritative (including disabled/broken).
 /// Legacy agents try person profile, agent profile, category default, Settings
 /// default, then the validated built-in model. Explicit/category lookups are
@@ -99,6 +101,7 @@ Future<RelationshipModelResolution?> resolveRelationshipAgentModel({
     final profile = details.profile;
     if (profile == null) return null;
     return (
+      setup: details,
       modelId: profile.thinkingModelId,
       provider: profile.thinkingProvider,
       geminiThinkingMode: profile.thinkingModel?.geminiThinkingMode,
@@ -113,6 +116,11 @@ Future<RelationshipModelResolution?> resolveRelationshipAgentModel({
     final profile = await profileResolver.resolveByProfileId(profileId);
     if (profile == null) return null;
     return (
+      setup: ResolvedAgentSetup(
+        status: AgentSetupResolutionStatus.resolved,
+        profile: profile,
+        source: AgentSetupResolutionSource.baseProfile,
+      ),
       modelId: profile.thinkingModelId,
       provider: profile.thinkingProvider,
       geminiThinkingMode: profile.thinkingModel?.geminiThinkingMode,
@@ -150,6 +158,15 @@ Future<RelationshipModelResolution?> resolveRelationshipAgentModel({
   );
   if (direct == null) return null;
   return (
+    setup: ResolvedAgentSetup(
+      status: AgentSetupResolutionStatus.resolved,
+      source: AgentSetupResolutionSource.legacyModel,
+      profile: ResolvedProfile(
+        thinkingModelId: direct.model.providerModelId,
+        thinkingModel: direct.model,
+        thinkingProvider: direct.provider,
+      ),
+    ),
     modelId: direct.model.providerModelId,
     provider: direct.provider,
     geminiThinkingMode: direct.model.geminiThinkingMode,
@@ -574,6 +591,16 @@ class RelationshipAgentWorkflow with AgentErrorLogging {
           runKey: runKey,
           threadId: threadId,
           strategy: strategy,
+          inferenceSnapshot: InferenceRunSnapshot(
+            runKey: runKey,
+            threadId: threadId,
+            executor: InferenceRouteSnapshot.fromResolvedProfile(
+              resolved.setup.profile!,
+            ),
+            setupSource: resolved.setup.source,
+            setupOrigin: resolved.setup.setupOrigin,
+            profileId: resolved.profileId,
+          ),
           derivation: derivation,
           now: now,
           replyToUser: interactive,
@@ -679,6 +706,9 @@ class RelationshipAgentWorkflow with AgentErrorLogging {
   /// persistOutputs shape): the interactive reply carrier, the briefing
   /// report + head, snoozes onto their rows, and at most one new banner.
   ///
+  /// [inferenceSnapshot] preserves the authoring route on each new report;
+  /// changing the selected setup later must not rewrite historical attribution.
+  ///
   /// [enforceEligibility] extends the in-transaction fence to revoked
   /// consent: an automatic wake whose relationship was un-marked
   /// `important` or archived while the model ran publishes NOTHING.
@@ -691,6 +721,7 @@ class RelationshipAgentWorkflow with AgentErrorLogging {
     required RelationshipAgentStrategy strategy,
     required RelationshipCadenceDerivation derivation,
     required DateTime now,
+    InferenceRunSnapshot? inferenceSnapshot,
     bool replyToUser = false,
     bool enforceEligibility = false,
   }) async {
@@ -879,6 +910,11 @@ class RelationshipAgentWorkflow with AgentErrorLogging {
               if (briefing.confidence != null)
                 RelationshipReportProvenanceKeys.healthConfidence:
                     briefing.confidence,
+              if (inferenceSnapshot != null)
+                taskAgentInferenceProvenanceKey:
+                    ReportInferenceProvenance.executorOnly(
+                      inferenceSnapshot,
+                    ).toJson(),
               'relationshipId': relationshipId,
               'dueDayKey': derivation.dueDayKey,
               if (attributionEnvelope != null)

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1393,7 +1393,6 @@
   "checkInSourceMessage": "Ze zprávy, kterou jsi poslal/a z této stránky. Vše jde upravit.",
   "checkInSourceMeta": "{type} · začátek v {time} · {minutes, plural, =0{necelá minuta} =1{asi 1 min} other{asi {minutes} min}}",
   "checkInSpeakButton": "Namluvit kontakt",
-  "checkInSpeakInstead": "Raději namluvit",
   "checkInStartedLabel": "Začátek",
   "checkInTopicsHint": "Oddělená čárkami, např. práce, cestování",
   "checkInTopicsLabel": "Témata",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -1564,7 +1564,6 @@
   "checkInSourceMessage": "Fra den besked, du sendte fra denne side. Alt kan redigeres.",
   "checkInSourceMeta": "{type} · startede kl. {time} · {minutes, plural, =0{under et minut} =1{cirka 1 min} other{cirka {minutes} min}}",
   "checkInSpeakButton": "Indtal check-in",
-  "checkInSpeakInstead": "Sig det i stedet",
   "checkInStartedLabel": "Startet",
   "checkInTopicsHint": "Kommasepareret, f.eks. arbejde, rejser",
   "checkInTopicsLabel": "Emner",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1386,7 +1386,6 @@
   "checkInSourceMessage": "Aus der Nachricht, die du von dieser Seite aus geschickt hast. Alles lässt sich ändern.",
   "checkInSourceMeta": "{type} · begonnen um {time} · {minutes, plural, =0{unter einer Minute} =1{etwa 1 Min.} other{etwa {minutes} Min.}}",
   "checkInSpeakButton": "Check-in sprechen",
-  "checkInSpeakInstead": "Lieber sprechen",
   "checkInStartedLabel": "Begonnen",
   "checkInTopicsHint": "Kommagetrennt, z. B. Arbeit, Reisen",
   "checkInTopicsLabel": "Themen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1933,7 +1933,6 @@
   "@checkInSpeakButton": {
     "description": "Button on the check-in sheet that records a spoken check-in and prefills the narrative with its transcript."
   },
-  "checkInSpeakInstead": "Speak instead",
   "checkInStartedLabel": "Started",
   "checkInTopicsHint": "Comma-separated, e.g. work, travel",
   "checkInTopicsLabel": "Topics",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1386,7 +1386,6 @@
   "checkInSourceMessage": "Del mensaje que enviaste desde esta página. Todo se puede editar.",
   "checkInSourceMeta": "{type} · empezó a las {time} · {minutes, plural, =0{menos de un minuto} =1{alrededor de 1 min} other{unos {minutes} min}}",
   "checkInSpeakButton": "Dictar el contacto",
-  "checkInSpeakInstead": "Mejor hablar",
   "checkInStartedLabel": "Empezó",
   "checkInTopicsHint": "Separados por comas, p. ej. trabajo, viajes",
   "checkInTopicsLabel": "Temas",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1386,7 +1386,6 @@
   "checkInSourceMessage": "D’après le message que tu as envoyé depuis cette page. Tout est modifiable.",
   "checkInSourceMeta": "{type} · commencé à {time} · {minutes, plural, =0{moins d’une minute} =1{environ 1 min} other{environ {minutes} min}}",
   "checkInSpeakButton": "Dicter l'échange",
-  "checkInSpeakInstead": "Plutôt le dire",
   "checkInStartedLabel": "Commencé",
   "checkInTopicsHint": "Séparés par des virgules, p. ex. travail, voyages",
   "checkInTopicsLabel": "Sujets",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1564,7 +1564,6 @@
   "checkInSourceMessage": "Dal messaggio che hai inviato da questa pagina. Tutto è modificabile.",
   "checkInSourceMeta": "{type} · inizio: {time} · {minutes, plural, =0{meno di un minuto} =1{circa 1 min} other{circa {minutes} min}}",
   "checkInSpeakButton": "Detta il contatto",
-  "checkInSpeakInstead": "Meglio a voce",
   "checkInStartedLabel": "Inizio",
   "checkInTopicsHint": "Separati da virgole, ad es. lavoro, viaggi",
   "checkInTopicsLabel": "Argomenti",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5388,12 +5388,6 @@ abstract class AppLocalizations {
   /// **'Speak check-in'**
   String get checkInSpeakButton;
 
-  /// No description provided for @checkInSpeakInstead.
-  ///
-  /// In en, this message translates to:
-  /// **'Speak instead'**
-  String get checkInSpeakInstead;
-
   /// No description provided for @checkInStartedLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3226,9 +3226,6 @@ class AppLocalizationsCs extends AppLocalizations {
   String get checkInSpeakButton => 'Namluvit kontakt';
 
   @override
-  String get checkInSpeakInstead => 'Raději namluvit';
-
-  @override
   String get checkInStartedLabel => 'Začátek';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3185,9 +3185,6 @@ class AppLocalizationsDa extends AppLocalizations {
   String get checkInSpeakButton => 'Indtal check-in';
 
   @override
-  String get checkInSpeakInstead => 'Sig det i stedet';
-
-  @override
   String get checkInStartedLabel => 'Startet';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3211,9 +3211,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get checkInSpeakButton => 'Check-in sprechen';
 
   @override
-  String get checkInSpeakInstead => 'Lieber sprechen';
-
-  @override
   String get checkInStartedLabel => 'Begonnen';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3170,9 +3170,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get checkInSpeakButton => 'Speak check-in';
 
   @override
-  String get checkInSpeakInstead => 'Speak instead';
-
-  @override
   String get checkInStartedLabel => 'Started';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3225,9 +3225,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get checkInSpeakButton => 'Dictar el contacto';
 
   @override
-  String get checkInSpeakInstead => 'Mejor hablar';
-
-  @override
   String get checkInStartedLabel => 'Empezó';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3229,9 +3229,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get checkInSpeakButton => 'Dicter l\'échange';
 
   @override
-  String get checkInSpeakInstead => 'Plutôt le dire';
-
-  @override
   String get checkInStartedLabel => 'Commencé';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3223,9 +3223,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get checkInSpeakButton => 'Detta il contatto';
 
   @override
-  String get checkInSpeakInstead => 'Meglio a voce';
-
-  @override
   String get checkInStartedLabel => 'Inizio';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3195,9 +3195,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get checkInSpeakButton => 'Check-in inspreken';
 
   @override
-  String get checkInSpeakInstead => 'Liever inspreken';
-
-  @override
   String get checkInStartedLabel => 'Begonnen';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3214,9 +3214,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get checkInSpeakButton => 'Ditar o contato';
 
   @override
-  String get checkInSpeakInstead => 'Prefiro falar';
-
-  @override
   String get checkInStartedLabel => 'Começou';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3237,9 +3237,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get checkInSpeakButton => 'Dictați contactul';
 
   @override
-  String get checkInSpeakInstead => 'Vorbiți în schimb';
-
-  @override
   String get checkInStartedLabel => 'Început';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3193,9 +3193,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get checkInSpeakButton => 'Tala in avstämning';
 
   @override
-  String get checkInSpeakInstead => 'Säg det i stället';
-
-  @override
   String get checkInStartedLabel => 'Startade';
 
   @override

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1563,7 +1563,6 @@
   "checkInSourceMessage": "Van het bericht dat je vanaf deze pagina stuurde. Alles is aan te passen.",
   "checkInSourceMeta": "{type} · begonnen om {time} · {minutes, plural, =0{minder dan een minuut} =1{ongeveer 1 min} other{ongeveer {minutes} min}}",
   "checkInSpeakButton": "Check-in inspreken",
-  "checkInSpeakInstead": "Liever inspreken",
   "checkInStartedLabel": "Begonnen",
   "checkInTopicsHint": "Kommagescheiden, bijv. werk, reizen",
   "checkInTopicsLabel": "Onderwerpen",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1563,7 +1563,6 @@
   "checkInSourceMessage": "Da mensagem que enviaste a partir desta página. Tudo é editável.",
   "checkInSourceMeta": "{type} · começou às {time} · {minutes, plural, =0{menos de um minuto} =1{cerca de 1 min} other{cerca de {minutes} min}}",
   "checkInSpeakButton": "Ditar o contato",
-  "checkInSpeakInstead": "Prefiro falar",
   "checkInStartedLabel": "Começou",
   "checkInTopicsHint": "Separados por vírgulas, ex.: trabalho, viagens",
   "checkInTopicsLabel": "Assuntos",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1386,7 +1386,6 @@
   "checkInSourceMessage": "Din mesajul pe care l-ați trimis de pe această pagină. Totul se poate edita.",
   "checkInSourceMeta": "{type} · început la {time} · {minutes, plural, =0{sub un minut} =1{circa 1 min} other{circa {minutes} min}}",
   "checkInSpeakButton": "Dictați contactul",
-  "checkInSpeakInstead": "Vorbiți în schimb",
   "checkInStartedLabel": "Început",
   "checkInTopicsHint": "Separate prin virgulă, de ex. muncă, călătorii",
   "checkInTopicsLabel": "Subiecte",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -1564,7 +1564,6 @@
   "checkInSourceMessage": "Från meddelandet du skickade från den här sidan. Allt går att ändra.",
   "checkInSourceMeta": "{type} · började kl. {time} · {minutes, plural, =0{under en minut} =1{cirka 1 min} other{cirka {minutes} min}}",
   "checkInSpeakButton": "Tala in avstämning",
-  "checkInSpeakInstead": "Säg det i stället",
   "checkInStartedLabel": "Startade",
   "checkInTopicsHint": "Kommaseparerade, t.ex. jobb, resor",
   "checkInTopicsLabel": "Ämnen",

--- a/test/features/agents/state/task_agent_model_providers_test.dart
+++ b/test/features/agents/state/task_agent_model_providers_test.dart
@@ -13,6 +13,7 @@ import 'package:lotti/features/ai/model/resolved_profile.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/state/profile_automation_providers.dart';
 import 'package:lotti/features/ai/util/known_models.dart';
+import 'package:lotti/features/relationships/state/relationship_agent_providers.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
@@ -167,6 +168,30 @@ void main() {
       expect(
         container.read(taskAgentSetupOptionsProvider).value?.models,
         [capable, added],
+      );
+    },
+  );
+
+  test(
+    'relationship setup delegates without requiring a task template',
+    () async {
+      final identity = makeTestIdentity(kind: AgentKinds.relationshipAgent);
+      const expected = ResolvedAgentSetup(
+        status: AgentSetupResolutionStatus.disabled,
+      );
+      final container = ProviderContainer(
+        overrides: [
+          agentIdentityProvider.overrideWith((ref, id) async => identity),
+          relationshipAgentResolvedSetupProvider.overrideWith(
+            (ref, id) async => expected,
+          ),
+          templateForAgentProvider.overrideWith((ref, id) async => null),
+        ],
+      );
+      addTearDown(container.dispose);
+      expect(
+        await container.read(taskAgentResolvedSetupProvider('agent').future),
+        same(expected),
       );
     },
   );

--- a/test/features/relationships/state/relationship_agent_providers_test.dart
+++ b/test/features/relationships/state/relationship_agent_providers_test.dart
@@ -558,6 +558,72 @@ void main() {
       );
     }
 
+    AiConfigModel stubLocalSetup() {
+      when(
+        () => agentRepository.getLinksFrom(
+          agentId,
+          type: AgentLinkTypes.agentRelationship,
+        ),
+      ).thenAnswer(
+        (_) async => [
+          AgentLink.agentRelationship(
+            id: 'link',
+            fromId: agentId,
+            toId: relationshipId,
+            createdAt: DateTime(2026, 8),
+            updatedAt: DateTime(2026, 8),
+            vectorClock: null,
+          ),
+        ],
+      );
+      when(
+        () => relationshipRepository.getRelationshipByIdUnfiltered(
+          relationshipId,
+        ),
+      ).thenAnswer((_) async => person());
+      final selectedModel = model('model-local', 'ollama-provider');
+      when(
+        () => aiConfigRepository.getConfigsByType(AiConfigType.model),
+      ).thenAnswer((_) async => [selectedModel]);
+      when(
+        () => aiConfigRepository.getConfigById(profileId),
+      ).thenAnswer((_) async => profile(selectedModel.id));
+      when(
+        () => aiConfigRepository.getConfigById('ollama-provider'),
+      ).thenAnswer((_) async => ollamaProvider);
+      when(
+        () => aiConfigRepository.getConfigsByType(
+          AiConfigType.inferenceProvider,
+        ),
+      ).thenAnswer((_) async => [ollamaProvider]);
+      return selectedModel;
+    }
+
+    ProviderContainer setupContainer({
+      AgentIdentityEntity? Function()? loadIdentity,
+      List<Override> overrides = const [],
+    }) {
+      final c = ProviderContainer(
+        overrides: [
+          templateForAgentProvider.overrideWith((ref, id) async => null),
+          aiConfigRepositoryProvider.overrideWithValue(aiConfigRepository),
+          agentRepositoryProvider.overrideWithValue(agentRepository),
+          agentIdentityProvider(
+            agentId,
+          ).overrideWith(
+            (ref) async => loadIdentity == null ? identity() : loadIdentity(),
+          ),
+          relationshipRepositoryProvider.overrideWithValue(
+            relationshipRepository,
+          ),
+          journalDbProvider.overrideWithValue(journalDb),
+          ...overrides,
+        ],
+      );
+      addTearDown(c.dispose);
+      return c;
+    }
+
     test(
       'setup and disclosure recover when Settings selects a valid default',
       () async {
@@ -570,59 +636,9 @@ void main() {
         ) async {
           defaultId = call.positionalArguments.single as String?;
         });
-        when(
-          () => agentRepository.getLinksFrom(
-            agentId,
-            type: AgentLinkTypes.agentRelationship,
-          ),
-        ).thenAnswer(
-          (_) async => [
-            AgentLink.agentRelationship(
-              id: 'link',
-              fromId: agentId,
-              toId: relationshipId,
-              createdAt: DateTime(2026, 8),
-              updatedAt: DateTime(2026, 8),
-              vectorClock: null,
-            ),
-          ],
-        );
-        when(
-          () => relationshipRepository.getRelationshipByIdUnfiltered(
-            relationshipId,
-          ),
-        ).thenAnswer((_) async => person());
-        final selectedModel = model('model-local', 'ollama-provider');
-        when(
-          () => aiConfigRepository.getConfigsByType(AiConfigType.model),
-        ).thenAnswer((_) async => [selectedModel]);
-        when(
-          () => aiConfigRepository.getConfigById(profileId),
-        ).thenAnswer((_) async => profile(selectedModel.id));
-        when(
-          () => aiConfigRepository.getConfigById('ollama-provider'),
-        ).thenAnswer((_) async => ollamaProvider);
-        when(
-          () => aiConfigRepository.getConfigsByType(
-            AiConfigType.inferenceProvider,
-          ),
-        ).thenAnswer((_) async => [ollamaProvider]);
-        final c = ProviderContainer(
-          overrides: [
-            templateForAgentProvider.overrideWith((ref, id) async => null),
-            aiConfigRepositoryProvider.overrideWithValue(aiConfigRepository),
-            agentRepositoryProvider.overrideWithValue(agentRepository),
-            agentIdentityProvider(
-              agentId,
-            ).overrideWith((ref) async => identity()),
-            relationshipRepositoryProvider.overrideWithValue(
-              relationshipRepository,
-            ),
-            journalDbProvider.overrideWithValue(journalDb),
-          ],
-        );
-        addTearDown(c.dispose);
-        c.listen(taskAgentResolvedSetupProvider(agentId), (_, _) {});
+        final selectedModel = stubLocalSetup();
+        final c = setupContainer()
+          ..listen(taskAgentResolvedSetupProvider(agentId), (_, _) {});
         await c.read(defaultInferenceProfileControllerProvider.future);
         expect(
           (await c.read(
@@ -632,7 +648,13 @@ void main() {
         );
         await expectLater(
           c.read(relationshipBriefingDisclosureProvider(relationshipId).future),
-          throwsA(isA<RelationshipInferenceSetupUnavailable>()),
+          throwsA(
+            isA<RelationshipInferenceSetupUnavailable>().having(
+              (error) => error.toString(),
+              'diagnostic',
+              contains('No inference provider resolves'),
+            ),
+          ),
         );
         await c
             .read(defaultInferenceProfileControllerProvider.notifier)
@@ -650,6 +672,113 @@ void main() {
           isNull,
           reason:
               'the newly selected local default can generate without cloud disclosure',
+        );
+      },
+    );
+
+    for (final token in [relationshipNotification, categoriesNotification]) {
+      test('setup follows synced route changes from $token', () async {
+        final selectedModel = stubLocalSetup();
+        final updates = StreamController<Set<String>>.broadcast(sync: true);
+        addTearDown(updates.close);
+        final notifications = MockUpdateNotifications();
+        when(
+          () => notifications.updateStream,
+        ).thenAnswer((_) => updates.stream);
+        final c = setupContainer(
+          overrides: [
+            maybeUpdateNotificationsProvider.overrideWithValue(notifications),
+          ],
+        );
+        final target = relationshipAgentResolvedSetupProvider(agentId);
+        c.listen(target, (_, _) {});
+        await c.read(defaultInferenceProfileControllerProvider.future);
+        expect(
+          (await c.read(target.future))?.status,
+          AgentSetupResolutionStatus.broken,
+        );
+
+        if (token == relationshipNotification) {
+          when(
+            () => relationshipRepository.getRelationshipByIdUnfiltered(
+              relationshipId,
+            ),
+          ).thenAnswer((_) async => person(withProfileId: profileId));
+        } else {
+          when(
+            () => relationshipRepository.getRelationshipByIdUnfiltered(
+              relationshipId,
+            ),
+          ).thenAnswer((_) async => person(categoryId: 'category'));
+          when(() => journalDb.getCategoryById('category')).thenAnswer(
+            (_) async => CategoryTestUtils.createTestCategory(
+              id: 'category',
+              name: 'Family',
+              defaultProfileId: profileId,
+            ),
+          );
+        }
+        updates.add({'unrelated-entry'});
+        await c.pump();
+        expect(
+          (await c.read(target.future))?.status,
+          AgentSetupResolutionStatus.broken,
+        );
+        updates.add({token});
+        final setup = await c.read(target.future);
+        expect(setup?.status, AgentSetupResolutionStatus.resolved);
+        expect(setup?.profile?.thinkingModelId, selectedModel.providerModelId);
+        expect(setup?.profile?.thinkingProvider.id, ollamaProvider.id);
+        c.dispose();
+        expect(
+          updates.hasListener,
+          isFalse,
+          reason: 'disposed setup must stop listening for route edits',
+        );
+      });
+    }
+
+    test(
+      'disabled AI does not silently use the valid default profile',
+      () async {
+        stubLocalSetup();
+        when(
+          aiConfigRepository.getDefaultProfileId,
+        ).thenAnswer((_) async => profileId);
+        final c = setupContainer(
+          loadIdentity: () => identity(
+            config: const AgentConfig(
+              inferenceSetup: AgentInferenceSetup(
+                mode: AgentInferenceSetupMode.disabled,
+                origin: AgentInferenceSetupOrigin.user,
+              ),
+            ),
+          ),
+        )..listen(relationshipAgentResolvedSetupProvider(agentId), (_, _) {});
+        final setup = await c.read(
+          relationshipAgentResolvedSetupProvider(agentId).future,
+        );
+        expect(setup?.status, AgentSetupResolutionStatus.disabled);
+        expect(setup?.profile, isNull);
+      },
+    );
+
+    test(
+      'a deleted identity has no setup or default inference route',
+      () async {
+        stubLocalSetup();
+        final c = setupContainer(
+          loadIdentity: () => null,
+        );
+        expect(
+          await c.read(relationshipAgentResolvedSetupProvider(agentId).future),
+          isNull,
+        );
+        verifyNever(
+          () => agentRepository.getLinksFrom(
+            agentId,
+            type: AgentLinkTypes.agentRelationship,
+          ),
         );
       },
     );

--- a/test/features/relationships/state/relationship_agent_providers_test.dart
+++ b/test/features/relationships/state/relationship_agent_providers_test.dart
@@ -13,8 +13,10 @@ import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/agents/state/task_agent_model_providers.dart';
 import 'package:lotti/features/agents/workflow/wake_result.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/resolved_profile.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
 import 'package:lotti/features/ai/state/ai_runtime_settings_controller.dart';
@@ -556,6 +558,102 @@ void main() {
       );
     }
 
+    test(
+      'setup and disclosure recover when Settings selects a valid default',
+      () async {
+        String? defaultId = 'missing-profile';
+        when(
+          aiConfigRepository.getDefaultProfileId,
+        ).thenAnswer((_) async => defaultId);
+        when(() => aiConfigRepository.setDefaultProfileId(any())).thenAnswer((
+          call,
+        ) async {
+          defaultId = call.positionalArguments.single as String?;
+        });
+        when(
+          () => agentRepository.getLinksFrom(
+            agentId,
+            type: AgentLinkTypes.agentRelationship,
+          ),
+        ).thenAnswer(
+          (_) async => [
+            AgentLink.agentRelationship(
+              id: 'link',
+              fromId: agentId,
+              toId: relationshipId,
+              createdAt: DateTime(2026, 8),
+              updatedAt: DateTime(2026, 8),
+              vectorClock: null,
+            ),
+          ],
+        );
+        when(
+          () => relationshipRepository.getRelationshipByIdUnfiltered(
+            relationshipId,
+          ),
+        ).thenAnswer((_) async => person());
+        final selectedModel = model('model-local', 'ollama-provider');
+        when(
+          () => aiConfigRepository.getConfigsByType(AiConfigType.model),
+        ).thenAnswer((_) async => [selectedModel]);
+        when(
+          () => aiConfigRepository.getConfigById(profileId),
+        ).thenAnswer((_) async => profile(selectedModel.id));
+        when(
+          () => aiConfigRepository.getConfigById('ollama-provider'),
+        ).thenAnswer((_) async => ollamaProvider);
+        when(
+          () => aiConfigRepository.getConfigsByType(
+            AiConfigType.inferenceProvider,
+          ),
+        ).thenAnswer((_) async => [ollamaProvider]);
+        final c = ProviderContainer(
+          overrides: [
+            templateForAgentProvider.overrideWith((ref, id) async => null),
+            aiConfigRepositoryProvider.overrideWithValue(aiConfigRepository),
+            agentRepositoryProvider.overrideWithValue(agentRepository),
+            agentIdentityProvider(
+              agentId,
+            ).overrideWith((ref) async => identity()),
+            relationshipRepositoryProvider.overrideWithValue(
+              relationshipRepository,
+            ),
+            journalDbProvider.overrideWithValue(journalDb),
+          ],
+        );
+        addTearDown(c.dispose);
+        c.listen(taskAgentResolvedSetupProvider(agentId), (_, _) {});
+        await c.read(defaultInferenceProfileControllerProvider.future);
+        expect(
+          (await c.read(
+            taskAgentResolvedSetupProvider(agentId).future,
+          ))?.status,
+          AgentSetupResolutionStatus.broken,
+        );
+        await expectLater(
+          c.read(relationshipBriefingDisclosureProvider(relationshipId).future),
+          throwsA(isA<RelationshipInferenceSetupUnavailable>()),
+        );
+        await c
+            .read(defaultInferenceProfileControllerProvider.notifier)
+            .selectProfile(profileId);
+        final setup = await c.read(
+          taskAgentResolvedSetupProvider(agentId).future,
+        );
+        expect(setup?.status, AgentSetupResolutionStatus.resolved);
+        expect(setup?.profile?.thinkingModelId, selectedModel.providerModelId);
+        expect(setup?.profile?.thinkingProvider.id, ollamaProvider.id);
+        expect(
+          await c.read(
+            relationshipBriefingDisclosureProvider(relationshipId).future,
+          ),
+          isNull,
+          reason:
+              'the newly selected local default can generate without cloud disclosure',
+        );
+      },
+    );
+
     for (final local in [true, false]) {
       test(
         'direct override discloses its own provider locality: local=$local',
@@ -850,7 +948,10 @@ void main() {
         ),
       );
 
-      await expectLater(disclosure(), throwsStateError);
+      await expectLater(
+        disclosure(),
+        throwsA(isA<RelationshipInferenceSetupUnavailable>()),
+      );
       // The shared stubs make every route fail, so the throw alone would
       // pass without the category branch ever running: prove it ran.
       verify(() => journalDb.getCategoryById('cat-1')).called(1);
@@ -882,7 +983,10 @@ void main() {
         ),
       ).thenAnswer((_) async => person());
 
-      await expectLater(disclosure(), throwsStateError);
+      await expectLater(
+        disclosure(),
+        throwsA(isA<RelationshipInferenceSetupUnavailable>()),
+      );
     });
 
     test('the relationship read is UNFILTERED — a hidden private person '

--- a/test/features/relationships/ui/pages/people_inventory_screenshots_test.dart
+++ b/test/features/relationships/ui/pages/people_inventory_screenshots_test.dart
@@ -1380,6 +1380,19 @@ void main() {
         'check_in_capture_${viewport}_dark',
         subdir: _subdir,
       );
+      await tester.ensureVisible(
+        find.byKey(const ValueKey('check-in-started')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('check-in-started')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Done'));
+      await tester.pumpAndSettle();
+      await captureScreenshot(
+        tester,
+        'check_in_time_${viewport}_dark',
+        subdir: _subdir,
+      );
     });
 
     testWidgets('$viewport check-in edit sheet — dark', (tester) async {

--- a/test/features/relationships/ui/pages/relationship_details_page_test.dart
+++ b/test/features/relationships/ui/pages/relationship_details_page_test.dart
@@ -8,9 +8,7 @@ import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/relationship_data.dart';
 import 'package:lotti/classes/task.dart';
-import 'package:lotti/database/database.dart';
 import 'package:lotti/database/fts5_db.dart';
-import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
@@ -30,7 +28,6 @@ import 'package:lotti/features/relationships/ui/widgets/relationship_action_bar.
 import 'package:lotti/features/relationships/ui/widgets/relationship_briefing_card.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
-import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/widgets/picker/entity_picker_sheet.dart';
@@ -67,10 +64,7 @@ void main() {
   late MockRelationshipReminderService mockReminders;
   late MockUpdateNotifications mockNotifications;
   late MockEntitiesCacheService mockCache;
-  // The post-interaction prompt mounted on this page reads the device-local
-  // marker, which lives in settings. A real in-memory db is simpler than a
-  // mock here and keeps the prompt's "no marker → renders nothing" default.
-  late SettingsDb settingsDb;
+  late TestGetItMocks testServices;
 
   Metadata meta(String id, {String? categoryId, bool? private}) => Metadata(
     id: id,
@@ -149,7 +143,8 @@ void main() {
 
   setUpAll(registerAllFallbackValues);
 
-  setUp(() {
+  setUp(() async {
+    testServices = await setUpTestGetIt();
     // The page is a full scroll — hero, header, cards, then the log — and
     // the default 800x600 surface leaves the Tasks card and most check-in
     // rows unbuilt, where a tap lands on nothing. Tall enough for every
@@ -158,17 +153,13 @@ void main() {
       ..physicalSize = const Size(1000, 2400)
       ..devicePixelRatio = 1;
     mockRepository = MockRelationshipRepository();
-    mockNotifications = MockUpdateNotifications();
-    settingsDb = SettingsDb(inMemoryDatabase: true);
+    mockNotifications = testServices.updateNotifications;
     // The header's eyebrow and the form's CategoryField resolve the category
     // name through the cache; the picker reads its sorted categories.
     mockCache = MockEntitiesCacheService();
     when(() => mockCache.getCategoryById(any())).thenReturn(null);
     when(() => mockCache.sortedCategories).thenReturn([]);
-    getIt
-      ..registerSingleton<UpdateNotifications>(mockNotifications)
-      ..registerSingleton<SettingsDb>(settingsDb)
-      ..registerSingleton<EntitiesCacheService>(mockCache);
+    getIt.registerSingleton<EntitiesCacheService>(mockCache);
     // Most tests exercise other sections; linked tasks default to empty.
     when(
       () => mockRepository.getLinkedTasks('rel-1'),
@@ -183,10 +174,7 @@ void main() {
 
   tearDown(() async {
     TestWidgetsFlutterBinding.instance.platformDispatcher.views.single.reset();
-    await getIt.unregister<UpdateNotifications>();
-    await getIt.unregister<SettingsDb>();
-    await getIt.unregister<EntitiesCacheService>();
-    await settingsDb.close();
+    await tearDownTestGetIt();
   });
 
   Widget buildPage({
@@ -1223,7 +1211,7 @@ void main() {
     late MockFts5Db mockFts5Db;
 
     setUp(() {
-      mockDb = MockJournalDb();
+      mockDb = testServices.journalDb;
       mockFts5Db = MockFts5Db();
       when(
         () => mockDb.getTasks(
@@ -1237,9 +1225,7 @@ void main() {
         () => mockFts5Db.watchFullTextMatches(any()),
       ).thenAnswer((_) => Stream.value(const <String>[]));
 
-      getIt
-        ..registerSingleton<JournalDb>(mockDb)
-        ..registerSingleton<Fts5Db>(mockFts5Db);
+      getIt.registerSingleton<Fts5Db>(mockFts5Db);
 
       when(() => mockRepository.getRelationshipById('rel-1')).thenAnswer(
         (_) async => relationship(),
@@ -1250,7 +1236,6 @@ void main() {
     });
 
     tearDown(() async {
-      await getIt.unregister<JournalDb>();
       await getIt.unregister<Fts5Db>();
     });
 

--- a/test/features/relationships/ui/widgets/check_in_capture_sheet_test.dart
+++ b/test/features/relationships/ui/widgets/check_in_capture_sheet_test.dart
@@ -257,12 +257,13 @@ void main() {
     void Function(String? categoryId)? onLaunch,
     bool canTranscribe = true,
     bool? enableSpeechRecognition,
+    bool startSpeaking = true,
     bool startImmediately = false,
   }) => makeTestableWidgetWithScaffold(
     withBar(
       (handle) => CheckInCaptureForm(
         relationshipId: 'rel-001',
-        startSpeaking: true,
+        startSpeaking: startSpeaking,
         handle: handle,
       ),
     ),
@@ -1524,8 +1525,7 @@ void main() {
       'rebuilding during pre-flight does not open a second recorder',
       (tester) async {
         final launches = <String?>[];
-        // Hold the pre-flight open: the automatic launch is mid-await when the
-        // user presses Speak.
+        // Hold the pre-flight open while additional frames rebuild the form.
         final gate = Completer<RelationshipEntry?>();
         when(
           () => mockRepository.getRelationshipById(any()),
@@ -1558,6 +1558,8 @@ void main() {
           recordedEntryId: null,
           transcript: null,
           onLaunch: launches.add,
+          startSpeaking: false,
+          startImmediately: true,
         ),
       );
       await tester.pumpAndSettle();

--- a/test/features/relationships/ui/widgets/check_in_capture_sheet_test.dart
+++ b/test/features/relationships/ui/widgets/check_in_capture_sheet_test.dart
@@ -10,7 +10,7 @@ import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/state/inference_error_controller.dart';
 import 'package:lotti/features/categories/repository/categories_repository.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
-import 'package:lotti/features/design_system/components/time_pickers/design_system_time_picker.dart';
+import 'package:lotti/features/design_system/components/time_pickers/design_system_picker_wheels.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/relationships/repository/relationship_repository.dart';
 import 'package:lotti/features/relationships/service/check_in_transcription_service.dart';
@@ -36,15 +36,20 @@ class _StubTranscriptionService implements CheckInTranscriptionService {
     required this.canTranscribeResult,
     required this.transcript,
     this.gate,
+    this.preflightGate,
   });
 
   final bool canTranscribeResult;
   final String? transcript;
   final Completer<String?>? gate;
+  final Completer<void>? preflightGate;
   int cancelCount = 0;
 
   @override
-  Future<bool> canTranscribe(String subjectId) async => canTranscribeResult;
+  Future<bool> canTranscribe(String subjectId) async {
+    await preflightGate?.future;
+    return canTranscribeResult;
+  }
 
   @override
   CheckInTranscriptWait transcribe({
@@ -150,6 +155,14 @@ void main() {
 
   late MockRelationshipRepository mockRepository;
   late _StubTranscriptionService stubTranscription;
+  late Completer<void> voiceStartGate;
+
+  // Release the top-level recorder preflight after the test has arranged
+  // any typing or pending inference state. No inner recording button exists.
+  Future<void> startRecording(WidgetTester tester) async {
+    voiceStartGate.complete();
+    await tester.pump();
+  }
 
   CheckInEntry createdEntry(CheckInData data) => CheckInEntry(
     meta: Metadata(
@@ -244,12 +257,12 @@ void main() {
     void Function(String? categoryId)? onLaunch,
     bool canTranscribe = true,
     bool? enableSpeechRecognition,
-    bool startSpeaking = false,
+    bool startImmediately = false,
   }) => makeTestableWidgetWithScaffold(
     withBar(
       (handle) => CheckInCaptureForm(
         relationshipId: 'rel-001',
-        startSpeaking: startSpeaking,
+        startSpeaking: true,
         handle: handle,
       ),
     ),
@@ -275,6 +288,9 @@ void main() {
       checkInTranscriptionServiceProvider.overrideWithValue(
         stubTranscription = _StubTranscriptionService(
           canTranscribeResult: canTranscribe,
+          preflightGate: startImmediately
+              ? null
+              : (voiceStartGate = Completer<void>()),
           transcript: transcript,
           gate: transcriptGate,
         ),
@@ -575,11 +591,21 @@ void main() {
       await tester.tap(find.text('Done'));
       await tester.pumpAndSettle();
 
+      final wheel = tester.widget<DesignSystemTimeWheel>(
+        find.byKey(const ValueKey('check-in-time-picker')),
+      );
+      expect(wheel.initialDateTime, interactionTime);
+      expect(wheel.semanticsLabel, 'Started');
+      expect(
+        wheel.use24hFormat,
+        isFalse,
+        reason: 'follows the same device preference as the journal editor',
+      );
       tester
-          .widget<DesignSystemTimePicker>(
+          .widget<DesignSystemTimeWheel>(
             find.byKey(const ValueKey('check-in-time-picker')),
           )
-          .onTimeChanged(const TimeOfDay(hour: 8, minute: 15));
+          .onDateTimeChanged(DateTime(2026, 8, 10, 8, 15));
       await tester.tap(find.byKey(const ValueKey('check-in-time-done')));
       await tester.pumpAndSettle();
 
@@ -616,10 +642,10 @@ void main() {
         await tester.tap(find.text('Done'));
         await tester.pumpAndSettle();
         tester
-            .widget<DesignSystemTimePicker>(
+            .widget<DesignSystemTimeWheel>(
               find.byKey(const ValueKey('check-in-time-picker')),
             )
-            .onTimeChanged(const TimeOfDay(hour: 23, minute: 45));
+            .onDateTimeChanged(DateTime(2026, 8, 13, 23, 45));
         await tester.tap(find.byKey(const ValueKey('check-in-time-done')));
         await tester.pumpAndSettle();
 
@@ -918,12 +944,13 @@ void main() {
     String narrativeText(WidgetTester tester) =>
         tester.widget<TextField>(narrativeField()).controller!.text;
 
-    testWidgets('offers the button on a fresh check-in', (tester) async {
+    testWidgets('text check-in has no duplicate microphone', (tester) async {
       await tester.pumpWidget(buildForm());
       await tester.pumpAndSettle();
 
-      expect(speakButton(), findsOne);
-      expect(find.text('Speak instead'), findsOne);
+      expect(speakButton(), findsNothing);
+      expect(find.byIcon(LottiIcons.mic), findsNothing);
+      expect(find.text('Speak instead'), findsNothing);
     });
 
     // The bug this guards: with no audio model — or a person filed under no
@@ -944,8 +971,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.ensureVisible(speakButton());
-      await tester.tap(speakButton());
+      await startRecording(tester);
       await tester.pumpAndSettle();
 
       expect(launches, 0, reason: 'no recording should be wasted');
@@ -967,8 +993,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.ensureVisible(speakButton());
-      await tester.tap(speakButton());
+      await startRecording(tester);
       await tester.pumpAndSettle();
 
       expect(narrativeText(tester), 'She got the job.');
@@ -985,8 +1010,7 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.enterText(narrativeField(), 'Called on the way home.');
-      await tester.ensureVisible(speakButton());
-      await tester.tap(speakButton());
+      await startRecording(tester);
       await tester.pumpAndSettle();
 
       expect(
@@ -1016,8 +1040,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.ensureVisible(speakButton());
-      await tester.tap(speakButton());
+      await startRecording(tester);
       await tester.pumpAndSettle();
 
       expect(launches, 1);
@@ -1037,8 +1060,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.ensureVisible(speakButton());
-      await tester.tap(speakButton());
+      await startRecording(tester);
       await tester.pump();
 
       expect(find.text('Transcribing…'), findsOne);
@@ -1047,7 +1069,7 @@ void main() {
       gate.complete('Arrived at last.');
       await tester.pumpAndSettle();
 
-      expect(find.text('Speak instead'), findsOne);
+      expect(find.text('Speak instead'), findsNothing);
       expect(narrativeText(tester), 'Arrived at last.');
     });
 
@@ -1060,8 +1082,7 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.enterText(narrativeField(), 'Typed only.');
-      await tester.ensureVisible(speakButton());
-      await tester.tap(speakButton());
+      await startRecording(tester);
       await tester.pumpAndSettle();
 
       expect(narrativeText(tester), 'Typed only.');
@@ -1077,8 +1098,7 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.enterText(narrativeField(), 'Typed only.');
-      await tester.ensureVisible(speakButton());
-      await tester.tap(speakButton());
+      await startRecording(tester);
       await tester.pumpAndSettle();
 
       expect(
@@ -1086,7 +1106,7 @@ void main() {
         findsOne,
       );
       expect(narrativeText(tester), 'Typed only.');
-      expect(find.text('Speak instead'), findsOne);
+      expect(find.text('Speak instead'), findsNothing);
     });
 
     // The HTTP 503 case. A failed run writes no transcript, so the wait alone
@@ -1109,8 +1129,7 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.enterText(narrativeField(), 'Typed only.');
-      await tester.ensureVisible(speakButton());
-      await tester.tap(speakButton());
+      await startRecording(tester);
       await tester.pump();
 
       expect(find.text('Transcribing…'), findsOne, reason: 'wait is open');
@@ -1168,8 +1187,7 @@ void main() {
           )
           .setError('a failure from the previous take');
 
-      await tester.ensureVisible(speakButton());
-      await tester.tap(speakButton());
+      await startRecording(tester);
       await tester.pump();
 
       expect(find.text('Transcribing…'), findsOne);
@@ -1181,7 +1199,7 @@ void main() {
       expect(narrativeText(tester), 'Arrived at last.');
     });
 
-    testWidgets('ignores a second tap while a transcript is in flight', (
+    testWidgets('offers no duplicate recording action while transcribing', (
       tester,
     ) async {
       final gate = Completer<String?>();
@@ -1196,10 +1214,9 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.ensureVisible(speakButton());
-      await tester.tap(speakButton());
+      await startRecording(tester);
       await tester.pump();
-      await tester.tap(speakButton(), warnIfMissed: false);
+      expect(speakButton(), findsNothing);
       await tester.pump();
 
       expect(launches, 1);
@@ -1228,8 +1245,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.ensureVisible(speakButton());
-      await tester.tap(speakButton());
+      await startRecording(tester);
       await tester.pumpAndSettle();
 
       expect(find.text('Transcribing…'), findsNothing);
@@ -1252,8 +1268,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.ensureVisible(speakButton());
-      await tester.tap(speakButton());
+      await startRecording(tester);
       await tester.pumpAndSettle();
 
       expect(narrativeText(tester), 'Spoken.');
@@ -1280,8 +1295,7 @@ void main() {
         reason: 'enabled before speaking',
       );
 
-      await tester.ensureVisible(speakButton());
-      await tester.tap(speakButton());
+      await startRecording(tester);
       // One frame for the form to publish, one for the pinned bar to read it.
       await tester.pump();
       await tester.pump();
@@ -1310,8 +1324,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.ensureVisible(speakButton());
-      await tester.tap(speakButton());
+      await startRecording(tester);
       await tester.pump();
       expect(stubTranscription.cancelCount, 0);
 
@@ -1321,13 +1334,14 @@ void main() {
       expect(stubTranscription.cancelCount, 1);
     });
 
-    testWidgets('is offered when editing an existing check-in too', (
+    testWidgets('editing a check-in has no duplicate microphone', (
       tester,
     ) async {
       await tester.pumpWidget(buildEditForm());
       await tester.pumpAndSettle();
 
-      expect(speakButton(), findsOne);
+      expect(speakButton(), findsNothing);
+      expect(find.byIcon(LottiIcons.mic), findsNothing);
     });
   });
 
@@ -1496,7 +1510,7 @@ void main() {
           recordedEntryId: null,
           transcript: null,
           onLaunch: launches.add,
-          startSpeaking: true,
+          startImmediately: true,
         ),
       );
       await tester.pumpAndSettle();
@@ -1506,42 +1520,34 @@ void main() {
       expect(find.text('When and how long'), findsOneWidget);
     });
 
-    testWidgets("a Speak press during the automatic launch's pre-flight does "
-        'not open a second recorder', (tester) async {
-      final launches = <String?>[];
-      // Hold the pre-flight open: the automatic launch is mid-await when the
-      // user presses Speak.
-      final gate = Completer<RelationshipEntry?>();
-      when(
-        () => mockRepository.getRelationshipById(any()),
-      ).thenAnswer((_) => gate.future);
-      await tester.pumpWidget(
-        buildSpeakableForm(
-          recordedEntryId: null,
-          transcript: null,
-          onLaunch: launches.add,
-          startSpeaking: true,
-        ),
-      );
-      await tester.pump();
+    testWidgets(
+      'rebuilding during pre-flight does not open a second recorder',
+      (tester) async {
+        final launches = <String?>[];
+        // Hold the pre-flight open: the automatic launch is mid-await when the
+        // user presses Speak.
+        final gate = Completer<RelationshipEntry?>();
+        when(
+          () => mockRepository.getRelationshipById(any()),
+        ).thenAnswer((_) => gate.future);
+        await tester.pumpWidget(
+          buildSpeakableForm(
+            recordedEntryId: null,
+            transcript: null,
+            onLaunch: launches.add,
+            startImmediately: true,
+          ),
+        );
+        await tester.pump();
 
-      final speak = find.widgetWithText(DesignSystemButton, 'Speak instead');
-      expect(
-        tester.widget<DesignSystemButton>(speak).onPressed,
-        isNull,
-        reason: 'the button is out while a spoken check-in is in flight',
-      );
-      await tester.tap(speak, warnIfMissed: false);
-      gate.complete(testRelationship);
-      await tester.pumpAndSettle();
+        expect(find.byKey(const Key('check_in_speak_button')), findsNothing);
+        await tester.pump();
+        gate.complete(testRelationship);
+        await tester.pumpAndSettle();
 
-      expect(launches, hasLength(1));
-      expect(
-        tester.widget<DesignSystemButton>(speak).onPressed,
-        isNotNull,
-        reason: 'a cancelled recording hands the button back',
-      );
-    });
+        expect(launches, hasLength(1));
+      },
+    );
 
     testWidgets('a form opened the ordinary way launches nothing on its own', (
       tester,

--- a/test/features/relationships/ui/widgets/relationship_briefing_card_test.dart
+++ b/test/features/relationships/ui/widgets/relationship_briefing_card_test.dart
@@ -208,6 +208,7 @@ void main() {
     bool modelResolved = true,
     int totalTokens = 0,
     String? disclosureProviderName,
+    bool setupUnavailable = false,
     Set<ContactAction> launchable = const {ContactAction.call},
   }) async {
     final launcher = _FakeContactLauncher(launchable: launchable);
@@ -257,7 +258,12 @@ void main() {
             relationshipAgentServiceProvider.overrideWithValue(agentService),
             relationshipBriefingDisclosureProvider(
               relationshipId,
-            ).overrideWith((ref) async => disclosureProviderName),
+            ).overrideWith((ref) async {
+              if (setupUnavailable) {
+                throw const RelationshipInferenceSetupUnavailable();
+              }
+              return disclosureProviderName;
+            }),
             relationshipRepositoryProvider.overrideWithValue(repository),
             contactLauncherProvider.overrideWithValue(launcher),
             pendingInteractionStoreProvider.overrideWithValue(store),
@@ -624,6 +630,20 @@ void main() {
       await tester.tap(find.text('Continue'));
       await tester.pumpAndSettle();
       verify(() => agentService.requestBriefing(any())).called(1);
+    });
+
+    testWidgets('unavailable setup explains recovery and opens configuration', (
+      tester,
+    ) async {
+      await pump(tester, checkIns: onTrackCheckIns, setupUnavailable: true);
+      await tester.tap(briefMe);
+      await tester.pumpAndSettle();
+      verifyNever(() => agentService.requestBriefing(any()));
+      expect(find.text('Could not request the briefing.'), findsNothing);
+      expect(find.text('Selected AI setup is unavailable'), findsOneWidget);
+      await tester.tap(find.text('Choose a model'));
+      await tester.pumpAndSettle();
+      expect(find.text('Agent setup'), findsOneWidget);
     });
 
     testWidgets('a failed request surfaces the error toast', (tester) async {

--- a/test/features/relationships/ui/widgets/relationship_briefing_card_test.dart
+++ b/test/features/relationships/ui/widgets/relationship_briefing_card_test.dart
@@ -209,6 +209,11 @@ void main() {
     int totalTokens = 0,
     String? disclosureProviderName,
     bool setupUnavailable = false,
+    TaskAgentSetupOptions setupOptions = const TaskAgentSetupOptions(
+      profiles: [],
+      models: [],
+      providers: [],
+    ),
     Set<ContactAction> launchable = const {ContactAction.call},
   }) async {
     final launcher = _FakeContactLauncher(launchable: launchable);
@@ -249,11 +254,7 @@ void main() {
               ],
             ),
             taskAgentSetupOptionsProvider.overrideWith(
-              (ref) async => const TaskAgentSetupOptions(
-                profiles: [],
-                models: [],
-                providers: [],
-              ),
+              (ref) async => setupOptions,
             ),
             relationshipAgentServiceProvider.overrideWithValue(agentService),
             relationshipBriefingDisclosureProvider(
@@ -635,7 +636,17 @@ void main() {
     testWidgets('unavailable setup explains recovery and opens configuration', (
       tester,
     ) async {
-      await pump(tester, checkIns: onTrackCheckIns, setupUnavailable: true);
+      final model = testAiModel();
+      await pump(
+        tester,
+        checkIns: onTrackCheckIns,
+        setupUnavailable: true,
+        setupOptions: TaskAgentSetupOptions(
+          profiles: const [],
+          models: [model],
+          providers: [testInferenceProvider()],
+        ),
+      );
       await tester.tap(briefMe);
       await tester.pumpAndSettle();
       verifyNever(() => agentService.requestBriefing(any()));
@@ -644,6 +655,10 @@ void main() {
       await tester.tap(find.text('Choose a model'));
       await tester.pumpAndSettle();
       expect(find.text('Agent setup'), findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('agent-choose-model')));
+      await tester.pumpAndSettle();
+      expect(find.byKey(ValueKey('agent-model-${model.id}')), findsOneWidget);
+      expect(find.text(model.name), findsWidgets);
     });
 
     testWidgets('a failed request surfaces the error toast', (tester) async {

--- a/test/features/relationships/workflow/relationship_agent_workflow_test.dart
+++ b/test/features/relationships/workflow/relationship_agent_workflow_test.dart
@@ -12,6 +12,7 @@ import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
+import 'package:lotti/features/agents/model/agent_report_provenance.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/model/proposal_ledger.dart';
 import 'package:lotti/features/agents/workflow/wake_result.dart';
@@ -544,6 +545,13 @@ void main() {
       contains('difficult calls'),
     );
     expect(report.provenance['relationshipId'], relationshipId);
+    final inference = ReportInferenceProvenance.tryRead(report.provenance);
+    expect(inference, isNotNull);
+    expect(inference!.executor.providerModelId, glmModel.providerModelId);
+    expect(inference.executor.modelConfigId, glmModel.id);
+    expect(inference.executor.servingProviderName, meliousProvider.name);
+    expect(inference.finalContentAuthor, ReportContentAuthor.executor);
+
     expect(upserts.whereType<AgentReportHeadEntity>(), hasLength(1));
 
     final banner = upserts.whereType<RelationshipNudgeEntity>().single;
@@ -1727,6 +1735,63 @@ void main() {
         );
         expect(resolved?.modelId, 'claude-x');
         expect(resolved?.profileId, 'profile-cat');
+      },
+    );
+
+    test(
+      'briefing recovers after selecting a usable default and records its author',
+      () async {
+        var selectedId = 'missing-profile';
+        when(
+          aiConfigRepository.getDefaultProfileId,
+        ).thenAnswer((_) async => selectedId);
+        stubCategoryProfileOnClaude();
+        final failed = await run(
+          tokens: {relationshipReportRefreshTriggerToken},
+        );
+        expect(failed.success, isFalse);
+        expect(conversationRepository.sendMessageDelegateCallCount, 0);
+        expect(upserts.whereType<AgentReportEntity>(), isEmpty);
+        selectedId = 'profile-cat';
+        conversationRepository.sendMessageDelegate =
+            ({
+              required conversationId,
+              required message,
+              required model,
+              required provider,
+              required inferenceRepo,
+              tools,
+              toolChoice,
+              temperature = 0,
+              strategy,
+            }) async {
+              expect(model, claudeModel.providerModelId);
+              expect(provider.id, anthropicProvider.id);
+              await strategy!.processToolCalls(
+                toolCalls: [
+                  toolCall(
+                    RelationshipAgentToolNames.updateRelationshipReport,
+                    briefingArgs(),
+                  ),
+                ],
+                manager: conversationManager,
+              );
+              return null;
+            };
+        final recovered = await run(
+          tokens: {relationshipReportRefreshTriggerToken},
+        );
+        expect(recovered.success, isTrue);
+        expect(recovered.reportUpdated, isTrue);
+        final report = upserts.whereType<AgentReportEntity>().single;
+        expect(report.content, contains('Full briefing'));
+        final provenance = ReportInferenceProvenance.tryRead(report.provenance);
+        expect(provenance?.profileId, selectedId);
+        expect(
+          provenance?.executor.servingProviderConfigId,
+          anthropicProvider.id,
+        );
+        expect(provenance?.executor.modelConfigId, claudeModel.id);
       },
     );
 


### PR DESCRIPTION
Relationship agents have no task template, but their briefing card and shared setup sheet used the task-template resolver. This falsely marked usable setups unavailable, including the Settings default profile. Both surfaces now use the relationship runtime resolver. Missing configurations fail immediately with recovery guidance and a working setup action, and every briefing attempt rereads configuration before disclosure. New reports retain the model/provider that authored them; historical reports without attribution remain explicitly unknown.

Check-in time selection now uses the journal editor's shared time wheel and device 12/24-hour preference. The duplicate microphone beside the narrative is removed; the person page's recorder still opens capture and supplies an editable transcript, with transcription progress announced accessibly.

Validation:
- 240 targeted tests pass; regression checks fail with their fixes removed. Coverage includes synced relationship/category route changes, disabled and deleted setups, and direct model recovery without inference profiles.
- The relationship details fixture uses the shared GetIt harness. A seeded registration reproduces the CI failure before this fix and passes after it.
- Full Dart MCP analysis reports no diagnostics, including after rebasing onto current main.
- Localization regenerated; knowledge/Mermaid and changelog checks pass.
- Three screenshot scenarios pass using synthetic penguin fixtures.
- Recovery through report generation is verified with a mocked provider. Live credentials and remote model availability were not tested.

| Surface | Before | After |
| --- | --- | --- |
| Check-in · mobile | <a href="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-briefing-check-in/9262ffd9616abe94f0c04cf9272551a10e9b88da/before/check_in_capture_mobile_dark.png"><img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-briefing-check-in/9262ffd9616abe94f0c04cf9272551a10e9b88da/before/check_in_capture_mobile_dark.png" width="300"></a> | <a href="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-briefing-check-in/9262ffd9616abe94f0c04cf9272551a10e9b88da/after/check_in_capture_mobile_dark.png"><img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-briefing-check-in/9262ffd9616abe94f0c04cf9272551a10e9b88da/after/check_in_capture_mobile_dark.png" width="300"></a> |
| Check-in · desktop | <a href="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-briefing-check-in/9262ffd9616abe94f0c04cf9272551a10e9b88da/before/check_in_capture_desktop_dark.png"><img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-briefing-check-in/9262ffd9616abe94f0c04cf9272551a10e9b88da/before/check_in_capture_desktop_dark.png" width="300"></a> | <a href="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-briefing-check-in/9262ffd9616abe94f0c04cf9272551a10e9b88da/after/check_in_capture_desktop_dark.png"><img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-briefing-check-in/9262ffd9616abe94f0c04cf9272551a10e9b88da/after/check_in_capture_desktop_dark.png" width="300"></a> |
| Time picker · mobile | <a href="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-briefing-check-in/9262ffd9616abe94f0c04cf9272551a10e9b88da/before/check_in_time_mobile_dark.png"><img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-briefing-check-in/9262ffd9616abe94f0c04cf9272551a10e9b88da/before/check_in_time_mobile_dark.png" width="300"></a> | <a href="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-briefing-check-in/9262ffd9616abe94f0c04cf9272551a10e9b88da/after/check_in_time_mobile_dark.png"><img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-briefing-check-in/9262ffd9616abe94f0c04cf9272551a10e9b88da/after/check_in_time_mobile_dark.png" width="300"></a> |
| Time picker · desktop | <a href="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-briefing-check-in/9262ffd9616abe94f0c04cf9272551a10e9b88da/before/check_in_time_desktop_dark.png"><img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-briefing-check-in/9262ffd9616abe94f0c04cf9272551a10e9b88da/before/check_in_time_desktop_dark.png" width="300"></a> | <a href="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-briefing-check-in/9262ffd9616abe94f0c04cf9272551a10e9b88da/after/check_in_time_desktop_dark.png"><img src="https://pub-3df7bcf4b8ca493fa6acea182d69d9c7.r2.dev/pr-screenshots/relationship-briefing-check-in/9262ffd9616abe94f0c04cf9272551a10e9b88da/after/check_in_time_desktop_dark.png" width="300"></a> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Relationship briefings now identify the AI setup, model, and provider used, including Settings defaults.
  - Unavailable AI setups provide clearer recovery guidance and a direct option to choose a model.
  - New briefings retain details about the setup used.
  - Check-in start times now follow the journal’s 12/24-hour preference.
  - Audio check-ins use the person page’s recorder, with duplicate microphone controls removed.
  - Speaking check-ins start automatically and show clearer transcription status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

