### PR TITLE
fix: retain relationship briefing preflight while settings load

### DIFF
--- a/changelog.d/2026-09-13-relationship-briefing-preflight.md
+++ b/changelog.d/2026-09-13-relationship-briefing-preflight.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **Relationship briefings wait for AI settings to load.** Requesting a
+  briefing no longer fails while its default profile or relationship data is
+  still loading.

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -733,6 +733,8 @@ removed:
   generic request-failed toast before any inference is queued. Disclosure
   captures its repository and category-lookup dependencies before awaiting
   reads, so a superseded resolution never reads a disposed `Ref`.
+  The click captures one relationship snapshot for disclosure, the queued
+  request and setup recovery; a card rebuild cannot retarget an in-flight action.
   The existing unavailable-status link opens the same
   sheet. A direct model
   override checks its own provider locality, not its optional base profile.

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -726,7 +726,14 @@ removed:
   provider retries are disabled for this preflight: the card immediately shows
   the unavailable setup, recovery guidance and a button opening `AgentModelSheet`.
   Every explicit briefing attempt refreshes disclosure so a repaired setup is
-  reread before consent. The existing unavailable-status link opens the same
+  reread before consent. The card holds a manual provider subscription until
+  that preflight settles, releasing it on success, failure or widget disposal.
+  Awaiting an auto-disposed provider's future alone does not retain it across
+  database reads or a default-profile reload; losing it mid-read causes the
+  generic request-failed toast before any inference is queued. Disclosure
+  captures its repository and category-lookup dependencies before awaiting
+  reads, so a superseded resolution never reads a disposed `Ref`.
+  The existing unavailable-status link opens the same
   sheet. A direct model
   override checks its own provider locality, not its optional base profile.
 

--- a/lib/features/relationships/state/relationship_agent_providers.dart
+++ b/lib/features/relationships/state/relationship_agent_providers.dart
@@ -327,19 +327,23 @@ relationshipBriefingDisclosureProvider = FutureProvider.autoDispose
             (value) => value.value,
           ),
         );
-        final relationship = await ref
-            .watch(relationshipRepositoryProvider)
+        final relationshipRepository = ref.watch(
+          relationshipRepositoryProvider,
+        );
+        final agentRepository = ref.watch(agentRepositoryProvider);
+        final categoryProfileLookup = ref.watch(
+          relationshipCategoryProfileLookupProvider,
+        );
+        final relationship = await relationshipRepository
             .getRelationshipByIdUnfiltered(relationshipId);
-        final identity = await ref
-            .watch(agentRepositoryProvider)
-            .getEntity(relationshipAgentIdFor(relationshipId));
+        final identity = await agentRepository.getEntity(
+          relationshipAgentIdFor(relationshipId),
+        );
         final resolved = await resolveRelationshipAgentModel(
           relationship: relationship,
           agentIdentity: identity is AgentIdentityEntity ? identity : null,
           aiConfigRepository: aiConfigRepository,
-          categoryProfileLookup: ref.watch(
-            relationshipCategoryProfileLookupProvider,
-          ),
+          categoryProfileLookup: categoryProfileLookup,
         );
         if (resolved == null) {
           throw const RelationshipInferenceSetupUnavailable();

--- a/lib/features/relationships/ui/widgets/relationship_briefing_card.dart
+++ b/lib/features/relationships/ui/widgets/relationship_briefing_card.dart
@@ -232,6 +232,22 @@ class _RelationshipBriefingCardState
     );
   }
 
