### PR TITLE
fix(agents): keep the wake-scan pass out of the caller's transaction zone

### DIFF
--- a/changelog.d/2026-09-13-wake-recheck-transaction-zone.md
+++ b/changelog.d/2026-09-13-wake-recheck-transaction-zone.md
@@ -1,0 +1,15 @@
+### Fixed
+- **Scheduled agent wakes could silently skip a scan after a relationship
+  came due.** When the relationship agent armed a check-in reminder it nudged
+  the wake scheduler from inside its own database write, and the scan that
+  followed ran against a transaction that had already closed. Every
+  maintenance step in that scan then failed at once and the due wake waited
+  for the next hourly poll. The nudge now fires after the write has committed,
+  and the scheduler runs every scan on its own footing so no caller can trip it
+  this way again.
+
+### Changed
+- **The sync log no longer reports leftover sequence reservations as errors on
+  every launch.** The start-up audit still records them, at informational
+  level, so real sync failures are no longer buried under the same line
+  repeated once per app start.

--- a/knowledge/features/agents/overview.md
+++ b/knowledge/features/agents/overview.md
@@ -145,6 +145,16 @@ flowchart TD
 values and due `ScheduledWakeEntity` records — the Daily OS planner's day-scoped
 pre-warms (ADR 0022).
 
+Every pass — the hourly tick, the settle re-checks and a caller's
+`requestCheck()` — runs in the zone `start()` was called in. A pass is
+un-awaited and queries the agent database across many awaits, and drift routes
+each query to the transaction executor of the zone it is issued in; a pass
+started from inside a `runInTransaction` zone (a Phase A nudging right after a
+write it has not yet committed) would otherwise have its later queries land on
+that closed transaction and fail every before-scan hook at once. Callers should
+still nudge only after their transaction has committed — the zone is the
+backstop, not the contract.
+
 Restoration turns a persisted `nextWakeAt` back into an in-memory `WakeJob`:
 future deadlines re-arm the deferred drain timer, overdue deadlines enqueue
 immediately and clear the persisted marker. A completed subscription wake only

--- a/knowledge/features/relationships.md
+++ b/knowledge/features/relationships.md
@@ -1238,6 +1238,7 @@ flowchart TD
   A[RelationshipAgentPhaseA] --> E{eligible?}
   E -->|"no — unimportant, dormant,<br/>archived, deleted, unresolvable"| C["clearFor(relationshipId)<br/>retract every open reminder"]
   E -->|yes| TX["agent transaction:<br/>sweep · register · escalation"]
+  TX --> NUDGE["ScheduledWakeManager.requestCheck<br/>AFTER the commit"]
   TX --> ARM["arm(relationship, derivation)<br/>AFTER the commit"]
   ARM --> ID["id = uuid5(relationshipId, dueDayKey)"]
   ID --> EX{"row for this episode<br/>already exists?"}
