### PR TITLE
fix: harden screenshot capture and sync regression tests

### DIFF
--- a/changelog.d/2026-09-13-screenshot-capture-timeout.md
+++ b/changelog.d/2026-09-13-screenshot-capture-timeout.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **A stalled screenshot tool no longer leaves the app minimized indefinitely.**
+  Screenshot capture on Linux and macOS now times out even when the tool keeps
+  its output streams open, and restores the app window.

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -6,68 +6,54 @@ Integration tests verify end-to-end functionality that cannot be adequately test
 
 ### 1. Matrix Sync Tests (`matrix_service_test.dart`)
 
-This suite contains four tests:
+The suite exercises the real Dendrite homeserver, encrypted Matrix transport,
+and per-device stores:
 
-**`Create room & join (sync v2)`** — the baseline two-device flow:
-- Two-device sync flow with real Matrix homeserver (Dendrite)
-- Room creation and encrypted room join
-- Device discovery and SAS emoji verification
-- Bidirectional message exchange (100 messages each direction, or 10 in slow network mode)
-- Self-event suppression (devices don't re-apply their own messages)
-- Message persistence to local database
+- Room creation, joining, SAS verification and bidirectional journal exchange
+  (100 entries per direction, or 10 in slow-network mode).
+- Image transfer to Bob and audio transfer to Alice, checking metadata and exact
+  media bytes in the receiver's own directory.
+- A withheld Megolm key followed by a complete Bob restart. The durable resume
+  floor survives the restart; the late key must restore the image and clear it.
+- A cold restart after Alice drains 1000 entries through the production outbox
+  (250 in slow-network mode), exercising bundled transfer and persisted markers.
+- Bob rejoining during a 600-entry outbox drain (150 in slow-network mode),
+  overlapping startup catch-up with new bundles and checking deduplication.
+- Peer repair of missing image and audio files after metadata has already
+  converged, checking both requests and the restored bytes.
 
-**`Late Megolm key survives Bob restart and clears the durable floor`** —
-Alice deliberately withholds a Megolm session from Bob, sends through the
-production outbox, and verifies that Bob records a durable resume floor without
-applying ciphertext. Bob is fully restarted on the same Matrix SDK, journal,
-settings, and sync databases, and a startup bridge proves the unresolved floor
-is retained. Alice then sends the real encrypted room key after Bob becomes
-eligible again. The restarted production queue must recover the event exactly
-once through its one-shot bootstrap re-decryption and clear the floor.
-
-**`Large-volume convergence: Bob catches up 1000 messages after cold restart`**
-(250 in slow network mode, 30-minute test timeout with a 15-minute internal
-convergence-wait budget) — Alice sends a large burst while Bob's
-client is closed; Bob then reopens with a fresh client/pipeline but the same
-persisted Matrix SDK database, journal, settings, and queue database. The
-surviving queue marker makes this a production-faithful reconnect rather than
-an artificial fresh-client bootstrap.
-
-**`Mid-burst rejoin`** — Alice pauses 40% into a 600-message burst while Bob comes online
-(150 in slow network mode, 30-minute test timeout with a 15-minute internal
-convergence-wait budget). Once Bob's startup bridge is in flight, Alice resumes the burst. This
-deterministically overlaps bridge pagination with new sends. After the startup bridge reaches the
-server's then-current end, the test runs the production full-history sweep to collect messages sent
-later without relying on a second forward walk. The `event_id UNIQUE` constraint on
-`inbound_event_queue` deduplicates events visited by both passes near the bridge boundary.
-
-**Problems this catches:**
-- Regressions in Matrix SDK integration
-- Encryption/decryption failures
-- Device verification protocol issues
-- Message ordering and deduplication bugs
-- Database persistence failures during sync
-- Race conditions in concurrent message processing
+The ordinary Matrix suite includes explicit history/retry actions in some
+convergence helpers. Use the resilience suite below to check recovery without
+those test-driven actions.
 
 ### 2. Sync Resilience Tests (`sync_resilience_test.dart`)
 
-Tests sync behavior under adverse network conditions using Toxiproxy.
+Tests automatic sync recovery under adverse network conditions using Toxiproxy.
+Alice and Bob have separate documents directories, Matrix stores, journal,
+settings and sync databases. Fixtures go through the real outbox, which records
+sender sequence history; both devices run the production backfill request and
+response services. Device host IDs match their vector-clock keys. Receiver assertions poll database state only;
+there are no calls to `forceRescan()` or `retryNow()` to make delivery succeed.
+Each scenario compares exact entries (including text, timestamps and vector
+clocks) and the JSON attachment bytes downloaded into Bob's directory against
+Alice's originals. Neither device may find attachments in the global directory.
+These real-network tests use bounded wall-clock waits under the real-I/O
+exception in [the fake-time policy](../test/README.md#fake-time-policy).
 
 #### Test Cases:
 
 | Test | Scenario | What It Verifies |
 |------|----------|------------------|
 | Network interruption during sync | Alice sends messages, network is cut mid-way, then restored | Messages sent while offline eventually sync after reconnection |
-| High latency | 2000ms latency added to all network calls | Sync completes correctly despite slow responses |
-| Bandwidth throttling | Network limited to 50 KB/s | Large payloads sync without data loss or corruption |
+| High latency | 2000ms added to Bob’s downstream traffic | Sync completes correctly despite slow responses |
+| Bandwidth throttling | Network limited to 50 KB/s | Large, poorly compressible JSON attachments sync without data loss or corruption |
 | Multiple network interruptions | Network toggled on/off multiple times during sync | Eventual consistency after repeated disruptions |
 
 **Problems this catches:**
-- Sync failures after device wake from sleep/standby
-- Message loss during network transitions (WiFi ↔ cellular)
-- Retry logic failures
-- Catch-up mechanism bugs after extended offline periods
-- Circuit breaker misbehavior
+- Entries missed while the receiver is offline
+- Recovery that depends on a manual rescan or retry
+- Stalled delivery under latency or bandwidth limits
+- Corrupted payloads and accidental sharing of device files
 
 ### 3. Home Integration Test (`home_integration_test.dart`)
 
@@ -165,6 +151,9 @@ project root.
    ```
    This script creates four temporary user pairs in docker and runs
    `sync_resilience_test.dart` with `TEST_USER1` through `TEST_USER8`.
+   MCP/IDE runners can supply the same names as process environment variables;
+   Dart defines take precedence. All eight users are required, so a missing
+   pair cannot silently reuse shared fallback accounts.
 
 4. **Run with simulated bad network:**
    ```shell
@@ -184,29 +173,24 @@ The run scripts create dedicated test users on the Dendrite server. Each resilie
 - `run_matrix_tests.sh` independently provisions its own freshly-created users and passes
   them as `TEST_USER1`/`TEST_USER2` for the standalone Matrix sync test.
 
-### Performance Expectations
+### Runtime budgets
 
-The individual figures below describe the baseline `Create room & join` test
-(which itself carries a 15-minute timeout). The complete degraded Matrix suite,
-including its Linux rebuild, is expected to stay below five minutes; the
-production-faithful persisted-marker run measured 4m40s locally. The
-`Large-volume convergence` (1000-message cold restart) and `Mid-burst rejoin`
-(600-message) tests each retain a 30-minute test timeout with a 15-minute
-internal per-wait convergence budget so a real regression still has room to
-produce useful diagnostics.
+Runtime depends on native build caching, host load and the injected network
+fault. The resilience cases allow five minutes each, except repeated outages
+(eight minutes); their final delivery observation allows three minutes.
 
-| Mode | Matrix Sync Test (baseline) | Resilience Tests |
-|------|-----------------------------|------------------|
-| Normal network | ~50s | ~2-3 min per test |
-| Degraded network | ~1m 25s | ~5-8 min per test |
+The Matrix baseline, late-key restart and peer-repair cases allow 15 minutes.
+The individual image/audio cases allow five minutes. Cold-restart and mid-drain
+convergence allow 30 minutes, with 15-minute internal convergence waits.
+These are failure bounds, not expected runtimes.
 
 ## Test Helpers
 
 Shared test utilities live in `integration_test/helpers/`:
 
 - **`sync_test_helpers.dart`** - Common utilities for Matrix sync tests:
-  - `createMatrixService()` - Factory for test MatrixService instances
-  - `sendTestMessage()` - Send a test journal entry via Matrix
+  - `createSyncTestDevice()` - Real Matrix, queue, outbox and backfill wiring
+  - `sendTestMessage()` - Persist a fixture, enqueue it and observe outbox completion
   - `createTestEntry()` - Create a test journal entry
   - `extractEmojiString()` - Extract emojis from verification flow
   - `waitUntil()` / `waitUntilAsync()` - Polling helpers with timeout
@@ -217,15 +201,12 @@ Shared test utilities live in `integration_test/helpers/`:
   - `limitBandwidth()` - Throttle throughput
   - `disconnect()` / `reconnect()` - Toggle connectivity
 
-## Confidence Gained
+## Scope
 
-These integration tests provide confidence that:
-
-1. **Multi-device sync works end-to-end** - Real Matrix protocol, real encryption, real database writes
-2. **Sync is resilient to real-world network conditions** - Handles the messy reality of mobile networks
-3. **Device verification is functional** - The security-critical emoji SAS flow works correctly
-4. **Recovery mechanisms work** - Catch-up, retry, and circuit breaker logic behaves correctly
-5. **No message loss under stress** - All messages eventually sync, even under adverse conditions
+These suites exercise encrypted transport, persistence, attachment transfer
+and selected recovery paths. Toxiproxy faults simulate network conditions;
+they do not simulate operating-system sleep or prove every network failure
+mode. The explicit assertions in each scenario define its guarantee.
 
 ## See Also
 

--- a/integration_test/helpers/sync_test_helpers.dart
+++ b/integration_test/helpers/sync_test_helpers.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:lotti/classes/config.dart';
 import 'package:lotti/classes/entry_text.dart';
@@ -9,6 +10,8 @@ import 'package:lotti/database/database.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
+import 'package:lotti/features/sync/backfill/backfill_request_service.dart';
+import 'package:lotti/features/sync/backfill/backfill_response_handler.dart';
 import 'package:lotti/features/sync/gateway/matrix_sync_gateway.dart';
 import 'package:lotti/features/sync/matrix/matrix_message_sender.dart';
 import 'package:lotti/features/sync/matrix/matrix_service.dart';
@@ -19,9 +22,11 @@ import 'package:lotti/features/sync/matrix/session_manager.dart';
 import 'package:lotti/features/sync/matrix/sync_event_processor.dart';
 import 'package:lotti/features/sync/matrix/sync_room_manager.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
+import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/features/sync/queue/queue_pipeline_coordinator.dart';
 import 'package:lotti/features/sync/secure_storage.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
+import 'package:lotti/features/sync/state/outbox_state_controller.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_persistence.dart';
 import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_repository.dart';
@@ -30,6 +35,7 @@ import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/vector_clock_service.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:matrix/encryption/utils/key_verification.dart';
 import 'package:uuid/uuid.dart';
@@ -132,33 +138,75 @@ JournalEntry createTestEntry({
   );
 }
 
-/// Create and send a test message
-Future<void> sendTestMessage({
-  required MatrixService matrixService,
-  required String deviceName,
+/// Persists a fixture and sends it through the real outbox, including the
+/// sequence binding peers need to request it after a network gap.
+Future<JournalEntry> sendTestMessage({
+  required SyncTestDevice device,
   required int index,
-  required String roomId,
   String? text,
 }) async {
   final entry = createTestEntry(
-    deviceName: deviceName,
-    index: index,
+    deviceName: device.hostId,
+    index: index + 1,
     timestamp: DateTime.utc(2024, 3, 15).add(Duration(seconds: index)),
     text: text,
   );
-
-  final jsonPath = relativeEntityPath(entry);
-  await saveJournalEntityJson(entry);
-
-  await matrixService.sendMatrixMsg(
+  await device.journalDb.updateJournalEntity(entry);
+  await device.outbox.enqueueMessageOrThrow(
     SyncMessage.journalEntity(
       id: entry.meta.id,
       status: SyncEntryStatus.initial,
-      vectorClock: entry.meta.vectorClock ?? const VectorClock({}),
-      jsonPath: jsonPath,
+      vectorClock: entry.meta.vectorClock,
+      jsonPath: relativeEntityPath(entry),
+      originatingHostId: device.hostId,
     ),
-    myRoomId: roomId,
   );
+  // Sending must finish before the test advances to its next network phase.
+  // This observer never nudges the runner or retries a failed row.
+  await waitUntilAsync(() async {
+    final pending = await device.syncDb.getOutboxItems(
+      limit: 100,
+      statuses: const [
+        OutboxStatus.pending,
+        OutboxStatus.sending,
+        OutboxStatus.error,
+      ],
+    );
+    if (pending.any((item) => item.status == OutboxStatus.error.index)) {
+      throw StateError('Outbox failed to send fixture ${entry.meta.id}');
+    }
+    return pending.isEmpty;
+  }, message: 'Outbox did not send fixture ${entry.meta.id}');
+  return entry;
+}
+
+/// A simulated device's real transport, outbox and automatic gap recovery.
+/// Database and Matrix-client lifetimes remain owned by the calling fixture.
+class SyncTestDevice {
+  SyncTestDevice({
+    required this.matrixService,
+    required this.outbox,
+    required this.backfill,
+    required this.journalDb,
+    required this.syncDb,
+    required this.hostId,
+  });
+
+  final MatrixService matrixService;
+  final MatrixOutboxService outbox;
+  final BackfillRequestService backfill;
+  final JournalDb journalDb;
+  final SyncDatabase syncDb;
+  final String hostId;
+
+  Future<void> dispose() async {
+    backfill.dispose();
+    try {
+      await outbox.dispose();
+    } finally {
+      await matrixService.dispose();
+    }
+  }
 }
 
 /// Setup Toxiproxy for testing
@@ -239,13 +287,15 @@ Future<bool> verifyTestEnvironment() async {
   }
 }
 
-/// Create a MatrixService instance for testing.
+/// Creates a device with the production queue, outbox and backfill services.
 ///
 /// The Phase-2 `InboundQueue` pipeline is wired up alongside the
 /// service — a dedicated SyncDatabase + SyncSequenceLogService +
 /// MatrixSessionManager + SyncRoomManager are built here and the
-/// coordinator is passed in as the only inbound path.
-Future<MatrixService> createMatrixService({
+/// coordinator is passed in as the only inbound path. The caller owns and
+/// closes the supplied databases after disposing the service. Both the loader
+/// and the ingestor resolve attachments in the supplied device directory.
+Future<SyncTestDevice> createSyncTestDevice({
   required MatrixConfig config,
   required MatrixSyncGateway gateway,
   required DomainLogger loggingService,
@@ -258,6 +308,8 @@ Future<MatrixService> createMatrixService({
   required UpdateNotifications updateNotifications,
   required AiConfigRepository aiConfigRepository,
   required SentEventRegistry sentEventRegistry,
+  required SyncDatabase syncDb,
+  required VectorClockService vectorClockService,
   bool collectSyncMetrics = true,
   AttachmentIndex? attachmentIndex,
 }) async {
@@ -269,16 +321,7 @@ Future<MatrixService> createMatrixService({
     journalDb: journalDb,
     documentsDirectory: documentsDirectory,
     sentEventRegistry: sentEventRegistry,
-  );
-  final eventProcessor = SyncEventProcessor(
-    loggingService: loggingService,
-    updateNotifications: updateNotifications,
-    aiConfigRepository: aiConfigRepository,
-    settingsDb: settingsDb,
-    savedTaskFiltersRepository: SavedTaskFiltersRepository(
-      SavedTaskFiltersPersistence(settingsDb),
-      updateNotifications,
-    ),
+    vectorClockService: vectorClockService,
   );
 
   // Share a single AttachmentIndex between MatrixService and the
@@ -297,16 +340,32 @@ Future<MatrixService> createMatrixService({
     verboseLogging: false,
   );
 
-  final syncDb = SyncDatabase(
-    overriddenFilename: 'sync_${uuid.v1()}.sqlite',
-    inMemoryDatabase: true,
-  );
-  final vectorClockService = VectorClockService();
   final sequenceLogService = SyncSequenceLogService(
     syncDatabase: syncDb,
     vectorClockService: vectorClockService,
     loggingService: loggingService,
   );
+  final eventProcessor = SyncEventProcessor(
+    loggingService: loggingService,
+    updateNotifications: updateNotifications,
+    aiConfigRepository: aiConfigRepository,
+    settingsDb: settingsDb,
+    journalEntityLoader: SmartJournalEntityLoader(
+      attachmentIndex: sharedAttachmentIndex,
+      loggingService: loggingService,
+      documentsDirectory: documentsDirectory,
+    ),
+    documentsDirectory: documentsDirectory,
+    attachmentIndex: sharedAttachmentIndex,
+    sequenceLogService: sequenceLogService,
+    journalDb: journalDb,
+    vectorClockService: vectorClockService,
+    savedTaskFiltersRepository: SavedTaskFiltersRepository(
+      SavedTaskFiltersPersistence(settingsDb),
+      updateNotifications,
+    ),
+  );
+
   final roomManager = SyncRoomManager(
     gateway: gateway,
     settingsDb: settingsDb,
@@ -335,7 +394,7 @@ Future<MatrixService> createMatrixService({
     attachmentIngestor: queueAttachmentIngestor,
   );
 
-  return MatrixService(
+  final matrixService = MatrixService(
     matrixConfig: config,
     gateway: gateway,
     loggingService: loggingService,
@@ -350,6 +409,59 @@ Future<MatrixService> createMatrixService({
     roomManager: roomManager,
     sessionManager: sessionManager,
     queueCoordinator: queueCoordinator,
+  );
+  await journalDb.upsertConfigFlag(
+    const ConfigFlag(
+      name: enableMatrixFlag,
+      description: 'Enable Matrix Sync',
+      status: true,
+    ),
+  );
+  final outbox = MatrixOutboxService(
+    syncDatabase: syncDb,
+    loggingService: loggingService,
+    vectorClockService: vectorClockService,
+    journalDb: journalDb,
+    documentsDirectory: documentsDirectory,
+    userActivityService: activityService,
+    matrixService: matrixService,
+    connectivityStream: const Stream<List<ConnectivityResult>>.empty(),
+    sequenceLogService: sequenceLogService,
+    domainLogger: loggingService,
+  );
+  final backfill = BackfillRequestService(
+    sequenceLogService: sequenceLogService,
+    syncDatabase: syncDb,
+    outboxService: outbox,
+    vectorClockService: vectorClockService,
+    loggingService: loggingService,
+    documentsDirectory: documentsDirectory,
+    queueCoordinator: queueCoordinator,
+    domainLogger: loggingService,
+  );
+  // Keep this wiring aligned with get_it_sync.dart: organic sequence gaps,
+  // bridge completion and queue drain must wake the same recovery services.
+  sequenceLogService.onMissingEntriesDetected = () {
+    backfill.nudge();
+    queueCoordinator.maybeStartGapRecovery();
+  };
+  queueCoordinator.onBridgeCompleted = backfill.nudge;
+  eventProcessor.backfillResponseHandler = BackfillResponseHandler(
+    journalDb: journalDb,
+    sequenceLogService: sequenceLogService,
+    outboxService: outbox,
+    loggingService: loggingService,
+    vectorClockService: vectorClockService,
+    domainLogger: loggingService,
+  );
+  backfill.start();
+  return SyncTestDevice(
+    matrixService: matrixService,
+    outbox: outbox,
+    backfill: backfill,
+    journalDb: journalDb,
+    syncDb: syncDb,
+    hostId: (await vectorClockService.getHost())!,
   );
 }
 

--- a/integration_test/sync_resilience_test.dart
+++ b/integration_test/sync_resilience_test.dart
@@ -1,18 +1,21 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:drift/drift.dart' as drift;
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_vodozemac/flutter_vodozemac.dart' as vod;
 import 'package:lotti/classes/config.dart';
+import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/ai/database/ai_config_db.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/sync/gateway/matrix_sdk_gateway.dart';
 import 'package:lotti/features/sync/matrix/client.dart';
-import 'package:lotti/features/sync/matrix/matrix_service.dart';
 import 'package:lotti/features/sync/matrix/sent_event_registry.dart';
 import 'package:lotti/features/sync/secure_storage.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
@@ -20,10 +23,12 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/logging_service.dart';
+import 'package:lotti/utils/file_utils.dart' hide uuid;
 import 'package:mocktail/mocktail.dart';
-import 'package:path_provider/path_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../test/mocks/mocks.dart';
+import '../test/widget_test_utils.dart';
 import 'helpers/sync_test_helpers.dart';
 import 'helpers/toxiproxy_controller.dart';
 import 'matrix_test_room.dart';
@@ -37,15 +42,31 @@ void main() {
     final secureStorageMock = MockSecureStorage();
 
     // Each test gets its own user pair to avoid device accumulation
-    // All env vars must be compile-time constants
-    const testUser1 = String.fromEnvironment('TEST_USER1');
-    const testUser2 = String.fromEnvironment('TEST_USER2');
-    const testUser3 = String.fromEnvironment('TEST_USER3');
-    const testUser4 = String.fromEnvironment('TEST_USER4');
-    const testUser5 = String.fromEnvironment('TEST_USER5');
-    const testUser6 = String.fromEnvironment('TEST_USER6');
-    const testUser7 = String.fromEnvironment('TEST_USER7');
-    const testUser8 = String.fromEnvironment('TEST_USER8');
+    // Scripts use Dart defines; MCP/IDE runners can supply process environment.
+    final testUser1 = const String.fromEnvironment('TEST_USER1').isNotEmpty
+        ? const String.fromEnvironment('TEST_USER1')
+        : Platform.environment['TEST_USER1'] ?? '';
+    final testUser2 = const String.fromEnvironment('TEST_USER2').isNotEmpty
+        ? const String.fromEnvironment('TEST_USER2')
+        : Platform.environment['TEST_USER2'] ?? '';
+    final testUser3 = const String.fromEnvironment('TEST_USER3').isNotEmpty
+        ? const String.fromEnvironment('TEST_USER3')
+        : Platform.environment['TEST_USER3'] ?? '';
+    final testUser4 = const String.fromEnvironment('TEST_USER4').isNotEmpty
+        ? const String.fromEnvironment('TEST_USER4')
+        : Platform.environment['TEST_USER4'] ?? '';
+    final testUser5 = const String.fromEnvironment('TEST_USER5').isNotEmpty
+        ? const String.fromEnvironment('TEST_USER5')
+        : Platform.environment['TEST_USER5'] ?? '';
+    final testUser6 = const String.fromEnvironment('TEST_USER6').isNotEmpty
+        ? const String.fromEnvironment('TEST_USER6')
+        : Platform.environment['TEST_USER6'] ?? '';
+    final testUser7 = const String.fromEnvironment('TEST_USER7').isNotEmpty
+        ? const String.fromEnvironment('TEST_USER7')
+        : Platform.environment['TEST_USER7'] ?? '';
+    final testUser8 = const String.fromEnvironment('TEST_USER8').isNotEmpty
+        ? const String.fromEnvironment('TEST_USER8')
+        : Platform.environment['TEST_USER8'] ?? '';
 
     // create separate databases for each simulated device & suppress warning
     drift.driftRuntimeOptions.dontWarnAboutMultipleDatabases = true;
@@ -79,6 +100,9 @@ void main() {
 
     late JournalDb aliceDb;
     late JournalDb bobDb;
+    late Directory aliceDocumentsDirectory;
+    late Directory bobDocumentsDirectory;
+    final expectedEntries = <JournalEntry>[];
     late AiConfigDb aiConfigDb;
 
     // Alice uses direct homeserver, Bob uses proxy so we can control his network
@@ -86,42 +110,26 @@ void main() {
     const bobHomeServer = 'http://localhost:18008';
     const testPassword = '?Secret123@';
 
-    // Check if first user pair is present
+    final testUsers = [
+      testUser1,
+      testUser2,
+      testUser3,
+      testUser4,
+      testUser5,
+      testUser6,
+      testUser7,
+      testUser8,
+    ];
     final missingEnv = <String>[
-      if (!const bool.hasEnvironment('TEST_USER1')) 'TEST_USER1',
-      if (!const bool.hasEnvironment('TEST_USER2')) 'TEST_USER2',
+      for (var i = 0; i < testUsers.length; i++)
+        if (testUsers[i].isEmpty) 'TEST_USER${i + 1}',
     ];
     final skipReason = missingEnv.isEmpty
         ? null
         : 'Missing: ${missingEnv.join(', ')}. Run via run_resilience_tests.sh';
 
-    /// Get user credentials for a specific test index
-    (String alice, String bob) getUserPair(int testIndex) {
-      switch (testIndex) {
-        case 0:
-          return (
-            testUser1.isNotEmpty ? testUser1 : '@test_alice:localhost',
-            testUser2.isNotEmpty ? testUser2 : '@test_bob:localhost',
-          );
-        case 1:
-          return (
-            testUser3.isNotEmpty ? testUser3 : '@test_alice:localhost',
-            testUser4.isNotEmpty ? testUser4 : '@test_bob:localhost',
-          );
-        case 2:
-          return (
-            testUser5.isNotEmpty ? testUser5 : '@test_alice:localhost',
-            testUser6.isNotEmpty ? testUser6 : '@test_bob:localhost',
-          );
-        case 3:
-          return (
-            testUser7.isNotEmpty ? testUser7 : '@test_alice:localhost',
-            testUser8.isNotEmpty ? testUser8 : '@test_bob:localhost',
-          );
-        default:
-          throw ArgumentError('Invalid test index: $testIndex');
-      }
-    }
+    (String alice, String bob) getUserPair(int testIndex) =>
+        (testUsers[testIndex * 2], testUsers[testIndex * 2 + 1]);
 
     /// Get configs for a specific test index
     (MatrixConfig alice, MatrixConfig bob) getConfigs(int testIndex) {
@@ -143,16 +151,14 @@ void main() {
     const defaultDelay = 5;
 
     setUpAll(() async {
+      SharedPreferences.setMockInitialValues({});
       await vod.init();
-      final tmpDir = await getTemporaryDirectory();
-      final docDir = Directory('${tmpDir.path}/${uuid.v1()}')
-        ..createSync(recursive: true);
+      final docDir = await Directory.systemTemp.createTemp('lotti-resilience-');
       debugPrint('Created temporary docDir ${docDir.path}');
       sharedDocumentsDirectory = docDir;
 
       aiConfigDb = AiConfigDb(inMemoryDatabase: true);
       sharedAiConfigRepository = AiConfigRepository(aiConfigDb);
-      sharedLoggingService = LoggingService();
       sharedUserActivityService = UserActivityService();
 
       // Setup Toxiproxy
@@ -160,60 +166,115 @@ void main() {
       await toxiproxy.setup();
       debugPrint('Toxiproxy setup complete');
 
-      // Register essential dependencies
-      getIt
-        ..registerSingleton<Directory>(sharedDocumentsDirectory)
-        ..registerSingleton<LoggingService>(sharedLoggingService)
-        ..registerSingleton<DomainLogger>(
-          DomainLogger(loggingService: sharedLoggingService),
-        )
-        ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
-        ..registerSingleton<UserActivityService>(sharedUserActivityService)
-        ..registerSingleton<JournalDb>(JournalDb(inMemoryDatabase: true))
-        ..registerSingleton<SettingsDb>(SettingsDb(inMemoryDatabase: true))
-        ..registerSingleton<SecureStorage>(secureStorageMock)
-        ..registerSingleton<AiConfigDb>(aiConfigDb)
-        ..registerSingleton<AiConfigRepository>(sharedAiConfigRepository);
-
-      // Give time for any async initializations to complete
-      await Future<void>.delayed(const Duration(seconds: 2));
+      final harness = await setUpTestGetIt(
+        additionalSetup: () {
+          getIt
+            ..registerSingleton<Directory>(sharedDocumentsDirectory)
+            ..unregister<UpdateNotifications>()
+            ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
+            ..registerSingleton<UserActivityService>(sharedUserActivityService)
+            ..unregister<JournalDb>()
+            ..registerSingleton<JournalDb>(JournalDb(inMemoryDatabase: true))
+            ..unregister<SettingsDb>()
+            ..registerSingleton<SettingsDb>(SettingsDb(inMemoryDatabase: true))
+            ..registerSingleton<SecureStorage>(secureStorageMock)
+            ..registerSingleton<AiConfigDb>(aiConfigDb)
+            ..registerSingleton<AiConfigRepository>(sharedAiConfigRepository);
+        },
+      );
+      sharedLoggingService = harness.loggingService;
     });
 
-    setUp(() {
+    setUp(() async {
+      expectedEntries.clear();
+      aliceDocumentsDirectory = await Directory(
+        '${sharedDocumentsDirectory.path}/alice-${uuid.v1()}',
+      ).create();
+      bobDocumentsDirectory = await Directory(
+        '${sharedDocumentsDirectory.path}/bob-${uuid.v1()}',
+      ).create();
+      expect(aliceDocumentsDirectory.path, isNot(bobDocumentsDirectory.path));
       // Create fresh databases for each test
       aliceDb = JournalDb(
         overriddenFilename: 'alice_resilience_${uuid.v1()}.sqlite',
+        documentsDirectory: aliceDocumentsDirectory,
         inMemoryDatabase: true,
       );
       bobDb = JournalDb(
         overriddenFilename: 'bob_resilience_${uuid.v1()}.sqlite',
+        documentsDirectory: bobDocumentsDirectory,
         inMemoryDatabase: true,
       );
     });
 
     tearDownAll(() async {
-      try {
-        await aiConfigDb.close();
-        toxiproxy.close();
-      } catch (e) {
-        debugPrint('Error during cleanup: $e');
-      }
+      await getIt<JournalDb>().close();
+      await getIt<SettingsDb>().close();
+      await aiConfigDb.close();
+      await sharedUserActivityService.dispose();
+      await sharedLoggingService.flush();
+      await sharedLoggingService.dispose();
+      toxiproxy.close();
+      await tearDownTestGetIt();
+      await sharedDocumentsDirectory.delete(recursive: true);
     });
 
     tearDown(() async {
-      // Reset toxiproxy to clean state
       await toxiproxy.reset(ToxiproxyController.dendriteProxy);
-
-      try {
-        await aliceDb.close();
-        await bobDb.close();
-      } catch (e) {
-        debugPrint('Error during database cleanup: $e');
-      }
+      await aliceDb.close();
+      await bobDb.close();
     });
 
-    Future<({MatrixService alice, MatrixService bob, String roomId})>
-    setupAliceAndBob({required int testIndex}) async {
+    // Polls only database state. No manual retry or rescan can make this pass.
+    Future<void> expectAutomaticDelivery({
+      Duration deliveryTimeout = timeout,
+    }) async {
+      await waitUntilAsync(
+        () async => await bobDb.getJournalCount() >= expectedEntries.length,
+        timeout: deliveryTimeout,
+        message: 'Bob did not recover automatically',
+      );
+      expect(await bobDb.getJournalCount(), expectedEntries.length);
+      for (final expected in expectedEntries) {
+        expect(
+          await bobDb.journalEntityById(expected.meta.id),
+          expected,
+          reason:
+              'Receiver must preserve ID, text, timestamps and vector clock',
+        );
+        final relativePath = relativeEntityPath(expected);
+        final bobFile = resolveJsonCandidateFileInDirectory(
+          relativePath,
+          bobDocumentsDirectory,
+        );
+        final aliceFile = resolveJsonCandidateFileInDirectory(
+          relativePath,
+          aliceDocumentsDirectory,
+        );
+        expect(
+          await bobFile.readAsBytes(),
+          await aliceFile.readAsBytes(),
+          reason:
+              'Receiver must download the sender attachment into its own sandbox',
+        );
+        expect(
+          jsonDecode(await bobFile.readAsString()),
+          jsonDecode(jsonEncode(expected)),
+        );
+        expect(
+          resolveJsonCandidateFileInDirectory(
+            relativePath,
+            sharedDocumentsDirectory,
+          ).existsSync(),
+          isFalse,
+          reason: 'Neither simulated device may use the global documents root',
+        );
+      }
+    }
+
+    Future<({SyncTestDevice alice, SyncTestDevice bob})> setupAliceAndBob({
+      required int testIndex,
+    }) async {
       // Ensure proxy is enabled at the start
       await toxiproxy.reset(ToxiproxyController.dendriteProxy);
 
@@ -225,16 +286,26 @@ void main() {
       debugPrint('\n--- Setting up Alice (direct connection)');
       debugPrint('Alice user: ${userPair.$1}');
       final aliceClient = await createMatrixClient(
-        documentsDirectory: sharedDocumentsDirectory,
+        documentsDirectory: aliceDocumentsDirectory,
         dbName: 'AliceResilience_${uuid.v1()}',
       );
+      addTearDown(aliceClient.dispose);
       final aliceRegistry = SentEventRegistry();
       final aliceGateway = MatrixSdkGateway(
         client: aliceClient,
         sentEventRegistry: aliceRegistry,
       );
       final aliceSettingsDb = SettingsDb(inMemoryDatabase: true);
-      final alice = await createMatrixService(
+      addTearDown(aliceSettingsDb.close);
+      final aliceSyncDb = SyncDatabase(inMemoryDatabase: true);
+      addTearDown(aliceSyncDb.close);
+      final aliceClock = MockVectorClockService();
+      when(() => aliceClock.initialized).thenAnswer((_) async {});
+      when(aliceClock.getHost).thenAnswer((_) async => 'alice-resilience');
+      when(
+        aliceClock.getHostHash,
+      ).thenAnswer((_) async => 'alice-resilience-hash');
+      final aliceDevice = await createSyncTestDevice(
         config: aliceConfig,
         gateway: aliceGateway,
         loggingService: getIt<DomainLogger>(),
@@ -243,12 +314,16 @@ void main() {
         secureStorage: secureStorageMock,
         deviceName: 'AliceResilience',
         activityService: sharedUserActivityService,
-        documentsDirectory: sharedDocumentsDirectory,
+        documentsDirectory: aliceDocumentsDirectory,
         updateNotifications: mockUpdateNotifications,
         aiConfigRepository: sharedAiConfigRepository,
         sentEventRegistry: aliceRegistry,
+        syncDb: aliceSyncDb,
+        vectorClockService: aliceClock,
       );
 
+      addTearDown(aliceDevice.dispose);
+      final alice = aliceDevice.matrixService;
       await alice.init();
       await alice.login();
       debugPrint('Alice - deviceId: ${alice.client.deviceID}');
@@ -262,16 +337,24 @@ void main() {
       debugPrint('\n--- Setting up Bob (via proxy)');
       debugPrint('Bob user: ${userPair.$2}');
       final bobClient = await createMatrixClient(
-        documentsDirectory: sharedDocumentsDirectory,
+        documentsDirectory: bobDocumentsDirectory,
         dbName: 'BobResilience_${uuid.v1()}',
       );
+      addTearDown(bobClient.dispose);
       final bobRegistry = SentEventRegistry();
       final bobGateway = MatrixSdkGateway(
         client: bobClient,
         sentEventRegistry: bobRegistry,
       );
       final bobSettingsDb = SettingsDb(inMemoryDatabase: true);
-      final bob = await createMatrixService(
+      addTearDown(bobSettingsDb.close);
+      final bobSyncDb = SyncDatabase(inMemoryDatabase: true);
+      addTearDown(bobSyncDb.close);
+      final bobClock = MockVectorClockService();
+      when(() => bobClock.initialized).thenAnswer((_) async {});
+      when(bobClock.getHost).thenAnswer((_) async => 'bob-resilience');
+      when(bobClock.getHostHash).thenAnswer((_) async => 'bob-resilience-hash');
+      final bobDevice = await createSyncTestDevice(
         config: bobConfig,
         gateway: bobGateway,
         loggingService: getIt<DomainLogger>(),
@@ -280,12 +363,16 @@ void main() {
         secureStorage: secureStorageMock,
         deviceName: 'BobResilience',
         activityService: sharedUserActivityService,
-        documentsDirectory: sharedDocumentsDirectory,
+        documentsDirectory: bobDocumentsDirectory,
         updateNotifications: mockUpdateNotifications,
         aiConfigRepository: sharedAiConfigRepository,
         sentEventRegistry: bobRegistry,
+        syncDb: bobSyncDb,
+        vectorClockService: bobClock,
       );
 
+      addTearDown(bobDevice.dispose);
+      final bob = bobDevice.matrixService;
       await bob.init();
       await bob.login();
       debugPrint('Bob - deviceId: ${bob.client.deviceID}');
@@ -321,7 +408,7 @@ void main() {
       // If there are no unverified devices, we're good to go
       if (unverifiedAlice.isEmpty) {
         debugPrint('No unverified devices found, skipping verification');
-        return (alice: alice, bob: bob, roomId: roomId);
+        return (alice: aliceDevice, bob: bobDevice);
       }
 
       final outgoingKeyVerificationStream = alice.keyVerificationStream;
@@ -330,7 +417,8 @@ void main() {
 
       var emojisFromBob = '';
       var emojisFromAlice = '';
-      var verificationComplete = false;
+      var aliceAccepted = false;
+      var bobAccepted = false;
 
       final incomingSubscription = incomingKeyVerificationRunnerStream.listen(
         (runner) async {
@@ -338,7 +426,8 @@ void main() {
           if (runner.lastStep == 'm.key.verification.request') {
             await runner.acceptVerification();
           }
-          if (runner.lastStep == 'm.key.verification.key') {
+          if (runner.lastStep == 'm.key.verification.key' && !bobAccepted) {
+            bobAccepted = true;
             emojisFromAlice = extractEmojiString(runner.emojis);
             debugPrint('Bob received emojis: $emojisFromAlice');
 
@@ -351,19 +440,20 @@ void main() {
 
             await runner.acceptEmojiVerification();
           }
-          if (runner.lastStep == 'm.key.verification.done') {
-            verificationComplete = true;
-          }
         },
         onError: (Object error, StackTrace stackTrace) {
-          debugPrint('incomingKeyVerificationRunnerStream error: $error');
+          fail(
+            'incomingKeyVerificationRunnerStream error: $error\n$stackTrace',
+          );
         },
       );
 
+      addTearDown(incomingSubscription.cancel);
       final outgoingSubscription = outgoingKeyVerificationStream.listen(
         (runner) async {
           debugPrint('Alice - outgoing verification step: ${runner.lastStep}');
-          if (runner.lastStep == 'm.key.verification.key') {
+          if (runner.lastStep == 'm.key.verification.key' && !aliceAccepted) {
+            aliceAccepted = true;
             emojisFromBob = extractEmojiString(runner.emojis);
             debugPrint('Alice received emojis: $emojisFromBob');
 
@@ -377,9 +467,11 @@ void main() {
           }
         },
         onError: (Object error, StackTrace stackTrace) {
-          debugPrint('keyVerificationStream error: $error');
+          fail('keyVerificationStream error: $error\n$stackTrace');
         },
       );
+
+      addTearDown(outgoingSubscription.cancel);
 
       // Verify all unverified devices one by one
       for (final device in unverifiedAlice) {
@@ -388,20 +480,23 @@ void main() {
 
         emojisFromBob = '';
         emojisFromAlice = '';
-        verificationComplete = false;
+        aliceAccepted = false;
+        bobAccepted = false;
 
         await alice.verifyDevice(device);
 
-        try {
-          await waitUntil(() => emojisFromAlice.isNotEmpty, timeout: timeout);
-          await waitUntil(() => emojisFromBob.isNotEmpty, timeout: timeout);
-          expect(emojisFromAlice, emojisFromBob);
-          await waitUntil(() => verificationComplete, timeout: timeout);
-          debugPrint('Device $deviceId verified successfully');
-        } catch (e) {
-          debugPrint('Failed to verify device $deviceId: $e');
-          // Continue with other devices even if one fails
-        }
+        await waitUntil(() => emojisFromAlice.isNotEmpty, timeout: timeout);
+        await waitUntil(() => emojisFromBob.isNotEmpty, timeout: timeout);
+        expect(emojisFromAlice, emojisFromBob);
+        // The SDK can dispose the runner without emitting a final step.
+        // Device trust is the durable outcome of the SAS exchange.
+        await waitUntil(
+          () =>
+              alice.getUnverifiedDevices().isEmpty &&
+              bob.getUnverifiedDevices().isEmpty,
+          timeout: timeout,
+        );
+        debugPrint('Device $deviceId verified successfully');
 
         await waitSeconds(2);
       }
@@ -414,12 +509,13 @@ void main() {
 
       // Check if there are still unverified devices
       unverifiedAlice = alice.getUnverifiedDevices();
-      debugPrint('Remaining unverified devices: ${unverifiedAlice.length}');
+      expect(unverifiedAlice, isEmpty);
+      expect(bob.getUnverifiedDevices(), isEmpty);
 
       debugPrint('\n--- Setup complete, devices verified');
       await waitSeconds(defaultDelay);
 
-      return (alice: alice, bob: bob, roomId: roomId);
+      return (alice: aliceDevice, bob: bobDevice);
     }
 
     test(
@@ -427,17 +523,6 @@ void main() {
       () async {
         final setup = await setupAliceAndBob(testIndex: 0);
         final alice = setup.alice;
-        final bob = setup.bob;
-        final roomId = setup.roomId;
-
-        addTearDown(() async {
-          try {
-            await alice.dispose();
-          } catch (_) {}
-          try {
-            await bob.dispose();
-          } catch (_) {}
-        });
 
         const totalMessages = 20;
         const interruptAfter = 8;
@@ -447,11 +532,11 @@ void main() {
 
         // Send first batch
         for (var i = 0; i < interruptAfter; i++) {
-          await sendTestMessage(
-            matrixService: alice,
-            deviceName: 'aliceResilience',
-            index: i,
-            roomId: roomId,
+          expectedEntries.add(
+            await sendTestMessage(
+              device: alice,
+              index: i,
+            ),
           );
           debugPrint('Alice sent message $i');
         }
@@ -462,15 +547,21 @@ void main() {
         // Cut network to Bob
         debugPrint('\n--- Cutting network to Bob');
         await toxiproxy.disconnect(ToxiproxyController.dendriteProxy);
+        final proxies = await toxiproxy.getProxies();
+        expect(
+          (proxies[ToxiproxyController.dendriteProxy]
+              as Map<String, dynamic>)['enabled'],
+          isFalse,
+        );
 
         // Send remaining messages while Bob is offline
         for (var i = interruptAfter; i < totalMessages; i++) {
           // Use direct homeserver for Alice (not via proxy)
-          await sendTestMessage(
-            matrixService: alice,
-            deviceName: 'aliceResilience',
-            index: i,
-            roomId: roomId,
+          expectedEntries.add(
+            await sendTestMessage(
+              device: alice,
+              index: i,
+            ),
           );
           debugPrint('Alice sent message $i (Bob offline)');
         }
@@ -478,39 +569,32 @@ void main() {
         // Wait a bit with network cut
         await waitSeconds(5);
 
+        final offlineEntry = expectedEntries.last;
+        expect(
+          await bobDb.journalEntityById(offlineEntry.meta.id),
+          isNull,
+          reason: 'Bob must actually miss entries during the outage',
+        );
+        expect(
+          resolveJsonCandidateFileInDirectory(
+            relativeEntityPath(offlineEntry),
+            bobDocumentsDirectory,
+          ).existsSync(),
+          isFalse,
+        );
+
         // Restore network
         debugPrint('\n--- Restoring network to Bob');
         await toxiproxy.reconnect(ToxiproxyController.dendriteProxy);
 
-        // Force Bob to catch up
-        debugPrint('\n--- Forcing Bob to rescan');
-        await bob.forceRescan();
-
         // Wait for Bob to receive all messages
-        var lastBobCount = -1;
-        await waitUntilAsync(
-          () async {
-            final currentCount = await bobDb.getJournalCount();
-            if (currentCount != lastBobCount) {
-              debugPrint('Bob journal count: $currentCount');
-              lastBobCount = currentCount;
-            }
-            if (currentCount < totalMessages) {
-              await bob.forceRescan();
-              await bob.retryNow();
-              await Future<void>.delayed(const Duration(milliseconds: 500));
-            }
-            return currentCount >= totalMessages;
-          },
-          timeout: timeout,
+        expect(expectedEntries, hasLength(totalMessages));
+        await expectAutomaticDelivery(
+          deliveryTimeout: const Duration(minutes: 3),
         );
 
-        final bobEntriesCount = await bobDb.getJournalCount();
-        debugPrint('Bob final count: $bobEntriesCount');
-        expect(bobEntriesCount, totalMessages);
-
         // Check metrics
-        final metrics = await bob.getSyncMetrics();
+        final metrics = await setup.bob.matrixService.getSyncMetrics();
         debugPrint('Bob metrics: $metrics');
       },
       timeout: const Timeout(Duration(minutes: 5)),
@@ -522,17 +606,6 @@ void main() {
       () async {
         final setup = await setupAliceAndBob(testIndex: 1);
         final alice = setup.alice;
-        final bob = setup.bob;
-        final roomId = setup.roomId;
-
-        addTearDown(() async {
-          try {
-            await alice.dispose();
-          } catch (_) {}
-          try {
-            await bob.dispose();
-          } catch (_) {}
-        });
 
         // Add significant latency
         debugPrint('\n--- Adding 2000ms latency');
@@ -547,36 +620,20 @@ void main() {
           '\n--- Alice sends $totalMessages messages with high latency',
         );
         for (var i = 0; i < totalMessages; i++) {
-          await sendTestMessage(
-            matrixService: alice,
-            deviceName: 'aliceLatency',
-            index: i,
-            roomId: roomId,
+          expectedEntries.add(
+            await sendTestMessage(
+              device: alice,
+              index: i,
+            ),
           );
           debugPrint('Alice sent message $i');
         }
 
         // Wait for Bob to receive with longer timeout due to latency
-        var lastBobCount = -1;
-        await waitUntilAsync(
-          () async {
-            final currentCount = await bobDb.getJournalCount();
-            if (currentCount != lastBobCount) {
-              debugPrint('Bob journal count: $currentCount');
-              lastBobCount = currentCount;
-            }
-            if (currentCount < totalMessages) {
-              await bob.forceRescan();
-              await Future<void>.delayed(const Duration(milliseconds: 500));
-            }
-            return currentCount >= totalMessages;
-          },
-          timeout: const Duration(minutes: 3),
+        expect(expectedEntries, hasLength(totalMessages));
+        await expectAutomaticDelivery(
+          deliveryTimeout: const Duration(minutes: 3),
         );
-
-        final bobEntriesCount = await bobDb.getJournalCount();
-        debugPrint('Bob final count: $bobEntriesCount');
-        expect(bobEntriesCount, totalMessages);
       },
       timeout: const Timeout(Duration(minutes: 5)),
       skip: skipReason ?? false,
@@ -587,17 +644,6 @@ void main() {
       () async {
         final setup = await setupAliceAndBob(testIndex: 2);
         final alice = setup.alice;
-        final bob = setup.bob;
-        final roomId = setup.roomId;
-
-        addTearDown(() async {
-          try {
-            await alice.dispose();
-          } catch (_) {}
-          try {
-            await bob.dispose();
-          } catch (_) {}
-        });
 
         // Severely limit bandwidth
         debugPrint('\n--- Limiting bandwidth to 50 KB/s');
@@ -607,41 +653,35 @@ void main() {
         );
 
         const totalMessages = 15;
+        // Repeated text compresses almost to nothing. Seeded random bytes keep
+        // each JSON attachment large enough to exercise the bandwidth limit.
+        final random = Random(42);
+        final payload = base64Encode(
+          List<int>.generate(
+            96 * 1024,
+            (_) => random.nextInt(256),
+          ),
+        );
 
         debugPrint(
           '\n--- Alice sends $totalMessages messages with limited bandwidth',
         );
         for (var i = 0; i < totalMessages; i++) {
-          await sendTestMessage(
-            matrixService: alice,
-            deviceName: 'aliceBandwidth',
-            index: i,
-            roomId: roomId,
+          expectedEntries.add(
+            await sendTestMessage(
+              device: alice,
+              text: 'Bandwidth fixture #$i: $payload',
+              index: i,
+            ),
           );
           debugPrint('Alice sent message $i');
         }
 
         // Wait for Bob to receive
-        var lastBobCount = -1;
-        await waitUntilAsync(
-          () async {
-            final currentCount = await bobDb.getJournalCount();
-            if (currentCount != lastBobCount) {
-              debugPrint('Bob journal count: $currentCount');
-              lastBobCount = currentCount;
-            }
-            if (currentCount < totalMessages) {
-              await bob.forceRescan();
-              await Future<void>.delayed(const Duration(milliseconds: 500));
-            }
-            return currentCount >= totalMessages;
-          },
-          timeout: const Duration(minutes: 3),
+        expect(expectedEntries, hasLength(totalMessages));
+        await expectAutomaticDelivery(
+          deliveryTimeout: const Duration(minutes: 3),
         );
-
-        final bobEntriesCount = await bobDb.getJournalCount();
-        debugPrint('Bob final count: $bobEntriesCount');
-        expect(bobEntriesCount, totalMessages);
       },
       timeout: const Timeout(Duration(minutes: 5)),
       skip: skipReason ?? false,
@@ -652,17 +692,6 @@ void main() {
       () async {
         final setup = await setupAliceAndBob(testIndex: 3);
         final alice = setup.alice;
-        final bob = setup.bob;
-        final roomId = setup.roomId;
-
-        addTearDown(() async {
-          try {
-            await alice.dispose();
-          } catch (_) {}
-          try {
-            await bob.dispose();
-          } catch (_) {}
-        });
 
         const totalMessages = 30;
         const messagesPerBatch = 10;
@@ -676,11 +705,11 @@ void main() {
           debugPrint('\n--- Batch $batch: Sending messages $start-${end - 1}');
 
           for (var i = start; i < end; i++) {
-            await sendTestMessage(
-              matrixService: alice,
-              deviceName: 'aliceIntermittent',
-              index: i,
-              roomId: roomId,
+            expectedEntries.add(
+              await sendTestMessage(
+                device: alice,
+                index: i,
+              ),
             );
           }
 
@@ -693,39 +722,14 @@ void main() {
             await toxiproxy.reconnect(ToxiproxyController.dendriteProxy);
             // Give Bob time to sync after reconnection
             await waitSeconds(5);
-            debugPrint('--- Forcing rescan after reconnect');
-            await bob.forceRescan();
-            await waitSeconds(3);
           }
         }
 
-        // Force catch-up
-        debugPrint('\n--- Final catch-up');
-        await bob.forceRescan();
-
         // Wait for Bob to receive all messages - use longer timeout for this test
-        const extendedTimeout = Duration(minutes: 4);
-        var lastBobCount = -1;
-        await waitUntilAsync(
-          () async {
-            final currentCount = await bobDb.getJournalCount();
-            if (currentCount != lastBobCount) {
-              debugPrint('Bob journal count: $currentCount');
-              lastBobCount = currentCount;
-            }
-            if (currentCount < totalMessages) {
-              await bob.forceRescan();
-              await bob.retryNow();
-              await Future<void>.delayed(const Duration(seconds: 1));
-            }
-            return currentCount >= totalMessages;
-          },
-          timeout: extendedTimeout,
+        expect(expectedEntries, hasLength(totalMessages));
+        await expectAutomaticDelivery(
+          deliveryTimeout: const Duration(minutes: 3),
         );
-
-        final bobEntriesCount = await bobDb.getJournalCount();
-        debugPrint('Bob final count: $bobEntriesCount');
-        expect(bobEntriesCount, totalMessages);
       },
       timeout: const Timeout(Duration(minutes: 8)),
       skip: skipReason ?? false,

--- a/knowledge/architecture/persistence.md
+++ b/knowledge/architecture/persistence.md
@@ -5,9 +5,13 @@ description: The eleven Drift/SQLite databases, attachment storage, how connecti
 resource: ../../lib/database
 tags: [architecture, persistence, drift, sqlite, migrations]
 status: stable
-generated: { by: codex/gpt-6, at: 2026-09-05T19:28:47Z }
+generated: { by: codex/gpt-6, at: 2026-09-13T12:25:00Z }
 stale_after: 2027-03-05
 sources:
+  - id: screenshot-capture
+    resource: ../../lib/utils/screenshots.dart
+    title: Screenshot capture and process timeout
+    last_modified: 2026-09-13
   - id: sync-db
     resource: ../../lib/database/sync_db.dart
     title: SyncDatabase
@@ -602,6 +606,14 @@ separators, for example `/images/2026-08-15/`. It is not an absolute filesystem
 path. Writers strip the metadata-only leading separator and construct physical
 paths with `path.join`; AI image readers resolve only this canonical location
 inside the documents directory.
+
+`takeScreenshot` uses `ScreenshotHost` for commands, portal access and window
+operations, with `clock.now()` supplying the capture date. The command timeout
+covers output draining and process exit together; timeout kills the process,
+and a `finally` block restores the window. A restoration error is logged without
+replacing the capture result or original error. `createScreenshot` accepts an
+optional capture callback and persists the returned metadata through
+`JournalRepository.createImageEntry` before requesting geolocation.
 
 A legacy screenshot writer persisted `images/...` and concatenated it directly
 to the documents path. A profile rooted at `Documents` therefore wrote the file

--- a/lib/logic/create/create_entry.dart
+++ b/lib/logic/create/create_entry.dart
@@ -410,13 +410,16 @@ Future<JournalEvent?> createEvent({String? linkedId, String? categoryId}) =>
       categoryId: categoryId,
     );
 
+/// Captures and persists a screenshot, optionally linking it to another entry.
+/// [capture] supplies the platform capture boundary.
 Future<JournalEntity?> createScreenshot({
   String? linkedId,
   String? categoryId,
   AutomaticImageAnalysisTrigger? analysisTrigger,
+  Future<ImageData> Function() capture = takeScreenshot,
 }) async {
   final persistenceLogic = getIt<PersistenceLogic>();
-  final imageData = await takeScreenshot();
+  final imageData = await capture();
   final entry = await JournalRepository.createImageEntry(
     imageData,
     linkedId: linkedId,

--- a/lib/utils/screenshots.dart
+++ b/lib/utils/screenshots.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/get_it.dart';
@@ -12,10 +13,57 @@ import 'package:lotti/utils/screenshot_consts.dart';
 import 'package:path/path.dart' as p;
 import 'package:window_manager/window_manager.dart';
 
+/// Operating-system boundary for screenshot capture.
+///
+/// Keeping these effects together lets callers exercise capture and recovery
+/// without launching desktop tools or changing the real application window.
+class ScreenshotHost {
+  const ScreenshotHost();
+
+  String get operatingSystem => Platform.operatingSystem;
+  bool get shouldUsePortal => PortalService.shouldUsePortal;
+
+  Future<bool> isPortalAvailable() => ScreenshotPortalService.isAvailable();
+
+  Future<String?> captureWithPortal({
+    required String directory,
+    required String filename,
+  }) => ScreenshotPortalService().takeScreenshot(
+    directory: directory,
+    filename: filename,
+    interactive: true,
+  );
+
+  Future<String> createDirectory(String relativePath) =>
+      createAssetDirectory(relativePath);
+
+  Future<void> minimizeWindow() => windowManager.minimize();
+  Future<void> showWindow() => windowManager.show();
+
+  Future<ProcessResult> run(String command, List<String> arguments) =>
+      Process.run(command, arguments);
+
+  Future<Process> start(
+    String command,
+    List<String> arguments, {
+    required String workingDirectory,
+  }) => Process.start(command, arguments, workingDirectory: workingDirectory);
+
+  Future<void> forwardOutput(Process process) async {
+    await Future.wait<void>([
+      stdout.addStream(process.stdout),
+      stderr.addStream(process.stderr),
+    ]);
+  }
+}
+
 /// Checks if a command is available on the system
-Future<bool> isCommandAvailable(String command) async {
+Future<bool> isCommandAvailable(
+  String command, {
+  ScreenshotHost host = const ScreenshotHost(),
+}) async {
   try {
-    final result = await Process.run(whichCommand, [command]);
+    final result = await host.run(whichCommand, [command]);
     return result.exitCode == successExitCode;
   } catch (e) {
     return false;
@@ -23,9 +71,11 @@ Future<bool> isCommandAvailable(String command) async {
 }
 
 /// Finds the first available screenshot tool on Linux
-Future<String?> findAvailableScreenshotTool() async {
+Future<String?> findAvailableScreenshotTool({
+  ScreenshotHost host = const ScreenshotHost(),
+}) async {
   for (final tool in linuxScreenshotTools) {
-    if (await isCommandAvailable(tool)) {
+    if (await isCommandAvailable(tool, host: host)) {
       return tool;
     }
   }
@@ -36,8 +86,9 @@ Future<String?> findAvailableScreenshotTool() async {
 Future<void> takeLinuxScreenshot(
   String tool,
   String filename,
-  String directory,
-) async {
+  String directory, {
+  ScreenshotHost host = const ScreenshotHost(),
+}) async {
   final config = screenshotToolConfigs[tool];
   if (config == null) {
     throw Exception('$unsupportedToolMessage$tool');
@@ -45,23 +96,16 @@ Future<void> takeLinuxScreenshot(
 
   final arguments = [...config.arguments, filename];
 
-  final process = await Process.start(
+  final process = await host.start(
     tool,
     arguments,
     workingDirectory: directory,
   );
 
-  await stdout.addStream(process.stdout);
-  await stderr.addStream(process.stderr);
-
-  final exitCode = await process.exitCode.timeout(
-    const Duration(seconds: screenshotProcessTimeoutSeconds),
-    onTimeout: () {
-      process.kill();
-      throw Exception(
-        '$toolFailedMessage$tool timed out after ${screenshotProcessTimeoutSeconds}s',
-      );
-    },
+  final exitCode = await _waitForCaptureProcess(
+    process,
+    host,
+    '$toolFailedMessage$tool timed out after ${screenshotProcessTimeoutSeconds}s',
   );
 
   if (exitCode != successExitCode) {
@@ -77,24 +121,24 @@ String screenshotRelativePath(DateTime created) {
   return '${p.posix.join(screenshotDirectoryPath, day)}/';
 }
 
-Future<ImageData> takeScreenshot() async {
+/// Captures an image and restores the window even if capture fails.
+Future<ImageData> takeScreenshot({
+  ScreenshotHost host = const ScreenshotHost(),
+}) async {
   try {
     final id = uuid.v1();
     final filename = '$id$screenshotFileExtension';
-    final created = DateTime.now();
+    final created = clock.now();
     final relativePath = screenshotRelativePath(created);
-    final directory = await createAssetDirectory(relativePath);
+    final directory = await host.createDirectory(relativePath);
 
     // Check if we should use portal (Flatpak environment)
-    if (Platform.isLinux && PortalService.shouldUsePortal) {
-      final portalService = ScreenshotPortalService();
-
+    if (host.operatingSystem == 'linux' && host.shouldUsePortal) {
       // Check if portal is available
-      if (await ScreenshotPortalService.isAvailable()) {
-        final screenshotPath = await portalService.takeScreenshot(
+      if (await host.isPortalAvailable()) {
+        final screenshotPath = await host.captureWithPortal(
           directory: directory,
           filename: filename,
-          interactive: true,
         );
 
         if (screenshotPath != null) {
@@ -118,34 +162,27 @@ Future<ImageData> takeScreenshot() async {
       );
     }
 
-    await windowManager.minimize();
+    await host.minimizeWindow();
     await Future<void>.delayed(const Duration(seconds: screenshotDelaySeconds));
 
-    if (Platform.isMacOS) {
-      final process = await Process.start(
+    if (host.operatingSystem == 'macos') {
+      final process = await host.start(
         screencaptureTool,
         [...screencaptureArguments, filename],
         workingDirectory: directory,
       );
 
-      await stdout.addStream(process.stdout);
-      await stderr.addStream(process.stderr);
-
-      final exitCode = await process.exitCode.timeout(
-        const Duration(seconds: screenshotProcessTimeoutSeconds),
-        onTimeout: () {
-          process.kill();
-          throw Exception(
-            'macOS screencapture timed out after ${screenshotProcessTimeoutSeconds}s',
-          );
-        },
+      final exitCode = await _waitForCaptureProcess(
+        process,
+        host,
+        'macOS screencapture timed out after ${screenshotProcessTimeoutSeconds}s',
       );
 
       if (exitCode != successExitCode) {
         throw Exception('$screencaptureFailedMessage$exitCode');
       }
-    } else if (Platform.isLinux) {
-      final availableTool = await findAvailableScreenshotTool();
+    } else if (host.operatingSystem == 'linux') {
+      final availableTool = await findAvailableScreenshotTool(host: host);
 
       if (availableTool == null) {
         final availableTools = linuxScreenshotTools.join(', ');
@@ -155,10 +192,10 @@ Future<ImageData> takeScreenshot() async {
         );
       }
 
-      await takeLinuxScreenshot(availableTool, filename, directory);
+      await takeLinuxScreenshot(availableTool, filename, directory, host: host);
     } else {
       throw UnsupportedError(
-        '$unsupportedPlatformMessage${Platform.operatingSystem}',
+        '$unsupportedPlatformMessage${host.operatingSystem}',
       );
     }
 
@@ -180,7 +217,7 @@ Future<ImageData> takeScreenshot() async {
   } finally {
     // Always restore the window, regardless of success or failure
     try {
-      await windowManager.show();
+      await host.showWindow();
     } catch (e) {
       // Log but don't rethrow window restoration errors
       getIt<DomainLogger>().error(
@@ -190,4 +227,24 @@ Future<ImageData> takeScreenshot() async {
       );
     }
   }
+}
+
+/// Bounds the whole process wait, including streams a hung process leaves open.
+Future<int> _waitForCaptureProcess(
+  Process process,
+  ScreenshotHost host,
+  String timeoutMessage,
+) async {
+  final exitCode = process.exitCode;
+  await Future.wait<Object?>([
+    host.forwardOutput(process),
+    exitCode,
+  ]).timeout(
+    const Duration(seconds: screenshotProcessTimeoutSeconds),
+    onTimeout: () {
+      process.kill();
+      throw Exception(timeoutMessage);
+    },
+  );
+  return exitCode;
 }

--- a/test/README.md
+++ b/test/README.md
@@ -119,6 +119,16 @@ opens in-memory databases and seeds them — the full-shell recipe in
 `setUp` and dispose it in `tearDown`, both of which run on the real event
 loop, and keep only the pumping inside the test.
 
+## Screenshot capture tests
+
+Use `ScreenshotHost` to control OS commands, portal responses and window calls
+in `test/utils/screenshots_test.dart`. Registering a `WindowManager` in GetIt
+cannot intercept capture's global `windowManager`, and filesystem overrides do
+not replace `Process.start` or `Process.run`. Keep the output future open when
+testing process timeouts: an already-drained stream misses hangs before exit.
+Entry-creation tests inject `createScreenshot(capture: ...)` and assert the saved
+image, link, category and geolocation request using the real journal database.
+
 ## Simulating a platform without a directory watch
 
 `FileWatcherMixin` polls where `FileSystemEntity.isWatchSupported` is false

--- a/test/logic/create/create_entry_more_test.dart
+++ b/test/logic/create/create_entry_more_test.dart
@@ -28,6 +28,7 @@ import '../../features/agents/test_utils.dart';
 import '../../helpers/fallbacks.dart';
 import '../../helpers/path_provider.dart';
 import '../../mocks/mocks.dart';
+import '../../test_data/test_data.dart';
 import '../../widget_test_utils.dart';
 
 void main() {
@@ -125,92 +126,67 @@ void main() {
       clearInteractions(mockTimeService);
       clearInteractions(mockOutboxService);
       clearInteractions(mockNavService);
+      clearInteractions(mockGeolocationService);
       await tearDownTestGetIt();
       await journalDb.close();
       await settingsDb.close();
     });
 
-    test('createScreenshot creates image entry with geolocation', () async {
-      // This test may skip on platforms without screenshot capabilities
-      try {
-        final entry = await createScreenshot();
-
-        expect(entry, isNotNull);
-        expect(entry, isA<JournalImage>());
-
-        final imageEntry = entry!;
-        expect((imageEntry as JournalImage).data.imageId, isNotEmpty);
-        expect(imageEntry.data.imageFile, isNotEmpty);
-      } catch (e) {
-        // Screenshot functionality may not be available in test environment
-        // This is acceptable - the important thing is the function doesn't crash
-        expect(
-          e.toString(),
-          anyOf(
-            contains('Unsupported'),
-            contains('screenshot'),
-            contains('command'),
-            contains('portal'),
-            contains('MissingPluginException'),
-          ),
+    test(
+      'createScreenshot persists captured data and requests geolocation',
+      () async {
+        final entry = await createScreenshot(
+          capture: () async => testImageEntry.data,
         );
-      }
-    });
+        expect(entry, isA<JournalImage>());
+        final image = entry! as JournalImage;
+        expect(image.data, testImageEntry.data);
+        expect(image.meta.dateFrom, testImageEntry.data.capturedAt);
+        expect(image.meta.dateTo, testImageEntry.data.capturedAt);
+        expect(await journalDb.journalEntityById(image.meta.id), image);
+        verify(
+          () => mockGeolocationService.addGeolocation(
+            image.meta.id,
+            getIt<PersistenceLogic>().updateDbEntity,
+          ),
+        ).called(1);
+      },
+    );
 
-    test('createScreenshot with linkedId creates linked image entry', () async {
+    test('createScreenshot persists the link to its parent', () async {
       final parent = await createTextEntry();
       expect(parent, isNotNull);
-
-      try {
-        final screenshot = await createScreenshot(linkedId: parent!.meta.id);
-
-        expect(screenshot, isNotNull);
-        expect(screenshot, isA<JournalImage>());
-
-        // Verify link exists
-        final linkedEntities = await getIt<JournalDb>().getLinkedEntities(
-          parent.meta.id,
-        );
-        expect(
-          linkedEntities.any((e) => e.meta.id == screenshot!.meta.id),
-          true,
-        );
-      } catch (e) {
-        // Screenshot functionality may not be available in test environment
-        expect(
-          e.toString(),
-          anyOf(
-            contains('Unsupported'),
-            contains('screenshot'),
-            contains('command'),
-            contains('portal'),
-            contains('MissingPluginException'),
-          ),
-        );
-      }
+      final screenshot = await createScreenshot(
+        linkedId: parent!.meta.id,
+        capture: () async => testImageEntry.data,
+      );
+      expect(screenshot, isA<JournalImage>());
+      final linked = await journalDb.getLinkedEntities(parent.meta.id);
+      expect(linked.map((e) => e.meta.id), [screenshot!.meta.id]);
+      expect((linked.single as JournalImage).data, testImageEntry.data);
     });
 
-    test('createScreenshot with categoryId sets category', () async {
-      const testCategoryId = 'screenshot-category-123';
+    test('createScreenshot persists the selected category', () async {
+      const categoryId = 'screenshot-category-123';
+      final screenshot = await createScreenshot(
+        categoryId: categoryId,
+        capture: () async => testImageEntry.data,
+      );
+      expect(screenshot?.categoryId, categoryId);
+      final saved = await journalDb.journalEntityById(screenshot!.meta.id);
+      expect(saved?.categoryId, categoryId);
+      expect((saved! as JournalImage).data, testImageEntry.data);
+    });
 
-      try {
-        final screenshot = await createScreenshot(categoryId: testCategoryId);
-
-        expect(screenshot, isNotNull);
-        expect(screenshot?.categoryId, testCategoryId);
-      } catch (e) {
-        // Screenshot functionality may not be available in test environment
-        expect(
-          e.toString(),
-          anyOf(
-            contains('Unsupported'),
-            contains('screenshot'),
-            contains('command'),
-            contains('portal'),
-            contains('MissingPluginException'),
-          ),
-        );
-      }
+    test('a capture failure creates no entry or geolocation request', () async {
+      final error = StateError('capture failed');
+      final before = await journalDb.select(journalDb.journal).get();
+      await expectLater(
+        createScreenshot(capture: () async => throw error),
+        throwsA(same(error)),
+      );
+      expect(await journalDb.select(journalDb.journal).get(), before);
+      verifyZeroInteractions(mockGeolocationService);
     });
 
     test('createTask inherits defaultProfileId from category', () async {

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -216,6 +216,7 @@ import 'package:lotti/services/vector_clock_service.dart';
 import 'package:lotti/services/window_service.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/location.dart';
+import 'package:lotti/utils/screenshots.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:matrix/encryption.dart';
 import 'package:matrix/encryption/cross_signing.dart';
@@ -1650,3 +1651,9 @@ class MockRelationshipProposalService extends Mock
     implements RelationshipProposalService {}
 
 class MockPlazaRepository extends Mock implements PlazaRepository {}
+
+class MockScreenshotHost extends Mock implements ScreenshotHost {}
+
+class MockProcess extends Mock implements io.Process {}
+
+class MockStdout extends Mock implements io.Stdout {}

--- a/test/utils/screenshots_test.dart
+++ b/test/utils/screenshots_test.dart
@@ -1,1284 +1,522 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:dbus/dbus.dart';
-import 'package:flutter/services.dart';
+import 'package:clock/clock.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:intl/intl.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/domain_logging.dart';
-import 'package:lotti/services/portals/portal_service.dart';
-import 'package:lotti/services/portals/screenshot_portal_service.dart';
-import 'package:lotti/utils/file_utils.dart';
-import 'package:lotti/utils/screenshot_consts.dart';
 import 'package:lotti/utils/screenshots.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:window_manager/window_manager.dart';
 
 import '../helpers/fallbacks.dart';
 import '../mocks/mocks.dart';
-
-// ---------------------------------------------------------------------------
-// Shared mocks and fakes
-// ---------------------------------------------------------------------------
-
-class MockWindowManager extends Mock implements WindowManager {}
-
-class MockDirectory extends Mock implements Directory {}
-
-class MockProcess extends Mock implements Process {}
-
-class FakeDBusObjectPath extends Fake implements DBusObjectPath {}
-
-class FakeDBusMethodCall extends Fake implements DBusMethodCall {}
-
-class FakeDBusSignature extends Fake implements DBusSignature {}
+import '../widget_test_utils.dart';
 
 void main() {
-  // ---------------------------------------------------------------------------
-  // Canonical tests (originally in screenshots_test.dart)
-  // ---------------------------------------------------------------------------
+  final capturedAt = DateTime(2026, 8, 15, 12, 34);
+  late MockScreenshotHost host;
+  late MockProcess process;
+  late MockDomainLogger logger;
 
-  group('Screenshot Tests', () {
-    late MockDomainLogger mockLoggingService;
-    late MockWindowManager mockWindowManager;
-    late MockDirectory mockDirectory;
+  Future<ImageData> capture() => withClock(
+    Clock.fixed(capturedAt),
+    () => takeScreenshot(host: host),
+  );
 
-    setUpAll(() {
-      registerAllFallbackValues();
-      registerFallbackValue(StackTrace.current);
+  Future<void> advanceCapture(WidgetTester tester) async {
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+  }
+
+  setUpAll(registerAllFallbackValues);
+  setUp(() async {
+    host = MockScreenshotHost();
+    process = MockProcess();
+    logger = MockDomainLogger();
+    await setUpTestGetIt(
+      additionalSetup: () {
+        getIt
+          ..unregister<DomainLogger>()
+          ..registerSingleton<DomainLogger>(logger);
+      },
+    );
+    when(() => host.operatingSystem).thenReturn('linux');
+    when(() => host.shouldUsePortal).thenReturn(false);
+    when(() => host.createDirectory(any())).thenAnswer(
+      (_) async => '/documents/images/2026-08-15',
+    );
+    when(host.minimizeWindow).thenAnswer((_) async {});
+    when(host.showWindow).thenAnswer((_) async {});
+    when(() => host.run(any(), any())).thenAnswer(
+      (_) async => ProcessResult(1, 0, '', ''),
+    );
+    when(
+      () => host.start(
+        any(),
+        any(),
+        workingDirectory: any(named: 'workingDirectory'),
+      ),
+    ).thenAnswer((_) async => process);
+    when(() => host.forwardOutput(process)).thenAnswer((_) async {});
+    when(() => process.exitCode).thenAnswer((_) async => 0);
+    when(() => process.kill()).thenReturn(true);
+  });
+  tearDown(tearDownTestGetIt);
+
+  test('default host drains stdout and stderr concurrently', () {
+    fakeAsync((async) {
+      final outputSink = MockStdout();
+      final errorSink = MockStdout();
+      final outputClosed = Completer<void>();
+      final errorClosed = Completer<void>();
+      final outputStream = Stream<List<int>>.value([1, 2]);
+      final errorStream = Stream<List<int>>.value([3, 4]);
+      when(() => process.stdout).thenAnswer((_) => outputStream);
+      when(() => process.stderr).thenAnswer((_) => errorStream);
+      when(
+        () => outputSink.addStream(outputStream),
+      ).thenAnswer((_) => outputClosed.future);
+      when(
+        () => errorSink.addStream(errorStream),
+      ).thenAnswer((_) => errorClosed.future);
+      var completed = false;
+      IOOverrides.runZoned(
+        () => unawaited(
+          const ScreenshotHost().forwardOutput(process).then((_) {
+            completed = true;
+          }),
+        ),
+        stdout: () => outputSink,
+        stderr: () => errorSink,
+      );
+      async.flushMicrotasks();
+      verify(() => outputSink.addStream(outputStream)).called(1);
+      verify(() => errorSink.addStream(errorStream)).called(1);
+      expect(completed, isFalse);
+      outputClosed.complete();
+      async.flushMicrotasks();
+      expect(completed, isFalse, reason: 'stderr has not finished');
+      errorClosed.complete();
+      async.flushMicrotasks();
+      expect(completed, isTrue);
+    });
+  });
+
+  group('command discovery', () {
+    for (final exitCode in [0, 1, 127]) {
+      test('uses which and treats exit code $exitCode correctly', () async {
+        when(() => host.run(any(), any())).thenAnswer(
+          (_) async => ProcessResult(1, exitCode, '', ''),
+        );
+        expect(await isCommandAvailable('scrot', host: host), exitCode == 0);
+        verify(() => host.run('which', ['scrot'])).called(1);
+      });
+    }
+
+    test('a process launch failure means unavailable', () async {
+      when(() => host.run(any(), any())).thenAnswer(
+        (_) async => throw const ProcessException('which', []),
+      );
+      expect(await isCommandAvailable('scrot', host: host), isFalse);
     });
 
-    setUp(() {
-      mockLoggingService = MockDomainLogger();
-      mockWindowManager = MockWindowManager();
-      mockDirectory = MockDirectory();
-
-      // Register mocks in GetIt
-      getIt
-        ..registerSingleton<DomainLogger>(mockLoggingService)
-        ..registerSingleton<WindowManager>(mockWindowManager)
-        ..registerSingleton<Directory>(mockDirectory);
-
-      // Setup default mock behaviors
-      when(() => mockDirectory.path).thenReturn('/test/documents');
-      when(() => mockWindowManager.minimize()).thenAnswer((_) async {});
-      when(() => mockWindowManager.show()).thenAnswer((_) async {});
+    test('selects the first installed tool and stops searching', () async {
+      when(() => host.run(any(), any())).thenAnswer((invocation) async {
+        final arguments = invocation.positionalArguments[1] as List<String>;
+        return ProcessResult(1, arguments.single == 'scrot' ? 0 : 1, '', '');
+      });
+      expect(await findAvailableScreenshotTool(host: host), 'scrot');
+      verifyInOrder([
+        () => host.run('which', ['spectacle']),
+        () => host.run('which', ['gnome-screenshot']),
+        () => host.run('which', ['scrot']),
+      ]);
+      verifyNoMoreInteractions(host);
     });
 
-    tearDown(getIt.reset);
+    test('returns null after exhausting all tools', () async {
+      when(() => host.run(any(), any())).thenAnswer(
+        (_) async => ProcessResult(1, 1, '', ''),
+      );
+      expect(await findAvailableScreenshotTool(host: host), isNull);
+      verifyInOrder([
+        () => host.run('which', ['spectacle']),
+        () => host.run('which', ['gnome-screenshot']),
+        () => host.run('which', ['scrot']),
+        () => host.run('which', ['import']),
+      ]);
+      verifyNoMoreInteractions(host);
+    });
+  });
 
-    group('isCommandAvailable', () {
-      test('returns true when command is available', () async {
-        // Test with a command that should be available on most systems
-        final result = await isCommandAvailable('ls');
-        expect(result, isTrue);
+  group('Linux capture', () {
+    const argumentsByTool = {
+      'spectacle': ['-f', '-b', '-n', '-o', 'capture.jpg'],
+      'gnome-screenshot': ['-f', 'capture.jpg'],
+      'scrot': ['capture.jpg'],
+      'import': ['-window', 'root', 'capture.jpg'],
+    };
+    for (final tool in argumentsByTool.entries) {
+      test('${tool.key} receives the filename and working directory', () async {
+        await takeLinuxScreenshot(
+          tool.key,
+          'capture.jpg',
+          '/documents/images',
+          host: host,
+        );
+        verify(
+          () => host.start(
+            tool.key,
+            tool.value,
+            workingDirectory: '/documents/images',
+          ),
+        ).called(1);
+        verify(() => host.forwardOutput(process)).called(1);
+        verifyNever(() => process.kill());
       });
+    }
 
-      test('returns false when command is not available', () async {
-        // Test with a command that should not exist
-        final result = await isCommandAvailable('nonexistent_command_12345');
-        expect(result, isFalse);
-      });
-
-      test('returns false when Process.run throws exception', () async {
-        // Test with an invalid command that might cause Process.run to throw
-        // Use empty string which should cause Process.run to throw
-        final result = await isCommandAvailable('');
-        expect(result, isFalse);
-      });
+    test('rejects unknown tools before launching a process', () async {
+      await expectLater(
+        takeLinuxScreenshot('unknown', 'capture.jpg', '/documents', host: host),
+        throwsA(
+          isException.having(
+            (e) => e.toString(),
+            'message',
+            contains('Unsupported screenshot tool'),
+          ),
+        ),
+      );
+      verifyZeroInteractions(host);
     });
 
-    group('findAvailableScreenshotTool', () {
-      test('returns a tool if available on the system', () async {
-        final result = await findAvailableScreenshotTool();
-        // On macOS, this should return null since we're not on Linux
-        // On Linux, it might return a tool if available
-        expect(result, anyOf(isA<String>(), isNull));
-      });
-
-      test('iterates through all tools when none are available', () async {
-        // This test ensures the loop iterates through all tools
-        // Since we're likely not on a system with these Linux tools,
-        // it should check all of them and return null
-        final result = await findAvailableScreenshotTool();
-
-        // If we're not on Linux or don't have the tools, result should be null
-        // If we're on Linux with tools, result should be one of the expected tools
-        if (result != null) {
-          expect(linuxScreenshotTools, contains(result));
-        }
-      });
+    test('propagates launch errors', () async {
+      const error = ProcessException('scrot', [], 'permission denied');
+      when(
+        () => host.start(
+          any(),
+          any(),
+          workingDirectory: any(named: 'workingDirectory'),
+        ),
+      ).thenAnswer((_) async => throw error);
+      await expectLater(
+        takeLinuxScreenshot('scrot', 'capture.jpg', '/documents', host: host),
+        throwsA(same(error)),
+      );
     });
 
-    group('takeLinuxScreenshot', () {
-      test('throws exception for unsupported tool', () async {
+    test('rejects a nonzero exit code', () async {
+      when(() => process.exitCode).thenAnswer((_) async => 7);
+      await expectLater(
+        takeLinuxScreenshot('scrot', 'capture.jpg', '/documents', host: host),
+        throwsA(
+          isException.having(
+            (e) => e.toString(),
+            'message',
+            allOf(contains('scrot'), contains('7')),
+          ),
+        ),
+      );
+    });
+
+    test('kills a hung process at the timeout boundary', () {
+      fakeAsync((async) {
+        final exitCode = Completer<int>();
+        when(() => process.exitCode).thenAnswer((_) => exitCode.future);
+        Object? failure;
+        unawaited(
+          takeLinuxScreenshot(
+            'scrot',
+            'capture.jpg',
+            '/documents',
+            host: host,
+          ).catchError((Object error) {
+            failure = error;
+          }),
+        );
+        async
+          ..flushMicrotasks()
+          ..elapse(const Duration(seconds: 29));
+        expect(failure, isNull);
+        verifyNever(() => process.kill());
+        async.elapse(const Duration(seconds: 1));
         expect(
-          () => takeLinuxScreenshot('unsupported', 'test.jpg', '/test/dir'),
+          failure,
+          isException.having(
+            (e) => e.toString(),
+            'message',
+            contains('scrot timed out after 30s'),
+          ),
+        );
+        verify(() => process.kill()).called(1);
+        exitCode.complete(-1);
+        async.flushMicrotasks();
+      });
+    });
+  });
+
+  group('capture workflow', () {
+    test('uses the canonical documents-relative path', () {
+      expect(screenshotRelativePath(capturedAt), '/images/2026-08-15/');
+    });
+
+    for (final os in ['linux', 'macos']) {
+      testWidgets('$os captures metadata and restores the window', (
+        tester,
+      ) async {
+        when(() => host.operatingSystem).thenReturn(os);
+        final future = capture();
+        await tester.pump();
+        verify(host.minimizeWindow).called(1);
+        verifyNever(
+          () => host.start(
+            any(),
+            any(),
+            workingDirectory: any(named: 'workingDirectory'),
+          ),
+        );
+        await tester.pump(const Duration(seconds: 1));
+        final result = await future;
+        expect(result.capturedAt, capturedAt);
+        expect(result.imageDirectory, '/images/2026-08-15/');
+        expect(result.imageId, isNotEmpty);
+        expect(result.imageFile, '${result.imageId}.screenshot.jpg');
+        verify(() => host.createDirectory('/images/2026-08-15/')).called(1);
+        verifyInOrder([
+          () => host.start(
+            os == 'linux' ? 'spectacle' : 'screencapture',
+            os == 'linux'
+                ? ['-f', '-b', '-n', '-o', result.imageFile]
+                : ['-tjpg', result.imageFile],
+            workingDirectory: '/documents/images/2026-08-15',
+          ),
+          () => host.forwardOutput(process),
+          host.showWindow,
+        ]);
+      });
+
+      testWidgets('$os times out even while process output stays open', (
+        tester,
+      ) async {
+        when(() => host.operatingSystem).thenReturn(os);
+        final output = Completer<void>();
+        final exitCode = Completer<int>();
+        when(
+          () => host.forwardOutput(process),
+        ).thenAnswer((_) => output.future);
+        when(() => process.exitCode).thenAnswer((_) => exitCode.future);
+        Object? failure;
+        final future = capture().then<ImageData?>(
+          (value) => value,
+          onError: (Object error) {
+            failure = error;
+            return null;
+          },
+        );
+        await advanceCapture(tester);
+        await tester.pump(const Duration(seconds: 29));
+        expect(failure, isNull);
+        verifyNever(() => process.kill());
+        await tester.pump(const Duration(seconds: 1));
+        // Drain controlled effects even when the regression assertion fails.
+        output.complete();
+        exitCode.complete(-1);
+        await tester.pump();
+        await future;
+        expect(
+          failure,
+          isException.having(
+            (e) => e.toString(),
+            'message',
+            contains('timed out after 30s'),
+          ),
+        );
+        verify(() => process.kill()).called(1);
+        verify(host.showWindow).called(1);
+      });
+
+      testWidgets('$os restores the window after capture fails', (
+        tester,
+      ) async {
+        when(() => host.operatingSystem).thenReturn(os);
+        when(() => process.exitCode).thenAnswer((_) async => 9);
+        final assertion = expectLater(
+          capture(),
           throwsA(
-            isA<Exception>().having(
+            isException.having(
               (e) => e.toString(),
               'message',
-              contains('Unsupported screenshot tool'),
+              contains('9'),
             ),
           ),
         );
+        await advanceCapture(tester);
+        await assertion;
+        verify(host.showWindow).called(1);
+        verify(
+          () => logger.error(
+            LogDomain.screenshots,
+            any(),
+            stackTrace: any(named: 'stackTrace'),
+          ),
+        ).called(1);
       });
+    }
 
-      test('validates tool configuration for supported tools', () {
-        // Test that all supported tools have valid configurations
-        for (final tool in linuxScreenshotTools) {
-          final config = screenshotToolConfigs[tool];
-          expect(
-            config,
-            isNotNull,
-            reason: 'Tool $tool should have configuration',
-          );
-          expect(config!.arguments, isA<List<String>>());
-        }
-      });
-
-      test('starts process with correct arguments for spectacle', () async {
-        // This test will attempt to run spectacle, which likely won't exist
-        // on most test systems, causing Process.start to fail
-        try {
-          await takeLinuxScreenshot(spectacleTool, 'test.jpg', '/tmp');
-        } catch (e) {
-          // Expected to fail on systems without spectacle
-          expect(e, isA<Exception>());
-        }
-      });
-
-      test('builds correct arguments list', () {
-        // Test that arguments are properly constructed
-        final config = screenshotToolConfigs[spectacleTool];
-        expect(config, isNotNull);
-
-        // The function should combine config arguments with filename
-        final expectedArgs = [...config!.arguments, 'test.jpg'];
-        expect(expectedArgs.last, equals('test.jpg'));
-        expect(expectedArgs.length, equals(config.arguments.length + 1));
-      });
+    testWidgets('reports missing Linux tools and restores the window', (
+      tester,
+    ) async {
+      when(
+        () => host.run(any(), any()),
+      ).thenAnswer((_) async => ProcessResult(1, 1, '', ''));
+      final assertion = expectLater(
+        capture(),
+        throwsA(
+          isException.having(
+            (e) => e.toString(),
+            'message',
+            contains('spectacle, gnome-screenshot, scrot, import'),
+          ),
+        ),
+      );
+      await advanceCapture(tester);
+      await assertion;
+      verifyNever(
+        () => host.start(
+          any(),
+          any(),
+          workingDirectory: any(named: 'workingDirectory'),
+        ),
+      );
+      verify(host.showWindow).called(1);
     });
 
-    group('takeScreenshot', () {
-      test('builds a canonical documents-relative screenshot path', () {
-        expect(
-          screenshotRelativePath(DateTime(2026, 8, 15)),
-          '/images/2026-08-15/',
+    testWidgets('rejects unsupported platforms and restores the window', (
+      tester,
+    ) async {
+      when(() => host.operatingSystem).thenReturn('windows');
+      final assertion = expectLater(
+        capture(),
+        throwsA(
+          isA<UnsupportedError>().having(
+            (e) => e.message,
+            'message',
+            contains('windows'),
+          ),
+        ),
+      );
+      await advanceCapture(tester);
+      await assertion;
+      verify(host.showWindow).called(1);
+    });
+
+    testWidgets('restoration failure preserves the successful capture', (
+      tester,
+    ) async {
+      final error = StateError('window gone');
+      when(host.showWindow).thenAnswer((_) async => throw error);
+      final future = capture();
+      await advanceCapture(tester);
+      expect((await future).imageDirectory, '/images/2026-08-15/');
+      verify(
+        () => logger.error(
+          LogDomain.screenshots,
+          error,
+          subDomain: 'window_restoration',
+        ),
+      ).called(1);
+    });
+
+    testWidgets('restoration failure preserves the original capture error', (
+      tester,
+    ) async {
+      final captureError = StateError('cannot create directory');
+      when(
+        () => host.createDirectory(any()),
+      ).thenAnswer((_) async => throw captureError);
+      when(
+        host.showWindow,
+      ).thenAnswer((_) async => throw StateError('window gone'));
+      final assertion = expectLater(capture(), throwsA(same(captureError)));
+      await tester.pump();
+      await assertion;
+      verify(host.showWindow).called(1);
+      verifyNever(host.minimizeWindow);
+    });
+
+    testWidgets(
+      'portal success returns matching metadata without a CLI capture',
+      (tester) async {
+        when(() => host.shouldUsePortal).thenReturn(true);
+        when(host.isPortalAvailable).thenAnswer((_) async => true);
+        when(
+          () => host.captureWithPortal(
+            directory: any(named: 'directory'),
+            filename: any(named: 'filename'),
+          ),
+        ).thenAnswer((_) async => '/documents/capture.jpg');
+        final future = capture();
+        await tester.pump();
+        final result = await future;
+        expect(result.capturedAt, capturedAt);
+        expect(result.imageDirectory, '/images/2026-08-15/');
+        expect(result.imageFile, '${result.imageId}.screenshot.jpg');
+        verify(
+          () => host.captureWithPortal(
+            directory: '/documents/images/2026-08-15',
+            filename: result.imageFile,
+          ),
+        ).called(1);
+        verifyNever(host.minimizeWindow);
+        verifyNever(() => host.run(any(), any()));
+        verifyNever(
+          () => host.start(
+            any(),
+            any(),
+            workingDirectory: any(named: 'workingDirectory'),
+          ),
         );
-      });
+        verify(host.showWindow).called(1);
+      },
+    );
 
-      test(
-        'creates ImageData with correct properties on supported platform',
-        () async {
-          // Mock the directory creation
+    for (final available in [false, true]) {
+      testWidgets(
+        'portal ${available ? 'cancellation' : 'unavailability'} falls back to CLI',
+        (tester) async {
+          when(() => host.shouldUsePortal).thenReturn(true);
+          when(host.isPortalAvailable).thenAnswer((_) async => available);
           when(
-            () => mockDirectory.create(recursive: any(named: 'recursive')),
-          ).thenAnswer((_) async => mockDirectory);
-
-          // This test will fail on unsupported platforms, which is expected
-          // We're testing the structure and error handling
-          try {
-            final result = await takeScreenshot();
-            expect(result, isA<ImageData>());
-            expect(result.imageFile, endsWith(screenshotFileExtension));
-            expect(result.imageDirectory, startsWith(screenshotDirectoryPath));
-            expect(result.capturedAt, isA<DateTime>());
-          } catch (e) {
-            // On unsupported platforms, we expect an exception
-            expect(e, anyOf(isA<Exception>(), isA<UnsupportedError>()));
-          }
+            () => host.captureWithPortal(
+              directory: any(named: 'directory'),
+              filename: any(named: 'filename'),
+            ),
+          ).thenAnswer((_) async => null);
+          final future = capture();
+          await advanceCapture(tester);
+          final result = await future;
+          verify(
+            () => host.start('spectacle', [
+              '-f',
+              '-b',
+              '-n',
+              '-o',
+              result.imageFile,
+            ], workingDirectory: '/documents/images/2026-08-15'),
+          ).called(1);
+          verify(host.minimizeWindow).called(1);
+          verify(host.showWindow).called(1);
+          verify(
+            () => logger.error(
+              LogDomain.screenshots,
+              any(),
+              subDomain: 'portal_fallback',
+            ),
+          ).called(1);
         },
       );
-    });
-
-    group('Screenshot Constants', () {
-      test('all required constants are defined', () {
-        expect(screenshotFileExtension, isNotEmpty);
-        expect(screenshotDirectoryPath, isNotEmpty);
-        expect(screenshotDateFormat, isNotEmpty);
-        expect(screenshotDelaySeconds, isPositive);
-        expect(linuxScreenshotTools, isNotEmpty);
-        expect(screenshotToolConfigs, isNotEmpty);
-      });
-
-      test('Linux screenshot tools list contains all expected tools', () {
-        expect(linuxScreenshotTools, contains(spectacleTool));
-        expect(linuxScreenshotTools, contains(gnomeScreenshotTool));
-        expect(linuxScreenshotTools, contains(scrotTool));
-        expect(linuxScreenshotTools, contains(importTool));
-      });
-
-      test('screenshot tool configurations are complete', () {
-        for (final tool in linuxScreenshotTools) {
-          final config = screenshotToolConfigs[tool];
-          expect(config, isNotNull);
-          expect(config!.arguments, isA<List<String>>());
-        }
-      });
-    });
-
-    group('Error Messages', () {
-      test('provides helpful error message for missing tools', () {
-        expect(
-          noScreenshotToolAvailableMessage,
-          contains('No screenshot tool available'),
-        );
-        expect(installInstructionsMessage, contains('sudo apt install'));
-        expect(installInstructionsMessage, contains('spectacle'));
-        expect(installInstructionsMessage, contains('gnome-screenshot'));
-        expect(installInstructionsMessage, contains('scrot'));
-        expect(installInstructionsMessage, contains('imagemagick'));
-      });
-
-      test('error messages are properly formatted', () {
-        expect(unsupportedToolMessage, contains('Unsupported screenshot tool'));
-        expect(toolFailedMessage, contains('Screenshot tool'));
-        expect(failedWithExitCodeMessage, contains('failed with exit code'));
-        expect(
-          screencaptureFailedMessage,
-          contains('macOS screencapture failed'),
-        );
-        expect(
-          unsupportedPlatformMessage,
-          contains('Screenshot functionality is not supported'),
-        );
-      });
-    });
-
-    group('Tool Arguments', () {
-      test('spectacle arguments are correctly defined', () {
-        final config = screenshotToolConfigs[spectacleTool];
-        expect(config, isNotNull);
-        expect(config!.arguments, equals(spectacleArguments));
-      });
-
-      test('gnome-screenshot arguments are correctly defined', () {
-        final config = screenshotToolConfigs[gnomeScreenshotTool];
-        expect(config, isNotNull);
-        expect(config!.arguments, equals(gnomeScreenshotArguments));
-      });
-
-      test('scrot arguments are correctly defined', () {
-        final config = screenshotToolConfigs[scrotTool];
-        expect(config, isNotNull);
-        expect(config!.arguments, equals(scrotArguments));
-      });
-
-      test('import arguments are correctly defined', () {
-        final config = screenshotToolConfigs[importTool];
-        expect(config, isNotNull);
-        expect(config!.arguments, equals(importArguments));
-      });
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // Comprehensive tests (originally in screenshots_comprehensive_test.dart)
-  // ---------------------------------------------------------------------------
-
-  group('Screenshots Comprehensive Tests', () {
-    late MockDomainLogger mockLoggingService;
-    late MockWindowManager mockWindowManager;
-    late Directory testTempDir;
-
-    setUpAll(() async {
-      TestWidgetsFlutterBinding.ensureInitialized();
-
-      registerAllFallbackValues();
-      registerFallbackValue(StackTrace.current);
-      registerFallbackValue(FakeDBusObjectPath());
-      registerFallbackValue(FakeDBusMethodCall());
-      registerFallbackValue(FakeDBusSignature());
-      registerFallbackValue(DBusDict.stringVariant(const {}));
-
-      // Create a real temp directory for integration tests
-      testTempDir = await Directory.systemTemp.createTemp('screenshot_test');
-    });
-
-    tearDownAll(() async {
-      if (testTempDir.existsSync()) {
-        await testTempDir.delete(recursive: true);
-      }
-    });
-
-    setUp(() {
-      mockLoggingService = MockDomainLogger();
-      mockWindowManager = MockWindowManager();
-
-      // Register mocks in GetIt
-      getIt
-        ..registerSingleton<DomainLogger>(mockLoggingService)
-        ..registerSingleton<WindowManager>(mockWindowManager)
-        ..registerSingleton<Directory>(testTempDir);
-
-      // Setup default mock behaviors
-      when(() => mockWindowManager.minimize()).thenAnswer((_) async {});
-      when(() => mockWindowManager.show()).thenAnswer((_) async {});
-
-      when(
-        () => mockLoggingService.log(
-          any<LogDomain>(),
-          any<String>(),
-          subDomain: any(named: 'subDomain'),
-        ),
-      ).thenReturn(null);
-
-      when(
-        () => mockLoggingService.error(
-          any<LogDomain>(),
-          any<Object>(),
-          stackTrace: any<StackTrace>(named: 'stackTrace'),
-          subDomain: any(named: 'subDomain'),
-        ),
-      ).thenAnswer((_) async {});
-    });
-
-    tearDown(getIt.reset);
-
-    group('Portal Environment Detection', () {
-      test('isRunningInFlatpak returns correct value based on environment', () {
-        final isRunning = PortalService.isRunningInFlatpak;
-        expect(isRunning, isA<bool>());
-
-        // Verify consistency with shouldUsePortal
-        if (Platform.isLinux) {
-          final hasFlatpakId =
-              Platform.environment['FLATPAK_ID'] != null &&
-              Platform.environment['FLATPAK_ID']!.isNotEmpty;
-          expect(isRunning, equals(hasFlatpakId));
-        } else {
-          expect(isRunning, isFalse);
-        }
-      });
-
-      test('shouldUsePortal is consistent with environment', () {
-        final shouldUse = PortalService.shouldUsePortal;
-        final isRunning = PortalService.isRunningInFlatpak;
-        expect(shouldUse, equals(isRunning));
-      });
-    });
-
-    group('Screenshot Portal Integration', () {
-      test('takeScreenshot uses portal when in Flatpak environment', () async {
-        // This test verifies the integration with portal services
-        // In non-Flatpak environment, it should fall back to traditional methods
-
-        if (PortalService.shouldUsePortal) {
-          // In Flatpak, should attempt to use portal
-          expect(
-            () async {
-              await takeScreenshot();
-            },
-            throwsA(
-              anyOf(
-                isA<MissingPluginException>(),
-                isA<UnsupportedError>(),
-                isA<Exception>(),
-              ),
-            ),
-          );
-        } else {
-          // Outside Flatpak, should use traditional screenshot tools
-          expect(
-            () async {
-              await takeScreenshot();
-            },
-            throwsA(
-              anyOf(
-                isA<MissingPluginException>(),
-                isA<UnsupportedError>(),
-                isA<Exception>(),
-              ),
-            ),
-          );
-        }
-      });
-
-      test('portal service availability check', () async {
-        final isAvailable = await ScreenshotPortalService.isAvailable();
-        expect(isAvailable, isA<bool>());
-
-        // Portal should only be available in Flatpak
-        if (!PortalService.shouldUsePortal) {
-          expect(isAvailable, isFalse);
-        }
-      });
-
-      test('handles portal fallback to traditional methods', () async {
-        // When portal fails, should fall back to traditional screenshot methods
-        // This is tested by the error handling in takeScreenshot
-
-        when(
-          () => mockLoggingService.error(
-            LogDomain.screenshots,
-            any<Object>(),
-            subDomain: 'portal_fallback',
-          ),
-        ).thenAnswer((_) async {});
-
-        // Attempt screenshot which should handle fallback
-        expect(() async {
-          await takeScreenshot();
-        }, throwsA(isA<Exception>()));
-      });
-    });
-
-    group('isCommandAvailable', () {
-      test('returns false for non-existent commands', () async {
-        // Test with a command that should not exist
-        final result = await isCommandAvailable('nonexistent_command_xyz123');
-        expect(result, isFalse);
-      });
-
-      test('returns true for existing commands', () async {
-        // Test with a command that should exist on most systems
-        if (Platform.isLinux || Platform.isMacOS) {
-          final result = await isCommandAvailable('ls');
-          expect(result, isTrue);
-        }
-      });
-    });
-
-    group('findAvailableScreenshotTool', () {
-      test('returns a tool or null depending on system', () async {
-        final result = await findAvailableScreenshotTool();
-        // On Linux, might return a tool if available
-        // On other systems, should return null
-        if (Platform.isLinux) {
-          expect(result, anyOf(isNull, isIn(linuxScreenshotTools)));
-        } else if (Platform.isMacOS) {
-          // macOS might have ImageMagick's import tool available
-          expect(result, anyOf(isNull, isIn(linuxScreenshotTools)));
-        } else {
-          expect(result, isNull);
-        }
-      });
-    });
-
-    group('takeLinuxScreenshot', () {
-      test('throws exception for unsupported tool', () async {
-        await expectLater(
-          takeLinuxScreenshot(
-            'unsupported_tool',
-            'test.jpg',
-            testTempDir.path,
-          ),
-          throwsA(
-            isA<Exception>().having(
-              (e) => e.toString(),
-              'message',
-              contains('Unsupported screenshot tool'),
-            ),
-          ),
-        );
-      });
-
-      test('validates tool arguments exist', () {
-        for (final tool in linuxScreenshotTools) {
-          final config = screenshotToolConfigs[tool];
-          expect(config, isNotNull, reason: 'Config for $tool should exist');
-          expect(config!.arguments, isA<List<String>>());
-        }
-      });
-
-      test('handles process execution structure', () async {
-        // We can't easily mock Process.start without IOOverrides
-        // But we can verify the tool configuration is correct
-        expect(spectacleArguments, contains('-f'));
-        expect(gnomeScreenshotArguments, contains('-f'));
-        expect(importArguments, containsAll(['-window', 'root']));
-      });
-    });
-
-    group('takeScreenshot main function', () {
-      test('throws UnsupportedError on unsupported platforms', () async {
-        // We can't easily mock Platform.operatingSystem
-        // but we can test the error message exists
-        expect(unsupportedPlatformMessage, contains('not supported'));
-      });
-
-      test('logs exceptions and rethrows them', () async {
-        // In test environment, takeScreenshot will throw MissingPluginException
-        await expectLater(
-          takeScreenshot(),
-          throwsA(isA<MissingPluginException>()),
-        );
-
-        // Logging should be attempted
-        verify(
-          () => mockLoggingService.error(
-            LogDomain.screenshots,
-            any<Object>(),
-            stackTrace: any<StackTrace>(named: 'stackTrace'),
-          ),
-        ).called(1);
-      });
-
-      test('restores window even on error', () async {
-        // This test would require mocking the global windowManager
-        // which is not easily possible without refactoring
-        // We verify the behavior exists through the _safelyRestoreWindow function
-        expect(() async {
-          await takeScreenshot();
-        }, throwsA(isA<MissingPluginException>()));
-      });
-
-      test('creates correct ImageData structure', () async {
-        // This test would need platform-specific mocking
-        // We verify the ImageData structure is correct
-        final testData = ImageData(
-          imageId: 'test-id',
-          imageFile: 'test.jpg',
-          imageDirectory: '/test/',
-          capturedAt: DateTime(2024, 3, 15, 10, 30),
-        );
-
-        expect(testData.imageFile, endsWith('.jpg'));
-        expect(testData.imageDirectory, contains('/'));
-        expect(testData.capturedAt, isA<DateTime>());
-      });
-
-      test('uses correct delay for window minimization', () async {
-        // Verify delay constants are reasonable
-        expect(screenshotDelaySeconds, greaterThan(0));
-        expect(screenshotDelaySeconds, lessThanOrEqualTo(5));
-      });
-    });
-
-    group('macOS screenshot', () {
-      test('uses correct screencapture arguments', () {
-        expect(screencaptureArguments, contains('-tjpg'));
-        expect(screencaptureTool, equals('screencapture'));
-      });
-
-      test('handles screencapture timeout', () async {
-        // Test timeout handling for macOS
-        expect(screenshotProcessTimeoutSeconds, greaterThan(0));
-        expect(screenshotProcessTimeoutSeconds, lessThanOrEqualTo(60));
-      });
-
-      test('handles screencapture failure', () {
-        expect(screencaptureFailedMessage, contains('screencapture failed'));
-      });
-    });
-
-    group('File and directory handling', () {
-      test('creates unique filenames', () async {
-        // Test that uuid is used for unique filenames
-        final uuid1 = uuid.v1();
-        final uuid2 = uuid.v1();
-        expect(uuid1, isNot(equals(uuid2)));
-      });
-
-      test('uses correct date format for directories', () {
-        final date = DateTime(2023, 12, 25);
-        final formatted = DateFormat(screenshotDateFormat).format(date);
-        expect(formatted, equals('2023-12-25'));
-      });
-
-      test('constructs correct relative paths', () {
-        const relativePath = screenshotDirectoryPath;
-        expect(relativePath, equals('/images/'));
-        expect(relativePath, startsWith('/'));
-      });
-    });
-
-    group('Error recovery', () {
-      test('window restoration is attempted on error', () async {
-        // We can't mock the global windowManager easily
-        // Instead verify error handling works
-        expect(() async {
-          await takeScreenshot();
-        }, throwsA(isA<MissingPluginException>()));
-      });
-
-      test('logging never prevents screenshot completion', () async {
-        // In test environment, we get MissingPluginException
-        await expectLater(
-          takeScreenshot(),
-          throwsA(isA<MissingPluginException>()),
-        );
-
-        // Verify logging was attempted
-        verify(
-          () => mockLoggingService.error(
-            LogDomain.screenshots,
-            any<Object>(),
-            stackTrace: any<StackTrace>(named: 'stackTrace'),
-          ),
-        ).called(1);
-      });
-    });
-
-    group('Platform detection', () {
-      test('correctly identifies platform tools', () {
-        if (Platform.isMacOS) {
-          expect(screencaptureTool, equals('screencapture'));
-        } else if (Platform.isLinux) {
-          expect(linuxScreenshotTools, isNotEmpty);
-          expect(linuxScreenshotTools.first, equals(spectacleTool));
-        }
-      });
-
-      test('has fallback tools for Linux', () {
-        expect(linuxScreenshotTools.length, greaterThan(1));
-        expect(
-          linuxScreenshotTools,
-          containsAll([
-            spectacleTool,
-            gnomeScreenshotTool,
-            scrotTool,
-            importTool,
-          ]),
-        );
-      });
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // Platform-specific tests (originally in screenshots_platform_test.dart)
-  // ---------------------------------------------------------------------------
-
-  group('Platform-specific Screenshot Tests', () {
-    late MockDomainLogger mockLoggingService;
-    late MockWindowManager mockWindowManager;
-    late Directory testTempDir;
-
-    setUpAll(() async {
-      registerAllFallbackValues();
-      registerFallbackValue(StackTrace.current);
-      testTempDir = await Directory.systemTemp.createTemp(
-        'platform_screenshot_test',
-      );
-    });
-
-    tearDownAll(() async {
-      if (testTempDir.existsSync()) {
-        await testTempDir.delete(recursive: true);
-      }
-    });
-
-    setUp(() {
-      mockLoggingService = MockDomainLogger();
-      mockWindowManager = MockWindowManager();
-
-      getIt
-        ..registerSingleton<DomainLogger>(mockLoggingService)
-        ..registerSingleton<WindowManager>(mockWindowManager)
-        ..registerSingleton<Directory>(testTempDir);
-
-      when(() => mockWindowManager.minimize()).thenAnswer((_) async {});
-      when(() => mockWindowManager.show()).thenAnswer((_) async {});
-
-      when(
-        () => mockLoggingService.log(
-          any<LogDomain>(),
-          any<String>(),
-          subDomain: any(named: 'subDomain'),
-        ),
-      ).thenReturn(null);
-
-      when(
-        () => mockLoggingService.error(
-          any<LogDomain>(),
-          any<Object>(),
-          stackTrace: any<StackTrace>(named: 'stackTrace'),
-          subDomain: any(named: 'subDomain'),
-        ),
-      ).thenAnswer((_) async {});
-    });
-
-    tearDown(getIt.reset);
-
-    group('Portal vs Traditional Screenshot Selection', () {
-      test('uses portal in Flatpak environment', () {
-        final usePortal = PortalService.shouldUsePortal;
-
-        if (Platform.isLinux) {
-          final hasFlatpakId =
-              Platform.environment['FLATPAK_ID'] != null &&
-              Platform.environment['FLATPAK_ID']!.isNotEmpty;
-          expect(usePortal, equals(hasFlatpakId));
-        } else {
-          expect(usePortal, isFalse);
-        }
-      });
-
-      test('falls back to traditional tools when portal unavailable', () async {
-        // When not in Flatpak, should use traditional screenshot tools
-        if (!PortalService.shouldUsePortal && Platform.isLinux) {
-          final availableTool = await findAvailableScreenshotTool();
-          // Should find a tool or return null
-          expect(availableTool, anyOf(isNull, isIn(linuxScreenshotTools)));
-        }
-      });
-
-      test('portal service singleton is properly managed', () {
-        final service1 = ScreenshotPortalService();
-        final service2 = ScreenshotPortalService();
-
-        // Should be the same instance (singleton)
-        expect(identical(service1, service2), isTrue);
-      });
-    });
-
-    group('macOS Screenshot', () {
-      test('uses correct screencapture command', () {
-        expect(screencaptureTool, equals('screencapture'));
-        expect(screencaptureArguments, contains('-tjpg'));
-      });
-
-      test('handles screencapture process correctly', () async {
-        final mockProcess = MockProcess();
-        const mockStdout = Stream<List<int>>.empty();
-        const mockStderr = Stream<List<int>>.empty();
-
-        when(() => mockProcess.stdout).thenAnswer((_) => mockStdout);
-        when(() => mockProcess.stderr).thenAnswer((_) => mockStderr);
-        when(() => mockProcess.exitCode).thenAnswer((_) async => 0);
-
-        // Can't easily test Process.start without IOOverrides
-        expect(screencaptureTool, isNotEmpty);
-        expect(screencaptureArguments, isNotEmpty);
-      });
-
-      test('formats error message correctly for macOS', () {
-        const exitCode = 1;
-        const errorMessage = '$screencaptureFailedMessage$exitCode';
-
-        expect(errorMessage, contains('macOS screencapture failed'));
-        expect(errorMessage, contains('1'));
-      });
-    });
-
-    group('Linux Screenshot Tools', () {
-      test('spectacle configuration is correct', () {
-        final config = screenshotToolConfigs[spectacleTool];
-
-        expect(config, isNotNull);
-        expect(config!.arguments, equals(spectacleArguments));
-        expect(config.arguments, contains('-f')); // fullscreen
-        expect(config.arguments, contains('-b')); // background
-        expect(config.arguments, contains('-n')); // no notification
-        expect(config.arguments, contains('-o')); // output to stdout
-      });
-
-      test('gnome-screenshot configuration is correct', () {
-        final config = screenshotToolConfigs[gnomeScreenshotTool];
-
-        expect(config, isNotNull);
-        expect(config!.arguments, equals(gnomeScreenshotArguments));
-        expect(config.arguments, contains('-f')); // file parameter
-      });
-
-      test('scrot configuration is correct', () {
-        final config = screenshotToolConfigs[scrotTool];
-
-        expect(config, isNotNull);
-        expect(config!.arguments, equals(scrotArguments));
-        expect(
-          config.arguments,
-          isEmpty,
-        ); // scrot uses filename as positional arg
-      });
-
-      test('import (ImageMagick) configuration is correct', () {
-        final config = screenshotToolConfigs[importTool];
-
-        expect(config, isNotNull);
-        expect(config!.arguments, equals(importArguments));
-        expect(config.arguments, contains('-window'));
-        expect(config.arguments, contains('root'));
-      });
-
-      test('tool priority order is correct', () {
-        expect(linuxScreenshotTools.first, equals(spectacleTool));
-        expect(linuxScreenshotTools[1], equals(gnomeScreenshotTool));
-        expect(linuxScreenshotTools[2], equals(scrotTool));
-        expect(linuxScreenshotTools.last, equals(importTool));
-      });
-
-      test('all tools have configurations', () {
-        for (final tool in linuxScreenshotTools) {
-          expect(
-            screenshotToolConfigs.containsKey(tool),
-            isTrue,
-            reason: 'Tool $tool should have a configuration',
-          );
-        }
-      });
-    });
-
-    group('Platform Detection', () {
-      test('provides helpful error for unsupported platforms', () {
-        const unsupportedPlatform = 'windows';
-        const errorMessage = '$unsupportedPlatformMessage$unsupportedPlatform';
-
-        expect(errorMessage, contains('not supported'));
-        expect(errorMessage, contains(unsupportedPlatform));
-      });
-
-      test('has platform-specific tool lists', () {
-        // Linux has multiple tools
-        expect(linuxScreenshotTools.length, greaterThan(1));
-
-        // macOS has single tool
-        expect(screencaptureTool, isNotEmpty);
-      });
-    });
-
-    group('Tool Availability', () {
-      test('checks command availability correctly', () async {
-        // Test with actual commands that should exist
-        if (Platform.isLinux || Platform.isMacOS) {
-          final lsAvailable = await isCommandAvailable('ls');
-          expect(lsAvailable, isTrue);
-
-          final fakeCommandAvailable = await isCommandAvailable(
-            'fake_command_xyz',
-          );
-          expect(fakeCommandAvailable, isFalse);
-        }
-      });
-
-      test('returns tool based on availability', () async {
-        // This test depends on the actual system
-        final tool = await findAvailableScreenshotTool();
-
-        if (Platform.isLinux) {
-          // On Linux, might find one of the tools or none
-          expect(tool, anyOf(isNull, isIn(linuxScreenshotTools)));
-        } else {
-          // On non-Linux (like macOS), may have ImageMagick's import tool
-          expect(tool, anyOf(isNull, isIn(linuxScreenshotTools)));
-        }
-      });
-
-      test('checks tools in priority order', () {
-        // Verify the tool order is correct
-        expect(linuxScreenshotTools, contains(spectacleTool));
-        expect(linuxScreenshotTools, contains(gnomeScreenshotTool));
-        expect(linuxScreenshotTools, contains(scrotTool));
-        expect(linuxScreenshotTools, contains(importTool));
-      });
-    });
-
-    group('Error Messages', () {
-      test('provides installation instructions for Linux', () {
-        expect(installInstructionsMessage, contains('sudo apt install'));
-        expect(installInstructionsMessage, contains('spectacle'));
-        expect(installInstructionsMessage, contains('gnome-screenshot'));
-        expect(installInstructionsMessage, contains('scrot'));
-        expect(installInstructionsMessage, contains('imagemagick'));
-      });
-
-      test('formats tool unavailable message correctly', () {
-        final tools = linuxScreenshotTools.join(', ');
-        final message = '$noScreenshotToolAvailableMessage$tools';
-
-        expect(message, contains('No screenshot tool available'));
-        expect(message, contains(spectacleTool));
-        expect(message, contains(gnomeScreenshotTool));
-      });
-
-      test('includes exit code in error messages', () {
-        const exitCode = 127;
-        const message = '$failedWithExitCodeMessage$exitCode';
-
-        expect(message, contains('failed with exit code'));
-        expect(message, contains('127'));
-      });
-    });
-
-    group('Process Execution', () {
-      test('uses correct process timeout', () {
-        expect(screenshotProcessTimeoutSeconds, equals(30));
-        expect(screenshotProcessTimeoutSeconds, greaterThan(0));
-        expect(screenshotProcessTimeoutSeconds, lessThanOrEqualTo(60));
-      });
-
-      test('expects zero exit code for success', () {
-        expect(successExitCode, equals(0));
-      });
-
-      test('handles process streams correctly', () async {
-        // Verify stdout and stderr are handled
-        final mockProcess = MockProcess();
-        final stdout = Stream<List<int>>.fromIterable([
-          [72, 101, 108, 108, 111], // "Hello"
-        ]);
-        const stderr = Stream<List<int>>.empty();
-
-        when(() => mockProcess.stdout).thenAnswer((_) => stdout);
-        when(() => mockProcess.stderr).thenAnswer((_) => stderr);
-
-        // Would be used in actual process execution
-        expect(mockProcess.stdout, isNotNull);
-        expect(mockProcess.stderr, isNotNull);
-      });
-    });
-
-    group('File Generation', () {
-      test('generates correct filename format', () {
-        final id = uuid.v1();
-        final filename = '$id$screenshotFileExtension';
-
-        expect(filename, endsWith(screenshotFileExtension));
-        expect(filename, contains('.screenshot.jpg'));
-        expect(filename, matches(RegExp(r'^[0-9a-f-]+\.screenshot\.jpg$')));
-      });
-
-      test('creates date-based directory structure', () {
-        final testDate = DateTime(2024, 3, 15, 10, 30);
-        final pathStr = screenshotRelativePath(testDate);
-
-        expect(pathStr, startsWith('/images/'));
-        expect(pathStr, endsWith('/'));
-        expect(pathStr, matches(RegExp(r'^/images/\d{4}-\d{2}-\d{2}/$')));
-      });
-
-      test('uses relative paths for sandboxed environments', () {
-        expect(screenshotDirectoryPath, equals('/images/'));
-        expect(screenshotDirectoryPath, isNot(startsWith('//')));
-      });
-    });
-
-    group('Window Management', () {
-      test('minimizes window before screenshot', () async {
-        // Verify initial state - no calls made yet
-        verifyNever(() => mockWindowManager.minimize());
-
-        // Would be called in actual screenshot flow
-        await mockWindowManager.minimize();
-        verify(() => mockWindowManager.minimize()).called(1);
-      });
-
-      test('uses appropriate delays', () {
-        expect(screenshotDelaySeconds, equals(1));
-
-        // Delays should be reasonable
-        expect(screenshotDelaySeconds, lessThanOrEqualTo(5));
-      });
-
-      test('restores window after screenshot', () async {
-        // Verify initial state - no calls made yet
-        verifyNever(() => mockWindowManager.show());
-
-        // Would be called in actual screenshot flow
-        await mockWindowManager.show();
-        verify(() => mockWindowManager.show()).called(1);
-      });
-    });
-
-    group('Flatpak Security and Permissions', () {
-      test('verifies restricted filesystem access in Flatpak', () {
-        // In Flatpak, only specific directories should be accessible
-        const flatpakAllowedPaths = [
-          'xdg-documents/Lotti',
-          'xdg-download/Lotti',
-          'xdg-pictures', // Read-only
-        ];
-
-        for (final path in flatpakAllowedPaths) {
-          // Verify Lotti-specific directories are isolated
-          if (path.contains('Lotti')) {
-            expect(path.endsWith('/Lotti'), isTrue);
-          }
-        }
-      });
-
-      test('ensures portal is used for privileged operations', () async {
-        // In Flatpak, screenshots must use portal instead of direct access
-        if (PortalService.isRunningInFlatpak) {
-          expect(PortalService.shouldUsePortal, isTrue);
-
-          // Should not attempt to use traditional screenshot tools directly
-          await expectLater(
-            // Direct screenshot tools should fail in sandboxed environment
-            takeLinuxScreenshot('spectacle', 'test.png', testTempDir.path),
-            throwsA(isA<Exception>()),
-          );
-        }
-      });
-
-      test('validates portal bus names and paths', () {
-        // Security: Ensure we're talking to the correct portal service
-        expect(
-          PortalConstants.portalBusName,
-          equals('org.freedesktop.portal.Desktop'),
-        );
-        expect(
-          PortalConstants.portalPath,
-          equals('/org/freedesktop/portal/desktop'),
-        );
-
-        // These should never change as they're part of the XDG spec
-        expect(
-          ScreenshotPortalConstants.interfaceName,
-          equals('org.freedesktop.portal.Screenshot'),
-        );
-      });
-
-      test('verifies sandbox restrictions are enforced', () {
-        // Test that the app respects sandbox boundaries
-        if (PortalService.isRunningInFlatpak) {
-          // Should not have direct access to system directories
-          final systemDirs = ['/usr', '/etc', '/var'];
-
-          for (final dir in systemDirs) {
-            // In a properly sandboxed Flatpak, these would be restricted
-            // We can't directly test this without being in Flatpak
-            expect(dir, startsWith('/'));
-          }
-        }
-      });
-
-      test('ensures proper cleanup of portal resources', () async {
-        final portalService = ScreenshotPortalService();
-
-        await portalService.initialize();
-        await portalService.dispose();
-
-        // Should not leak resources after disposal
-        expect(() => portalService.client, throwsStateError);
-      });
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // Portal integration tests
-  // (originally in screenshots_portal_integration_test.dart)
-  // ---------------------------------------------------------------------------
-
-  group('Screenshots Portal Integration', () {
-    late MockDomainLogger mockLoggingService;
-    late MockWindowManager mockWindowManager;
-
-    setUpAll(() {
-      registerAllFallbackValues();
-      registerFallbackValue(StackTrace.current);
-    });
-
-    setUp(() {
-      mockLoggingService = MockDomainLogger();
-      mockWindowManager = MockWindowManager();
-
-      // Register mocks in GetIt
-      getIt
-        ..registerSingleton<DomainLogger>(mockLoggingService)
-        ..registerSingleton<WindowManager>(mockWindowManager);
-
-      // Setup default mock behaviors
-      when(() => mockWindowManager.minimize()).thenAnswer((_) async {});
-      when(() => mockWindowManager.show()).thenAnswer((_) async {});
-    });
-
-    tearDown(getIt.reset);
-
-    group('Portal Detection', () {
-      test('should detect Flatpak environment correctly', () {
-        final shouldUse = PortalService.shouldUsePortal;
-        final isLinux = Platform.isLinux;
-        final hasFlatpakId = Platform.environment['FLATPAK_ID'] != null;
-
-        expect(shouldUse, equals(isLinux && hasFlatpakId));
-      });
-
-      test('should use portal when in Flatpak environment', () {
-        final shouldUsePortal =
-            Platform.isLinux && PortalService.shouldUsePortal;
-
-        // This test verifies the logic used in takeScreenshot()
-        expect(shouldUsePortal, isA<bool>());
-      });
-    });
-
-    group('Portal Service Integration', () {
-      test('should create ScreenshotPortalService instance', () {
-        final portalService = ScreenshotPortalService();
-        expect(portalService, isA<ScreenshotPortalService>());
-      });
-
-      test('should check portal availability', () async {
-        final available = await ScreenshotPortalService.isAvailable();
-        expect(available, isA<bool>());
-      });
-
-      test('should handle portal unavailability gracefully', () async {
-        if (!PortalService.shouldUsePortal) {
-          // Skip test in non-Flatpak environment
-          return;
-        }
-
-        // This test verifies that the portal fallback logic exists
-        // The actual implementation will handle portal unavailability
-        expect(ScreenshotPortalService.isAvailable(), isA<Future<bool>>());
-      });
-    });
-
-    group('Portal Fallback Logic', () {
-      test('should not attempt portal when not in Flatpak', () async {
-        // When not in Flatpak, takeScreenshot should not use portal
-        // This test verifies the non-Flatpak path
-        expect(
-          PortalService.shouldUsePortal,
-          isFalse,
-          reason: 'This test verifies non-Flatpak behavior',
-        );
-
-        // Mock logging to ensure no portal fallback is logged
-        when(
-          () => mockLoggingService.error(
-            LogDomain.screenshots,
-            any<Object>(),
-            subDomain: 'portal_fallback',
-          ),
-        ).thenAnswer((_) async {});
-
-        // The screenshot will fail because we don't have the actual tools
-        // but it should NOT log portal_fallback
-        try {
-          await takeScreenshot();
-        } catch (e) {
-          // Expected to fail
-        }
-
-        // Verify portal fallback was NOT logged (because we're not in Flatpak)
-        verifyNever(
-          () => mockLoggingService.error(
-            LogDomain.screenshots,
-            any<Object>(),
-            subDomain: 'portal_fallback',
-          ),
-        );
-      });
-
-      test('portal service should throw when used outside Flatpak', () async {
-        // This test verifies that ScreenshotPortalService properly guards against
-        // being used outside of Flatpak
-        expect(
-          PortalService.shouldUsePortal,
-          isFalse,
-          reason: 'This test requires non-Flatpak environment',
-        );
-
-        final portalService = ScreenshotPortalService();
-
-        // Should throw UnsupportedError when not in Flatpak
-        await expectLater(
-          portalService.takeScreenshot(
-            directory: '/tmp',
-            filename: 'test.png',
-          ),
-          throwsA(isA<UnsupportedError>()),
-        );
-      });
-    });
-
-    group('Portal Integration Tests', () {
-      test('should use traditional flow when not in Flatpak', () async {
-        // Verify we're not in Flatpak
-        expect(
-          PortalService.shouldUsePortal,
-          isFalse,
-          reason: 'This test verifies non-Flatpak behavior',
-        );
-
-        // Mock logging to capture any exceptions
-        when(
-          () => mockLoggingService.error(
-            LogDomain.screenshots,
-            any<Object>(),
-            stackTrace: any<StackTrace?>(named: 'stackTrace'),
-          ),
-        ).thenAnswer((_) async {});
-
-        // The screenshot will fail because we don't have the actual screenshot tools
-        await expectLater(
-          takeScreenshot(),
-          throwsA(anyOf(isA<Exception>(), isA<StateError>())),
-        );
-
-        // Verify that the exception was logged (but NOT as portal_fallback)
-        verify(
-          () => mockLoggingService.error(
-            LogDomain.screenshots,
-            any<Object>(),
-            stackTrace: any<StackTrace?>(named: 'stackTrace'),
-          ),
-        ).called(1);
-      });
-
-      test('portal service lifecycle in non-Flatpak environment', () async {
-        // Even when not in Flatpak, the portal service should handle
-        // initialization and disposal gracefully
-        expect(PortalService.shouldUsePortal, isFalse);
-
-        final portalService = ScreenshotPortalService();
-
-        // Initialization should succeed even outside Flatpak.
-        await expectLater(portalService.initialize(), completes);
-
-        await expectLater(portalService.dispose(), completes);
-        expect(() => portalService.client, throwsStateError);
-      });
-
-      test('portal service client access should fail outside Flatpak', () {
-        expect(PortalService.shouldUsePortal, isFalse);
-
-        final portalService = ScreenshotPortalService();
-
-        // Accessing client without initialization should throw
-        expect(
-          () => portalService.client,
-          throwsA(
-            isA<StateError>().having(
-              (e) => e.message,
-              'message',
-              contains('not initialized'),
-            ),
-          ),
-        );
-      });
-    });
-
-    group('Portal Constants Integration', () {
-      test('should use correct portal constants', () {
-        expect(
-          ScreenshotPortalConstants.interfaceName,
-          equals('org.freedesktop.portal.Screenshot'),
-        );
-        expect(
-          ScreenshotPortalConstants.screenshotMethod,
-          equals('Screenshot'),
-        );
-      });
-
-      test('should use correct portal timeout', () {
-        expect(
-          PortalConstants.responseTimeout,
-          equals(const Duration(seconds: 30)),
-        );
-      });
-    });
-
-    group('Portal Service Lifecycle', () {
-      test('should initialize portal service correctly', () async {
-        final portalService = ScreenshotPortalService();
-        await expectLater(portalService.initialize(), completes);
-        await expectLater(portalService.dispose(), completes);
-        expect(() => portalService.client, throwsStateError);
-      });
-
-      test('should handle portal service disposal', () async {
-        final portalService = ScreenshotPortalService();
-        await portalService.initialize();
-        await expectLater(portalService.dispose(), completes);
-        expect(() => portalService.client, throwsStateError);
-      });
-    });
+    }
   });
 }

--- a/test/vector_clock_glados_test.dart
+++ b/test/vector_clock_glados_test.dart
@@ -20,34 +20,27 @@ extension AnyVectorClock on Any {
       return VectorClock({'a': v1, 'b': v2, 'c': v3});
     },
   );
-  Generator<VectorClock> get possiblyInvalidVc =>
-      any.combine2(any.int, any.int, (int v1, int v2) {
-        return VectorClock({'a': v1, 'b': v2});
-      });
+  Generator<VectorClock> get sparseVc => any
+      .listWithLengthInRange(0, 7, any.choose<int?>([null, 0, 1, 2, 100]))
+      .map(
+        (counters) => VectorClock({
+          for (var i = 0; i < counters.length; i++)
+            if (counters[i] case final int counter) 'node-$i': counter,
+        }),
+      );
 }
 
-bool aGtB(VectorClock a, VectorClock b) {
-  final nodeIds = <String>{}
-    ..addAll(a.vclock.keys)
-    ..addAll(b.vclock.keys);
-
-  for (final nodeId in nodeIds) {
-    if (b.get(nodeId) > a.get(nodeId)) {
-      return false;
-    }
-  }
-
-  if (b.vclock.values.reduce((acc, elem) => acc + elem) >=
-      a.vclock.values.reduce((acc, elem) => acc + elem)) {
-    return false;
-  }
-
-  return true;
+// Compare components directly: summing counters can overflow and an empty
+// clock has no values to reduce. This oracle does not call production helpers.
+bool _dominates(VectorClock a, VectorClock b) {
+  final nodes = {...a.vclock.keys, ...b.vclock.keys};
+  return nodes.every(
+        (node) => (a.vclock[node] ?? 0) >= (b.vclock[node] ?? 0),
+      ) &&
+      nodes.any((node) => (a.vclock[node] ?? 0) > (b.vclock[node] ?? 0));
 }
 
 void main() {
-  Any.setDefault<VectorClock>(any.vc);
-
   Glados<VectorClock>(any.vc3).test(
     'fromJson(toJson(vc)) round-trips to an equal clock',
     (vc) {
@@ -62,69 +55,66 @@ void main() {
     tags: 'glados',
   );
 
-  Glados2<VectorClock, VectorClock>().test('compare two vector clocks', (
-    vc1,
-    vc2,
-  ) {
-    if (const DeepCollectionEquality().equals(vc1.vclock, vc2.vclock)) {
-      expect(VectorClock.compare(vc1, vc2), VclockStatus.equal);
-    } else if (aGtB(vc1, vc2)) {
-      expect(VectorClock.compare(vc1, vc2), VclockStatus.a_gt_b);
-    } else if (aGtB(vc2, vc1)) {
-      expect(VectorClock.compare(vc1, vc2), VclockStatus.b_gt_a);
-    } else {
-      expect(VectorClock.compare(vc1, vc2), VclockStatus.concurrent);
-    }
-  }, tags: 'glados');
+  for (final (a, b) in const [
+    (VectorClock({'a': 1, 'b': 2}), VectorClock({'a': 1, 'b': 2, 'c': 0})),
+    (VectorClock({}), VectorClock({'a': 0})),
+    (VectorClock({}), VectorClock({'a': 1})),
+    (VectorClock({'a': 1}), VectorClock({'b': 1})),
+  ]) {
+    test('comparison oracle handles sparse clocks $a and $b', () {
+      _expectComparison(a, b);
+      _expectComparison(b, a);
+    });
+  }
 
-  Glados2<VectorClock, VectorClock>(any.vc3, any.vc3).test(
-    'compare two vector clocks with three nodes',
-    (vc1, vc2) {
-      if (const DeepCollectionEquality().equals(vc1.vclock, vc2.vclock)) {
-        expect(VectorClock.compare(vc1, vc2), VclockStatus.equal);
-      } else if (aGtB(vc1, vc2)) {
-        expect(VectorClock.compare(vc1, vc2), VclockStatus.a_gt_b);
-      } else if (aGtB(vc2, vc1)) {
-        expect(VectorClock.compare(vc1, vc2), VclockStatus.b_gt_a);
-      } else {
-        expect(VectorClock.compare(vc1, vc2), VclockStatus.concurrent);
+  for (final (name, first, second) in [
+    ('two nodes', any.vc, any.vc),
+    ('three nodes', any.vc3, any.vc3),
+    ('different node sets', any.vc, any.vc3),
+    ('sparse node sets including empty clocks', any.sparseVc, any.sparseVc),
+  ]) {
+    Glados2<VectorClock, VectorClock>(first, second).test(
+      'compare clocks with $name',
+      _expectComparison,
+      tags: 'glados',
+    );
+  }
+
+  Glados2<VectorClock, int>(any.sparseVc, any.negativeInt).test(
+    'rejects a negative counter in either operand',
+    (valid, negative) {
+      final invalid = VectorClock({...valid.vclock, 'invalid': negative});
+      for (final (a, b) in [(invalid, valid), (valid, invalid)]) {
+        expect(
+          () => VectorClock.compare(a, b),
+          throwsA(isA<VclockException>()),
+          reason: '$a vs $b',
+        );
       }
     },
     tags: 'glados',
   );
 
-  Glados2<VectorClock, VectorClock>(any.vc, any.vc3).test(
-    'compare two vector clocks, one with three nodes',
-    (vc1, vc2) {
-      if (const DeepCollectionEquality().equals(vc1.vclock, vc2.vclock)) {
-        expect(VectorClock.compare(vc1, vc2), VclockStatus.equal);
-      } else if (aGtB(vc1, vc2)) {
-        expect(VectorClock.compare(vc1, vc2), VclockStatus.a_gt_b);
-      } else if (aGtB(vc2, vc1)) {
-        expect(VectorClock.compare(vc1, vc2), VclockStatus.b_gt_a);
-      } else {
-        expect(VectorClock.compare(vc1, vc2), VclockStatus.concurrent);
-      }
+  Glados<VectorClock>(any.sparseVc).test(
+    'adding explicit zero counters preserves causal equality',
+    (clock) {
+      final padded = VectorClock({...clock.vclock, 'unused-node': 0});
+      expect(VectorClock.compare(clock, padded), VclockStatus.equal);
+      expect(VectorClock.compare(padded, clock), VclockStatus.equal);
     },
     tags: 'glados',
   );
 
-  Glados2<VectorClock, VectorClock>(
-    any.possiblyInvalidVc,
-    any.possiblyInvalidVc,
-  ).test('compare two vector clocks, throw exception when invalid', (vc1, vc2) {
-    if (!vc1.isValid() || !vc2.isValid()) {
-      expect(
-        () => VectorClock.compare(vc1, vc2),
-        throwsA(
-          predicate(
-            (e) =>
-                e is VclockException &&
-                e.toString() == 'Invalid vector clock inputs',
-          ),
-        ),
-      );
-    }
+  Glados3<VectorClock, VectorClock, VectorClock>(
+    any.sparseVc,
+    any.sparseVc,
+    any.sparseVc,
+  ).test('merge is associative across sparse clocks', (a, b, c) {
+    expect(
+      VectorClock.merge(VectorClock.merge(a, b), c),
+      VectorClock.merge(a, VectorClock.merge(b, c)),
+      reason: '$a, $b, $c',
+    );
   }, tags: 'glados');
 
   group('VectorClock.merge — algebraic laws', () {
@@ -188,4 +178,23 @@ void main() {
       expect(result.contains(b), isTrue);
     });
   });
+}
+
+void _expectComparison(VectorClock a, VectorClock b) {
+  Map<String, int> nonZeroCounters(VectorClock clock) => {
+    for (final entry in clock.vclock.entries)
+      if (entry.value != 0) entry.key: entry.value,
+  };
+  final expected =
+      const DeepCollectionEquality().equals(
+        nonZeroCounters(a),
+        nonZeroCounters(b),
+      )
+      ? VclockStatus.equal
+      : _dominates(a, b)
+      ? VclockStatus.a_gt_b
+      : _dominates(b, a)
+      ? VclockStatus.b_gt_a
+      : VclockStatus.concurrent;
+  expect(VectorClock.compare(a, b), expected, reason: '$a vs $b');
 }


### PR DESCRIPTION
A screenshot tool that kept its output streams open could leave the app minimized indefinitely: the timeout started only after those streams closed. Capture now drains stdout and stderr concurrently, bounds output and process exit with one timeout, cancels both pipe subscriptions, and restores the window on failure. Per-chunk forwarding leaves global sinks available even when a child retains its parent's pipes.

This also strengthens three areas identified in the test-suite review:

- Screenshot tests control the OS boundary, assert command arguments, timeout boundaries, metadata and window restoration, and verify screenshot entries and links through the real journal database.
- Sync resilience tests use separate device databases and filesystem roots, the real outbox and production backfill recovery, and exact persisted content assertions. Tests only observe recovery; they no longer force rescans. Throttling uses incompressible payloads, and the harness verifies device trust and cleans up owned resources.
- Vector-clock properties use component-wise dominance with explicit-zero normalization, exercise sparse and empty clocks, and always assert invalid-input rejection.

Validation:

- Full Dart MCP analyzer: no diagnostics; formatter clean.
- 65 focused screenshot, entry-creation and vector-clock tests pass, including the output-cancellation follow-up.
- All four native Linux resilience scenarios pass locally against disposable Dendrite accounts and Toxiproxy (4m 10s), and the manually triggered CI Matrix workflow also passes: disconnect, latency, bandwidth and repeated outages.
- Regression checks fail with the old timeout/output behavior, missing subscription cancellation, legacy vector-clock oracle and shared-directory wiring restored; assertion mutations also fail.
- Knowledge validation, Mermaid parsing, test-policy and changelog checks pass.

CI passes all ten unit/widget shards, Glados, analysis, Matrix tests, and Android/macOS builds. Codecov reports 100% patch coverage and 99.38% project coverage. This PR implements the first set of review improvements; it does not claim to address every suite-wide finding.