### PR TITLE
fix: respect human-approved checklist changes from chat

### DIFF
--- a/changelog.d/2026-09-13-chat-checklist-approval.md
+++ b/changelog.d/2026-09-13-chat-checklist-approval.md
@@ -1,0 +1,4 @@
+### Fixed
+- **Task agents respect checkmarks you approve in chat.** Approved changes now
+  retain their human approval history, so background updates no longer propose
+  reversing them just because the task notes lack matching evidence.

--- a/knowledge/features/agents/query-chat.md
+++ b/knowledge/features/agents/query-chat.md
@@ -5,7 +5,7 @@ description: Task, project and category conversations with isolated source check
 resource: ../../../lib/features/agents/query
 tags: [agents, chat, retrieval, evidence, privacy, sync]
 status: stable
-generated: { by: codex/gpt-6, at: 2026-09-13T04:00:59Z }
+generated: { by: codex/gpt-6, at: 2026-09-13T07:18:59Z }
 stale_after: 2026-10-12
 sources:
   - id: controller
@@ -418,6 +418,9 @@ live targets before every dispatch through the shared task handlers and
 `ChangeSetConfirmationService`. Its in-flight guard prevents repeated local
 Accept taps; retries reuse item statuses and skip applied items. The existing
 confirmation service's persist-before-dispatch crash semantics still apply.
+Checklist mutations additionally persist their human approval receipt with the
+journal item. See [chat checklist approval provenance](task-agents.md#chat-checklist-approval-provenance)
+for the receipt fields, confirmation-mode mapping and background reversal guard.
 Failures show content-free app copy, never provider or handler error strings.
 
 Chat action sets and their decisions are excluded before limits from wake

--- a/knowledge/features/agents/task-agents.md
+++ b/knowledge/features/agents/task-agents.md
@@ -5,9 +5,21 @@ description: The primary agent workflow — inference setup resolution, the auto
 resource: ../../../lib/features/agents/workflow/task_agent_workflow.dart
 tags: [agents, task-agent, tools, proposals, inference]
 status: stable
-generated: { by: codex/gpt-5, at: 2026-08-01T20:31:24Z }
+generated: { by: codex/gpt-6, at: 2026-09-13T07:18:59Z }
 stale_after: 2026-10-12
 sources:
+  - id: checklist-provenance
+    resource: ../../../lib/classes/checklist_item_data.dart
+    title: Durable checklist approval receipts
+    last_modified: 2026-09-13
+  - id: checklist-update
+    resource: ../../../lib/features/ai/functions/lotti_checklist_update_handler.dart
+    title: Trusted approval stamping and execution guard
+    last_modified: 2026-09-13
+  - id: proposal-builder
+    resource: ../../../lib/features/agents/workflow/change_set_builder.dart
+    title: Live background proposal protection
+    last_modified: 2026-09-13
   - id: workflow
     resource: ../../../lib/features/agents/workflow/task_agent_workflow.dart
     title: TaskAgentWorkflow
@@ -569,6 +581,65 @@ write path for both auto-applied values and user-confirmed edits, so the
 not the mutation boundary where it would block legitimate edits.
 
 # Proposals and confirmation
+
+## Chat checklist approval provenance
+
+`ChangeSetConfirmationService` recognizes the persisted chat-owned set identity
+(`query-chat:<questionId>:actions`, with the corresponding `runKey` and chat
+`threadId`). Its trusted `ApprovedTaskToolDispatch` channel carries a typed
+`ChecklistItemProvenance` separately from model-generated tool arguments:
+
+- `approvedBy: user` is the human actor; `approvalHost` is their local sync host.
+  Lotti has no separate signed-in human account ID for this action.
+- `approvedAt` and `decisionId` come from the persisted human confirmation
+  decision; `changeSetId`, `conversationId` and `originatingMessageId` trace the
+  saved proposal back to the question event.
+- `approvalMode` records the gesture: `confirmItem` uses `individual`;
+  `confirmAll`, including chat's Accept-set action, uses `confirm_all` even when
+  only one item is in the set.
+- `source: chat_suggestion`, `appliedBy: task_agent` and `agentId` distinguish
+  human authorization from the executing agent. No model identity is invented.
+
+Creation, updates and migration append receipts to the checklist item's
+`approvalHistory` in the **same journal write as the change**, including sync
+serialization. Migration retains existing history on the copy and source.
+Checked-state receipts also record `isChecked`; title/archival-only approvals
+leave it null. An explicit approval of an already-matching check still stamps
+human intent. Failed writes leave no new receipt on the item. Rejection creates
+no checklist receipt. Chat deletion can remove the referenced chat event but
+neither removes the journal receipt nor requires retaining the user's words.
+Legacy and direct UI edits create no receipt; absent history decodes as empty.
+
+`checkedStateApproval` returns the latest checked-state receipt only while its
+value and timestamp still match `isChecked`/`checkedAt` and `checkedBy` is user.
+A later rename keeps protection; a later direct checkbox toggle supersedes it
+without erasing the audit history. The AI input repository exports only that
+current receipt for wake context, and compact markdown marks it as explicit
+user-approved chat state. The scaffold forbids reversing it for missing log
+evidence.
+
+This is also enforced without relying on model obedience: the wake wires a
+live journal resolver into `ChangeSetBuilder`, and both singular and exploded
+batch update paths reject opposing checked-state proposals. A handler-level
+check also blocks stale background proposals at execution, even if their
+`reason` sounds persuasive; the dispatcher reports a non-retryable failure so
+the confirmation service retracts them. A fresh human-approved chat instruction
+can change that state. Unprotected legacy/agent edits remain eligible for
+proposals and retain the existing user-sovereignty reason checks at execution.
+
+```mermaid
+flowchart TD
+    Question[User question] --> Proposal[Saved chat proposal]
+    Proposal --> Approval[Human confirms item or set]
+    Approval --> Decision[Persist human decision]
+    Decision --> Receipt[Typed receipt outside model arguments]
+    Receipt --> Write[Journal mutation and approval history]
+    Write --> Wake[Next wake reads live checklist]
+    Wake --> Protected{Current checked state has approval?}
+    Protected -->|yes| Reject[Reject opposing proposal]
+    Protected -->|no| Review[Existing anomaly review rules]
+```
+
 
 `ChangeSetBuilder` owns the deferred path. It explodes batch tools into
 individually reviewable items, deduplicates identical proposals within a wake,

--- a/knowledge/features/agents/task-agents.md
+++ b/knowledge/features/agents/task-agents.md
@@ -613,10 +613,12 @@ Legacy and direct UI edits create no receipt; absent history decodes as empty.
 `checkedStateApproval` returns the latest checked-state receipt only while its
 value and timestamp still match `isChecked`/`checkedAt` and `checkedBy` is user.
 A later rename keeps protection; a later direct checkbox toggle supersedes it
-without erasing the audit history. The AI input repository exports only that
-current receipt for wake context, and compact markdown marks it as explicit
-user-approved chat state. The scaffold forbids reversing it for missing log
-evidence.
+without erasing the audit history. The AI input repository maps the current
+receipt to `AiChecklistApproval`: only the checked value, approval timestamp
+and mode enter generic prompt JSON. The sync host and conversation, question,
+change-set, decision and agent identifiers stay in the journal receipt.
+Compact markdown marks this as explicit user-approved chat state. The scaffold
+forbids reversing it for missing log evidence.
 
 This is also enforced without relying on model obedience: the wake wires a
 live journal resolver into `ChangeSetBuilder`, and both singular and exploded

--- a/lib/classes/checklist_item_data.dart
+++ b/lib/classes/checklist_item_data.dart
@@ -18,8 +18,55 @@ abstract class ChecklistItemData with _$ChecklistItemData {
     @JsonKey(unknownEnumValue: ChangeSource.user)
     ChangeSource checkedBy,
     DateTime? checkedAt,
+    @Default([]) List<ChecklistItemProvenance> approvalHistory,
   }) = _ChecklistItemData;
 
   factory ChecklistItemData.fromJson(Map<String, dynamic> json) =>
       _$ChecklistItemDataFromJson(json);
+  const ChecklistItemData._();
+
+  /// Approval backing the current checked state, independent of chat retention.
+  /// Later title edits preserve it; a later direct toggle supersedes it.
+  ChecklistItemProvenance? get checkedStateApproval {
+    if (checkedBy != ChangeSource.user || checkedAt == null) return null;
+    for (final approval in approvalHistory.reversed) {
+      if (approval.isChecked != null) {
+        return approval.source == 'chat_suggestion' &&
+                approval.approvedBy == 'user' &&
+                approval.isChecked == isChecked &&
+                approval.approvedAt == checkedAt
+            ? approval
+            : null;
+      }
+    }
+    return null;
+  }
+}
+
+/// The actual confirmation gesture, rather than the number of changes in it.
+@JsonEnum(fieldRename: FieldRename.snake)
+enum ChecklistApprovalMode { individual, confirmAll }
+
+/// Trusted approval receipt written with the checklist mutation, never parsed
+/// from model tool arguments. Lotti's human actor is the local user; the host
+/// identifies their approving device, not a fabricated account identity.
+@freezed
+abstract class ChecklistItemProvenance with _$ChecklistItemProvenance {
+  const factory ChecklistItemProvenance({
+    required String approvedBy,
+    required String approvalHost,
+    required DateTime approvedAt,
+    required ChecklistApprovalMode approvalMode,
+    required String originatingMessageId,
+    required String conversationId,
+    required String changeSetId,
+    required String decisionId,
+    required String agentId,
+    @Default('chat_suggestion') String source,
+    @Default('task_agent') String appliedBy,
+    bool? isChecked,
+  }) = _ChecklistItemProvenance;
+
+  factory ChecklistItemProvenance.fromJson(Map<String, dynamic> json) =>
+      _$ChecklistItemProvenanceFromJson(json);
 }

--- a/lib/classes/checklist_item_data.freezed.dart
+++ b/lib/classes/checklist_item_data.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ChecklistItemData {
 
- String get title; bool get isChecked; List<String> get linkedChecklists; bool get isArchived; String? get id;@JsonKey(unknownEnumValue: ChangeSource.user) ChangeSource get checkedBy; DateTime? get checkedAt;
+ String get title; bool get isChecked; List<String> get linkedChecklists; bool get isArchived; String? get id;@JsonKey(unknownEnumValue: ChangeSource.user) ChangeSource get checkedBy; DateTime? get checkedAt; List<ChecklistItemProvenance> get approvalHistory;
 /// Create a copy of ChecklistItemData
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $ChecklistItemDataCopyWith<ChecklistItemData> get copyWith => _$ChecklistItemDat
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChecklistItemData&&(identical(other.title, title) || other.title == title)&&(identical(other.isChecked, isChecked) || other.isChecked == isChecked)&&const DeepCollectionEquality().equals(other.linkedChecklists, linkedChecklists)&&(identical(other.isArchived, isArchived) || other.isArchived == isArchived)&&(identical(other.id, id) || other.id == id)&&(identical(other.checkedBy, checkedBy) || other.checkedBy == checkedBy)&&(identical(other.checkedAt, checkedAt) || other.checkedAt == checkedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChecklistItemData&&(identical(other.title, title) || other.title == title)&&(identical(other.isChecked, isChecked) || other.isChecked == isChecked)&&const DeepCollectionEquality().equals(other.linkedChecklists, linkedChecklists)&&(identical(other.isArchived, isArchived) || other.isArchived == isArchived)&&(identical(other.id, id) || other.id == id)&&(identical(other.checkedBy, checkedBy) || other.checkedBy == checkedBy)&&(identical(other.checkedAt, checkedAt) || other.checkedAt == checkedAt)&&const DeepCollectionEquality().equals(other.approvalHistory, approvalHistory));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,title,isChecked,const DeepCollectionEquality().hash(linkedChecklists),isArchived,id,checkedBy,checkedAt);
+int get hashCode => Object.hash(runtimeType,title,isChecked,const DeepCollectionEquality().hash(linkedChecklists),isArchived,id,checkedBy,checkedAt,const DeepCollectionEquality().hash(approvalHistory));
 
 @override
 String toString() {
-  return 'ChecklistItemData(title: $title, isChecked: $isChecked, linkedChecklists: $linkedChecklists, isArchived: $isArchived, id: $id, checkedBy: $checkedBy, checkedAt: $checkedAt)';
+  return 'ChecklistItemData(title: $title, isChecked: $isChecked, linkedChecklists: $linkedChecklists, isArchived: $isArchived, id: $id, checkedBy: $checkedBy, checkedAt: $checkedAt, approvalHistory: $approvalHistory)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $ChecklistItemDataCopyWith<$Res>  {
   factory $ChecklistItemDataCopyWith(ChecklistItemData value, $Res Function(ChecklistItemData) _then) = _$ChecklistItemDataCopyWithImpl;
 @useResult
 $Res call({
- String title, bool isChecked, List<String> linkedChecklists, bool isArchived, String? id,@JsonKey(unknownEnumValue: ChangeSource.user) ChangeSource checkedBy, DateTime? checkedAt
+ String title, bool isChecked, List<String> linkedChecklists, bool isArchived, String? id,@JsonKey(unknownEnumValue: ChangeSource.user) ChangeSource checkedBy, DateTime? checkedAt, List<ChecklistItemProvenance> approvalHistory
 });
 
 
@@ -65,7 +65,7 @@ class _$ChecklistItemDataCopyWithImpl<$Res>
 
 /// Create a copy of ChecklistItemData
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? isChecked = null,Object? linkedChecklists = null,Object? isArchived = null,Object? id = freezed,Object? checkedBy = null,Object? checkedAt = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? isChecked = null,Object? linkedChecklists = null,Object? isArchived = null,Object? id = freezed,Object? checkedBy = null,Object? checkedAt = freezed,Object? approvalHistory = null,}) {
   return _then(_self.copyWith(
 title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,isChecked: null == isChecked ? _self.isChecked : isChecked // ignore: cast_nullable_to_non_nullable
@@ -74,7 +74,8 @@ as List<String>,isArchived: null == isArchived ? _self.isArchived : isArchived /
 as bool,id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String?,checkedBy: null == checkedBy ? _self.checkedBy : checkedBy // ignore: cast_nullable_to_non_nullable
 as ChangeSource,checkedAt: freezed == checkedAt ? _self.checkedAt : checkedAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,
+as DateTime?,approvalHistory: null == approvalHistory ? _self.approvalHistory : approvalHistory // ignore: cast_nullable_to_non_nullable
+as List<ChecklistItemProvenance>,
   ));
 }
 
@@ -159,10 +160,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String title,  bool isChecked,  List<String> linkedChecklists,  bool isArchived,  String? id, @JsonKey(unknownEnumValue: ChangeSource.user)  ChangeSource checkedBy,  DateTime? checkedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String title,  bool isChecked,  List<String> linkedChecklists,  bool isArchived,  String? id, @JsonKey(unknownEnumValue: ChangeSource.user)  ChangeSource checkedBy,  DateTime? checkedAt,  List<ChecklistItemProvenance> approvalHistory)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _ChecklistItemData() when $default != null:
-return $default(_that.title,_that.isChecked,_that.linkedChecklists,_that.isArchived,_that.id,_that.checkedBy,_that.checkedAt);case _:
+return $default(_that.title,_that.isChecked,_that.linkedChecklists,_that.isArchived,_that.id,_that.checkedBy,_that.checkedAt,_that.approvalHistory);case _:
   return orElse();
 
 }