+  /// Refreshes disclosure while retaining it across asynchronous reads and
+  /// default-profile changes. Release the subscription on success or failure;
+  /// WidgetRef also releases it if this card is disposed during the request.
+  Future<String?> _resolveBriefingDisclosure() async {
+    final provider = relationshipBriefingDisclosureProvider(
+      widget.relationship.meta.id,
+    );
+    ref.invalidate(provider);
+    final subscription = ref.listenManual(provider, (_, _) {});
+    try {
+      return await ref.read(provider.future);
+    } finally {
+      subscription.close();
+    }
+  }
+
   /// Asks for a briefing: the first one, an update, or a retry after a
   /// failure — one path, one trigger token.
   Future<void> _briefMe() async {
@@ -241,11 +257,7 @@ class _RelationshipBriefingCardState
     try {
       // Name the provider BEFORE any cloud-bound trigger (ADR 0037): the
       // locality check fails closed, so an unresolvable profile discloses.
-      final providerName = await ref.refresh(
-        relationshipBriefingDisclosureProvider(
-          widget.relationship.meta.id,
-        ).future,
-      );
+      final providerName = await _resolveBriefingDisclosure();
       if (!mounted) return;
       if (providerName != null) {
         final confirmed = await showDialog<bool>(

--- a/lib/features/relationships/ui/widgets/relationship_briefing_card.dart
+++ b/lib/features/relationships/ui/widgets/relationship_briefing_card.dart
@@ -235,10 +235,8 @@ class _RelationshipBriefingCardState
   /// Refreshes disclosure while retaining it across asynchronous reads and
   /// default-profile changes. Release the subscription on success or failure;
   /// WidgetRef also releases it if this card is disposed during the request.
-  Future<String?> _resolveBriefingDisclosure() async {
-    final provider = relationshipBriefingDisclosureProvider(
-      widget.relationship.meta.id,
-    );
+  Future<String?> _resolveBriefingDisclosure(String relationshipId) async {
+    final provider = relationshipBriefingDisclosureProvider(relationshipId);
     ref.invalidate(provider);
     final subscription = ref.listenManual(provider, (_, _) {});
     try {
@@ -252,12 +250,15 @@ class _RelationshipBriefingCardState
   /// failure — one path, one trigger token.
   Future<void> _briefMe() async {
     if (_requesting) return;
+    final relationship = widget.relationship;
     final messages = context.messages;
     setState(() => _requesting = true);
     try {
       // Name the provider BEFORE any cloud-bound trigger (ADR 0037): the
       // locality check fails closed, so an unresolvable profile discloses.
-      final providerName = await _resolveBriefingDisclosure();
+      final providerName = await _resolveBriefingDisclosure(
+        relationship.meta.id,
+      );
       if (!mounted) return;
       if (providerName != null) {
         final confirmed = await showDialog<bool>(
@@ -287,7 +288,7 @@ class _RelationshipBriefingCardState
       }
       await ref
           .read(relationshipAgentServiceProvider)
-          .requestBriefing(widget.relationship);
+          .requestBriefing(relationship);
       if (!mounted) return;
       context.showToast(
         tone: DesignSystemToastTone.success,
@@ -303,8 +304,8 @@ class _RelationshipBriefingCardState
           label: messages.inferenceProfileChooseModelTitle,
           onPressed: () => AgentModelSheet.show(
             context: context,
-            agentId: _agentId,
-            entityId: widget.relationship.meta.id,
+            agentId: relationshipAgentIdFor(relationship.meta.id),
+            entityId: relationship.meta.id,
           ),
         ),
       );

--- a/test/features/relationships/ui/widgets/relationship_briefing_card_test.dart
+++ b/test/features/relationships/ui/widgets/relationship_briefing_card_test.dart
@@ -206,6 +206,7 @@ void main() {
   Future<_FakeContactLauncher> pump(
     WidgetTester tester, {
     RelationshipEntry? entry,
+    ValueNotifier<RelationshipEntry>? entryNotifier,
     List<CheckInEntry> checkIns = const [],
     AgentReportEntity? current,
     AgentStateEntity? state,
@@ -227,32 +228,40 @@ void main() {
     await withClock(Clock.fixed(now), () async {
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
-          RelationshipBriefingCard(
-            relationship: entry ?? relationship(),
-            checkIns: checkIns,
-          ),
+          entryNotifier == null
+              ? RelationshipBriefingCard(
+                  relationship: entry ?? relationship(),
+                  checkIns: checkIns,
+                )
+              : ValueListenableBuilder<RelationshipEntry>(
+                  valueListenable: entryNotifier,
+                  builder: (context, value, child) => RelationshipBriefingCard(
+                    relationship: value,
+                    checkIns: checkIns,
+                  ),
+                ),
           overrides: [
-            agentReportProvider(agentId).overrideWith((ref) async => current),
-            agentStateProvider(agentId).overrideWith((ref) async => state),
-            agentIsRunningProvider(
-              agentId,
-            ).overrideWith((ref) => Stream.value(running)),
-            agentIdentityProvider(agentId).overrideWith(
-              (ref) async => makeTestIdentity(
-                agentId: agentId,
+            agentReportProvider.overrideWith((ref, id) async => current),
+            agentStateProvider.overrideWith((ref, id) async => state),
+            agentIsRunningProvider.overrideWith(
+              (ref, id) => Stream.value(running),
+            ),
+            agentIdentityProvider.overrideWith(
+              (ref, id) async => makeTestIdentity(
+                agentId: id,
                 kind: AgentKinds.relationshipAgent,
                 displayName: 'Commander Pip Frostbeak',
               ),
             ),
-            taskAgentResolvedSetupProvider(agentId).overrideWith(
-              (ref) async => modelResolved
+            taskAgentResolvedSetupProvider.overrideWith(
+              (ref, id) async => modelResolved
                   ? resolvedSetup()
                   : const ResolvedAgentSetup(
                       status: AgentSetupResolutionStatus.disabled,
                     ),
             ),
-            agentTokenUsageSummariesProvider(agentId).overrideWith(
-              (ref) async => [
+            agentTokenUsageSummariesProvider.overrideWith(
+              (ref, id) async => [
                 if (totalTokens > 0)
                   AgentTokenUsageSummary(
                     modelId: 'model-1',
@@ -728,6 +737,44 @@ void main() {
         },
       );
     }
+
+    testWidgets('a card replacement during disclosure cannot retarget '
+        'the briefing request', (tester) async {
+      final original = relationship();
+      final replacement = original.copyWith(
+        meta: original.meta.copyWith(id: 'person-2'),
+        data: original.data.copyWith(title: 'Another person'),
+      );
+      final entry = ValueNotifier(original);
+      addTearDown(entry.dispose);
+      final disclosure = Completer<String?>();
+      final disclosedIds = <String>[];
+      await pump(
+        tester,
+        entryNotifier: entry,
+        checkIns: onTrackCheckIns,
+        realDisclosure: true,
+        additionalOverrides: [
+          relationshipBriefingDisclosureProvider.overrideWith((ref, id) async {
+            disclosedIds.add(id);
+            return disclosure.future;
+          }),
+        ],
+      );
+      await tester.tap(briefMe);
+      await tester.pump();
+      entry.value = replacement;
+      await tester.pump();
+      disclosure.complete('Original provider');
+      await tester.pumpAndSettle();
+      expect(disclosedIds, [original.meta.id]);
+      expect(find.text('Send to Original provider?'), findsOneWidget);
+      verifyNever(() => agentService.requestBriefing(any()));
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+      verify(() => agentService.requestBriefing(original)).called(1);
+      verifyNever(() => agentService.requestBriefing(replacement));
+    });
 
     testWidgets('unavailable setup explains recovery and opens configuration', (
       tester,

--- a/test/features/relationships/ui/widgets/relationship_briefing_card_test.dart
+++ b/test/features/relationships/ui/widgets/relationship_briefing_card_test.dart
@@ -1,4 +1,8 @@
+import 'dart:async';
+
 import 'package:clock/clock.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/classes/check_in_data.dart';
@@ -8,12 +12,13 @@ import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_token_usage.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
-import 'package:lotti/features/agents/state/agent_query_providers.dart';
 import 'package:lotti/features/agents/state/task_agent_model_providers.dart';
 import 'package:lotti/features/agents/ui/agent_internals_panel.dart';
 import 'package:lotti/features/agents/ui/widgets/agent_markdown_view.dart';
 import 'package:lotti/features/agents/ui/widgets/ai_card_chrome.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/resolved_profile.dart';
+import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/cards/design_system_section_card.dart';
 import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
@@ -209,6 +214,8 @@ void main() {
     int totalTokens = 0,
     String? disclosureProviderName,
     bool setupUnavailable = false,
+    bool realDisclosure = false,
+    List<Override> additionalOverrides = const [],
     TaskAgentSetupOptions setupOptions = const TaskAgentSetupOptions(
       profiles: [],
       models: [],
@@ -257,17 +264,19 @@ void main() {
               (ref) async => setupOptions,
             ),
             relationshipAgentServiceProvider.overrideWithValue(agentService),
-            relationshipBriefingDisclosureProvider(
-              relationshipId,
-            ).overrideWith((ref) async {
-              if (setupUnavailable) {
-                throw const RelationshipInferenceSetupUnavailable();
-              }
-              return disclosureProviderName;
-            }),
+            if (!realDisclosure)
+              relationshipBriefingDisclosureProvider(
+                relationshipId,
+              ).overrideWith((ref) async {
+                if (setupUnavailable) {
+                  throw const RelationshipInferenceSetupUnavailable();
+                }
+                return disclosureProviderName;
+              }),
             relationshipRepositoryProvider.overrideWithValue(repository),
             contactLauncherProvider.overrideWithValue(launcher),
             pendingInteractionStoreProvider.overrideWithValue(store),
+            ...additionalOverrides,
           ],
         ),
       );
@@ -632,6 +641,93 @@ void main() {
       await tester.pumpAndSettle();
       verify(() => agentService.requestBriefing(any())).called(1);
     });
+
+    for (final route in ['cloud', 'local', 'unavailable']) {
+      testWidgets(
+        'a delayed default-profile preflight survives frames: $route',
+        (tester) async {
+          final readGate = Completer<RelationshipEntry?>();
+          final aiRepository = MockAiConfigRepository();
+          final agentRepository = MockAgentRepository();
+          final provider = route == 'local'
+              ? testLocalInferenceProvider()
+              : testInferenceProvider();
+          final model = testAiModel(inferenceProviderId: provider.id);
+          final profile = testInferenceProfile(thinkingModelId: model.id);
+          when(
+            () => repository.getRelationshipByIdUnfiltered(relationshipId),
+          ).thenAnswer((_) => readGate.future);
+          when(
+            () => agentRepository.getEntity(agentId),
+          ).thenAnswer((_) async => null);
+          when(
+            aiRepository.getDefaultProfileId,
+          ).thenAnswer((_) async => profile.id);
+          when(
+            () => aiRepository.getConfigById(profile.id),
+          ).thenAnswer((_) async => route == 'unavailable' ? null : profile);
+          when(
+            () => aiRepository.getConfigById(provider.id),
+          ).thenAnswer((_) async => provider);
+          when(
+            () => aiRepository.getConfigsByType(AiConfigType.model),
+          ).thenAnswer((_) async => [model]);
+          when(
+            () => aiRepository.getConfigsByType(AiConfigType.inferenceProvider),
+          ).thenAnswer((_) async => [provider]);
+          await pump(
+            tester,
+            checkIns: onTrackCheckIns,
+            realDisclosure: true,
+            additionalOverrides: [
+              aiConfigRepositoryProvider.overrideWithValue(aiRepository),
+              agentRepositoryProvider.overrideWithValue(agentRepository),
+            ],
+          );
+          await tester.tap(briefMe);
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+          verifyNever(() => agentService.requestBriefing(any()));
+          expect(find.text('Could not request the briefing.'), findsNothing);
+
+          readGate.complete(relationship());
+          await tester.pumpAndSettle();
+          final context = tester.element(find.byType(RelationshipBriefingCard));
+          final container = ProviderScope.containerOf(context, listen: false);
+          expect(
+            container.exists(
+              relationshipBriefingDisclosureProvider(relationshipId),
+            ),
+            isFalse,
+            reason:
+                'the preflight subscription must be released after completion',
+          );
+          if (route == 'unavailable') {
+            expect(
+              find.text(context.messages.taskAgentSetupBroken),
+              findsOneWidget,
+            );
+            verifyNever(() => agentService.requestBriefing(any()));
+          } else {
+            if (route == 'cloud') {
+              expect(
+                find.text(
+                  context.messages.relationshipBriefingDisclosureTitle(
+                    provider.name,
+                  ),
+                ),
+                findsOneWidget,
+              );
+              verifyNever(() => agentService.requestBriefing(any()));
+              await tester.tap(find.text('Continue'));
+              await tester.pumpAndSettle();
+            }
+            verify(() => agentService.requestBriefing(any())).called(1);
+          }
+          expect(find.text('Could not request the briefing.'), findsNothing);
+        },
+      );
+    }
 
     testWidgets('unavailable setup explains recovery and opens configuration', (
       tester,


### PR DESCRIPTION
A valid default AI profile can still produce “Could not request the briefing” before inference starts. The button awaited an auto-disposed disclosure provider without retaining a subscription. Database reads spanning frames, including a cold default-profile load, could dispose that provider while its future was pending.

The button now holds a manual subscription for the fresh disclosure preflight and releases it on success or failure; Flutter also closes it when the card is disposed. Disclosure captures its repository and category-lookup dependencies before asynchronous reads. Disclosure, the queued request, and setup recovery use the same relationship snapshot captured at click time, so a card rebuild cannot retarget the request.

Follow-up to #4262, based on the repeated failure after that merge.

Validation:
- 65 targeted briefing-card and relationship-provider tests pass; full Dart MCP analyzer is clean.
- Three regressions exercise the real disclosure provider with a database read held across frames: cloud default, local default, and unavailable default. All fail with the subscription fix removed and pass with it restored.
- The tests verify consent before queuing, actionable unavailable-setup guidance, and release of the temporary subscription. A fourth regression replaces the card with another person during disclosure and verifies the request still targets the original person; it also fails with its fix removed.
- `make knowledge_check`, `make changelog_check`, and formatting pass.
- Config repositories and the briefing service are mocked; no live provider API request was made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relationship briefings now wait for AI settings and relationship data to finish loading before making a request.
  * Briefing disclosures remain stable during profile updates and asynchronous loading, preventing failed or incomplete requests.
  * Briefing cards now preserve the originally selected relationship while disclosure and briefing requests are in progress.
  * Briefing cards correctly handle cloud, local, and unavailable provider outcomes.

* **Documentation**
  * Clarified relationship briefing disclosure behavior, including loading, failure, and unavailable-status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
