### PR TITLE
chore(release): 1.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.12]
+
+### Added
+
+- **Task chat can propose changes for review.** Ask it to add checklist items,
+  record time, or propose other task changes. Accept or dismiss the changes
+  directly in chat before anything is applied.
+
+### Changed
+
+- **Project and category chats keep their details in place.** Chat opens beside
+  the detail on wide screens or in an expandable sheet on smaller screens.
+  Category edits stay intact, and the project list returns after closing chat.
+
+### Fixed
+
+- **Chat now receives the current local date and time.** Questions about today,
+  yesterday or tomorrow get a fresh device timestamp with its UTC offset,
+  rather than leaving the model to infer today from old reports or messages.
+- **Relationship briefings now show the AI setup they actually use.** The
+  status and configuration sheet recognize the default profile from Settings.
+  Unavailable setups explain how to choose a working model, and new briefings
+  identify the model and provider that wrote them.
+- **Check-in time selection now matches the journal editor.** It follows your
+  12/24-hour preference. Audio check-ins use the person page's recorder;
+  the duplicate microphone beside the text field has been removed.
+
 ## [1.1.11]
 
 ### Added

--- a/changelog.d/2026-09-13-project-category-chat-companion.md
+++ b/changelog.d/2026-09-13-project-category-chat-companion.md
@@ -1,4 +1,0 @@
-### Changed
-- **Project and category chats keep their details in place.** Chat opens beside
-  the detail on wide screens or in an expandable sheet on smaller screens.
-  Category edits stay intact, and the project list returns after closing chat.

--- a/changelog.d/2026-09-13-query-chat-current-time.md
+++ b/changelog.d/2026-09-13-query-chat-current-time.md
@@ -1,4 +1,0 @@
-### Fixed
-- **Chat now receives the current local date and time.** Questions about today,
-  yesterday or tomorrow get a fresh device timestamp with its UTC offset,
-  rather than leaving the model to infer today from old reports or messages.

--- a/changelog.d/2026-09-13-relationship-briefing-and-check-in.md
+++ b/changelog.d/2026-09-13-relationship-briefing-and-check-in.md
@@ -1,8 +1,0 @@
-### Fixed
-- **Relationship briefings now show the AI setup they actually use.** The
-  status and configuration sheet recognize the default profile from Settings.
-  Unavailable setups explain how to choose a working model, and new briefings
-  identify the model and provider that wrote them.
-- **Check-in time selection now matches the journal editor.** It follows your
-  12/24-hour preference. Audio check-ins use the person page's recorder;
-  the duplicate microphone beside the text field has been removed.

--- a/changelog.d/2026-09-13-task-chat-actions.md
+++ b/changelog.d/2026-09-13-task-chat-actions.md
@@ -1,5 +1,0 @@
-### Added
-
-- **Task chat can propose changes for review.** Ask it to add checklist items,
-  record time, or propose other task changes. Accept or dismiss the changes
-  directly in chat before anything is applied.

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -40,6 +40,15 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="1.1.12" date="2026-09-13">
+      <description>
+        <p>Added: task chat can propose changes for review. Ask it to add checklist items, record time, or propose other task changes. Accept or dismiss the changes directly in chat before anything is applied.</p>
+        <p>Changed: project and category chats keep their details in place. Chat opens beside the detail on wide screens or in an expandable sheet on smaller screens. Category edits stay intact, and the project list returns after closing chat.</p>
+        <p>Fixed: chat now receives the current local date and time. Questions about today, yesterday or tomorrow get a fresh device timestamp with its UTC offset, rather than leaving the model to infer today from old reports or messages.</p>
+        <p>Fixed: relationship briefings now show the AI setup they actually use. The status and configuration sheet recognize the default profile from Settings. Unavailable setups explain how to choose a working model, and new briefings identify the model and provider that wrote them.</p>
+        <p>Fixed: check-in time selection now matches the journal editor. It follows your 12/24-hour preference. Audio check-ins use the person page's recorder; the duplicate microphone beside the text field has been removed.</p>
+      </description>
+    </release>
     <release version="1.1.11" date="2026-09-13">
       <description>
         <p>Added: choose a separate model for chat in an inference profile. The optional Chat model setting lets task, project and category conversations use a different model from background agent work. Leave it unset to keep using the profile's resolved Thinking model.</p>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 1.1.11+4389
+version: 1.1.12+4390
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
## [1.1.12]

### Added

- **Task chat can propose changes for review.** Ask it to add checklist items,
  record time, or propose other task changes. Accept or dismiss the changes
  directly in chat before anything is applied.

### Changed

- **Project and category chats keep their details in place.** Chat opens beside
  the detail on wide screens or in an expandable sheet on smaller screens.
  Category edits stay intact, and the project list returns after closing chat.

### Fixed

- **Chat now receives the current local date and time.** Questions about today,
  yesterday or tomorrow get a fresh device timestamp with its UTC offset,
  rather than leaving the model to infer today from old reports or messages.
- **Relationship briefings now show the AI setup they actually use.** The
  status and configuration sheet recognize the default profile from Settings.
  Unavailable setups explain how to choose a working model, and new briefings
  identify the model and provider that wrote them.
- **Check-in time selection now matches the journal editor.** It follows your
  12/24-hour preference. Audio check-ins use the person page's recorder;
  the duplicate microphone beside the text field has been removed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Task chats can propose checklist updates, time entries, and other task changes for review before applying them.
  - Project and category chats now appear beside details on wide screens and in an expandable sheet on smaller screens.

- **Bug Fixes**
  - Chat queries now use the correct local date and time.
  - Relationship briefings display their configured AI setup.
  - Check-in time selection follows 12/24-hour preferences, with improved audio controls.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->