@@ -180,10 +181,10 @@ return $default(_that.title,_that.isChecked,_that.linkedChecklists,_that.isArchi
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String title,  bool isChecked,  List<String> linkedChecklists,  bool isArchived,  String? id, @JsonKey(unknownEnumValue: ChangeSource.user)  ChangeSource checkedBy,  DateTime? checkedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String title,  bool isChecked,  List<String> linkedChecklists,  bool isArchived,  String? id, @JsonKey(unknownEnumValue: ChangeSource.user)  ChangeSource checkedBy,  DateTime? checkedAt,  List<ChecklistItemProvenance> approvalHistory)  $default,) {final _that = this;
 switch (_that) {
 case _ChecklistItemData():
-return $default(_that.title,_that.isChecked,_that.linkedChecklists,_that.isArchived,_that.id,_that.checkedBy,_that.checkedAt);case _:
+return $default(_that.title,_that.isChecked,_that.linkedChecklists,_that.isArchived,_that.id,_that.checkedBy,_that.checkedAt,_that.approvalHistory);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -200,10 +201,10 @@ return $default(_that.title,_that.isChecked,_that.linkedChecklists,_that.isArchi
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String title,  bool isChecked,  List<String> linkedChecklists,  bool isArchived,  String? id, @JsonKey(unknownEnumValue: ChangeSource.user)  ChangeSource checkedBy,  DateTime? checkedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String title,  bool isChecked,  List<String> linkedChecklists,  bool isArchived,  String? id, @JsonKey(unknownEnumValue: ChangeSource.user)  ChangeSource checkedBy,  DateTime? checkedAt,  List<ChecklistItemProvenance> approvalHistory)?  $default,) {final _that = this;
 switch (_that) {
 case _ChecklistItemData() when $default != null:
-return $default(_that.title,_that.isChecked,_that.linkedChecklists,_that.isArchived,_that.id,_that.checkedBy,_that.checkedAt);case _:
+return $default(_that.title,_that.isChecked,_that.linkedChecklists,_that.isArchived,_that.id,_that.checkedBy,_that.checkedAt,_that.approvalHistory);case _:
   return null;
 
 }
@@ -214,8 +215,8 @@ return $default(_that.title,_that.isChecked,_that.linkedChecklists,_that.isArchi
 /// @nodoc
 @JsonSerializable()
 
-class _ChecklistItemData implements ChecklistItemData {
-  const _ChecklistItemData({required this.title, required this.isChecked, required final  List<String> linkedChecklists, this.isArchived = false, this.id, @JsonKey(unknownEnumValue: ChangeSource.user) this.checkedBy = ChangeSource.user, this.checkedAt}): _linkedChecklists = linkedChecklists;
+class _ChecklistItemData extends ChecklistItemData {
+  const _ChecklistItemData({required this.title, required this.isChecked, required final  List<String> linkedChecklists, this.isArchived = false, this.id, @JsonKey(unknownEnumValue: ChangeSource.user) this.checkedBy = ChangeSource.user, this.checkedAt, final  List<ChecklistItemProvenance> approvalHistory = const []}): _linkedChecklists = linkedChecklists,_approvalHistory = approvalHistory,super._();
   factory _ChecklistItemData.fromJson(Map<String, dynamic> json) => _$ChecklistItemDataFromJson(json);
 
 @override final  String title;
@@ -231,6 +232,13 @@ class _ChecklistItemData implements ChecklistItemData {
 @override final  String? id;
 @override@JsonKey(unknownEnumValue: ChangeSource.user) final  ChangeSource checkedBy;
 @override final  DateTime? checkedAt;
+ final  List<ChecklistItemProvenance> _approvalHistory;
+@override@JsonKey() List<ChecklistItemProvenance> get approvalHistory {
+  if (_approvalHistory is EqualUnmodifiableListView) return _approvalHistory;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_approvalHistory);
+}
+
 
 /// Create a copy of ChecklistItemData
 /// with the given fields replaced by the non-null parameter values.
@@ -245,16 +253,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ChecklistItemData&&(identical(other.title, title) || other.title == title)&&(identical(other.isChecked, isChecked) || other.isChecked == isChecked)&&const DeepCollectionEquality().equals(other._linkedChecklists, _linkedChecklists)&&(identical(other.isArchived, isArchived) || other.isArchived == isArchived)&&(identical(other.id, id) || other.id == id)&&(identical(other.checkedBy, checkedBy) || other.checkedBy == checkedBy)&&(identical(other.checkedAt, checkedAt) || other.checkedAt == checkedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ChecklistItemData&&(identical(other.title, title) || other.title == title)&&(identical(other.isChecked, isChecked) || other.isChecked == isChecked)&&const DeepCollectionEquality().equals(other._linkedChecklists, _linkedChecklists)&&(identical(other.isArchived, isArchived) || other.isArchived == isArchived)&&(identical(other.id, id) || other.id == id)&&(identical(other.checkedBy, checkedBy) || other.checkedBy == checkedBy)&&(identical(other.checkedAt, checkedAt) || other.checkedAt == checkedAt)&&const DeepCollectionEquality().equals(other._approvalHistory, _approvalHistory));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,title,isChecked,const DeepCollectionEquality().hash(_linkedChecklists),isArchived,id,checkedBy,checkedAt);
+int get hashCode => Object.hash(runtimeType,title,isChecked,const DeepCollectionEquality().hash(_linkedChecklists),isArchived,id,checkedBy,checkedAt,const DeepCollectionEquality().hash(_approvalHistory));
 
 @override
 String toString() {
-  return 'ChecklistItemData(title: $title, isChecked: $isChecked, linkedChecklists: $linkedChecklists, isArchived: $isArchived, id: $id, checkedBy: $checkedBy, checkedAt: $checkedAt)';
+  return 'ChecklistItemData(title: $title, isChecked: $isChecked, linkedChecklists: $linkedChecklists, isArchived: $isArchived, id: $id, checkedBy: $checkedBy, checkedAt: $checkedAt, approvalHistory: $approvalHistory)';
 }
 
 
@@ -265,7 +273,7 @@ abstract mixin class _$ChecklistItemDataCopyWith<$Res> implements $ChecklistItem
   factory _$ChecklistItemDataCopyWith(_ChecklistItemData value, $Res Function(_ChecklistItemData) _then) = __$ChecklistItemDataCopyWithImpl;
 @override @useResult
 $Res call({
- String title, bool isChecked, List<String> linkedChecklists, bool isArchived, String? id,@JsonKey(unknownEnumValue: ChangeSource.user) ChangeSource checkedBy, DateTime? checkedAt
+ String title, bool isChecked, List<String> linkedChecklists, bool isArchived, String? id,@JsonKey(unknownEnumValue: ChangeSource.user) ChangeSource checkedBy, DateTime? checkedAt, List<ChecklistItemProvenance> approvalHistory
 });
 
 
@@ -282,7 +290,7 @@ class __$ChecklistItemDataCopyWithImpl<$Res>
 
 /// Create a copy of ChecklistItemData
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? title = null,Object? isChecked = null,Object? linkedChecklists = null,Object? isArchived = null,Object? id = freezed,Object? checkedBy = null,Object? checkedAt = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? title = null,Object? isChecked = null,Object? linkedChecklists = null,Object? isArchived = null,Object? id = freezed,Object? checkedBy = null,Object? checkedAt = freezed,Object? approvalHistory = null,}) {
   return _then(_ChecklistItemData(
 title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,isChecked: null == isChecked ? _self.isChecked : isChecked // ignore: cast_nullable_to_non_nullable
@@ -291,7 +299,304 @@ as List<String>,isArchived: null == isArchived ? _self.isArchived : isArchived /
 as bool,id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String?,checkedBy: null == checkedBy ? _self.checkedBy : checkedBy // ignore: cast_nullable_to_non_nullable
 as ChangeSource,checkedAt: freezed == checkedAt ? _self.checkedAt : checkedAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,
+as DateTime?,approvalHistory: null == approvalHistory ? _self._approvalHistory : approvalHistory // ignore: cast_nullable_to_non_nullable
+as List<ChecklistItemProvenance>,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$ChecklistItemProvenance {
+
+ String get approvedBy; String get approvalHost; DateTime get approvedAt; ChecklistApprovalMode get approvalMode; String get originatingMessageId; String get conversationId; String get changeSetId; String get decisionId; String get agentId; String get source; String get appliedBy; bool? get isChecked;
+/// Create a copy of ChecklistItemProvenance
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ChecklistItemProvenanceCopyWith<ChecklistItemProvenance> get copyWith => _$ChecklistItemProvenanceCopyWithImpl<ChecklistItemProvenance>(this as ChecklistItemProvenance, _$identity);
+
+  /// Serializes this ChecklistItemProvenance to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ChecklistItemProvenance&&(identical(other.approvedBy, approvedBy) || other.approvedBy == approvedBy)&&(identical(other.approvalHost, approvalHost) || other.approvalHost == approvalHost)&&(identical(other.approvedAt, approvedAt) || other.approvedAt == approvedAt)&&(identical(other.approvalMode, approvalMode) || other.approvalMode == approvalMode)&&(identical(other.originatingMessageId, originatingMessageId) || other.originatingMessageId == originatingMessageId)&&(identical(other.conversationId, conversationId) || other.conversationId == conversationId)&&(identical(other.changeSetId, changeSetId) || other.changeSetId == changeSetId)&&(identical(other.decisionId, decisionId) || other.decisionId == decisionId)&&(identical(other.agentId, agentId) || other.agentId == agentId)&&(identical(other.source, source) || other.source == source)&&(identical(other.appliedBy, appliedBy) || other.appliedBy == appliedBy)&&(identical(other.isChecked, isChecked) || other.isChecked == isChecked));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,approvedBy,approvalHost,approvedAt,approvalMode,originatingMessageId,conversationId,changeSetId,decisionId,agentId,source,appliedBy,isChecked);
+
+@override
+String toString() {
+  return 'ChecklistItemProvenance(approvedBy: $approvedBy, approvalHost: $approvalHost, approvedAt: $approvedAt, approvalMode: $approvalMode, originatingMessageId: $originatingMessageId, conversationId: $conversationId, changeSetId: $changeSetId, decisionId: $decisionId, agentId: $agentId, source: $source, appliedBy: $appliedBy, isChecked: $isChecked)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ChecklistItemProvenanceCopyWith<$Res>  {
+  factory $ChecklistItemProvenanceCopyWith(ChecklistItemProvenance value, $Res Function(ChecklistItemProvenance) _then) = _$ChecklistItemProvenanceCopyWithImpl;
+@useResult
+$Res call({
+ String approvedBy, String approvalHost, DateTime approvedAt, ChecklistApprovalMode approvalMode, String originatingMessageId, String conversationId, String changeSetId, String decisionId, String agentId, String source, String appliedBy, bool? isChecked
+});
+
+
+
+
+}
+/// @nodoc
+class _$ChecklistItemProvenanceCopyWithImpl<$Res>
+    implements $ChecklistItemProvenanceCopyWith<$Res> {
+  _$ChecklistItemProvenanceCopyWithImpl(this._self, this._then);
+
+  final ChecklistItemProvenance _self;
+  final $Res Function(ChecklistItemProvenance) _then;
+
+/// Create a copy of ChecklistItemProvenance
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? approvedBy = null,Object? approvalHost = null,Object? approvedAt = null,Object? approvalMode = null,Object? originatingMessageId = null,Object? conversationId = null,Object? changeSetId = null,Object? decisionId = null,Object? agentId = null,Object? source = null,Object? appliedBy = null,Object? isChecked = freezed,}) {
+  return _then(_self.copyWith(
+approvedBy: null == approvedBy ? _self.approvedBy : approvedBy // ignore: cast_nullable_to_non_nullable
+as String,approvalHost: null == approvalHost ? _self.approvalHost : approvalHost // ignore: cast_nullable_to_non_nullable
+as String,approvedAt: null == approvedAt ? _self.approvedAt : approvedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,approvalMode: null == approvalMode ? _self.approvalMode : approvalMode // ignore: cast_nullable_to_non_nullable
+as ChecklistApprovalMode,originatingMessageId: null == originatingMessageId ? _self.originatingMessageId : originatingMessageId // ignore: cast_nullable_to_non_nullable
+as String,conversationId: null == conversationId ? _self.conversationId : conversationId // ignore: cast_nullable_to_non_nullable
+as String,changeSetId: null == changeSetId ? _self.changeSetId : changeSetId // ignore: cast_nullable_to_non_nullable
+as String,decisionId: null == decisionId ? _self.decisionId : decisionId // ignore: cast_nullable_to_non_nullable
+as String,agentId: null == agentId ? _self.agentId : agentId // ignore: cast_nullable_to_non_nullable
+as String,source: null == source ? _self.source : source // ignore: cast_nullable_to_non_nullable
+as String,appliedBy: null == appliedBy ? _self.appliedBy : appliedBy // ignore: cast_nullable_to_non_nullable
+as String,isChecked: freezed == isChecked ? _self.isChecked : isChecked // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ChecklistItemProvenance].
+extension ChecklistItemProvenancePatterns on ChecklistItemProvenance {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ChecklistItemProvenance value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ChecklistItemProvenance() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ChecklistItemProvenance value)  $default,){
+final _that = this;
+switch (_that) {
+case _ChecklistItemProvenance():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ChecklistItemProvenance value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ChecklistItemProvenance() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String approvedBy,  String approvalHost,  DateTime approvedAt,  ChecklistApprovalMode approvalMode,  String originatingMessageId,  String conversationId,  String changeSetId,  String decisionId,  String agentId,  String source,  String appliedBy,  bool? isChecked)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ChecklistItemProvenance() when $default != null:
+return $default(_that.approvedBy,_that.approvalHost,_that.approvedAt,_that.approvalMode,_that.originatingMessageId,_that.conversationId,_that.changeSetId,_that.decisionId,_that.agentId,_that.source,_that.appliedBy,_that.isChecked);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String approvedBy,  String approvalHost,  DateTime approvedAt,  ChecklistApprovalMode approvalMode,  String originatingMessageId,  String conversationId,  String changeSetId,  String decisionId,  String agentId,  String source,  String appliedBy,  bool? isChecked)  $default,) {final _that = this;
+switch (_that) {
+case _ChecklistItemProvenance():
+return $default(_that.approvedBy,_that.approvalHost,_that.approvedAt,_that.approvalMode,_that.originatingMessageId,_that.conversationId,_that.changeSetId,_that.decisionId,_that.agentId,_that.source,_that.appliedBy,_that.isChecked);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String approvedBy,  String approvalHost,  DateTime approvedAt,  ChecklistApprovalMode approvalMode,  String originatingMessageId,  String conversationId,  String changeSetId,  String decisionId,  String agentId,  String source,  String appliedBy,  bool? isChecked)?  $default,) {final _that = this;
+switch (_that) {
+case _ChecklistItemProvenance() when $default != null:
+return $default(_that.approvedBy,_that.approvalHost,_that.approvedAt,_that.approvalMode,_that.originatingMessageId,_that.conversationId,_that.changeSetId,_that.decisionId,_that.agentId,_that.source,_that.appliedBy,_that.isChecked);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _ChecklistItemProvenance implements ChecklistItemProvenance {
+  const _ChecklistItemProvenance({required this.approvedBy, required this.approvalHost, required this.approvedAt, required this.approvalMode, required this.originatingMessageId, required this.conversationId, required this.changeSetId, required this.decisionId, required this.agentId, this.source = 'chat_suggestion', this.appliedBy = 'task_agent', this.isChecked});
+  factory _ChecklistItemProvenance.fromJson(Map<String, dynamic> json) => _$ChecklistItemProvenanceFromJson(json);
+
+@override final  String approvedBy;
+@override final  String approvalHost;
+@override final  DateTime approvedAt;
+@override final  ChecklistApprovalMode approvalMode;
+@override final  String originatingMessageId;
+@override final  String conversationId;
+@override final  String changeSetId;
+@override final  String decisionId;
+@override final  String agentId;
+@override@JsonKey() final  String source;
+@override@JsonKey() final  String appliedBy;
+@override final  bool? isChecked;
+
+/// Create a copy of ChecklistItemProvenance
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ChecklistItemProvenanceCopyWith<_ChecklistItemProvenance> get copyWith => __$ChecklistItemProvenanceCopyWithImpl<_ChecklistItemProvenance>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ChecklistItemProvenanceToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ChecklistItemProvenance&&(identical(other.approvedBy, approvedBy) || other.approvedBy == approvedBy)&&(identical(other.approvalHost, approvalHost) || other.approvalHost == approvalHost)&&(identical(other.approvedAt, approvedAt) || other.approvedAt == approvedAt)&&(identical(other.approvalMode, approvalMode) || other.approvalMode == approvalMode)&&(identical(other.originatingMessageId, originatingMessageId) || other.originatingMessageId == originatingMessageId)&&(identical(other.conversationId, conversationId) || other.conversationId == conversationId)&&(identical(other.changeSetId, changeSetId) || other.changeSetId == changeSetId)&&(identical(other.decisionId, decisionId) || other.decisionId == decisionId)&&(identical(other.agentId, agentId) || other.agentId == agentId)&&(identical(other.source, source) || other.source == source)&&(identical(other.appliedBy, appliedBy) || other.appliedBy == appliedBy)&&(identical(other.isChecked, isChecked) || other.isChecked == isChecked));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,approvedBy,approvalHost,approvedAt,approvalMode,originatingMessageId,conversationId,changeSetId,decisionId,agentId,source,appliedBy,isChecked);
+
+@override
+String toString() {
+  return 'ChecklistItemProvenance(approvedBy: $approvedBy, approvalHost: $approvalHost, approvedAt: $approvedAt, approvalMode: $approvalMode, originatingMessageId: $originatingMessageId, conversationId: $conversationId, changeSetId: $changeSetId, decisionId: $decisionId, agentId: $agentId, source: $source, appliedBy: $appliedBy, isChecked: $isChecked)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ChecklistItemProvenanceCopyWith<$Res> implements $ChecklistItemProvenanceCopyWith<$Res> {
+  factory _$ChecklistItemProvenanceCopyWith(_ChecklistItemProvenance value, $Res Function(_ChecklistItemProvenance) _then) = __$ChecklistItemProvenanceCopyWithImpl;
+@override @useResult
+$Res call({
+ String approvedBy, String approvalHost, DateTime approvedAt, ChecklistApprovalMode approvalMode, String originatingMessageId, String conversationId, String changeSetId, String decisionId, String agentId, String source, String appliedBy, bool? isChecked
+});
+
+
+
+
+}
+/// @nodoc
+class __$ChecklistItemProvenanceCopyWithImpl<$Res>
+    implements _$ChecklistItemProvenanceCopyWith<$Res> {
+  __$ChecklistItemProvenanceCopyWithImpl(this._self, this._then);
+
+  final _ChecklistItemProvenance _self;
+  final $Res Function(_ChecklistItemProvenance) _then;
+
+/// Create a copy of ChecklistItemProvenance
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? approvedBy = null,Object? approvalHost = null,Object? approvedAt = null,Object? approvalMode = null,Object? originatingMessageId = null,Object? conversationId = null,Object? changeSetId = null,Object? decisionId = null,Object? agentId = null,Object? source = null,Object? appliedBy = null,Object? isChecked = freezed,}) {
+  return _then(_ChecklistItemProvenance(
+approvedBy: null == approvedBy ? _self.approvedBy : approvedBy // ignore: cast_nullable_to_non_nullable
+as String,approvalHost: null == approvalHost ? _self.approvalHost : approvalHost // ignore: cast_nullable_to_non_nullable
+as String,approvedAt: null == approvedAt ? _self.approvedAt : approvedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,approvalMode: null == approvalMode ? _self.approvalMode : approvalMode // ignore: cast_nullable_to_non_nullable
+as ChecklistApprovalMode,originatingMessageId: null == originatingMessageId ? _self.originatingMessageId : originatingMessageId // ignore: cast_nullable_to_non_nullable
+as String,conversationId: null == conversationId ? _self.conversationId : conversationId // ignore: cast_nullable_to_non_nullable
+as String,changeSetId: null == changeSetId ? _self.changeSetId : changeSetId // ignore: cast_nullable_to_non_nullable
+as String,decisionId: null == decisionId ? _self.decisionId : decisionId // ignore: cast_nullable_to_non_nullable
+as String,agentId: null == agentId ? _self.agentId : agentId // ignore: cast_nullable_to_non_nullable
+as String,source: null == source ? _self.source : source // ignore: cast_nullable_to_non_nullable
+as String,appliedBy: null == appliedBy ? _self.appliedBy : appliedBy // ignore: cast_nullable_to_non_nullable
+as String,isChecked: freezed == isChecked ? _self.isChecked : isChecked // ignore: cast_nullable_to_non_nullable
+as bool?,
   ));
 }
 

--- a/lib/classes/checklist_item_data.g.dart
+++ b/lib/classes/checklist_item_data.g.dart
@@ -25,6 +25,14 @@ _ChecklistItemData _$ChecklistItemDataFromJson(Map<String, dynamic> json) =>
       checkedAt: json['checkedAt'] == null
           ? null
           : DateTime.parse(json['checkedAt'] as String),
+      approvalHistory:
+          (json['approvalHistory'] as List<dynamic>?)
+              ?.map(
+                (e) =>
+                    ChecklistItemProvenance.fromJson(e as Map<String, dynamic>),
+              )
+              .toList() ??
+          const [],
     );
 
 Map<String, dynamic> _$ChecklistItemDataToJson(_ChecklistItemData instance) =>
@@ -36,9 +44,52 @@ Map<String, dynamic> _$ChecklistItemDataToJson(_ChecklistItemData instance) =>
       'id': instance.id,
       'checkedBy': _$ChangeSourceEnumMap[instance.checkedBy]!,
       'checkedAt': instance.checkedAt?.toIso8601String(),
+      'approvalHistory': instance.approvalHistory,
     };
 
 const _$ChangeSourceEnumMap = {
   ChangeSource.user: 'user',
   ChangeSource.agent: 'agent',
+};
+
+_ChecklistItemProvenance _$ChecklistItemProvenanceFromJson(
+  Map<String, dynamic> json,
+) => _ChecklistItemProvenance(
+  approvedBy: json['approvedBy'] as String,
+  approvalHost: json['approvalHost'] as String,
+  approvedAt: DateTime.parse(json['approvedAt'] as String),
+  approvalMode: $enumDecode(
+    _$ChecklistApprovalModeEnumMap,
+    json['approvalMode'],
+  ),
+  originatingMessageId: json['originatingMessageId'] as String,
+  conversationId: json['conversationId'] as String,
+  changeSetId: json['changeSetId'] as String,
+  decisionId: json['decisionId'] as String,
+  agentId: json['agentId'] as String,
+  source: json['source'] as String? ?? 'chat_suggestion',
+  appliedBy: json['appliedBy'] as String? ?? 'task_agent',
+  isChecked: json['isChecked'] as bool?,
+);
+
+Map<String, dynamic> _$ChecklistItemProvenanceToJson(
+  _ChecklistItemProvenance instance,
+) => <String, dynamic>{
+  'approvedBy': instance.approvedBy,
+  'approvalHost': instance.approvalHost,
+  'approvedAt': instance.approvedAt.toIso8601String(),
+  'approvalMode': _$ChecklistApprovalModeEnumMap[instance.approvalMode]!,
+  'originatingMessageId': instance.originatingMessageId,
+  'conversationId': instance.conversationId,
+  'changeSetId': instance.changeSetId,
+  'decisionId': instance.decisionId,
+  'agentId': instance.agentId,
+  'source': instance.source,
+  'appliedBy': instance.appliedBy,
+  'isChecked': instance.isChecked,
+};
+
+const _$ChecklistApprovalModeEnumMap = {
+  ChecklistApprovalMode.individual: 'individual',
+  ChecklistApprovalMode.confirmAll: 'confirm_all',
 };

--- a/lib/features/agents/query/query_chat_action_service.dart
+++ b/lib/features/agents/query/query_chat_action_service.dart
@@ -28,7 +28,7 @@ class QueryChatActionService {
 
   final QueryChatStore store;
   final QueryActionContextReader readContext;
-  final AgentToolDispatch dispatch;
+  final ApprovedTaskToolDispatch dispatch;
   final LabelsRepository labels;
   final bool Function() enabled;
   final _running = <String>{};
@@ -91,7 +91,9 @@ class QueryChatActionService {
       final service = ChangeSetConfirmationService(
         syncService: store.sync,
         labelsRepository: labels,
-        toolDispatcher: (name, args, taskId) async {
+        toolDispatcher: (name, args, taskId) =>
+            dispatch(name, args, taskId, null),
+        approvedToolDispatcher: (name, args, taskId, approval) async {
           final current = await _authorize(agentId, chatId, questionId);
           if (taskId != current.taskId) throw const QueryScopeUnavailable();
           final context = await readContext(
@@ -105,7 +107,7 @@ class QueryChatActionService {
           // Re-check after asynchronous context reads and immediately before
           // the existing handler is allowed to mutate the task.
           await _authorize(agentId, chatId, questionId);
-          return dispatch(name, args, taskId);
+          return dispatch(name, args, taskId, approval);
         },
       );
       return await service.confirmAll(set);

--- a/lib/features/agents/query/query_chat_action_service.dart
+++ b/lib/features/agents/query/query_chat_action_service.dart
@@ -1,3 +1,4 @@
+import 'package:lotti/classes/checklist_item_data.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/model/query_chat_models.dart';
@@ -88,27 +89,35 @@ class QueryChatActionService {
         if (approved) throw const QueryScopeUnavailable();
         return const [];
       }
+      // Both dispatch channels re-check access; the receipt remains separate
+      // from model arguments and is present only for a persisted chat approval.
+      Future<ToolExecutionResult> authorizedDispatch(
+        String name,
+        Map<String, dynamic> args,
+        String taskId, [
+        ChecklistItemProvenance? approval,
+      ]) async {
+        final current = await _authorize(agentId, chatId, questionId);
+        if (taskId != current.taskId) throw const QueryScopeUnavailable();
+        final context = await readContext(
+          taskId,
+          current.answer.dependencies.map((s) => s.id),
+        );
+        await QueryTaskActionPlanner.validateItem(
+          ChangeItem(toolName: name, args: args, humanSummary: ''),
+          context,
+        );
+        // Re-check after asynchronous context reads and immediately before
+        // the existing handler is allowed to mutate the task.
+        await _authorize(agentId, chatId, questionId);
+        return dispatch(name, args, taskId, approval);
+      }
+
       final service = ChangeSetConfirmationService(
         syncService: store.sync,
         labelsRepository: labels,
-        toolDispatcher: (name, args, taskId) =>
-            dispatch(name, args, taskId, null),
-        approvedToolDispatcher: (name, args, taskId, approval) async {
-          final current = await _authorize(agentId, chatId, questionId);
-          if (taskId != current.taskId) throw const QueryScopeUnavailable();
-          final context = await readContext(
-            taskId,
-            current.answer.dependencies.map((s) => s.id),
-          );
-          await QueryTaskActionPlanner.validateItem(
-            ChangeItem(toolName: name, args: args, humanSummary: ''),
-            context,
-          );
-          // Re-check after asynchronous context reads and immediately before
-          // the existing handler is allowed to mutate the task.
-          await _authorize(agentId, chatId, questionId);
-          return dispatch(name, args, taskId, approval);
-        },
+        toolDispatcher: authorizedDispatch,
+        approvedToolDispatcher: authorizedDispatch,
       );
       return await service.confirmAll(set);
     } finally {

--- a/lib/features/agents/query/query_chat_providers.dart
+++ b/lib/features/agents/query/query_chat_providers.dart
@@ -73,7 +73,7 @@ final queryChatActionServiceProvider = Provider<QueryChatActionService>(
   (ref) => QueryChatActionService(
     store: ref.watch(queryChatStoreProvider),
     readContext: ref.watch(queryActionContextReaderProvider),
-    dispatch: taskToolDispatcher(ref).dispatch,
+    dispatch: taskToolDispatcher(ref).dispatchApproved,
     labels: ref.watch(labelsRepositoryProvider),
     enabled: () => ref.read(queryChatEnabledProvider),
   ),

--- a/lib/features/agents/service/change_set_confirmation_service.dart
+++ b/lib/features/agents/service/change_set_confirmation_service.dart
@@ -1,5 +1,6 @@
 import 'package:clock/clock.dart';
 import 'package:collection/collection.dart';
+import 'package:lotti/classes/checklist_item_data.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
@@ -11,6 +12,15 @@ import 'package:lotti/features/agents/tools/agent_tool_registry.dart';
 import 'package:lotti/features/agents/tools/running_timer_update_handler.dart';
 import 'package:lotti/features/labels/repository/labels_repository.dart';
 import 'package:lotti/services/domain_logging.dart';
+
+/// Dispatch with optional trusted chat approval metadata, outside tool JSON.
+typedef ApprovedTaskToolDispatch =
+    Future<ToolExecutionResult> Function(
+      String name,
+      Map<String, dynamic> args,
+      String taskId,
+      ChecklistItemProvenance? approval,
+    );
 
 typedef ConfirmedDecisionCallback =
     Future<void> Function({
@@ -51,10 +61,12 @@ class ChangeSetConfirmationService {
     this._domainLogger,
     this._onConfirmedDecision,
     this._onChangeSetResolved,
+    this.approvedToolDispatcher,
   });
 
   final AgentSyncService _syncService;
   final AgentToolDispatch _toolDispatcher;
+  final ApprovedTaskToolDispatch? approvedToolDispatcher;
   final LabelsRepository _labelsRepository;
   final DomainLogger? _domainLogger;
   final ConfirmedDecisionCallback? _onConfirmedDecision;
@@ -78,6 +90,12 @@ class ChangeSetConfirmationService {
   Future<ToolExecutionResult> confirmItem(
     ChangeSetEntity changeSet,
     int itemIndex,
+  ) => _confirmItem(changeSet, itemIndex, ChecklistApprovalMode.individual);
+
+  Future<ToolExecutionResult> _confirmItem(
+    ChangeSetEntity changeSet,
+    int itemIndex,
+    ChecklistApprovalMode approvalMode,
   ) async {
     // Re-read persisted state to guard against stale snapshots from the
     // caller (e.g. rapid repeated taps or concurrent clients).
@@ -129,6 +147,13 @@ class ChangeSetConfirmationService {
       subDomain: _sub,
     );
 
+    final isChat =
+        current.id == '${current.runKey}:actions' &&
+        current.runKey.startsWith('query-chat:');
+    final approvalHost = isChat && approvedToolDispatcher != null
+        ? await _syncService.localHost()
+        : null;
+
     // 1. Mark the item as confirmed and persist the decision BEFORE
     //    dispatching the tool. This ensures that if the process dies after
     //    a successful dispatch but before persistence, the item will not
@@ -160,11 +185,29 @@ class ChangeSetConfirmationService {
     late final ToolExecutionResult result;
     var dispatchThrew = false;
     try {
-      result = await _toolDispatcher(
-        item.toolName,
-        dispatchArgs,
-        current.taskId,
-      );
+      final approval = approvalHost == null
+          ? null
+          : ChecklistItemProvenance(
+              approvedBy: 'user',
+              approvalHost: approvalHost,
+              approvedAt: decision.createdAt,
+              approvalMode: approvalMode,
+              originatingMessageId: current.runKey.substring(
+                'query-chat:'.length,
+              ),
+              conversationId: current.threadId,
+              changeSetId: current.id,
+              decisionId: decision.id,
+              agentId: current.agentId,
+            );
+      result = approvedToolDispatcher == null
+          ? await _toolDispatcher(item.toolName, dispatchArgs, current.taskId)
+          : await approvedToolDispatcher!(
+              item.toolName,
+              dispatchArgs,
+              current.taskId,
+              approval,
+            );
     } catch (error, stackTrace) {
       dispatchThrew = true;
       _domainLogger?.error(
@@ -586,7 +629,11 @@ class ChangeSetConfirmationService {
 
     for (var i = 0; i < current.items.length; i++) {
       if (current.items[i].status == ChangeItemStatus.pending) {
-        final result = await confirmItem(current, i);
+        final result = await _confirmItem(
+          current,
+          i,
+          ChecklistApprovalMode.confirmAll,
+        );
         results.add(result);
 
         // Re-read the updated change set from the persisted state

--- a/lib/features/agents/state/change_set_providers.dart
+++ b/lib/features/agents/state/change_set_providers.dart
@@ -230,6 +230,7 @@ ChangeSetConfirmationService changeSetConfirmationService(Ref ref) {
   return ChangeSetConfirmationService(
     syncService: ref.watch(agentSyncServiceProvider),
     toolDispatcher: taskToolDispatcher(ref).dispatch,
+    approvedToolDispatcher: taskToolDispatcher(ref).dispatchApproved,
     labelsRepository: labelsRepository,
     domainLogger: logger,
     onChangeSetResolved: notificationService?.syncAfterUserDecision,

--- a/lib/features/agents/tools/checklist_migration_handler.dart
+++ b/lib/features/agents/tools/checklist_migration_handler.dart
@@ -1,3 +1,4 @@
+import 'package:lotti/classes/checklist_item_data.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
@@ -16,9 +17,11 @@ class ChecklistMigrationHandler {
     required this._checklistRepository,
     required this._journalDb,
     this._domainLogger,
+    this.approval,
   });
 
   final ChecklistRepository _checklistRepository;
+  final ChecklistItemProvenance? approval;
   final JournalDb _journalDb;
   final DomainLogger? _domainLogger;
 
@@ -148,6 +151,15 @@ class ChecklistMigrationHandler {
       title: itemEntity.data.title,
       isChecked: itemEntity.data.isChecked,
       categoryId: targetTask.meta.categoryId,
+      checkedBy: approval == null
+          ? itemEntity.data.checkedBy
+          : ChangeSource.user,
+      checkedAt: approval?.approvedAt ?? itemEntity.data.checkedAt,
+      approvalHistory: [
+        ...itemEntity.data.approvalHistory,
+        if (approval case final receipt?)
+          receipt.copyWith(isChecked: itemEntity.data.isChecked),
+      ],
     );
 
     if (newItem == null) {
@@ -164,7 +176,13 @@ class ChecklistMigrationHandler {
     // inconsistency that beats duplicate target items.
     final archived = await _checklistRepository.updateChecklistItem(
       checklistItemId: itemId,
-      data: itemEntity.data.copyWith(isArchived: true),
+      data: itemEntity.data.copyWith(
+        isArchived: true,
+        approvalHistory: [
+          ...itemEntity.data.approvalHistory,
+          if (approval case final receipt?) receipt.copyWith(isChecked: null),
+        ],
+      ),
       taskId: sourceTaskId,
     );
 

--- a/lib/features/agents/workflow/change_proposal_filter.dart
+++ b/lib/features/agents/workflow/change_proposal_filter.dart
@@ -100,8 +100,7 @@ class ChangeProposalFilter {
     if (result.rejected > 0) {
       final details = result.rejectedDetails.join('; ');
       parts.add(
-        'Rejected ${result.rejected} item(s) that reference entities which '
-        'do not exist (most likely invented ids): $details. '
+        'Rejected ${result.rejected} item(s): $details. '
         'Do not propose these again.',
       );
     }

--- a/lib/features/agents/workflow/change_set_batch_exploder.dart
+++ b/lib/features/agents/workflow/change_set_batch_exploder.dart
@@ -194,6 +194,16 @@ extension ChangeSetBatchExplosion on ChangeSetBuilder {
           }
         }
 
+        final protected = await _chatApprovalReversal(
+          singularToolName,
+          element,
+        );
+        if (protected != null) {
+          rejected++;
+          rejectedDetails.add(protected);
+          continue;
+        }
+
         // Check for redundant update_checklist_item proposals.
         final redundancyDetail = _checkRedundancy(
           singularToolName,

--- a/lib/features/agents/workflow/change_set_builder.dart
+++ b/lib/features/agents/workflow/change_set_builder.dart
@@ -67,8 +67,8 @@ class BatchAddResult {
   /// e.g. `'"Buy groceries" is already checked'`.
   final List<String> redundantDetails;
 
-  /// Number of items rejected because they reference an entity that does not
-  /// exist — a hallucinated id the model invented. Distinct from [redundant]
+  /// Number of items rejected for invalid IDs or protected user-approved state.
+  /// Distinct from [redundant]
   /// (a real but no-op change) and [skipped] (a malformed array element).
   final int rejected;
 
@@ -91,6 +91,7 @@ class ChangeSetBuilder {
     required this.threadId,
     required this.runKey,
     this.checklistItemStateResolver,
+    this.userApprovedChecklistStateResolver,
     this.existingChecklistTitlesResolver,
     this.labelNameResolver,
     this.existingLabelIdsResolver,
@@ -114,6 +115,31 @@ class ChangeSetBuilder {
   /// LLM references by ID only (without including the title in the tool args).
   /// Also used to detect and suppress redundant updates.
   final ChecklistItemStateResolver? checklistItemStateResolver;
+
+  /// Current checked state protected by a chat receipt; null means unprotected.
+  /// Only background builders wire this; chat proposals still require approval.
+  final Future<bool?> Function(String id)? userApprovedChecklistStateResolver;
+
+  Future<String?> _chatApprovalReversal(
+    String toolName,
+    Map<String, dynamic> args,
+  ) async {
+    if (toolName != TaskAgentToolNames.updateChecklistItem) return null;
+    final id = args['id'];
+    final requested = args['isChecked'];
+    if (id is! String || requested is! bool) return null;
+    try {
+      final protected = await userApprovedChecklistStateResolver?.call(
+        id.trim(),
+      );
+      return protected != null && protected != requested
+          ? 'User-approved chat state cannot be reversed. Do not retry this change.'
+          : null;
+    } catch (_) {
+      // Do not turn a failed lookup into permission to reverse user intent.
+      return 'Cannot verify checklist approval state. Do not retry this change.';
+    }
+  }
 
   /// Optional resolver for existing checklist item titles. When provided,
   /// `add_checklist_item` proposals are checked against existing titles
@@ -195,6 +221,8 @@ class ChangeSetBuilder {
     required Map<String, dynamic> args,
     required String humanSummary,
   }) async {
+    final protected = await _chatApprovalReversal(toolName, args);
+    if (protected != null) return protected;
     // Within-wake fingerprint dedup: skip if an identical item is already
     // queued in this builder (e.g. model calling update_task_priority twice).
     final fingerprint = ChangeItem.fingerprintFromParts(toolName, args);

--- a/lib/features/agents/workflow/task_agent_execute.dart
+++ b/lib/features/agents/workflow/task_agent_execute.dart
@@ -389,6 +389,13 @@ extension TaskAgentExecute on TaskAgentWorkflow {
         threadId: threadId,
         runKey: runKey,
         domainLogger: domainLogger,
+        userApprovedChecklistStateResolver: (itemId) async {
+          final entity = await journalDb.journalEntityById(itemId);
+          return entity is ChecklistItem &&
+                  entity.data.checkedStateApproval != null
+              ? entity.data.isChecked
+              : null;
+        },
         checklistItemStateResolver: (itemId) async {
           final entity = await journalDb.journalEntityById(itemId);
           if (entity is ChecklistItem) {

--- a/lib/features/agents/workflow/task_agent_prompt_builder.dart
+++ b/lib/features/agents/workflow/task_agent_prompt_builder.dart
@@ -607,7 +607,10 @@ linked task's own agent does not push updates to you.
 - **Checklist sovereignty**: items record who last toggled them and when.
   - Items you last set, you may change freely.
   - Items the USER last set keep their checked state unless you have evidence
-    timestamped after their `checkedAt`. Absence of evidence is not grounds for
+    timestamped after their `checkedAt`. A user-approved chat state is explicit
+    human intent: never propose reversing it, even if the task log contains no
+    supporting evidence. Only a new human-approved instruction may change it.
+    Absence of evidence is not grounds for
     unchecking — they may have finished it outside the app.
   - Overriding a user-set item requires a `reason` naming that later evidence;
     without one the change is rejected.

--- a/lib/features/agents/workflow/task_state_markdown.dart
+++ b/lib/features/agents/workflow/task_state_markdown.dart
@@ -17,7 +17,8 @@ import 'package:lotti/features/ai/model/ai_input.dart';
 /// - `Due`, `Language`, `Labels` and the suppressed-label line are omitted
 ///   when empty;
 /// - a checklist item renders as `- [ ] title (id: …)` with `, due …`,
-///   `, checked by …` (when completed) and `, archived` tags as applicable.
+///   `, checked by …` (when completed), current chat approval and `, archived`
+///   tags as applicable.
 String renderTaskStateMarkdown(
   AiInputTaskObject task, {
   List<Map<String, String>> labels = const [],
@@ -81,6 +82,8 @@ String _renderActionItem(AiActionItem item) {
     if (item.deadline != null) 'due ${item.deadline!.toIso8601String()}',
     if (item.completed && item.checkedBy != null)
       'checked by ${item.checkedBy}',
+    if (item.checkedStateApproval case final approval?)
+      'user-approved chat state at ${approval.approvedAt.toIso8601String()} (approval: ${approval.approvalMode.name}; do not reverse)',
     if (item.isArchived) 'archived',
   ];
   final suffix = tags.isEmpty ? '' : ' (${tags.join(', ')})';

--- a/lib/features/agents/workflow/task_tool_dispatcher.dart
+++ b/lib/features/agents/workflow/task_tool_dispatcher.dart
@@ -1,5 +1,6 @@
 import 'dart:developer' as developer;
 
+import 'package:lotti/classes/checklist_item_data.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/agents/database/agent_repository.dart';
@@ -52,6 +53,14 @@ class TaskToolDispatcher {
   final AgentSyncService? syncService;
   final String? requestingAgentId;
 
+  /// Human confirmation supplies this receipt separately from untrusted args.
+  Future<ToolExecutionResult> dispatchApproved(
+    String name,
+    Map<String, dynamic> args,
+    String taskId,
+    ChecklistItemProvenance? approval,
+  ) => dispatch(name, args, taskId, approval: approval);
+
   /// Executes a tool handler by delegating to the appropriate existing
   /// journal-domain handler.
   ///
@@ -60,8 +69,9 @@ class TaskToolDispatcher {
   Future<ToolExecutionResult> dispatch(
     String toolName,
     Map<String, dynamic> args,
-    String taskId,
-  ) async {
+    String taskId, {
+    ChecklistItemProvenance? approval,
+  }) async {
     developer.log(
       'Dispatching tool handler: $toolName',
       name: 'TaskToolDispatcher',
@@ -126,6 +136,7 @@ class TaskToolDispatcher {
             'items': [normalizedArgs],
           },
           taskId,
+          approval: approval,
         );
 
       case TaskAgentToolNames.addMultipleChecklistItems:
@@ -134,6 +145,7 @@ class TaskToolDispatcher {
           resolvedName,
           normalizedArgs,
           taskId,
+          approval: approval,
         );
 
       case TaskAgentToolNames.updateChecklistItem:
@@ -144,6 +156,7 @@ class TaskToolDispatcher {
             'items': [normalizedArgs],
           },
           taskId,
+          approval: approval,
         );
 
       case TaskAgentToolNames.updateChecklistItems:
@@ -152,6 +165,7 @@ class TaskToolDispatcher {
           resolvedName,
           normalizedArgs,
           taskId,
+          approval: approval,
         );
 
       case TaskAgentToolNames.assignTaskLabel:
@@ -177,7 +191,11 @@ class TaskToolDispatcher {
 
       case TaskAgentToolNames.migrateChecklistItem:
       case TaskAgentToolNames.migrateChecklistItems:
-        return handleMigrateChecklistItem(normalizedArgs, taskId);
+        return handleMigrateChecklistItem(
+          normalizedArgs,
+          taskId,
+          approval: approval,
+        );
 
       case TaskAgentToolNames.linkTask:
         return handleLinkTask(normalizedArgs, taskId);

--- a/lib/features/agents/workflow/task_tool_handlers.dart
+++ b/lib/features/agents/workflow/task_tool_handlers.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:lotti/classes/checklist_item_data.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
 import 'package:lotti/features/agents/tools/agent_tool_registry.dart';
@@ -273,8 +274,9 @@ extension TaskToolHandlers on TaskToolDispatcher {
     Task task,
     String toolName,
     Map<String, dynamic> args,
-    String taskId,
-  ) async {
+    String taskId, {
+    ChecklistItemProvenance? approval,
+  }) async {
     final items = args['items'];
     if (items is! List || items.isEmpty) {
       return ToolExecutionResult(
@@ -292,6 +294,7 @@ extension TaskToolHandlers on TaskToolDispatcher {
 
     final handler = LottiBatchChecklistHandler(
       task: task,
+      approval: approval,
       autoChecklistService: autoChecklistService,
       checklistRepository: checklistRepository,
     );
@@ -334,8 +337,9 @@ extension TaskToolHandlers on TaskToolDispatcher {
     Task task,
     String toolName,
     Map<String, dynamic> args,
-    String taskId,
-  ) async {
+    String taskId, {
+    ChecklistItemProvenance? approval,
+  }) async {
     final items = args['items'];
     if (items is! List || items.isEmpty) {
       return ToolExecutionResult(
@@ -349,6 +353,7 @@ extension TaskToolHandlers on TaskToolDispatcher {
 
     final handler = LottiChecklistUpdateHandler(
       task: task,
+      approval: approval,
       checklistRepository: checklistRepository,
     );
 
@@ -371,15 +376,19 @@ extension TaskToolHandlers on TaskToolDispatcher {
     }
 
     final count = await handler.executeUpdates(parseResult);
+    final protectedState = handler.skippedItems.any(
+      (s) => s.reason == LottiChecklistUpdateHandler.userApprovedStateReason,
+    );
     final hasRealFailures =
         count == 0 &&
         handler.skippedItems.any(
           (s) => s.reason != 'No changes detected',
         );
     return ToolExecutionResult(
-      // Return success=true as long as parsing succeeded — a count of 0
-      // just means all items were already in the requested state (no-op).
-      success: true,
+      // A protected state retracts a stale background proposal. Other
+      // zero-count updates retain the existing no-op result semantics.
+      success: !protectedState,
+      nonRetryable: protectedState,
       output: handler.createToolResponse(parseResult),
       mutatedEntityId: count > 0 ? taskId : null,
       // Surface real failures (not found, wrong task, DB error) so
@@ -406,10 +415,12 @@ extension TaskToolHandlers on TaskToolDispatcher {
 
   Future<ToolExecutionResult> handleMigrateChecklistItem(
     Map<String, dynamic> args,
-    String sourceTaskId,
-  ) async {
+    String sourceTaskId, {
+    ChecklistItemProvenance? approval,
+  }) async {
     final handler = ChecklistMigrationHandler(
       checklistRepository: checklistRepository,
+      approval: approval,
       journalDb: journalDb,
       domainLogger: domainLogger,
     );

--- a/lib/features/ai/functions/lotti_batch_checklist_handler.dart
+++ b/lib/features/ai/functions/lotti_batch_checklist_handler.dart
@@ -18,7 +18,10 @@ class LottiBatchChecklistHandler extends FunctionHandler {
     required this.autoChecklistService,
     required this.checklistRepository,
     this.onTaskUpdated,
+    this.approval,
   });
+
+  final ChecklistItemProvenance? approval;
 
   Task task;
   final AutoChecklistService autoChecklistService;
@@ -197,7 +200,16 @@ Do NOT recreate the items that were already successful.''';
               title: item['title'] as String,
               isChecked: (item['isChecked'] as bool?) ?? false,
               linkedChecklists: [],
-              checkedBy: ChangeSource.agent,
+              checkedBy: approval == null
+                  ? ChangeSource.agent
+                  : ChangeSource.user,
+              checkedAt: approval?.approvedAt,
+              approvalHistory: [
+                if (approval case final receipt?)
+                  receipt.copyWith(
+                    isChecked: (item['isChecked'] as bool?) ?? false,
+                  ),
+              ],
             ),
         ];
 
@@ -252,7 +264,14 @@ Do NOT recreate the items that were already successful.''';
             title: title,
             isChecked: isChecked,
             categoryId: currentTask.meta.categoryId,
-            checkedBy: ChangeSource.agent,
+            checkedBy: approval == null
+                ? ChangeSource.agent
+                : ChangeSource.user,
+            checkedAt: approval?.approvedAt,
+            approvalHistory: [
+              if (approval case final receipt?)
+                receipt.copyWith(isChecked: isChecked),
+            ],
           );
 
           if (newItem != null) {

--- a/lib/features/ai/functions/lotti_checklist_update_handler.dart
+++ b/lib/features/ai/functions/lotti_checklist_update_handler.dart
@@ -21,7 +21,10 @@ import 'package:openai_dart/openai_dart.dart';
 ///
 /// Enforces user sovereignty: when a checklist item was last toggled by the
 /// user, the agent must provide a `reason` citing post-dated evidence to
-/// change its checked state. Title and archival updates are always allowed
+/// change its checked state. Chat-approved state additionally requires a new
+/// trusted human approval; model-provided reasons cannot reverse it. Approval
+/// receipts are persisted with each update, including reaffirmed checked state.
+/// Title and archival updates are always allowed
 /// (agent-proposed archivals pass the ChangeSet human gate before reaching
 /// this handler).
 class LottiChecklistUpdateHandler extends FunctionHandler {
@@ -29,6 +32,7 @@ class LottiChecklistUpdateHandler extends FunctionHandler {
     required this.task,
     required this.checklistRepository,
     this.onTaskUpdated,
+    this.approval,
     DateTime Function()? clock,
   }) : _clock = clock ?? DateTime.now;
 
@@ -40,6 +44,9 @@ class LottiChecklistUpdateHandler extends FunctionHandler {
   /// checklistIds). The [onTaskUpdated] callback is invoked when refreshed.
   Task task;
   final ChecklistRepository checklistRepository;
+
+  /// Supplied only by the human confirmation path, never by the model.
+  final ChecklistItemProvenance? approval;
   final void Function(Task)? onTaskUpdated;
 
   /// Clock function for timestamps — injectable for testing.
@@ -50,6 +57,10 @@ class LottiChecklistUpdateHandler extends FunctionHandler {
   /// a user-set checklist state. A substantive reason must cite specific
   /// evidence (e.g., "User said 'not done' in 22:30 recording").
   static const minReasonLength = 20;
+
+  /// Stable reason used to retract stale background proposals at dispatch.
+  static const userApprovedStateReason =
+      'User-approved chat state cannot be reversed by the agent.';
 
   final List<UpdatedItemDetail> _updatedItems = [];
   final List<SkippedItemDetail> _skippedItems = [];
@@ -360,8 +371,31 @@ class LottiChecklistUpdateHandler extends FunctionHandler {
       final isArchivedChanged =
           newIsArchived != null && newIsArchived != currentIsArchived;
 
-      if (!isCheckedChanged && !titleChanged && !isArchivedChanged) {
+      final approvedCheck = approval != null && newIsChecked != null;
+      if (!isCheckedChanged &&
+          !titleChanged &&
+          !isArchivedChanged &&
+          approval == null) {
         _skip(id, 'No changes detected');
+        continue;
+      }
+
+      // A model-written reason cannot override a human-approved chat state.
+      if (isCheckedChanged &&
+          approval == null &&
+          entity.data.checkedStateApproval != null) {
+        _skip(id, userApprovedStateReason);
+        if (await _applyNonCheckedChanges(
+          id: id,
+          entity: entity,
+          newTitle: newTitle,
+          titleChanged: titleChanged,
+          newIsArchived: newIsArchived,
+          isArchivedChanged: isArchivedChanged,
+          currentIsChecked: currentIsChecked,
+        )) {
+          successCount++;
+        }
         continue;
       }
 
@@ -369,7 +403,9 @@ class LottiChecklistUpdateHandler extends FunctionHandler {
       // When the user last toggled isChecked, the agent needs a substantive
       // reason citing post-dated evidence to override it. We enforce a
       // minimum length to prevent trivial/hallucinated justifications.
-      if (isCheckedChanged && entity.data.checkedBy == ChangeSource.user) {
+      if (isCheckedChanged &&
+          approval == null &&
+          entity.data.checkedBy == ChangeSource.user) {
         final checkedAtStr =
             entity.data.checkedAt?.toIso8601String() ?? 'unknown';
         final trimmedReason = reason?.trim() ?? '';
@@ -416,10 +452,19 @@ class LottiChecklistUpdateHandler extends FunctionHandler {
         isChecked: newIsChecked ?? currentIsChecked,
         title: newTitle ?? currentTitle,
         isArchived: newIsArchived ?? currentIsArchived,
-        checkedBy: isCheckedChanged
-            ? ChangeSource.agent
+        checkedBy: (isCheckedChanged || approvedCheck)
+            ? (approval == null ? ChangeSource.agent : ChangeSource.user)
             : entity.data.checkedBy,
-        checkedAt: isCheckedChanged ? _clock() : entity.data.checkedAt,
+        checkedAt: (isCheckedChanged || approvedCheck)
+            ? (approval?.approvedAt ?? _clock())
+            : entity.data.checkedAt,
+        approvalHistory: [
+          ...entity.data.approvalHistory,
+          if (approval case final receipt?)
+            receipt.copyWith(
+              isChecked: newIsChecked,
+            ),
+        ],
       );
 
       final success = await checklistRepository.updateChecklistItem(

--- a/lib/features/ai/model/ai_input.dart
+++ b/lib/features/ai/model/ai_input.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:lotti/classes/checklist_item_data.dart';
 
 part 'ai_input.freezed.dart';
 part 'ai_input.g.dart';
@@ -41,6 +42,7 @@ abstract class AiActionItem with _$AiActionItem {
     DateTime? completionDate,
     String? checkedBy,
     DateTime? checkedAt,
+    ChecklistItemProvenance? checkedStateApproval,
   }) = _AiActionItem;
 
   factory AiActionItem.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/ai/model/ai_input.dart
+++ b/lib/features/ai/model/ai_input.dart
@@ -42,11 +42,25 @@ abstract class AiActionItem with _$AiActionItem {
     DateTime? completionDate,
     String? checkedBy,
     DateTime? checkedAt,
-    ChecklistItemProvenance? checkedStateApproval,
+    AiChecklistApproval? checkedStateApproval,
   }) = _AiActionItem;
 
   factory AiActionItem.fromJson(Map<String, dynamic> json) =>
       _$AiActionItemFromJson(json);
+}
+
+/// Minimal human intent for prompts. Audit identifiers stay on the journal
+/// receipt and cannot be serialized through this model-facing type.
+@freezed
+abstract class AiChecklistApproval with _$AiChecklistApproval {
+  const factory AiChecklistApproval({
+    required bool isChecked,
+    required DateTime approvedAt,
+    required ChecklistApprovalMode approvalMode,
+  }) = _AiChecklistApproval;
+
+  factory AiChecklistApproval.fromJson(Map<String, dynamic> json) =>
+      _$AiChecklistApprovalFromJson(json);
 }
 
 /// A single journal/log entry attached to a task, as seen by the model inside

--- a/lib/features/ai/model/ai_input.freezed.dart
+++ b/lib/features/ai/model/ai_input.freezed.dart
@@ -316,7 +316,7 @@ as String?,
 /// @nodoc
 mixin _$AiActionItem {
 
- String get title; bool get completed; bool get isArchived; String? get id; DateTime? get deadline; DateTime? get completionDate; String? get checkedBy; DateTime? get checkedAt; ChecklistItemProvenance? get checkedStateApproval;
+ String get title; bool get completed; bool get isArchived; String? get id; DateTime? get deadline; DateTime? get completionDate; String? get checkedBy; DateTime? get checkedAt; AiChecklistApproval? get checkedStateApproval;
 /// Create a copy of AiActionItem
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -349,11 +349,11 @@ abstract mixin class $AiActionItemCopyWith<$Res>  {
   factory $AiActionItemCopyWith(AiActionItem value, $Res Function(AiActionItem) _then) = _$AiActionItemCopyWithImpl;
 @useResult
 $Res call({
- String title, bool completed, bool isArchived, String? id, DateTime? deadline, DateTime? completionDate, String? checkedBy, DateTime? checkedAt, ChecklistItemProvenance? checkedStateApproval
+ String title, bool completed, bool isArchived, String? id, DateTime? deadline, DateTime? completionDate, String? checkedBy, DateTime? checkedAt, AiChecklistApproval? checkedStateApproval
 });
 
 
-$ChecklistItemProvenanceCopyWith<$Res>? get checkedStateApproval;
+$AiChecklistApprovalCopyWith<$Res>? get checkedStateApproval;
 
 }
 /// @nodoc
@@ -377,19 +377,19 @@ as DateTime?,completionDate: freezed == completionDate ? _self.completionDate : 
 as DateTime?,checkedBy: freezed == checkedBy ? _self.checkedBy : checkedBy // ignore: cast_nullable_to_non_nullable
 as String?,checkedAt: freezed == checkedAt ? _self.checkedAt : checkedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,checkedStateApproval: freezed == checkedStateApproval ? _self.checkedStateApproval : checkedStateApproval // ignore: cast_nullable_to_non_nullable
-as ChecklistItemProvenance?,
+as AiChecklistApproval?,
   ));
 }
 /// Create a copy of AiActionItem
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$ChecklistItemProvenanceCopyWith<$Res>? get checkedStateApproval {
+$AiChecklistApprovalCopyWith<$Res>? get checkedStateApproval {
     if (_self.checkedStateApproval == null) {
     return null;
   }
 
-  return $ChecklistItemProvenanceCopyWith<$Res>(_self.checkedStateApproval!, (value) {
+  return $AiChecklistApprovalCopyWith<$Res>(_self.checkedStateApproval!, (value) {
     return _then(_self.copyWith(checkedStateApproval: value));
   });
 }
@@ -474,7 +474,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String title,  bool completed,  bool isArchived,  String? id,  DateTime? deadline,  DateTime? completionDate,  String? checkedBy,  DateTime? checkedAt,  ChecklistItemProvenance? checkedStateApproval)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String title,  bool completed,  bool isArchived,  String? id,  DateTime? deadline,  DateTime? completionDate,  String? checkedBy,  DateTime? checkedAt,  AiChecklistApproval? checkedStateApproval)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _AiActionItem() when $default != null:
 return $default(_that.title,_that.completed,_that.isArchived,_that.id,_that.deadline,_that.completionDate,_that.checkedBy,_that.checkedAt,_that.checkedStateApproval);case _:
@@ -495,7 +495,7 @@ return $default(_that.title,_that.completed,_that.isArchived,_that.id,_that.dead
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String title,  bool completed,  bool isArchived,  String? id,  DateTime? deadline,  DateTime? completionDate,  String? checkedBy,  DateTime? checkedAt,  ChecklistItemProvenance? checkedStateApproval)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String title,  bool completed,  bool isArchived,  String? id,  DateTime? deadline,  DateTime? completionDate,  String? checkedBy,  DateTime? checkedAt,  AiChecklistApproval? checkedStateApproval)  $default,) {final _that = this;
 switch (_that) {
 case _AiActionItem():
 return $default(_that.title,_that.completed,_that.isArchived,_that.id,_that.deadline,_that.completionDate,_that.checkedBy,_that.checkedAt,_that.checkedStateApproval);case _:
@@ -515,7 +515,7 @@ return $default(_that.title,_that.completed,_that.isArchived,_that.id,_that.dead
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String title,  bool completed,  bool isArchived,  String? id,  DateTime? deadline,  DateTime? completionDate,  String? checkedBy,  DateTime? checkedAt,  ChecklistItemProvenance? checkedStateApproval)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String title,  bool completed,  bool isArchived,  String? id,  DateTime? deadline,  DateTime? completionDate,  String? checkedBy,  DateTime? checkedAt,  AiChecklistApproval? checkedStateApproval)?  $default,) {final _that = this;
 switch (_that) {
 case _AiActionItem() when $default != null:
 return $default(_that.title,_that.completed,_that.isArchived,_that.id,_that.deadline,_that.completionDate,_that.checkedBy,_that.checkedAt,_that.checkedStateApproval);case _:
@@ -541,7 +541,7 @@ class _AiActionItem implements AiActionItem {
 @override final  DateTime? completionDate;
 @override final  String? checkedBy;
 @override final  DateTime? checkedAt;
-@override final  ChecklistItemProvenance? checkedStateApproval;
+@override final  AiChecklistApproval? checkedStateApproval;
 
 /// Create a copy of AiActionItem
 /// with the given fields replaced by the non-null parameter values.
@@ -576,11 +576,11 @@ abstract mixin class _$AiActionItemCopyWith<$Res> implements $AiActionItemCopyWi
   factory _$AiActionItemCopyWith(_AiActionItem value, $Res Function(_AiActionItem) _then) = __$AiActionItemCopyWithImpl;
 @override @useResult
 $Res call({
- String title, bool completed, bool isArchived, String? id, DateTime? deadline, DateTime? completionDate, String? checkedBy, DateTime? checkedAt, ChecklistItemProvenance? checkedStateApproval
+ String title, bool completed, bool isArchived, String? id, DateTime? deadline, DateTime? completionDate, String? checkedBy, DateTime? checkedAt, AiChecklistApproval? checkedStateApproval
 });
 
 
-@override $ChecklistItemProvenanceCopyWith<$Res>? get checkedStateApproval;
+@override $AiChecklistApprovalCopyWith<$Res>? get checkedStateApproval;
 
 }
 /// @nodoc
@@ -604,7 +604,7 @@ as DateTime?,completionDate: freezed == completionDate ? _self.completionDate : 
 as DateTime?,checkedBy: freezed == checkedBy ? _self.checkedBy : checkedBy // ignore: cast_nullable_to_non_nullable
 as String?,checkedAt: freezed == checkedAt ? _self.checkedAt : checkedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,checkedStateApproval: freezed == checkedStateApproval ? _self.checkedStateApproval : checkedStateApproval // ignore: cast_nullable_to_non_nullable
-as ChecklistItemProvenance?,
+as AiChecklistApproval?,
   ));
 }
 
@@ -612,15 +612,284 @@ as ChecklistItemProvenance?,
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$ChecklistItemProvenanceCopyWith<$Res>? get checkedStateApproval {
+$AiChecklistApprovalCopyWith<$Res>? get checkedStateApproval {
     if (_self.checkedStateApproval == null) {
     return null;
   }
 
-  return $ChecklistItemProvenanceCopyWith<$Res>(_self.checkedStateApproval!, (value) {
+  return $AiChecklistApprovalCopyWith<$Res>(_self.checkedStateApproval!, (value) {
     return _then(_self.copyWith(checkedStateApproval: value));
   });
 }
+}
+
+
+/// @nodoc
+mixin _$AiChecklistApproval {
+
+ bool get isChecked; DateTime get approvedAt; ChecklistApprovalMode get approvalMode;
+/// Create a copy of AiChecklistApproval
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AiChecklistApprovalCopyWith<AiChecklistApproval> get copyWith => _$AiChecklistApprovalCopyWithImpl<AiChecklistApproval>(this as AiChecklistApproval, _$identity);
+
+  /// Serializes this AiChecklistApproval to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AiChecklistApproval&&(identical(other.isChecked, isChecked) || other.isChecked == isChecked)&&(identical(other.approvedAt, approvedAt) || other.approvedAt == approvedAt)&&(identical(other.approvalMode, approvalMode) || other.approvalMode == approvalMode));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,isChecked,approvedAt,approvalMode);
+
+@override
+String toString() {
+  return 'AiChecklistApproval(isChecked: $isChecked, approvedAt: $approvedAt, approvalMode: $approvalMode)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AiChecklistApprovalCopyWith<$Res>  {
+  factory $AiChecklistApprovalCopyWith(AiChecklistApproval value, $Res Function(AiChecklistApproval) _then) = _$AiChecklistApprovalCopyWithImpl;
+@useResult
+$Res call({
+ bool isChecked, DateTime approvedAt, ChecklistApprovalMode approvalMode
+});
+
+
+
+
+}
+/// @nodoc
+class _$AiChecklistApprovalCopyWithImpl<$Res>
+    implements $AiChecklistApprovalCopyWith<$Res> {
+  _$AiChecklistApprovalCopyWithImpl(this._self, this._then);
+
+  final AiChecklistApproval _self;
+  final $Res Function(AiChecklistApproval) _then;
+
+/// Create a copy of AiChecklistApproval
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? isChecked = null,Object? approvedAt = null,Object? approvalMode = null,}) {
+  return _then(_self.copyWith(
+isChecked: null == isChecked ? _self.isChecked : isChecked // ignore: cast_nullable_to_non_nullable
+as bool,approvedAt: null == approvedAt ? _self.approvedAt : approvedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,approvalMode: null == approvalMode ? _self.approvalMode : approvalMode // ignore: cast_nullable_to_non_nullable
+as ChecklistApprovalMode,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [AiChecklistApproval].
+extension AiChecklistApprovalPatterns on AiChecklistApproval {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AiChecklistApproval value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AiChecklistApproval() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AiChecklistApproval value)  $default,){
+final _that = this;
+switch (_that) {
+case _AiChecklistApproval():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AiChecklistApproval value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AiChecklistApproval() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool isChecked,  DateTime approvedAt,  ChecklistApprovalMode approvalMode)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AiChecklistApproval() when $default != null:
+return $default(_that.isChecked,_that.approvedAt,_that.approvalMode);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool isChecked,  DateTime approvedAt,  ChecklistApprovalMode approvalMode)  $default,) {final _that = this;
+switch (_that) {
+case _AiChecklistApproval():
+return $default(_that.isChecked,_that.approvedAt,_that.approvalMode);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool isChecked,  DateTime approvedAt,  ChecklistApprovalMode approvalMode)?  $default,) {final _that = this;
+switch (_that) {
+case _AiChecklistApproval() when $default != null:
+return $default(_that.isChecked,_that.approvedAt,_that.approvalMode);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _AiChecklistApproval implements AiChecklistApproval {
+  const _AiChecklistApproval({required this.isChecked, required this.approvedAt, required this.approvalMode});
+  factory _AiChecklistApproval.fromJson(Map<String, dynamic> json) => _$AiChecklistApprovalFromJson(json);
+
+@override final  bool isChecked;
+@override final  DateTime approvedAt;
+@override final  ChecklistApprovalMode approvalMode;
+
+/// Create a copy of AiChecklistApproval
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AiChecklistApprovalCopyWith<_AiChecklistApproval> get copyWith => __$AiChecklistApprovalCopyWithImpl<_AiChecklistApproval>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$AiChecklistApprovalToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AiChecklistApproval&&(identical(other.isChecked, isChecked) || other.isChecked == isChecked)&&(identical(other.approvedAt, approvedAt) || other.approvedAt == approvedAt)&&(identical(other.approvalMode, approvalMode) || other.approvalMode == approvalMode));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,isChecked,approvedAt,approvalMode);
+
+@override
+String toString() {
+  return 'AiChecklistApproval(isChecked: $isChecked, approvedAt: $approvedAt, approvalMode: $approvalMode)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AiChecklistApprovalCopyWith<$Res> implements $AiChecklistApprovalCopyWith<$Res> {
+  factory _$AiChecklistApprovalCopyWith(_AiChecklistApproval value, $Res Function(_AiChecklistApproval) _then) = __$AiChecklistApprovalCopyWithImpl;
+@override @useResult
+$Res call({
+ bool isChecked, DateTime approvedAt, ChecklistApprovalMode approvalMode
+});
+
+
+
+
+}
+/// @nodoc
+class __$AiChecklistApprovalCopyWithImpl<$Res>
+    implements _$AiChecklistApprovalCopyWith<$Res> {
+  __$AiChecklistApprovalCopyWithImpl(this._self, this._then);
+
+  final _AiChecklistApproval _self;
+  final $Res Function(_AiChecklistApproval) _then;
+
+/// Create a copy of AiChecklistApproval
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? isChecked = null,Object? approvedAt = null,Object? approvalMode = null,}) {
+  return _then(_AiChecklistApproval(
+isChecked: null == isChecked ? _self.isChecked : isChecked // ignore: cast_nullable_to_non_nullable
+as bool,approvedAt: null == approvedAt ? _self.approvedAt : approvedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,approvalMode: null == approvalMode ? _self.approvalMode : approvalMode // ignore: cast_nullable_to_non_nullable
+as ChecklistApprovalMode,
+  ));
+}
+
+
 }
 
 /// @nodoc

--- a/lib/features/ai/model/ai_input.freezed.dart
+++ b/lib/features/ai/model/ai_input.freezed.dart
@@ -316,7 +316,7 @@ as String?,
 /// @nodoc
 mixin _$AiActionItem {
 
- String get title; bool get completed; bool get isArchived; String? get id; DateTime? get deadline; DateTime? get completionDate; String? get checkedBy; DateTime? get checkedAt;
+ String get title; bool get completed; bool get isArchived; String? get id; DateTime? get deadline; DateTime? get completionDate; String? get checkedBy; DateTime? get checkedAt; ChecklistItemProvenance? get checkedStateApproval;
 /// Create a copy of AiActionItem
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -329,16 +329,16 @@ $AiActionItemCopyWith<AiActionItem> get copyWith => _$AiActionItemCopyWithImpl<A
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AiActionItem&&(identical(other.title, title) || other.title == title)&&(identical(other.completed, completed) || other.completed == completed)&&(identical(other.isArchived, isArchived) || other.isArchived == isArchived)&&(identical(other.id, id) || other.id == id)&&(identical(other.deadline, deadline) || other.deadline == deadline)&&(identical(other.completionDate, completionDate) || other.completionDate == completionDate)&&(identical(other.checkedBy, checkedBy) || other.checkedBy == checkedBy)&&(identical(other.checkedAt, checkedAt) || other.checkedAt == checkedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AiActionItem&&(identical(other.title, title) || other.title == title)&&(identical(other.completed, completed) || other.completed == completed)&&(identical(other.isArchived, isArchived) || other.isArchived == isArchived)&&(identical(other.id, id) || other.id == id)&&(identical(other.deadline, deadline) || other.deadline == deadline)&&(identical(other.completionDate, completionDate) || other.completionDate == completionDate)&&(identical(other.checkedBy, checkedBy) || other.checkedBy == checkedBy)&&(identical(other.checkedAt, checkedAt) || other.checkedAt == checkedAt)&&(identical(other.checkedStateApproval, checkedStateApproval) || other.checkedStateApproval == checkedStateApproval));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,title,completed,isArchived,id,deadline,completionDate,checkedBy,checkedAt);
+int get hashCode => Object.hash(runtimeType,title,completed,isArchived,id,deadline,completionDate,checkedBy,checkedAt,checkedStateApproval);
 
 @override
 String toString() {
-  return 'AiActionItem(title: $title, completed: $completed, isArchived: $isArchived, id: $id, deadline: $deadline, completionDate: $completionDate, checkedBy: $checkedBy, checkedAt: $checkedAt)';
+  return 'AiActionItem(title: $title, completed: $completed, isArchived: $isArchived, id: $id, deadline: $deadline, completionDate: $completionDate, checkedBy: $checkedBy, checkedAt: $checkedAt, checkedStateApproval: $checkedStateApproval)';
 }
 
 
@@ -349,11 +349,11 @@ abstract mixin class $AiActionItemCopyWith<$Res>  {
   factory $AiActionItemCopyWith(AiActionItem value, $Res Function(AiActionItem) _then) = _$AiActionItemCopyWithImpl;
 @useResult
 $Res call({
- String title, bool completed, bool isArchived, String? id, DateTime? deadline, DateTime? completionDate, String? checkedBy, DateTime? checkedAt
+ String title, bool completed, bool isArchived, String? id, DateTime? deadline, DateTime? completionDate, String? checkedBy, DateTime? checkedAt, ChecklistItemProvenance? checkedStateApproval
 });
 
 
-
+$ChecklistItemProvenanceCopyWith<$Res>? get checkedStateApproval;
 
 }
 /// @nodoc
@@ -366,7 +366,7 @@ class _$AiActionItemCopyWithImpl<$Res>
 
 /// Create a copy of AiActionItem
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? completed = null,Object? isArchived = null,Object? id = freezed,Object? deadline = freezed,Object? completionDate = freezed,Object? checkedBy = freezed,Object? checkedAt = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? completed = null,Object? isArchived = null,Object? id = freezed,Object? deadline = freezed,Object? completionDate = freezed,Object? checkedBy = freezed,Object? checkedAt = freezed,Object? checkedStateApproval = freezed,}) {
   return _then(_self.copyWith(
 title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,completed: null == completed ? _self.completed : completed // ignore: cast_nullable_to_non_nullable
@@ -376,10 +376,23 @@ as String?,deadline: freezed == deadline ? _self.deadline : deadline // ignore: 
 as DateTime?,completionDate: freezed == completionDate ? _self.completionDate : completionDate // ignore: cast_nullable_to_non_nullable
 as DateTime?,checkedBy: freezed == checkedBy ? _self.checkedBy : checkedBy // ignore: cast_nullable_to_non_nullable
 as String?,checkedAt: freezed == checkedAt ? _self.checkedAt : checkedAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,
+as DateTime?,checkedStateApproval: freezed == checkedStateApproval ? _self.checkedStateApproval : checkedStateApproval // ignore: cast_nullable_to_non_nullable
+as ChecklistItemProvenance?,
   ));
 }
+/// Create a copy of AiActionItem
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ChecklistItemProvenanceCopyWith<$Res>? get checkedStateApproval {
+    if (_self.checkedStateApproval == null) {
+    return null;
+  }
 
+  return $ChecklistItemProvenanceCopyWith<$Res>(_self.checkedStateApproval!, (value) {
+    return _then(_self.copyWith(checkedStateApproval: value));
+  });
+}
 }
 
 
@@ -461,10 +474,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String title,  bool completed,  bool isArchived,  String? id,  DateTime? deadline,  DateTime? completionDate,  String? checkedBy,  DateTime? checkedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String title,  bool completed,  bool isArchived,  String? id,  DateTime? deadline,  DateTime? completionDate,  String? checkedBy,  DateTime? checkedAt,  ChecklistItemProvenance? checkedStateApproval)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _AiActionItem() when $default != null:
-return $default(_that.title,_that.completed,_that.isArchived,_that.id,_that.deadline,_that.completionDate,_that.checkedBy,_that.checkedAt);case _:
+return $default(_that.title,_that.completed,_that.isArchived,_that.id,_that.deadline,_that.completionDate,_that.checkedBy,_that.checkedAt,_that.checkedStateApproval);case _:
   return orElse();
 
 }
@@ -482,10 +495,10 @@ return $default(_that.title,_that.completed,_that.isArchived,_that.id,_that.dead
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String title,  bool completed,  bool isArchived,  String? id,  DateTime? deadline,  DateTime? completionDate,  String? checkedBy,  DateTime? checkedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String title,  bool completed,  bool isArchived,  String? id,  DateTime? deadline,  DateTime? completionDate,  String? checkedBy,  DateTime? checkedAt,  ChecklistItemProvenance? checkedStateApproval)  $default,) {final _that = this;
 switch (_that) {
 case _AiActionItem():
-return $default(_that.title,_that.completed,_that.isArchived,_that.id,_that.deadline,_that.completionDate,_that.checkedBy,_that.checkedAt);case _:
+return $default(_that.title,_that.completed,_that.isArchived,_that.id,_that.deadline,_that.completionDate,_that.checkedBy,_that.checkedAt,_that.checkedStateApproval);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -502,10 +515,10 @@ return $default(_that.title,_that.completed,_that.isArchived,_that.id,_that.dead
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String title,  bool completed,  bool isArchived,  String? id,  DateTime? deadline,  DateTime? completionDate,  String? checkedBy,  DateTime? checkedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String title,  bool completed,  bool isArchived,  String? id,  DateTime? deadline,  DateTime? completionDate,  String? checkedBy,  DateTime? checkedAt,  ChecklistItemProvenance? checkedStateApproval)?  $default,) {final _that = this;
 switch (_that) {
 case _AiActionItem() when $default != null:
-return $default(_that.title,_that.completed,_that.isArchived,_that.id,_that.deadline,_that.completionDate,_that.checkedBy,_that.checkedAt);case _:
+return $default(_that.title,_that.completed,_that.isArchived,_that.id,_that.deadline,_that.completionDate,_that.checkedBy,_that.checkedAt,_that.checkedStateApproval);case _:
   return null;
 
 }
@@ -517,7 +530,7 @@ return $default(_that.title,_that.completed,_that.isArchived,_that.id,_that.dead
 @JsonSerializable()
 
 class _AiActionItem implements AiActionItem {
-  const _AiActionItem({required this.title, required this.completed, this.isArchived = false, this.id, this.deadline, this.completionDate, this.checkedBy, this.checkedAt});
+  const _AiActionItem({required this.title, required this.completed, this.isArchived = false, this.id, this.deadline, this.completionDate, this.checkedBy, this.checkedAt, this.checkedStateApproval});
   factory _AiActionItem.fromJson(Map<String, dynamic> json) => _$AiActionItemFromJson(json);
 
 @override final  String title;
@@ -528,6 +541,7 @@ class _AiActionItem implements AiActionItem {
 @override final  DateTime? completionDate;
 @override final  String? checkedBy;
 @override final  DateTime? checkedAt;
+@override final  ChecklistItemProvenance? checkedStateApproval;
 
 /// Create a copy of AiActionItem
 /// with the given fields replaced by the non-null parameter values.
@@ -542,16 +556,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AiActionItem&&(identical(other.title, title) || other.title == title)&&(identical(other.completed, completed) || other.completed == completed)&&(identical(other.isArchived, isArchived) || other.isArchived == isArchived)&&(identical(other.id, id) || other.id == id)&&(identical(other.deadline, deadline) || other.deadline == deadline)&&(identical(other.completionDate, completionDate) || other.completionDate == completionDate)&&(identical(other.checkedBy, checkedBy) || other.checkedBy == checkedBy)&&(identical(other.checkedAt, checkedAt) || other.checkedAt == checkedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AiActionItem&&(identical(other.title, title) || other.title == title)&&(identical(other.completed, completed) || other.completed == completed)&&(identical(other.isArchived, isArchived) || other.isArchived == isArchived)&&(identical(other.id, id) || other.id == id)&&(identical(other.deadline, deadline) || other.deadline == deadline)&&(identical(other.completionDate, completionDate) || other.completionDate == completionDate)&&(identical(other.checkedBy, checkedBy) || other.checkedBy == checkedBy)&&(identical(other.checkedAt, checkedAt) || other.checkedAt == checkedAt)&&(identical(other.checkedStateApproval, checkedStateApproval) || other.checkedStateApproval == checkedStateApproval));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,title,completed,isArchived,id,deadline,completionDate,checkedBy,checkedAt);
+int get hashCode => Object.hash(runtimeType,title,completed,isArchived,id,deadline,completionDate,checkedBy,checkedAt,checkedStateApproval);
 
 @override
 String toString() {
-  return 'AiActionItem(title: $title, completed: $completed, isArchived: $isArchived, id: $id, deadline: $deadline, completionDate: $completionDate, checkedBy: $checkedBy, checkedAt: $checkedAt)';
+  return 'AiActionItem(title: $title, completed: $completed, isArchived: $isArchived, id: $id, deadline: $deadline, completionDate: $completionDate, checkedBy: $checkedBy, checkedAt: $checkedAt, checkedStateApproval: $checkedStateApproval)';
 }
 
 
@@ -562,11 +576,11 @@ abstract mixin class _$AiActionItemCopyWith<$Res> implements $AiActionItemCopyWi
   factory _$AiActionItemCopyWith(_AiActionItem value, $Res Function(_AiActionItem) _then) = __$AiActionItemCopyWithImpl;
 @override @useResult
 $Res call({
- String title, bool completed, bool isArchived, String? id, DateTime? deadline, DateTime? completionDate, String? checkedBy, DateTime? checkedAt
+ String title, bool completed, bool isArchived, String? id, DateTime? deadline, DateTime? completionDate, String? checkedBy, DateTime? checkedAt, ChecklistItemProvenance? checkedStateApproval
 });
 
 
-
+@override $ChecklistItemProvenanceCopyWith<$Res>? get checkedStateApproval;
 
 }
 /// @nodoc
@@ -579,7 +593,7 @@ class __$AiActionItemCopyWithImpl<$Res>
 
 /// Create a copy of AiActionItem
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? title = null,Object? completed = null,Object? isArchived = null,Object? id = freezed,Object? deadline = freezed,Object? completionDate = freezed,Object? checkedBy = freezed,Object? checkedAt = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? title = null,Object? completed = null,Object? isArchived = null,Object? id = freezed,Object? deadline = freezed,Object? completionDate = freezed,Object? checkedBy = freezed,Object? checkedAt = freezed,Object? checkedStateApproval = freezed,}) {
   return _then(_AiActionItem(
 title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,completed: null == completed ? _self.completed : completed // ignore: cast_nullable_to_non_nullable
@@ -589,11 +603,24 @@ as String?,deadline: freezed == deadline ? _self.deadline : deadline // ignore: 
 as DateTime?,completionDate: freezed == completionDate ? _self.completionDate : completionDate // ignore: cast_nullable_to_non_nullable
 as DateTime?,checkedBy: freezed == checkedBy ? _self.checkedBy : checkedBy // ignore: cast_nullable_to_non_nullable
 as String?,checkedAt: freezed == checkedAt ? _self.checkedAt : checkedAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,
+as DateTime?,checkedStateApproval: freezed == checkedStateApproval ? _self.checkedStateApproval : checkedStateApproval // ignore: cast_nullable_to_non_nullable
+as ChecklistItemProvenance?,
   ));
 }
 
+/// Create a copy of AiActionItem
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ChecklistItemProvenanceCopyWith<$Res>? get checkedStateApproval {
+    if (_self.checkedStateApproval == null) {
+    return null;
+  }
 
+  return $ChecklistItemProvenanceCopyWith<$Res>(_self.checkedStateApproval!, (value) {
+    return _then(_self.copyWith(checkedStateApproval: value));
+  });
+}
 }
 
 /// @nodoc

--- a/lib/features/ai/model/ai_input.g.dart
+++ b/lib/features/ai/model/ai_input.g.dart
@@ -38,7 +38,7 @@ _AiActionItem _$AiActionItemFromJson(Map<String, dynamic> json) =>
           : DateTime.parse(json['checkedAt'] as String),
       checkedStateApproval: json['checkedStateApproval'] == null
           ? null
-          : ChecklistItemProvenance.fromJson(
+          : AiChecklistApproval.fromJson(
               json['checkedStateApproval'] as Map<String, dynamic>,
             ),
     );
@@ -55,6 +55,29 @@ Map<String, dynamic> _$AiActionItemToJson(_AiActionItem instance) =>
       'checkedAt': instance.checkedAt?.toIso8601String(),
       'checkedStateApproval': instance.checkedStateApproval,
     };
+
+_AiChecklistApproval _$AiChecklistApprovalFromJson(Map<String, dynamic> json) =>
+    _AiChecklistApproval(
+      isChecked: json['isChecked'] as bool,
+      approvedAt: DateTime.parse(json['approvedAt'] as String),
+      approvalMode: $enumDecode(
+        _$ChecklistApprovalModeEnumMap,
+        json['approvalMode'],
+      ),
+    );
+
+Map<String, dynamic> _$AiChecklistApprovalToJson(
+  _AiChecklistApproval instance,
+) => <String, dynamic>{
+  'isChecked': instance.isChecked,
+  'approvedAt': instance.approvedAt.toIso8601String(),
+  'approvalMode': _$ChecklistApprovalModeEnumMap[instance.approvalMode]!,
+};
+
+const _$ChecklistApprovalModeEnumMap = {
+  ChecklistApprovalMode.individual: 'individual',
+  ChecklistApprovalMode.confirmAll: 'confirm_all',
+};
 
 Map<String, dynamic> _$AiInputLogEntryObjectToJson(
   _AiInputLogEntryObject instance,

--- a/lib/features/ai/model/ai_input.g.dart
+++ b/lib/features/ai/model/ai_input.g.dart
@@ -36,6 +36,11 @@ _AiActionItem _$AiActionItemFromJson(Map<String, dynamic> json) =>
       checkedAt: json['checkedAt'] == null
           ? null
           : DateTime.parse(json['checkedAt'] as String),
+      checkedStateApproval: json['checkedStateApproval'] == null
+          ? null
+          : ChecklistItemProvenance.fromJson(
+              json['checkedStateApproval'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$AiActionItemToJson(_AiActionItem instance) =>
@@ -48,6 +53,7 @@ Map<String, dynamic> _$AiActionItemToJson(_AiActionItem instance) =>
       'completionDate': instance.completionDate?.toIso8601String(),
       'checkedBy': instance.checkedBy,
       'checkedAt': instance.checkedAt?.toIso8601String(),
+      'checkedStateApproval': instance.checkedStateApproval,
     };
 
 Map<String, dynamic> _$AiInputLogEntryObjectToJson(

--- a/lib/features/ai/repository/ai_input_repository.dart
+++ b/lib/features/ai/repository/ai_input_repository.dart
@@ -202,7 +202,14 @@ class AiInputRepository {
             id: item.id,
             checkedBy: item.checkedBy.name,
             checkedAt: item.checkedAt,
-            checkedStateApproval: item.checkedStateApproval,
+            checkedStateApproval: switch (item.checkedStateApproval) {
+              final approval? => AiChecklistApproval(
+                isChecked: item.isChecked,
+                approvedAt: approval.approvedAt,
+                approvalMode: approval.approvalMode,
+              ),
+              null => null,
+            },
           ),
         )
         .toList();

--- a/lib/features/ai/repository/ai_input_repository.dart
+++ b/lib/features/ai/repository/ai_input_repository.dart
@@ -202,6 +202,7 @@ class AiInputRepository {
             id: item.id,
             checkedBy: item.checkedBy.name,
             checkedAt: item.checkedAt,
+            checkedStateApproval: item.checkedStateApproval,
           ),
         )
         .toList();

--- a/lib/features/tasks/repository/checklist_repository.dart
+++ b/lib/features/tasks/repository/checklist_repository.dart
@@ -112,6 +112,7 @@ class ChecklistRepository {
             categoryId: newChecklist.meta.categoryId,
             checkedBy: item.checkedBy,
             checkedAt: item.checkedAt,
+            approvalHistory: item.approvalHistory,
           );
           if (checklistItem != null) {
             createdIds.add(checklistItem.id);
@@ -151,7 +152,8 @@ class ChecklistRepository {
   /// Does *not* add the item to the parent checklist's `linkedChecklistItems`;
   /// callers that need the bidirectional link should use [addItemToChecklist]
   /// (or update the checklist themselves). [checkedBy] defaults to
-  /// [ChangeSource.user]. Returns the created item, or `null` on failure.
+  /// [ChangeSource.user]. Approval history is persisted in the same write.
+  /// Returns the created item, or `null` on failure.
   Future<ChecklistItem?> createChecklistItem({
     required String checklistId,
     required String title,
@@ -159,6 +161,7 @@ class ChecklistRepository {
     required String? categoryId,
     ChangeSource? checkedBy,
     DateTime? checkedAt,
+    List<ChecklistItemProvenance> approvalHistory = const [],
   }) async {
     try {
       final meta = await _persistenceLogic.createMetadata();
@@ -170,6 +173,7 @@ class ChecklistRepository {
           linkedChecklists: [checklistId],
           checkedBy: checkedBy ?? ChangeSource.user,
           checkedAt: checkedAt,
+          approvalHistory: approvalHistory,
         ),
       );
 
@@ -286,6 +290,7 @@ class ChecklistRepository {
     required String? categoryId,
     ChangeSource? checkedBy,
     DateTime? checkedAt,
+    List<ChecklistItemProvenance> approvalHistory = const [],
   }) async {
     try {
       // Create the new checklist item first
@@ -296,6 +301,7 @@ class ChecklistRepository {
         categoryId: categoryId,
         checkedBy: checkedBy,
         checkedAt: checkedAt,
+        approvalHistory: approvalHistory,
       );
 
       if (newItem == null) {

--- a/test/classes/checklist_item_data_test.dart
+++ b/test/classes/checklist_item_data_test.dart
@@ -4,7 +4,64 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/classes/checklist_item_data.dart';
 
+import '../features/agents/test_utils.dart' show makeTestChecklistApproval;
+
 void main() {
+  test('chat approval survives JSON and a rename but not a later toggle', () {
+    final receipt = makeTestChecklistApproval();
+    final data = ChecklistItemData(
+      title: 'Inspect feeder',
+      isChecked: true,
+      linkedChecklists: ['checklist'],
+      checkedAt: receipt.approvedAt,
+      approvalHistory: [receipt],
+    );
+    final stored = ChecklistItemData.fromJson(
+      jsonDecode(jsonEncode(data)) as Map<String, dynamic>,
+    );
+    expect(stored.approvalHistory.single, receipt);
+    expect(stored.checkedStateApproval, receipt);
+    expect(
+      stored
+          .copyWith(
+            title: 'Inspect orbital feeder',
+            approvalHistory: [
+              receipt,
+              receipt.copyWith(isChecked: null, decisionId: 'rename'),
+            ],
+          )
+          .checkedStateApproval,
+      receipt,
+    );
+    expect(stored.copyWith(isChecked: false).checkedStateApproval, isNull);
+    expect(
+      stored
+          .copyWith(
+            checkedAt: receipt.approvedAt.add(
+              const Duration(minutes: 1),
+            ),
+          )
+          .checkedStateApproval,
+      isNull,
+    );
+    expect(
+      stored.copyWith(checkedBy: ChangeSource.agent).checkedStateApproval,
+      isNull,
+    );
+    expect(stored.copyWith(approvalHistory: []).checkedStateApproval, isNull);
+  });
+  for (final mode in ChecklistApprovalMode.values) {
+    test('approval JSON uses stable ${mode.name} wire mode', () {
+      final receipt = makeTestChecklistApproval(mode: mode);
+      final json = receipt.toJson();
+      expect(
+        json['approvalMode'],
+        mode == ChecklistApprovalMode.individual ? 'individual' : 'confirm_all',
+      );
+      expect(ChecklistItemProvenance.fromJson(json), receipt);
+    });
+  }
+
   group('ChecklistItemData serialization', () {
     test('round-trips with all fields', () {
       final data = ChecklistItemData(

--- a/test/features/agents/query/query_chat_action_service_test.dart
+++ b/test/features/agents/query/query_chat_action_service_test.dart
@@ -94,8 +94,12 @@ void main() {
         input: const {},
         dependencies: const [],
       ),
-      dispatch: (name, args, taskId) async {
+      dispatch: (name, args, taskId, approval) async {
         expect(taskId, 'task');
+        expect(approval?.originatingMessageId, question);
+        expect(approval?.conversationId, chat);
+        expect(approval?.approvedBy, 'user');
+        expect(approval?.approvalMode, ChecklistApprovalMode.confirmAll);
         calls.add(name);
         if (hold != null) await hold!.future;
         if (deleteAfterFirst) {
@@ -309,7 +313,7 @@ void main() {
           enabled: () => true,
           labels: MockLabelsRepository(),
           readContext: (taskId, ids) => loader.load(taskId, relatedIds: ids),
-          dispatch: (name, args, taskId) async {
+          dispatch: (name, args, taskId, approval) async {
             calls.add(name);
             if (name == 'create_follow_up_task') {
               // Model the journal mutation/ID returned by FollowUpTaskHandler.

--- a/test/features/agents/query/query_test_utils.dart
+++ b/test/features/agents/query/query_test_utils.dart
@@ -21,6 +21,7 @@ class QueryPersistenceBench extends QueryTestBench {
   QueryPersistenceBench() {
     repository = AgentRepository(agentDb);
     final vc = MockVectorClockService();
+    when(vc.getHost).thenAnswer((_) async => 'device');
     when(
       () => vc.getNextVectorClock(previous: any(named: 'previous')),
     ).thenAnswer((_) async => const VectorClock({'device': 1}));

--- a/test/features/agents/service/change_set_confirmation_service_test.dart
+++ b/test/features/agents/service/change_set_confirmation_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
+import 'package:lotti/classes/checklist_item_data.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
@@ -262,6 +263,85 @@ void main() {
   }
 
   group('ChangeSetConfirmationService', () {
+    for (final mode in ChecklistApprovalMode.values) {
+      test(
+        'chat confirmation dispatches trusted ${mode.name} approval',
+        () async {
+          final receipts = <ChecklistItemProvenance>[];
+          var current =
+              makeChangeSetWith(
+                items: const [
+                  ChangeItem(
+                    toolName: 'update_checklist_item',
+                    args: {'id': 'one', 'isChecked': true},
+                    humanSummary: 'Check feeder',
+                  ),
+                  ChangeItem(
+                    toolName: 'update_checklist_item',
+                    args: {'id': 'two', 'isChecked': true},
+                    humanSummary: 'Check sensor',
+                  ),
+                ],
+              ).copyWith(
+                id: 'query-chat:question:actions',
+                runKey: 'query-chat:question',
+                threadId: 'chat',
+              );
+          when(
+            () => mockRepository.getEntity(current.id),
+          ).thenAnswer((_) async => current);
+          when(() => mockSyncService.upsertEntity(any())).thenAnswer((
+            call,
+          ) async {
+            final entity = call.positionalArguments.first;
+            if (entity is ChangeSetEntity) current = entity;
+          });
+          service = ChangeSetConfirmationService(
+            syncService: mockSyncService,
+            labelsRepository: mockLabelsRepository,
+            toolDispatcher: mockToolDispatcher.dispatch,
+            approvedToolDispatcher: (name, args, taskId, approval) async {
+              receipts.add(approval!);
+              expect(args.containsKey('approvalHistory'), isFalse);
+              return const ToolExecutionResult(
+                success: true,
+                output: 'Applied',
+              );
+            },
+          );
+          await withClock(testClock, () async {
+            if (mode == ChecklistApprovalMode.individual) {
+              await service.confirmItem(current, 0);
+            } else {
+              await service.confirmAll(current);
+            }
+          });
+          expect(receipts, isNotEmpty);
+          final decisions = verify(
+            () => mockSyncService.upsertEntity(captureAny()),
+          ).captured.whereType<ChangeDecisionEntity>().toList();
+          for (final receipt in receipts) {
+            expect(receipt.approvedBy, 'user');
+            expect(receipt.approvalHost, 'test-host');
+            expect(receipt.approvedAt, testClock.now());
+            expect(receipt.approvalMode, mode);
+            expect(receipt.originatingMessageId, 'question');
+            expect(receipt.conversationId, 'chat');
+            expect(receipt.changeSetId, current.id);
+            expect(
+              decisions.any(
+                (d) =>
+                    d.id == receipt.decisionId &&
+                    d.actor == DecisionActor.user &&
+                    d.createdAt == receipt.approvedAt,
+              ),
+              isTrue,
+            );
+          }
+        },
+      );
+    }
+
     group('confirmItem', () {
       test('persists decision before dispatch and returns result', () async {
         final changeSet = makeChangeSetWith();

--- a/test/features/agents/test_utils.dart
+++ b/test/features/agents/test_utils.dart
@@ -1,3 +1,4 @@
+import 'package:lotti/classes/checklist_item_data.dart';
 // Barrel file — re-exports all agent test factories from focused files.
 //
 // Existing imports of `test_utils.dart` continue to work unchanged.
@@ -14,3 +15,20 @@ export 'test_data/link_factories.dart';
 export 'test_data/soul_factories.dart';
 export 'test_data/template_factories.dart';
 export 'test_data/wake_factories.dart';
+
+/// Stable receipt for synthetic checklist approval regressions.
+ChecklistItemProvenance makeTestChecklistApproval({
+  ChecklistApprovalMode mode = ChecklistApprovalMode.individual,
+  bool? isChecked = true,
+}) => ChecklistItemProvenance(
+  approvedBy: 'user',
+  approvalHost: 'device',
+  approvedAt: DateTime.utc(2026, 9, 13, 8, 46),
+  approvalMode: mode,
+  originatingMessageId: 'question',
+  conversationId: 'chat',
+  changeSetId: 'query-chat:question:actions',
+  decisionId: 'decision',
+  agentId: 'agent',
+  isChecked: isChecked,
+);

--- a/test/features/agents/tools/checklist_migration_handler_test.dart
+++ b/test/features/agents/tools/checklist_migration_handler_test.dart
@@ -10,6 +10,7 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
+import '../test_utils.dart' show makeTestChecklistApproval;
 
 enum _GeneratedChecklistMigrationBranch {
   invalidItemId,
@@ -391,9 +392,57 @@ void main() {
         title: any(named: 'title'),
         isChecked: any(named: 'isChecked'),
         categoryId: any(named: 'categoryId'),
+        checkedBy: any(named: 'checkedBy'),
+        checkedAt: any(named: 'checkedAt'),
+        approvalHistory: any(named: 'approvalHistory'),
       ),
     ).thenAnswer((_) async => created);
   }
+
+  test('chat migration preserves history on both source and copy', () async {
+    final approval = makeTestChecklistApproval();
+    final item = makeChecklistItem(isChecked: true);
+    stubItemLookup(item);
+    stubSourceTask();
+    stubTargetTask();
+    stubArchiveUpdate();
+    stubAddItemToChecklist(item);
+    handler = ChecklistMigrationHandler(
+      checklistRepository: mockChecklistRepository,
+      journalDb: mockJournalDb,
+      approval: approval,
+    );
+    final result = await handler.handle(sourceTaskId, {
+      'id': item.id,
+      'targetTaskId': targetTaskId,
+    });
+    expect(result.success, isTrue);
+    final copied =
+        verify(
+              () => mockChecklistRepository.addItemToChecklist(
+                checklistId: any(named: 'checklistId'),
+                title: any(named: 'title'),
+                isChecked: any(named: 'isChecked'),
+                categoryId: any(named: 'categoryId'),
+                checkedBy: ChangeSource.user,
+                checkedAt: approval.approvedAt,
+                approvalHistory: captureAny(named: 'approvalHistory'),
+              ),
+            ).captured.single
+            as List<ChecklistItemProvenance>;
+    expect(copied.single, approval.copyWith(isChecked: item.data.isChecked));
+    final source =
+        verify(
+              () => mockChecklistRepository.updateChecklistItem(
+                checklistItemId: item.id,
+                data: captureAny(named: 'data'),
+                taskId: sourceTaskId,
+              ),
+            ).captured.single
+            as ChecklistItemData;
+    expect(source.isArchived, isTrue);
+    expect(source.approvalHistory.single, approval.copyWith(isChecked: null));
+  });
 
   group('ChecklistMigrationHandler', () {
     group('validation', () {
@@ -572,6 +621,9 @@ void main() {
             title: 'Buy milk',
             isChecked: false,
             categoryId: 'cat-002',
+            checkedBy: any(named: 'checkedBy'),
+            checkedAt: any(named: 'checkedAt'),
+            approvalHistory: any(named: 'approvalHistory'),
           ),
         ).called(1);
       });
@@ -612,6 +664,9 @@ void main() {
             title: 'Buy milk',
             isChecked: true,
             categoryId: any(named: 'categoryId'),
+            checkedBy: any(named: 'checkedBy'),
+            checkedAt: any(named: 'checkedAt'),
+            approvalHistory: any(named: 'approvalHistory'),
           ),
         ).called(1);
       });
@@ -692,6 +747,9 @@ void main() {
             title: 'Buy milk',
             isChecked: false,
             categoryId: any(named: 'categoryId'),
+            checkedBy: any(named: 'checkedBy'),
+            checkedAt: any(named: 'checkedAt'),
+            approvalHistory: any(named: 'approvalHistory'),
           ),
         ).called(1);
       });
@@ -894,6 +952,9 @@ void main() {
                 title: any(named: 'title'),
                 isChecked: any(named: 'isChecked'),
                 categoryId: any(named: 'categoryId'),
+                checkedBy: any(named: 'checkedBy'),
+                checkedAt: any(named: 'checkedAt'),
+                approvalHistory: any(named: 'approvalHistory'),
               ),
             ).thenAnswer((_) async {
               if (scenario.branch ==
@@ -1001,6 +1062,9 @@ void main() {
                 title: scenario.title,
                 isChecked: scenario.itemChecked,
                 categoryId: scenario.targetCategoryId,
+                checkedBy: any(named: 'checkedBy'),
+                checkedAt: any(named: 'checkedAt'),
+                approvalHistory: any(named: 'approvalHistory'),
               ),
             ).called(1);
           } else {
@@ -1010,6 +1074,9 @@ void main() {
                 title: any(named: 'title'),
                 isChecked: any(named: 'isChecked'),
                 categoryId: any(named: 'categoryId'),
+                checkedBy: any(named: 'checkedBy'),
+                checkedAt: any(named: 'checkedAt'),
+                approvalHistory: any(named: 'approvalHistory'),
               ),
             );
           }
@@ -1244,6 +1311,9 @@ void main() {
             title: any(named: 'title'),
             isChecked: any(named: 'isChecked'),
             categoryId: any(named: 'categoryId'),
+            checkedBy: any(named: 'checkedBy'),
+            checkedAt: any(named: 'checkedAt'),
+            approvalHistory: any(named: 'approvalHistory'),
           ),
         ).thenAnswer((_) async => null);
 

--- a/test/features/agents/workflow/change_proposal_filter_test.dart
+++ b/test/features/agents/workflow/change_proposal_filter_test.dart
@@ -13,6 +13,25 @@ import 'change_proposal_filter_test_helpers.dart';
 
 void main() {
   group('ChangeProposalFilter.formatBatchResponse', () {
+    test(
+      'protected-state rejection does not claim that the item is missing',
+      () {
+        final response = ChangeProposalFilter.formatBatchResponse(
+          const BatchAddResult(
+            added: 0,
+            skipped: 0,
+            rejected: 1,
+            rejectedDetails: ['User-approved chat state cannot be reversed.'],
+          ),
+        );
+        expect(
+          response,
+          contains('User-approved chat state cannot be reversed'),
+        );
+        expect(response, contains('Do not propose these again'));
+        expect(response, isNot(contains('do not exist')));
+      },
+    );
     test('formats clean batch with only added items', () {
       const result = BatchAddResult(added: 3, skipped: 0);
       expect(

--- a/test/features/agents/workflow/change_set_builder_test.dart
+++ b/test/features/agents/workflow/change_set_builder_test.dart
@@ -498,6 +498,81 @@ extension _AnyGeneratedBuildScenario on glados.Any {
 }
 
 void main() {
+  test(
+    'unavailable approval lookup rejects the proposal without aborting wake',
+    () async {
+      final builder = ChangeSetBuilder(
+        agentId: 'agent',
+        taskId: 'task',
+        threadId: 'wake',
+        runKey: 'run',
+        userApprovedChecklistStateResolver: (_) async =>
+            throw StateError('unavailable'),
+      );
+      expect(
+        await builder.addItem(
+          toolName: TaskAgentToolNames.updateChecklistItem,
+          args: {'id': 'item', 'isChecked': false},
+          humanSummary: 'Uncheck',
+        ),
+        contains('Cannot verify checklist approval state'),
+      );
+      expect(builder.items, isEmpty);
+    },
+  );
+
+  for (final checked in [true, false]) {
+    test(
+      'background suppresses six chat-approved reversals: $checked',
+      () async {
+        final protected = {for (var i = 0; i < 6; i++) 'item-$i': checked};
+        final builder = ChangeSetBuilder(
+          agentId: 'agent',
+          taskId: 'task',
+          threadId: 'wake',
+          runKey: 'run',
+          userApprovedChecklistStateResolver: (id) async => protected[id],
+        );
+        final result = await builder.addBatchItem(
+          toolName: TaskAgentToolNames.updateChecklistItems,
+          args: {
+            'items': [
+              for (final id in protected.keys)
+                {
+                  'id': id,
+                  'isChecked': !checked,
+                  'reason': 'No supporting evidence was found in the task log.',
+                },
+              {'id': 'unexplained', 'isChecked': !checked},
+            ],
+          },
+          summaryPrefix: 'Update',
+        );
+        expect(result.rejected, 6);
+        expect(result.added, 1);
+        expect(builder.items.single.args['id'], 'unexplained');
+        final detail = await builder.addItem(
+          toolName: TaskAgentToolNames.updateChecklistItem,
+          args: {'id': 'item-0', 'isChecked': !checked},
+          humanSummary: 'Reverse',
+        );
+        expect(detail, contains('User-approved chat state'));
+        expect(builder.items.length, 1);
+        // A later UI edit removes the active receipt; lookup must stay live.
+        protected.remove('item-0');
+        expect(
+          await builder.addItem(
+            toolName: TaskAgentToolNames.updateChecklistItem,
+            args: {'id': 'item-0', 'isChecked': !checked},
+            humanSummary: 'Reverse',
+          ),
+          isNull,
+        );
+        expect(builder.items.length, 2);
+      },
+    );
+  }
+
   late ChangeSetBuilder builder;
   late MockAgentSyncService mockSyncService;
   late MockAgentRepository mockRepository;

--- a/test/features/agents/workflow/task_agent_workflow_tools_test.dart
+++ b/test/features/agents/workflow/task_agent_workflow_tools_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/checklist_item_data.dart';
 import 'package:lotti/classes/entity_definitions.dart';
@@ -1048,6 +1050,23 @@ void main() {
         );
 
         test('update_checklist_items is deferred', () async {
+          final date = makeTestChecklistApproval().approvedAt;
+          when(() => mockJournalDb.journalEntityById('item-1')).thenAnswer(
+            (_) async => ChecklistItem(
+              meta: Metadata(
+                id: 'item-1',
+                createdAt: date,
+                updatedAt: date,
+                dateFrom: date,
+                dateTo: date,
+              ),
+              data: const ChecklistItemData(
+                title: 'Inspect feeder',
+                isChecked: false,
+                linkedChecklists: [],
+              ),
+            ),
+          );
           final result = await executeWithToolCallOnRealTask(
             'update_checklist_items',
             '{"items":[{"id":"item-1","isChecked":true}]}',
@@ -1111,6 +1130,64 @@ void main() {
         });
 
         test(
+          'wake rejects six persisted chat approvals but reviews unexplained edits',
+          () async {
+            final approval = makeTestChecklistApproval();
+            for (var i = 0; i < 7; i++) {
+              final item = ChecklistItem(
+                meta: Metadata(
+                  id: 'item-$i',
+                  createdAt: approval.approvedAt,
+                  updatedAt: approval.approvedAt,
+                  dateFrom: approval.approvedAt,
+                  dateTo: approval.approvedAt,
+                ),
+                data: ChecklistItemData(
+                  title: 'Inspect feeder $i',
+                  isChecked: true,
+                  linkedChecklists: [],
+                  checkedAt: approval.approvedAt,
+                  approvalHistory: i < 6 ? [approval] : [],
+                ),
+              );
+              // Read through the actual journal JSON representation, independent
+              // of chat history and the AI input repository's cached prompt.
+              final persisted = JournalEntity.fromJson(
+                jsonDecode(jsonEncode(item)) as Map<String, dynamic>,
+              );
+              when(
+                () => mockJournalDb.journalEntityById(item.id),
+              ).thenAnswer((_) async => persisted);
+            }
+            final result = await executeWithToolCallOnRealTask(
+              'update_checklist_items',
+              jsonEncode({
+                'items': [
+                  for (var i = 0; i < 7; i++)
+                    {
+                      'id': 'item-$i',
+                      'isChecked': false,
+                      'reason':
+                          'No evidence of completion exists in the task log.',
+                    },
+                ],
+              }),
+            );
+            expect(result.success, isTrue);
+            final sets = verify(
+              () => mockSyncService.upsertEntity(captureAny()),
+            ).captured.whereType<ChangeSetEntity>();
+            final proposals = sets.expand((set) => set.items).toList();
+            expect(proposals, isNotEmpty);
+            expect(proposals.every((p) => p.args['id'] == 'item-6'), isTrue);
+            expect(
+              proposals.every((p) => p.args['isChecked'] == false),
+              isTrue,
+            );
+          },
+        );
+
+        test(
           'update_checklist_items resolves title from DB for ID-only items',
           () async {
             // Stub journalEntityById to return a ChecklistItem for the
@@ -1144,7 +1221,7 @@ void main() {
             // Verify the resolver looked up the checklist item.
             verify(
               () => mockJournalDb.journalEntityById('cl-item-1'),
-            ).called(1);
+            ).called(2);
           },
         );
 
@@ -1231,7 +1308,7 @@ void main() {
                 'the duplicate visible proposal must not create or merge a '
                 'change set',
           );
-          verify(() => mockJournalDb.journalEntityById('cl-new')).called(1);
+          verify(() => mockJournalDb.journalEntityById('cl-new')).called(2);
         });
       });
 

--- a/test/features/agents/workflow/task_state_markdown_test.dart
+++ b/test/features/agents/workflow/task_state_markdown_test.dart
@@ -56,7 +56,11 @@ void main() {
           AiActionItem(
             title: 'Inspect feeder',
             completed: true,
-            checkedStateApproval: approval,
+            checkedStateApproval: AiChecklistApproval(
+              isChecked: true,
+              approvedAt: approval.approvedAt,
+              approvalMode: approval.approvalMode,
+            ),
           ),
           const AiActionItem(title: 'Unexplained check', completed: true),
         ],

--- a/test/features/agents/workflow/task_state_markdown_test.dart
+++ b/test/features/agents/workflow/task_state_markdown_test.dart
@@ -3,6 +3,8 @@ import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/agents/workflow/task_state_markdown.dart';
 import 'package:lotti/features/ai/model/ai_input.dart';
 
+import '../test_utils.dart' show makeTestChecklistApproval;
+
 AiInputTaskObject _task({
   String title = 'Test task',
   String status = 'IN PROGRESS',
@@ -46,6 +48,37 @@ extension _AnyActionItems on glados.Any {
 }
 
 void main() {
+  test('prompt distinguishes approved chat state from unexplained checks', () {
+    final approval = makeTestChecklistApproval();
+    final text = renderTaskStateMarkdown(
+      _task(
+        actionItems: [
+          AiActionItem(
+            title: 'Inspect feeder',
+            completed: true,
+            checkedStateApproval: approval,
+          ),
+          const AiActionItem(title: 'Unexplained check', completed: true),
+        ],
+      ),
+    );
+    final lines = text.split('\n');
+    expect(
+      lines.singleWhere((l) => l.contains('Inspect feeder')),
+      contains(
+        'user-approved chat state at ${approval.approvedAt.toIso8601String()}',
+      ),
+    );
+    expect(
+      lines.singleWhere((l) => l.contains('Inspect feeder')),
+      contains('do not reverse'),
+    );
+    expect(
+      lines.singleWhere((l) => l.contains('Unexplained check')),
+      isNot(contains('user-approved')),
+    );
+  });
+
   group('renderTaskStateMarkdown', () {
     // ── generative properties ────────────────────────────────────────────────
 

--- a/test/features/agents/workflow/task_tool_dispatcher_test.dart
+++ b/test/features/agents/workflow/task_tool_dispatcher_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
+import 'package:lotti/database/conversions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/attention_negotiation.dart';
@@ -17,6 +18,8 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
+import '../../../widget_test_utils.dart';
+import '../test_utils.dart' show makeTestChecklistApproval;
 
 enum _GeneratedDispatchGuardTool {
   setTaskTitle,
@@ -341,6 +344,105 @@ void main() {
       persistenceLogic: mockPersistenceLogic,
       timeService: mockTimeService,
     );
+  });
+
+  group('trusted chat checklist dispatch', () {
+    setUp(() async {
+      await setUpTestGetIt(
+        additionalSetup: () {
+          getIt
+            ..unregister<JournalDb>()
+            ..registerSingleton<JournalDb>(mockJournalDb);
+        },
+      );
+    });
+    tearDown(tearDownTestGetIt);
+
+    for (final approved in [true, false]) {
+      test(
+        'passes approval outside tool JSON and reports protection: $approved',
+        () async {
+          final receipt = makeTestChecklistApproval();
+          final task = _makeTestTask(taskId);
+          final home = task.copyWith(
+            data: task.data.copyWith(checklistIds: ['checklist']),
+          );
+          final item = ChecklistItem(
+            meta: task.meta.copyWith(id: 'item'),
+            data: ChecklistItemData(
+              title: 'Inspect feeder',
+              isChecked: true,
+              linkedChecklists: ['checklist'],
+              checkedAt: receipt.approvedAt,
+              approvalHistory: [receipt],
+            ),
+          );
+          when(
+            () => mockJournalDb.journalEntityById(taskId),
+          ).thenAnswer((_) async => home);
+          when(
+            () => mockJournalDb.entriesForIds(['item']),
+          ).thenReturn(MockSelectable([toDbEntity(item)]));
+          when(
+            () => mockChecklistRepository.updateChecklistItem(
+              checklistItemId: 'item',
+              data: any(named: 'data'),
+              taskId: taskId,
+            ),
+          ).thenAnswer((_) async => true);
+          final next = receipt.copyWith(
+            decisionId: 'next',
+            isChecked: null,
+            approvedAt: receipt.approvedAt.add(const Duration(minutes: 1)),
+          );
+          final args = <String, dynamic>{
+            'id': 'item',
+            'isChecked': false,
+            'reason':
+                'There is no evidence that the feeder has been inspected.',
+            'approval': next.toJson(),
+          };
+          final result = approved
+              ? await dispatcher.dispatchApproved(
+                  'update_checklist_item',
+                  args,
+                  taskId,
+                  next,
+                )
+              : await dispatcher.dispatch(
+                  'update_checklist_item',
+                  args,
+                  taskId,
+                );
+          expect(result.success, approved);
+          expect(result.nonRetryable, !approved);
+          if (approved) {
+            final written =
+                verify(
+                      () => mockChecklistRepository.updateChecklistItem(
+                        checklistItemId: 'item',
+                        data: captureAny(named: 'data'),
+                        taskId: taskId,
+                      ),
+                    ).captured.single
+                    as ChecklistItemData;
+            expect(
+              written.checkedStateApproval,
+              next.copyWith(isChecked: false),
+            );
+            expect(written.approvalHistory.length, 2);
+          } else {
+            verifyNever(
+              () => mockChecklistRepository.updateChecklistItem(
+                checklistItemId: 'item',
+                data: any(named: 'data'),
+                taskId: taskId,
+              ),
+            );
+          }
+        },
+      );
+    }
   });
 
   group('TaskToolDispatcher', () {

--- a/test/features/ai/functions/lotti_batch_checklist_handler_test.dart
+++ b/test/features/ai/functions/lotti_batch_checklist_handler_test.dart
@@ -9,6 +9,7 @@ import 'package:uuid/uuid.dart';
 
 import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart' show setUpTestGetIt, tearDownTestGetIt;
+import '../../agents/test_utils.dart' show makeTestChecklistApproval;
 import '../test_utils.dart' show ChecklistTestDataFactory;
 
 const _uuid = Uuid();
@@ -63,6 +64,8 @@ void main() {
         isChecked: any(named: 'isChecked'),
         categoryId: any(named: 'categoryId'),
         checkedBy: any(named: 'checkedBy'),
+        checkedAt: any(named: 'checkedAt'),
+        approvalHistory: any(named: 'approvalHistory'),
       ),
     ).thenAnswer((invocation) async {
       final title = invocation.namedArguments[#title] as String? ?? '';
@@ -111,6 +114,62 @@ void main() {
         error: null,
       );
     });
+  }
+
+  for (final existing in [false, true]) {
+    test(
+      'chat creation carries approval with existing checklist: $existing',
+      () async {
+        final approval = makeTestChecklistApproval();
+        testTask = ChecklistTestDataFactory.createTask(
+          checklistIds: existing ? ['checklist'] : [],
+        );
+        stubTaskById();
+        stubAddItemEcho();
+        stubAutoCreateChecklistEcho();
+        handler = LottiBatchChecklistHandler(
+          task: testTask,
+          autoChecklistService: mockAutoChecklistService,
+          checklistRepository: mockChecklistRepository,
+          approval: approval,
+        );
+        final count = await handler.createBatchItems(
+          const FunctionCallResult(
+            success: true,
+            data: {
+              'items': [
+                {'title': 'Inspect feeder', 'isChecked': true},
+              ],
+            },
+          ),
+        );
+        expect(count, 1);
+        if (existing) {
+          verify(
+            () => mockChecklistRepository.addItemToChecklist(
+              checklistId: 'checklist',
+              title: 'Inspect feeder',
+              isChecked: true,
+              categoryId: testTask.meta.categoryId,
+              checkedBy: ChangeSource.user,
+              checkedAt: approval.approvedAt,
+              approvalHistory: [approval],
+            ),
+          ).called(1);
+        } else {
+          final suggestions =
+              verify(
+                    () => mockAutoChecklistService.autoCreateChecklist(
+                      taskId: testTask.id,
+                      suggestions: captureAny(named: 'suggestions'),
+                      title: 'Todos',
+                    ),
+                  ).captured.single
+                  as List<ChecklistItemData>;
+          expect(suggestions.single.checkedStateApproval, approval);
+        }
+      },
+    );
   }
 
   group('LottiBatchChecklistHandler', () {

--- a/test/features/ai/functions/lotti_checklist_update_handler_test.dart
+++ b/test/features/ai/functions/lotti_checklist_update_handler_test.dart
@@ -994,6 +994,55 @@ void main() {
         ).thenAnswer((_) async => true);
       }
 
+      test(
+        'blocked chat reversal still applies title and archival edits',
+        () async {
+          final receipt = makeTestChecklistApproval();
+          final original = ChecklistTestDataFactory.createChecklistItem(
+            id: 'item-1',
+            title: 'Inspect feeder',
+            isChecked: true,
+            checkedAt: receipt.approvedAt,
+          );
+          final item = original.copyWith(
+            data: original.data.copyWith(approvalHistory: [receipt]),
+          );
+          stubSingleItem(item);
+          final count = await handler.executeUpdates(
+            makeUpdateResult([
+              {
+                'id': item.id,
+                'isChecked': false,
+                'title': 'Inspect penguin feeder',
+                'isArchived': true,
+                'reason': 'There is no evidence of completion in the task log.',
+              },
+            ]),
+          );
+          expect(count, 1);
+          expect(
+            handler.skippedItems.single.reason,
+            LottiChecklistUpdateHandler.userApprovedStateReason,
+          );
+          final written =
+              verify(
+                    () => mockChecklistRepository.updateChecklistItem(
+                      checklistItemId: item.id,
+                      data: captureAny(named: 'data'),
+                      taskId: testTask.id,
+                    ),
+                  ).captured.single
+                  as ChecklistItemData;
+          expect(written.title, 'Inspect penguin feeder');
+          expect(written.isArchived, isTrue);
+          expect(written.isChecked, isTrue);
+          expect(written.checkedAt, receipt.approvedAt);
+          expect(written.checkedBy, ChangeSource.user);
+          expect(written.approvalHistory, [receipt]);
+          expect(written.checkedStateApproval, receipt);
+        },
+      );
+
       for (final approved in [false, true]) {
         test(
           'chat receipt blocks reversal unless freshly approved: $approved',

--- a/test/features/ai/functions/lotti_checklist_update_handler_test.dart
+++ b/test/features/ai/functions/lotti_checklist_update_handler_test.dart
@@ -11,6 +11,7 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart' show setUpTestGetIt, tearDownTestGetIt;
+import '../../agents/test_utils.dart' show makeTestChecklistApproval;
 import '../test_utils.dart' show ChecklistTestDataFactory;
 
 // Mocks
@@ -993,6 +994,120 @@ void main() {
         ).thenAnswer((_) async => true);
       }
 
+      for (final approved in [false, true]) {
+        test(
+          'chat receipt blocks reversal unless freshly approved: $approved',
+          () async {
+            final receipt = makeTestChecklistApproval();
+            final original = ChecklistTestDataFactory.createChecklistItem(
+              id: 'item-1',
+              title: 'Inspect feeder',
+              isChecked: true,
+              checkedAt: receipt.approvedAt,
+            );
+            final item = original.copyWith(
+              data: original.data.copyWith(
+                approvalHistory: [receipt],
+              ),
+            );
+            stubSingleItem(item);
+            final next = receipt.copyWith(
+              decisionId: 'next',
+              isChecked: null,
+              approvedAt: receipt.approvedAt.add(const Duration(minutes: 1)),
+            );
+            handler = LottiChecklistUpdateHandler(
+              task: testTask,
+              checklistRepository: mockChecklistRepository,
+              approval: approved ? next : null,
+            );
+            final count = await handler.executeUpdates(
+              makeUpdateResult([
+                {
+                  'id': item.id,
+                  'isChecked': false,
+                  'approval': next.toJson(),
+                  'reason':
+                      'There is no evidence of completion in the task log.',
+                },
+              ]),
+            );
+            expect(count, approved ? 1 : 0);
+            if (approved) {
+              final written =
+                  verify(
+                        () => mockChecklistRepository.updateChecklistItem(
+                          checklistItemId: item.id,
+                          data: captureAny(named: 'data'),
+                          taskId: testTask.id,
+                        ),
+                      ).captured.single
+                      as ChecklistItemData;
+              expect(written.isChecked, isFalse);
+              expect(written.checkedBy, ChangeSource.user);
+              expect(written.checkedAt, next.approvedAt);
+              expect(written.approvalHistory, [
+                receipt,
+                next.copyWith(isChecked: false),
+              ]);
+              expect(
+                written.checkedStateApproval,
+                next.copyWith(isChecked: false),
+              );
+            } else {
+              expect(
+                handler.skippedItems.single.reason,
+                contains('User-approved chat state'),
+              );
+              verifyNever(
+                () => mockChecklistRepository.updateChecklistItem(
+                  checklistItemId: any(named: 'checklistItemId'),
+                  data: any(named: 'data'),
+                  taskId: any(named: 'taskId'),
+                ),
+              );
+            }
+          },
+        );
+      }
+      test(
+        'chat approval of an unchanged check still records user intent',
+        () async {
+          final receipt = makeTestChecklistApproval();
+          final item = ChecklistTestDataFactory.createChecklistItem(
+            id: 'item-1',
+            title: 'Inspect feeder',
+            isChecked: true,
+            checkedBy: ChangeSource.agent,
+          );
+          stubSingleItem(item);
+          handler = LottiChecklistUpdateHandler(
+            task: testTask,
+            checklistRepository: mockChecklistRepository,
+            approval: receipt,
+          );
+          expect(
+            await handler.executeUpdates(
+              makeUpdateResult([
+                {'id': item.id, 'isChecked': true},
+              ]),
+            ),
+            1,
+          );
+          final written =
+              verify(
+                    () => mockChecklistRepository.updateChecklistItem(
+                      checklistItemId: item.id,
+                      data: captureAny(named: 'data'),
+                      taskId: testTask.id,
+                    ),
+                  ).captured.single
+                  as ChecklistItemData;
+          expect(written.checkedStateApproval, receipt);
+          expect(written.checkedBy, ChangeSource.user);
+        },
+      );
+
       test('blocks isChecked change on user-set item without reason', () async {
         final item = ChecklistTestDataFactory.createChecklistItem(
           id: 'item-1',
@@ -1446,15 +1561,7 @@ JournalDbEntity _createDbEntity(ChecklistItem item) {
         'dateTo': item.meta.dateTo.toIso8601String(),
         'categoryId': item.meta.categoryId,
       },
-      'data': {
-        'title': item.data.title,
-        'isChecked': item.data.isChecked,
-        'isArchived': item.data.isArchived,
-        'linkedChecklists': item.data.linkedChecklists,
-        'checkedBy': item.data.checkedBy.name,
-        if (item.data.checkedAt != null)
-          'checkedAt': item.data.checkedAt!.toIso8601String(),
-      },
+      'data': item.data.toJson(),
     }),
     schemaVersion: 1,
     deleted: false,

--- a/test/features/ai/model/ai_input_test.dart
+++ b/test/features/ai/model/ai_input_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/checklist_item_data.dart';
 import 'package:lotti/features/ai/model/ai_input.dart';
 
 /// Full JSON round-trip through encode/decode so nested freezed objects are
@@ -24,6 +25,28 @@ void main() {
     test('AiActionItem survives a JSON round-trip', () {
       expect(AiActionItem.fromJson(_roundTrip(actionItem)), actionItem);
     });
+
+    for (final mode in ChecklistApprovalMode.values) {
+      for (final checked in [true, false]) {
+        test('approval prompt round-trip keeps intent: $mode / $checked', () {
+          final approval = AiChecklistApproval(
+            isChecked: checked,
+            approvedAt: DateTime.utc(2026, 9, 13, 8),
+            approvalMode: mode,
+          );
+          final item = actionItem.copyWith(checkedStateApproval: approval);
+          final json = _roundTrip(item);
+          expect(json['checkedStateApproval'], {
+            'isChecked': checked,
+            'approvedAt': '2026-09-13T08:00:00.000Z',
+            'approvalMode': mode == ChecklistApprovalMode.individual
+                ? 'individual'
+                : 'confirm_all',
+          });
+          expect(AiActionItem.fromJson(json), item);
+        });
+      }
+    }
 
     test('AiInputLogEntryObject emits the prompt transport shape', () {
       final entry = AiInputLogEntryObject(

--- a/test/features/ai/repository/ai_input_repository_test.dart
+++ b/test/features/ai/repository/ai_input_repository_test.dart
@@ -30,6 +30,7 @@ import 'package:mocktail/mocktail.dart';
 import '../../../helpers/entity_factories.dart';
 import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
+import '../../agents/test_utils.dart' show makeTestChecklistApproval;
 import '../test_utils.dart';
 
 // Local fake (not a plain mock): computes real union durations so the
@@ -564,10 +565,12 @@ void main() {
             createdAt: creationDate,
             updatedAt: creationDate,
           ),
-          data: const ChecklistItemData(
+          data: ChecklistItemData(
             title: 'Test Checklist Item',
             isChecked: true,
             linkedChecklists: [checklistId],
+            checkedAt: makeTestChecklistApproval().approvedAt,
+            approvalHistory: [makeTestChecklistApproval()],
           ),
         );
 
@@ -627,6 +630,10 @@ void main() {
         expect(result.actionItems.length, 1);
         expect(result.actionItems[0].title, 'Test Checklist Item');
         expect(result.actionItems[0].completed, true);
+        expect(
+          result.actionItems[0].checkedStateApproval,
+          makeTestChecklistApproval(),
+        );
 
         // Check log entries
         expect(result.logEntries.length, 1);

--- a/test/features/ai/repository/ai_input_repository_test.dart
+++ b/test/features/ai/repository/ai_input_repository_test.dart
@@ -632,8 +632,21 @@ void main() {
         expect(result.actionItems[0].completed, true);
         expect(
           result.actionItems[0].checkedStateApproval,
-          makeTestChecklistApproval(),
+          AiChecklistApproval(
+            isChecked: true,
+            approvedAt: makeTestChecklistApproval().approvedAt,
+            approvalMode: ChecklistApprovalMode.individual,
+          ),
         );
+
+        // Generic task prompts must carry intent, never the audit identifiers.
+        final prompt = jsonDecode(jsonEncode(result)) as Map<String, dynamic>;
+        expect(prompt['actionItems'][0]['checkedStateApproval'], {
+          'isChecked': true,
+          'approvedAt': makeTestChecklistApproval().approvedAt
+              .toIso8601String(),
+          'approvalMode': 'individual',
+        });
 
         // Check log entries
         expect(result.logEntries.length, 1);

--- a/test/features/tasks/repository/checklist_repository_test.dart
+++ b/test/features/tasks/repository/checklist_repository_test.dart
@@ -17,6 +17,7 @@ import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../../../test_data/test_data.dart';
 import '../../../widget_test_utils.dart';
+import '../../agents/test_utils.dart' show makeTestChecklistApproval;
 
 void main() {
   final testDate = DateTime(2024, 3, 15, 10, 30);
@@ -168,14 +169,17 @@ void main() {
       final checklistItemMetadata = testTask.meta.copyWith(
         id: 'checklist-item-id',
       );
+      final approval = makeTestChecklistApproval();
       final items = [
         const ChecklistItemData(
           title: 'Item 1',
           isChecked: false,
           linkedChecklists: [],
         ),
-        const ChecklistItemData(
+        ChecklistItemData(
           title: 'Item 2',
+          checkedAt: approval.approvedAt,
+          approvalHistory: [approval],
           isChecked: true,
           linkedChecklists: [],
         ),
@@ -232,9 +236,24 @@ void main() {
       // Assert
       expect(result.checklist, isNotNull);
       expect(result.createdItems, hasLength(items.length));
-      verify(
-        () => mockPersistenceLogic.createDbEntity(any()),
-      ).called(greaterThan(1));
+      final written = verify(
+        () => mockPersistenceLogic.createDbEntity(captureAny()),
+      ).captured.whereType<ChecklistItem>().toList();
+      expect(written.length, 2);
+      expect(
+        written
+            .singleWhere((item) => item.data.title == 'Item 2')
+            .data
+            .checkedStateApproval,
+        approval,
+      );
+      expect(
+        written
+            .singleWhere((item) => item.data.title == 'Item 1')
+            .data
+            .approvalHistory,
+        isEmpty,
+      );
     });
 
     test('handles checklist items not being created', () async {
@@ -342,6 +361,32 @@ void main() {
   });
 
   group('createChecklistItem', () {
+    test('persists chat receipt together with the checklist item', () async {
+      final approval = makeTestChecklistApproval();
+      when(
+        () => mockPersistenceLogic.createMetadata(),
+      ).thenAnswer((_) async => fallbackChecklistItem.meta);
+      when(
+        () => mockPersistenceLogic.createDbEntity(any()),
+      ).thenAnswer((_) async => true);
+      final item = await repository.createChecklistItem(
+        checklistId: 'checklist',
+        title: 'Inspect feeder',
+        isChecked: true,
+        categoryId: null,
+        checkedAt: approval.approvedAt,
+        approvalHistory: [approval],
+      );
+      final written =
+          verify(
+                () => mockPersistenceLogic.createDbEntity(captureAny()),
+              ).captured.single
+              as ChecklistItem;
+      expect(written.data.approvalHistory.single, approval);
+      expect(written.data.checkedStateApproval, approval);
+      expect(item, written);
+    });
+
     test('creates checklist item successfully', () async {
       // Arrange
       const checklistId = 'checklist-id';
@@ -822,18 +867,22 @@ void main() {
           () => mockPersistenceLogic.updateDbEntity(any()),
         ).thenAnswer((_) async => true);
 
+        final approval = makeTestChecklistApproval(isChecked: isChecked);
         // Act
         final result = await repository.addItemToChecklist(
           checklistId: checklistId,
           title: title,
           isChecked: isChecked,
           categoryId: categoryId,
+          checkedAt: approval.approvedAt,
+          approvalHistory: [approval],
         );
 
         // Assert
         expect(result, isNotNull);
         expect(result!.data.title, equals(title));
         expect(result.data.isChecked, equals(isChecked));
+        expect(result.data.checkedStateApproval, approval);
 
         // Verify that the checklist was updated with the new item
         final capturedChecklist =


### PR DESCRIPTION
After a user confirms checklist changes in task chat, the background task agent can see checks without supporting task-note evidence and propose reversing them. Record human approval with each checklist mutation and enforce that approval when the background agent proposes or applies later changes.

Each new chat approval appends a receipt to the checklist item's persisted, synced `approvalHistory` in the same write as the mutation. It records the local human actor and approving device, approval time, originating question/chat, proposal and decision IDs, executing agent, approval mode (`individual` or `confirm_all`), and checked value when applicable. The trusted confirmation channel supplies this metadata separately from model arguments. Creation, updates and migration preserve the history.

Model context receives only the approved value, timestamp and approval mode through a separate prompt type; internal audit identifiers remain in the journal receipt. Wake context explains the current human-approved state. Live proposal guards and execution guards prevent autonomous reversals, including stale pending proposals with a persuasive reason. A later explicit human-approved instruction can change the state; a later direct checkbox toggle supersedes the old receipt. Renames preserve protection. Legacy items remain eligible for the existing checks; this does not invent or backfill historical approvals.

Validation: 616 targeted tests across affected models, confirmation/dispatch, handlers, repositories, providers and wake workflow passed. The synthetic six-item reproduction produces zero reversal proposals while unprotected edits remain reviewable. Regression counter-checks fail with the fixes disabled. Full analyzer, knowledge and changelog checks pass on the current main/Flutter 3.47.4 base. The review follow-up passes all 169 affected tests, including exact prompt-JSON redaction and a protected reversal combined with valid title/archival changes. The approval UI is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Human-approved chat checklist changes now retain approval history, including timestamp and approval mode.
  * Approved checklist states are displayed to task agents with guidance not to reverse them.
  * Approved checklist updates and migrations preserve user attribution and approval details.

* **Bug Fixes**
  * Task agents now reject proposals that would reverse human-approved checklist states.
  * Failed approval checks safely prevent potentially conflicting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->