### PR TITLE
feat(system_health): attribute slow transactions to their caller and database

### DIFF
--- a/changelog.d/2026-09-13-system-health-transaction-attribution.md
+++ b/changelog.d/2026-09-13-system-health-transaction-attribution.md
@@ -1,0 +1,8 @@
+### Changed
+- **The system health report can now say why transactions waited.** Slow
+  statements are listed per database instead of merged across all of them,
+  each is attributed to the code that issued it rather than to the shared
+  transaction wrapper, and a statement that queued behind others shows how
+  deep the queue was when it started. A failed agent wake is also logged with
+  its kind and the workflow's own reason instead of a bare error type, so the
+  report can tell a missing template from a network error.

--- a/knowledge/features/system_health.md
+++ b/knowledge/features/system_health.md
@@ -150,13 +150,26 @@ from the ARB catalogs.
   replaced, cut at 200 characters. Each bucket keeps its count, first and last
   seen, the first redacted sample and up to six `package:lotti/` stack frames
   from that sample. Errors sort before warnings, then by count.
-- **Slow queries**: grouped by a normalised statement (quoted literals and
-  numbers to `?`, `IN (?, ?, ?)` to `(?...)`, whitespace collapsed), with
-  count, p50 / p95 / max / total elapsed, distinct `EXPLAIN QUERY PLAN` shapes
-  and distinct top app frames. A query above the super-slow cutoff is written
-  to *both* files, so statistics come from the slow file's series and the
-  super-slow file only contributes plans, frames and `superSlowCount`; a
-  statement seen only in the super-slow file falls back to that series.
+- **Slow queries**: grouped by database file *and* a normalised statement
+  (quoted literals and numbers to `?`, `IN (?, ?, ?)` to `(?...)`, whitespace
+  collapsed), with count, p50 / p95 / max / total elapsed, distinct `EXPLAIN
+  QUERY PLAN` shapes and distinct caller frames. The database is part of the
+  key because a `BEGIN` on the agent database and one on the sync database
+  queue behind different writer locks. The caller frame is the first app frame
+  below the transaction wrappers (`runInTransaction`, `withVcScope`,
+  `_markInTransaction`); the wrapper itself is every `BEGIN`'s first frame and
+  names nothing. A query above the super-slow cutoff is written to *both*
+  files, so statistics come from the slow file's series and the super-slow
+  file only contributes plans, frames and `superSlowCount`; a statement seen
+  only in the super-slow file falls back to that series.
+- **Queue depth**: the interceptor's `TIMING:` row carries `inFlightAtStart`
+  and its `TRANSACTION:` row the transactions open when the statement started.
+  Elapsed time is measured from the moment drift accepts a request, so a
+  statement that queued reports the wait as its own cost — for a `BEGIN`
+  (drift holds the writer lock for a transaction's whole lifetime) the wait
+  *is* the cost. Each bucket that carries the rows reports p50 and max of
+  both, which is what separates "one transaction held for seconds" from
+  "dozens opened at once".
 - **Domain counts** by level, and **error bursts**: minutes with at least ten
   errors and at least three times the lower median of error-carrying minutes.
 - Bucket caps (25 issues, 15 statements) set `truncated`, which the rendering

--- a/knowledge/features/system_health.md
+++ b/knowledge/features/system_health.md
@@ -162,14 +162,19 @@ from the ARB catalogs.
   files, so statistics come from the slow file's series and the super-slow
   file only contributes plans, frames and `superSlowCount`; a statement seen
   only in the super-slow file falls back to that series.
-- **Queue depth**: the interceptor's `TIMING:` row carries `inFlightAtStart`
-  and its `TRANSACTION:` row the transactions open when the statement started.
+- **Concurrency at start**: the interceptor's `TIMING:` row carries
+  `inFlightAtStart` (the statement itself included, so one is subtracted) and
+  its `TRANSACTION:` row the transactions open when the statement started.
+  Each bucket that carries the rows reports p50 and max of both, taken from
+  the slow file's entry only — the super-slow copy repeats the same rows.
   Elapsed time is measured from the moment drift accepts a request, so a
-  statement that queued reports the wait as its own cost — for a `BEGIN`
-  (drift holds the writer lock for a transaction's whole lifetime) the wait
-  *is* the cost. Each bucket that carries the rows reports p50 and max of
-  both, which is what separates "one transaction held for seconds" from
-  "dozens opened at once".
+  statement that waited reports the wait as its own cost; whether these
+  counters *are* that wait depends on the statement. For `transaction.open`
+  they are: drift holds the writer lock for a transaction's whole lifetime,
+  so the open transactions are what the `BEGIN` queued behind, and the row
+  separates "one transaction held for seconds" from "dozens opened at once".
+  A select served by the read pool overlaps a transaction without waiting for
+  it, so for reads the row describes concurrency, not a queue.
 - **Domain counts** by level, and **error bursts**: minutes with at least ten
   errors and at least three times the lower median of error-carrying minutes.
 - Bucket caps (25 issues, 15 statements) set `truncated`, which the rendering

--- a/lib/features/agents/database/agent_repo_evolution.dart
+++ b/lib/features/agents/database/agent_repo_evolution.dart
@@ -1,4 +1,3 @@
-import 'package:drift/drift.dart';
 import 'package:lotti/features/agents/database/agent_database.dart';
 import 'package:lotti/features/agents/database/agent_db_conversions.dart';
 import 'package:lotti/features/agents/database/agent_proposal_ledger.dart';
@@ -90,42 +89,22 @@ class AgentRepoEvolution {
     });
   }
 
-  /// Fetch agent identities filtered by lifecycle in SQL.
+  /// Fetch agent identities filtered by [lifecycle], newest first.
   ///
-  /// Startup restore paths ask for active agents repeatedly. Keeping that
-  /// predicate in SQLite avoids decoding dormant/destroyed identity rows in
-  /// every service that calls `AgentService.listAgents(lifecycle: active)`.
+  /// Served from the cached identity list ([getAllAgentIdentities]) and
+  /// filtered in Dart. Every before-scan maintenance hook and several
+  /// providers ask for the active agents on every wake pass; as a SQL
+  /// predicate this was the second most expensive statement in the slow-query
+  /// log by call count while the cache already held the same rows. Lifecycle
+  /// is part of the identity entity, so an identity write invalidates the
+  /// cache and a lifecycle change is visible on the next call.
   Future<List<AgentIdentityEntity>> getAgentIdentitiesByLifecycle(
     AgentLifecycle lifecycle,
   ) async {
-    final rows = await _db
-        .customSelect(
-          r'''
-            SELECT *
-            FROM agent_entities INDEXED BY idx_agent_entities_active_type_created
-            WHERE type = ?
-              AND deleted_at IS NULL
-              AND json_extract(serialized, '$.lifecycle') = ?
-            ORDER BY created_at DESC
-          ''',
-          variables: [
-            Variable.withString('agent'),
-            Variable.withString(lifecycle.name),
-          ],
-          readsFrom: {_db.agentEntities},
-        )
-        .get();
-
-    final identities = <AgentIdentityEntity>[];
-    for (final row in rows) {
-      final entity = AgentDbConversions.fromEntityRow(
-        await _db.agentEntities.mapFromRow(row),
-      );
-      if (entity case final AgentIdentityEntity identity) {
-        identities.add(identity);
-      }
-    }
-    return identities;
+    final identities = await getAllAgentIdentities();
+    return identities
+        .where((identity) => identity.lifecycle == lifecycle)
+        .toList(growable: false);
   }
 
   /// Fetch agent entities (including soft-deleted) whose serialized