@@ -1248,6 +1249,16 @@ flowchart TD
   ROW --> OS["NotificationScheduler → zonedSchedule"]
   ROW --> RET["retract superseded episodes<br/>(the old due day means nothing now)"]
 ```
+
+**The wake-manager nudge also waits for the commit.** `requestCheck` starts a
+scan pass that runs un-awaited across many agent-database queries. Drift routes
+a query to the transaction executor of the zone it is issued in, so a nudge
+fired from inside the transaction closure hands the pass a transaction that has
+closed by the time its later queries run — every before-scan maintenance hook
+then fails with drift's "used after being closed" `StateError` in one burst.
+Phase A therefore records whether an escalation was armed and nudges after
+`runInTransaction` returns; the manager additionally runs every pass in the
+zone it was started in (see [agents overview](agents/overview.md)).
 
 **A due day already behind us earns no alarm.** `NotificationScheduler.schedule`
 routes a past `scheduledFor` to `showNotificationNow`, so arming a lapsed

--- a/lib/features/agents/wake/scheduled_wake_manager.dart
+++ b/lib/features/agents/wake/scheduled_wake_manager.dart
@@ -114,17 +114,31 @@ class ScheduledWakeManager with AgentErrorLogging {
   /// generation belongs to a restarted manager, not to the pass in flight.
   int _rerunGeneration = 0;
 
+  /// The zone [start] was called in, which every pass runs in.
+  ///
+  /// A pass runs un-awaited and queries the agent database across many
+  /// awaits. Drift routes a query to the transaction executor of the zone it
+  /// is issued in, so a pass started from inside a `runInTransaction` zone
+  /// — a caller nudging after a write it has not yet committed — would have
+  /// its later queries land on a closed transaction and fail with drift's
+  /// "transaction was used after being closed" StateError, one per
+  /// maintenance hook. Running every pass in the zone the runtime started
+  /// the manager in keeps a caller's zone from poisoning the scan.
+  Zone? _homeZone;
+
   /// Runs one scan pass now (single-flighted with the periodic timer).
   ///
   /// For callers that just persisted an immediately-due record — e.g. a
   /// goal Phase A arming an escalation — and must not wait out the hourly
-  /// poll on the arming device.
+  /// poll on the arming device. Safe to call from inside a transaction zone
+  /// once the manager has been started; see [_homeZone].
   void requestCheck() {
-    unawaited(_checkAndEnqueue());
+    (_homeZone ?? Zone.current).run(() => unawaited(_checkAndEnqueue()));
   }
 
   /// Start periodic checking. Also immediately checks for missed wakes.
   void start() {
+    _homeZone = Zone.current;
     unawaited(_checkAndEnqueue());
 
     _timer?.cancel();

--- a/lib/features/relationships/runtime/relationship_agent_phase_a.dart
+++ b/lib/features/relationships/runtime/relationship_agent_phase_a.dart
@@ -179,6 +179,9 @@ class RelationshipAgentPhaseA {
         derivation.lastCheckInAt != null &&
         (report == null || derivation.lastCheckInAt!.isAfter(report.createdAt));
 
+    // Whether this tick armed a NEW escalation record. Read after the
+    // transaction: the nudge below must not fire from inside it.
+    var armed = false;
     await _syncService.runInTransaction(() async {
       await _sweepNudges(agentId, derivation, now);
       await _upsertRegister(
@@ -195,25 +198,33 @@ class RelationshipAgentPhaseA {
         // (ADR 0039): one escalation — one briefing, at most one banner —
         // per due day. An ignored banner expires and the agent stays quiet
         // until a check-in moves the due day and mints a fresh episode.
-        final armed = await _armEscalation(
+        armed = await _armEscalation(
           relationshipEscalationWake(agentId, derivation, updatedAt: now),
         );
-        if (armed) _onEscalationArmed?.call();
       } else if (reportStale) {
         // A lapse escalation regenerates the briefing anyway, so the
         // refresh episode arms only when no lapse is arming this tick. Its
         // own episode key: consuming the lapse key early would let
         // per-episode idempotence suppress the real lapse escalation.
-        final armed = await _armEscalation(
+        armed = await _armEscalation(
           relationshipReportRefreshEscalationWake(
             agentId,
             derivation,
             updatedAt: now,
           ),
         );
-        if (armed) _onEscalationArmed?.call();
       }
     });
+
+    // Deliberately AFTER the transaction, not inside it. The nudge starts an
+    // un-awaited scan pass on the scheduled-wake manager, and a pass started
+    // inside this zone would have every one of its agent-database queries
+    // routed by drift to THIS transaction's executor — which is closed by the
+    // time the pass reaches them. That is the "transaction was used after
+    // being closed" StateError burst across every before-scan maintenance
+    // hook, not a database fault. The record is durable once the transaction
+    // has committed, so nudging afterwards is also the correct ordering.
+    if (armed) _onEscalationArmed?.call();
 
     // Deliberately AFTER the transaction, not inside it. The reminder row
     // lives in `notifications.sqlite` behind its own vector-clock scope and

--- a/lib/get_it_sync.dart
+++ b/lib/get_it_sync.dart
@@ -350,10 +350,15 @@ Future<String? Function()> _registerMatrixSyncStack({
             subDomain: 'vc.burn.reconcile',
           );
         }
+        // Diagnostic only (see `reservedCountersForHost`): plain reservations
+        // are never reconciled here, so the same counters surface on every
+        // launch. Logged at info, not error — as an error this one line was
+        // the most frequent "failure" in the system health report on a phone
+        // that starts the process many times a day, burying real ones.
         final reservedCounters = await syncSequenceLogService
             .reservedCountersForHost(hostId: hostId);
         if (reservedCounters.isNotEmpty) {
-          domainLogger.error(
+          domainLogger.log(
             LogDomain.sync,
             'vc.reserved.audit host=$hostId '
             'count=${reservedCounters.length} '

--- a/test/README.md
+++ b/test/README.md
@@ -472,6 +472,20 @@ behavior belongs in exactly one of these six suites; direct coverage for
 `WakeQueue`, `WakeRunner`, `WakeThrottleCoordinator`, `WakeSuppressionTracker`,
 and `ScheduledWakeManager` remains in each collaborator's mirrored test file.
 
+## Drift routes a query by the zone it is issued in
+
+`db.transaction(() async { ... })` runs its body in a zone, and drift sends any
+query issued from that zone — or from a Timer, stream callback or un-awaited
+future created inside it — to that transaction's executor. Once the closure
+returns and the transaction commits, such a query fails with `Bad state: This
+database or transaction runner has already been closed`. No mock reproduces
+this, so a regression test for it needs a real in-memory database: open
+`AgentDatabase(inMemoryDatabase: true, background: false)`, have the mocked
+repository methods issue genuine selects against it, and trigger the code under
+test from inside `db.transaction(...)`. The pattern is
+`test/features/agents/wake/scheduled_wake_manager_test.dart` ("requestCheck
+from inside an agent-database transaction zone").
+
 ## Mocktail global-state hygiene
 
 Mocktail stores argument matchers (`any`, `captureAny`) in **process-global**

--- a/test/features/agents/wake/scheduled_wake_manager_test.dart
+++ b/test/features/agents/wake/scheduled_wake_manager_test.dart
@@ -4,6 +4,7 @@ import 'package:clock/clock.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
+import 'package:lotti/features/agents/database/agent_database.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
@@ -311,6 +312,65 @@ void main() {
 
       manager.requestCheck();
       await untilCalled(() => repository.getDueScheduledWakeRecords(any()));
+      verify(() => repository.getDueScheduledWakeRecords(any())).called(1);
+    });
+
+    test('requestCheck from inside an agent-database transaction zone runs '
+        'the pass in the zone the manager was started in — drift would '
+        "otherwise route the pass's later queries to the caller's "
+        'transaction, closed by then', () async {
+      // A real drift database: the failure mode is drift's zone-based query
+      // routing, which no mock reproduces. Each repository read below issues
+      // a genuine select so the pass has queries for drift to route.
+      final db = AgentDatabase(inMemoryDatabase: true, background: false);
+      addTearDown(db.close);
+      final logger = MockDomainLogger();
+      when(
+        () => logger.error(
+          any<LogDomain>(),
+          any<Object>(),
+          message: any<String?>(named: 'message'),
+          stackTrace: any<StackTrace?>(named: 'stackTrace'),
+        ),
+      ).thenAnswer((_) {});
+      when(() => repository.getDueScheduledAgentStates(any())).thenAnswer((
+        invocation,
+      ) async {
+        final now = invocation.positionalArguments.single as DateTime;
+        await db.getDueScheduledAgentStates(now.toIso8601String()).get();
+        return [];
+      });
+      when(() => repository.getDueScheduledWakeRecords(any())).thenAnswer((
+        invocation,
+      ) async {
+        final now = invocation.positionalArguments.single as DateTime;
+        await db.getDueScheduledWakeRecords(now.toIso8601String()).get();
+        return [];
+      });
+      final manager = createAndStart(domainLogger: logger);
+      addTearDown(manager.stop);
+      // Let the start-up pass drain so the nudge below is a fresh pass, not
+      // a coalesced re-run of one already in flight.
+      await pumpEventQueue();
+      clearInteractions(repository);
+
+      // The relationship Phase A shape: a write, then the nudge, still inside
+      // the transaction closure. The transaction commits as soon as the
+      // closure returns, while the pass is mid-flight.
+      await db.transaction(() async {
+        manager.requestCheck();
+      });
+      await pumpEventQueue();
+
+      verifyNever(
+        () => logger.error(
+          any<LogDomain>(),
+          any<Object>(),
+          message: 'error checking scheduled wakes',
+          stackTrace: any<StackTrace?>(named: 'stackTrace'),
+        ),
+      );
+      verify(() => repository.getDueScheduledAgentStates(any())).called(1);
       verify(() => repository.getDueScheduledWakeRecords(any())).called(1);
     });
 

--- a/test/features/relationships/runtime/relationship_agent_phase_a_test.dart
+++ b/test/features/relationships/runtime/relationship_agent_phase_a_test.dart
@@ -117,7 +117,10 @@ void main() {
       repository: repository,
       syncService: syncService,
       relationshipRepository: relationshipRepository,
-      onEscalationArmed: () => escalationCallbacks++,
+      onEscalationArmed: () {
+        escalationCallbacks++;
+        events.add('escalation:armed');
+      },
       reminders: reminders,
     );
     when(() => repository.getEntity(any())).thenAnswer((_) async => null);
@@ -468,6 +471,28 @@ void main() {
         ]),
       );
       expect(escalationCallbacks, 1);
+    });
+
+    test('the escalation nudge fires AFTER the transaction has committed — '
+        "the manager's scan pass runs un-awaited across many queries, and "
+        'one started inside the transaction zone would have them routed to '
+        'the closed transaction (the 01:29 StateError burst)', () async {
+      await withClock(Clock.fixed(now), run);
+
+      expect(events, contains('escalation:armed'));
+      expect(
+        events.indexOf('escalation:armed'),
+        greaterThan(events.lastIndexOf('tx:commit')),
+        reason: 'nudge before commit — the pass would run in the tx zone',
+      );
+      // The escalation record itself is still part of the atomic write (the
+      // cadence tick re-armed before the transaction is also a wake record,
+      // hence the LAST one).
+      final wake = events.lastIndexWhere(
+        (e) => e.startsWith('upsert:') && e.contains('ScheduledWake'),
+      );
+      expect(wake, greaterThan(events.lastIndexOf('tx:begin')));
+      expect(wake, lessThan(events.lastIndexOf('tx:commit')));
     });
 
     test('with no previous register the escalation carries no baseline '


### PR DESCRIPTION
## Summary

The 2026-09-13 system health report showed a burst of 13 `StateError`s at 01:29 across every `beforeWakeScan` maintenance hook (stale planner wake expiry, coordinator digest repair, day-agent retirement, goal and relationship maintenance, the due-states query). The digest blamed the database or the slow-query interceptor. The real cause is a drift zone hazard:

`RelationshipAgentPhaseA` invoked `onEscalationArmed` → `ScheduledWakeManager.requestCheck()` from **inside** its `runInTransaction` closure. The scan pass that starts is un-awaited and issues agent-database queries across many awaits. Drift routes every query to the transaction executor of the zone it is issued in, so once the closure returned and the transaction committed, every remaining query in the pass failed with drift's "used after being closed" error. One pass = 6 hooks + the due-states query; two passes ran, hence 2+2+2+2+2+2+1 = 13.

## Changes

- **`relationship_agent_phase_a.dart`** — record whether an escalation was armed and nudge the wake manager after the transaction has committed. The goal Phase A already did it this way.
- **`scheduled_wake_manager.dart`** — every pass (hourly tick, settle re-checks, `requestCheck()`) now runs in the zone `start()` was called in, so a future caller cannot poison a scan by nudging from inside a transaction.
- **`get_it_sync.dart`** — the `vc.reserved.audit` start-up line is logged at info instead of error. It is diagnostic by its own contract, repeats the same counters on every launch, and was the single most frequent "error" in both the desktop (×14/week) and mobile (×28/day) health reports, burying real failures.
- Knowledge concepts (`relationships.md`, `agents/overview.md`) and `test/README.md` document the mechanism.

## Tests

- `relationship_agent_phase_a_test.dart`: asserts the nudge lands after the `tx:commit` marker while the escalation record is written inside the transaction.
- `scheduled_wake_manager_test.dart`: real in-memory `AgentDatabase`; calls `requestCheck()` from inside `db.transaction(...)`. Without the manager fix it fails with `Bad state: This database or transaction runner has already been closed` and the "error checking scheduled wakes" log line, i.e. the production failure.

Both regression tests were re-run with their respective fix reverted and fail there.

## Not changed (findings from the same reports)

- `transaction.open` p50 ≈ 1 s is writer-lock **queue wait** (drift's transaction `ensureOpen`), not slow `BEGIN`s; the lifetime scope shows a p50 hold of 18 ms. The digest merges databases and attributes to the `runInTransaction` wrapper frame, so the fan-out site needs the raw `inFlightAtStart`/`activeAtStart` fields.
- The 12.7-minute `getAgentIdentitiesByLifecycle` max (desktop) and the 23-minute `COMMIT`/`BEGIN`/`sync_sequence_log` ceiling (mobile) are single suspended-process outliers, not plan problems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Scheduled agent wake scans now reliably run after relationship updates and remain stable across transaction boundaries.
  - Startup synchronization audits no longer report leftover sequence reservations as errors, while reconciliation behavior remains unchanged.
  - Escalation and reminder wake-ups are triggered only after updates are committed.

- **Documentation**
  - Added guidance explaining scheduled-wake execution zones and transaction-safe wake requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->