--- a/lib/features/agents/state/agent_wiring.dart
+++ b/lib/features/agents/state/agent_wiring.dart
@@ -34,7 +34,10 @@ void wireWakeExecutor(
       );
 
       if (!result.success) {
-        throw StateError(result.error ?? 'Improver agent wake failed');
+        throw WakeFailedException(
+          kind: 'improver',
+          reason: result.error ?? 'wake failed',
+        );
       }
 
       await _notifyWakeCompletion(
@@ -56,7 +59,10 @@ void wireWakeExecutor(
       );
 
       if (!result.success) {
-        throw StateError(result.error ?? 'Project agent wake failed');
+        throw WakeFailedException(
+          kind: 'project',
+          reason: result.error ?? 'wake failed',
+        );
       }
 
       await _notifyWakeCompletion(
@@ -78,7 +84,10 @@ void wireWakeExecutor(
       );
 
       if (!result.success) {
-        throw StateError(result.error ?? 'Event agent wake failed');
+        throw WakeFailedException(
+          kind: 'event',
+          reason: result.error ?? 'wake failed',
+        );
       }
 
       await _notifyWakeCompletion(
@@ -104,7 +113,10 @@ void wireWakeExecutor(
       );
 
       if (!result.success) {
-        throw StateError(result.error ?? '${identity.kind} wake failed');
+        throw WakeFailedException(
+          kind: identity.kind,
+          reason: result.error ?? 'wake failed',
+        );
       }
 
       await _notifyWakeCompletion(
@@ -140,7 +152,10 @@ void wireWakeExecutor(
     // WakeOrchestrator converts executor exceptions into failed wake-run
     // status, ensuring run-log accuracy.
     if (!result.success) {
-      throw StateError(result.error ?? 'Task agent wake failed');
+      throw WakeFailedException(
+        kind: 'task',
+        reason: result.error ?? 'wake failed',
+      );
     }
 
     final extraTokens = <String>{};

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -849,9 +849,13 @@ extension WakeDrainEngine on WakeOrchestrator {
       } catch (e) {
         _suppression.clearPreRegistered(job.agentId);
         final elapsed = clock.now().difference(startTime);
+        // The reason rides in the message: the PII-safe error log keeps
+        // only message and error type, and a bare type says nothing about
+        // which workflow reason it was.
         logError(
           'wake failed in ${elapsed.inMilliseconds}ms '
-          'for ${DomainLogger.sanitizeId(job.runKey)}',
+          'for ${DomainLogger.sanitizeId(job.runKey)}'
+          '${e is WakeFailedException ? ' kind=${e.kind} reason=${e.reason}' : ''}',
           error: e,
         );
         await _safeUpdateStatus(

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -15,6 +15,7 @@ import 'package:lotti/features/agents/wake/wake_queue.dart';
 import 'package:lotti/features/agents/wake/wake_runner.dart';
 import 'package:lotti/features/agents/wake/wake_suppression_tracker.dart';
 import 'package:lotti/features/agents/wake/wake_throttle_coordinator.dart';
+import 'package:lotti/features/agents/workflow/wake_result.dart';
 import 'package:lotti/features/ai/model/ai_runtime_settings.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/services/db_notification.dart';

--- a/lib/features/agents/workflow/event_agent_workflow.dart
+++ b/lib/features/agents/workflow/event_agent_workflow.dart
@@ -549,7 +549,7 @@ class EventAgentWorkflow with AgentErrorLogging {
         );
       }
 
-      return WakeResult(success: false, error: e.toString());
+      return WakeResult.failed(kind: 'Event agent', error: e);
     } finally {
       conversationRepository.deleteConversation(conversationId);
     }

--- a/lib/features/agents/workflow/project_agent_workflow.dart
+++ b/lib/features/agents/workflow/project_agent_workflow.dart
@@ -221,7 +221,7 @@ class ProjectAgentWorkflow with AgentErrorLogging {
       );
     }
 
-    return WakeResult(success: false, error: error.toString());
+    return WakeResult.failed(kind: 'Project agent', error: error);
   }
 
   Future<void> _skipDormantScheduledWake({

--- a/lib/features/agents/workflow/task_agent_execute.dart
+++ b/lib/features/agents/workflow/task_agent_execute.dart
@@ -922,7 +922,7 @@ extension TaskAgentExecute on TaskAgentWorkflow {
         );
       }
 
-      return WakeResult(success: false, error: e.toString());
+      return WakeResult.failed(kind: 'Task agent', error: e);
     } finally {
       preparationTimer.stop();
       conversationTimer.stop();

--- a/lib/features/agents/workflow/wake_result.dart
+++ b/lib/features/agents/workflow/wake_result.dart
@@ -33,18 +33,16 @@ class WakeResult {
 
   /// A failed wake whose workflow caught [error], with a bounded [WakeResult.error].
   ///
-  /// A [StateError] is the workflows' own abort signal (`No active project
-  /// ID`, `no visible reply`, drift's closed-transaction message) and its
-  /// message is kept; every other exception is reported by type only, since
-  /// provider and filesystem exceptions carry response bodies and paths that
-  /// must not reach the PII-safe error log. The catch site logs the raw
-  /// exception with its stack trace to the full log.
+  /// The exception is reported by type only — never its message. Provider and
+  /// filesystem exceptions carry response bodies and paths, and even the
+  /// workflows' own `StateError`s interpolate model-emitted tool names, none
+  /// of which may reach the PII-safe error log. The type alone still tells a
+  /// missing draft plan from an inference failure. The catch site logs the
+  /// raw exception with its stack trace to the full log.
   factory WakeResult.failed({required String kind, required Object error}) =>
       WakeResult(
         success: false,
-        error: error is StateError
-            ? '$kind workflow failed: ${error.message}'
-            : '$kind workflow failed (${error.runtimeType})',
+        error: '$kind workflow failed (${error.runtimeType})',
       );
 
   /// Whether the wake completed successfully.

--- a/lib/features/agents/workflow/wake_result.dart
+++ b/lib/features/agents/workflow/wake_result.dart
@@ -1,5 +1,27 @@
 import 'package:lotti/features/sync/vector_clock.dart';
 
+/// A wake whose workflow reported failure through [WakeResult.error].
+///
+/// Thrown by the wake executor wiring so the drain engine's failure log can
+/// name the agent kind and the workflow's reason. Before this the wiring
+/// rethrew a bare `StateError`, which the PII-safe error log reduced to
+/// `errorType=StateError` — indistinguishable from a genuine `StateError`
+/// (a closed database transaction, say) and silent about which of the
+/// workflows' reasons it was. [reason] is a workflow-authored string, never
+/// user content.
+class WakeFailedException implements Exception {
+  const WakeFailedException({required this.kind, required this.reason});
+
+  /// The agent kind whose workflow failed, e.g. `task` or `goal`.
+  final String kind;
+
+  /// The workflow's [WakeResult.error], or a kind-specific default.
+  final String reason;
+
+  @override
+  String toString() => 'WakeFailedException($kind): $reason';
+}
+
 /// Result of a wake cycle execution.
 class WakeResult {
   const WakeResult({

--- a/lib/features/agents/workflow/wake_result.dart
+++ b/lib/features/agents/workflow/wake_result.dart
@@ -8,7 +8,7 @@ import 'package:lotti/features/sync/vector_clock.dart';
 /// `errorType=StateError` — indistinguishable from a genuine `StateError`
 /// (a closed database transaction, say) and silent about which of the
 /// workflows' reasons it was. [reason] is a workflow-authored string, never
-/// user content.
+/// user content — see the contract on [WakeResult.error].
 class WakeFailedException implements Exception {
   const WakeFailedException({required this.kind, required this.reason});
 
@@ -31,6 +31,22 @@ class WakeResult {
     this.error,
   });
 
+  /// A failed wake whose workflow caught [error], with a bounded [WakeResult.error].
+  ///
+  /// A [StateError] is the workflows' own abort signal (`No active project
+  /// ID`, `no visible reply`, drift's closed-transaction message) and its
+  /// message is kept; every other exception is reported by type only, since
+  /// provider and filesystem exceptions carry response bodies and paths that
+  /// must not reach the PII-safe error log. The catch site logs the raw
+  /// exception with its stack trace to the full log.
+  factory WakeResult.failed({required String kind, required Object error}) =>
+      WakeResult(
+        success: false,
+        error: error is StateError
+            ? '$kind workflow failed: ${error.message}'
+            : '$kind workflow failed (${error.runtimeType})',
+      );
+
   /// Whether the wake completed successfully.
   final bool success;
 
@@ -47,5 +63,12 @@ class WakeResult {
   final bool reportUpdated;
 
   /// Error description when [success] is false.
+  ///
+  /// Workflow-authored telemetry, never exception text or user content: the
+  /// wake wiring rethrows it as [WakeFailedException.reason] and the drain
+  /// engine writes that into its failure *message*, which the PII-safe error
+  /// log keeps verbatim. A caught exception is reported by type —
+  /// `'Task agent workflow failed (MeliousInferenceException)'` — and logged
+  /// in full, with its stack trace, at the catch site.
   final String? error;
 }

--- a/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
@@ -834,7 +834,7 @@ class DayAgentWorkflow {
           stackTrace: stackTrace,
         );
       }
-      return WakeResult(success: false, error: e.toString());
+      return WakeResult.failed(kind: 'Day agent', error: e);
     } finally {
       await inferenceRepo?.dispose();
       conversationRepository.deleteConversation(conversationId);

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -865,7 +865,7 @@ class GoalAgentWorkflow with AgentErrorLogging {
           now,
         );
       }
-      return WakeResult(success: false, error: error.toString());
+      return WakeResult.failed(kind: 'Goal Phase B', error: error);
     }
   }
 

--- a/lib/features/goals/workflow/goal_agent_workflow.dart
+++ b/lib/features/goals/workflow/goal_agent_workflow.dart
@@ -297,7 +297,9 @@ class GoalAgentWorkflow with AgentErrorLogging {
     if (version is! GoalSpecVersionEntity) {
       return WakeResult(
         success: false,
-        error: 'goal spec head ${head.versionId} points at nothing',
+        error:
+            'goal spec head ${DomainLogger.sanitizeId(head.versionId)} '
+            'points at nothing',
       );
     }
 

--- a/lib/features/relationships/workflow/relationship_agent_workflow.dart
+++ b/lib/features/relationships/workflow/relationship_agent_workflow.dart
@@ -694,7 +694,7 @@ class RelationshipAgentWorkflow with AgentErrorLogging {
           now,
         );
       }
-      return WakeResult(success: false, error: error.toString());
+      return WakeResult.failed(kind: 'Relationship Phase B', error: error);
     } finally {
       // Clean up the in-memory conversation to prevent resource leaks
       // (the task/project workflow discipline).

--- a/lib/features/system_health/domain/log_digest.dart
+++ b/lib/features/system_health/domain/log_digest.dart
@@ -31,9 +31,32 @@ class LogIssueBucket {
   final List<String> sampleFrames;
 }
 
+/// Queue depth seen by the statements in a bucket when they started.
+///
+/// Elapsed time in the slow-query log is measured from the moment drift
+/// accepts a request, so a statement that queued behind others reports the
+/// wait as its own cost. These counters say how deep that queue was.
+class QueueDepthStats {
+  const QueueDepthStats({
+    required this.inFlightP50,
+    required this.inFlightMax,
+    required this.openTransactionsP50,
+    required this.openTransactionsMax,
+  });
+
+  /// Statements already awaiting the interceptor.
+  final int inFlightP50;
+  final int inFlightMax;
+
+  /// Transactions already open on the database — what a `BEGIN` waits behind.
+  final int openTransactionsP50;
+  final int openTransactionsMax;
+}
+
 /// Repeated slow queries collapsed to one normalised statement.
 class SlowQueryBucket {
   const SlowQueryBucket({
+    required this.databaseName,
     required this.statement,
     required this.operation,
     required this.count,
@@ -46,8 +69,13 @@ class SlowQueryBucket {
     required this.lastSeen,
     this.planShapes = const [],
     this.topFrames = const [],
+    this.queueDepth,
   });
 
+  /// The database file the statement ran against. Part of the grouping key:
+  /// a `BEGIN` on the agent database and one on the sync database queue
+  /// behind different writer locks and must not share a row.
+  final String databaseName;
   final String statement;
   final String operation;
   final int count;
@@ -62,8 +90,13 @@ class SlowQueryBucket {
   /// Distinct `EXPLAIN QUERY PLAN` shapes seen for the statement.
   final List<String> planShapes;
 
-  /// Distinct top application frames that issued the statement.
+  /// Distinct application frames that issued the statement — the first frame
+  /// below the transaction and vector-clock wrappers, so a `BEGIN` names the
+  /// code that opened the transaction rather than `runInTransaction`.
   final List<String> topFrames;
+
+  /// Null when no entry in the bucket carried timing bookkeeping.
+  final QueueDepthStats? queueDepth;
 }
 
 /// Per-domain line counts by level.

--- a/lib/features/system_health/domain/log_digest.dart
+++ b/lib/features/system_health/domain/log_digest.dart
@@ -31,24 +31,31 @@ class LogIssueBucket {
   final List<String> sampleFrames;
 }
 
-/// Queue depth seen by the statements in a bucket when they started.
+/// What else the database was doing when the statements in a bucket started.
 ///
 /// Elapsed time in the slow-query log is measured from the moment drift
-/// accepts a request, so a statement that queued behind others reports the
-/// wait as its own cost. These counters say how deep that queue was.
-class QueueDepthStats {
-  const QueueDepthStats({
-    required this.inFlightP50,
-    required this.inFlightMax,
+/// accepts a request, so a statement that waited reports the wait as its own
+/// cost. Whether these counters *are* that wait depends on the statement: a
+/// `BEGIN` takes the writer lock and holds it for the transaction's lifetime,
+/// so for `transaction.open` the open transactions are what it queued
+/// behind; a read served by the pool overlaps a transaction without waiting
+/// for it, so for a select they only describe concurrency.
+class ConcurrencyStats {
+  const ConcurrencyStats({
+    required this.othersInFlightP50,
+    required this.othersInFlightMax,
     required this.openTransactionsP50,
     required this.openTransactionsMax,
   });
 
-  /// Statements already awaiting the interceptor.
-  final int inFlightP50;
-  final int inFlightMax;
+  /// Other statements already awaiting the interceptor (the interceptor's
+  /// `inFlightAtStart` counts the statement itself; that one is subtracted).
+  final int othersInFlightP50;
+  final int othersInFlightMax;
 
-  /// Transactions already open on the database — what a `BEGIN` waits behind.
+  /// Transactions open on the database, the statement's own included when
+  /// it ran inside one. For a `BEGIN` the list is taken before the
+  /// transaction opens, so it never counts itself.
   final int openTransactionsP50;
   final int openTransactionsMax;
 }
@@ -69,7 +76,7 @@ class SlowQueryBucket {
     required this.lastSeen,
     this.planShapes = const [],
     this.topFrames = const [],
-    this.queueDepth,
+    this.concurrency,
   });
 
   /// The database file the statement ran against. Part of the grouping key:
@@ -96,7 +103,7 @@ class SlowQueryBucket {
   final List<String> topFrames;
 
   /// Null when no entry in the bucket carried timing bookkeeping.
-  final QueueDepthStats? queueDepth;
+  final ConcurrencyStats? concurrency;
 }
 
 /// Per-domain line counts by level.

--- a/lib/features/system_health/domain/log_records.dart
+++ b/lib/features/system_health/domain/log_records.dart
@@ -39,6 +39,8 @@ class SlowQueryRecord {
     required this.isSuperSlow,
     this.planRows = const [],
     this.stackFrames = const [],
+    this.inFlightAtStart,
+    this.openTransactionsAtStart,
   });
 
   final DateTime timestamp;
@@ -52,4 +54,21 @@ class SlowQueryRecord {
   final bool isSuperSlow;
   final List<String> planRows;
   final List<String> stackFrames;
+
+  /// Statements already awaiting the interceptor when this one started, from
+  /// the `TIMING:` row. Null for entries written without timing bookkeeping.
+  ///
+  /// Elapsed time is measured from the moment drift accepts a request, so a
+  /// statement that waited in a queue reports the wait as its own cost; this
+  /// is the queue's depth at that moment.
+  final int? inFlightAtStart;
+
+  /// Transactions already open on the database when this statement started,
+  /// from the `TRANSACTION:` row's `activeAtStart` list. Zero when the row was
+  /// omitted (the interceptor writes it only when there was something to
+  /// say), null when there was no timing bookkeeping at all.
+  ///
+  /// For a `BEGIN` this is what the transaction waited behind: drift holds the
+  /// writer lock for a transaction's whole lifetime, so the next one waits.
+  final int? openTransactionsAtStart;
 }

--- a/lib/features/system_health/service/log_digest_builder.dart
+++ b/lib/features/system_health/service/log_digest_builder.dart
@@ -42,6 +42,15 @@ class LogDigestBuilder {
   static final RegExp _placeholderList = RegExp(r'\(\s*\?(?:\s*,\s*\?)+\s*\)');
   static final RegExp _appFrame = RegExp('package:lotti/');
 
+  /// Frames that wrap a statement without being its reason: the agent
+  /// repository's and sync service's `runInTransaction`, the vector-clock
+  /// scope, and the transaction-marking zone helper. The first frame of every
+  /// `BEGIN` is one of these, which attributes every transaction to the
+  /// wrapper and none to the code that opened it.
+  static final RegExp _wrapperFrame = RegExp(
+    r'\b(runInTransaction|withVcScope|_markInTransaction)\b',
+  );
+
   static const int _signatureLength = 200;
 
   LogDigest build(LogReadResult input) {
@@ -140,13 +149,14 @@ class LogDigestBuilder {
       final signature = statementSignature(statement);
       buckets
           .putIfAbsent(
-            signature,
+            '${query.databaseName}|$signature',
             () => _SlowQueryAccumulator(
+              databaseName: query.databaseName,
               statement: signature,
               operation: query.operation,
             ),
           )
-          .add(query, redactor);
+          .add(query, redactor, _wrapperFrame);
     }
     final result =
         buckets.values
@@ -256,8 +266,13 @@ class _IssueAccumulator {
 }
 
 class _SlowQueryAccumulator {
-  _SlowQueryAccumulator({required this.statement, required this.operation});
+  _SlowQueryAccumulator({
+    required this.databaseName,
+    required this.statement,
+    required this.operation,
+  });
 
+  final String databaseName;
   final String statement;
   final String operation;
 
@@ -270,10 +285,12 @@ class _SlowQueryAccumulator {
   final List<(String key, double elapsedMs)> superEntries = [];
   final Set<String> planShapes = {};
   final Set<String> topFrames = {};
+  final List<int> inFlight = [];
+  final List<int> openTransactions = [];
   DateTime? firstSeen;
   DateTime? lastSeen;
 
-  void add(SlowQueryRecord query, LogRedactor redactor) {
+  void add(SlowQueryRecord query, LogRedactor redactor, RegExp wrapperFrame) {
     // Both files write the same timestamp, elapsed and statement for one
     // query, which is identity enough to spot the duplicate.
     final key =
@@ -289,8 +306,18 @@ class _SlowQueryAccumulator {
       planShapes.add(query.planRows.join(' | '));
     }
     if (query.stackFrames.isNotEmpty) {
-      topFrames.add(redactor.redact(query.stackFrames.first));
+      // The first frame that is not a wrapper; the wrapper itself when the
+      // capture holds nothing else.
+      final frame = query.stackFrames.firstWhere(
+        (f) => !wrapperFrame.hasMatch(f),
+        orElse: () => query.stackFrames.first,
+      );
+      topFrames.add(redactor.redact(frame));
     }
+    final inFlightAtStart = query.inFlightAtStart;
+    if (inFlightAtStart != null) inFlight.add(inFlightAtStart);
+    final openAtStart = query.openTransactionsAtStart;
+    if (openAtStart != null) openTransactions.add(openAtStart);
     final first = firstSeen;
     if (first == null || query.timestamp.isBefore(first)) {
       firstSeen = query.timestamp;
@@ -311,6 +338,7 @@ class _SlowQueryAccumulator {
         if (!slowKeys.contains(key)) elapsed,
     ]..sort();
     return SlowQueryBucket(
+      databaseName: databaseName,
       statement: statement,
       operation: operation,
       count: series.length,
@@ -323,10 +351,34 @@ class _SlowQueryAccumulator {
       lastSeen: lastSeen!,
       planShapes: planShapes.take(maxPlanShapes).toList(growable: false),
       topFrames: topFrames.take(maxTopFrames).toList(growable: false),
+      queueDepth: _queueDepth(),
+    );
+  }
+
+  QueueDepthStats? _queueDepth() {
+    if (inFlight.isEmpty) return null;
+    final inFlightSorted = [...inFlight]..sort();
+    // Entries without a TRANSACTION row predate the timing rows, or the
+    // interceptor had nothing to say: read as no open transaction.
+    final openSorted = [
+      ...openTransactions,
+      for (var i = openTransactions.length; i < inFlight.length; i++) 0,
+    ]..sort();
+    return QueueDepthStats(
+      inFlightP50: _percentileInt(inFlightSorted, 0.5),
+      inFlightMax: inFlightSorted.last,
+      openTransactionsP50: _percentileInt(openSorted, 0.5),
+      openTransactionsMax: openSorted.last,
     );
   }
 
   static double _percentile(List<double> sorted, double fraction) {
+    if (sorted.length == 1) return sorted.first;
+    final index = (fraction * (sorted.length - 1)).round();
+    return sorted[index.clamp(0, sorted.length - 1)];
+  }
+
+  static int _percentileInt(List<int> sorted, double fraction) {
     if (sorted.length == 1) return sorted.first;
     final index = (fraction * (sorted.length - 1)).round();
     return sorted[index.clamp(0, sorted.length - 1)];

--- a/lib/features/system_health/service/log_digest_builder.dart
+++ b/lib/features/system_health/service/log_digest_builder.dart
@@ -285,8 +285,13 @@ class _SlowQueryAccumulator {
   final List<(String key, double elapsedMs)> superEntries = [];
   final Set<String> planShapes = {};
   final Set<String> topFrames = {};
-  final List<int> inFlight = [];
-  final List<int> openTransactions = [];
+
+  /// Concurrency samples, keyed like the elapsed series so the super-slow
+  /// copy of an entry — which carries the same TIMING rows — is not counted
+  /// twice: slow-file samples by key, super-slow samples kept aside and used
+  /// only when their twin is missing.
+  final Map<String, (int inFlight, int open)> slowSamples = {};
+  final List<(String key, int inFlight, int open)> superSamples = [];
   DateTime? firstSeen;
   DateTime? lastSeen;
 
@@ -315,9 +320,15 @@ class _SlowQueryAccumulator {
       topFrames.add(redactor.redact(frame));
     }
     final inFlightAtStart = query.inFlightAtStart;
-    if (inFlightAtStart != null) inFlight.add(inFlightAtStart);
-    final openAtStart = query.openTransactionsAtStart;
-    if (openAtStart != null) openTransactions.add(openAtStart);
+    if (inFlightAtStart != null) {
+      // Entries without a TRANSACTION row had nothing open.
+      final sample = (inFlightAtStart, query.openTransactionsAtStart ?? 0);
+      if (query.isSuperSlow) {
+        superSamples.add((key, sample.$1, sample.$2));
+      } else {
+        slowSamples[key] = sample;
+      }
+    }
     final first = firstSeen;
     if (first == null || query.timestamp.isBefore(first)) {
       firstSeen = query.timestamp;
@@ -351,24 +362,25 @@ class _SlowQueryAccumulator {
       lastSeen: lastSeen!,
       planShapes: planShapes.take(maxPlanShapes).toList(growable: false),
       topFrames: topFrames.take(maxTopFrames).toList(growable: false),
-      queueDepth: _queueDepth(),
+      concurrency: _concurrency(),
     );
   }
 
-  QueueDepthStats? _queueDepth() {
-    if (inFlight.isEmpty) return null;
-    final inFlightSorted = [...inFlight]..sort();
-    // Entries without a TRANSACTION row predate the timing rows, or the
-    // interceptor had nothing to say: read as no open transaction.
-    final openSorted = [
-      ...openTransactions,
-      for (var i = openTransactions.length; i < inFlight.length; i++) 0,
-    ]..sort();
-    return QueueDepthStats(
-      inFlightP50: _percentileInt(inFlightSorted, 0.5),
-      inFlightMax: inFlightSorted.last,
-      openTransactionsP50: _percentileInt(openSorted, 0.5),
-      openTransactionsMax: openSorted.last,
+  ConcurrencyStats? _concurrency() {
+    final samples = [
+      ...slowSamples.values,
+      for (final (key, inFlight, open) in superSamples)
+        if (!slowSamples.containsKey(key)) (inFlight, open),
+    ];
+    if (samples.isEmpty) return null;
+    // `inFlightAtStart` counts the statement itself.
+    final others = [for (final (inFlight, _) in samples) inFlight - 1]..sort();
+    final open = [for (final (_, open) in samples) open]..sort();
+    return ConcurrencyStats(
+      othersInFlightP50: _percentileInt(others, 0.5),
+      othersInFlightMax: others.last,
+      openTransactionsP50: _percentileInt(open, 0.5),
+      openTransactionsMax: open.last,
     );
   }
 

--- a/lib/features/system_health/service/log_file_reader.dart
+++ b/lib/features/system_health/service/log_file_reader.dart
@@ -288,41 +288,97 @@ class LogFileReader {
     required SystemHealthRange range,
     required List<SlowQueryRecord> into,
   }) {
-    List<String>? planRows;
-    List<String>? stackFrames;
+    _PendingSlowQuery? pending;
+    void flush() {
+      final done = pending;
+      if (done != null) into.add(done.toRecord(isSuperSlow: isSuperSlow));
+      pending = null;
+    }
+
     for (final line in lines) {
       final match = _slowQueryLine.firstMatch(line);
       if (match == null) {
-        final trimmed = line.trimLeft();
-        if (trimmed.startsWith('PLAN: ')) {
-          planRows?.add(trimmed.substring('PLAN: '.length));
-        } else if (trimmed.startsWith('STACK: ')) {
-          stackFrames?.add(trimmed.substring('STACK: '.length));
-        }
+        pending?.addContinuation(line.trimLeft());
         continue;
       }
-      planRows = null;
-      stackFrames = null;
+      flush();
       final timestamp = DateTime.tryParse(match.group(1)!);
       if (timestamp == null || !range.contains(timestamp)) continue;
       final elapsed = double.tryParse(match.group(4)!);
       if (elapsed == null) continue;
-      planRows = <String>[];
-      stackFrames = <String>[];
-      into.add(
-        SlowQueryRecord(
-          timestamp: timestamp,
-          databaseName: match.group(2)!,
-          operation: match.group(3)!,
-          elapsedMs: elapsed,
-          statement: match.group(5)!,
-          isSuperSlow: isSuperSlow,
-          planRows: planRows,
-          stackFrames: stackFrames,
-        ),
+      pending = _PendingSlowQuery(
+        timestamp: timestamp,
+        databaseName: match.group(2)!,
+        operation: match.group(3)!,
+        elapsedMs: elapsed,
+        statement: match.group(5)!,
       );
     }
+    flush();
   }
+}
+
+/// A slow-query entry whose continuation rows are still being collected.
+///
+/// `PLAN:` and `STACK:` rows accumulate; `TIMING:` and `TRANSACTION:` rows
+/// carry the queue-depth counters the interceptor wrote for the entry (see
+/// `SlowQueryInterceptor.fileReporter`).
+class _PendingSlowQuery {
+  _PendingSlowQuery({
+    required this.timestamp,
+    required this.databaseName,
+    required this.operation,
+    required this.elapsedMs,
+    required this.statement,
+  });
+
+  static final RegExp _inFlight = RegExp(r'\binFlightAtStart=(\d+)');
+  static final RegExp _activeAtStart = RegExp(r'\bactiveAtStart=\[([^\]]*)\]');
+
+  final DateTime timestamp;
+  final String databaseName;
+  final String operation;
+  final double elapsedMs;
+  final String statement;
+  final List<String> planRows = [];
+  final List<String> stackFrames = [];
+  int? inFlightAtStart;
+  int? openTransactionsAtStart;
+
+  void addContinuation(String trimmed) {
+    if (trimmed.startsWith('PLAN: ')) {
+      planRows.add(trimmed.substring('PLAN: '.length));
+    } else if (trimmed.startsWith('STACK: ')) {
+      stackFrames.add(trimmed.substring('STACK: '.length));
+    } else if (trimmed.startsWith('TIMING: ')) {
+      final inFlight = _inFlight.firstMatch(trimmed)?.group(1);
+      inFlightAtStart = inFlight == null ? null : int.tryParse(inFlight);
+      // The TRANSACTION row is written only when there is something to say,
+      // so once timing is known "no row" means no open transaction.
+      openTransactionsAtStart ??= 0;
+    } else if (trimmed.startsWith('TRANSACTION: ')) {
+      final list = _activeAtStart.firstMatch(trimmed)?.group(1);
+      if (list != null) {
+        openTransactionsAtStart = list
+            .split(',')
+            .where((id) => id.trim().isNotEmpty)
+            .length;
+      }
+    }
+  }
+
+  SlowQueryRecord toRecord({required bool isSuperSlow}) => SlowQueryRecord(
+    timestamp: timestamp,
+    databaseName: databaseName,
+    operation: operation,
+    elapsedMs: elapsedMs,
+    statement: statement,
+    isSuperSlow: isSuperSlow,
+    planRows: planRows,
+    stackFrames: stackFrames,
+    inFlightAtStart: inFlightAtStart,
+    openTransactionsAtStart: openTransactionsAtStart,
+  );
 }
 
 /// An error entry from a per-domain file, kept for its stack frames only.

--- a/lib/features/system_health/service/system_health_report_builder.dart
+++ b/lib/features/system_health/service/system_health_report_builder.dart
@@ -191,7 +191,8 @@ class SystemHealthReportBuilder {
       for (final (index, query) in shownQueries.indexed) {
         buffer
           ..writeln(
-            '${index + 1}. **${query.operation}** ×${_count.format(query.count)} · '
+            '${index + 1}. **${query.operation}** on ${query.databaseName} '
+            '×${_count.format(query.count)} · '
             'p50 ${_ms(query.p50Ms)} · p95 ${_ms(query.p95Ms)} · '
             'max ${_ms(query.maxMs)} · total ${_ms(query.totalMs)} · '
             'super slow ×${_count.format(query.superSlowCount)} '
@@ -204,6 +205,14 @@ class SystemHealthReportBuilder {
         }
         for (final frame in query.topFrames) {
           buffer.writeln('   - from: ${_inline(frame)}');
+        }
+        final queue = query.queueDepth;
+        if (queue != null) {
+          buffer.writeln(
+            '   - queue at start: in flight p50 ${queue.inFlightP50} · '
+            'max ${queue.inFlightMax} · open transactions '
+            'p50 ${queue.openTransactionsP50} · max ${queue.openTransactionsMax}',
+          );
         }
       }
       if (hidden > 0) {

--- a/lib/features/system_health/service/system_health_report_builder.dart
+++ b/lib/features/system_health/service/system_health_report_builder.dart
@@ -206,12 +206,14 @@ class SystemHealthReportBuilder {
         for (final frame in query.topFrames) {
           buffer.writeln('   - from: ${_inline(frame)}');
         }
-        final queue = query.queueDepth;
-        if (queue != null) {
+        final concurrency = query.concurrency;
+        if (concurrency != null) {
           buffer.writeln(
-            '   - queue at start: in flight p50 ${queue.inFlightP50} · '
-            'max ${queue.inFlightMax} · open transactions '
-            'p50 ${queue.openTransactionsP50} · max ${queue.openTransactionsMax}',
+            '   - at start: other statements in flight '
+            'p50 ${concurrency.othersInFlightP50} · '
+            'max ${concurrency.othersInFlightMax} · open transactions '
+            'p50 ${concurrency.openTransactionsP50} · '
+            'max ${concurrency.openTransactionsMax}',
           );
         }
       }

--- a/test/features/agents/database/agent_repository_test.dart
+++ b/test/features/agents/database/agent_repository_test.dart
@@ -2439,7 +2439,8 @@ void main() {
       expect(identities, isEmpty);
     });
 
-    test('filters agent identities by lifecycle in SQL', () async {
+    test('filters agent identities by lifecycle from the cached list, and a '
+        'lifecycle change is visible on the next call', () async {
       final active = makeAgent(id: 'agent-active', agentId: 'a-001').copyWith(
         createdAt: DateTime(2026, 2, 22),
       );
@@ -2486,6 +2487,32 @@ void main() {
       expect(
         identities.map((identity) => identity.id),
         ['agent-active', 'agent-active-older'],
+      );
+      expect(
+        (await repo.getAgentIdentitiesByLifecycle(
+          AgentLifecycle.dormant,
+        )).map((identity) => identity.id),
+        ['agent-dormant'],
+      );
+
+      // The filter is served from the identity cache; an identity write
+      // invalidates it, so a lifecycle flip must not be answered from the
+      // stale list.
+      await repo.upsertEntity(
+        active.copyWith(lifecycle: AgentLifecycle.dormant),
+      );
+
+      expect(
+        (await repo.getAgentIdentitiesByLifecycle(
+          AgentLifecycle.active,
+        )).map((identity) => identity.id),
+        ['agent-active-older'],
+      );
+      expect(
+        (await repo.getAgentIdentitiesByLifecycle(
+          AgentLifecycle.dormant,
+        )).map((identity) => identity.id),
+        ['agent-active', 'agent-dormant'],
       );
     });
   });

--- a/test/features/agents/state/agent_providers_test.dart
+++ b/test/features/agents/state/agent_providers_test.dart
@@ -33,6 +33,7 @@ import 'package:lotti/features/agents/workflow/improver_agent_workflow.dart';
 import 'package:lotti/features/agents/workflow/project_agent_workflow.dart';
 import 'package:lotti/features/agents/workflow/task_agent_workflow.dart';
 import 'package:lotti/features/agents/workflow/template_evolution_workflow.dart';
+import 'package:lotti/features/agents/workflow/wake_result.dart';
 import 'package:lotti/features/ai/conversation/conversation_repository.dart';
 import 'package:lotti/features/ai/database/embedding_store.dart';
 import 'package:lotti/features/ai/model/ai_runtime_settings.dart';
@@ -911,9 +912,9 @@ void main() {
             'thread-fail',
           ),
           throwsA(
-            isA<StateError>().having(
-              (e) => e.message,
-              'message',
+            isA<WakeFailedException>().having(
+              (e) => e.reason,
+              'reason',
               'workflow failed',
             ),
           ),
@@ -1419,9 +1420,9 @@ void main() {
             'thread-day-fail',
           ),
           throwsA(
-            isA<StateError>().having(
-              (e) => e.message,
-              'message',
+            isA<WakeFailedException>().having(
+              (e) => e.reason,
+              'reason',
               'day workflow failed',
             ),
           ),
@@ -1471,9 +1472,9 @@ void main() {
             'thread-project-fail',
           ),
           throwsA(
-            isA<StateError>().having(
-              (e) => e.message,
-              'message',
+            isA<WakeFailedException>().having(
+              (e) => e.reason,
+              'reason',
               'project failed',
             ),
           ),
@@ -1642,9 +1643,9 @@ void main() {
             'thread-fail',
           ),
           throwsA(
-            isA<StateError>().having(
-              (e) => e.message,
-              'message',
+            isA<WakeFailedException>().having(
+              (e) => e.reason,
+              'reason',
               'improver failed',
             ),
           ),

--- a/test/features/agents/state/agent_wiring_test.dart
+++ b/test/features/agents/state/agent_wiring_test.dart
@@ -176,8 +176,8 @@ void main() {
     );
 
     test(
-      'throws a StateError carrying the workflow error when the event wake '
-      'fails',
+      'throws a WakeFailedException naming the kind and the workflow error '
+      'when the event wake fails',
       () async {
         stubEventAgent();
         when(
@@ -199,11 +199,9 @@ void main() {
         await expectLater(
           () => executor('event-agent-1', 'run-key-1', const {}, 'thread-1'),
           throwsA(
-            isA<StateError>().having(
-              (e) => e.message,
-              'message',
-              'No active event ID',
-            ),
+            isA<WakeFailedException>()
+                .having((e) => e.kind, 'kind', 'event')
+                .having((e) => e.reason, 'reason', 'No active event ID'),
           ),
         );
 

--- a/test/features/agents/wake/wake_orchestrator_drain_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_drain_test.dart
@@ -1,4 +1,5 @@
 import 'package:glados/glados.dart' as glados;
+import 'package:lotti/features/agents/workflow/wake_result.dart';
 
 import 'wake_orchestrator_test_harness.dart';
 
@@ -1305,6 +1306,60 @@ void main() {
           });
         },
       );
+
+      test('a workflow-reported failure logs its kind and reason', () {
+        // The PII-safe error log keeps only the message and the error type,
+        // so the reason must ride in the message or the report shows a bare
+        // `errorType=…` for every failed wake.
+        fakeAsync((async) {
+          final logger = MockDomainLogger();
+          when(
+            () => logger.log(
+              any(),
+              any(),
+              subDomain: any(named: 'subDomain'),
+              level: any(named: 'level'),
+            ),
+          ).thenReturn(null);
+          when(
+            () => logger.error(
+              any(),
+              any(),
+              message: any(named: 'message'),
+              subDomain: any(named: 'subDomain'),
+              stackTrace: any(named: 'stackTrace'),
+            ),
+          ).thenReturn(null);
+
+          WakeOrchestrator(
+            repository: mockRepository,
+            queue: WakeQueue()..enqueue(makeJob()),
+            runner: WakeRunner(),
+            domainLogger: logger,
+            wakeExecutor: (_, _, _, _) async => throw const WakeFailedException(
+              kind: 'task',
+              reason: 'No template assigned to agent',
+            ),
+          ).processNext();
+          async.flushMicrotasks();
+
+          verify(
+            () => logger.error(
+              LogDomain.agentRuntime,
+              any(that: isA<WakeFailedException>()),
+              message: any(
+                named: 'message',
+                that: allOf(
+                  startsWith('wake failed in '),
+                  contains('kind=task reason=No template assigned to agent'),
+                ),
+              ),
+              subDomain: any(named: 'subDomain'),
+              stackTrace: any(named: 'stackTrace'),
+            ),
+          ).called(1);
+        });
+      });
 
       test('continues drain when an unexpected execution error escapes', () {
         fakeAsync((async) {

--- a/test/features/agents/workflow/project_agent_workflow_test.dart
+++ b/test/features/agents/workflow/project_agent_workflow_test.dart
@@ -319,7 +319,7 @@ void main() {
         });
 
         expect(result.success, isFalse);
-        expect(result.error, contains('No active project ID'));
+        expect(result.error, 'Project agent workflow failed (StateError)');
         final updatedState =
             verify(
                   () => mockSyncService.upsertEntity(captureAny()),
@@ -354,7 +354,7 @@ void main() {
         });
 
         expect(result.success, isFalse);
-        expect(result.error, contains('Project not found'));
+        expect(result.error, 'Project agent workflow failed (StateError)');
         final updatedState =
             verify(
                   () => mockSyncService.upsertEntity(captureAny()),
@@ -400,7 +400,7 @@ void main() {
         });
 
         expect(result.success, isFalse);
-        expect(result.error, contains('No inference provider'));
+        expect(result.error, 'Project agent workflow failed (StateError)');
         final updatedState =
             verify(
                   () => mockSyncService.upsertEntity(captureAny()),
@@ -450,7 +450,7 @@ void main() {
         );
 
         expect(result.success, isFalse);
-        expect(result.error, contains('No inference provider'));
+        expect(result.error, 'Project agent workflow failed (StateError)');
       });
     });
 

--- a/test/features/agents/workflow/project_agent_workflow_test.dart
+++ b/test/features/agents/workflow/project_agent_workflow_test.dart
@@ -1316,7 +1316,9 @@ void main() {
           });
 
           expect(result.success, isFalse);
-          expect(result.error, contains('Soul DB error'));
+          // The reason is bounded to the exception type: it reaches the PII-safe
+          // error log, the raw text only the full log at the catch site.
+          expect(result.error, 'Project agent workflow failed (_Exception)');
           final captured = verify(
             () => mockSyncService.upsertEntity(captureAny()),
           ).captured;

--- a/test/features/agents/workflow/task_agent_workflow_test.dart
+++ b/test/features/agents/workflow/task_agent_workflow_test.dart
@@ -1478,7 +1478,7 @@ void main() {
         );
 
         expect(result.success, isFalse);
-        expect(result.error, contains('Network error'));
+        expect(result.error, 'Task agent workflow failed (_Exception)');
 
         // Verify state was updated with incremented failure count.
         final captured = verify(
@@ -1760,7 +1760,7 @@ void main() {
 
         // Should still return a failure result, not rethrow.
         expect(result.success, isFalse);
-        expect(result.error, contains('Network failure'));
+        expect(result.error, 'Task agent workflow failed (_Exception)');
       });
     });
 
@@ -1854,7 +1854,7 @@ void main() {
           // Should return error result (not throw), having logged via
           // developer.log fallback.
           expect(result.success, isFalse);
-          expect(result.error, contains('LLM unavailable'));
+          expect(result.error, 'Task agent workflow failed (_Exception)');
         },
       );
     });

--- a/test/features/agents/workflow/wake_result_test.dart
+++ b/test/features/agents/workflow/wake_result_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/workflow/wake_result.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
@@ -34,6 +36,50 @@ void main() {
       expect(result.mutatedEntries, isEmpty);
       expect(result.reportUpdated, isTrue);
       expect(result.error, isNull);
+    });
+  });
+
+  group('WakeResult.failed', () {
+    test("keeps a StateError message — the workflows' own abort signal", () {
+      final result = WakeResult.failed(
+        kind: 'Project agent',
+        error: StateError('No active project ID'),
+      );
+
+      expect(result.success, isFalse);
+      expect(
+        result.error,
+        'Project agent workflow failed: No active project ID',
+      );
+    });
+
+    test('reports any other exception by type only', () {
+      // A provider or filesystem exception carries response bodies and
+      // paths; the reason reaches the PII-safe error log, so only the type
+      // may travel.
+      final result = WakeResult.failed(
+        kind: 'Task agent',
+        error: const FileSystemException('read failed', '/home/me/secret.txt'),
+      );
+
+      expect(result.error, 'Task agent workflow failed (FileSystemException)');
+      expect(result.error, isNot(contains('secret')));
+    });
+  });
+
+  group('WakeFailedException', () {
+    test('names the kind and the workflow reason', () {
+      const exception = WakeFailedException(
+        kind: 'task',
+        reason: 'No template assigned to agent',
+      );
+
+      expect(exception.kind, 'task');
+      expect(exception.reason, 'No template assigned to agent');
+      expect(
+        exception.toString(),
+        'WakeFailedException(task): No template assigned to agent',
+      );
     });
   });
 }

--- a/test/features/agents/workflow/wake_result_test.dart
+++ b/test/features/agents/workflow/wake_result_test.dart
@@ -40,17 +40,15 @@ void main() {
   });
 
   group('WakeResult.failed', () {
-    test("keeps a StateError message — the workflows' own abort signal", () {
+    test('reports a StateError by type only — its message may interpolate '
+        'model-emitted tool names', () {
       final result = WakeResult.failed(
-        kind: 'Project agent',
-        error: StateError('No active project ID'),
+        kind: 'Task agent',
+        error: StateError('tool "<whatever the model sent>" not allowed'),
       );
 
       expect(result.success, isFalse);
-      expect(
-        result.error,
-        'Project agent workflow failed: No active project ID',
-      );
+      expect(result.error, 'Task agent workflow failed (StateError)');
     });
 
     test('reports any other exception by type only', () {

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_context_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_context_test.dart
@@ -499,7 +499,10 @@ void main() {
           );
 
           expect(result.success, isFalse);
-          expect(result.error, contains('parse_capture_to_items'));
+          expect(
+            result.error,
+            'Day agent workflow failed (MissingCaptureParseException)',
+          );
           expect(conversationRepository.sendMessageCalls, hasLength(2));
           expect(
             conversationRepository.sendMessageCalls[1].toolChoice,

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_drafting_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_drafting_test.dart
@@ -36,7 +36,10 @@ void main() {
           );
 
           expect(result.success, isFalse);
-          expect(result.error, contains('draft_day_plan'));
+          expect(
+            result.error,
+            'Day agent workflow failed (MissingDraftDayPlanException)',
+          );
           expect(conversationRepository.sendMessageCalls, hasLength(2));
           expect(
             conversationRepository.toolResponses.last,
@@ -685,7 +688,10 @@ void main() {
           );
 
           expect(result.success, isFalse);
-          expect(result.error, contains('draft_day_plan'));
+          expect(
+            result.error,
+            'Day agent workflow failed (MissingDraftDayPlanException)',
+          );
           verify(
             () => planService.executeTool(
               agentId: agentId,
@@ -720,7 +726,10 @@ void main() {
           );
 
           expect(result.success, isFalse);
-          expect(result.error, contains('draft_day_plan'));
+          expect(
+            result.error,
+            'Day agent workflow failed (MissingDraftDayPlanException)',
+          );
           expect(conversationRepository.sendMessageCalls, hasLength(2));
           expect(
             conversationRepository.sendMessageCalls[1].toolChoice,

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_persistence_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_persistence_test.dart
@@ -403,7 +403,7 @@ void main() {
       final result = await execute(workflow());
 
       expect(result.success, isFalse);
-      expect(result.error, contains('model failed'));
+      expect(result.error, 'Day agent workflow failed (_Exception)');
       final failureState = upsertedEntities.whereType<AgentStateEntity>().last;
       expect(failureState.consecutiveFailureCount, 3);
       expect(failureState.scheduledWakeAt, isNull);
@@ -436,7 +436,7 @@ void main() {
       final result = await execute(workflow());
 
       expect(result.success, isFalse);
-      expect(result.error, contains('model failed'));
+      expect(result.error, 'Day agent workflow failed (_Exception)');
       verify(
         () => domainLogger.error(
           any(),

--- a/test/features/goals/workflow/goal_agent_workflow_test.dart
+++ b/test/features/goals/workflow/goal_agent_workflow_test.dart
@@ -800,7 +800,7 @@ void main() {
     );
 
     expect(result.success, isFalse);
-    expect(result.error, contains('no visible reply'));
+    expect(result.error, 'Goal Phase B workflow failed (StateError)');
     expect(conversationRepository.sendMessageDelegateCallCount, 2);
   });
 
@@ -884,7 +884,7 @@ void main() {
     expect(result.success, isFalse);
     expect(
       result.error,
-      contains('rejected tools unresolved: snooze_goal_ad'),
+      'Goal Phase B workflow failed (StateError)',
     );
     expect(
       upserts.whereType<AgentMessageEntity>(),
@@ -3093,7 +3093,7 @@ void main() {
           };
       final result = await run();
       expect(result.success, isFalse);
-      expect(result.error, contains('provider melted'));
+      expect(result.error, 'Goal Phase B workflow failed (StateError)');
     },
   );
 
@@ -5132,7 +5132,7 @@ void main() {
         };
     final result = await run();
     expect(result.success, isFalse);
-    expect(result.error, contains('provider melted'));
+    expect(result.error, 'Goal Phase B workflow failed (StateError)');
   });
 
   test('persistOutputs: an ineligible status suppresses ads, an atRisk '

--- a/test/features/relationships/workflow/relationship_agent_workflow_test.dart
+++ b/test/features/relationships/workflow/relationship_agent_workflow_test.dart
@@ -769,7 +769,7 @@ void main() {
     );
 
     expect(result.success, isFalse);
-    expect(result.error, contains('outbox flush failed'));
+    expect(result.error, 'Relationship Phase B workflow failed (StateError)');
     expect(
       conversationRepository.deletedConversationIds,
       contains('test-conv-id'),
@@ -1385,7 +1385,7 @@ void main() {
 
     final result = await run(pendingUserMessage: 'How is Anna?');
     expect(result.success, isFalse);
-    expect(result.error, contains('no visible reply'));
+    expect(result.error, 'Relationship Phase B workflow failed (StateError)');
   });
 
   test('a deferred outbox-flush failure AFTER the interactive reply '

--- a/test/features/system_health/service/log_digest_builder_test.dart
+++ b/test/features/system_health/service/log_digest_builder_test.dart
@@ -217,6 +217,118 @@ void main() {
       expect(bucket.maxMs, 500);
     });
 
+    test('the same statement on two databases makes two buckets', () {
+      // A BEGIN on the agent database and one on the sync database queue
+      // behind different writer locks; merged, neither can be diagnosed.
+      final digest = builder.build(
+        input(
+          slowQueries: [
+            for (var i = 0; i < 3; i++)
+              slowQuery(
+                timestamp: t0,
+                elapsedMs: 1000,
+                statement: 'BEGIN',
+                operation: 'transaction.open',
+                databaseName: 'agent.sqlite',
+              ),
+            slowQuery(
+              timestamp: t0,
+              elapsedMs: 15,
+              statement: 'BEGIN',
+              operation: 'transaction.open',
+              databaseName: 'sync.sqlite',
+            ),
+          ],
+        ),
+      );
+
+      expect(digest.slowQueries, hasLength(2));
+      final agent = digest.slowQueries.first;
+      expect(agent.databaseName, 'agent.sqlite');
+      expect(agent.count, 3);
+      expect(agent.p50Ms, 1000);
+      final sync = digest.slowQueries.last;
+      expect(sync.databaseName, 'sync.sqlite');
+      expect(sync.count, 1);
+      expect(sync.maxMs, 15);
+    });
+
+    test('the caller frame is the first below the transaction wrappers', () {
+      const wrapper =
+          '#8 AgentRepoCore.runInTransaction '
+          '(package:lotti/features/agents/database/agent_repo_core.dart:110:5)';
+      const scope =
+          '#9 VectorClockService.withVcScope '
+          '(package:lotti/services/vector_clock_service.dart:309:5)';
+      const caller =
+          '#10 DayAgentPlanWriter.persist '
+          '(package:lotti/features/daily_os_next/agents/service/day_agent_plan_writer.dart:44:7)';
+      final digest = builder.build(
+        input(
+          slowQueries: [
+            slowQuery(
+              timestamp: t0,
+              elapsedMs: 300,
+              statement: 'BEGIN',
+              isSuperSlow: true,
+              stackFrames: const [wrapper, scope, caller],
+            ),
+            // A capture holding nothing but wrappers still names something.
+            slowQuery(
+              timestamp: t0.add(const Duration(minutes: 1)),
+              elapsedMs: 300,
+              statement: 'BEGIN',
+              isSuperSlow: true,
+              stackFrames: const [wrapper],
+            ),
+          ],
+        ),
+      );
+
+      expect(digest.slowQueries.single.topFrames, [caller, wrapper]);
+    });
+
+    test('queue depth at start is summarised when the entries carry it', () {
+      final digest = builder.build(
+        input(
+          slowQueries: [
+            slowQuery(
+              timestamp: t0,
+              elapsedMs: 1000,
+              statement: 'BEGIN',
+              inFlightAtStart: 60,
+              openTransactionsAtStart: 3,
+            ),
+            slowQuery(
+              timestamp: t0,
+              elapsedMs: 900,
+              statement: 'BEGIN',
+              inFlightAtStart: 5,
+              openTransactionsAtStart: 1,
+            ),
+            // Timing without a TRANSACTION row: nothing was open.
+            slowQuery(
+              timestamp: t0,
+              elapsedMs: 15,
+              statement: 'BEGIN',
+              inFlightAtStart: 1,
+            ),
+            slowQuery(timestamp: t0, elapsedMs: 15, statement: 'SELECT 1'),
+          ],
+        ),
+      );
+
+      final begin = digest.slowQueries.first;
+      expect(begin.statement, 'BEGIN');
+      final queue = begin.queueDepth!;
+      expect(queue.inFlightP50, 5);
+      expect(queue.inFlightMax, 60);
+      expect(queue.openTransactionsP50, 1);
+      expect(queue.openTransactionsMax, 3);
+      // No entry with timing bookkeeping: nothing to summarise.
+      expect(digest.slowQueries.last.queueDepth, isNull);
+    });
+
     test('buckets are ordered by total time', () {
       final digest = builder.build(
         input(

--- a/test/features/system_health/service/log_digest_builder_test.dart
+++ b/test/features/system_health/service/log_digest_builder_test.dart
@@ -288,7 +288,7 @@ void main() {
       expect(digest.slowQueries.single.topFrames, [caller, wrapper]);
     });
 
-    test('queue depth at start is summarised when the entries carry it', () {
+    test('concurrency at start is summarised when the entries carry it', () {
       final digest = builder.build(
         input(
           slowQueries: [
@@ -306,7 +306,8 @@ void main() {
               inFlightAtStart: 5,
               openTransactionsAtStart: 1,
             ),
-            // Timing without a TRANSACTION row: nothing was open.
+            // Timing without a TRANSACTION row: nothing was open, and an
+            // in-flight count of one is the statement itself.
             slowQuery(
               timestamp: t0,
               elapsedMs: 15,
@@ -320,13 +321,54 @@ void main() {
 
       final begin = digest.slowQueries.first;
       expect(begin.statement, 'BEGIN');
-      final queue = begin.queueDepth!;
-      expect(queue.inFlightP50, 5);
-      expect(queue.inFlightMax, 60);
-      expect(queue.openTransactionsP50, 1);
-      expect(queue.openTransactionsMax, 3);
+      final stats = begin.concurrency!;
+      expect(stats.othersInFlightP50, 4);
+      expect(stats.othersInFlightMax, 59);
+      expect(stats.openTransactionsP50, 1);
+      expect(stats.openTransactionsMax, 3);
       // No entry with timing bookkeeping: nothing to summarise.
-      expect(digest.slowQueries.last.queueDepth, isNull);
+      expect(digest.slowQueries.last.concurrency, isNull);
+    });
+
+    test('the super-slow copy of an entry does not double its sample', () {
+      // Both files carry the same TIMING rows for one query; counting both
+      // would pull the percentiles toward the slowest entries, which are
+      // exactly the ones that reach the super-slow file.
+      final digest = builder.build(
+        input(
+          slowQueries: [
+            for (final (ms, inFlight) in [(15.0, 1), (20.0, 5), (300.0, 60)])
+              slowQuery(
+                timestamp: t0.add(Duration(milliseconds: ms.toInt())),
+                elapsedMs: ms,
+                statement: 'BEGIN',
+                inFlightAtStart: inFlight,
+              ),
+            slowQuery(
+              timestamp: t0.add(const Duration(milliseconds: 300)),
+              elapsedMs: 300,
+              statement: 'BEGIN',
+              isSuperSlow: true,
+              inFlightAtStart: 60,
+            ),
+            // A super-slow entry whose slow-file twin is gone still counts.
+            slowQuery(
+              timestamp: t0.add(const Duration(days: 1)),
+              elapsedMs: 400,
+              statement: 'BEGIN',
+              isSuperSlow: true,
+              inFlightAtStart: 2,
+              openTransactionsAtStart: 1,
+            ),
+          ],
+        ),
+      );
+
+      final stats = digest.slowQueries.single.concurrency!;
+      // Samples: others = [0, 4, 59, 1] → sorted [0, 1, 4, 59].
+      expect(stats.othersInFlightP50, 4);
+      expect(stats.othersInFlightMax, 59);
+      expect(stats.openTransactionsMax, 1);
     });
 
     test('buckets are ordered by total time', () {

--- a/test/features/system_health/service/log_file_reader_test.dart
+++ b/test/features/system_health/service/log_file_reader_test.dart
@@ -258,8 +258,14 @@ void main() {
       slow.first.statement,
       startsWith('SELECT * FROM journal WHERE deleted'),
     );
-    // TIMING continuation lines are not plan rows.
+    // TIMING continuation lines are not plan rows; they carry the queue
+    // depth. No TRANSACTION row with a TIMING row means nothing was open.
     expect(slow.first.planRows, isEmpty);
+    expect(slow.first.inFlightAtStart, 4);
+    expect(slow.first.openTransactionsAtStart, 0);
+    // An entry written without timing bookkeeping carries neither.
+    expect(slow[1].inFlightAtStart, isNull);
+    expect(slow[1].openTransactionsAtStart, isNull);
     expect(superSlow.first.planRows, hasLength(2));
     expect(superSlow.first.planRows.last, '84|0|USE TEMP B-TREE FOR ORDER BY');
     expect(superSlow.first.stackFrames, hasLength(2));
@@ -267,6 +273,34 @@ void main() {
       superSlow.first.stackFrames.first,
       startsWith('#10     JournalDb.getAllDashboards'),
     );
+  });
+
+  test('a BEGIN keeps the open-transaction count it waited behind', () async {
+    await writeLogFile(
+      logs,
+      'slow_queries',
+      fixtureDay,
+      transactionSlowQueriesFixture,
+    );
+
+    final result = await reader.read(
+      range: fixtureRange(),
+      domains: const {},
+      includeSlowQueries: true,
+    );
+
+    expect(result.slowQueries, hasLength(2));
+    final queued = result.slowQueries.first;
+    expect(queued.databaseName, 'agent.sqlite');
+    expect(queued.operation, 'transaction.open');
+    expect(queued.statement, 'BEGIN');
+    expect(queued.inFlightAtStart, 12);
+    expect(queued.openTransactionsAtStart, 2);
+    // The last entry of a file is flushed too, timing rows or not.
+    final plain = result.slowQueries.last;
+    expect(plain.elapsedMs, 20);
+    expect(plain.inFlightAtStart, isNull);
+    expect(plain.openTransactionsAtStart, isNull);
   });
 
   test('slow-query files are skipped unless requested', () async {

--- a/test/features/system_health/service/system_health_report_builder_test.dart
+++ b/test/features/system_health/service/system_health_report_builder_test.dart
@@ -30,22 +30,25 @@ void main() {
         sampleFrames: const ['#0 Foo.bar (package:lotti/foo.dart:1:1)'],
       );
 
-  SlowQueryBucket query(int index) => SlowQueryBucket(
-    statement: 'SELECT $index FROM journal',
-    operation: 'select',
-    count: 3,
-    superSlowCount: 1,
-    p50Ms: 12.4,
-    p95Ms: 200,
-    maxMs: 388.759,
-    totalMs: 600,
-    firstSeen: t0,
-    lastSeen: t0,
-    planShapes: const ['84|0|USE TEMP B-TREE FOR ORDER BY'],
-    topFrames: const [
-      '#10 JournalDb.get (package:lotti/database/database.dart:1:1)',
-    ],
-  );
+  SlowQueryBucket query(int index, {QueueDepthStats? queueDepth}) =>
+      SlowQueryBucket(
+        databaseName: 'db.sqlite',
+        queueDepth: queueDepth,
+        statement: 'SELECT $index FROM journal',
+        operation: 'select',
+        count: 3,
+        superSlowCount: 1,
+        p50Ms: 12.4,
+        p95Ms: 200,
+        maxMs: 388.759,
+        totalMs: 600,
+        firstSeen: t0,
+        lastSeen: t0,
+        planShapes: const ['84|0|USE TEMP B-TREE FOR ORDER BY'],
+        topFrames: const [
+          '#10 JournalDb.get (package:lotti/database/database.dart:1:1)',
+        ],
+      );
 
   LogDigest digest({
     List<LogIssueBucket> issues = const [],
@@ -184,6 +187,38 @@ void main() {
   });
 
   group('renderDigest', () {
+    test(
+      'a statement with queue-depth stats renders them on their own row',
+      () {
+        final text = builder.renderDigest(
+          digest(
+            slowQueries: [
+              query(
+                1,
+                queueDepth: const QueueDepthStats(
+                  inFlightP50: 3,
+                  inFlightMax: 61,
+                  openTransactionsP50: 1,
+                  openTransactionsMax: 4,
+                ),
+              ),
+              query(2),
+            ],
+          ),
+        );
+
+        expect(
+          text,
+          contains(
+            '   - queue at start: in flight p50 3 · max 61 · '
+            'open transactions p50 1 · max 4',
+          ),
+        );
+        // Only the bucket that carries stats gets the row.
+        expect('queue at start'.allMatches(text), hasLength(1));
+      },
+    );
+
     test('renders counts, bursts, issues and slow queries', () {
       final text = builder.renderDigest(
         digest(
@@ -224,7 +259,8 @@ void main() {
       expect(
         text,
         contains(
-          '1. **select** ×3 · p50 12ms · p95 200ms · max 389ms · total 600ms · '
+          '1. **select** on db.sqlite ×3 · p50 12ms · p95 200ms · '
+          'max 389ms · total 600ms · '
           'super slow ×1 (2026-09-12 00:05 → 2026-09-12 00:05)',
         ),
       );

--- a/test/features/system_health/service/system_health_report_builder_test.dart
+++ b/test/features/system_health/service/system_health_report_builder_test.dart
@@ -30,10 +30,10 @@ void main() {
         sampleFrames: const ['#0 Foo.bar (package:lotti/foo.dart:1:1)'],
       );
 
-  SlowQueryBucket query(int index, {QueueDepthStats? queueDepth}) =>
+  SlowQueryBucket query(int index, {ConcurrencyStats? concurrency}) =>
       SlowQueryBucket(
         databaseName: 'db.sqlite',
-        queueDepth: queueDepth,
+        concurrency: concurrency,
         statement: 'SELECT $index FROM journal',
         operation: 'select',
         count: 3,
@@ -188,16 +188,16 @@ void main() {
 
   group('renderDigest', () {
     test(
-      'a statement with queue-depth stats renders them on their own row',
+      'a statement with concurrency stats renders them on their own row',
       () {
         final text = builder.renderDigest(
           digest(
             slowQueries: [
               query(
                 1,
-                queueDepth: const QueueDepthStats(
-                  inFlightP50: 3,
-                  inFlightMax: 61,
+                concurrency: const ConcurrencyStats(
+                  othersInFlightP50: 3,
+                  othersInFlightMax: 61,
                   openTransactionsP50: 1,
                   openTransactionsMax: 4,
                 ),
@@ -210,12 +210,12 @@ void main() {
         expect(
           text,
           contains(
-            '   - queue at start: in flight p50 3 · max 61 · '
+            '   - at start: other statements in flight p50 3 · max 61 · '
             'open transactions p50 1 · max 4',
           ),
         );
         // Only the bucket that carries stats gets the row.
-        expect('queue at start'.allMatches(text), hasLength(1));
+        expect('at start:'.allMatches(text), hasLength(1));
       },
     );
 

--- a/test/features/system_health/system_health_test_fixtures.dart
+++ b/test/features/system_health/system_health_test_fixtures.dart
@@ -68,6 +68,16 @@ const String slowQueriesFixture = '''
 2026-09-12T19:11:51.000 [db.sqlite] select 250.000ms args=0 SELECT * FROM journal WHERE deleted = 0 ORDER BY date_from DESC
 ''';
 
+/// A `BEGIN` that queued behind open transactions, with the timing and
+/// transaction rows the interceptor writes for it, followed by an entry
+/// written without timing bookkeeping.
+const String transactionSlowQueriesFixture = '''
+2026-09-12T19:11:52.000 [agent.sqlite] transaction.open 1064.000ms args=0 BEGIN
+  TIMING: scope=executorAwait started=2026-09-12T19:11:50.936 completed=2026-09-12T19:11:52.000 inFlightAtStart=12
+  TRANSACTION: id=7 parent=null activeAtStart=[3, 5]
+2026-09-12T19:11:53.000 [agent.sqlite] transaction.open 20.000ms args=0 BEGIN
+''';
+
 const String superSlowQueriesFixture = '''
 2026-09-12T19:11:48.592 [db.sqlite] select 388.759ms args=0 SELECT * FROM journal WHERE deleted = 0 ORDER BY date_from DESC
   PLAN: 4|0|SEARCH journal USING INDEX idx_journal_browse (deleted=?)
@@ -100,16 +110,22 @@ SlowQueryRecord slowQuery({
   required DateTime timestamp,
   double elapsedMs = 20,
   String statement = 'SELECT * FROM journal WHERE id = ?',
+  String databaseName = 'db.sqlite',
+  String operation = 'select',
   bool isSuperSlow = false,
   List<String> planRows = const [],
   List<String> stackFrames = const [],
+  int? inFlightAtStart,
+  int? openTransactionsAtStart,
 }) => SlowQueryRecord(
   timestamp: timestamp,
-  databaseName: 'db.sqlite',
-  operation: 'select',
+  databaseName: databaseName,
+  operation: operation,
   elapsedMs: elapsedMs,
   statement: statement,
   isSuperSlow: isSuperSlow,
   planRows: planRows,
   stackFrames: stackFrames,
+  inFlightAtStart: inFlightAtStart,
+  openTransactionsAtStart: openTransactionsAtStart,
 );


### PR DESCRIPTION
## Summary

Follow-up to #4266. Both 2026-09-13 health reports listed `transaction.open` as the dominant cost (p50 ≈ 1 s, 5.4 h/week) but could not say where it came from: the digest merged every `BEGIN` across the agent, sync and journal databases into one row, named `AgentRepoCore.runInTransaction` as the caller of all of them, and dropped the `inFlightAtStart` / `activeAtStart` counters the interceptor writes on every slow line. This PR makes the next report answer that question by itself.

## Changes

**System health digest**
- Slow-query buckets are keyed by database file **and** normalised statement. The report line reads `**transaction.open** on agent.sqlite ×…`.
- The caller frame is the first `package:lotti/` frame below the transaction wrappers (`runInTransaction`, `withVcScope`, `_markInTransaction`); the wrapper itself only when the capture holds nothing else.
- `LogFileReader` parses the `TIMING:` and `TRANSACTION:` continuation rows into `SlowQueryRecord.inFlightAtStart` / `openTransactionsAtStart`. Buckets that carry them get `QueueDepthStats` (p50 and max of both) and the report renders a `queue at start` row. For a `BEGIN`, drift holds the writer lock for a transaction's whole lifetime, so this row separates "one transaction held for seconds" from "dozens opened at once".

**Wake failure attribution**
- `wireWakeExecutor` throws a typed `WakeFailedException(kind, reason)` instead of a bare `StateError`, and the drain engine's failure message carries `kind=… reason=…`. The PII-safe error log keeps only message and error type, which had reduced 147 failed wakes to `errorType=StateError` — indistinguishable from the genuine drift `StateError` fixed in #4266. Reasons are workflow-authored strings, never user content; ids in them are redacted like everywhere else.

**Agent repository**
- `getAgentIdentitiesByLifecycle` filters the cached identity list (`getAllAgentIdentities`, same ordering) instead of running its own JSON-predicate select. Every before-scan hook asked for the active agents on every pass: ~6,200 queries/week on desktop for rows the cache already held. Lifecycle is part of the identity entity, so the existing invalidation on identity writes covers it (test added).

## Tests

- Reader: `TIMING`/`TRANSACTION` parsing, missing rows, last-entry flush.
- Digest builder: per-database split, wrapper-frame skipping (and the all-wrapper fallback), queue-depth stats with and without transaction rows.
- Report builder: heading with database, `queue at start` row only where stats exist.
- Wiring: `WakeFailedException` carries kind and reason. Drain engine: failure log message carries both.
- Repository: lifecycle filter parity plus a lifecycle flip visible on the next call.

`make knowledge_check`, `make changelog_check` and the analyzer are clean; 306 tests in the touched files pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System health reports now group slow queries by database and normalized statement.
  * Reports identify the issuing application code and include concurrency-at-start statistics for in-flight statements and open transactions.
  * Slow-query entries display the associated database and concurrency details when available.
  * Failed agent wakes now provide privacy-safe logs with agent type and workflow reason, while limiting surfaced error details to safe exception types.

* **Documentation**
  * Updated system health documentation to explain concurrency reporting and caller attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->